### PR TITLE
Fix Spark dependencies

### DIFF
--- a/admin/spark-standalone.sh
+++ b/admin/spark-standalone.sh
@@ -8,6 +8,7 @@ PACKAGES_DIR=`dirname $0`/../packages
 
 echo 'Meteor = {};'
 cat $PACKAGES_DIR/underscore/underscore.js
+cat $PACKAGES_DIR/logging/logging.js
 cat $PACKAGES_DIR/uuid/uuid.js
 cat $PACKAGES_DIR/deps/deps.js
 cat $PACKAGES_DIR/deps/deps-utils.js


### PR DESCRIPTION
Underscore.js is also required to use Spark standalone. This dep was not included in `admin/spark-standalone.sh`.
