### PR TITLE
Added a hook to livedata detach

### DIFF
--- a/packages/livedata/livedata_server.js
+++ b/packages/livedata/livedata_server.js
@@ -79,6 +79,7 @@ _.extend(Meteor._LivedataSession.prototype, {
   // may have led us to believe otherwise.
   detach: function (socket) {
     var self = this;
+    if (Meteor.hooks && Meteor.hooks.detach) Meteor.hooks.detach.call(socket);
     if (socket === self.socket) {
       self.socket = null;
       self.last_detach_time = +(new Date);


### PR DESCRIPTION
I'm not sure where you would add a hooks object so I've left it like this for now. But in general, I would like to see a lot of hooks available in many of meteor's core packages.

`Meteor.hooks` should be created in a new package if going by this code.

Another alternative is `socket.detach.call(socket)` might be a better pattern in terms of providing hooks.

Please, any information on the plan for hooks going into the future will be invaluable. I'll fix this PR as needed.
