### PR TITLE
#617 fixed, added tests

### DIFF
--- a/packages/handlebars/handlebars-client_tests.html
+++ b/packages/handlebars/handlebars-client_tests.html
@@ -1,0 +1,9 @@
+<template name="test_helpers_00">
+  Hi
+</template>
+
+<!-- Test for Issue 617 - Type casting for helpers -->
+<template name="test_helpers_10">
+{{testTypeCasting 'string' true false 10 -10 }}
+</template>
+

--- a/packages/handlebars/handlebars-client_tests.js
+++ b/packages/handlebars/handlebars-client_tests.js
@@ -1,0 +1,56 @@
+(function () {
+	if (typeof Handlebars !== 'undefined') {
+		//{{getSession 'key'}}
+		Handlebars.registerHelper('testTypeCasting', function (myStr, myTrue, myFalse, myTen, myNegTen) {
+			//Expect 'string' true false 10 -10
+			var result  = (myStr == 'string') 	?'1':(myStr == undefined)?'u':'-';
+				result += (myTrue == true) 		?'2':(myTrue == undefined)?'u':'-';
+				result += (myFalse == false)	?'3':(myFalse == undefined)?'u':'-';
+				result += (myTen == 10)			?'4':(myTen == undefined)?'u':'-';
+				result += (myNegTen == -10)		?'5':(myNegTen == undefined)?'u':'-';
+			return result;
+		});
+	}	
+})();
+
+(function () {
+  Tinytest.add('Handlebars - init templates', function (test) {
+	  var frag = Meteor.render(Template.test_helpers_00);
+	  test.equal(canonicalizeHtml(DomUtils.fragmentToHtml(frag)), "Hi");
+	});
+
+	Tinytest.add('Handlebars - init test helpers', function (test) {
+	  test.notEqual(Handlebars._default_helpers['testTypeCasting'], undefined, 'testTypeCasting: Handlebars loaded after session_helpers?');
+	});
+
+	Tinytest.add('Handlebars - helper typecast Issue #617', function (test) {
+	  var frag = Meteor.render(Template.test_helpers_10);
+	  var result = canonicalizeHtml(DomUtils.fragmentToHtml(frag));
+	  test.equal(result.substr(0, 1), "1", 'Error in type casting string');
+	  test.equal(result.substr(1, 1), "2", 'Error in type casting boolean true');
+	  test.equal(result.substr(2, 1), "3", 'Error in type casting boolean false');
+	  test.equal(result.substr(3, 1), "4", 'Error in type casting number');
+	  test.equal(result.substr(4, 1), "5", 'Error in type casting number negative');
+	});
+
+
+})();
+
+//Test API:
+//test.isFalse(v, msg)
+//test.isTrue(v, msg)
+//test.equalactual, expected, message, not
+//test.length(obj, len)
+//test.include(s, v)
+//test.isNaN(v, msg)
+//test.isUndefined(v, msg)
+//test.isNotNull
+//test.isNull
+//test.throws(func)
+//test.instanceOf(obj, klass)
+//test.notEqual(actual, expected, message)
+//test.runId()
+//test.exception(exception)
+//test.expect_fail()
+//test.ok(doc)
+//test.fail(doc)

--- a/packages/handlebars/package.js
+++ b/packages/handlebars/package.js
@@ -21,3 +21,15 @@ Package.on_use(function (api) {
 // making it the default default, providing the compiler code,
 // depending on the node package (or packaging the compiler
 // ourselves..)
+Package.on_test(function (api) {
+  api.use(['tinytest', 
+           'test-helpers', 
+           'session', 
+           'templating',
+           'mongo-livedata']);
+  
+  api.add_files(['handlebars-client_tests.html',
+                 'handlebars-client_tests.js',
+                 ], 'client');
+
+});

--- a/packages/handlebars/parse.js
+++ b/packages/handlebars/parse.js
@@ -65,11 +65,18 @@ Handlebars.to_json_ast = function (code) {
   };
 
   var value = function (node) {
+    //Work around handlebars.js Issue #422 - Negative integers for helpers get trapped as ID
+    if (node.type == 'ID' && node.string.slice(0,1) == '-' && !isNaN(node.string)) { //node.string eg. '-10'
+      //Reconstruct node
+      node.type = 'INTEGER';
+      node.integer = node.string;
+    } //EO Workaround handlebars.js Issue #422
+
     var choices = {
       ID: function (node) {return identifier(node);},
-      STRING: function (node) {return node.string;},
-      INTEGER: function (node) {return node.integer;},
-      BOOLEAN: function (node) {return node.bool;},
+      STRING: function (node) {return ''+node.string;},
+      INTEGER: function (node) {return +node.integer;},
+      BOOLEAN: function (node) {return (node.bool === 'true');},
     };
     if (!(node.type in choices))
       throw new Error("got ast node " + node.type + " for value");


### PR DESCRIPTION
- Added fix #617
  It now supports `string`, `boolean`, `integer` and `negative integer` in helpers
- Added workaround handlebars issue 422 - negative integers are trapped as `ID` not `INTEGER`
- Added tests for issue #617
