### PR TITLE
Add a complete() method to the subscription handle.

### DIFF
--- a/packages/livedata/livedata_connection.js
+++ b/packages/livedata/livedata_connection.js
@@ -218,28 +218,23 @@ _.extend(Meteor._LivedataConnection.prototype, {
         // just update the database. observe takes care of the rest.
         self.subs.update({_id: id}, {$inc: {count: -1}});
       },
-      complete: function() {
+      isReady: function() {
         if (!self.sub_ready_callbacks[id])
           return true;
         
         // not yet complete, save the context for invalidation once we are
-        var context = Meteor.deps.Context.current;
-        if (context)
-          this._contexts[context.id] = context;
-          
+        token._contexts.addCurrentContext();
+        
         return false;
       },
-      _contexts : {}
+      _contexts : new Meteor.deps._ContextSet()
     };
     
     // invalidate all saved contexts
     self.sub_ready_callbacks[id].push(function() { 
-      _.each(token._contexts, function(context) {
-        context.invalidate();
-      });
+      token._contexts.invalidateAll();
     });
     
-
     if (Meteor._capture_subs)
       Meteor._capture_subs.push(token);
 

--- a/packages/livedata/livedata_connection_tests.js
+++ b/packages/livedata/livedata_connection_tests.js
@@ -67,18 +67,11 @@ Tinytest.add("livedata stub - subscribe", function (test) {
   });
   test.isFalse(callback_fired);
   
-  var subscription_complete = false;
-  var setup_context = function() {
-   var context = new Meteor.deps.Context();
-   context.on_invalidate(function() {
-     setup_context();
-   });
-   context.run(function() {
-     subscription_complete = sub.complete();
-   });
-  }
-  setup_context();
-  test.isFalse(subscription_complete);
+  var subscriptionReady = false;
+  Meteor._autorun(function() {
+    subscriptionReady = sub.isReady()
+  });
+  test.isFalse(subscriptionReady);
   
   var message = JSON.parse(stream.sent.shift());
   var id = message.id;
@@ -90,7 +83,7 @@ Tinytest.add("livedata stub - subscribe", function (test) {
   test.isTrue(callback_fired);
   
   Meteor.flush();
-  test.isTrue(subscription_complete);
+  test.isTrue(subscriptionReady);
 });
 
 


### PR DESCRIPTION
A reactive function that can be used as an alternative to the onComplete callback. This allows us to do:

``` handlebars
{{#if postsLoading}}
  Loading...
{{else}}
  {{#each posts}..{{/each}}
{{/if}}
```

``` js
var posts = Meteor.collection('posts');
var postsHandle = Meteor.subscribe('posts');

Template.foo.postsLoading = function() {
  return !postsHandle.complete();
}

Template.foo.posts = function() { 
  return posts.find();
}
```

(Note that this change would be significantly simpler if deps had a slightly larger toolkit, like #193)
