### PR TITLE
Generate a bundler manifest.

### DIFF
--- a/app/lib/bundler.js
+++ b/app/lib/bundler.js
@@ -403,7 +403,7 @@ _.extend(Bundle.prototype, {
       var name = '/' + hash + '.' + type;
       self.files.client_cacheable[name] = contents;
       self.manifest.push({
-        path: '/static_cacheable' + name,
+        path: 'static_cacheable' + name,
         where: 'client',
         type: type,
         cacheable: true,
@@ -535,16 +535,17 @@ _.extend(Bundle.prototype, {
           files.cp_r(path.join(project_dir, 'public'),
                      path.join(build_path, 'static'), {ignore: ignore_files});
 
-        _.each(copied, function (array_path) {
-          filepath = path.join.apply(null, [].concat(build_path, 'static', array_path));
+        _.each(copied, function (fs_relative_path) {
+          var filepath = path.join(build_path, 'static', fs_relative_path);
+          var normalized = fs_relative_path.split(path.sep).join('/');
           self.manifest.push({
             // path is normalized to use forward slashes, so deliberately
             // not using path.sep here
-            path: '/static/' + array_path.join('/'),
+            path: 'static/' + normalized,
             type: 'static',
             where: 'client',
             cacheable: false,
-            url: '/' + array_path.join('/'),
+            url: '/' + normalized,
             size: fs.statSync(filepath).size,
             hash: self._hash(fs.readFileSync(filepath))
           });
@@ -574,7 +575,7 @@ _.extend(Bundle.prototype, {
 
       self.manifest.push({
         // path is normalized to use forward slashes
-        path: '/static_cacheable' + file.split(path.sep).join('/'),
+        path: 'static_cacheable' + file.split(path.sep).join('/'),
         where: 'client',
         type: type,
         cacheable: true,

--- a/app/lib/files.js
+++ b/app/lib/files.js
@@ -295,11 +295,9 @@ var files = module.exports = {
   // file whose basename matches one of the regexps, before
   // transformation, will be skipped.
   //
-  // Returns the list of file paths copied to the destination, as
-  // filtered by ignore and transformed by transformer_filename.  For
-  // the convenience of the caller (so as not to need to split
-  // os-specific paths), file paths are represented as an array:
-  // "foo/bar/baz.js" as ["foo", "bar", "baz.js"].
+  // Returns the list of relative file paths copied to the
+  // destination, as filtered by ignore and transformed by
+  // transformer_filename.
   cp_r: function (from, to, options) {
     options = options || {};
     files.mkdir_p(to, 0755);
@@ -315,14 +313,8 @@ var files = module.exports = {
       var full_to = path.join(to, f);
       if (fs.statSync(full_from).isDirectory()) {
         var subdir_paths = files.cp_r(full_from, full_to, options);
-        copied = copied.concat(_.map(subdir_paths, function (path) {
-          // At this point f is the name of the subdirectory that just
-          // got copied, and path is the relative path of a file inside
-          // the subdirectory.  Prepend the subdirectory name to the
-          // path: ["bar", "baz.js"] => ["foo", "bar", "baz.js"]
-          path = path.slice(0);
-          path.unshift(f);
-          return path;
+        copied = copied.concat(_.map(subdir_paths, function (subpath) {
+          return path.join(f, subpath);
         }));
       }
       else {
@@ -334,7 +326,7 @@ var files = module.exports = {
           contents = options.transform_contents(contents, f);
           fs.writeFileSync(full_to, contents);
         }
-        copied.push([f]);
+        copied.push(f);
       }
     });
     return copied;

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -88,7 +88,7 @@ var run = function () {
   var info_raw =
     fs.readFileSync(path.join(bundle_dir, 'app.json'), 'utf8');
   var info = JSON.parse(info_raw);
-  var bundler = {app_info: info, bundle_dir: bundle_dir};
+  var bundle = {manifest: info.manifest, root: bundle_dir};
 
   // start up app
 
@@ -96,7 +96,7 @@ var run = function () {
     require: require,
     startup_hooks: [],
     app: app,
-    bundler: bundler
+    bundle: bundle
   };
 
   __meteor_runtime_config__ = {};


### PR DESCRIPTION
Creates a manifest of the static files delivered to the client, for use
by the app cache.  The manifest is also designed to be usable to generate
etag's for issue #626.

In the original bundler code `self.css` and `self.js.client` starts
out as an array of os-specific file paths and later becomes an array
of URLs (including query parameters).  While I tried to minimize code
changes to avoid creating extra work for the engine project, this
turned out to be too crazy to deal with... so in this version `self.css`
and `self.js.client` stay as file paths, and _generate_app_html now
pulls the client URLs from the new manifest.

This PR is thus proposing a design where the bundler manifest becomes
the source of knowledge about client static resources included in the
bundle, and is then used to generate the app html, the app cache, and
perhaps etag's in the future.  (If it makes sense then the `load` list
of server Javascript files could also be folded into the manifest,
making the manifest the source of knowledge about all static
resources... but the code in this PR don't include any steps in that
direction).
