### PR TITLE
Start inner server with debug enabled

### DIFF
--- a/app/meteor/meteor.js
+++ b/app/meteor/meteor.js
@@ -88,6 +88,10 @@ Commands.push({
       .describe('port', 'Port to listen on. NOTE: Also uses port N+1 and N+2.')
       .boolean('production')
       .describe('production', 'Run in production mode. Minify and bundle CSS and JS files.')
+      .boolean('debug')
+      .describe('debug', 'Run in debug mode for node-inspector')
+      .boolean('debug_brk')
+      .describe('debug_brk', 'Run in debug mode and break on first line')
       .usage(
 "Usage: meteor run [options]\n" +
 "\n" +
@@ -111,7 +115,8 @@ Commands.push({
     }
 
     var app_dir = path.resolve(require_project("run", true)); // app or package
-    var bundle_opts = { no_minify: !new_argv.production, symlink_dev_bundle: true };
+    var bundle_opts = { no_minify: !new_argv.production, symlink_dev_bundle: true, 
+        debug: new_argv.debug, debug_brk: new_argv.debug_brk};
     require('./run.js').run(app_dir, bundle_opts, new_argv.port);
   }
 });

--- a/app/meteor/run.js
+++ b/app/meteor/run.js
@@ -15,6 +15,7 @@ var _ = require('../lib/third/underscore.js');
 
 ////////// Globals //////////
 
+var debug, debug_brk;
 // list of log objects from the child process.
 var server_log = [];
 
@@ -178,9 +179,23 @@ var start_server = function (bundle_path, outer_port, inner_port, mongo_url,
   env.MONGO_URL = mongo_url;
   env.ROOT_URL = env.ROOT_URL || ('http://localhost:' + outer_port);
 
-  var proc = spawn(process.execPath,
+  //spawn inner server, with debug enabled if requested
+  if (debug_brk){  console.log('Debug break on first line');
+    	var proc = spawn(process.execPath,
+                  ['--debug-brk', path.join(bundle_path, 'main.js'), '--keepalive'],
+                  {env: env});
+		} else {
+  if (debug) {  var proc = spawn(process.execPath,
+                   ['--debug', path.join(bundle_path, 'main.js'), '--keepalive'],
+                   {env: env});
+		}  else {
+                var proc = spawn(process.execPath,
                    [path.join(bundle_path, 'main.js'), '--keepalive'],
                    {env: env});
+
+  } }
+
+
 
   // XXX deal with test server logging differently?!
 
@@ -450,6 +465,8 @@ var start_update_checks = function () {
 // can't continue. If you change this, remember to call
 // watcher.destroy() as appropriate.
 exports.run = function (app_dir, bundle_opts, port) {
+  debug = bundle_opts.debug;
+  debug_brk = bundle_opts.debug_brk;
   var outer_port = port || 3000;
   var inner_port = outer_port + 1;
   var mongo_port = outer_port + 2;


### PR DESCRIPTION
This patch adds support for node-inspector debugging of Meteor apps. 

It adds --debug and --debug_brk as options for meteor run. 

The options are passed from meteor.js to global variables in run.js via bundle_options. Not sure if that is the right way to do it, but it seemed like the least intrusive mechanism.

In run.js the inner server is then started in plain vanilla, debug or debug-brk mode, depending on command line option (if any) specified. 

Then node-inspector can be started, and it will attach to the inner server.
