### PR TITLE
Adjust accounts-twitter to use Twitter's id_str instead of id

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -208,7 +208,23 @@
 
     // Look for a user with the appropriate service user id.
     var selector = {};
-    selector["services." + serviceName + ".id"] = serviceData.id;
+    var serviceIdKey = "services." + serviceName + ".id";
+
+    // XXX Temporary special case for Twitter. (Issue #629)
+    //   The serviceData.id will be a string representation of an integer.
+    //   We want it to match either a stored string or int representation.
+    //   This is to cater to earlier versions of Meteor storing twitter
+    //   user IDs in number form, and recent versions storing them as strings.
+    //   This can be removed once migration technology is in place, and twitter
+    //   users stored with integer IDs have been migrated to string IDs.
+    if (serviceName === "twitter" && !isNaN(serviceData.id)) {
+      selector["$or"] = [{},{}];
+      selector["$or"][0][serviceIdKey] = serviceData.id;
+      selector["$or"][1][serviceIdKey] = parseInt(serviceData.id, 10);
+    } else {
+      selector[serviceIdKey] = serviceData.id;
+    }
+
     var user = Meteor.users.findOne(selector);
 
     if (user) {

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -7,11 +7,8 @@ Tinytest.add('accounts - config validates keys', function (test) {
   });
 });
 
-Tinytest.add('accounts - updateOrCreateUserFromExternalService', function (test) {
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - Facebook', function (test) {
   var facebookId = Meteor.uuid();
-  var weiboId1 = Meteor.uuid();
-  var weiboId2 = Meteor.uuid();
-
 
   // create an account with facebook
   var uid1 = Accounts.updateOrCreateUserFromExternalService(
@@ -38,6 +35,11 @@ Tinytest.add('accounts - updateOrCreateUserFromExternalService', function (test)
 
   // cleanup
   Meteor.users.remove(uid1);
+});
+
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - Weibo', function (test) {
+  var weiboId1 = Meteor.uuid();
+  var weiboId2 = Meteor.uuid();
 
   // users that have different service ids get different users
   uid1 = Accounts.updateOrCreateUserFromExternalService(
@@ -53,8 +55,33 @@ Tinytest.add('accounts - updateOrCreateUserFromExternalService', function (test)
   // cleanup
   Meteor.users.remove(uid1);
   Meteor.users.remove(uid2);
-
 });
+
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - Twitter', function (test) {
+  var twitterIdOld = 123;
+  var twitterIdNew = '123';
+
+  // create an account with twitter using the old ID format of integer
+  var uid1 = Accounts.updateOrCreateUserFromExternalService(
+    'twitter', {id: twitterIdOld, monkey: 42}, {profile: {foo: 1}}).id;
+  var users = Meteor.users.find({"services.twitter.id": twitterIdOld}).fetch();
+  test.length(users, 1);
+  test.equal(users[0].profile.foo, 1);
+  test.equal(users[0].services.twitter.monkey, 42);
+
+  // Update the account with the new ID format of string
+  // test that the existing user is found, and that the ID
+  // gets updated to a string value
+  var uid2 = Accounts.updateOrCreateUserFromExternalService(
+    'twitter', {id: twitterIdNew, monkey: 42}, {profile: {foo: 1}}).id;
+  test.equal(uid1, uid2);
+  users = Meteor.users.find({"services.twitter.id": twitterIdNew}).fetch();
+  test.length(users, 1);
+
+  // cleanup
+  Meteor.users.remove(uid1);
+});
+
 
 Tinytest.add('accounts - insertUserDoc username', function (test) {
   var userIn = {

--- a/packages/accounts-twitter/twitter_server.js
+++ b/packages/accounts-twitter/twitter_server.js
@@ -5,7 +5,7 @@
 
     return {
       serviceData: {
-        id: identity.id,
+        id: identity.id_str,
         screenName: identity.screen_name,
         accessToken: oauthBinding.accessToken,
         accessTokenSecret: oauthBinding.accessTokenSecret


### PR DESCRIPTION
This is a PR to resolve issue #629.

Suggestions for release notes (3rd one explains a potential breaking change):
- When someone signs in with Twitter, their Twitter User ID will now be stored as a string.  Previous versions of Meteor stored it as an integer. This change is in preparation for Twitter's User IDs getting longer:  https://dev.twitter.com/blog/64-bit-twitter-user-idpocalypse
- Existing users with integer ids will be found as the user signs in, and their ID will be updated to a string.
- Meteor Apps that look up users by Twitter User ID should update their code to look them up by the string representation of the ID.  Twitter provides this in their user objects as id_str.
