### PR TITLE
include logging in spark-standalone

### DIFF
--- a/admin/spark-standalone.sh
+++ b/admin/spark-standalone.sh
@@ -7,6 +7,7 @@ set -e
 PACKAGES_DIR=`dirname $0`/../packages
 
 echo 'Meteor = {};'
+cat $PACKAGES_DIR/logging/logging.js
 cat $PACKAGES_DIR/uuid/uuid.js
 cat $PACKAGES_DIR/deps/deps.js
 cat $PACKAGES_DIR/deps/deps-utils.js


### PR DESCRIPTION
spark-standalone.js (created via admin/spark-standalone.sh) includes calls to `Meteor._debug`, which is undefined unless we include logging
