### PR TITLE
Twitter instruction to allow Sign in with Twitter

### DIFF
--- a/packages/twitter/twitter_configure.html
+++ b/packages/twitter/twitter_configure.html
@@ -9,5 +9,8 @@
     <li>
       Set Callback URL to: <span class="url">{{siteUrl}}_oauth/twitter?close</span>
     </li>
+    <li>
+      Check "Allow this application to be used to Sign in with Twitter"
+    </li>
   </ol>
 </template>


### PR DESCRIPTION
Extra instruction to inform developers that they need to check "Allow this
application to be used to Sign in with Twitter" in their Twitter application
settings.

If this option isn't checked then users will be asked to re-authorise the
application everytime they log in - more clicks than necessary!
