### PR TITLE
Exclude node_modules/ from monitoring

### DIFF
--- a/app/lib/files.js
+++ b/app/lib/files.js
@@ -44,6 +44,9 @@ var files = module.exports = {
     // third, we don't update the app now if anything here changes
     if (filename.indexOf('/public/') !== -1) { return false; }
 
+    // Don't load the node_modules directory
+    if (filename.indexOf('/node_modules/') !== -1) { return false; }
+
     return true;
   },
 

--- a/app/meteor/run.js
+++ b/app/meteor/run.js
@@ -282,7 +282,8 @@ var DependencyWatcher = function (deps, app_dir, on_change) {
     return new RegExp(pattern);
   });
   self.exclude_paths = [
-    path.join(app_dir, '.meteor', 'local')
+    path.join(app_dir, '.meteor', 'local'),
+    path.join(app_dir, 'node_modules')
   ];
 
   // Start monitoring


### PR DESCRIPTION
I'm currently trying to use npm modules in a somewhat sane way in my project. It seems like the method of choice at the moment is to stick them in public/node_modules:

http://stackoverflow.com/questions/10476170/how-can-i-deploy-node-modules-in-a-meteor-app-on-meteor-com

To me, this seems incredibly hacky. It SORT of works, but it will break down when developing in a mac if you have a lot of modules, because it ends up watching way too many files (http://stackoverflow.com/questions/11300969/error-watch-emfile-when-putting-node-modules-in-public)

In my opinion be much nicer if meteor simply ignored the node_modules directory - I've attached a commit suggesting how to do that.
