### PR TITLE
Check for err.stack in logErr in wrapAsync

### DIFF
--- a/packages/meteor/helpers.js
+++ b/packages/meteor/helpers.js
@@ -84,7 +84,7 @@ _.extend(Meteor, {
       var logErr = function (err) {
         if (err)
           return Meteor._debug("Exception in callback of async function",
-                               err ? err.stack : err);
+                               err.stack ? err.stack : err);
       };
 
       // Pop off optional args that are undefined


### PR DESCRIPTION
`err` has already true value at that point, so we probably want to check if there is `err.stack` available. Otherwise code can be simplified in another way.
