### PR TITLE
Allow CoffeeScript to set global vars when using "use strict".

### DIFF
--- a/packages/coffeescript/coffeescript_strict_tests.coffee
+++ b/packages/coffeescript/coffeescript_strict_tests.coffee
@@ -1,0 +1,3 @@
+'use strict'
+
+@__COFFEESCRIPT_TEST_GLOBAL2 = 456

--- a/packages/coffeescript/coffeescript_tests.js
+++ b/packages/coffeescript/coffeescript_tests.js
@@ -7,3 +7,6 @@ Tinytest.add("literate coffeescript - presence", function(test) {
 Tinytest.add("coffeescript - set global variable", function(test) {
   test.equal(__COFFEESCRIPT_TEST_GLOBAL, 123);
 });
+Tinytest.add("coffeescript - set global variable with 'use strict'", function(test) {
+  test.equal(__COFFEESCRIPT_TEST_GLOBAL2, 456);
+});

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -31,6 +31,10 @@ Package.register_extension("coffee", coffeescript_handler);
 Package.register_extension("litcoffee", coffeescript_handler);
 
 Package.on_test(function (api) {
-  api.add_files(['coffeescript_tests.coffee', 'litcoffeescript_tests.litcoffee', 'coffeescript_tests.js'],
-                ['client', 'server']);
+  api.add_files([
+    'coffeescript_tests.coffee',
+    'coffeescript_strict_tests.coffee',
+    'litcoffeescript_tests.litcoffee',
+    'coffeescript_tests.js'
+  ], ['client', 'server']);
 });

--- a/tools/bundler.js
+++ b/tools/bundler.js
@@ -336,11 +336,16 @@ var Bundle = function () {
             // On the client, wrap each file in a closure, to give it a separate
             // scope (eg, file-level vars are file-scoped). On the server, this
             // is done in server/server.js to inject the Npm symbol.
+            //
+            // The ".call(this)" allows you to do a top-level "this.foo = "
+            // to define global variables when using "use strict"
+            // (http://es5.github.io/#x15.3.4.4); this is the only way to do
+            // it in CoffeeScript.
             if (w === "client") {
               wrapped = Buffer.concat([
                 new Buffer("(function(){ "),
                 data,
-                new Buffer("\n})();\n")]);
+                new Buffer("\n}).call(this);\n")]);
             }
             self.files[w][options.path] = wrapped;
             self.js[w].push(options.path);

--- a/tools/server/server.js
+++ b/tools/server/server.js
@@ -279,7 +279,11 @@ var run = function () {
       // error message on parse error. it's what require() uses to
       // generate its errors.
       var func = require('vm').runInThisContext(wrapped, filename, true);
-      func(Npm);
+      // Setting `this` to `global` allows you to do a top-level
+      // "this.foo = " to define global variables when using "use strict"
+      // (http://es5.github.io/#x15.3.4.4); this is the only way to do
+      // it in CoffeeScript.
+      func.call(global, Npm);
     });
 
 


### PR DESCRIPTION
Ha.  Turns out that `.call(this)` is needed after all when a
CoffeeScript file is using "use strict".
(http://es5.github.io/#x15.3.4.4)

Thanks to pipedreambomb on stackoverflow for the bug report and to
user1737909 for the documentation reference.
