### PR TITLE
Add support to configure the listened hostname via an environement variable

### DIFF
--- a/tools/server/server.js
+++ b/tools/server/server.js
@@ -169,7 +169,7 @@ var run = function () {
 
   // check environment
   var port = process.env.PORT ? parseInt(process.env.PORT) : 80;
-  var hostname = process.env.HOSTNAME ? parseInt(process.env.HOSTNAME) : 'INADDR_ANY';
+  var hostname = process.env.HOSTNAME ? process.env.HOSTNAME : 'INADDR_ANY';
 
   // check for a valid MongoDB URL right away
   if (!process.env.MONGO_URL)


### PR DESCRIPTION
With this pull request, I just want to know if the Meteor team consider adding support for binding a specific IP or if I should use a nginx proxy instead?
