### PR TITLE
add count command support in mongo-livedata package

### DIFF
--- a/packages/mongo-livedata/collection.js
+++ b/packages/mongo-livedata/collection.js
@@ -158,6 +158,11 @@ _.extend(Meteor.Collection.prototype, {
   findOne: function (/* selector, options */) {
     var self = this;
     return self._collection.findOne.apply(self._collection, _.toArray(arguments));
+  },
+
+  count: function (/* selector, options */) {
+    var self = this;
+    return self._collection.count.apply(self._collection, _.toArray(arguments));
   }
 
 });

--- a/packages/mongo-livedata/mongo_driver.js
+++ b/packages/mongo-livedata/mongo_driver.js
@@ -244,6 +244,28 @@ _Mongo.prototype._ensureIndex = function (collectionName, index, options) {
   future.wait();
 };
 
+// count documents in this collection
+_Mongo.prototype.count = function (collectionName, options) {
+  var self = this;
+
+  var future = new Future;
+  self._withCollection(collectionName, function (err, collection) {
+    if (err) {
+      future.throw(err);
+      return;
+    }
+    // XXX do we have to bindEnv or Fiber.run this callback?
+    collection.count(options, function (err, length) {
+      if (err) {
+        future.throw(err);
+        return;
+      }
+      future.ret(length);
+    });
+  });
+  return future.wait();
+};
+
 // CURSORS
 
 // There are several classes which relate to cursors:

--- a/packages/mongo-livedata/remote_collection_driver.js
+++ b/packages/mongo-livedata/remote_collection_driver.js
@@ -9,7 +9,7 @@ _.extend(Meteor._RemoteCollectionDriver.prototype, {
     var self = this;
     var ret = {};
     _.each(
-      ['find', 'findOne', 'insert', 'update', 'remove', '_ensureIndex'],
+      ['find', 'findOne', 'insert', 'update', 'remove', '_ensureIndex', 'count'],
       function (m) {
         ret[m] = _.bind(self.mongo[m], self.mongo, name);
       });


### PR DESCRIPTION
Support the count command on mongo collections. If one needs the amount of documents in a collection, find().count() is no viable way as it actually pulls the documents' data.

The actual code is taken from the ensureIndex function, just added returning the result. It won't work on the client however, as the underlying minimongo does not have the respective count method. I assume that there's a way to pass this on to the server but I'm not deep enough into meteor's code to implement this.
