### PR TITLE
Update to fibers 1.0.1

### DIFF
--- a/docs/client/concepts.html
+++ b/docs/client/concepts.html
@@ -698,7 +698,7 @@ have `npm` available, and run the following:
 
     $ cd bundle/server/node_modules
     $ rm -r fibers
-    $ npm install fibers@1.0.0
+    $ npm install fibers@1.0.1
 {{/warning}}
 
 {{/better_markdown}}

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -122,7 +122,7 @@ npm install progress@0.0.5
 # If you update the version of fibers in the dev bundle, also update the "npm
 # install" command in docs/client/concepts.html and in the README in
 # app/lib/bundler.js.
-npm install fibers@1.0.0
+npm install fibers@1.0.1
 # Fibers ships with compiled versions of its C code for a dozen platforms. This
 # bloats our dev bundle, and confuses dpkg-buildpackage and rpmbuild into
 # thinking that the packages need to depend on both 32- and 64-bit versions of

--- a/tools/bundler.js
+++ b/tools/bundler.js
@@ -765,7 +765,7 @@ _.extend(Bundle.prototype, {
 "This is a Meteor application bundle. It has only one dependency,\n" +
 "node.js (with the 'fibers' package). To run the application:\n" +
 "\n" +
-"  $ npm install fibers@1.0.0\n" +
+"  $ npm install fibers@1.0.1\n" +
 "  $ export MONGO_URL='mongodb://user:password@host:port/databasename'\n" +
 "  $ export ROOT_URL='http://example.com'\n" +
 "  $ export MAIL_URL='smtp://user:password@mailhost:port/'\n" +


### PR DESCRIPTION
This includes critical fixes for Windows thread locals, but also
includes support for node 0.11.x

Obviously the dev bundle version will need updating after this change.
