### PR TITLE
Revised fix to make browser console show hyperlinks in stack traces

### DIFF
--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -37,7 +37,7 @@
 
             // arguments.join(" ") doesn't work, so use _.each instead (TypeError: Object #<Object> has no method 'join')
             var argumentString="";
-            _.each(graeme,function(element) { argumentString+=" "+element });
+            _.each(arguments,function(element) { argumentString+=" "+element });
             argumentString=argumentString.trim();
 
             console.log.apply(console,[argumentString]);


### PR DESCRIPTION
Changed according to @dgreensp recommendations at https://github.com/meteor/meteor/issues/732#issuecomment-13975991

How about this: If all the arguments are strings, then join them on " " to make a single string argument. Otherwise, leave them alone. This will fix cases like Meteor._debug("Error:", e.stack) without otherwise changing the behavior in any case that I'm aware of.
