### PR TITLE
API docs typo and formatting fixes

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -405,7 +405,7 @@ collection with `new Meteor.Collection`.
 
 {{> api_box meteor_collection}}
 
-Calling this function is analogous to declaring a model in an
+Calling this function is analogous to declaring a model in a
 traditional ORM (Object-Relation Mapper)-centric framework. It sets up a
 *collection* (a storage space for records, or "documents") that can be
 used to store a particular type of information, like users, posts,
@@ -629,20 +629,20 @@ Find all of the documents that match `selector` and delete them from the
 collection. Or instead of a selector, you may pass a string, to delete
 the document with that `_id`.  As a safety measure, do nothing if the
 selector is undefined.  If the selector is `{}`, remove all the
-documents from the collection.)
+documents from the collection.
 
 On the server, if you don't provide a callback, then `remove` blocks
 until the database acknowledges the write, or throws an exception if
 something went wrong.  If you do provide a callback, `remove` returns
 immediately.  Once the remove completes, the callback is called with a
 single error argument in the case of failure, or no arguments if the
-update was successful.
+remove was successful.
 
 On the client, `remove` never blocks.  If you do not provide a callback
 and the remove fails on the server, then Meteor will log a warning to
 the console.  If you provide a callback, Meteor will call that function
 with an error argument if there was an error, or no arguments if the
-update was successful.
+remove was successful.
 
 Example:
 
@@ -875,13 +875,13 @@ length of the list.
 
 {{#dtdd "changed(newDocument, atIndex, oldDocument)"}}
 The contents of the document at position `atIndex`
-changed to `newDocument`, was previously `oldDocument`.
+(`oldDocument`) changed to `newDocument`.
 {{/dtdd}}
 
 {{#dtdd "moved(document, oldIndex, newIndex)"}}
 A document changed its position in the result set,
 from `oldIndex` to `newIndex`. For your
-convenience, its current contents is `document`. (This will
+convenience, its current contents is `document`. This will
 only fire immediately after `changed`.
 {{/dtdd}}
 

--- a/docs/client/api.js
+++ b/docs/client/api.js
@@ -355,7 +355,7 @@ Template.api.find = {
      descr: "Sort order (default: natural order)"},
     {name: "skip",
      type: "Number",
-     descr: "Number of result to skip at the beginning"},
+     descr: "Number of results to skip at the beginning"},
     {name: "limit",
      type: "Number",
      descr: "Maximum number of results to return"},
@@ -365,7 +365,7 @@ Template.api.find = {
      descr: "Dictionary of fields to return or exclude."},
     {name: "reactive",
      type: "Boolean",
-     descr: "Default true; pass false to disable reactivity"}
+     descr: "Default `true`; pass `false` to disable reactivity"}
   ]
 };
 
@@ -387,7 +387,7 @@ Template.api.findone = {
      descr: "Sort order (default: natural order)"},
     {name: "skip",
      type: "Number",
-     descr: "Number of result to skip at the beginning"},
+     descr: "Number of results to skip at the beginning"},
     {name: "fields",
      type: "Object: field specifier",
      type_link: "fieldspecifiers",
@@ -538,7 +538,7 @@ Template.api.cursor_observe = {
   descr: ["Watch a query.  Receive callbacks as the result set changes."],
   args: [
     {name: "callbacks",
-     type: "Object (may include added, changed, moved, removed callbacks)",
+     type: "Object (may include `added`, `changed`, `moved`, `removed` callbacks)",
      descr: "Functions to call to deliver the result set as it changes"}
   ]
 };
@@ -1352,7 +1352,7 @@ Template.api.template_preserve = {
   args: [
     {name: "selectors",
      type: "Array or Object",
-     descr: "Array of selectors that each match at most one element, such as `['.thing1', '.thing2']`, or, alternatively, a dictionary of selectors and node-labeling functions (see below)."}
+     descr: "Array of CSS selectors that each match at most one element, such as `['.thing1', '.thing2']`, or, alternatively, a dictionary of selectors and node-labeling functions (see below)."}
   ]
 };
 


### PR DESCRIPTION
Minor fixes, except for adding "CSS" to "Array of selectors" in Template.mytemplate.preserve
