### PR TITLE
Route policy declarations (for network routes only for now).

### DIFF
--- a/packages/accounts-oauth-helper/oauth_server.js
+++ b/packages/accounts-oauth-helper/oauth_server.js
@@ -1,6 +1,8 @@
 (function () {
   var connect = __meteor_bootstrap__.require("connect");
 
+  Meteor._routePolicy.declare('/_oauth/', 'network');
+
   Accounts.oauth._services = {};
 
   // Register a handler for an OAuth service. The handler will be called

--- a/packages/accounts-oauth-helper/package.js
+++ b/packages/accounts-oauth-helper/package.js
@@ -5,6 +5,7 @@ Package.describe({
 
 Package.on_use(function (api) {
   api.use('accounts-base', ['client', 'server']);
+  api.use('routepolicy', 'server');
 
   api.add_files('oauth_common.js', ['client', 'server']);
   api.add_files('oauth_client.js', 'client');

--- a/packages/routepolicy/package.js
+++ b/packages/routepolicy/package.js
@@ -1,0 +1,12 @@
+Package.describe({
+  summary: "route policy declarations",
+  internal: true
+});
+
+Package.on_use(function (api) {
+  api.add_files('routepolicy.js', 'server');
+});
+
+Package.on_test(function (api) {
+  api.add_files(['routepolicy_tests.js'], 'server');
+});

--- a/packages/routepolicy/routepolicy.js
+++ b/packages/routepolicy/routepolicy.js
@@ -1,0 +1,89 @@
+(function () {
+
+  // The route policy is a singleton in a running application, but we
+  // can't unit test the real singleton because messing with the real
+  // routes would break tinytest... so allow policy instances to be
+  // constructed for testing.
+
+  Meteor.__RoutePolicyConstructor = function () {
+    var self = this;
+    self.urlPrefixTypes = {};
+  };
+
+  _.extend(Meteor.__RoutePolicyConstructor.prototype, {
+
+    urlPrefixMatches: function (urlPrefix, url) {
+      return url.substr(0, urlPrefix.length) === urlPrefix;
+    },
+
+    checkType: function (type) {
+      if (! _.contains(['network'], type))
+        return 'the route type must be "network"';
+      return null;
+    },
+
+    checkUrlPrefix: function (urlPrefix) {
+      var self = this;
+      if (urlPrefix.charAt(0) !== '/')
+        return 'a route URL prefix must begin with a slash';
+      if (urlPrefix === '/')
+        return 'a route URL prefix cannot be /';
+      if (self.urlPrefixTypes[urlPrefix] && self.urlPrefixTypes[urlPrefix] !== type)
+        return 'the route URL prefix ' + urlPrefix + ' has already been declared to be of type ' + type;
+      return null;
+    },
+
+    checkForConflictWithStatic: function (urlPrefix, type, _testManifest) {
+      var self = this;
+      var manifest = _testManifest || __meteor_bootstrap__.bundle.manifest;
+      var conflict = _.find(manifest, function (resource) {
+        return (resource.type === 'static' &&
+                resource.where === 'client' &&
+                self.urlPrefixMatches(urlPrefix, resource.url));
+      });
+      if (conflict)
+        return ('static resource ' + conflict.url + ' conflicts with ' +
+                type + ' route ' + urlPrefix);
+      else
+        return null;
+    },
+
+    declare: function (urlPrefix, type) {
+      var self = this;
+      var problem = self.checkType(type) ||
+                    self.checkUrlPrefix(urlPrefix) ||
+                    self.checkForConflictWithStatic(urlPrefix, type);
+      if (problem)
+        throw new Error(problem);
+      // TODO overlapping prefixes, e.g. /foo/ and /foo/bar/
+      self.urlPrefixTypes[urlPrefix] = type;
+    },
+
+    classify: function (url) {
+      var self = this;
+      if (url.charAt(0) !== '/')
+        throw new Error('url must be a relative URL: ' + url);
+      var prefix = _.find(_.keys(self.urlPrefixTypes), function (_prefix) {
+        return self.urlPrefixMatches(_prefix, url);
+      });
+      if (prefix)
+        return self.urlPrefixTypes[prefix];
+      else
+        return null;
+    },
+
+    urlPrefixesFor: function (type) {
+      var self = this;
+      var prefixes = [];
+      _.each(self.urlPrefixTypes, function (_type, _prefix) {
+        if (_type === type)
+          prefixes.push(_prefix);
+      });
+      return prefixes.sort();
+    }
+  });
+
+  __meteor_bootstrap__._routePolicy = Meteor._routePolicy =
+    new Meteor.__RoutePolicyConstructor();
+
+})();

--- a/packages/routepolicy/routepolicy_tests.js
+++ b/packages/routepolicy/routepolicy_tests.js
@@ -1,0 +1,39 @@
+Tinytest.add("routepolicy", function (test) {
+  var policy = new Meteor.__RoutePolicyConstructor();
+
+  policy.declare('/sockjs/', 'network');
+  // App routes might look like this...
+  // policy.declare('/posts/', 'app');
+  // policy.declare('/about', 'app');
+
+  test.equal(policy.classify('/'), null);
+  test.equal(policy.classify('/foo'), null);
+  test.equal(policy.classify('/sockjs'), null);
+
+  test.equal(policy.classify('/sockjs/'), 'network');
+  test.equal(policy.classify('/sockjs/foo'), 'network');
+
+  // test.equal(policy.classify('/posts/'), 'app');
+  // test.equal(policy.classify('/posts/1234'), 'app');
+
+  test.equal(policy.urlPrefixesFor('network'), ['/sockjs/']);
+  // test.equal(policy.urlPrefixesFor('app'), ['/about', '/posts/']);
+});
+
+Tinytest.add("routepolicy - static conflicts", function (test) {
+  var manifest = [
+    {
+      "path": "static/sockjs/socks-are-comfy.jpg",
+      "type": "static",
+      "where": "client",
+      "cacheable": false,
+      "url": "/sockjs/socks-are-comfy.jpg"
+    },
+  ];
+  var policy = new Meteor.__RoutePolicyConstructor();
+
+  test.equal(
+    policy.checkForConflictWithStatic('/sockjs/', 'network', manifest),
+    "static resource /sockjs/socks-are-comfy.jpg conflicts with network route /sockjs/"
+  );
+});

--- a/packages/stream/package.js
+++ b/packages/stream/package.js
@@ -6,6 +6,7 @@ Package.describe({
 Package.on_use(function (api) {
   api.use(['underscore', 'logging', 'uuid', 'json'], ['client', 'server']);
   api.use('reload', 'client');
+  api.use('routepolicy', 'server');
 
   api.add_files('sockjs-0.3.4.js', 'client');
 

--- a/packages/stream/stream_server.js
+++ b/packages/stream/stream_server.js
@@ -1,3 +1,5 @@
+Meteor._routePolicy.declare('/sockjs/', 'network');
+
 // unique id for this instantiation of the server. If this changes
 // between client reconnects, the client will reload. You can set the
 // environment variable "SERVER_ID" to control this. For example, if


### PR DESCRIPTION
Allows packages such as stream and accounts to declare URL prefixes
such as /sockjs/ and /_oauth/ to be network routes.

Updates server to avoid serving app HTML on network routes.

Checks for conflict between files in public/ and network routes.  For
example, the developer might not know that /sockjs/ is reserved, and
might create a file "public/sockjs/socks-are-great.png".
