### PR TITLE
Fix bug with dot notation selector not working 

### DIFF
--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -395,7 +395,7 @@ LocalCollection._exprForKeypathPredicate = function (keypath, value, literals) {
       // for all but the innermost level of a dotted expression,
       // if the runtime type is an array, search it
       ret = 'f._matches(' + formal + '[' + JSON.stringify(part) +
-        '], function(x){return ' + ret + ';}';
+        '], function(x){return ' + ret + ';})';
     }
   }
 


### PR DESCRIPTION
How to reproduce:

``` js
MyCollection.find({ "my.complex.doc": "foobar" });
```

// will output in the (Chrome) console

``` js
Uncaught SyntaxError: Unexpected token ;
```

There were simply a parenthesis missing.
