### PR TITLE
Fixed bug with auth - erases other properties of profile on login

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -200,7 +200,7 @@
     if (user) {
       // don't overwrite existing fields
       // XXX subobjects (aka 'profile', 'services')?
-      var newKeys = _.without(_.keys(extra), _.keys(user));
+      var newKeys = _.difference(_.keys(extra), _.keys(user));
       var newAttrs = _.pick(extra, newKeys);
       Meteor.users.update(user._id, {$set: newAttrs});
 


### PR DESCRIPTION
The code used _.without but passed an array as the second argument when _.without takes an argument list.  Changed to _.difference which takes an array as the second argument.  This was causing the properties of the user doc to get overwritten during login.
