### PR TITLE
Adding documentation explaining Collections in the introductory Data sec...

### DIFF
--- a/docs/client/concepts.html
+++ b/docs/client/concepts.html
@@ -136,6 +136,24 @@ client cache, the server *publishes* sets of JSON documents, and the
 client *subscribes* to those sets.  As documents in a set change, the
 server patches each client's cache.
 
+Documents are created, and the data inside them managed by, the
+[`Meteor.Collection`](http://docs.meteor.com/#meteor_collection) class.
+Meteor uses a subset of MongoDB, called
+[minimongo](https://github.com/slacy/minimongo), so the syntax is very
+similar.
+
+    // common code on client and server declares mongo collection
+    // (aka document)
+    Rooms = new Meteor.Collection("rooms");
+    Rooms.insert({name: "Conference Room A"});
+    var myRooms = Rooms.find({}).fetch();
+
+    Messages = new Meteor.Collection("messages");
+    Messages.insert({text: "Hello world", room: myRooms[0].id});
+
+    Parties = new Meteor.Collection("parties");
+    Parties.insert({name: "Super Bowl Party"}); 
+
 Each document set is defined by a publish function on the server.  The
 publish function runs each time a new client subscribes to a document
 set.  The data in a document set can come from anywhere, but the common


### PR DESCRIPTION
Adding documentation explaining Collections in the introductory Data section, fixes #149. The worry with this ticket was that sample code uses Collections before explaining them, so someone reading the docs in order might get confused. 

This adds a few sentences and a code example declaring the Collections that are used in the next code sample. This just just a start after quickly reading the docs on Collections. Let me know if something needs to be restated.
