### PR TITLE
Allows user to set and get environment mode the project runs in

### DIFF
--- a/app/meteor/meteor.js
+++ b/app/meteor/meteor.js
@@ -86,8 +86,8 @@ Commands.push({
     var opt = require('optimist')
       .alias('port', 'p').default('port', 3000)
       .describe('port', 'Port to listen on. NOTE: Also uses port N+1 and N+2.')
-      .boolean('production')
-      .describe('production', 'Run in production mode. Minify and bundle CSS and JS files.')
+      .default('env', 'development')
+      .describe('env', 'Environment to run this project in: development, staging, or production.')
       .usage(
 "Usage: meteor run [options]\n" +
 "\n" +
@@ -111,8 +111,7 @@ Commands.push({
     }
 
     var app_dir = require_project("run", true); // app or package
-    var bundle_opts = { no_minify: !new_argv.production, symlink_dev_bundle: true };
-    require('./run.js').run(app_dir, bundle_opts, new_argv.port);
+    require('./run.js').run(app_dir, new_argv.env, new_argv.port);
   }
 });
 

--- a/app/meteor/run.js
+++ b/app/meteor/run.js
@@ -447,7 +447,7 @@ var start_update_checks = function () {
 // This function never returns and will call process.exit() if it
 // can't continue. If you change this, remember to call
 // watcher.destroy() as appropriate.
-exports.run = function (app_dir, bundle_opts, port) {
+exports.run = function (app_dir, environment, port) {
   var outer_port = port || 3000;
   var inner_port = outer_port + 1;
   var mongo_port = outer_port + 2;
@@ -459,7 +459,24 @@ exports.run = function (app_dir, bundle_opts, port) {
         ("mongodb://127.0.0.1:" + mongo_port + "/meteor");
   var test_mongo_url = "mongodb://127.0.0.1:" + mongo_port + "/meteor_test";
 
+  var bundle_opts = {symlink_dev_bundle: true};
   var test_bundle_opts;
+
+  // As more bundle options are added they can be placed here based on the run environment
+  switch (environment) {
+    case "production":
+    case "staging":
+      bundle_opts.no_minify = false;
+      break;
+
+    case "development":
+    default:
+      bundle_opts.no_minify = true;
+      break;
+  }
+
+  process.env.METEOR_ENV = environment;
+
   if (files.is_app_dir(app_dir)) {
     // If we're an app, make separate test_bundle_opts to trigger a
     // separate runner.

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -50,6 +50,10 @@ var supported_browser = function (user_agent) {
 // add any runtime configuration options needed to app_html
 var runtime_config = function (app_html) {
   var insert = '';
+
+  // Make sure the environment is available on the client
+  insert += "__meteor_runtime_config__.METEOR_ENV = '" + process.env.METEOR_ENV + "';\n";
+
   if (process.env.DEFAULT_DDP_ENDPOINT)
     insert += "__meteor_runtime_config__.DEFAULT_DDP_ENDPOINT = '" +
       process.env.DEFAULT_DDP_ENDPOINT + "';";

--- a/packages/meteor/client_environment.js
+++ b/packages/meteor/client_environment.js
@@ -1,4 +1,8 @@
 Meteor = {
   is_client: true,
-  is_server: false
+  is_server: false,
+  is_development: __meteor_runtime_config__.METEOR_ENV === 'development',
+  is_staging: __meteor_runtime_config__.METEOR_ENV === 'staging',
+  is_production: __meteor_runtime_config__.METEOR_ENV === 'production'
 };
+

--- a/packages/meteor/server_environment.js
+++ b/packages/meteor/server_environment.js
@@ -1,4 +1,7 @@
 Meteor = {
   is_client: false,
   is_server: true
+  is_development: process.env.METEOR_ENV === 'development',
+  is_staging: process.env.METEOR_ENV === 'staging',
+  is_production: process.env.METEOR_ENV === 'production'
 };


### PR DESCRIPTION
Allows user to specify the environment when starting a server through the run --env param, eg:

$ meteor run --env=production

supports 3 environment modes:
- development: separate source files, cache busting, auto updates, etc.
- staging: behaves exactly like production but lets you demarcate code on client and server from production ready code, like your production analytics tracking code.
- production

Patch also reveals 3 properties on the Meteor object on both server and client, is_development, is_staging, and is_production to help facilitate environment demarcation.
