### PR TITLE
Fixed bug on "meteor create"

### DIFF
--- a/meteor
+++ b/meteor
@@ -20,7 +20,7 @@ if [ "$UNAME" = "Darwin" ] ; then
     fi
     ARCH="x86_64"
 elif [ "$UNAME" = "Linux" ] ; then
-    ARCH=$(uname -m)
+    ARCH="$(uname -m)"
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then
         echo "Unsupported architecture: $ARCH"
         echo "Meteor only supports i686 and x86_64 for now."
@@ -36,7 +36,7 @@ if [ -L "$(basename $0)" ] ; then
     cd $(dirname $(readlink $(basename "$0") ) )
 fi
 SCRIPT_DIR=$(pwd -P)
-cd $ORIG_DIR
+cd "$ORIG_DIR"
 
 
 


### PR DESCRIPTION
I tried to create a new app but it failed because it was in a directory with a space in its name.
So I added missing quotes in meteor script to handle paths with whitespace. See line 39 of meteor file.
