### PR TITLE
fixed mouseenter/mouseleave

### DIFF
--- a/packages/liveui/liveevents_w3c.js
+++ b/packages/liveui/liveevents_w3c.js
@@ -35,7 +35,7 @@ Meteor.ui._event._loadW3CImpl = function() {
   var focusBlurMode = ('onfocusin' in document.createElement("DIV")) ?
         SIMULATE_NEITHER : SIMULATE_FOCUSIN_FOCUSOUT;
 
-  // mouseenter/mouseleave is non-bubbling mousein/mouseout.  It's
+  // mouseenter/mouseleave is non-bubbling mouseover/mouseout.  It's
   // standard but only IE and Opera seem to support it,
   // so we simulate it (which works in IE but not in Opera for some reason).
   var simulateMouseEnterLeave = (! window.opera);
@@ -118,13 +118,14 @@ Meteor.ui._event._loadW3CImpl = function() {
     Meteor.ui._event._handleEventFunc(
       Meteor.ui._event._fixEvent(event));
 
+
     // fire mouseleave after mouseout
-    if (simulateMouseEnterLeave &&
-        (event.currentTarget === event.target)) {
-      if (event.type === 'mousein')
-        sendUIEvent('mouseenter', event.target, false);
+    if (simulateMouseEnterLeave && event.currentTarget !== event.relatedTarget && !jQuery.contains(event.currentTarget, event.relatedTarget)) {
+      if (event.type === 'mouseover'){
+        sendUIEvent('mouseenter', event.currentTarget, false);
+      }
       else if (event.type === 'mouseout') {
-        sendUIEvent('mouseleave', event.target, false);
+        sendUIEvent('mouseleave', event.currentTarget, false);
       }
     }
   };
@@ -145,7 +146,7 @@ Meteor.ui._event._loadW3CImpl = function() {
     }
     if (simulateMouseEnterLeave) {
       if (eventType === 'mouseenter')
-        installCapturer('mousein');
+        installCapturer('mouseover');
       else if (eventType === 'mouseleave')
         installCapturer('mouseout');
     }
@@ -159,7 +160,7 @@ Meteor.ui._event._loadW3CImpl = function() {
 
   var eventsCaptured = {};
 
-  Meteor.ui._event.registerEventType = function(eventType, subtreeRoot) {
+  Meteor.ui._event.registerEventTypeImpl = function(eventType, subtreeRoot) {
     // We capture on the entire document, so don't actually care
     // about subtreeRoot!
     installCapturer(eventType);


### PR DESCRIPTION
Fixed broken mouseenter/mouseleave events.  New code uses jQuery.contains, you may want to change this but the logic is correct.
