### PR TITLE
Make eventData an empty object if no data context is found.

### DIFF
--- a/packages/spark/spark.js
+++ b/packages/spark/spark.js
@@ -801,7 +801,7 @@ Spark.attachEvents = withRenderer(function (eventMap, html, _renderer) {
           }
 
           // Found a matching handler. Call it.
-          var eventData = Spark.getDataContext(event.currentTarget);
+          var eventData = Spark.getDataContext(event.currentTarget) || {};
           var landmarkRange =
                 findParentOfType(Spark._ANNOTATION_LANDMARK, range);
           var landmark = (landmarkRange && landmarkRange.landmark);


### PR DESCRIPTION
This prevents the thisArg from getting set to `window` if eventData is
undefined.

See:
http://stackoverflow.com/questions/15137206/the-context-of-this-in-meteor-template-event-handlers-using-handlebars-for-te/15149650#15149650
