### PR TITLE
Change ordering of template to allow user JS and CSS

### DIFF
--- a/app/lib/app.html.in
+++ b/app/lib/app.html.in
@@ -4,10 +4,10 @@
 {{#each stylesheets}}  <link rel="stylesheet" href="{{this}}">
 {{/each}}
 
-{{{head_extra}}}
-
 {{#each scripts}}  <script type="text/javascript" src="{{this}}"></script>
 {{/each}}
+
+{{{head_extra}}}
 </head>
 <body>
 {{{body_extra}}}


### PR DESCRIPTION
This is to allow any user added script in their header to be able to use the libraries in Meteor. For example including a plugin would have to be always written as a plugin which is probably beyond some users.
