### PR TITLE
Fix small typo in Less package exception handling.

### DIFF
--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -26,7 +26,7 @@ Package.register_extension(
           where: where
         });
       });
-    } catch (e) {
+    } catch (err) {
       // less.render() is supposed to report any errors via its
       // callback. But sometimes, it throws them instead. This is
       // probably a bug in less. Be prepared for either behavior.


### PR DESCRIPTION
Fixed `ReferenceError: err is not defined` in `packages/less/package.js`.

A small fix needs a small pull request message.
