### PR TITLE
Fix line endings of shrink wrap files (for Windows)

### DIFF
--- a/packages/.gitattributes
+++ b/packages/.gitattributes
@@ -1,5 +1,0 @@
-# Make sure git uses line endings that match how files get regenerated
-# (by 'npm shrinkwrap' and meteor_npm.js)
-*/.npm/npm-shrinkwrap.json  eol=lf
-*/.npm/.gitignore           eol=lf
-*/.npm/README               eol=lf

--- a/tools/meteor_npm.js
+++ b/tools/meteor_npm.js
@@ -108,6 +108,12 @@ _.extend(exports, {
     fs.writeFileSync(
       path.join(newPackageNpmDir, '.gitignore'),
       ['node_modules', ''/*git diff complains without trailing newline*/].join('\n'));
+
+    // create a .gitattributes to ensure git diff expects what was generated.
+    fs.writeFileSync(
+      path.join(newPackageNpmDir, '.gitattributes'),
+      ['/npm-shrinkwrap.json eol=lf', '/README eol=lf', '/.git* eol=lf',
+       ''/*git diff complains without trailing newline*/].join('\n'));
   },
 
   _updateExistingNpmDirectory: function(


### PR DESCRIPTION
On Windows npm outputs \r\n and git checks the files out with \r\n.
This change fixes this so that after a 'meteor --get-ready',  git status
no longer shows diffs.
