### PR TITLE
Added a caveat to "synchronous" method calls.

### DIFF
--- a/docs/client/api.js
+++ b/docs/client/api.js
@@ -260,7 +260,7 @@ Template.api.meteor_call = {
      descr: "Optional method arguments"},
     {name: "asyncCallback",
      type: "Function",
-     descr: "Optional callback.  If passed, the method runs asynchronously, instead of synchronously, and calls asyncCallback passing either the error or the result."}
+     descr: "Optional callback.  If passed, the method runs asynchronously, instead of synchronously, and calls asyncCallback passing either the error or the result. Note that synchronous server method calls are not possible client side."}
   ]
 };
 
@@ -278,7 +278,7 @@ Template.api.meteor_apply = {
      descr: "Method arguments"},
     {name: "asyncCallback",
      type: "Function",
-     descr: "Optional callback.  If passed, the method runs asynchronously, instead of synchronously, and calls asyncCallback passing either the error or the result."}
+     descr: "Optional callback.  If passed, the method runs asynchronously, instead of synchronously, and calls asyncCallback passing either the error or the result. Note that synchronous server method calls are not possible client side."}
   ],
   options: [
     {name: "wait",


### PR DESCRIPTION
For instance, see
http://stackoverflow.com/questions/13368456/meteor-callfunction-arg-not-occurring-synchronously/13370724#13370724
as an example of someone misreading this section of the docs.
