### PR TITLE
Add bash completions.

### DIFF
--- a/completions/meteor.bash
+++ b/completions/meteor.bash
@@ -1,0 +1,95 @@
+_meteor() {
+  local cur prev commands
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  commands=" \
+  help \
+  run \
+  create \
+  deploy \
+  logs \
+  update \
+  add \
+  remove \
+  list \
+  mongo \
+  reset \
+  bundle"
+
+  case "${prev}" in
+    --example)
+      local examples=" \
+      leaderboard \
+      parties \
+      todos \
+      wordplay"
+
+      COMPREPLY=($(compgen -W "${examples}" -- ${cur}))
+      return 0
+      ;;
+
+    run)
+      local run=" \
+      -p \
+      --port \
+      --production"
+
+      COMPREPLY=($(compgen -W "${run}" -- ${cur}))
+      return 0
+      ;;
+
+    create)
+      local create=" \
+      --example \
+      --list"
+
+      COMPREPLY=($(compgen -W "${create}" -- ${cur}))
+      return 0
+      ;;
+
+    deploy)
+      local deploy=" \
+      -P \
+      -D \
+      --password \
+      --delete \
+      --settings \
+      --debug"
+
+      COMPREPLY=($(compgen -W "${deploy}" -- ${cur}))
+      return 0
+      ;;
+
+    update)
+      local update=" \
+      --release"
+
+      COMPREPLY=($(compgen -W "${update}" -- ${cur}))
+      return 0
+      ;;
+
+    list)
+      local list=" \
+      --using"
+
+      COMPREPLY=($(compgen -W "${list}" -- ${cur}))
+      return 0
+      ;;
+
+    mongo)
+      local mongo=" \
+      -U \
+      --url"
+
+      COMPREPLY=($(compgen -W "${mongo}" -- ${cur}))
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+  return 0
+}
+
+complete -F _meteor meteor


### PR DESCRIPTION
Depending on how you installed meteor, add this to your .bashrc (or .bash_profile) to use them:

``` bash
if [ -f /path/to/meteor.bash ]; then
  . /path/to/meteor.bash
fi
```

Also, if accepted, I'll send a pull request for linking the completions up during Homebrew installation.
