### PR TITLE
reactivity and better support to _allSubscriptionsReady

### DIFF
--- a/packages/livedata/livedata_connection.js
+++ b/packages/livedata/livedata_connection.js
@@ -1355,6 +1355,7 @@ Meteor._LivedataConnection._allConnections = [];
 Meteor._LivedataConnection._allSubscriptionsReady = function () {
   return _.all(Meteor._LivedataConnection._allConnections, function (conn) {
     return _.all(conn._subscriptions, function (sub) {
+      sub.readyDeps.depend();
       return sub.ready;
     });
   });


### PR DESCRIPTION
### Scenario

_I want to have in the client side of my app a loading message while the data loading (subscriptions) is still not completed (ready)_.

In my specific case, my app does some requests to third party services inside `publish` methods and the user is supposed to wait for some time before the publish is `ready`. So, a loading message is necessary.

Would be nice to have control over when **all** your data loading is completed or not, so you could decide if you wanna wait more or show what you already have based on an incomplete database.
### Problem

The function `Meteor._LivedataConnection._allSubscriptionsReady` tells us when all subscriptions are ready, but it has some issues:
- it is documented as a simple _"Hack for spiderable package"_. I do not feel comfortable relying my code on this.
- It is not reactive. No one wants to be checking it all the time.
### Solution
- Promote `_allSubscriptionsReady` from an obscure function to something explicitly supported.
- Make it reactive.

---

This pull request solves only the reactivity question, just adding a line of code. I haven't solved the other issue because it is purely a design and organizational decision.
