### PR TITLE
Tag mismatch in docs.html

### DIFF
--- a/docs/client/docs.html
+++ b/docs/client/docs.html
@@ -11,7 +11,7 @@
   </div>
   <div id="main">
     <div id="top"></div>
-    <h2 class="main-headline">Meteor 0.3.8</h1>
+    <h1 class="main-headline">Meteor 0.3.8</h1>
     {{> introduction }}
     {{> concepts }}
     {{> api }}


### PR DESCRIPTION
Mismatched opening h2 tag and closing h1 tag causes the page to fail under some browsers (i.e. Safari 5.0.4).
