### PR TITLE
event propagation

### DIFF
--- a/packages/liveui/liveui.js
+++ b/packages/liveui/liveui.js
@@ -659,7 +659,7 @@ Meteor.ui = Meteor.ui || {};
           event.preventDefault();
         }
         if (event.isImmediatePropagationStopped())
-          break; // stop handling by this and other event maps
+          return; // stop handling by this and other event maps
       }
     }
 


### PR DESCRIPTION
fix event.stopImmediatePropagation() - it wasn't stopping immediately after being called
