### PR TITLE
Add callback param to oauth request handler, allowing async calls

### DIFF
--- a/packages/oauth1/oauth1_binding.js
+++ b/packages/oauth1/oauth1_binding.js
@@ -115,16 +115,12 @@ OAuth1Binding.prototype._call = function(method, url, headers, params, callback)
   var authString = self._getAuthHeaderString(headers);
 
   // Make signed request
-  try {
-    return Meteor.http.call(method, url, {
-      params: params,
-      headers: {
-        Authorization: authString
-      }
-    }, callback);
-  } catch (err) {
-    throw new Error("Failed to send OAuth1 request to " + url + ". " + err.message);
-  }
+  return Meteor.http.call(method, url, {
+    params: params,
+    headers: {
+      Authorization: authString
+    }
+  }, callback);
 };
 
 OAuth1Binding.prototype._encodeHeader = function(header) {


### PR DESCRIPTION
This works well for my scenarios.

However, I'm not sure if a) There's some edge cases I should be considering or b) if the value returned from _call should get some special treatment with the async method.  

Seeing as it's handing off to a fairly bullet proof Meteor.http.call, I figure it's probably good, but would be happy to revisit if there's anything you think warrants more attention.
