### PR TITLE
Check that the argument to EJSON.parse is a string.

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -211,6 +211,8 @@ EJSON.stringify = function (item) {
 };
 
 EJSON.parse = function (item) {
+  if (typeof item !== 'string')
+    throw new Error("EJSON.parse argument should be a string");
   return EJSON.fromJSONValue(JSON.parse(item));
 };
 

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -72,3 +72,11 @@ Tinytest.add("ejson - clone", function (test) {
   };
   testCloneArgs(1, 2, "foo", [4]);
 });
+
+Tinytest.add("ejson - parse", function (test) {
+  test.equal(EJSON.parse("[1,2,3]"), [1,2,3]);
+  test.throws(
+    function () { EJSON.parse(null) },
+    /argument should be a string/
+  );
+});


### PR DESCRIPTION
Some Android browser versions of JSON.parse can crash when passed null
(https://code.google.com/p/android/issues/detail?id=11973), so it's
better not to pass on a non-string argument to JSON.parse.

Thanks to @raix for raising the issue in #1401.
