### PR TITLE
Fix Issue #654, cursor.count not ordered 

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -156,10 +156,10 @@ LocalCollection.Cursor.prototype.fetch = function () {
 LocalCollection.Cursor.prototype.count = function () {
   var self = this;
 
-  if (self.reactive)
+  if (self.reactive) {
     var ordered = !! self.skip || !! self.limit || !! self.sort_f;
-    console.log('ordered: '+ordered);
     self._markAsReactive({ordered: ordered, added: true, removed: true});
+  }
 
   if (self.db_objects === null)
     self.db_objects = self._getRawObjects(true);

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -128,11 +128,22 @@ Tinytest.add("minimongo - basics", function (test) {
   test.equal(c.find({_id: 1}, {skip: 1}).count(), 0);
   test.equal(c.find({}, {skip: 1}).count(), 2);
   test.equal(c.find({}, {skip: 2}).count(), 1);
-  test.equal(c.find({}, {limit: 1}).count(), 7);
+  test.equal(c.find({}, {limit: 2}).count(), 2);
+  test.equal(c.find({}, {limit: 1}).count(), 1);
   test.equal(c.find({}, {skip: 1, limit: 1}).count(), 1);
   test.equal(c.find({tags: "fruit"}, {skip: 1}).count(), 1);
   test.equal(c.find({tags: "fruit"}, {limit: 1}).count(), 1);
   test.equal(c.find({tags: "fruit"}, {skip: 1, limit: 1}).count(), 1);
+  test.equal(c.find(1, {sort: ['_id','desc'], skip: 1}).count(), 0);
+  test.equal(c.find({_id: 1}, {sort: ['_id','desc'], skip: 1}).count(), 0);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 1}).count(), 2);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 2}).count(), 1);
+  test.equal(c.find({}, {sort: ['_id','desc'], limit: 2}).count(), 2);
+  test.equal(c.find({}, {sort: ['_id','desc'], limit: 1}).count(), 1);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 1, limit: 1}).count(), 1);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], skip: 1}).count(), 1);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], limit: 1}).count(), 1);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], skip: 1, limit: 1}).count(), 1);
 
   // Regression test for #455.
   c.insert({foo: {bar: 'baz'}});


### PR DESCRIPTION
Passed all tests on my machine.  This is in response to https://github.com/meteor/meteor/issues/654.

This code makes 'ordered' true if any of 'skip', 'limit', or 'sort' is true.  I _think_ that's the correct logic.
