### PR TITLE
Allows to define a callback event triggered after Template rendering & re-rendering

### DIFF
--- a/packages/liveui/liveui.js
+++ b/packages/liveui/liveui.js
@@ -15,7 +15,7 @@ Meteor.ui = Meteor.ui || {};
   Meteor.ui.render = function (html_func, react_data, in_range) {
 
     // Empty the render_callbacks array each time we do a render
-    Meteor.ui_render_callbacks_nodes    = [];
+    Meteor.ui._render_callbacks_nodes = [];
 
     if (typeof html_func !== "function")
       throw new Error("Meteor.ui.render() requires a function as its first argument.");


### PR DESCRIPTION
This event will be triggered after the rendering and DOM insertion of each inner HTML nodes inside a Template.

``` html
<template name="header">
    <h1>Node1</h1>
    <p>Node2</p>
</template>
```

Definition of callback : 

``` javascript
Template.header.events = {
    'afterinsert' : function(e) { }
};
```

The callback context is the DOMWindow.

In this example, the event will be triggered for each node of Template#header : h1, p.

EDIT, see commit : 6dacfb2
EDIT : Now working with 0.3.4 : cf19d58 , 593295a
