### PR TITLE
Removed needless compilation of selector.

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -66,7 +66,11 @@ LocalCollection.Cursor = function (collection, selector, options) {
   if ((typeof selector === "string") || (typeof selector === "number")) {
     // stash for fast path
     this.selector_id = selector;
-    this.selector_f = LocalCollection._compileSelector(selector);
+    // No need to compile selector because direct look-up is performed.
+  } else if (selector instanceof Object && _.size(selector) === 1 && "_id" in selector &&
+            ((typeof selector._id === "string") || (typeof selector._id === "number"))) {
+    // ditto
+    this.selector_id = selector._id;
   } else {
     this.selector_f = LocalCollection._compileSelector(selector);
     this.sort_f = options.sort ? LocalCollection._compileSort(options.sort) : null;


### PR DESCRIPTION
When the selector is a string or a number or the selector contains
only the _id of a document, a direct lookup is performed in
_getRawDocuments, making the compilation of the selector superfluous.

I believe this was the original intention of whoever wrote this part of the code,
he probably just forgot not to compile the selector (or is it used anywhere else?
All tests pass here).
