### PR TITLE
Ignore stylus files whose names begin with an underscore.

### DIFF
--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -8,6 +8,11 @@ var fs = require('fs');
 
 Package.register_extension(
   'styl', function(bundle, source_path, serve_path, where) {
+    // ignore this file if it starts with an _, 
+    // it's file that will be included by others.
+    if (source_path.match(/\/_[^\/]*$/))
+      return;
+    
     serve_path = serve_path + '.css';
 
     var contents = fs.readFileSync(source_path);


### PR DESCRIPTION
A better (IMO) solution than #421.

I've gone with the `_mixin.styl` solution because that's what I've seen from the rails world, and that's what I'm used to. Probably the precedent that's set here should be followed for the less package and any other CSS preprocessors that later appear.

Some other ideas that could be better than leading underscores:
- named directories (e.g. `/include`, `/lib`). No one can ever agree on naming however. We could force it though.
- different extensions (say `mixins.styl_`). I'm not sure if we could guarantee that all preprocessors are going to be able to `@include` the weird extension though.
