### PR TITLE
Add the option to use a hosted domain with google's oauth

### DIFF
--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -44,6 +44,10 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
         '&access_type=' + accessType +
         '&approval_prompt=' + approvalPrompt;
 
+  if (options.hostedDomain) {
+    loginUrl += '&hd=' + encodeURIComponent(options.hostedDomain);
+  }
+
   Oauth.initiateLogin(credentialToken,
                       loginUrl,
                       credentialRequestCompleteCallback,


### PR DESCRIPTION
The hd option is used to restrict which email domain that are allowed to
log in to your app.

Starting from this commit you can pass `hostedDomain: 'example.com'` to
only allow emails from the domain `example.com`.
