### PR TITLE
On the server, make the Mongo collection operation result available.

### DIFF
--- a/packages/mongo-livedata/collection.js
+++ b/packages/mongo-livedata/collection.js
@@ -378,8 +378,8 @@ _.each(["insert", "update", "remove"], function (name) {
 
     var wrappedCallback;
     if (callback) {
-      wrappedCallback = function (error, result) {
-        callback(error, !error && ret);
+      wrappedCallback = function (error, mongoResult) {
+        callback(error, !error && ret, mongoResult);
       };
     }
 

--- a/packages/mongo-livedata/mongo_livedata_tests.js
+++ b/packages/mongo-livedata/mongo_livedata_tests.js
@@ -612,6 +612,23 @@ if (Meteor.isServer) {
     x++;
   });
 
+  Tinytest.addAsync("mongo-livedata - mongo result from server-side update, " + idGeneration, function (test, onComplete) {
+    var cname = Random.id();
+    var coll = new Meteor.Collection(cname);
+    var doc = { foo: "bar", n: 0 };
+    var id = coll.insert(doc);
+    coll.update({ foo: "zzz" }, { $set: { n: 1 } }, function (err, result, mongoResult) {
+      test.equal(err, null);
+      test.equal(mongoResult, 0);
+
+      coll.update({ foo: "bar" }, { $set: { n : 1 } }, function (err, result, mongoResult) {
+        test.equal(err, null);
+        test.equal(mongoResult, 1);
+        onComplete();
+      });
+    });
+  });
+
   Tinytest.addAsync("mongo-livedata - async server-side remove, " + idGeneration, function (test, onComplete) {
     // Tests that remove returns before the callback runs.
     var cname = Random.id();


### PR DESCRIPTION
Some MongoDB design patterns such as [Update if Current](http://docs.mongodb.org/manual/tutorial/isolate-sequence-of-operations/#update-if-current) need access to the Mongo result.

This only makes sense on the server, since the client doesn't have a
way to do atomic updates by itself anyway.

For collection methods where a callback is included, call the callback
with the Mongo result as the third parameter.

(This means the Mongo result isn't available when using collection
methods synchronously, but this is a pretty specialized case and the
developer is more likely to be using a package providing e.g.
optimistic update-with-retry functionality rather than using it
directly).
