### PR TITLE
Fixes #1470

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -113,13 +113,14 @@ WebApp.connectHandlers.use(function(req, res, next) {
   _.each(WebApp.clientProgram.manifest, function (resource) {
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(resource.url)) {
-      if (resource.cacheable)
+      if (resource.cacheable) {
         manifest += resource.url;
+        manifest += "\n";
+      }
       // If the resource is not already cacheable (has a query
       // parameter, presumably with a hash or version of some sort),
       // put a version with a hash in the fallback section instead.
 
-      manifest += "\n";
     }
   });
   manifest += "\n";

--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -150,6 +150,9 @@ WebApp.connectHandlers.use(function(req, res, next) {
   manifest += "\n";
 
   manifest += "NETWORK:\n";
+  // TODO adding the manifest file to NETWORK should be unnecessary?
+  // Want more testing to be sure.
+  manifest += "/app.manifest" + "\n";
 
   _.each(
     [].concat(

--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -126,6 +126,10 @@ WebApp.connectHandlers.use(function(req, res, next) {
   manifest += "\n";
 
   manifest += "FALLBACK:\n";
+
+  // Add fallback strategy for routes not allready defined in the appcache
+  manifest += "/ /" + "\n";
+
   // Add a fallback entry for each uncacheable asset we added above.
   //
   // This means requests for the bare url (/image.png instead of

--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -113,16 +113,11 @@ WebApp.connectHandlers.use(function(req, res, next) {
   _.each(WebApp.clientProgram.manifest, function (resource) {
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(resource.url)) {
-      manifest += resource.url;
+      if (resource.cacheable)
+        manifest += resource.url;
       // If the resource is not already cacheable (has a query
       // parameter, presumably with a hash or version of some sort),
-      // put a version with a hash in the cache.
-      //
-      // Avoid putting a non-cacheable asset into the cache, otherwise
-      // the user can't modify the asset until the cache headers
-      // expire.
-      if (!resource.cacheable)
-        manifest += "?" + resource.hash;
+      // put a version with a hash in the fallback section instead.
 
       manifest += "\n";
     }
@@ -130,7 +125,6 @@ WebApp.connectHandlers.use(function(req, res, next) {
   manifest += "\n";
 
   manifest += "FALLBACK:\n";
-  manifest += "/ /" + "\n";
   // Add a fallback entry for each uncacheable asset we added above.
   //
   // This means requests for the bare url (/image.png instead of
@@ -151,9 +145,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
   manifest += "\n";
 
   manifest += "NETWORK:\n";
-  // TODO adding the manifest file to NETWORK should be unnecessary?
-  // Want more testing to be sure.
-  manifest += "/app.manifest" + "\n";
+
   _.each(
     [].concat(
       RoutePolicy.urlPrefixesFor('network'),


### PR DESCRIPTION
Files should only be added once to the app.manifest into one of the sections: `CACHE`;`FALLBACK`;`NETWORK`
Otherwise it confuses some app cache implementations on mobile browser and safarie 5,6 on mac os x.

Changes:
* All `non-cacheable` assets are placed in fallback section and added a
hash
* `/` is only present i the cached section
* `app.manifest` is handled by the appcache itself

Credit goes to @awwx and @akralj
