### PR TITLE
add configuration option to add extra resources to cache manifest

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -28,6 +28,8 @@ _.each(browsersEnabledByDefault, function (browser) {
   enabledBrowsers[browser] = true;
 });
 
+var extraResources = {};
+
 Meteor.AppCache = {
   config: function(options) {
     _.each(options, function (value, option) {
@@ -43,6 +45,11 @@ Meteor.AppCache = {
       else if (option === 'onlineOnly') {
         _.each(value, function (urlPrefix) {
           Meteor._routePolicy.declare(urlPrefix, 'static-online');
+        });
+      }
+      else if (option === 'extraResources') {
+        _.each(value, function (resource) {
+          extraResources[resource] = 1;
         });
       }
       else {
@@ -126,6 +133,10 @@ app.use(function(req, res, next) {
 
       manifest += "\n";
     }
+  });
+  _.each(_.keys(extraResources), function (url) {
+    manifest += url;
+    manifest += "\n";
   });
   manifest += "\n";
 


### PR DESCRIPTION
In order to add extra resources to the appcache manifest, I added an extra configuration option 'extraResources'. This options accepts an array of urls, that are appended after the bundle manifest cacheable assets.

```
Meteor.AppCache.config(
  {
    extraResources: ['url_1', 'url_2]
  }
);
```

I needed this functionality to add maptiles of a tiling service (cloudmade.com) to my appcache, to be able to navigate through maps without connectivity.
