### PR TITLE
Don't watch public directory for changes. See #894

### DIFF
--- a/app/lib/bundler.js
+++ b/app/lib/bundler.js
@@ -49,7 +49,8 @@ var ignore_files = [
     /~$/, /^\.#/, /^#.*#$/,
     /^\.DS_Store$/, /^ehthumbs\.db$/, /^Icon.$/, /^Thumbs\.db$/,
     /^\.meteor$/, /* avoids scanning N^2 files when bundling all packages */
-    /^\.git$/ /* often has too many files to watch */
+    /^\.git$/, /* often has too many files to watch */
+    /^public$/ /* so that public files can be changed without restarting the server */
 ];
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I made a simple change to not watch public directory for changes. I do not see a reason why it should be watched, but it prevents server restarting when new files are added to public directory. See #894 for more details.
