### PR TITLE
serve facebookexternalhit user agent with spiderable

### DIFF
--- a/packages/spiderable/spiderable.js
+++ b/packages/spiderable/spiderable.js
@@ -4,13 +4,14 @@
   var querystring = __meteor_bootstrap__.require('querystring');
   var urlParser = __meteor_bootstrap__.require('url');
   var app = __meteor_bootstrap__.app;
+  var agents = ['facebookexternalhit']; // list of bot-agents to serve (possibly make this list configurable by user)
 
   // how long to let phantomjs run before we kill it
   var REQUEST_TIMEOUT = 15*1000;
 
   app.use(function (req, res, next) {
-    if (/\?.*_escaped_fragment_=/.test(req.url) || req.headers['user-agent'].indexOf('facebookexternalhit') !== -1) {
-      // reassemblying url without escaped fragment if exists
+    if (/\?.*_escaped_fragment_=/.test(req.url) || agents.indexOf(req.headers['user-agent']) !== -1) {
+      // reassembling url without escaped fragment if exists
       var parsedUrl = urlParser.parse(req.url);
       var parsedQuery = querystring.parse(parsedUrl.query);
       delete parsedQuery['_escaped_fragment_'];


### PR DESCRIPTION
This change will make Spiderable serve facebookexternalhit user agent.

Using Spiderable after this change would enable one to manipulate the head tag in "client code", which would then actually be served to the Facebook bot when it comes looking for "open graph meta tags" (i.e https://developers.facebook.com/docs/opengraphprotocol/)

The main code-change is adding "facebookexternalhit" to the condition under-which the phantomjs process is initiated. Other than that there are two other complementing code-changes:
1. A rewrite of the code that re-assembles the request url without the "_escaped_fragment_" query param. This is needed because in the current version of Spiderable the code assumes there is always a query string (which might not be the case in the proposed version)
2. A small bug-fix to the regex test for html validity of the phantomjs response page (html openning tag might contain attributes, especially after client manipulation, which is the case here)

To test this:
1. Create a new meteor app
2. On client startup, add a meta tag to head. Something like: 

``` javascript
$("head").append('<meta property="og:title" content="spidy" />');
```
1. Optionally try having the content arrtibute be something you fetch from the DB in order to simulate how a user might use this. Preferably don't use autopublish, and put the code in the callback of the "subscribe" call to the data you're using. This is to make sure "_allSubscriptionsReady() === false" until you've done your manipulation. 
2. Test this with Facebook Debugger: https://developers.facebook.com/tools/debug (notice there's an option at the bottom to actually see what your server served Facebook)
