### PR TITLE
Add variables & command-line options for binding

### DIFF
--- a/tools/meteor.js
+++ b/tools/meteor.js
@@ -185,8 +185,12 @@ Fiber(function () {
       // reparse args
       // This help logic should probably move to run.js eventually
       var opt = require('optimist')
-            .alias('port', 'p').default('port', 3000)
-            .describe('port', 'Port to listen on. NOTE: Also uses port N+1 and N+2.')
+            .alias('port', 'p').default('port', process.env.METEOR_PORT || 3000)
+            .describe('port', 'Port to listen on')
+            .describe('inner_port', 'Port for the internal server').default('inner_port', process.env.METEOR_INNER_PORT || 3001)
+            .describe('mongo_port', "MongoDB port").default('mongo_port', process.env.METEOR_MONGO_PORT || 3002)
+            .alias('bind', 'b').default('bind', process.env.METEOR_IP || "0.0.0.0")
+            .describe('inner_bind', 'IP of the internal server').default('inner_bind', process.env.METEOR_INNER_IP || "127.0.0.1")
             .boolean('production')
             .describe('production', 'Run in production mode. Minify and bundle CSS and JS files.')
             .describe('settings',  'Set optional data for Meteor.settings on the server')
@@ -222,6 +226,10 @@ Fiber(function () {
       maybePrintUserOverrideMessage();
       runner.run(context, {
         port: new_argv.port,
+        inner_port: new_argv.inner_port,
+        mongo_port: new_argv.mongo_port,
+        bind: new_argv.bind,
+        inner_bind: new_argv.inner_bind,
         minify: new_argv.production,
         once: new_argv.once,
         settingsFile: new_argv.settings
@@ -677,7 +685,7 @@ Fiber(function () {
             process.exit(1);
           }
 
-          var mongo_url = "mongodb://127.0.0.1:" + mongod_port + "/meteor";
+          var mongo_url = "mongodb://" + new_argv.inner_bind +  ":" + mongod_port + "/meteor";
 
           if (new_argv.url)
             console.log(mongo_url);
@@ -829,8 +837,12 @@ Fiber(function () {
       // reparse args
       // This help logic should probably move to run.js eventually
       var opt = require('optimist')
-            .alias('port', 'p').default('port', 3000)
-            .describe('port', 'Port to listen on. NOTE: Also uses port N+1 and N+2.')
+            .alias('port', 'p').default('port', process.env.METEOR_PORT || 3000)
+            .describe('port', 'Port to listen on')
+            .describe('inner_port', 'Port for the internal server').default('inner_port', process.env.METEOR_INNER_PORT || 3001)
+            .describe('mongo_port', "MongoDB port").default('mongo_port', process.env.METEOR_MONGO_PORT || 3002)
+            .alias('bind', 'b').default('bind', process.env.METEOR_IP || "0.0.0.0")
+            .describe('inner_bind', 'IP of the internal server').default('inner_bind', process.env.METEOR_INNER_IP || "127.0.0.1")
             .describe('deploy', 'Optionally, specify a domain to deploy to, rather than running locally.')
             .boolean('production')
             .describe('production', 'Run in production mode. Minify and bundle CSS and JS files.')
@@ -919,6 +931,10 @@ Fiber(function () {
       } else {
         runner.run(context, {
           port: new_argv.port,
+          inner_port: new_argv.inner_port,
+          mongo_port: new_argv.mongo_port,
+          bind: new_argv.bind,
+          inner_bind: new_argv.inner_bind,
           minify: new_argv.production,
           once: new_argv.once,
           testPackages: testPackages,

--- a/tools/mongo_runner.js
+++ b/tools/mongo_runner.js
@@ -125,7 +125,7 @@ var find_mongo_and_kill_it_dead = function (port, callback) {
   });
 };
 
-exports.launch_mongo = function (app_dir, port, launch_callback, on_exit_callback) {
+exports.launch_mongo = function (app_dir, ip, port, launch_callback, on_exit_callback) {
   var handle = {stop: function (callback) { callback(); } };
   launch_callback = launch_callback || function () {};
   on_exit_callback = on_exit_callback || function () {};
@@ -158,7 +158,7 @@ exports.launch_mongo = function (app_dir, port, launch_callback, on_exit_callbac
     }
 
     var proc = child_process.spawn(mongod_path, [
-      '--bind_ip', '127.0.0.1',
+      '--bind_ip', ip,
       '--smallfiles',
       '--port', port,
       '--dbpath', data_path

--- a/tools/server/server.js
+++ b/tools/server/server.js
@@ -169,6 +169,7 @@ var run = function () {
 
   // check environment
   var port = process.env.PORT ? parseInt(process.env.PORT) : 80;
+  var ip = process.env.IP || "127.0.0.1";
 
   // check for a valid MongoDB URL right away
   if (!process.env.MONGO_URL)
@@ -329,7 +330,7 @@ var run = function () {
     _.each(__meteor_bootstrap__.startup_hooks, function (x) { x(); });
 
     // only start listening after all the startup code has run.
-    httpServer.listen(port, function() {
+    httpServer.listen(port, ip, function() {
       if (argv.keepalive)
         console.log("LISTENING"); // must match run.js
     });


### PR DESCRIPTION
**In short:** This pull request adds environment variables and additional command-line options for specifying what address and ports to bind to. This, among other things, allows you to use Meteor on Cloud9.

At [Cloud9](https://c9.io) we dig Meteor :+1: :) And we want it to work out of the box on our platform. Right now, that means that Meteor needs to be bound to a specific IP and port, as described in [this blog post](https://c9.io/site/blog/2013/05/can-i-use-cloud9-to-do-x/). This pull request adds the options needed to do that to Meteor.

I understand there have been other patches for this problem before, but we want to move forward with this and be able to support Meteor as soon as possible :) What we'll do on our end is pre-set all the environment variables so it all just works.

In short, this PR makes sure Meteor has the following options, adding a bit of extra configurability:
- `--port` and `METEOR_PORT` set the port (normally 3000)
- `--inner_port` and `METEOR_INNER_PORT` set the internal port (normally 3001)
- `--mongo_port` and `METEOR_MONGO_PORT` set the port used by MongoDB (normally 3002)
- `--bind` and `METEOR_IP` set the IP to bind to (normally `0.0.0.0`)
- `--inner_bind` and <del>`METEOR_INNER_BIND`</del> `METEOR_INNER_IP` set the IP to bind to for the internal ports (normally `127.0.0.1`)
