### PR TITLE
mongo-client-friendly printout for `meteor mongo --url *`

### DIFF
--- a/app/meteor/deploy.js
+++ b/app/meteor/deploy.js
@@ -207,6 +207,14 @@ var mongo = function (url, just_credential) {
         // just print the URL
         process.stdout.write(body + "\n");
 
+        var uri_match = body.match(/^mongodb:\/\/([^:]+):([^@]+)@(.*)$/);
+        if (uri_match) {
+          process.stdout.write("\nUsing the console:\n"
+                               + "mongo -u " + uri_match[1]
+                               + " -p " + uri_match[2]
+                               + " " + uri_match[3] + "\n");
+        }
+
       } else {
         // pause stdin so we don't try to read it while mongo is
         // running.


### PR DESCRIPTION
When you run `meteor mongo --url example.com` it prints out a URI. The mongo client—for some reason—doesn’t understand URIs. This commit additionally prints out a mongo-client-friendly string for connecting via the shell.

Separately, I’ve been trying a bunch to connect via the shell and I can’t connect anymore, I’m not sure if I got locked out somehow by the skybreak.member0.mongolayer.com servers. I’m pretty new to mongo, so I’m not sure if there’s a common timeout or something that people should expect.
