### PR TITLE
fixed #721

### DIFF
--- a/packages/spiderable/spiderable.js
+++ b/packages/spiderable/spiderable.js
@@ -9,18 +9,16 @@
   // not obey the _escaped_fragment_ protocol. The page is served
   // statically to any client whos user agent matches any of these
   // regexps. (possibly make this list configurable by user).
-  // Uses different caps LinkedInBot facebookexternalhit FacebookExternalHit
-  var AGENTS = [/^facebookexternalhit/, /^linkedinbot/];
+  var AGENTS = [/^facebookexternalhit/i, /^linkedinbot/i];
 
   // how long to let phantomjs run before we kill it
   var REQUEST_TIMEOUT = 15*1000;
 
   app.use(function (req, res, next) {
-    var userAgentSmallCaps = req.headers['user-agent'].toLowerCase();
 
     if (/\?.*_escaped_fragment_=/.test(req.url) ||
         _.any(AGENTS, function (re) {
-          return re.test(userAgentSmallCaps); })) {
+          return re.test(req.headers['user-agent']); })) {
 
       // reassembling url without escaped fragment if exists
       var parsedUrl = urlParser.parse(req.url);


### PR DESCRIPTION
Spiderable failed when facebook bot tried to fetch without parametres eg. `http://meteorrain.meteor.com` - Spiderable now depending on the reg.ex to catch the bot user agent.

The reg.ex failed to catch this due to a change in facebook bot header. Header going from low case to CamelCase like the `LinkedInBot`
- Fixed by making the user agent string lower case
- Added linkedin bot

_Tested in facebook and linkedin_
