### PR TITLE
Prevent npm install from picking up existing node_modules dirs

### DIFF
--- a/tools/meteor_npm.js
+++ b/tools/meteor_npm.js
@@ -84,6 +84,10 @@ _.extend(exports, {
     self._tmpDirs.push(newPackageNpmDir); // keep track so that we can remove them on process exit
     fs.mkdirSync(newPackageNpmDir);
 
+    // create node_modules -- prevent npm install from installing
+    // to an existing node_modules dir higher up in the filesystem
+    fs.mkdirSync(path.join(newPackageNpmDir,'node_modules'));
+
     // create .gitignore -- node_modules shouldn't be in git since we
     // recreate it as needed by using `npm install`. since we use `npm
     // shrinkwrap` we're guaranteed to have the same version installed


### PR DESCRIPTION
Currently meteor bundle will break if there exists a node_modules folder anywhere in a folder above the app dir.

This is due to the fact that if npm sees an existing node_modules folder in the current directory OR higher up in the folder tree, it will choose to install into it. (See https://npmjs.org/doc/folders.html under "More Information").

This fix creates a node_modules directly after creating the .npm folder so that npm install will work as expected.
