### PR TITLE
Preserve tag filter state on reload in "todos" example.

### DIFF
--- a/examples/todos/client/todos.js
+++ b/examples/todos/client/todos.js
@@ -4,11 +4,9 @@
 Lists = new Meteor.Collection("lists");
 Todos = new Meteor.Collection("todos");
 
-// ID of currently selected list
-Session.set('list_id', null);
+// ID of currently selected list: list_id in Session
 
-// Name of currently selected tag for filtering
-Session.set('tag_filter', null);
+// Name of currently selected tag for filtering: tag_filter in Session
 
 // When adding tag to a todo, ID of the todo
 Session.set('editing_addtag', null);
@@ -303,9 +301,12 @@ var TodosRouter = Backbone.Router.extend({
   routes: {
     ":list_id": "main"
   },
-  main: function (list_id) {
-    Session.set("list_id", list_id);
-    Session.set("tag_filter", null);
+  main: function (newListId) {
+    var oldListId = Session.get('list_id');
+    if (oldListId !== newListId) {
+      Session.set("list_id", newListId);
+      Session.set("tag_filter", null);
+    }
   },
   setList: function (list_id) {
     this.navigate(list_id, true);


### PR DESCRIPTION
When the "todos" example app reloads following a code change, the
current state of the tag filter is preserved by session
migration... but is then lost following the reload in two places: on
startup the tag filter state is unilaterally set to `null`, and is set
to `null` again when initializing the list_id.

Reproduction: open the "todos" app, select a tag filter such as "Physics", make a trivial code change, observe that the tag filter selection has been lost.

This commit avoids the unilateral initialization, and only sets the
tag filter to `null` if the selected list has changed.
