### PR TITLE
Added experimental `getEnclosingTemplate` routine

### DIFF
--- a/packages/templating/deftemplate.js
+++ b/packages/templating/deftemplate.js
@@ -101,6 +101,12 @@ Meteor._template_decl_methods = {
   }
 };
 
+// XXX this is experimental; child nodes may
+// get template instances of their parents
+Meteor._getEnclosingTemplate = function (node) {
+  return templateObjFromLandmark(Spark._getEnclosingLandmark(node));
+};
+
 Meteor._def_template = function (name, raw_func) {
   Meteor._hook_handlebars();
 


### PR DESCRIPTION
Currently, I can find no other way to get access to the parent template data from the context of a child template. This proves to be quite useful in situations where the DOM structure is interfering with the application logic.
