### PR TITLE
Avital

### DIFF
--- a/packages/madewith/madewith.js
+++ b/packages/madewith/madewith.js
@@ -1,8 +1,18 @@
 (function () {
-// automatically capture this app's hostname
+  // Duplicated in the madewith app (search for #DisplayAppName in
+  // https://github.com/meteor/madewith)
+  // XXX - Can this code somehow be shared reasonably?
+  var displayAppName = function (name) {
+    var parts = name.split('.');
+    if (parts.length === 3 && parts[1] === 'meteor' && parts[2] === 'com')
+      return parts[0];
+    else
+      return name;
+  };
+
+  // automatically capture this app's hostname
   var hostname = window.location.host;
-  var match = hostname.match(/(.*)\.meteor.com$/);
-  var shortname = match ? match[1] : hostname;
+  var shortname = displayAppName(hostname);
 
   // connect to madewith and subscribe to my app's record
   var server = Meteor.connect("http://madewith.meteor.com/sockjs");


### PR DESCRIPTION
This pull request fixes the madewith badge bug discovered by Nick related to subdomains such as "foo.bar.meteor.com"

For example, the badge on foo.bar.meteor.com now points to
madewith.meteor.com/foo.bar.meteor.com. I updated comments on the madewith
app in a separate commit to reflect this.

This was tested by deploying a sample app to ab.meteor.com and a.b.meteor.com
and verifying that the links go to the right URL. Upvoting was not tested
explicitly but the code uses the same url for that.
