### PR TITLE
Fixed problem with `LocalCollection._deepcopy` destroying dates.

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -372,6 +372,8 @@ LocalCollection._deepcopy = function (v) {
     return v;
   if (v === null)
     return null; // null has typeof "object"
+  if (v instanceof Date)
+    return new Date(v.getTime());
   if (_.isArray(v)) {
     var ret = v.slice(0);
     for (var i = 0; i < v.length; i++)

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -199,7 +199,7 @@ Tinytest.add("minimongo - cursors", function (test) {
 Tinytest.add("minimongo - misc", function (test) {
   // deepcopy
   var a = {a: [1, 2, 3], b: "x", c: true, d: {x: 12, y: [12]},
-           f: null};
+           f: null, g: new Date()};
   var b = LocalCollection._deepcopy(a);
   test.isTrue(LocalCollection._f._equal(a, b));
   a.a.push(4);
@@ -211,7 +211,10 @@ Tinytest.add("minimongo - misc", function (test) {
   test.equal(b.d.z, 15);
   a.d.y.push(88);
   test.length(b.d.y, 1);
-
+  test.equal(a.g, b.g)
+  b.g.setDate(b.g.getDate() + 1);
+  test.notEqual(a.g, b.g)
+  
   a = {x: function () {}};
   b = LocalCollection._deepcopy(a);
   a.x.a = 14;


### PR DESCRIPTION
This fixes #295

In the browser, `deepcopy` seemed to be successfully cloning dates, but server-side this was not the case. Commit b21da0f274a59424b38573dfef43938582951350 introduced a `deepcopy` to the process of pulling data out of mongo, so this is needed.
