### PR TITLE
Allow static resources to be configured as online only.

### DIFF
--- a/app/server/server.js
+++ b/app/server/server.js
@@ -157,9 +157,9 @@ var appUrl = function (url) {
   if (url === '/app.manifest')
     return false;
 
-  // Avoid serving app HTML for declared network routes such as /sockjs/.
+  // Avoid serving app HTML for declared routes such as /sockjs/.
   if (__meteor_bootstrap__._routePolicy &&
-      __meteor_bootstrap__._routePolicy.classify(url) === 'network')
+      __meteor_bootstrap__._routePolicy.classify(url))
     return false;
 
   // we currently return app HTML on all URLs by default

--- a/packages/routepolicy/routepolicy_tests.js
+++ b/packages/routepolicy/routepolicy_tests.js
@@ -2,9 +2,8 @@ Tinytest.add("routepolicy", function (test) {
   var policy = new Meteor.__RoutePolicyConstructor();
 
   policy.declare('/sockjs/', 'network');
-  // App routes might look like this...
-  // policy.declare('/posts/', 'app');
-  // policy.declare('/about', 'app');
+  policy.declare('/bigphoto.jpg', 'static-online');
+  policy.declare('/anotherphoto.png', 'static-online');
 
   test.equal(policy.classify('/'), null);
   test.equal(policy.classify('/foo'), null);
@@ -13,11 +12,14 @@ Tinytest.add("routepolicy", function (test) {
   test.equal(policy.classify('/sockjs/'), 'network');
   test.equal(policy.classify('/sockjs/foo'), 'network');
 
-  // test.equal(policy.classify('/posts/'), 'app');
-  // test.equal(policy.classify('/posts/1234'), 'app');
+  test.equal(policy.classify('/bigphoto.jpg'), 'static-online');
+  test.equal(policy.classify('/bigphoto.jpg.orig'), 'static-online');
 
   test.equal(policy.urlPrefixesFor('network'), ['/sockjs/']);
-  // test.equal(policy.urlPrefixesFor('app'), ['/about', '/posts/']);
+  test.equal(
+    policy.urlPrefixesFor('static-online'),
+    ['/anotherphoto.png', '/bigphoto.jpg']
+  );
 });
 
 Tinytest.add("routepolicy - static conflicts", function (test) {
@@ -26,14 +28,24 @@ Tinytest.add("routepolicy - static conflicts", function (test) {
       "path": "static/sockjs/socks-are-comfy.jpg",
       "type": "static",
       "where": "client",
-      "cacheable": false,
       "url": "/sockjs/socks-are-comfy.jpg"
     },
+    {
+      "path": "static/bigphoto.jpg",
+      "type": "static",
+      "where": "client",
+      "url": "/bigphoto.jpg"
+    }
   ];
   var policy = new Meteor.__RoutePolicyConstructor();
 
   test.equal(
     policy.checkForConflictWithStatic('/sockjs/', 'network', manifest),
     "static resource /sockjs/socks-are-comfy.jpg conflicts with network route /sockjs/"
+  );
+
+  test.equal(
+    policy.checkForConflictWithStatic('/bigphoto.jpg', 'static-online', manifest),
+    null
   );
 });


### PR DESCRIPTION
Add a route policy type "static-online" for files in public/ that
shouldn't be cached offline.

Put "static-online" files in the manifest NETWORK section instead of
in the CACHE section.
