### PR TITLE
Fix bug in d3 tab character parsing

### DIFF
--- a/packages/d3/d3.v3.js
+++ b/packages/d3/d3.v3.js
@@ -1789,7 +1789,7 @@ d3 = function() {
     return dsv;
   }
   d3.csv = d3_dsv(",", "text/csv");
-  d3.tsv = d3_dsv(" ", "text/tab-separated-values");
+  d3.tsv = d3_dsv("	", "text/tab-separated-values");
   var d3_timer_id = 0, d3_timer_byId = {}, d3_timer_queue = null, d3_timer_interval, d3_timer_timeout;
   d3.timer = function(callback, delay, then) {
     if (arguments.length < 3) {


### PR DESCRIPTION
Copy/paste probably replaced tab with space. See the current code here:

https://github.com/mbostock/d3/blob/master/d3.js
