### PR TITLE
Fix exception when liverange node is removed from parentNode

### DIFF
--- a/packages/liverange/liverange.js
+++ b/packages/liverange/liverange.js
@@ -643,7 +643,7 @@ LiveRange.findRange = function(tag, node) {
   if (result)
     return result;
 
-  if (! node.parentNode)
+  if (! (node && node.parentNode))
     return null;
 
   return LiveRange.findRange(tag, node.parentNode);
@@ -658,6 +658,9 @@ var enclosingRangeSearch = function(tag, end, endIndex) {
 
   if (typeof endIndex === "undefined")
     endIndex = -1;
+
+  if (! end)
+    return null;
 
   if (end[tag] && endIndex + 1 < end[tag][1].length) {
     // immediately enclosing range ends at same node as this one

--- a/packages/liverange/liverange_tests.js
+++ b/packages/liverange/liverange_tests.js
@@ -567,6 +567,18 @@ Tinytest.add("liverange - findParent", function(test) {
 
 });
 
+Tinytest.add("liverange - findParent: node removed", function(test) {
+  var str = "I[A*a]i*";
+  var pat = makeTestPattern(str);
+  test.equal(pat.currentString(), str);
+
+  var ranges = pat.ranges;
+
+  ranges.A._end.parentNode.removeChild(ranges.A._end);
+
+  test.equal(ranges.A.findParent() && 'found parent',null);
+});
+
 Tinytest.add("liverange - destroy", function(test) {
   var str = "I*[[AB[H***FDE*ed*fG*gh]*baC*c*]]J*ji*";
   var pat = makeTestPattern(str);


### PR DESCRIPTION
Particularly when running tests but also in production code
Deps.flush() will cause a stack trace to be logged to the console
because the _end tag's parent no longer exists.

This patch makes findRange and enclosingRangeSearch check that the
parentNode exists and if not return null.
