### PR TITLE
Fixed link to StackOverflow in docs

### DIFF
--- a/docs/client/introduction.html
+++ b/docs/client/introduction.html
@@ -114,8 +114,8 @@ with the project!
 
 <dl class="involved">
 <dt><span>Stack Overflow</span></dt>
-<dd>The best place to ask (and answer!) technical questions is on [Stack
-  Overflow](http://stackoverflow.com/questions/tagged/meteor).  Be sure to add
+<dd>The best place to ask (and answer!) technical questions is on <a href="http://stackoverflow.com/questions/tagged/meteor">Stack
+  Overflow</a>.  Be sure to add
   the <code>meteor</code> tag to your question.
 </dd>
 


### PR DESCRIPTION
Seems a markdown-formatted link was missed.
