### PR TITLE
Fix check for duplicate api.register_extension.

### DIFF
--- a/app/lib/packages.js
+++ b/app/lib/packages.js
@@ -72,7 +72,7 @@ var Package = function () {
     },
 
     register_extension: function (extension, callback) {
-      if (self.on_test)
+      if (extension in self.extensions)
         throw new Error("This package has already registered a handler for " +
                        extension);
       self.extensions[extension] = callback;


### PR DESCRIPTION
Tested by:
- Editing packages/less/package.js to have a duplicate call to register_extension.
- Running 'meteor' in the 'docs' directory: no error. Kill meteor.
- Applying this patch.
- Running 'meteor' in the 'docs' directory: appropriate error.
