### PR TITLE
add ReactiveDict, ReactiveDict on template, and firstRender

### DIFF
--- a/examples/landmark-demo/client/landmark-demo.js
+++ b/examples/landmark-demo/client/landmark-demo.js
@@ -12,10 +12,6 @@ if (! Session.get("z")) {
   Session.set("z", 1);
 }
 
-if (typeof Session.get("spinForward") !== 'boolean') {
-  Session.set("spinForward", true);
-}
-
 Template.redrawButtons.events = {
   'click input.x': function () {
     Session.set("x", Session.get("x") + 1);
@@ -32,17 +28,23 @@ Template.redrawButtons.events = {
 
 Template.preserveDemo.preserve = [ '.spinner', '.spinforward' ];
 
+Template.preserveDemo.create = function() {
+  if (typeof this.get("spinForward") !== 'boolean') {
+    this.set("spinForward", true);
+  }
+}
+
 Template.preserveDemo.spinForwardChecked = function () {
-  return Session.get('spinForward') ? 'checked="checked"' : '';
+  return this.template.get('spinForward') ? 'checked="checked"' : '';
 };
 
 Template.preserveDemo.spinAnim = function () {
-  return Session.get('spinForward') ? 'spinForward' : 'spinBackward';
+  return this.template.get('spinForward') ? 'spinForward' : 'spinBackward';
 };
 
 Template.preserveDemo.events = {
-  'change .spinforward' : function (event) {
-    Session.set('spinForward', event.currentTarget.checked);
+  'change .spinforward' : function (event,template) {
+    template.set('spinForward', event.currentTarget.checked);
   }
 };
 
@@ -153,7 +155,8 @@ Template.circles.events = {
     // XXX actually want to create a ReactiveVar on the template!
     // (but how will it be preserved across migration?)
     // (maybe template.get, template.set?? rather than form??)
-    Session.set("selectedCircle:" + this.group, evt.currentTarget.id);
+    template.set("selectedCircle:" + this.group, evt.currentTarget.id);
+    
   },
   'click .add': function () {
     Circles.insert({x: Meteor.random(), y: Meteor.random(),
@@ -166,11 +169,11 @@ Template.circles.events = {
                     group: this.group
                    });
   },
-  'click .remove': function () {
-    var selected = Session.get("selectedCircle:" + this.group);
+  'click .remove': function (evt,template) {
+    var selected = template.get("selectedCircle:" + this.group);
     if (selected) {
       Circles.remove(selected);
-      Session.set("selectedCircle:" + this.group, null);
+      template.set("selectedCircle:" + this.group, null);
     }
   },
   'click .scram': function () {
@@ -193,12 +196,12 @@ var colorToString = function (color) {
     + f(color.g) + "," + + f(color.b) + ")";
 };
 
-Template.circles.count = function () {
+Template.circles.count = function (arg1,arg2) {
   return Circles.find({group: this.group}).count();
 };
 
 Template.circles.disabled = function () {
-  return Session.get("selectedCircle:" + this.group) ?
+  return this.template.get("selectedCircle:" + this.group) ?
     '' : 'disabled="disabled"';
 };
 
@@ -296,7 +299,7 @@ Template.circles.render = function () {
         .remove();
 
       // XXX this doesn't animate as I'd hoped when you press Scram
-      var selectionId = Session.get("selectedCircle:" + data.group);
+      var selectionId = self.get("selectedCircle:" + data.group);
       var s = selectionId && Circles.findOne(selectionId);
       var rect = d3.select(self.node).select("rect");
       if (s)

--- a/packages/deps/package.js
+++ b/packages/deps/package.js
@@ -9,5 +9,5 @@ Package.on_use(function (api, where) {
   where = where || ['client', 'server'];
 
   api.use('underscore', where);
-  api.add_files('deps.js', where);
+  api.add_files(['deps.js','tools.js'], where);
 });

--- a/packages/deps/tools.js
+++ b/packages/deps/tools.js
@@ -1,0 +1,136 @@
+// ReactiveVar is like a portable Session var.  When you get it,
+// it registers a dependency, and when it's set, it invalidates
+// its dependencies.
+//
+// When set to a primitive value, invalidation
+// is only fired if the new value is !== the old one.  When set
+// to an object value, invalidation always happens.  Each behavior
+// may be desirable in different test scenarios.
+// body and keeps track of it, providing methods that query it,
+// mutate, and destroy it.
+//
+// Constructor, with optional 'new':
+// var R = [new] ReactiveVar([initialValue])
+
+
+var ReactiveVar = function(initialValue) {
+  if (! (this instanceof ReactiveVar))
+    return new ReactiveVar(initialValue);
+
+  this._value = (typeof initialValue === "undefined" ? null :
+                 initialValue);
+  this._deps = {};
+  this._equals_deps = {};
+};
+
+ReactiveVar.prototype.get = function() {
+  var self = this;
+
+  var context = Meteor.deps.Context.current;
+  if (context && !(context.id in self._deps)) {
+    self._deps[context.id] = context;
+    context.on_invalidate(function() {
+      delete self._deps[context.id];
+    });
+  }
+
+  return self._value;
+};
+
+ReactiveVar.prototype.set = function(newValue) {
+  var self = this;
+  var oldValue = self._value;
+  // detect equality and don't invalidate dependers
+  // when value is a primitive.
+  if ((typeof newValue !== 'object') && self._value === newValue)
+    return;
+
+  self._value = newValue;
+
+  for(var id in self._deps)
+    self._deps[id].invalidate();
+  for(var id in self._equals_deps[newValue])
+    self._equals_deps[newValue][id].invalidate();
+  for(var id in self._equals_deps[oldValue])
+    self._equals_deps[oldValue][id].invalidate();
+
+};
+
+ReactiveVar.prototype.equals = function(value) {
+  var self = this;
+  var equals_deps = self._equals_deps;
+  var context = Meteor.deps.Context.current;
+
+  if (context) {
+    if (!(value in equals_deps))
+      equals_deps[value] = {};
+
+    if (!(context.id in equals_deps[value])) {
+      equals_deps[value][context.id] = context;
+      context.on_invalidate(function () {
+        delete equals_deps[value][context.id];
+
+        if (_.keys(equals_deps[value]).length == 0)
+          delete equals_deps[value];
+      });
+    }
+  }
+  return self._value === value;
+
+}
+
+ReactiveVar.prototype.numListeners = function() {
+  return _.keys(this._deps).length;
+};
+
+ReactiveVar.prototype.toJSON = function() {
+  return this._value;
+}
+
+
+var ReactiveDict = function(initialValues) {
+  if (! (this instanceof ReactiveDict))
+    return new ReactiveDict(initialValues);
+
+  this._vars = {};
+
+  for (key in initialValues)
+    this._vars[key] = ReactiveVar(initialValues[key]);
+}
+
+ReactiveDict.prototype.get = function(key) {
+  this._ensureKey(key);
+  return this._vars[key].get();
+}
+
+ReactiveDict.prototype.set = function(key, value) {
+  this._ensureKey(key);
+  return this._vars[key].set(value);
+}
+
+ReactiveDict.prototype.setMany = function(values) {
+  var self = this;
+  _.each(values,function(value,key) {
+    self.set(key,value);
+  });
+}
+
+ReactiveDict.prototype.equals = function(key, value) {
+  this._ensureKey(key);
+  return this._vars[key].equals(value);
+}
+
+ReactiveDict.prototype._ensureKey = function(key) {
+  if (!(key in this._vars))
+    this._vars[key] = ReactiveVar();
+}
+
+ReactiveDict.prototype.toJSON = function() {
+  var self = this;
+  var json = {};
+  _.each(self._vars,function(v,key) {
+    json[key] = v.toJSON();
+  });
+  return json;
+}
+

--- a/packages/mongo-livedata/local_collection_driver.js
+++ b/packages/mongo-livedata/local_collection_driver.js
@@ -2,6 +2,7 @@
 Meteor._LocalCollectionDriver = function () {
   var self = this;
   self.collections = {};
+  self.migrationData = {};
 };
 
 _.extend(Meteor._LocalCollectionDriver.prototype, {
@@ -9,11 +10,31 @@ _.extend(Meteor._LocalCollectionDriver.prototype, {
     var self = this;
     if (!name)
       return new LocalCollection;
-    if (!(name in self.collections))
+    if (!(name in self.collections)) {
       self.collections[name] = new LocalCollection;
+      if (name in self.migrationData )
+        self.collections[name].docs = self.migrationData[name];
+    }
+
     return self.collections[name];
   }
 });
 
 // singleton
 Meteor._LocalCollectionDriver = new Meteor._LocalCollectionDriver;
+
+
+//speed up reload and ensure that first render after reload 
+//has same state as the last render before reload
+if (Meteor._reload) {
+  Meteor._reload.on_migrate('Collections',function() {
+    var collections = {};
+    _.each(Meteor._LocalCollectionDriver.collections,function(collection,name) {
+      collections[name] = collection.docs;
+    });
+    return [true,collections];
+  });
+  (function() {
+    Meteor._LocalCollectionDriver.migrationData = Meteor._reload.migration_data('Collections') || {};
+  })();
+}

--- a/packages/session/session.js
+++ b/packages/session/session.js
@@ -1,119 +1,18 @@
 // XXX could use some tests
 
-Session = _.extend({}, {
-  keys: {},
-  key_deps: {}, // key -> context id -> context
-  key_value_deps: {}, // key -> value -> context id -> context
-
-  // XXX remove debugging method (or improve it, but anyway, don't
-  // ship it in production)
-  dump_state: function () {
-    var self = this;
-    console.log("=== Session state ===");
-    for (var key in self.key_deps) {
-      var ids = _.keys(self.key_deps[key]);
-      if (!ids.length)
-        continue;
-      console.log(key + ": " + _.reject(ids, function (x) {return x === "_once"}).join(' '));
-    }
-
-    for (var key in self.key_value_deps) {
-      for (var value in self.key_value_deps[key]) {
-        var ids = _.keys(self.key_value_deps[key][value]);
-        if (!ids.length)
-          continue;
-        console.log(key + "(" + value + "): " + _.reject(ids, function (x) {return x === "_once";}).join(' '));
-      }
-    }
-  },
-
-  set: function (key, value) {
-    var self = this;
-
-    var old_value = self.keys[key];
-    if (value === old_value)
-      return;
-    self.keys[key] = value;
-
-    var invalidate = function (map) {
-      if (map)
-        for (var id in map)
-          map[id].invalidate();
-    };
-
-    self._ensureKey(key);
-    invalidate(self.key_deps[key]);
-    invalidate(self.key_value_deps[key][old_value]);
-    invalidate(self.key_value_deps[key][value]);
-  },
-
-  get: function (key) {
-    var self = this;
-    var context = Meteor.deps.Context.current;
-    self._ensureKey(key);
-
-    if (context && !(context.id in self.key_deps[key])) {
-      self.key_deps[key][context.id] = context;
-      context.on_invalidate(function () {
-        delete self.key_deps[key][context.id];
-      });
-    }
-
-    return self.keys[key];
-  },
-
-  equals: function (key, value) {
-    var self = this;
-    var context = Meteor.deps.Context.current;
-
-    if (typeof value !== 'string' &&
-        typeof value !== 'number' &&
-        typeof value !== 'boolean' &&
-        value !== null && value !== undefined)
-      throw new Error("Session.equals: value can't be an object");
-
-    if (context) {
-      self._ensureKey(key);
-      if (!(value in self.key_value_deps[key]))
-        self.key_value_deps[key][value] = {};
-
-      if (!(context.id in self.key_value_deps[key][value])) {
-        self.key_value_deps[key][value][context.id] = context;
-        context.on_invalidate(function () {
-          delete self.key_value_deps[key][value][context.id];
-
-          // clean up [key][value] if it's now empty, so we don't use
-          // O(n) memory for n = values seen ever
-          for (var x in self.key_value_deps[key][value])
-            return;
-          delete self.key_value_deps[key][value];
-        });
-      }
-    }
-
-    return self.keys[key] === value;
-  },
-
-  _ensureKey: function (key) {
-    var self = this;
-    if (!(key in self.key_deps)) {
-      self.key_deps[key] = {};
-      self.key_value_deps[key] = {};
-    }
-  }
-});
+Session = new ReactiveDict();
 
 
 if (Meteor._reload) {
   Meteor._reload.on_migrate('session', function () {
     // XXX sanitize and make sure it's JSONible?
-    return [true, {keys: Session.keys}];
+    return [true, Session.toJSON()];
   });
 
   (function () {
     var migration_data = Meteor._reload.migration_data('session');
-    if (migration_data && migration_data.keys) {
-      Session.keys = migration_data.keys;
+    if (migration_data) {
+      Session = new ReactiveDict(migration_data)
     }
   })();
 }


### PR DESCRIPTION
Implemented some of the features mentioned in the landmark-demo comments. If you like the changes, I'm happy to clean up the code and test better. Right now the landmark demo works exactly as it did before, but I have not done any testing beyond that.

Implemented a ReactiveDict that Session utilizes.

```
// XXX make Session be a ReactiveDict (ReactiveMap?)
```

Added a ReactiveDict to each template.

```
// XXX actually want to create a ReactiveVar on the template!
// (but how will it be preserved across migration?)
// (maybe template.get, template.set?? rather than form??)
```

Handled the migration by storing each template store by the dom path of the firstNode of the template. When the template is rendered after a migration it checks the migration data to see if any stores match the dom path of the firstNode.

Migration Setup

``` javascript
var templateStoresByPath = {};
  if (Meteor._reload) {
    Meteor._reload.on_migrate('templateStores',function() {
      var stores = {}
      _.each(templateInstanceData,function(template) {
        stores[template.path()] = template.store;
      });
      return [true,stores];
    });
    (function() {
      var migration_data = Meteor._reload.migration_data('templateStores');
      if (migration_data) {
        templateStoresByPath = migration_data;
      }
    })();
  }
```

path

``` javascript
return "/" + $(this.firstNode).parents().andSelf().map(function() {
  var $this = $(this);
  var tagName = this.nodeName;
  if ($this.siblings(tagName).length > 0) {
     tagName += "[" + $this.prevAll(tagName).length + "]";
   }
   return tagName;
}).get().join("/");
```

restore

``` javascript
var path = template.path();
  if (template.firstRender && path in templateStoresByPath) {
    template.store.setMany(templateStoresByPath[path]);
   }
```

Also added template.firstRender.

```
// XXX template.firstRender would be handy here
```
