### PR TITLE
Make the shark example work

### DIFF
--- a/examples/unfinished/shark/client/shark.js
+++ b/examples/unfinished/shark/client/shark.js
@@ -85,7 +85,7 @@ _.each({
 });
 
 UI.body.rendered = function () {
-  this.$('#list').sortable({
+  $(this.find('#list')).sortable({
     stop: function (event, ui) {
       var el = ui.item.get(0);
       var before = ui.item.prev().get(0);

--- a/packages/animation/animated_each.js
+++ b/packages/animation/animated_each.js
@@ -256,7 +256,7 @@ var apply = function (el, events) {
   }
 };
 
-AnimatedList = Package.ui.Component.extend({
+AnimatedList = UI.Component.extend({
   typeName: 'AnimatedList',
   render: function (buf) {
     buf.write(this.content);


### PR DESCRIPTION
- Animated each reference to `UI`
- Fix example reference

Is `this.$` deprecated? or should it be added to scope in the
`ui/render.js -> comp.templateInstance`

``` js
$: function(selector) {
  return $(this.find(selector));
}
```
