### PR TITLE
Fix exclusion of favicon.ico and robots.txt on Windows.

### DIFF
--- a/app/server/server.js
+++ b/app/server/server.js
@@ -124,7 +124,7 @@ var run = function () {
 
     app.use(function (req, res) {
       // prevent favicon.ico and robots.txt from returning app_html
-      if (_.indexOf([path.sep + 'favicon.ico', path.sep + 'robots.txt'], req.url) !== -1) {
+      if (_.indexOf(['/favicon.ico', '/robots.txt'], req.url) !== -1) {
         res.writeHead(404);
         res.end();
         return;


### PR DESCRIPTION
This fixes a bug where the exclusion of favicon.ico and robots.txt was not working on Windows.  (That it, on Windows, fetching e.g. /robots.txt would retrieve the app html, when it shouldn't).

The use of path.sep is incorrect because req.url is a URL, not a file
path, and so always contains forward slashes.

I verified that the original code does not work on Windows and that
the new code does.

See https://github.com/TomWij/meteor/issues/50 for discussion.
