### PR TITLE
Typo fix in docs example

### DIFF
--- a/docs/client/concepts.html
+++ b/docs/client/concepts.html
@@ -164,7 +164,7 @@ case is to publish a database query.
     // server: publish all room documents
     Meteor.publish("all-rooms", function () {
       return Rooms.find(); // everything
-    );
+    });
 
     // server: publish all messages for a given room
     Meteor.publish("messages", function (roomId) {


### PR DESCRIPTION
There were mismatched braces in the all-rooms example in the docs.  One-character change.
