### PR TITLE
Updated title on the documentation

### DIFF
--- a/docs/client/docs.html
+++ b/docs/client/docs.html
@@ -1,5 +1,5 @@
 <head>
-  <title>Meteor</title>
+  <title>Documentation - Meteor</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="favicon.ico" type="image/x-icon" />
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
Updated title on the documentation to be more friendly to people that has many tabs open. "Meteor" gets confusing when you have both the documentation, and say, the examples open at the same time, as they are both titled "Meteor". Heads up to @debergalis.
