### PR TITLE
choose encoding for http.call

### DIFF
--- a/packages/http/httpcall_server.js
+++ b/packages/http/httpcall_server.js
@@ -92,7 +92,7 @@ Meteor.http.call = function(method, url, options, callback) {
   var req_options = {
     url: new_url,
     method: method,
-    encoding: "utf8",
+    encoding: (options.encoding || "utf8"),
     jar: false,
     timeout: options.timeout,
     body: content,


### PR DESCRIPTION
I needed the ability to choose the encoding for the http.call method, so I changed line 95 in httpcall_server.js 
