### PR TITLE
Allow publish function to return an array or set of cursors

### DIFF
--- a/packages/livedata/livedata_server.js
+++ b/packages/livedata/livedata_server.js
@@ -376,8 +376,20 @@ _.extend(Meteor._LivedataSession.prototype, {
       //       reactiveThingy.publishMe();
       //     });
       //   };
-      if (res && res._publishCursor)
-        res._publishCursor(sub);
+      if (res) {
+        if (res._publishCursor) {
+          res._publishCursor(sub);
+        } else {
+          _.each(res, function(res) {
+            if (res && res._publishCursor)
+              res._publishCursor(sub);
+          });
+        }
+        // _publishCursor only returns after the initial added callbacks have run.
+        // mark subscription as completed.
+        sub.complete();
+        sub.flush();
+      }
     };
 
     sub._runHandler();

--- a/packages/mongo-livedata/mongo_driver.js
+++ b/packages/mongo-livedata/mongo_driver.js
@@ -314,11 +314,6 @@ Cursor.prototype._publishCursor = function (sub) {
     }
   });
 
-  // _observeUnordered only returns after the initial added callbacks have run.
-  // mark subscription as completed.
-  sub.complete();
-  sub.flush();
-
   // register stop callback (expects lambda w/ no args).
   sub.onStop(function () {observeHandle.stop();});
 };


### PR DESCRIPTION
Allow publish function to return an array or set of cursors to be able to publish dependent data sets, like:

```
  Meteor.publish('multi', function (num) {
    return [ Foo.find({ num: num }), Bar.find({ num: num }) ];
  });
```

or

```
  Meteor.publish('multi', function (num) {
    return {
      foo: Foo.find({ num: num }),
      bar: bar.find({ num: num })
    };
  });
```
