### PR TITLE
Method.http allow non-UTF8 encoding

### DIFF
--- a/packages/http/httpcall_server.js
+++ b/packages/http/httpcall_server.js
@@ -93,7 +93,7 @@ Meteor.http = Meteor.http || {};
     var req_options = {
       url: new_url,
       method: method,
-      encoding: "utf8",
+      encoding: options.encoding || "utf8",
       jar: false,
       timeout: options.timeout,
       body: content,


### PR DESCRIPTION
when http response encoding is gbk, need convert to utf8 via [node-iconv](https://github.com/bnoordhuis/node-iconv)

```
  Meteor.methods({getMyFunds: function() {
    this.unblock();
    var result = Meteor.http.get("http://hq.sinajs.cn/list=of110002"
      , { encoding: "base64" }
      );
    if (result.statusCode === 200) {
        var require = __meteor_bootstrap__.require;
        var Iconv = require('iconv').Iconv;
        var iconv = new Iconv('GBK', 'UTF-8//TRANSLIT//IGNORE');
        return iconv.convert(new Buffer(result.content,'base64')).toString();
    }

  }});
```

[another link about this problem](http://stackoverflow.com/questions/5135450/nodejs-http-response-encoding)
