### PR TITLE
Clean up leftover comment

### DIFF
--- a/packages/minimongo/diff.js
+++ b/packages/minimongo/diff.js
@@ -5,8 +5,6 @@
 //    if unordered, they are maps {_id: doc}.
 // observer: object with 'added', 'changed', 'removed',
 //           and (if ordered) 'moved' functions (each optional)
-// deepcopy: if true, elements of new_results that are passed
-//           to callbacks are deepcopied first.
 LocalCollection._diffQueryChanges = function (ordered, oldResults, newResults,
                                        observer) {
   if (ordered)


### PR DESCRIPTION
`deepcopy` argument was removed in 4b9d41e1a199d896bf9b7ee2d92fd5fc1ce74a03
