### PR TITLE
`check` with predicate functions.

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -2291,7 +2291,7 @@ values are of the expected type. For example:
       check(roomId, String);
       check(message, {
         text: String,
-        timestamp: Date,
+        timestamp: Match.Is(Date),
         // Optional, but if present must be an array of strings.
         tags: Match.Optional([String])
       });
@@ -2353,22 +2353,24 @@ Matches either `undefined` or something that matches *pattern*.
 Matches any value that matches at least one of the provided patterns.
 {{/dtdd}}
 
-{{#dtdd "Any constructor function (eg, <code>Date</code>)"}}
-Matches any element that is an instance of that type.
+{{#dtdd "<code>Match.Is(<em>constructor</em>)</code>"}}
+Matches any element that is an instance of the constructor.
 {{/dtdd}}
 
-{{#dtdd "<code>Match.Where(<em>condition</em>)</code>"}}
-Calls the function *condition* with the value as the argument. If *condition*
-returns true, this matches. If *condition* throws a `Match.Error` or returns
-false, this fails. If *condition* throws any other error, that error is thrown
-from the call to `check` or `Match.test`. Examples:
+{{#dtdd "<code><em>predicate</em></code> (any function)"}}
+Calls the predicate function with the value as the argument, and
+matches if the function returns true and fails otherwise.  The
+function can also cause the match to fail with a more descriptive
+error message by throwing `Match.Error`. If the function throws any
+other error, that error is thrown from the call to `check` or
+`Match.test`. Examples:
 
-    check(buffer, Match.Where(EJSON.isBinary));
+    check(buffer, EJSON.isBinary);
 
-    NonEmptyString = Match.Where(function (x) {
+    NonEmptyString = function (x) {
       check(x, String);
       return x.length > 0;
-    }
+    };
     check(arg, NonEmptyString);
 {{/dtdd}}
 </dl>

--- a/examples/parties/model.js
+++ b/examples/parties/model.js
@@ -42,15 +42,15 @@ attending = function (party) {
   return (_.groupBy(party.rsvps, 'rsvp').yes || []).length;
 };
 
-var NonEmptyString = Match.Where(function (x) {
+var NonEmptyString = function (x) {
   check(x, String);
   return x.length !== 0;
-});
+};
 
-var Coordinate = Match.Where(function (x) {
+var Coordinate = function (x) {
   check(x, Number);
   return x >= 0 && x <= 1;
-});
+};
 
 Meteor.methods({
   // options should include: title, description, x, y, public

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -16,7 +16,7 @@ var selectorFromUserQuery = function (user) {
   throw new Error("shouldn't happen (validation missed something)");
 };
 
-var userQueryValidator = Match.Where(function (user) {
+var userQueryValidator = function (user) {
   check(user, {
     id: Match.Optional(String),
     username: Match.Optional(String),
@@ -25,7 +25,7 @@ var userQueryValidator = Match.Where(function (user) {
   if (_.keys(user).length !== 1)
     throw new Match.Error("User property must have exactly one field");
   return true;
-});
+};
 
 // Step 1 of SRP password exchange. This puts an `M` value in the
 // session data for this connection. If a client later sends the same

--- a/packages/check/match_test.js
+++ b/packages/check/match_test.js
@@ -41,40 +41,44 @@ Tinytest.add("check - check", function (test) {
         matches(pair[0], type);
         matches(pair[0], Match.Optional(type));
         matches(undefined, Match.Optional(type));
-        matches(pair[0], Match.Where(function () {
+        matches(pair[0], function () {
           check(pair[0], type);
           return true;
-        }));
-        matches(pair[0], Match.Where(function () {
+        });
+        matches(pair[0], function () {
           try {
             check(pair[0], type);
             return true;
           } catch (e) {
             return false;
           }
-        }));
+        });
       } else {
         fails(pair[0], type);
         matches(pair[0], Match.OneOf(type, pair[1]));
         matches(pair[0], Match.OneOf(pair[1], type));
-        fails(pair[0], Match.Where(function () {
+        fails(pair[0], function () {
           check(pair[0], type);
           return true;
-        }));
-        fails(pair[0], Match.Where(function () {
+        });
+        fails(pair[0], function () {
           try {
             check(pair[0], type);
             return true;
           } catch (e) {
             return false;
           }
-        }));
+        });
       }
       fails(pair[0], [type]);
       fails(pair[0], Object);
     });
   });
   fails(true, Match.OneOf(String, Number, undefined, null, [Boolean]));
+
+  fails(new String("foo"), String);
+  fails(new Boolean(true), Boolean);
+  fails(new Number(123), Number);
 
   matches([1, 2, 3], [Number]);
   matches([], [Number]);
@@ -99,15 +103,15 @@ Tinytest.add("check - check", function (test) {
   // objects.
   fails({a: undefined}, {a: Match.Optional(Number)});
 
-  matches(/foo/, RegExp);
+  matches(/foo/, Match.Is(RegExp));
   fails(/foo/, String);
-  matches(new Date, Date);
+  matches(new Date, Match.Is(Date));
   fails(new Date, Number);
-  matches(EJSON.newBinary(42), Match.Where(EJSON.isBinary));
-  fails([], Match.Where(EJSON.isBinary));
+  matches(EJSON.newBinary(42), EJSON.isBinary);
+  fails([], EJSON.isBinary);
 
-  matches(42, Match.Where(function (x) { return x % 2 === 0; }));
-  fails(43, Match.Where(function (x) { return x % 2 === 0; }));
+  matches(42, function (x) { return x % 2 === 0; });
+  fails(43, function (x) { return x % 2 === 0; });
 
   matches({
     a: "something",


### PR DESCRIPTION
Gives the function pattern slot to predicate functions, replacing
`Match.Where`; and replaces the constructor pattern (which was in the
function slot) by `Match.Is`.
