### PR TITLE
Adding onSuccess callback to Accounts.ui.config

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -47,7 +47,7 @@
           Accounts._makeClientLoggedOut();
           throw error;
         } else {
-          // nothing to do
+            Accounts.ui && Accounts.ui._performOnSuccessCallback && Accounts.ui._performOnSuccessCallback();
         }
       });
     };
@@ -65,6 +65,8 @@
         data.loaded = true;
         userLoadedListeners.invalidateAll();
       });
+
+    Accounts.ui && Accounts.ui._performOnSuccessCallback && Accounts.ui._performOnSuccessCallback();
   };
 
   Meteor.logout = function (callback) {

--- a/packages/accounts-ui-unstyled/accounts_ui.js
+++ b/packages/accounts-ui-unstyled/accounts_ui.js
@@ -10,7 +10,7 @@ if (!Accounts.ui._options) {
 
 Accounts.ui.config = function(options) {
   // validate options keys
-  var VALID_KEYS = ['passwordSignupFields', 'requestPermissions'];
+  var VALID_KEYS = ['passwordSignupFields', 'requestPermissions', 'onSuccess'];
   _.each(_.keys(options), function (key) {
     if (!_.contains(VALID_KEYS, key))
       throw new Error("Accounts.ui.config: Invalid key: " + key);
@@ -45,6 +45,19 @@ Accounts.ui.config = function(options) {
       }
     });
   }
+
+  // wire up authentication `callback`
+  if (options.onSuccess) {
+      if (_.isFunction(options.onSuccess))
+          Accounts.ui._options.onSuccess = options.onSuccess;
+      else
+          throw new Error("Accounts.ui.config: Value for `onSuccess` must be a function");
+  }
+
+};
+
+Accounts.ui._performOnSuccessCallback = function (err) {
+    Accounts.ui._options.onSuccess && Accounts.ui._options.onSuccess();
 };
 
 Accounts.ui._passwordSignupFields = function () {

--- a/packages/accounts-ui-unstyled/accounts_ui_tests.js
+++ b/packages/accounts-ui-unstyled/accounts_ui_tests.js
@@ -13,5 +13,9 @@ Tinytest.add('accounts-ui - config validates keys', function (test) {
   test.throws(function () {
     Accounts.ui.config({requestPermissions: {facebook: "not an array"}});
   });
+
+  test.throws(function () {
+      Accounts.ui.config({ onSuccess: "not a function" });
+  });
 });
 


### PR DESCRIPTION
I wanted to leverage the `{{loginButtons}}` handlebars helper method to create the account management widget, but that left me with little low-level control over the `callback` specified in one of the `Meteor.loginWithXXX` methods.

So I amended the `Accounts.ui.config` to accept an `onSuccess` callback. I'm sure my impl is not ideal, as this is my first PR for meteor. I'm happy to adjust this if need be.

What this enables me to do from the client is this:

```
Accounts.ui.config({
    onSuccess: function () {
        //perform addl authorization on Meteor.user() here
    }
});
```

Keep up the great work!
