### PR TITLE
Pluggable templates.

### DIFF
--- a/packages/templating/deftemplate.js
+++ b/packages/templating/deftemplate.js
@@ -179,9 +179,19 @@
             // (and receive 'landmark')
             
             var helpers = _.extend({}, partial, tmplData.helpers || {});
-            _.each(tmplData.plugins, function (plugin) {
-              if (plugin.helpers) _.extend(helpers, plugin.helpers);
-            });
+            var addPluginHelpers = function (plugin) {
+              if (plugin.helpers) {
+                _.each(plugin.helpers, function (fn, key) {
+                  // make sure the plugin is always the first parameter
+                  helpers[key] = function () {
+                    var args = [plugin].concat(_.toArray(arguments));
+                    return fn.apply(this, args);
+                  }
+                });
+              }
+            }
+
+            _.each(tmplData.plugins, addPluginHelpers);
 
             return raw_func(data, {
               helpers: helpers,


### PR DESCRIPTION
This is an initial sketch! Hope you have time to take a look.

Actual example with form parsing: https://github.com/cmather/meteor-pluggable-templates-example.

Adds ability to plug functionality into templates. A plugin can have its
own created, rendered and destroyed callbacks, as well as define its own
events.

Example:

``` javascript
SimpleForm = function (options) {};
SimpleForm.prototype = {
  constructor: SimpleForm,
  created: function (template) {
    // this points to SimpleForm instance
  },
  rendered: function (template) {},
  destroyed: function (template) {},
  events: {},

  serialize: function () {},
  onSubmit: function () {}
};

SomeOtherPlugin = function (options) {};

Template.myForm.plugins({
  "someName": new SimpleForm({ selector: "form" }),
  "someOtherPlugin": new SomeOtherPlugin({});
});
```
