### PR TITLE
Spiderable: should always respond to google even if _escaped_fragment_ not present

### DIFF
--- a/packages/spiderable/spiderable.js
+++ b/packages/spiderable/spiderable.js
@@ -10,7 +10,12 @@ Spiderable = {};
 // not obey the _escaped_fragment_ protocol. The page is served
 // statically to any client whos user agent matches any of these
 // regexps. Users may modify this array.
-Spiderable.userAgentRegExps = [/^facebookexternalhit/i, /^linkedinbot/i];
+Spiderable.userAgentRegExps = [
+  /facebookexternalhit/i
+, /linkedinbot/i
+, /twitterbot/i
+, /googlebot/i
+];
 
 // how long to let phantomjs run before we kill it
 var REQUEST_TIMEOUT = 15*1000;


### PR DESCRIPTION
_escaped_fragment_ is posted by Google only when # are present and only for hash starting by ! (as mentioned in the header &lt;meta name="fragment" content="!"&gt;)

so in order for Google to pass the _escaped_fragment_ it need to recognize the pattern:
http://mysite.com/#!page/to/crawl

this will be requested as:
http://mysite.com/?_escaped_fragment_=page/to/crawl

But if you use pushState Google will not provide you any custom parameter (_escaped_fragment_) to render the page

If you want to verify that you have a simple example:
https://github.com/benjaminchelli/spiderable-error

Thanks
