### PR TITLE
Add the error message to the Meteor._debug call

### DIFF
--- a/packages/livedata/livedata_server.js
+++ b/packages/livedata/livedata_server.js
@@ -1018,7 +1018,7 @@ Server = function () {
       } catch (e) {
         // XXX print stack nicely
         Meteor._debug("Internal exception while processing message", msg,
-                      e.stack);
+                      e.message, e.stack);
       }
     });
 


### PR DESCRIPTION
Example console output before commit:
Internal exception while processing message { msg: 'method', method: 'compare', params: [], id: '14' } undefined

Console output after commit:
Internal exception while processing message { msg: 'method', method: 'compare', params: [], id: '14' } Maximum call stack size exceeded undefined
