### PR TITLE
support objectids as userid in password change

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -64,7 +64,7 @@
         var serialized = this._sessionData.srpChallenge;
         if (!serialized || serialized.M !== options.M)
           throw new Meteor.Error(403, "Incorrect password");
-        if (serialized.userId !== this.userId)
+        if (!EJSON.equals(serialized.userId, this.userId))
           // No monkey business!
           throw new Meteor.Error(403, "Incorrect password");
         // Only can use challenges once.


### PR DESCRIPTION
to support usage of oncreateuser like:

Accounts.onCreateUser(function(options, user) {
    user._id = new Meteor.Collection.ObjectID();
    if (options.profile)
        user.profile = options.profile;
    return user;
});
