### PR TITLE
Add support for checking if the app is reloading (migrating)

### DIFF
--- a/packages/reload/reload.js
+++ b/packages/reload/reload.js
@@ -150,4 +150,9 @@
     tryReload();
   };
 
+  // Used to see if Meteor is reloading. Useful for 'window.onbeforeunload'
+  Meteor._reload.isReloading = function() {
+    return reloading;
+  }
+
 })();


### PR DESCRIPTION
Currently I'm doing something similar to the code below, to check if Meteor is Migrating.

``` js
window.onbeforeunload = function() {
    isReloading = window.sessionStorage ? sessionStorage.getItem('Meteor_Reload') : false;
    if (!isReloading && Session.get('current_timer')) {
        return "You've got active timers. Do you want to close the page, and leave them running in the background?";
    }
}
```

The problem is, that this won't work for browsers not supporting sessionStorage.
With this pull request, I can now simply do something like the code below, and it should work for more than just browsers that support sessionStorage

``` js
window.onbeforeunload = function() {
    if (!Meteor._reload.isReloading() && Session.get('current_timer')) {
        return "You've got active timers. Do you want to close the page, and leave them running in the background?";
    }
}
```
