### PR TITLE
Allow customizing the HTTP response body charset.

### DIFF
--- a/docs/client/api.js
+++ b/docs/client/api.js
@@ -1626,7 +1626,10 @@ Template.api.httpcall = {
      descr: "Maximum time in milliseconds to wait for the request before failing.  There is no timeout by default."},
     {name: "followRedirects",
      type: "Boolean",
-     descr: "If true, transparently follow HTTP redirects.  Cannot be set to false on the client."}
+     descr: "If true, transparently follow HTTP redirects.  Cannot be set to false on the client."},
+    {name: "encoding",
+     type: "String",
+     descr: "Charset used to interpret the response body. Ignored on the client. Defaults to `utf8`. The node.js documentation has [a list of possible encodings](http://nodejs.org/api/buffer.html#buffer_buffer)."}
   ]
 };
 

--- a/packages/http/httpcall_server.js
+++ b/packages/http/httpcall_server.js
@@ -75,7 +75,7 @@ var _call = function(method, url, options, callback) {
   var req_options = {
     url: new_url,
     method: method,
-    encoding: "utf8",
+    encoding: options.encoding || "utf8",
     jar: false,
     timeout: options.timeout,
     body: content,


### PR DESCRIPTION
This allows to interpret HTTP responses with other encodings than utf-8 and with wrong encodings correctly.

_Example:_ If the response body is latin-1-encoded, utf-8 decoding would replace characters like `ü` with `�`, making it impossible to guess which character was in the original response. With a customizable encoding, `binary` can be used to get the unchanged response body. The string can then be converted with a library like [iconv-lite](https://github.com/ashtuchkin/iconv-lite).
