### PR TITLE
Fix for issue #14: project can't be created in directories with spaces

### DIFF
--- a/meteor
+++ b/meteor
@@ -36,7 +36,7 @@ if [ -L "$(basename $0)" ] ; then
     cd $(dirname $(readlink $(basename "$0") ) )
 fi
 SCRIPT_DIR=$(pwd -P)
-cd $ORIG_DIR
+cd "$ORIG_DIR"
 
 
 


### PR DESCRIPTION
Pretty simple fix. In a directory with spaces in its path, `meteor create` was instead creating the project in `/usr/local/meteor/bin`.
