### PR TITLE
Allow NPM packages to be installed from a URL

### DIFF
--- a/tools/meteor_npm.js
+++ b/tools/meteor_npm.js
@@ -26,8 +26,9 @@ var meteorNpm = exports;
 _.extend(exports, {
   _tmpDirs: [],
 
-  _isGitHubTarball: function (x) {
-    return /^https:\/\/github.com\/.*\/tarball\/[0-9a-f]{40}/.test(x);
+  // Checks if package URL is passed instead of a version number
+  _isUrl: function(version) {
+    return !!version && version.substr(0, 4) === 'http';
   },
 
   ensureOnlyExactVersions: function(npmDependencies) {
@@ -37,7 +38,7 @@ _.extend(exports, {
       // .npm/npm-shrinkwrap.json) to pin down its dependencies precisely, so we
       // don't want anything too vague. For now, we support semvers and github
       // tarballs pointing at an exact commit.
-      if (!semver.valid(version) && !self._isGitHubTarball(version))
+      if (!semver.valid(version) && !self._isUrl(version))
         throw new Error(
           "Must declare exact version of npm package dependency: " + name + '@' + version);
     });
@@ -302,7 +303,7 @@ _.extend(exports, {
   // If more logic is added here, it should probably go in minimizeModule too.
   _canonicalVersion: function (depObj) {
     var self = this;
-    if (self._isGitHubTarball(depObj.from))
+    if (self._isUrl(depObj.from))
       return depObj.from;
     else
       return depObj.version;
@@ -333,7 +334,7 @@ _.extend(exports, {
   _installNpmModule: function(name, version, dir) {
     this._ensureConnected();
 
-    var installArg = this._isGitHubTarball(version)
+    var installArg = this._isUrl(version)
           ? version : (name + "@" + version);
 
     // We don't use npm.commands.install since we couldn't
@@ -398,7 +399,7 @@ _.extend(exports, {
 
     var minimizeModule = function (module) {
       var minimized = {};
-      if (self._isGitHubTarball(module.from))
+      if (self._isUrl(module.from))
         minimized.from = module.from;
       else
         minimized.version = module.version;


### PR DESCRIPTION
Update the NPM integration module to allow installing an npm package from a private URL instead of limiting it to public npm modules only.

This replaces the _isGitHubTarball() function to handle not just git tarballs, but to handle any compressed package on any server.

You then use this the same way as the current github tarball feature:
Inside your package.js file add:

``` javascript
Npm.depends({
  'your-package-name': 'http://website.com/example/your-package-name-0.0.1.tar.gz'
});
```
