### PR TITLE
Clearer error message when calling Meteor.Collection without "new".

### DIFF
--- a/packages/mongo-livedata/collection.js
+++ b/packages/mongo-livedata/collection.js
@@ -3,6 +3,8 @@
 
 Meteor.Collection = function (name, options) {
   var self = this;
+  if (! (self instanceof Meteor.Collection))
+    throw new Error('use "new" to construct a Meteor.Collection');
   if (options && options.methods) {
     // Backwards compatibility hack with original signature (which passed
     // "manager" directly instead of in options. (Managers must have a "methods"

--- a/packages/mongo-livedata/collection_tests.js
+++ b/packages/mongo-livedata/collection_tests.js
@@ -1,0 +1,11 @@
+Tinytest.add(
+  'collection - call Meteor.Collection without new',
+  function (test) {
+    test.throws(
+      function () {
+        Meteor.Collection(null);
+      },
+      /use "new" to construct a Meteor\.Collection/
+    );
+  }
+);

--- a/packages/mongo-livedata/package.js
+++ b/packages/mongo-livedata/package.js
@@ -28,8 +28,11 @@ Package.on_test(function (api) {
   api.use('mongo-livedata');
   api.use('tinytest');
   api.use('test-helpers');
+  // XXX test order dependency: the allow_tests "partial allow" test
+  // fails if it is run before mongo_livedata_tests.
   api.add_files('mongo_livedata_tests.js', ['client', 'server']);
   api.add_files('allow_tests.js', ['client', 'server']);
+  api.add_files('collection_tests.js', ['client', 'server']);
   api.add_files('observe_changes_tests.js', ['client', 'server']);
 });
 


### PR DESCRIPTION
Fixes #457.

Add an optional "expected" predicate to Tinytest's throws.
