### PR TITLE
Stop node tar from including proprietary tags

### DIFF
--- a/tools/files.js
+++ b/tools/files.js
@@ -462,7 +462,7 @@ _.extend(exports, {
   // directory named after dirPath.
   createTarGzStream: function (dirPath) {
     return fstream.Reader({ path: dirPath, type: 'Directory' }).pipe(
-      tar.Pack()).pipe(zlib.createGzip());
+      tar.Pack({noProprietary: true})).pipe(zlib.createGzip());
   },
 
   // Tar-gzips a directory into a tarball on disk, synchronously.


### PR DESCRIPTION
The linux tar whinges about unrecognised headers (though newer versions
include an option to not warn).
By building tar files without proprietary, we will be able to use
files.createTarball() in more places.
For example, undo commits 1c36bbaa79d76efd4817c5e1faeeed0c9429e0a3 and
1e2a40ef2bab5134ff2d6d813cd3ea5a0822a748

My aim for this is to be able to use the portable tarball code in more places - as on windows there isn't a standard tar (without using cygwin or mingw etc.)
