### PR TITLE
Make bundler.js ignore node_modules and Gruntfile.js

### DIFF
--- a/tools/bundler.js
+++ b/tools/bundler.js
@@ -177,6 +177,7 @@ var ignoreFiles = [
     /~$/, /^\.#/, /^#.*#$/,
     /^\.DS_Store\/?$/, /^ehthumbs\.db$/, /^Icon.$/, /^Thumbs\.db$/,
     /^node_modules\/$/, /* avoids bubndling files created by "npm install" */
+    /^Gruntfile.js$/, /* Gruntfile contains "module.exports" which cause ReferenceError */
     /^\.meteor\/$/, /* avoids scanning N^2 files when bundling all packages */
     /^\.git\/$/ /* often has too many files to watch */
 ];


### PR DESCRIPTION
This pull request makes bundler ignore `node_modules` and `Gruntfile.js` folder from tar.gz bundle.
Also it fixes app crashes when project root contain `Gruntfile.js`

Fix for issue #1454
