### PR TITLE
Allow the SockJS server to connect to WebSocket clients.

### DIFF
--- a/packages/stream/stream_server.js
+++ b/packages/stream/stream_server.js
@@ -13,7 +13,7 @@ Meteor._StreamServer = function () {
   // set up socket.io
   var sockjs = __meteor_bootstrap__.require('sockjs');
   self.server = sockjs.createServer({
-    prefix: '/sockjs', websocket: false, log: function(){},
+    prefix: '/sockjs', log: function(){},
     jsessionid: false});
   self.server.installHandlers(__meteor_bootstrap__.app);
 


### PR DESCRIPTION
This commit allows the SockJS server to connect to WebSocket clients on the url http://site:port+1/sockjs/websocket.

I understand that there are issues with websockets on the client, so I've left that disabled, but I'm not sure why they were disabled on the server. This change allows non-browsers to easily interact with the meteor server. I'm working on an implementation of DDP for other languages and this is the only way that sockjs supports non-browser clients speaking to it.

If there is a compelling reason to disable websockets server-side, then I'll try to go through the rigamarole of reimplementing SockJS's protocol outside of the browser..
