### PR TITLE
Detect update available on first stream connection.

### DIFF
--- a/app/lib/bundler.js
+++ b/app/lib/bundler.js
@@ -208,6 +208,10 @@ _.extend(PackageInstance.prototype, {
 var Bundle = function () {
   var self = this;
 
+  // Uniquely identify this bundle.
+  // self.bundle_id = Meteor.uuid();
+  self.bundle_id = ('' + Math.random()).substr(2);
+
   // Packages being used. Map from a package id to a PackageInstance.
   self.packages = {};
 
@@ -450,7 +454,7 @@ _.extend(Bundle.prototype, {
   // dev_bundle_mode should be "skip", "symlink", or "copy"
   write_to_directory: function (output_path, project_dir, dev_bundle_mode) {
     var self = this;
-    var app_json = {};
+    var app_json = {bundle_id: self.bundle_id};
     var dependencies_json = {core: [], app: [], packages: {}};
     var is_app = files.is_app_dir(project_dir);
 

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -89,9 +89,17 @@ var run = function () {
     fs.readFileSync(path.join(bundle_dir, 'app.json'), 'utf8');
   var info = JSON.parse(info_raw);
 
+  // unique id for this instantiation of the server. If this changes
+  // between client reconnects, the client will reload. You can set the
+  // environment variable "SERVER_ID" to control this. For example, if
+  // you want to only force a reload on major changes, you can use a
+  // custom server_id which you only change when something worth pushing
+  // to clients immediately happens.
+  var server_id = process.env.SERVER_ID || info.bundle_id;
+
   // start up app
   __meteor_bootstrap__ = {require: require, startup_hooks: [], app: app};
-  __meteor_runtime_config__ = {};
+  __meteor_runtime_config__ = {server_id: server_id};
   Fiber(function () {
     // (put in a fiber to let Meteor.db operations happen during loading)
 

--- a/packages/stream/stream_client.js
+++ b/packages/stream/stream_client.js
@@ -7,7 +7,6 @@ Meteor._Stream = function (url) {
   self.rawUrl = url;
   self.socket = null;
   self.event_callbacks = {}; // name -> [callback]
-  self.server_id = null;
   self.sent_update_available = false;
   self.force_fail = false; // for debugging.
 
@@ -202,10 +201,8 @@ _.extend(Meteor._Stream.prototype, {
     }
 
     if (welcome_data && welcome_data.server_id) {
-      if (!self.server_id)
-        self.server_id = welcome_data.server_id;
-
-      if (self.server_id && self.server_id !== welcome_data.server_id &&
+      if (__meteor_runtime_config__.server_id &&
+          __meteor_runtime_config__.server_id !== welcome_data.server_id &&
           !self.sent_update_available) {
         self.update_available = true;
         _.each(self.event_callbacks.update_available,

--- a/packages/stream/stream_server.js
+++ b/packages/stream/stream_server.js
@@ -3,17 +3,6 @@ Meteor._StreamServer = function () {
   self.registration_callbacks = [];
   self.open_sockets = [];
 
-  // unique id for this instantiation of the server. If this changes
-  // between client reconnects, the client will reload. You can set the
-  // environment variable "SERVER_ID" to control this. For example, if
-  // you want to only force a reload on major changes, you can use a
-  // custom server_id which you only change when something worth pushing
-  // to clients immediately happens.
-  if (process.env.SERVER_ID)
-    self.server_id = process.env.SERVER_ID;
-  else
-    self.server_id = Meteor.uuid();
-
   // set up sockjs
   var sockjs = __meteor_bootstrap__.require('sockjs');
   self.server = sockjs.createServer({
@@ -46,7 +35,7 @@ Meteor._StreamServer = function () {
 
     // Send a welcome message with the server_id. Client uses this to
     // reload if needed.
-    socket.send(JSON.stringify({server_id: self.server_id}));
+    socket.send(JSON.stringify({server_id: __meteor_runtime_config__.server_id}));
 
     // call all our callbacks when we get a new socket. they will do the
     // work of setting up handlers and such for specific messages.


### PR DESCRIPTION
Between flights in PHL :)

Meteor has a small race condition: it is possible (if rather unlikely) that in between delivering the app html and the browser making the first stream connection, the server might have reloaded its code.  Since the stream client uses the first connection to get the server_id in the welcome message, it won't notice that it's running outdated code.

The race condition has greater impact when using an app cache.  The browser will normally start up with cached code, which means that most of the time a returning user after a code update will be out of date at the time of the first stream connection.

This PR includes the server_id in the Meteor runtime config (which is included in the HTML delivered to the browser).  The client is then able to detect that a code update is available on the first stream connection.
