### PR TITLE
Adding a force-trigger argument to Session.set

### DIFF
--- a/packages/session/session.js
+++ b/packages/session/session.js
@@ -27,11 +27,13 @@ Session = _.extend({}, {
     }
   },
 
-  set: function (key, value) {
+  set: function (key, value, trigger) {
     var self = this;
 
+    trigger = trigger == null || typeof trigger == 'undefined' ? false : true;
+	
     var old_value = self.keys[key];
-    if (value === old_value)
+    if (value === old_value && !trigger) 
       return;
     self.keys[key] = value;
 


### PR DESCRIPTION
As a solution for [issue 215](https://github.com/meteor/meteor/issues/215), I added an argument to `Session.set()` that forces the function to trigger any listeners. This makes it possible to store arrays and objects in the `Session` while still letting them be reactive, without sacrificing any efficiency by doing an in-depth comparison of the existing and new objects.
