### PR TITLE
Store dates in Mongo as ISODate rather than Integer #1228

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,17 @@
 
 ## vNEXT
 
+* Write dates to Mongo as ISODate rather than Integer #1228
+
+  Existing data can be fixed using the following code:
+
+    ```
+    db.users.find().forEach(function(user) {
+      db.users.update({ _id: user._id }, { $set: {createdAt: new Date(user.createdAt)}});
+      print('Fixed user: ' + user._id);
+    });
+    ```
+
 ## v0.6.4.1
 
 * Update mongodb driver to use version 0.2.1 of the bson module.

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -141,7 +141,7 @@ Accounts.insertUserDoc = function (options, user) {
   // the user document (in which you can modify its contents), and
   // one that gets called after (in which you should change other
   // collections)
-  user = _.extend({createdAt: +(new Date), _id: Random.id()}, user);
+  user = _.extend({createdAt: new Date(), _id: Random.id()}, user);
 
   var result = {};
   if (options.generateLoginToken) {

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -224,7 +224,7 @@ Accounts.sendResetPasswordEmail = function (userId, email) {
     throw new Error("No such email for user.");
 
   var token = Random.id();
-  var when = +(new Date);
+  var when = new Date();
   Meteor.users.update(userId, {$set: {
     "services.password.reset": {
       token: token,
@@ -264,7 +264,7 @@ Accounts.sendEnrollmentEmail = function (userId, email) {
 
 
   var token = Random.id();
-  var when = +(new Date);
+  var when = new Date();
   Meteor.users.update(userId, {$set: {
     "services.password.reset": {
       token: token,
@@ -346,7 +346,7 @@ Accounts.sendVerificationEmail = function (userId, address) {
   var tokenRecord = {
     token: Random.id(),
     address: address,
-    when: +(new Date)};
+    when: new Date()};
   Meteor.users.update(
     {_id: userId},
     {$push: {'services.email.verificationTokens': tokenRecord}});


### PR DESCRIPTION
I found +(new Date) in the following files:
- examples/unfinished/benchmark/benchmark.js
- examples/other/quiescence/quiescence.js 
- packages/livedata/livedata_server.js 
- packages/accounts-base/accounts_server.js 
- packages/accounts-password/password_server.js 
- packages/livedata/sockjs-0.3.4.js 
- packages/minimongo/minimongo_tests.js 
- examples/other/template-demo/client/d3.v2.js 

I updated only the code that would be used to generate production data and cause difficulties in querying the data with the MongoDB Aggregation Framework.
- packages/accounts-base/accounts_server.js
- packages/accounts-password/password_server.js
