### PR TITLE
fix for Issue #328

### DIFF
--- a/packages/accounts-oauth-helper/oauth_client.js
+++ b/packages/accounts-oauth-helper/oauth_client.js
@@ -10,6 +10,9 @@
     var popup = openCenteredPopup(url, 650, 331);
 
     var checkPopupOpen = setInterval(function() {
+      // Fix for #328 - added a second test criteria (popup.closed === undefined) 
+      // to humour this Android quirk: 
+      // http://code.google.com/p/android/issues/detail?id=21061
       if (popup.closed || popup.closed === undefined) {
         clearInterval(checkPopupOpen);
         tryLoginAfterPopupClosed(state);


### PR DESCRIPTION
Wasn't such a big deal in the end. Tested on iOS, Chrome, Safari, Firefox, Android 2.3.3 & 4.0.

On Android, `window.closed` is set either to `false` (window is open) or `undefined` (window is closed).
