### PR TITLE
oauth.credentialRequestCompleteHandler - check callback exists before invoking

### DIFF
--- a/packages/accounts-oauth/oauth_client.js
+++ b/packages/accounts-oauth/oauth_client.js
@@ -19,7 +19,7 @@ Accounts.oauth.tryLoginAfterPopupClosed = function(credentialToken, callback) {
 Accounts.oauth.credentialRequestCompleteHandler = function(callback) {
   return function (credentialTokenOrError) {
     if(credentialTokenOrError && credentialTokenOrError instanceof Error) {
-      callback(credentialTokenOrError);
+      callback && callback(credentialTokenOrError);
     } else {
       Accounts.oauth.tryLoginAfterPopupClosed(credentialTokenOrError, callback);
     }


### PR DESCRIPTION
The callback is optional, so don't assume it exists.
