### PR TITLE
A trivial way to implement Npm.resolve for #845

### DIFF
--- a/tools/server/boot.js
+++ b/tools/server/boot.js
@@ -82,32 +82,39 @@ Fiber(function () {
   _.each(serverJson.load, function (fileInfo) {
     var code = fs.readFileSync(path.resolve(serverDir, fileInfo.path));
 
+    var require_or_resolve = function (f, name) {
+      if (! fileInfo.node_modules) {
+        return f(name);
+      }
+
+      var nodeModuleDir =
+        path.resolve(serverDir, fileInfo.node_modules, name);
+
+      if (fs.existsSync(nodeModuleDir)) {
+        return f(nodeModuleDir);
+        }
+      try {
+        return f(name);
+      } catch (e) {
+        // Try to guess the package name so we can print a nice
+        // error message
+        var filePathParts = fileInfo.path.split(path.sep);
+        var packageName = filePathParts[1].replace(/\.js$/, '');
+
+        // XXX better message
+        throw new Error(
+          "Can't find npm module '" + name +
+            "'. Did you forget to call 'Npm.depends' in package.js " +
+            "within the '" + packageName + "' package?");
+        }
+    };
+
     var Npm = {
       require: function (name) {
-        if (! fileInfo.node_modules) {
-          return require(name);
-        }
-
-        var nodeModuleDir =
-          path.resolve(serverDir, fileInfo.node_modules, name);
-
-        if (fs.existsSync(nodeModuleDir)) {
-          return require(nodeModuleDir);
-          }
-        try {
-          return require(name);
-        } catch (e) {
-          // Try to guess the package name so we can print a nice
-          // error message
-          var filePathParts = fileInfo.path.split(path.sep);
-          var packageName = filePathParts[1].replace(/\.js$/, '');
-
-          // XXX better message
-          throw new Error(
-            "Can't find npm module '" + name +
-              "'. Did you forget to call 'Npm.depends' in package.js " +
-              "within the '" + packageName + "' package?");
-          }
+        return require_or_resolve(require, name);
+      },
+      resolve: function (name) {
+        return require_or_resolve(require.resolve, name);
       }
     };
     var getAsset = function (assetPath, encoding, callback) {


### PR DESCRIPTION
This is a fix for #845 to add `require.resolve` to `Npm`. The idea is that sometimes you have to have access to files bundled in npm packages and not import them as node.js modules.

(Updated version of #1188 against current `devel` branch.)
