### PR TITLE
Proxy websocket requests into inner web server

### DIFF
--- a/app/meteor/run.js
+++ b/app/meteor/run.js
@@ -96,6 +96,25 @@ var start_proxy = function (outer_port, inner_port, callback) {
     }
   });
 
+  // Proxy websocket requests using same buffering logic as for regular HTTP requests
+  p.on('upgrade', function(req, socket, head) {
+    if (Status.listening) {
+      // server is listening. things are hunky dory!
+      p.proxy.proxyWebSocketRequest(req, socket, head, {
+        host: '127.0.0.1', port: inner_port
+      });
+    } else {
+      // Not listening yet. Queue up request.
+      var buffer = httpProxy.buffer(req);
+      request_queue.push(function () {
+        p.proxy.proxyWebSocketRequest(req, socket, head, {
+          host: '127.0.0.1', port: inner_port,
+          buffer: buffer
+        });
+      });
+    }
+  });
+
   p.on('error', function (err) {
     if (err.code == 'EADDRINUSE') {
       process.stderr.write("Can't listen on port " + outer_port


### PR DESCRIPTION
One should now be able to connect to ws://localhost:3000/sockjs/websocket,
e.g. running the following code in the dev console of a locally running app:

> var sock = new WebSocket("ws://localhost:3000/sockjs/websocket")
> sock.onmessage = function(event) { console.log(event.data); }
> sock.send('{"msg": "connect"}');
> {"msg":"connected","session":"ab887541-a4ac-4623-8778-a0c53e8f7fe6"}
