### PR TITLE
Argument convension as helpers

### DIFF
--- a/examples/other/controllers-demo/client/controllers-demo.html
+++ b/examples/other/controllers-demo/client/controllers-demo.html
@@ -14,7 +14,7 @@
     <div class="span6">
       <h2>Add something</h2>
       {{#controller MyForm}}
-        Your message: {{{ContinuouslySavingTextArea "entry"}}}<br>
+        Your message: {{{ContinuouslySavingTextArea "entry" value=entry style="color: blue;" required="required"}}}<br>
         {{{SaveButton}}}<br>
         {{charsLeft}} chars left
         <hr>
@@ -37,5 +37,7 @@
 
 
 <template name="ContinuouslySavingTextAreaView">
-  <textarea class="textbox">
+  <textarea class="textbox" style="{{style}}" {{required}}></textarea>
+  <br/>
+  Current value: {{value}}
 </template>

--- a/packages/controllers/controllers.js
+++ b/packages/controllers/controllers.js
@@ -76,7 +76,7 @@ Meteor.makeComponent = function (options) {
 
       var args = _.toArray(arguments);
       args.unshift(config.controller);
-      args.pop(); // lose extra handlebars data for now
+      config.template.helpers(args.pop().hash); // add extra handlebars data for now
       args.push(config.template);
       return Spark.attachController.apply(Spark, args);
     };


### PR DESCRIPTION
Would be nice to pass parametres like `style`, `required` and customs for making reusable widgets.
Added some to the example:

``` html
{{{ContinuouslySavingTextArea "entry" value=entry style="color: blue;" required="required"}}}
```

Widget:

``` html
<template name="ContinuouslySavingTextAreaView">
  <textarea class="textbox" style="{{style}}" {{required}}></textarea>
  <br/>
  Current value: {{value}}
</template>
```
