### PR TITLE
Persist weibo's access token on authorized

### DIFF
--- a/packages/accounts-weibo/weibo_server.js
+++ b/packages/accounts-weibo/weibo_server.js
@@ -14,7 +14,7 @@
         services: {
           weibo: {
             id: accessToken.uid,
-            accessToken: accessToken.accessToken,
+            accessToken: accessToken.access_token,
             screenName: identity.screen_name
           }
         }


### PR DESCRIPTION
This is a quick fix for a bug in the original 'accounts-weibo' package
