### PR TITLE
Fix routepolicy checkUrlPrefix

### DIFF
--- a/packages/routepolicy/routepolicy.js
+++ b/packages/routepolicy/routepolicy.js
@@ -42,14 +42,19 @@ _.extend(Meteor.__RoutePolicyConstructor.prototype, {
     return null;
   },
 
-  checkUrlPrefix: function (urlPrefix) {
+  checkUrlPrefix: function (urlPrefix, type) {
     var self = this;
+
     if (urlPrefix.charAt(0) !== '/')
       return 'a route URL prefix must begin with a slash';
+
     if (urlPrefix === '/')
       return 'a route URL prefix cannot be /';
-    if (self.urlPrefixTypes[urlPrefix] && self.urlPrefixTypes[urlPrefix] !== type)
-      return 'the route URL prefix ' + urlPrefix + ' has already been declared to be of type ' + type;
+
+    var existingType = self.urlPrefixTypes[urlPrefix];
+    if (existingType && existingType !== type)
+      return 'the route URL prefix ' + urlPrefix + ' has already been declared to be of type ' + existingType;
+
     return null;
   },
 
@@ -73,7 +78,7 @@ _.extend(Meteor.__RoutePolicyConstructor.prototype, {
   declare: function (urlPrefix, type) {
     var self = this;
     var problem = self.checkType(type) ||
-                  self.checkUrlPrefix(urlPrefix) ||
+                  self.checkUrlPrefix(urlPrefix, type) ||
                   self.checkForConflictWithStatic(urlPrefix, type);
     if (problem)
       throw new Error(problem);

--- a/packages/routepolicy/routepolicy_tests.js
+++ b/packages/routepolicy/routepolicy_tests.js
@@ -1,4 +1,4 @@
-Tinytest.add("routepolicy", function (test) {
+Tinytest.add("routepolicy - declare", function (test) {
   var policy = new Meteor.__RoutePolicyConstructor();
 
   policy.declare('/sockjs/', 'network');
@@ -47,5 +47,25 @@ Tinytest.add("routepolicy - static conflicts", function (test) {
   test.equal(
     policy.checkForConflictWithStatic('/bigphoto.jpg', 'static-online', manifest),
     null
+  );
+});
+
+Tinytest.add("routepolicy - checkUrlPrefix", function (test) {
+  var policy = new Meteor.__RoutePolicyConstructor();
+  policy.declare('/sockjs/', 'network');
+
+  test.equal(
+    policy.checkUrlPrefix('foo/bar', 'network'),
+    "a route URL prefix must begin with a slash"
+  );
+
+  test.equal(
+    policy.checkUrlPrefix('/', 'network'),
+    "a route URL prefix cannot be /"
+  );
+
+  test.equal(
+    policy.checkUrlPrefix('/sockjs/', 'static-online'),
+    "the route URL prefix /sockjs/ has already been declared to be of type network"
   );
 });


### PR DESCRIPTION
Forgot to pass in `type` to checkUrlPrefix.

Found because I was checking out the linker and happened to be looking
at the linker output for this package and I was thinking, "um, why is `type` 
being declared as a package-scope variable?"  :-)

Added checkUrlPrefix unit test.
