### PR TITLE
Haml-Coffee smart package

### DIFF
--- a/packages/haml-coffee/package.js
+++ b/packages/haml-coffee/package.js
@@ -1,0 +1,29 @@
+Package.describe({
+  summary: "Javascript template that uses HAML as markup and understands coffeescript"
+});
+
+var HamlCoffee = require('haml-coffee-meteor').Compiler;
+var CoffeeScript = require('coffee-script')
+var fs = require('fs');
+
+Package.register_extension(
+  "hamlc", function (bundle, source_path, serve_path, where) {
+    serve_path = serve_path + '.js';
+
+    var contents = fs.readFileSync(source_path);
+    var compiler;
+    var compiler = new HamlCoffee();
+    var splits = source_path.split('/');
+    var template_name = splits[splits.length-1];
+    template_name = template_name.split('.')[0];
+    compiler.parse(contents.toString('utf8'));
+    contents = new Buffer("if (typeof HAML == 'undefined') {var HAML = {}}; HAML['"+template_name+"']=function(params) { return (function(){"+CoffeeScript.compile(compiler.precompile(), {bare: true})+"}).call(params) };");
+
+    bundle.add_resource({
+      type: "js",
+      path: serve_path,
+      data: contents,
+      where: where
+    });
+  }
+);


### PR DESCRIPTION
I've added a smart package to be able to render .hamlc files via https://github.com/9elements/haml-coffee. I had to ever-so-slightly tweak their npm package into my own version, called 'haml-coffee-meteor', to get it to work. Templates generated by .hamlc files are currently available via a global HAML object. So calling HAML['filename'] when you have a file named filename.hamlc in your app will give you a function that you can call to render.

Please let me know what else I might need to do to get the package merged.
