### PR TITLE
Temporary fix for less compilation problems

### DIFF
--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -11,8 +11,26 @@ Package.register_extension(
 
     var contents = fs.readFileSync(source_path);
 
+    /* Meteor is currently unable to compile bootstrap (or other
+     * any other .less "library" wich deals with imports).
+     * That's because it just tries to compile every single .less file
+     * as a separate css.
+     * This temporary fix is designed to check whether the first 9 chars
+     * in a less file are "!!lessc!!" and, if so, compile the files.
+     * If the file does not contain the pattern it is ignored.
+     * A better way to do this would be to add to register_extension the
+     * ability to check for a .<extension_name>_ignore file in the root
+     * of the meteor project and not compile the files into them (much
+     * like git's .gitignore).
+     */
+    var to_compile = contents.toString('utf8').substr(0,9) === "!!lessc!!";
+
+    if(!to_compile){
+      return;
+    }
+
     try {
-      less.render(contents.toString('utf8'), function (err, css) {
+      less.render(contents.toString('utf8').substr(9), function (err, css) {
         // XXX why is this a callback? it's not async.
         if (err) {
           bundle.error(source_path + ": Less compiler error: " + err.message);


### PR DESCRIPTION
This commit is aimed at temporarely fix the problem that is caused by meteor when it tries to compile all the less files in a folder.
Infact if some of them import others the dependencies should not be compiled ...
Still, this does not fix the problem that exists with @import in less...
