### PR TITLE
`check` with predicate functions, introducing declareConstructor.

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -2322,6 +2322,19 @@ Matches any value.
 Matches a primitive of the given type.
 {{/dtdd}}
 
+{{#dtdd "<em>constructor</em> (<code>Date</code>, <code>Error</code>, <code>Function</code>, <code>Regexp</code>)"}}
+Matches any value that is an instance of the given
+<em>constructor</em>, where the constructor is known to Meteor.
+
+Use [`Meteor.declareConstructor`](#constructors) to make a constructor
+known to Meteor, or use `Match.InstanceOf` to match against any
+constructor.
+{{/dtdd}}
+
+{{#dtdd "<code>Match.InstanceOf(<em>constructor</em>)</code>"}}
+Matches any value that is an instance of the specified constructor.
+{{/dtdd}}
+
 {{#dtdd "<code>[<em>pattern</em>]</code>"}}
 A one-element array matches an array of elements, each of which match
 *pattern*. For example, `[Number]` matches a (possibly empty) array of numbers;
@@ -2353,25 +2366,60 @@ Matches either `undefined` or something that matches *pattern*.
 Matches any value that matches at least one of the provided patterns.
 {{/dtdd}}
 
-{{#dtdd "Any constructor function (eg, <code>Date</code>)"}}
-Matches any element that is an instance of that type.
-{{/dtdd}}
+{{#dtdd "<code><em>predicate</em></code> (any function)"}}
+Calls the predicate function with the value as the argument, and
+matches if the function returns a boolean `true`.  The function can
+also cause the match to fail with a more descriptive error message by
+throwing `Match.Error`. If the function throws any other error, that
+error is thrown from the call to `check` or `Match.test`.  Examples:
 
-{{#dtdd "<code>Match.Where(<em>condition</em>)</code>"}}
-Calls the function *condition* with the value as the argument. If *condition*
-returns true, this matches. If *condition* throws a `Match.Error` or returns
-false, this fails. If *condition* throws any other error, that error is thrown
-from the call to `check` or `Match.test`. Examples:
+    check(buffer, EJSON.isBinary);
 
-    check(buffer, Match.Where(EJSON.isBinary));
-
-    NonEmptyString = Match.Where(function (x) {
+    NonEmptyString = function (x) {
       check(x, String);
       return x.length > 0;
-    }
+    };
     check(arg, NonEmptyString);
 {{/dtdd}}
 </dl>
+
+{{/api_box_inline}}
+
+{{#api_box_inline constructors}}
+
+A constructor function can be declared to so that it is recognized as
+a constructor by Meteor.
+
+{{#note}}
+
+In JavaScript, a "constructor" is simply a function called with `new`,
+and so there is no general mechanism to detect whether a function is
+intended to be used as a constructor or not.  Future releases may
+improve the ability to easily annotate a constructor.
+
+{{/note}}
+
+<dl>
+{{#dtdd "<code>Meteor.declareConstructor(<em>constructor</em>)</code>"}}
+Makes *constructor* known as a constructor to Meteor.  For example:
+
+    function Point(x, y) {
+      this.x = x;
+      this.y = y;
+    };
+    Meteor.declareConstructor(Point);
+
+    p = new Point(13, 180);
+    check(p, Point);
+
+{{/dtdd}}
+
+{{#dtdd "<code>Meteor.isConstructor(<em>value</em>)</code>"}}
+Returns `true` if *value* is known to be a constructor.
+{{/dtdd}}
+
+</dl>
+
 
 {{/api_box_inline}}
 

--- a/docs/client/api.js
+++ b/docs/client/api.js
@@ -1400,6 +1400,11 @@ Template.api.matchpatterns = {
   name: "Match patterns"
 };
 
+Template.api.constructors = {
+  id: "constructors",
+  name: "Constructors"
+};
+
 Template.api.setTimeout = {
   id: "meteor_settimeout",
   name: "Meteor.setTimeout(func, delay)",

--- a/examples/parties/model.js
+++ b/examples/parties/model.js
@@ -42,15 +42,15 @@ attending = function (party) {
   return (_.groupBy(party.rsvps, 'rsvp').yes || []).length;
 };
 
-var NonEmptyString = Match.Where(function (x) {
+var NonEmptyString = function (x) {
   check(x, String);
   return x.length !== 0;
-});
+};
 
-var Coordinate = Match.Where(function (x) {
+var Coordinate = function (x) {
   check(x, Number);
   return x >= 0 && x <= 1;
-});
+};
 
 Meteor.methods({
   // options should include: title, description, x, y, public

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -16,7 +16,7 @@ var selectorFromUserQuery = function (user) {
   throw new Error("shouldn't happen (validation missed something)");
 };
 
-var userQueryValidator = Match.Where(function (user) {
+var userQueryValidator = function (user) {
   check(user, {
     id: Match.Optional(String),
     username: Match.Optional(String),
@@ -25,7 +25,7 @@ var userQueryValidator = Match.Where(function (user) {
   if (_.keys(user).length !== 1)
     throw new Match.Error("User property must have exactly one field");
   return true;
-});
+};
 
 // Step 1 of SRP password exchange. This puts an `M` value in the
 // session data for this connection. If a client later sends the same

--- a/packages/check/constructor_tests.js
+++ b/packages/check/constructor_tests.js
@@ -1,0 +1,3 @@
+Tinytest.add("constructor - isConstructor", function (test) {
+  test.isTrue(Meteor.isConstructor(RegExp));
+});

--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -22,13 +22,12 @@ Match = {
     return new OneOf(_.toArray(arguments));
   },
   Any: ['__any__'],
-  Where: function (condition) {
-    return new Where(condition);
-  },
   ObjectIncluding: function (pattern) {
     return new ObjectIncluding(pattern);
   },
-
+  InstanceOf: function (constructor) {
+    return new InstanceOf(constructor);
+  },
   // XXX should we record the path down the tree in the error message?
   // XXX matchers should know how to describe themselves for errors
   Error: Meteor.makeErrorType("Match.Error", function (msg) {
@@ -67,7 +66,7 @@ Match = {
     // If f didn't itself throw, make sure it checked all of its arguments.
     argChecker.throwUnlessAllArgumentsHaveBeenChecked();
     return result;
-  }
+  },
 };
 
 var Optional = function (pattern) {
@@ -80,12 +79,12 @@ var OneOf = function (choices) {
   this.choices = choices;
 };
 
-var Where = function (condition) {
-  this.condition = condition;
-};
-
 var ObjectIncluding = function (pattern) {
   this.pattern = pattern;
+};
+
+var InstanceOf = function (constructor) {
+  this._constructor = constructor;
 };
 
 var typeofChecks = [
@@ -103,8 +102,7 @@ var checkSubtree = function (value, pattern) {
     return;
 
   // Basic atomic types.
-  // XXX do we have to worry about if value is boxed (eg String)? will that
-  //     happen?
+  // Do not match boxed objects (e.g. String)
   for (var i = 0; i < typeofChecks.length; ++i) {
     if (pattern === typeofChecks[i][0]) {
       if (typeof value === typeofChecks[i][1])
@@ -138,16 +136,6 @@ var checkSubtree = function (value, pattern) {
     return;
   }
 
-  // Arbitrary validation checks. The condition can return false or throw a
-  // Match.Error (ie, it can internally use check()) to fail.
-  if (pattern instanceof Where) {
-    if (pattern.condition(value))
-      return;
-    // XXX this error is terrible
-    throw new Match.Error("Failed Match.Where validation");
-  }
-
-
   if (pattern instanceof Optional)
     pattern = Match.OneOf(undefined, pattern.pattern);
 
@@ -168,13 +156,37 @@ var checkSubtree = function (value, pattern) {
     throw new Match.Error("Failed Match.OneOf validation");
   }
 
-  // A function that isn't something we special-case is assumed to be a
-  // constructor.
-  if (pattern instanceof Function) {
-    if (value instanceof pattern)
+  if (pattern instanceof InstanceOf) {
+    if (value instanceof pattern._constructor)
       return;
-    // XXX what if .name isn't defined
-    throw new Match.Error("Expected " + pattern.name);
+    throw new Match.Error(
+      "Expected " +
+      (pattern.name ? pattern.name : "instance of constructor")
+    );
+  }
+
+  if (typeof pattern === 'function') {
+    if (Meteor.isConstructor(pattern)) {
+      if (value instanceof pattern)
+        return;
+      throw new Match.Error(
+        "Expected " +
+        (pattern.name ? pattern.name : "instance of constructor")
+      );
+    }    
+    else {
+      var result = pattern(value);
+      if (result && result !== true)
+        throw new Error(
+          'predicate functions must return true to match; for a constructor use Match.InstanceOf'
+        );
+      if (result)
+        return;
+      throw new Match.Error(
+        "Expected " +
+        (pattern.name ? pattern.name : 'to pass predicate test')
+      );
+    }
   }
 
   var unknownKeysAllowed = false;

--- a/packages/check/match_test.js
+++ b/packages/check/match_test.js
@@ -41,40 +41,44 @@ Tinytest.add("check - check", function (test) {
         matches(pair[0], type);
         matches(pair[0], Match.Optional(type));
         matches(undefined, Match.Optional(type));
-        matches(pair[0], Match.Where(function () {
+        matches(pair[0], function () {
           check(pair[0], type);
           return true;
-        }));
-        matches(pair[0], Match.Where(function () {
+        });
+        matches(pair[0], function () {
           try {
             check(pair[0], type);
             return true;
           } catch (e) {
             return false;
           }
-        }));
+        });
       } else {
         fails(pair[0], type);
         matches(pair[0], Match.OneOf(type, pair[1]));
         matches(pair[0], Match.OneOf(pair[1], type));
-        fails(pair[0], Match.Where(function () {
+        fails(pair[0], function () {
           check(pair[0], type);
           return true;
-        }));
-        fails(pair[0], Match.Where(function () {
+        });
+        fails(pair[0], function () {
           try {
             check(pair[0], type);
             return true;
           } catch (e) {
             return false;
           }
-        }));
+        });
       }
       fails(pair[0], [type]);
       fails(pair[0], Object);
     });
   });
   fails(true, Match.OneOf(String, Number, undefined, null, [Boolean]));
+
+  fails(new String("foo"), String);
+  fails(new Boolean(true), Boolean);
+  fails(new Number(123), Number);
 
   matches([1, 2, 3], [Number]);
   matches([], [Number]);
@@ -102,12 +106,15 @@ Tinytest.add("check - check", function (test) {
   matches(/foo/, RegExp);
   fails(/foo/, String);
   matches(new Date, Date);
+  matches(new Date, Match.InstanceOf(Date));
+  fails(123, Match.InstanceOf(Date));
+  matches(function () {}, Function);
   fails(new Date, Number);
-  matches(EJSON.newBinary(42), Match.Where(EJSON.isBinary));
-  fails([], Match.Where(EJSON.isBinary));
+  matches(EJSON.newBinary(42), EJSON.isBinary);
+  fails([], EJSON.isBinary);
 
-  matches(42, Match.Where(function (x) { return x % 2 === 0; }));
-  fails(43, Match.Where(function (x) { return x % 2 === 0; }));
+  matches(42, function (x) { return x % 2 === 0; });
+  fails(43, function (x) { return x % 2 === 0; });
 
   matches({
     a: "something",

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -211,8 +211,8 @@ EJSON.parse = function (item) {
 };
 
 EJSON.isBinary = function (obj) {
-  return (typeof Uint8Array !== 'undefined' && obj instanceof Uint8Array) ||
-    (obj && obj.$Uint8ArrayPolyfill);
+  return !!((typeof Uint8Array !== 'undefined' && obj instanceof Uint8Array) ||
+    (obj && obj.$Uint8ArrayPolyfill));
 };
 
 EJSON.equals = function (a, b, options) {

--- a/packages/meteor/constructor.js
+++ b/packages/meteor/constructor.js
@@ -1,0 +1,16 @@
+var knownConstructors;
+
+// for unit tests
+Meteor.__resetConstructors = function () {
+  knownConstructors = [Date, Error, Function, RegExp];
+};
+Meteor.__resetConstructors();
+
+Meteor.isConstructor = function (x) {
+  return _.contains(knownConstructors, x);
+};
+
+Meteor.declareConstructor = function (constructor) {
+  if (! _.contains(knownConstructors, constructor))
+    knownConstructors.push(constructor);
+};

--- a/packages/meteor/constructor_tests.js
+++ b/packages/meteor/constructor_tests.js
@@ -1,0 +1,16 @@
+Tinytest.add("constructor - isConstructor", function (test) {
+  test.isTrue(Meteor.isConstructor(RegExp));
+  test.isFalse(Meteor.isConstructor(123));
+});
+
+Tinytest.add("constructor - declareConstructor", function (test) {
+  var Foo = function () {
+    this.bar = 123;
+  };
+  var foo = new Foo();
+  Meteor.declareConstructor(Foo);
+  test.isFalse(Meteor.isConstructor(123));
+  test.isFalse(Meteor.isConstructor(foo));
+  test.isTrue(Meteor.isConstructor(Foo));
+  Meteor.__resetConstructors();
+});

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -49,6 +49,8 @@ Package.on_use(function (api, where) {
   // in this case server must load first.
   api.add_files('url_server.js', 'server');
   api.add_files('url_common.js', ['client', 'server']);
+
+  api.add_files('constructor.js', ['client', 'server']);
 });
 
 Package.on_test(function (api) {
@@ -63,4 +65,6 @@ Package.on_test(function (api) {
   api.add_files('fiber_helpers_test.js', ['server']);
 
   api.add_files('url_tests.js', ['client', 'server']);
+
+  api.add_files('constructor_tests.js', ['client', 'server']);
 });


### PR DESCRIPTION
Variant of https://github.com/meteor/meteor/pull/1008, moving the code to recognize constructors out of the matching code to where it can be used elsewhere (such as by controllers), and as a convenient place to add heuristics to detect constructors if desired.

Allows predicates to be used as a match pattern, replacing
`Match.Where`.

Constructors can be used in a match pattern either with
`Match.InstanceOf`, or by making the constructor known to Meteor with
`Meteor.declareConstructor`.

Predicates are required to return a boolean `true` to match, which
avoids the problem of an undeclared constructor being used as a match
pattern silently succeeding for arbitrary input.
