### PR TITLE
Fixes Issue #654 - Count doesn't work when limit is specified.

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -184,7 +184,7 @@ LocalCollection.Cursor.prototype.count = function () {
   var self = this;
 
   if (self.reactive)
-    self._depend({added: true, removed: true});
+    self._depend({added: true, removed: true}, true);
 
   if (self.db_objects === null)
     self.db_objects = self._getRawObjects(true);
@@ -243,7 +243,7 @@ _.extend(LocalCollection.Cursor.prototype, {
 
     var ordered = LocalCollection._isOrderedChanges(options);
 
-    if (!ordered && (self.skip || self.limit))
+    if (!options._suppress_ordered && !ordered && (self.skip || self.limit))
       throw new Error("must use ordered observe with skip or limit");
 
     // XXX merge this object w/ "this" Cursor.  they're the same.
@@ -391,7 +391,7 @@ LocalCollection.Cursor.prototype._getRawObjects = function (ordered) {
 
 // XXX Maybe we need a version of observe that just calls a callback if
 // anything changed.
-LocalCollection.Cursor.prototype._depend = function (changers) {
+LocalCollection.Cursor.prototype._depend = function (changers, _suppress_ordered) {
   var self = this;
 
   if (Deps.active) {
@@ -399,7 +399,10 @@ LocalCollection.Cursor.prototype._depend = function (changers) {
     v.depend();
     var notifyChange = _.bind(v.changed, v);
 
-    var options = {_suppress_initial: true};
+    var options = {
+      _suppress_initial: true,
+      _suppress_ordered: _suppress_ordered
+    };
     _.each(['added', 'changed', 'removed', 'addedBefore', 'movedBefore'],
            function (fnName) {
              if (changers[fnName])

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -1875,3 +1875,29 @@ Tinytest.add("minimongo - immediate invalidate", function (test) {
 
   c.stop();
 });
+
+
+Tinytest.add("minimongo - count on cursor with limit", function(test){
+  var coll = new LocalCollection(), called = 0;
+
+  coll.insert({_id: 'A'});
+  coll.insert({_id: 'B'});
+  coll.insert({_id: 'C'});
+  coll.insert({_id: 'D'});
+
+  var c = Deps.autorun(function (c) {
+    var cursor = coll.find({_id: {$exists: true}}, {sort: {_id: 1}, limit: 3});
+    test.equal(cursor.count(), 3)
+    if (!c.firstRun){
+      called = called + 1;
+    }
+  });
+
+  coll.remove('A');
+
+  coll.insert('A');
+
+  test.equal(called, 2)
+  c.stop();
+
+});


### PR DESCRIPTION
Quick test & fix for minimongo - count() wont work when a limit is applied.

Could be optimised to not invalidate the current computation while the count is still above or equal to the limit.
