### PR TITLE
Fix output of compiled coffeescript applications

### DIFF
--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -10,7 +10,9 @@ Package.register_extension(
     serve_path = serve_path + '.js';
 
     var contents = fs.readFileSync(source_path);
-    contents = new Buffer(coffee.compile(contents.toString('utf8')));
+		var options = {};
+		options.bare = true;
+    contents = new Buffer(coffee.compile(contents.toString('utf8'),options));
     // XXX report coffee compile failures better?
 
     bundle.add_resource({


### PR DESCRIPTION
The compiler was wrapping each javascript file compiled from coffee script with a function, which prevents any methods/variables from being used by other coffee scripts. I fixed this by passing the 'bare' option to the compiler.
