### PR TITLE
Clarified when reactivity works

### DIFF
--- a/docs/client/concepts.html
+++ b/docs/client/concepts.html
@@ -190,11 +190,12 @@ providers like `Session`, on the other hand, make note of
 the context they are called from and what data was requested, and they
 are prepared to send an invalidation signal when the data changes.
 
-This simple pattern has wide applicability.  Above, the programmer is
-saved from writing unsubscribe/resubscribe calls and making sure they
-are called at the right time.  In general, Meteor can eliminate whole
-classes of data propagation code which would otherwise clog up your
-application with error-prone logic.
+This simple pattern (reactive context + reactive data source) has wide
+applicability.  Above, the programmer is saved from writing
+unsubscribe/resubscribe calls and making sure they are called at the
+right time.  In general, Meteor can eliminate whole classes of data
+propagation code which would otherwise clog up your application with
+error-prone logic.
 
 These Meteor functions run your code in a reactive context:
 


### PR DESCRIPTION
After reading the Reactivity section for the first time, I was under the slight impression that a reactive context would be sufficient for triggering changes. E.g. if the name in the fragment example were set not from `Session`, but from a global, it could be surmised that the HTML fragment would still be automatically updated if the global variable changed.

This small patch tries to make it clearer that reactivity requires _both_ a reactive context and a reactive data source.
