### PR TITLE
Bump CoffeeScript version to 1.6.2.

### DIFF
--- a/packages/coffeescript/.npm/npm-shrinkwrap.json
+++ b/packages/coffeescript/.npm/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "coffee-script": {
-      "version": "1.5.0",
-      "from": "coffee-script@1.5.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.5.0.tgz"
+      "version": "1.6.2",
+      "from": "coffee-script@1.6.2",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.2.tgz"
     }
   }
 }

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -2,7 +2,7 @@ Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons"
 });
 
-Npm.depends({"coffee-script": "1.5.0"});
+Npm.depends({"coffee-script": "1.6.2"});
 
 var coffeescript_handler = function(bundle, source_path, serve_path, where) {
   var fs = Npm.require('fs');


### PR DESCRIPTION
Fixes a bug in multiline string interpolation.
