### PR TITLE
Attach response object to accounts generated errors resulting from HTTP failures

### DIFF
--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -59,7 +59,8 @@ var getTokenResponse = function (query) {
         }
       }).content;
   } catch (err) {
-    throw new Error("Failed to complete OAuth handshake with Facebook. " + err.message);
+    throw _.extend(new Error("Failed to complete OAuth handshake with Facebook. " + err.message),
+                   {response: err.response});
   }
 
   // If 'responseContent' parses as JSON, it is an error.
@@ -89,7 +90,8 @@ var getIdentity = function (accessToken) {
     return HTTP.get("https://graph.facebook.com/me", {
       params: {access_token: accessToken}}).data;
   } catch (err) {
-    throw new Error("Failed to fetch identity from Facebook. " + err.message);
+    throw _.extend(new Error("Failed to fetch identity from Facebook. " + err.message),
+                   {response: err.response});
   }
 };
 

--- a/packages/github/github_server.js
+++ b/packages/github/github_server.js
@@ -43,7 +43,8 @@ var getAccessToken = function (query) {
         }
       });
   } catch (err) {
-    throw new Error("Failed to complete OAuth handshake with Github. " + err.message);
+    throw _.extend(new Error("Failed to complete OAuth handshake with Github. " + err.message),
+                   {response: err.response});
   }
   if (response.data.error) { // if the http response was a json object with an error attribute
     throw new Error("Failed to complete OAuth handshake with GitHub. " + response.data.error);
@@ -60,7 +61,8 @@ var getIdentity = function (accessToken) {
         params: {access_token: accessToken}
       }).data;
   } catch (err) {
-    throw new Error("Failed to fetch identity from GitHub. " + err.message);
+    throw _.extend(new Error("Failed to fetch identity from Github. " + err.message),
+                   {response: err.response});
   }
 };
 

--- a/packages/google/google_server.js
+++ b/packages/google/google_server.js
@@ -51,7 +51,8 @@ var getTokens = function (query) {
         grant_type: 'authorization_code'
       }});
   } catch (err) {
-    throw new Error("Failed to complete OAuth handshake with Google. " + err.message);
+    throw _.extend(new Error("Failed to complete OAuth handshake with Google. " + err.message),
+                   {response: err.response});
   }
 
   if (response.data.error) { // if the http response was a json object with an error attribute
@@ -71,7 +72,8 @@ var getIdentity = function (accessToken) {
       "https://www.googleapis.com/oauth2/v1/userinfo",
       {params: {access_token: accessToken}}).data;
   } catch (err) {
-    throw new Error("Failed to fetch identity from Google. " + err.message);
+    throw _.extend(new Error("Failed to fetch identity from Google. " + err.message),
+                   {response: err.response});
   }
 };
 

--- a/packages/meetup/meetup_server.js
+++ b/packages/meetup/meetup_server.js
@@ -31,7 +31,8 @@ var getAccessToken = function (query) {
         state: query.state
       }});
   } catch (err) {
-    throw new Error("Failed to complete OAuth handshake with Meetup. " + err.message);
+    throw _.extend(new Error("Failed to complete OAuth handshake with Meetup. " + err.message),
+                   {response: err.response});
   }
 
   if (response.data.error) { // if the http response was a json object with an error attribute
@@ -48,7 +49,8 @@ var getIdentity = function (accessToken) {
       {params: {member_id: 'self', access_token: accessToken}});
     return response.data.results && response.data.results[0];
   } catch (err) {
-    throw new Error("Failed to fetch identity from Meetup: " + err.message);
+    throw _.extend(new Error("Failed to fetch identity from Meetup. " + err.message),
+                   {response: err.response});
   }
 };
 

--- a/packages/oauth1/oauth1_binding.js
+++ b/packages/oauth1/oauth1_binding.js
@@ -123,7 +123,8 @@ OAuth1Binding.prototype._call = function(method, url, headers, params, callback)
       }
     }, callback);
   } catch (err) {
-    throw new Error("Failed to send OAuth1 request to " + url + ". " + err.message);
+    throw _.extend(new Error("Failed to send OAuth1 request to " + url + ". " + err.message),
+                   {response: err.response});
   }
 };
 

--- a/packages/weibo/weibo_server.js
+++ b/packages/weibo/weibo_server.js
@@ -46,7 +46,8 @@ var getTokenResponse = function (query) {
         grant_type: 'authorization_code'
       }});
   } catch (err) {
-    throw new Error("Failed to complete OAuth handshake with Weibo. " + err.message);
+    throw _.extend(new Error("Failed to complete OAuth handshake with Weibo. " + err.message),
+                   {response: err.response});
   }
 
   // result.headers["content-type"] is 'text/plain;charset=UTF-8', so
@@ -66,7 +67,8 @@ var getIdentity = function (accessToken, userId) {
       "https://api.weibo.com/2/users/show.json",
       {params: {access_token: accessToken, uid: userId}}).data;
   } catch (err) {
-    throw new Error("Failed to fetch identity from Weibo. " + err.message);
+    throw _.extend(new Error("Failed to fetch identity from Weibo. " + err.message),
+                   {response: err.response});
   }
 };
 


### PR DESCRIPTION
@n1mmy @avital As discussed.  

This allows callers that receive the error to access properties in the response object, such as the statusCode.
