### PR TITLE
Add preLogin and postLogin Hooks to Accounts package accounts-base accounts_server.js

### DIFF
--- a/packages/email/.npm/npm-shrinkwrap.json
+++ b/packages/email/.npm/npm-shrinkwrap.json
@@ -1,24 +1,14 @@
 {
   "dependencies": {
-    "mailcomposer": {
-      "version": "0.1.15",
-      "from": "mailcomposer@0.1.15",
-      "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.1.15.tgz",
-      "dependencies": {
-        "mimelib-noiconv": {
-          "version": "0.1.9",
-          "from": "mimelib-noiconv@0.1.9"
-        }
-      }
-    },
     "simplesmtp": {
       "version": "0.1.25",
-      "from": "simplesmtp@0.1.25",
+      "from": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.1.25.tgz",
       "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.1.25.tgz",
       "dependencies": {
         "rai": {
           "version": "0.1.7",
-          "from": "rai@0.1.7"
+          "from": "rai@0.1.7",
+          "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.7.tgz"
         },
         "xoauth2": {
           "version": "0.1.6",
@@ -29,7 +19,20 @@
     },
     "stream-buffers": {
       "version": "0.2.3",
-      "from": "stream-buffers@0.2.3"
+      "from": "stream-buffers@0.2.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.3.tgz"
+    },
+    "mailcomposer": {
+      "version": "0.1.15",
+      "from": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.1.15.tgz",
+      "dependencies": {
+        "mimelib-noiconv": {
+          "version": "0.1.9",
+          "from": "mimelib-noiconv@0.1.9",
+          "resolved": "https://registry.npmjs.org/mimelib-noiconv/-/mimelib-noiconv-0.1.9.tgz"
+        }
+      }
     }
   }
 }

--- a/packages/livedata/.npm/npm-shrinkwrap.json
+++ b/packages/livedata/.npm/npm-shrinkwrap.json
@@ -1,23 +1,25 @@
 {
   "dependencies": {
+    "websocket": {
+      "version": "1.0.7",
+      "from": "https://registry.npmjs.org/websocket/-/websocket-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.7.tgz"
+    },
     "sockjs": {
       "version": "0.3.4",
       "from": "sockjs@0.3.4",
       "dependencies": {
         "node-uuid": {
           "version": "1.3.3",
-          "from": "node-uuid@1.3.3"
+          "from": "node-uuid@1.3.3",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.3.3.tgz"
         },
         "faye-websocket": {
           "version": "0.4.0",
-          "from": "faye-websocket@0.4.0"
+          "from": "faye-websocket@0.4.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.0.tgz"
         }
       }
-    },
-    "websocket": {
-      "version": "1.0.7",
-      "from": "https://registry.npmjs.org/websocket/-/websocket-1.0.7.tgz",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.7.tgz"
     }
   }
 }

--- a/packages/mongo-livedata/.npm/npm-shrinkwrap.json
+++ b/packages/mongo-livedata/.npm/npm-shrinkwrap.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "mongodb": {
       "version": "1.2.13",
-      "from": "mongodb@1.2.13",
+      "from": "https://registry.npmjs.org/mongodb/-/mongodb-1.2.13.tgz",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.2.13.tgz",
       "dependencies": {
         "bson": {


### PR DESCRIPTION
Add preLogin and postLogin Hooks to Accounts package accounts-base accounts_server.js

Exposes a preLogin and postLogin Accounts package hook server side.

```
Accounts.preLogin(function(options){})
```

and

```
Accounts.postLogin(function(result){})
```

[Test App GIT](https://github.com/stephentcannon/meteor_prepostlogintest)
