### PR TITLE
Fixed #1358 Dont throw an error if weak package dont exist

### DIFF
--- a/tools/packages.js
+++ b/tools/packages.js
@@ -211,8 +211,13 @@ _.extend(Slice.prototype, {
       _.each(self[field], function (u) {
         var pkg = self.pkg.library.get(u.package, /* throwOnError */ false);
         if (! pkg) {
-          buildmessage.error("no such package: '" + u.package + "'");
-          // recover by omitting this package from the field
+          // Dont throw a build error if its a weak dependency
+          if (! u.weak) {
+            buildmessage.error("no such package: '" + u.package + "'");
+            // recover by omitting this package from the field            
+          } else {
+            // XXX Maybe warn that the weak dependency package is non existing
+          }
         } else
           scrubbed.push(u);
       });


### PR DESCRIPTION
I'm having an issue where I have a weak dependency - Its not installed
but I didnt expect that to be a problem.

This limits development of packages, specially testing packages that
depends on external/non-core packages.

Since its a weak dependency we would expect that the package survive
even if the weak dependency is not found.
