### PR TITLE
Make static not cacheable.

### DIFF
--- a/admin/generate-dev-bundle.sh
+++ b/admin/generate-dev-bundle.sh
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-BUNDLE_VERSION=0.2.16
+BUNDLE_VERSION=0.2.17
 UNAME=$(uname)
 ARCH=$(uname -m)
 
@@ -78,7 +78,6 @@ which npm
 
 cd "$DIR/lib/node_modules"
 npm install connect@1.9.2 # not 2.x yet. sockjs doesn't work w/ new connect
-npm install gzippo@0.1.7
 npm install optimist@0.3.5
 npm install coffee-script@1.4.0
 npm install less@1.3.3
@@ -100,6 +99,10 @@ npm install underscore@1.4.2
 npm install fstream@0.1.21
 npm install tar@0.1.14
 npm install websocket@1.0.8
+
+# allow clientMaxAge to be set to 0:
+# https://github.com/tomgco/gzippo/pull/49
+npm install https://github.com/meteor/gzippo/tarball/1e4b955439
 
 # uglify-js has a bug which drops 'undefined' in arrays:
 # https://github.com/mishoo/UglifyJS2/pull/97

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -82,7 +82,7 @@ var run = function () {
   var static_cacheable_path = path.join(bundle_dir, 'static_cacheable');
   if (fs.existsSync(static_cacheable_path))
     app.use(gzippo.staticGzip(static_cacheable_path, {clientMaxAge: 1000 * 60 * 60 * 24 * 365}));
-  app.use(gzippo.staticGzip(path.join(bundle_dir, 'static')));
+  app.use(gzippo.staticGzip(path.join(bundle_dir, 'static'), {clientMaxAge: 0}));
 
   // read bundle config file
   var info_raw =

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUNDLE_VERSION=0.2.16
+BUNDLE_VERSION=0.2.17
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.


### PR DESCRIPTION
Fixes #631.

Update the dev_bundle to use the Meteor version of gzippo which allows
clientMaxAge to be set to 0, and change server.js to set the
clientMaxAge to 0 for static.
