### PR TITLE
Fix leaderboard.css example

### DIFF
--- a/examples/leaderboard/leaderboard.css
+++ b/examples/leaderboard/leaderboard.css
@@ -1,5 +1,5 @@
 body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, san-serif;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-weight: 200;
     margin: 50px 0;
     padding: 0;


### PR DESCRIPTION
Noticed small error in the example CSS styles.

san-serif --> sans-serif

Possibility for it actually affecting visual presentation is small (unless all of the traditional typefaces are missing) but would good thing to fix anyway.
