### PR TITLE
add options to creation callback

### DIFF
--- a/packages/templating/deftemplate.js
+++ b/packages/templating/deftemplate.js
@@ -108,7 +108,7 @@ Meteor._def_template = function (name, raw_func) {
 
   // Define the function assigned to Template.<name>.
 
-  var partial = function (data) {
+  var partial = function (data, options) {
     var tmpl = name && Template[name] || {};
     var tmplData = tmpl._tmpl_data || {};
 
@@ -118,7 +118,7 @@ Meteor._def_template = function (name, raw_func) {
         created: function () {
           var template = templateObjFromLandmark(this);
           template.data = data;
-          tmpl.created && tmpl.created.call(template);
+          tmpl.created && tmpl.created.call(template, options);
         },
         rendered: function () {
           var template = templateObjFromLandmark(this);


### PR DESCRIPTION
Sometimes I need to create a template which behavior depends on some configurable parameters. To my understanding, the only way to let the template know about such parameters is to create a "proxy" data context:

``` javascript
Template.myTemplate({
    context : this, // the original context
    options : {},   // some options
});
```

However, I would rather do something like this:

``` javascript
Template.myTemplate(this, options);
```

After that, it would be nice to refer to this `options` in the `created` callback:

``` javascript
Template.myTemplate.created = function (options) {
    // ... do somthing or save for later use
    this._options = options;
}
```

This pull request trivially solves the issue, but I'm not entirely sure wheter it complies with your design assumptions.
