### PR TITLE
Remove jquery dependency in localstorage

### DIFF
--- a/packages/localstorage/localstorage.js
+++ b/packages/localstorage/localstorage.js
@@ -11,8 +11,13 @@ if (window.localStorage) {
     }
   };
 }
-// XXX eliminate dependency on jQuery, detect browsers ourselves
-else if ($.browser.msie) { // If we are on IE, which support userData
+else if (document.all && !window.opera) {
+  /*
+   * If we are on IE before IE 11, which support userData
+   * IE 8 and beyond support localStorage and sessionStorage.
+   * document.all returns false in IE 11.
+   * Pre-webkit Opera document.all may not return false.
+   */
   var userdata = document.createElement('span'); // could be anything
   userdata.style.behavior = 'url("#default#userData")';
   userdata.id = 'localstorage-helper';

--- a/packages/localstorage/package.js
+++ b/packages/localstorage/package.js
@@ -4,8 +4,6 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
-  api.use('jquery', 'client'); // XXX only used for browser detection. remove.
-
   api.add_files('localstorage.js', 'client');
 });
 


### PR DESCRIPTION
Fix IE detection, eliminate deprecated jquery

Test this in many versions of IE and opera.
Also it's better to test for features than browsers, and that would fix support for IE8 and above which support localStorage.

document.all returned true in IE 10 and previous
returns false in IE 11

http://msdn.microsoft.com/en-us/library/ie/ms537434(v=vs.85).aspx
http://www.nczonline.net/blog/2013/07/02/internet-explorer-11-dont-call-me-ie/

document.all available in pre-webkit versions of opera, window.opera available:

http://my.opera.com/community/openweb/idopera/
(how dojotoolkit detects ie)
http://download.dojotoolkit.org/release-1.9.1/dojo.js.uncompressed.js

$.browser deprecated in jquery 1.3 and not available in jquery 1.9 and above

http://api.jquery.com/jQuery.browser/

localStorage available in IE 8 and above
userData deprecated

http://msdn.microsoft.com/en-us/library/ie/ms531424(v=vs.85).aspx
http://msdn.microsoft.com/en-us/library/ie/bg142799(v=vs.85).aspx
