### PR TITLE
Mismatched tag in docs.html

### DIFF
--- a/docs/client/docs.html
+++ b/docs/client/docs.html
@@ -11,7 +11,7 @@
   </div>
   <div id="main">
     <div id="top"></div>
-    <h2 class="main-headline">Meteor 0.3.8</h1>
+    <h1 class="main-headline">Meteor 0.3.8</h1>
     {{> introduction }}
     {{> concepts }}
     {{> api }}


### PR DESCRIPTION
Mismatched tag caused the entire page to fail under Safari 5.0.4.
