### PR TITLE
Consider bare option for compiling CoffeeScript to remove top-level function safety wrapper

### DIFF
--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -10,7 +10,9 @@ Package.register_extension(
     serve_path = serve_path + '.js';
 
     var contents = fs.readFileSync(source_path);
-    contents = new Buffer(coffee.compile(contents.toString('utf8')));
+    var options = {bare: true};
+    
+    contents = new Buffer( coffee.compile(contents.toString('utf8'), options) );
     // XXX report coffee compile failures better?
 
     bundle.add_resource({


### PR DESCRIPTION
Consider bare option for compiling CoffeeScript to remove top-level function safety wrapper

... safety wrapper](http://coffeescript.org/#lexical_scope).

<myserver.coffee>
Lists = new Meteor.Collection("lists")
</myserver.coffee>
