### PR TITLE
Fixed #721

### DIFF
--- a/packages/spiderable/spiderable.js
+++ b/packages/spiderable/spiderable.js
@@ -9,7 +9,7 @@
   // not obey the _escaped_fragment_ protocol. The page is served
   // statically to any client whos user agent matches any of these
   // regexps. (possibly make this list configurable by user).
-  var AGENTS = [/^facebookexternalhit/];
+  var AGENTS = [/^facebookexternalhit/i, /^linkedinbot/i];
 
   // how long to let phantomjs run before we kill it
   var REQUEST_TIMEOUT = 15*1000;


### PR DESCRIPTION
Testing for bots should be case insensitive - facebook bots are not all
lowercase - they adapted CamelCase on some servers. I've added the
linkedin bot just for the sake of it.

_Text from first PR:_
Spiderable failed when facebook bot tried to fetch without parametres eg. `http://meteorrain.meteor.com` - Spiderable now depending on the reg.ex to catch the bot user agent.

The reg.ex failed to catch this due to a change in facebook bot header. Header going from low case to CamelCase like the `LinkedInBot`
- Fixed by add 'i' to the reg.ex
- Added linkedinbot

_Tested in facebook and linkedin_
