### PR TITLE
Fix height of doc's Nav so that all content is shown

### DIFF
--- a/docs/client/docs.css
+++ b/docs/client/docs.css
@@ -106,7 +106,6 @@ a:hover {
 /** Section nav **/
 
 #nav {
-    padding-top: 38px;
     padding-left: 30px;
     padding-right: 30px;
     line-height: 1.2;
@@ -116,7 +115,7 @@ a:hover {
 }
 
 #nav > div {
-    margin-top: -50px;
+    margin-bottom: 30px;
 }
 
 #nav a {
@@ -420,6 +419,8 @@ pre {
     display: block;
     width: 200px;
     position: fixed;
+    top: 0;
+    left: 0;
     overflow: auto;
     height: 100%;
 }


### PR DESCRIPTION
On the documentation page the left nav has its bottom content truncated.

This fix insures that all sidebar content is visible and accessible to the user. 

(fyi saw this bug on Chrome 18 and iPad simulator, this fix is for both devices)
