### PR TITLE
Check more carefully for a development environment

### DIFF
--- a/app/lib/files.js
+++ b/app/lib/files.js
@@ -175,7 +175,8 @@ var files = module.exports = {
   // an installation.)
   in_checkout: function () {
     try {
-      if (path.existsSync(path.join(__dirname, "../../.git")))
+      if (path.existsSync(path.join(__dirname, "../../.git")) ||
+          path.existsSync(path.join(__dirname, "../../.gitignore")))
         return true;
     } catch (e) { console.log(e);}
 

--- a/meteor
+++ b/meteor
@@ -68,7 +68,8 @@ function install_dev_bundle {
 }
 
 
-if [ -d "$SCRIPT_DIR/.git" ] || [ -f "$SCRIPT_DIR/.git" ]; then
+if [ -d "$SCRIPT_DIR/.git" ] || [ -f "$SCRIPT_DIR/.git" ] \
+                || [ -f "$SCRIPT_DIR/.gitignore" ]; then
     # In a checkout.
     if [ ! -d "$SCRIPT_DIR/dev_bundle" ] ; then
         echo "It's the first time you've run Meteor from a git checkout."


### PR DESCRIPTION
The check for a .git directory fails when meteor is brought into a project via the [git-subtree](https://github.com/git/git/tree/master/contrib/subtree) command.
