### PR TITLE
Server-side debugging

### DIFF
--- a/app/meteor/run.js
+++ b/app/meteor/run.js
@@ -178,9 +178,12 @@ var start_server = function (bundle_path, outer_port, inner_port, mongo_url,
   env.MONGO_URL = mongo_url;
   env.ROOT_URL = env.ROOT_URL || ('http://localhost:' + outer_port);
 
-  var proc = spawn(process.execPath,
-                   [path.join(bundle_path, 'main.js'), '--keepalive'],
-                   {env: env});
+  var procArgs = [path.join(bundle_path, 'main.js'), '--keepalive'];
+  if (env.DEBUG){
+    procArgs.unshift("--debug");
+  }
+
+  var proc = spawn(process.execPath, procArgs, {env: env});
 
   // XXX deal with test server logging differently?!
 


### PR DESCRIPTION
Do developers usually debug server-side by sending the Meteor node process a USR1 signal? I find it quicker to launch Meteor with the `--debug` node option..  attached is my current method, let me know if any use.. 

usage:
`$ DEBUG=1 meteor`
`Running on: http://localhost:3000/`
`debugger listening on port 5858`
