### PR TITLE
Added note warning users about placing arrays/objects in the session.

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -826,6 +826,11 @@ you call [`Session.get`](#session_get)`("currentList")`
 from inside a template, the template will automatically be rerendered
 whenever [`Session.set`](#session_set)`("currentList", x)` is called.
 
+{{#warning}}
+Note that the `Session` only supports scalar values; reactivity will not be 
+triggered if you place objects or arrays in it.
+{{/warning}}
+
 {{> api_box set}}
 
 Example:


### PR DESCRIPTION
This is a common gotcha, see for example #215. I'm not sure if the plan is to
eventually support serializable objects in the session, but in the meantime..
