### PR TITLE
Added the trivial fast path for empty selectors

### DIFF
--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -277,6 +277,10 @@ LocalCollection._compileSelector = function (selector) {
   if (!selector || (('_id' in selector) && !selector._id))
     return function (doc) {return false;};
 
+  // return every document if the selector is an empty object
+  if (_.size(selector) === 0)
+    return function(doc) {return true;};
+
   // eval() does not return a value in IE8, nor does the spec say it
   // should. Assign to a local to get the value, instead.
   var _func;


### PR DESCRIPTION
On further investigation, I found that a lot of queries simply ask for
every document with an empty selector. I assume that this is a common
case not just for me.

Maybe this should be special-cased somewhere earlier, but I don't know my ways around the code very well yet.
