### PR TITLE
Fiber middleware and reserved session methods

### DIFF
--- a/examples/users/users.css
+++ b/examples/users/users.css
@@ -1,0 +1,1 @@
+/* CSS declarations go here */

--- a/examples/users/users.html
+++ b/examples/users/users.html
@@ -1,0 +1,20 @@
+<head>
+  <title>usersconnected</title>
+</head>
+
+<body>
+  {{> users}}
+</body>
+
+<template name="users">
+  <div class="users-view">
+  	<div id="set-user-box">
+      <input type="text" id="set-user" placeholder="user" />
+    </div>
+    <ul id="users-list">
+      {{#each users}}
+      	<div class="name">{{name}}</div>
+      {{/each}}
+    </ul>
+  </div>
+</template>

--- a/examples/users/users.js
+++ b/examples/users/users.js
@@ -1,0 +1,91 @@
+  Sessions = new Meteor.Collection('sessions');
+
+if (Meteor.is_client) {
+
+  // Returns an event_map key for attaching "ok/cancel" events to
+  // a text input (given by selector)
+  var okcancel_events = function (selector) {
+    return 'keyup '+selector+', keydown '+selector+', focusout '+selector;
+  };
+
+  // Creates an event handler for interpreting "escape", "return", and "blur"
+  // on a text field and calling "ok" or "cancel" callbacks.
+  var make_okcancel_handler = function (options) {
+    var ok = options.ok || function () {};
+    var cancel = options.cancel || function () {};
+
+    return function (evt) {
+      if (evt.type === "keydown" && evt.which === 27) {
+        // escape = cancel
+        cancel.call(this, evt);
+
+      } else if (evt.type === "keyup" && evt.which === 13 ||
+                 evt.type === "focusout") {
+        // blur/return/enter = ok/submit if non-empty
+        var value = String(evt.target.value || "");
+        if (value)
+          ok.call(this, value, evt);
+        else
+          cancel.call(this, evt);
+      }
+    };
+  };
+
+  Template.users.users = function() {
+    // return the users that are connected
+    return _.map(Sessions.find({connected: true, user: {$exists: true}}).fetch(),function(session) {
+      return {name: session.user};
+    });
+  }
+
+  Template.users.events = {};
+
+  // Attach events to keydown, keyup, and blur on "New list" input box.
+  Template.users.events[ okcancel_events('#set-user-box') ] =
+    make_okcancel_handler({
+      ok: function (text, evt) {
+        // sets the user for this session
+        Sessions.update({id: Session.id},{$set: {user: text}});
+        evt.target.value = "";
+      }
+    });
+
+}
+
+if (Meteor.is_server) {
+  Meteor.methods({
+    // on session creation add a session document to the 
+    // sessions collection with the id of the new session
+    session: function() {
+      var ret = Sessions.insert({id: Session.CURRENT_ID.get(), connected: false});
+    },
+
+    // on new connection update the session document 
+    connect: function() {
+      Sessions.update({id: Session.CURRENT_ID.get()}, {$set: {connected: true}});
+    },
+
+    // on disconnection update the session document
+    disconnect: function() {
+      Sessions.update({id: Session.CURRENT_ID.get()}, {$set: {connected: false}});
+    },
+
+    // when session is destroyed remove it from collection
+    destroy: function() {
+      Sessions.remove({id: Session.CURRENT_ID.get()});
+    }
+  })
+
+  Meteor.startup(function () {
+    Sessions.remove({});
+
+    // create environment variable for current session id
+    Session.CURRENT_ID = new Meteor.EnvironmentVariable;
+
+    // set the current session id environment variable whenever a livedata
+    // session startsup a new fiber
+    Meteor.use(function(session,next) {
+      Session.CURRENT_ID.withValue(session.id,next);
+    });
+  });
+}

--- a/packages/livedata/livedata_test_service.js
+++ b/packages/livedata/livedata_test_service.js
@@ -61,3 +61,20 @@ Meteor.methods({
     Meteor.refresh({collection: 'ledger', world: world});
   }
 });
+
+if (Meteor.is_server) {
+
+  Meteor.startup(function() {
+    Meteor.use(function(session,next) {
+      CURRENT_SESSION_ID.withValue(session.id,next);
+    });
+  });
+
+
+  CURRENT_SESSION_ID = new Meteor.EnvironmentVariable;
+  Meteor.methods({
+    'sessionID': function() {
+      return CURRENT_SESSION_ID.get();
+    }
+  });
+}

--- a/packages/livedata/livedata_tests.js
+++ b/packages/livedata/livedata_tests.js
@@ -238,6 +238,21 @@ testAsyncMulti("livedata - compound methods", [
   }
 ]);
 
+Tinytest.addAsync("livedata - env middleware", function(test,done) {
+  if (Meteor.is_client) {
+    onQuiesce(function() {
+      Meteor.call('sessionID',function(err,sid) {
+        test.equal(sid,Session.id);
+        done();
+      })
+    })
+  } else {
+    done();
+  }
+    
+  }
+);
+
 // XXX some things to test in greater detail:
 // staying in simulation mode
 // time warp

--- a/packages/livedata/server_convenience.js
+++ b/packages/livedata/server_convenience.js
@@ -17,7 +17,7 @@ _.extend(Meteor, {
 
 // Proxy the public methods of Meteor.default_server so they can
 // be called directly on Meteor.
-_.each(['publish', 'methods', 'call', 'apply'],
+_.each(['publish', 'methods', 'call', 'apply', 'use'],
        function (name) {
          Meteor[name] = _.bind(Meteor.default_server[name],
                                Meteor.default_server);

--- a/packages/session/package.js
+++ b/packages/session/package.js
@@ -18,5 +18,7 @@ Package.on_use(function (api, where) {
     api.use("reload", "client");
   }
 
+  api.use('livedata','client');
+
   api.add_files('session.js', where);
 });

--- a/packages/session/session.js
+++ b/packages/session/session.js
@@ -103,6 +103,12 @@ Session = _.extend({}, {
   }
 });
 
+if (Meteor.is_client) {
+  Session.__defineGetter__('id',function() {
+    return Meteor.default_connection.last_session_id;
+  });
+}
+
 
 if (Meteor._reload) {
   Meteor._reload.on_migrate('session', function () {


### PR DESCRIPTION
I found that to keep track of which users are connected, some features needed to be added to Meteor.
## Fiber Middleware

Every time the server starts up a new fiber, the fiber first runs through a middleware stack, passing the middleware the session object and the next function (may want to pass the middleware some other stuff, but this has worked for me so far). 

This Fiber middleware is very useful for setting up environment variables.

``` javascript
Session.CURRENT_ID = new Meteor.EnvironmentVariable;

Meteor.startup(function() {
    Meteor.use(function(session,next) {
      Session.CURRENT_ID.withValue(session.id,next);
    });
});
```
## Reserved Session Methods

_session_ - called when session is created
_connect_ - called when client connects
_disconnect_ - called when client disconnects
_destroy_ - called when session is destroyed

In the users example the reserved methods are used to modify the Sessions collection:

``` javascript
Meteor.methods({
    session: function() {
      Sessions.insert({id: Session.CURRENT_ID.get(), connected: false});
    },

    connect: function() {
      Sessions.update({id: Session.CURRENT_ID.get()}, {$set: {connected: true}});
    },

    disconnect: function() {
      Sessions.update({id: Session.CURRENT_ID.get()}, {$set: {connected: false}});
    },

    destroy: function() {
      Sessions.remove({id: Session.CURRENT_ID.get()});
    }
  })
```

Check out the simple users app to see these features in action and please let me know what you think.
