### PR TITLE
addition for subscriptions to other servers

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -456,7 +456,15 @@ sets, call `Meteor.connect` with the URL of the application.
 By default, clients open a connection to the server from which they're loaded.
 When you call `Meteor.subscribe`, `Meteor.status`, `Meteor.call`, and
 `Meteor.apply`, you are using a connection back to that default
-server.
+server. 
+
+Make sure to set your collection manager to the object returned
+from `Meteor.connect` call in order for your subscriptions to work,
+e.g: 
+```
+srv = Meteor.connect('other-server-url');
+MyCollection = new Meteor.Collection('name',{manager: srv});
+```
 
 {{#warning}}
 In this release, `Meteor.connect` can only be called on the client.


### PR DESCRIPTION
Added docs to make it clear that for remote subscriptions manager needs to be passed explicitly
