### PR TITLE
Ensure Facebook service data is current

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -202,6 +202,13 @@
       // XXX subobjects (aka 'profile', 'services')?
       var newKeys = _.difference(_.keys(extra), _.keys(user));
       var newAttrs = _.pick(extra, newKeys);
+
+      // Temporary hack: ensure Facebook service data is refreshed
+      // in case the user changed his email address or
+      // Facebook issued a new Access Token
+      if (options.services && options.services.facebook){
+        newAttrs.services = options.services;
+      }
       Meteor.users.update(user._id, {$set: newAttrs});
 
       return user._id;


### PR DESCRIPTION
Eventually Facebook access tokens expire or Facebook may invalidate them (see [here](http://developers.facebook.com/docs/authentication/access-token-expiration/)). Also, a Facebook user may change his email address. These changes need persisting in our Meteor apps. 

I attached some code to show the hacky way i'm doing this atm. 
