### PR TITLE
Fix CoffeeScript error reporting.

### DIFF
--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -15,7 +15,11 @@ var coffeescript_handler = function(bundle, source_path, serve_path, where) {
   try {
     contents = coffee.compile(contents.toString('utf8'), options);
   } catch (e) {
-    return bundle.error(e.message);
+    return bundle.error(
+      source_path + ':' +
+      (e.location ? (e.location.first_line + ': ') : ' ') +
+      e.message
+    );
   }
 
   contents = new Buffer(contents);


### PR DESCRIPTION
Fixes #1050.

With the upgrade to CoffeeScript 1.6.2 the source file name and line
number of a parse error is no longer present in the `message` field of
the exception.
