### PR TITLE
Document reconnect behavior with unnamed publish sets.

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -164,8 +164,7 @@ If you publish an attribute set with no name (the first argument to
 (which publishes unnamed sets for all collections), then if the client
 loses its connection and reconnects the subscription's collections will
 be refreshed: the documents in the collection will be removed and
-re-added.  This will cause templates to be rerendered but will not
-affect the final result.
+re-added.
 {{/warning}}
 
 {{> api_box subscription_userId}}


### PR DESCRIPTION
Fixes #955.
