### PR TITLE
Add extraSignupFields config option to Accounts.ui

### DIFF
--- a/packages/accounts-ui-unstyled/accounts_ui.js
+++ b/packages/accounts-ui-unstyled/accounts_ui.js
@@ -5,14 +5,14 @@ if (!Accounts.ui._options) {
   Accounts.ui._options = {
     requestPermissions: {},
     requestOfflineToken: {},
-    extraFields: []
+    extraSignupFields: []
   };
 }
 
 
 Accounts.ui.config = function(options) {
   // validate options keys
-  var VALID_KEYS = ['passwordSignupFields', 'requestPermissions', 'requestOfflineToken', 'extraFields'];
+  var VALID_KEYS = ['passwordSignupFields', 'requestPermissions', 'requestOfflineToken', 'extraSignupFields'];
   _.each(_.keys(options), function (key) {
     if (!_.contains(VALID_KEYS, key))
       throw new Error("Accounts.ui.config: Invalid key: " + key);
@@ -62,17 +62,17 @@ Accounts.ui.config = function(options) {
     });
   }
 
-  // deal with `extraFields`
-  if (typeof options.extraFields !== 'object' || ! options.extraFields instanceof Array) {
-    throw new Error("Accounts.ui.config: `extraFields` must be an array.");
+  // deal with `extraSignupFields`
+  if (typeof options.extraSignupFields !== 'object' || ! options.extraSignupFields instanceof Array) {
+    throw new Error("Accounts.ui.config: `extraSignupFields` must be an array.");
   } else {
-    if (options.extraFields) {
-      _.each(options.extraFields, function (field, index) {
+    if (options.extraSignupFields) {
+      _.each(options.extraSignupFields, function (field, index) {
         if (! field.fieldName || ! field.fieldLabel)
-          throw new Error("Accounts.ui.config: `extraFields` objects must have `fieldName` and `fieldLabel` attributes.");
+          throw new Error("Accounts.ui.config: `extraSignupFields` objects must have `fieldName` and `fieldLabel` attributes.");
         if (typeof field.visible === 'undefined')
           field.visible = true;
-        Accounts.ui._options.extraFields[index] = field;
+        Accounts.ui._options.extraSignupFields[index] = field;
       });
     }
   }

--- a/packages/accounts-ui-unstyled/login_buttons_dropdown.js
+++ b/packages/accounts-ui-unstyled/login_buttons_dropdown.js
@@ -252,7 +252,7 @@
        }}
     ];
 
-    signupFields = Accounts.ui._options.extraFields.concat(signupFields);
+    signupFields = Accounts.ui._options.extraSignupFields.concat(signupFields);
 
     return loginButtonsSession.get('inSignupFlow') ? signupFields : loginFields;
   };
@@ -423,28 +423,28 @@
     // prepare the profile object
     options.profile = {};
 
-    // define a proxy function to allow extraFields set error messages
+    // define a proxy function to allow extraSignupFields set error messages
     var errorFn = function(errorMessage) {
       Accounts._loginButtonsSession.errorMessage(errorMessage);
     };
 
-    var invalidExtraFields = false;
+    var invalidExtraSignupFields = false;
 
-    // parse extraFields to populate account's profile data
-    _.each(Accounts.ui._options.extraFields, function (field, index) {
+    // parse extraSignupFields to populate account's profile data
+    _.each(Accounts.ui._options.extraSignupFields, function (field, index) {
       var value = elementValueById('login-' + field.fieldName);
       if (typeof field.validate === 'function') {
         if (field.validate(value, errorFn)) {
           options.profile[field.fieldName] = elementValueById('login-' + field.fieldName);
         } else {
-          invalidExtraFields = true;
+          invalidExtraSignupFields = true;
         }
       } else {
         options.profile[field.fieldName] = elementValueById('login-' + field.fieldName);
       }
     });
 
-    if (invalidExtraFields)
+    if (invalidExtraSignupFields)
       return;
 
     Accounts.createUser(options, function (error) {


### PR DESCRIPTION
Allows you to define extra fields for Accounts.ui signup form.

The fields must have a fieldName and fieldLabel attributes and can have visible and validate functions. If you don't specify a visible function it will be visible by default, also if you don't set a validate function it will be valid by default.

The info introduced in those fields is putted into the account profile's data using fieldName's value  as attribute's name.

The validate functions are called with two arguments, value and errorFn. Value contains the submitted value for that field and errorFn is a function you can call with a custom error message as a string.

An usage example:

``` javascript
Accounts.ui.config({
    requestPermissions: {
        facebook: ['email'],
    },
    passwordSignupFields: 'EMAIL_ONLY',
    extraSignupFields: [{
        fieldName: 'name',
        fieldLabel: 'Name',
        validate: function(value, errorFn) {
            if (value == '') {
                errorFn('Name must have a value');
                return false;
            }
            return true;
        }
    },{
        fieldName: 'surname',
        fieldLabel: 'Surname'
    }]
});
```

This will add two fields to the signup form and save the entered values to profile.name and profile.surname user attributes.
