### PR TITLE
Upgrade useragent to 2.0.1.

### DIFF
--- a/admin/generate-dev-bundle.sh
+++ b/admin/generate-dev-bundle.sh
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-BUNDLE_VERSION=0.2.17
+BUNDLE_VERSION=0.2.18
 UNAME=$(uname)
 ARCH=$(uname -m)
 
@@ -88,7 +88,7 @@ npm install semver@1.1.0
 npm install handlebars@1.0.7
 npm install mongodb@1.1.11
 npm install clean-css@0.8.3
-npm install useragent@1.1.0
+npm install useragent@2.0.1
 npm install request@2.12.0
 npm install simplesmtp@0.1.25
 npm install stream-buffers@0.2.3

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUNDLE_VERSION=0.2.17
+BUNDLE_VERSION=0.2.18
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.


### PR DESCRIPTION
Will be using for the appcache.  I tested 2.0.1 and it seems to work
fine.  I figured that all else being equal it would be good to use the
latest version to give us the most recent user agent matches, and so
that if we had any bug reports we wouldn't be out of date.
