### PR TITLE
Added how to read local docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ will cause ```meteor``` to be in your ```PATH```.
 
     ./install.sh
     meteor --help
+    
+After installing, you can read the docs locally. The ```/docs``` directory is a meteor application, so simply change into the ```/docs``` directory and launch the app:
+	
+	cd docs/
+	meteor
+
+You'll then be able to read the docs locally in your browser at ```http://localhost:3000/```
 
 ## Developer Resources
 


### PR DESCRIPTION
It took me a little while to guess that the `/docs` directory was a meteor application itself, so if I wanted to read the docs locally, I needed to launch it.

I think it would be helpful to put that in the README under the Slow Start section.
