### PR TITLE
Run Callback on Template render & re-render

### DIFF
--- a/packages/liveui/liveui.js
+++ b/packages/liveui/liveui.js
@@ -13,6 +13,8 @@ Meteor.ui = Meteor.ui || {};
   // `in_range` is a package-private argument used to render inside
   // an existing LiveRange on an update.
   Meteor.ui.render = function (html_func, react_data, in_range) {
+    
+    Meteor.ui._rendered_templates = [];
     if (typeof html_func !== "function")
       throw new Error("Meteor.ui.render() requires a function as its first argument.");
 


### PR DESCRIPTION
Will run Template.xxx.callback every time a Template is rendered and  re-rendered due to a data update.

The callback has full access to DOM.

Borrowed heavily from Gabriel Dehan at https://github.com/meteor/meteor/pull/97
