### PR TITLE
More minimongo tests

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -580,8 +580,12 @@ Tinytest.add("minimongo - selector_compiler", function (test) {
   nomatch({"a.b": {$in: [1, 2, 3]}}, {a: {b: [4]}});
 
   // $or
-  match({$or: []}, {}); // should throw error!
-  match({$or: []}, {a: 1}); // should throw error!
+  test.throws(function () {
+    match({$or: []}, {});
+  });
+  test.throws(function () {
+    match({$or: []}, {a: 1});
+  });
   match({$or: [{a: 1}]}, {a: 1});
   nomatch({$or: [{b: 2}]}, {a: 1});
   match({$or: [{a: 1}, {b: 2}]}, {a: 1});
@@ -657,8 +661,12 @@ Tinytest.add("minimongo - selector_compiler", function (test) {
   // this is possibly an open-ended task, so we stop here ...
   
   // $nor
-  match({$nor: []}, {}); // should throw error!
-  match({$nor: []}, {a: 1}); // should throw error!
+  test.throws(function () {
+    match({$nor: []}, {});
+  });
+  test.throws(function () {
+    match({$nor: []}, {a: 1});
+  });
   nomatch({$nor: [{a: 1}]}, {a: 1});
   match({$nor: [{b: 2}]}, {a: 1});
   nomatch({$nor: [{a: 1}, {b: 2}]}, {a: 1});
@@ -730,8 +738,13 @@ Tinytest.add("minimongo - selector_compiler", function (test) {
   nomatch({$nor: [{a: {$not: {$mod: [10, 1]}}}, {a: {$mod: [10, 2]}}]}, {a: 3});
 
   // $and
-  match({$and: []}, {}); // should throw error!
-  match({$and: []}, {a: 1}); // should throw error!
+
+  test.throws(function () {
+    match({$and: []}, {});
+  });
+  test.throws(function () {
+    match({$and: []}, {a: 1});
+  });
   match({$and: [{a: 1}]}, {a: 1});
   nomatch({$and: [{a: 1}, {a: 2}]}, {a: 1});
   nomatch({$and: [{a: 1}, {b: 1}]}, {a: 1});

--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -321,6 +321,8 @@ LocalCollection._exprForSelector = function (selector, literals) {
 LocalCollection._exprForDocumentPredicate = function (op, value, literals) {
   if (op === '$or') {
     var clauses = [];
+    if (value.length === 0)
+      throw Error("$and/$or/$nor must be a nonempty array");
     _.each(value, function (c) {
       clauses.push(LocalCollection._exprForSelector(c, literals));
     });
@@ -330,6 +332,8 @@ LocalCollection._exprForDocumentPredicate = function (op, value, literals) {
 
   if (op === '$and') {
     var clauses = [];
+    if (value.length === 0)
+      throw Error("$and/$or/$nor must be a nonempty array");
     _.each(value, function (c) {
       clauses.push(LocalCollection._exprForSelector(c, literals));
     });
@@ -339,6 +343,8 @@ LocalCollection._exprForDocumentPredicate = function (op, value, literals) {
 
   if (op === '$nor') {
     var clauses = [];
+    if (value.length === 0)
+      throw Error("$and/$or/$nor must be a nonempty array");
     _.each(value, function (c) {
       clauses.push("!(" + LocalCollection._exprForSelector(c, literals) + ")");
     });


### PR DESCRIPTION
Added > 200 tests for minimongo selectors.

Also fixed minor bug where minimongo accepted empty arrays for $and/$or/$nor, but mongodb does not:

```
> db.testcol.find({$nor: []})
error: { "$err" : "$and/$or/$nor must be a nonempty array", "code" : 13086 }
```
