### PR TITLE
Update docs/client/concepts.html

### DIFF
--- a/docs/client/concepts.html
+++ b/docs/client/concepts.html
@@ -594,7 +594,7 @@ To get started, run
 
 This command will generate a fully-contained Node.js application in
 the form of a tarball.  To run this application, you need to provide
-Node.js 0.6 and a MongoDB server.  You can then run the application by
+Node.js 0.8 and a MongoDB server.  You can then run the application by
 invoking node, specifying the HTTP port for the application to listen
 on, and the MongoDB endpoint.  If you don't already have a MongoDB
 server, we can recommend our friends at [MongoHQ](http://mongohq.com).


### PR DESCRIPTION
Deployment section still specified that Node 0.6 
was required for deploying on your own infrastructure,
rather than Node 0.8
