### PR TITLE
Portable bash shebangs

### DIFF
--- a/examples/unfinished/benchmark/run-local.sh
+++ b/examples/unfinished/benchmark/run-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PORT=9000
 NUM_CLIENTS=10

--- a/meteor
+++ b/meteor
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUNDLE_VERSION=0.3.8
 

--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd `dirname $0`
 cd ../..

--- a/scripts/admin/bless-release.js
+++ b/scripts/admin/bless-release.js
@@ -180,7 +180,7 @@ var writeBigRedButton = function (blessedReleaseName, gitTagSourceSha, gitTag) {
                 'com.meteor.warehouse/releases']);
   s3Files.push(['manifest.json', 'com.meteor.static/update']);
   var scriptText =
-        "#!/bin/bash\n" +
+        "#!/usr/bin/env bash\n" +
         "# Wow! It's time to release Meteor " + blessedReleaseName + "!\n" +
         "# Look at the contents of this directory, cross your fingers, and\n" +
         "# run this script!\n\n" +

--- a/scripts/admin/build-package-tarballs.sh
+++ b/scripts/admin/build-package-tarballs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Build a tarball for each smart package, which will later be put on
 ### warehouse.meteor.com. Compute a version for each package by

--- a/scripts/admin/build-release.sh
+++ b/scripts/admin/build-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/scripts/admin/build-tools-tarballs.sh
+++ b/scripts/admin/build-tools-tarballs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/scripts/admin/build-tools-tree.sh
+++ b/scripts/admin/build-tools-tree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script fills TARGET_DIR with what should go into
 #     ~/.meteor/tools/VERSION

--- a/scripts/admin/copy-dev-bundle-from-jenkins.sh
+++ b/scripts/admin/copy-dev-bundle-from-jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires s3cmd to be installed and an appropriate ~/.s3cfg.
 # Usage:

--- a/scripts/admin/deploy-examples.sh
+++ b/scripts/admin/deploy-examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/admin/find-new-npm-versions.sh
+++ b/scripts/admin/find-new-npm-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 BASEDIR=`dirname $0`
 cat $BASEDIR/generate-dev-bundle.sh | grep "npm install" | sed "s/npm install //" | sed "s/@.*//" | while read PACKAGE
 do

--- a/scripts/admin/launch-meteor
+++ b/scripts/admin/launch-meteor
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is the script that we install somewhere in your $PATH (as "meteor")
 # when you run

--- a/scripts/admin/publish-release.sh
+++ b/scripts/admin/publish-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 cd `dirname $0`

--- a/scripts/admin/spark-standalone.sh
+++ b/scripts/admin/spark-standalone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Creates a self-contained spark.js and writes it stdout.
 

--- a/scripts/admin/upgrade-to-engine/build-fake-release.sh
+++ b/scripts/admin/upgrade-to-engine/build-fake-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Builds a tarball that can be downloaded by pre-engine "meteor update" to
 # bootstrap us into engine-land.

--- a/scripts/bundler-test.sh
+++ b/scripts/bundler-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # stop on any non-zero return value from test_bundler.js, and print "FAILED"
 set -e

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # NOTE: by default this tests the working copy, not the installed
 # meteor.  To test the installed meteor, pass in --global. To test a

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ORIGDIR=$(pwd)
 cd $(dirname $0)

--- a/scripts/run-tools-tests.sh
+++ b/scripts/run-tools-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Setup
 cd `dirname $0`

--- a/scripts/tools-springboard-test.sh
+++ b/scripts/tools-springboard-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -x
 


### PR DESCRIPTION
This change makes bash scripts more portable by using `#!/usr/bin/env bash` shebangs instead of just `#!/bin/bash`, which only is common in GNU/Linux systems, but not other Unix-like systems. Currently supported systems will most likely remain completely unaffected by this change.

An example of such an operating system is FreeBSD (see #630), which doesn't come with bash per default, but requires it to be installed from the ports collection. It otherwise appears to work pretty good (in fact I am working on porting it there currently. It compiles already).

See [Wikipedia](http://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability) for further reference.
