### PR TITLE
Force source URLs to be hyperlinks in stack traces in browser consoles

### DIFF
--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -27,7 +27,24 @@
         // http://patik.com/blog/complete-cross-browser-console-log/
         if (typeof console.log.apply === "function") {
           // Most browsers
-          console.log.apply(console, arguments);
+          
+          // Chrome and Safari only hyperlink URLs to source files in arguments[0], so join arguments into single string 
+          // if all arguments are strings
+          // See https://github.com/meteor/meteor/pull/732#issuecomment-13975991
+          var allArgumentsOfTypeString=_.every(arguments,function(element) { return typeof element=="string" });
+
+          if (allArgumentsOfTypeString) {
+
+            // arguments.join(" ") doesn't work, so use _.each instead (TypeError: Object #<Object> has no method 'join')
+            var argumentString="";
+            _.each(arguments,function(element) { argumentString+=" "+element });
+            argumentString=argumentString.trim();
+
+            console.log.apply(console,[argumentString]);
+
+          } else
+            console.log.apply(console,arguments);
+            
         } else if (typeof Function.prototype.bind === "function") {
           // IE9
           var log = Function.prototype.bind.call(console.log, console);


### PR DESCRIPTION
Changed according to @dgreensp recommendations at #732

How about this: If all the arguments are strings, then join them on " " to make a single string argument. Otherwise, leave them alone. This will fix cases like Meteor._debug("Error:", e.stack) without otherwise changing the behavior in any case that I'm aware of.
