### PR TITLE
Added a fast path to compilation of selectors if only the _id of a document is queried.

### DIFF
--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -277,10 +277,14 @@ LocalCollection._compileSelector = function (selector) {
   if (!selector || (('_id' in selector) && !selector._id))
     return function (doc) {return false;};
 
-  // fast path for simply matching the _id of a document and nothing
-  // else.
-  if (_.size(selector) === 1 && ("_id" in selector))
-    return function (doc) {return doc._id === selector._id;};
+  // fast path for simple queries with just one field (like _id)
+  // without any modifiers.
+  if (_.size(selector) === 1) {
+    for (key in selector) {
+      if (LocalCollection._selectorIsId(selector[key]))
+        return function (doc) {return doc[key] === selector[key];};
+    }
+  }
 
   // eval() does not return a value in IE8, nor does the spec say it
   // should. Assign to a local to get the value, instead.


### PR DESCRIPTION
As requested, this is part one of a split-up of the previous pull request. I have briefly looked at adding a fast-path to `upgrade`, but I don't have a good test case for that, so I can't be sure it really matters. I'll be looking at that issue again once it appears on my profiling output :)

Also, I filled out the contributers form.
