### PR TITLE
#899 handlebars block helper multiple args fix

### DIFF
--- a/packages/handlebars/evaluate.js
+++ b/packages/handlebars/evaluate.js
@@ -243,11 +243,12 @@ Handlebars.evaluate = function (ast, data, options) {
       // at least one positional argument; not no args
       // or only hash args.
       var oneArg = values[1];
-      if (typeof oneArg === "function")
+      if (typeof oneArg === "function") {
         // invoke the positional arguments
         // (and hash arguments) as a nested helper invocation.
         oneArg = apply(values.slice(1), {hash:hash});
-      values = [values[0], oneArg];
+        values = [values[0], oneArg];
+      }
       // keyword args don't go to the block helper, then.
       extra.hash = {};
     } else {


### PR DESCRIPTION
Before the fix the second select did not work. After the fix both selects are populated with identical options.

``` javascript
Handlebars.registerHelper('range', function(from, to) {
    var accum = [];
    for(var i = from; i < to; i++)
        accum.push(i);
    return accum;
});

Handlebars.registerHelper('for', function(from, to, block) {
    var accum = '';
    for(var i = from; i < to; i++)
        accum += block.fn(i);
    return accum;
});
```

``` html
<select name="year">
    {{#each range 1920 2013}}
        <option>{{this}}</option>
    {{/each}}
</select>

<select name="year">
    {{#for 1920 2013}}
        <option>{{this}}</option>
    {{/each}}
</select>
```
