### PR TITLE
Fixed flaw in uuid generation . . .

### DIFF
--- a/packages/minimongo/uuid.js
+++ b/packages/minimongo/uuid.js
@@ -112,7 +112,7 @@ LocalCollection.uuid = function () {
     s[i] = hexDigits.substr(Math.floor(LocalCollection.random() * 0x10), 1);
   }
   s[14] = "4";
-  s[19] = hexDigits.substr((s[19] & 0x3) | 0x8, 1);
+  s[19] = hexDigits.substr((parseInt(s[19],16) & 0x3) | 0x8, 1);
   s[8] = s[13] = s[18] = s[23] = "-";
 
   var uuid = s.join("");


### PR DESCRIPTION
where a "&" between an integer and string gives the improper result for characters a-f.

View commit message in monospaced font to see error.
