### PR TITLE
Allow new Random instances to be constructed with specified seed.

### DIFF
--- a/packages/random/package.js
+++ b/packages/random/package.js
@@ -7,3 +7,8 @@ Package.on_use(function (api, where) {
   where = where || ['client', 'server'];
   api.add_files('random.js', where);
 });
+
+Package.on_test(function(api) {
+  api.use('random');
+  api.add_files('random_tests.js', ['client', 'server']);
+});

--- a/packages/random/random.js
+++ b/packages/random/random.js
@@ -1,8 +1,6 @@
-Random = {};
-
 // see http://baagoe.org/en/wiki/Better_random_numbers_for_javascript
 // for a full discussion and Alea implementation.
-Random._Alea = function () {
+var Alea = function () {
   function Mash() {
     var n = 0xefc8249d;
 
@@ -75,6 +73,53 @@ Random._Alea = function () {
   } (Array.prototype.slice.call(arguments)));
 };
 
+var UNMISTAKABLE_CHARS = "23456789ABCDEFGHJKLMNPQRSTWXYZabcdefghijkmnopqrstuvwxyz";
+
+var create = function (/* arguments */) {
+
+  var random = Alea.apply(null, arguments);
+
+  var self = {};
+
+  var bind = function (fn) {
+    return _.bind(fn, self);
+  };
+
+  return _.extend(self, {
+    _Alea: Alea,
+
+    create: create,
+
+    fraction: random,
+
+    choice: bind(function (arrayOrString) {
+      var index = Math.floor(this.fraction() * arrayOrString.length);
+      if (typeof arrayOrString === "string")
+        return arrayOrString.substr(index, 1);
+      else
+        return arrayOrString[index];
+    }),
+
+    id: bind(function() {
+      var digits = [];
+      // Length of 17 preserves around 96 bits of entropy, which is the
+      // amount of state in our PRNG
+      for (var i = 0; i < 17; i++) {
+        digits[i] = this.choice(UNMISTAKABLE_CHARS);
+      }
+      return digits.join("");
+    }),
+
+    hexString: bind(function (digits) {
+      var hexDigits = [];
+      for (var i = 0; i < digits; ++i) {
+        hexDigits.push(this.choice("0123456789abcdef"));
+      }
+      return hexDigits.join('');
+    })
+  });
+};
+
 // instantiate RNG.  Heuristically collect entropy from various sources
 
 // client sources
@@ -104,33 +149,6 @@ var pid = (typeof process !== 'undefined' && process.pid) || 1;
 // XXX On the server, use the crypto module (OpenSSL) instead of this PRNG.
 //     (Make Random.fraction be generated from Random.hexString instead of the
 //     other way around, and generate Random.hexString from crypto.randomBytes.)
-Random.fraction = new Random._Alea([
-  new Date(), height, width, agent, pid, Math.random()]);
-
-Random.choice = function (arrayOrString) {
-  var index = Math.floor(Random.fraction() * arrayOrString.length);
-  if (typeof arrayOrString === "string")
-    return arrayOrString.substr(index, 1);
-  else
-    return arrayOrString[index];
-};
-
-var UNMISTAKABLE_CHARS = "23456789ABCDEFGHJKLMNPQRSTWXYZabcdefghijkmnopqrstuvwxyz";
-Random.id = function() {
-  var digits = [];
-  // Length of 17 preserves around 96 bits of entropy, which is the
-  // amount of state in our PRNG
-  for (var i = 0; i < 17; i++) {
-    digits[i] = Random.choice(UNMISTAKABLE_CHARS);
-  }
-  return digits.join("");
-};
-
-var HEX_DIGITS = "0123456789abcdef";
-Random.hexString = function (digits) {
-  var hexDigits = [];
-  for (var i = 0; i < digits; ++i) {
-    hexDigits.push(Random.choice("0123456789abcdef"));
-  }
-  return hexDigits.join('');
-};
+Random = create([
+  new Date(), height, width, agent, pid, Math.random()
+]);

--- a/packages/random/random_tests.js
+++ b/packages/random/random_tests.js
@@ -1,0 +1,15 @@
+Tinytest.add('random', function (test) {
+  // Deterministic with a specified seed, which should generate the
+  // same sequence in all environments.
+  //
+  // For repeatable unit test failures using deterministic random
+  // number sequences it's fine if a new Meteor release changes the
+  // algorithm being used and it starts generating a different
+  // sequence for a seed, as long as the sequence is consistent for
+  // a particular release.
+  var random = Random.create(0);
+  test.equal(random.id(), "cp9hWvhg8GSvuZ9os");
+  test.equal(random.id(), "3f3k6Xo7rrHCifQhR");
+  test.equal(random.id(), "shxDnjWWmnKPEoLhM");
+  test.equal(random.id(), "6QTjB8C5SEqhmz4ni");
+});


### PR DESCRIPTION
For repeatable unit test failures with "random" data it's useful to be
able to create deterministic random number sequences.

Introduce `Random.create(seed...)` which returns a object with the
`Random` API (`id()`, `choice()`, etc.) initialized with the passed
seed(s).
