### PR TITLE
check static cacheable dir exists before using gzippo

### DIFF
--- a/app/server/server.js
+++ b/app/server/server.js
@@ -58,7 +58,9 @@ var run = function (bundle_dir) {
 
   // webserver
   var app = connect.createServer();
-  app.use(gzippo.staticGzip(path.join(bundle_dir, 'static_cacheable'), {clientMaxAge: 1000 * 60 * 60 * 24 * 365}));
+  var static_cacheable_path = path.join(bundle_dir, 'static_cacheable');
+  if (path.existsSync(static_cacheable_path))
+    app.use(gzippo.staticGzip(static_cacheable_path, {clientMaxAge: 1000 * 60 * 60 * 24 * 365}));
   app.use(gzippo.staticGzip(path.join(bundle_dir, 'static')));
 
   var app_html = fs.readFileSync(path.join(bundle_dir, 'app.html'));


### PR DESCRIPTION
When gzippo can't find the directory, it serves an empty file. This checks whether the static_cacheable directory exists before using gzippo for it. [related issue](https://github.com/meteor/meteor/issues/177)

To reproduce the problem / solution.
from your meteor repo

```
cd docs
../meteor
```

and then load localhost:3000 from a browser with a clean cache, you should be prompted to download an empty file if you don't have the change.
