### PR TITLE
Adding expiresAt property to Google login data for accounts-google.

### DIFF
--- a/packages/accounts-google/google_server.js
+++ b/packages/accounts-google/google_server.js
@@ -2,20 +2,21 @@
 
   Accounts.oauth.registerService('google', 2, function(query) {
 
-    var accessToken = getAccessToken(query);
-    var identity = getIdentity(accessToken);
+    var accessObject = getAccessObject(query);
+    var identity = getIdentity(accessObject.accessToken);
 
     return {
       serviceData: {
         id: identity.id,
-        accessToken: accessToken,
+        accessToken: accessObject.accessToken,
+        expiresAt: new Date().getTime() + (1000 * parseInt(accessObject.expiresIn, 10)),
         email: identity.email
       },
       options: {profile: {name: identity.name}}
     };
   });
 
-  var getAccessToken = function (query) {
+  var getAccessObject = function (query) {
     var config = Accounts.loginServiceConfiguration.findOne({service: 'google'});
     if (!config)
       throw new Accounts.ConfigError("Service not configured");
@@ -33,7 +34,10 @@
       throw result.error;
     if (result.data.error) // if the http response was a json object with an error attribute
       throw result.data;
-    return result.data.access_token;
+    return {
+      accessToken: result.data.access_token,
+      expiresIn: result.data.expires_in
+    };
   };
 
   var getIdentity = function (accessToken) {


### PR DESCRIPTION
fixes #525

This adds a "expiresAt" attribute for Google access tokens.
The "expires_in" attribute from Google contains the number of seconds until it expires, the newly added expiresAt gives the milliseconds (as in Date.getTime()) when the token expires.
