### PR TITLE
improve modularity of oauth2_client

### DIFF
--- a/packages/accounts-oauth2-helper/oauth2_client.js
+++ b/packages/accounts-oauth2-helper/oauth2_client.js
@@ -1,6 +1,9 @@
 (function () {
 
+  // Interface registry
   var interfaces = {
+    
+    // Defines a popup window interface (the default) for oauth2 authentication
     popup: function(url, options, afterLogin) {
       options = options || {};
       var width = options.width || 650;


### PR DESCRIPTION
Avital, I wanted to start work on a non-popup ui package for account. My first experiment will be iframes inside bootstrap dialogs. Unsure how well it will work but I figured if I could decouple the oauth client from popups I could register my own interface and get on with it.

Pull request contains a small refactoring in this direction... what do you think of it? Should I keep going on this tangent?

Thanks, Mike
