### PR TITLE
Print release notes of intermediate releases too, not just most recent.

### DIFF
--- a/app/meteor/post-upgrade.js
+++ b/app/meteor/post-upgrade.js
@@ -5,29 +5,52 @@ try {
   // updater didn't have the right NODE_PATH set. At some point we can
   // remove this and just use updater.CURRENT_VERSION.
   var VERSION = "0.3.8";
+  // If the previous version wasn't new enough to pass this argument to us, this
+  // will be undefined, which will be OK.
+  var oldVersion = process.argv[2];
 
-  var fs = require('fs');
-  var path = require('path');
-  var files = require("../lib/files.js");
+  if (VERSION !== oldVersion) {
+    var fs = require('fs');
+    var path = require('path');
+    var files = require("../lib/files.js");
 
-  var _ = require("../lib/third/underscore.js");
+    var _ = require("../lib/third/underscore.js");
 
-  var topDir = files.get_dev_bundle();
-  var changelogPath = path.join(topDir, 'History.md');
+    var topDir = files.get_dev_bundle();
+    var changelogPath = path.join(topDir, 'History.md');
 
-  if (path.existsSync(changelogPath)) {
-    var changelogData = fs.readFileSync(changelogPath, 'utf8');
-    var changelogSections = changelogData.split(/\n\#\#/);
+    if (path.existsSync(changelogPath)) {
+      var changelogData = fs.readFileSync(changelogPath, 'utf8');
+      var changelogSections = changelogData.split(/\n\#\#/);
 
-    _.each(changelogSections, function (section) {
-      var m = /^\s*v([^\s]+)/.exec(section);
-      if (m && m[1] === VERSION) {
-        section = section.replace(/^\s+/, '').replace(/\s+$/, '');
-        console.log();
-        console.log(section);
+      var matchingSections = [];
+      var found_new = false;
+      var found_old = false;
+
+      _.each(changelogSections, function (section) {
+        var m = /^\s*v([^\s]+)/.exec(section);
+        if (m && m[1] === VERSION) {
+          found_new = true;
+        } else if (m && m[1] === oldVersion) {
+          found_old = true;
+        }
+        if (found_new && !found_old) {
+          matchingSections.push(section.replace(/^\s+/, '').replace(/\s+$/, ''));
+        }
+      });
+      if (found_new) {
+        if (!found_old) {
+          // We did not find the old version, so rather than print out every version,
+          // just print the newest version.
+          matchingSections = [matchingSections[0]];
+        }
+        _.each(matchingSections, function(section) {
+          console.log();
+          console.log(section);
+        });
         console.log();
       }
-    });
+    }
   }
 } catch (err) {
   // don't print a weird error message if something goes wrong.

--- a/app/meteor/update.js
+++ b/app/meteor/update.js
@@ -61,7 +61,8 @@ updater.get_manifest(function (manifest) {
       env.NODE_PATH = modules_path;
 
       // launch it.
-      var postup_proc = spawn(nodejs_path, [postup_path], {env: env});
+      var postup_proc = spawn(
+          nodejs_path, [postup_path, updater.CURRENT_VERSION], {env: env});
       postup_proc.stderr.setEncoding('utf8');
       postup_proc.stderr.on('data', function (data) {
         process.stderr.write(data);


### PR DESCRIPTION
Not sure how to fully test this. I ran post-upgrade.js under node by hand (with changelogPath hardcoded to a particular History.md) with and without args, and it printed the right things. To really test this, though, I need to build a tarball (or whatever) with this change in it and with more history entries, and run the updater configured to download my test tarball. Looks like this is possible but a bit of a pain.
