### PR TITLE
Add Mongo Aggregation Framework to Meteor

### DIFF
--- a/packages/mongo-livedata/collection.js
+++ b/packages/mongo-livedata/collection.js
@@ -158,6 +158,13 @@ _.extend(Meteor.Collection.prototype, {
   findOne: function (/* selector, options */) {
     var self = this;
     return self._collection.findOne.apply(self._collection, _.toArray(arguments));
+  },
+
+  aggregate: function (/* pipeline */) {
+    var self = this;
+    if (!self._collection.aggregate)
+      throw new Error("Can only call aggregate on server collections");
+    return self._collection.aggregate.apply(self._collection, _.toArray(arguments));
   }
 
 });

--- a/packages/mongo-livedata/remote_collection_driver.js
+++ b/packages/mongo-livedata/remote_collection_driver.js
@@ -9,7 +9,7 @@ _.extend(Meteor._RemoteCollectionDriver.prototype, {
     var self = this;
     var ret = {};
     _.each(
-      ['find', 'findOne', 'insert', 'update', 'remove', '_ensureIndex'],
+      ['find', 'findOne', 'insert', 'update', 'remove', '_ensureIndex', 'aggregate'],
       function (m) {
         ret[m] = _.bind(self.mongo[m], self.mongo, name);
       });


### PR DESCRIPTION
I've started to add support for Mongo's Aggregation framework to Meteor's mongo_driver. It should be able to return a cursor so it can be used with the rest of Meteor's Collections. However, I'm not sure the best place to wire it up. Please take a look at this pull request and if you provide a little guidance, I'll be happy to finish this off. Thanks.
