### PR TITLE
Template override

### DIFF
--- a/packages/templating/deftemplate.js
+++ b/packages/templating/deftemplate.js
@@ -44,16 +44,15 @@
 
 
     if (name) {
-      var originalTemplate;
-      if (Template[name]) {
-        originalTemplate = Template[name];
-      }
+      var original;
+
+      if (Template[name])
+        original = Template[name];
 
       Template[name] = partial;
 
-      if (originalTemplate) {
-        _.extend(Template[name], originalTemplate);
-      }
+      if (original)
+        _.extend(Template[name], original);
 
       Meteor._partials[name] = partial;
     }


### PR DESCRIPTION
I'm in a situation where I want my smart package to include templates that can be optionally used by the end user. Problem is if they want to use customized copies of my the package's templates there's no mechanism for overriding. My solution is pretty blunt but without it I have to ask users to do horrible things to override the smart templates without losing events and methods defined for the original template in the package.

Is there a baked in solution to this problem that's better? Better patch approach? Suggestions?
