### PR TITLE
[Devel] Allows users to enabled HTTP-Basic-Auth using a .auth file.

### DIFF
--- a/app/server/server.js
+++ b/app/server/server.js
@@ -58,6 +58,21 @@ var run = function (bundle_dir) {
 
   // webserver
   var app = connect.createServer();
+  try {
+    var authData = fs.readFileSync(path.join(bundle_dir,"../../../.auth"), "ascii");
+    var identities = authData.split("\n");
+    app.use(connect.basicAuth(function(username, password) {
+      for(var i=0, len = identities.length; i < len; i++) {
+        var credentials = identities[i].split(":");
+        if(credentials.length < 2) continue;
+
+        if(username === credentials[0] && password === credentials[1]) return true;
+      }
+      return false;
+    }));
+  } catch(e) {
+    console.log("No .auth file present. Starting without HTTP Auth");
+  }
   app.use(gzippo.staticGzip(path.join(bundle_dir, 'static_cacheable'), {clientMaxAge: 1000 * 60 * 60 * 24 * 365}));
   app.use(gzippo.staticGzip(path.join(bundle_dir, 'static')));
 


### PR DESCRIPTION
After a request in the IRC channel, I decided to allow users to enable connect.basicAuth for their site.

To do so, they'll have to create a .auth file in the app root directory containing valid users+passwords like this:

```
alice:herpassword
bob:hispassword
...
```

If the .auth file is not existing, there is no auth at all.
P.S. I am not sure, if the directory is the best choice. I am happy for any feedback / corrections, as I am new to meteor.js
