### PR TITLE
Fixed issue with node v0.10.0 Arguments to path.join must be strings

### DIFF
--- a/tools/server/server.js
+++ b/tools/server/server.js
@@ -173,7 +173,7 @@ var run = function () {
     // named by their hash (eg meteor bundled js and css files).
     // cache them ~forever (1yr)
     app.use(gzippo.staticGzip(static_cacheable_path,
-                              {clientMaxAge: 1000 * 60 * 60 * 24 * 365}));
+                              {clientMaxAge: 1000 * 60 * 60 * 24 * 365, root: bundle_dir}));
   // cache non-cacheable file anyway. This isn't really correct, as
   // users can change the files and changes won't propogate
   // immediately. However, if we don't cache them, browsers will
@@ -183,7 +183,7 @@ var run = function () {
   // allow users to change assets without delay.
   // https://github.com/meteor/meteor/issues/773
   app.use(gzippo.staticGzip(path.join(bundle_dir, 'static'),
-                            {clientMaxAge: 1000 * 60 * 60 * 24}));
+                            {clientMaxAge: 1000 * 60 * 60 * 24, root: bundle_dir}));
 
   // read bundle config file
   var info_raw =


### PR DESCRIPTION
Running Ubuntu 12.04. NodeJs was updated to v0.10.0 and I started getting the following error.

```
path.js:360
        throw new TypeError('Arguments to path.join must be strings');
              ^
TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at exports.join (path.js:358:36)
    at exports.send (/var/www/snakedraft/bundle/server/node_modules/connect/lib/middleware/static.js:129:20)
    at pass (/var/www/snakedraft/bundle/server/node_modules/gzippo/lib/staticGzip.js:111:4)
    at /var/www/snakedraft/bundle/server/node_modules/gzippo/lib/staticGzip.js:180:12
    at Object.oncomplete (fs.js:93:15)
```

I only got this error on Meteor apps that I bundled and deployed on my own hardware. It isn't an issue when working in the development environment. It was caused by this change to NodeJs.

> http://nodejs.org/changelog.html
> 2013.03.01 Version 0.9.11
> path: Throw TypeError on non-string args to path.resolve/join (isaacs, Arianit Uka)

Now by passing `root: bundle_dir` to `gzippo.staticGzip` the root path is now defined instead of being null allowing my bundled app to run.
