### PR TITLE
Fix capturing the twitter identity information

### DIFF
--- a/packages/accounts-twitter/twitter_server.js
+++ b/packages/accounts-twitter/twitter_server.js
@@ -1,7 +1,7 @@
 (function () {
 
   Accounts.oauth.registerService('twitter', 1, function(oauthBinding) {
-    var identity = oauthBinding.get('https://api.twitter.com/1/account/verify_credentials.json');
+    var identity = oauthBinding.get('https://api.twitter.com/1/account/verify_credentials.json').data;
 
     return {
       serviceData: {


### PR DESCRIPTION
The oauth1Binding now returns the http result instead of just the data.  The built in twitter_server hadn't been updated to handle the change.
