### PR TITLE
Improve error reporting of 'audit-argument-checks' package

### DIFF
--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -72,7 +72,7 @@ Match = {
   // (using `description` in the message).
   //
   _failIfArgumentsAreNotAllChecked: function (f, context, args, description) {
-    var argChecker = new ArgumentChecker(args, description);
+    var argChecker = new ArgumentChecker(f, args, description);
     var result = currentArgumentChecker.withValue(argChecker, function () {
       return f.apply(context, args);
     });
@@ -260,15 +260,13 @@ var checkSubtree = function (value, pattern) {
   });
 };
 
-var ArgumentChecker = function (args, description) {
+var ArgumentChecker = function (f, args, description) {
   var self = this;
   // Make a SHALLOW copy of the arguments. (We'll be doing identity checks
   // against its contents.)
   self.args = _.clone(args);
-  // Since the common case will be to check arguments in order, and we splice
-  // out arguments when we check them, make it so we splice out from the end
-  // rather than the beginning.
-  self.args.reverse();
+  // The argument names will be used to display more precise error messages
+  self.argNames = _argumentNames(f);
   self.description = description;
 };
 
@@ -292,6 +290,7 @@ _.extend(ArgumentChecker.prototype, {
       // check.)
       if (value === self.args[i]) {
         self.args.splice(i, 1);
+        self.argNames.splice(i, 1);
         return true;
       }
     }
@@ -299,9 +298,15 @@ _.extend(ArgumentChecker.prototype, {
   },
   throwUnlessAllArgumentsHaveBeenChecked: function () {
     var self = this;
-    if (!_.isEmpty(self.args))
-      throw new Error("Did not check() all arguments during " +
-                      self.description);
+    if (!_.isEmpty(self.args)) {
+      // Are there any named arguments left unchecked?
+      if (!_.isEmpty(self.argNames))
+        throw new Error("Some arguments (" + self.argNames.join(", ") +
+                        ") left unchecked during " + self.description);
+      else
+        throw new Error("Passed too many arguments to function " +
+                        self.description);
+    }
   }
 });
 
@@ -326,3 +331,12 @@ var _prependPath = function (key, base) {
   return key + base;
 };
 
+// To extract the name of the arguments, convert the function to a string
+// and run it through a regex. The regex has been battled tested by Prototype
+// https://ajax.googleapis.com/ajax/libs/prototype/1.7.1.0/prototype.js
+var _argumentNames = function (f) {
+  var names = f.toString().match(/^[\s\(]*function[^(]*\(([^)]*)\)/)[1]
+    .replace(/\/\/.*?[\r\n]|\/\*(?:.|[\r\n])*?\*\//g, '')
+    .replace(/\s+/g, '').split(",");
+  return names.length === 1 && !names[0] ? [] : names;
+};

--- a/packages/check/match_test.js
+++ b/packages/check/match_test.js
@@ -178,31 +178,34 @@ Tinytest.add("check - argument checker", function (test) {
     check(_.toArray(arguments).slice(1), [String]);
   }, 1, "foo", "bar", "baz");
 
-  var doesntCheckAllArguments = function (f /*arguments*/) {
+  var doesntCheckAllArguments = function (message, f /*arguments*/) {
     try {
       Match._failIfArgumentsAreNotAllChecked(
-        f, {}, _.toArray(arguments).slice(1), "test");
+        f, {}, _.toArray(arguments).slice(2), "test");
       test.fail({message: "expected _failIfArgumentsAreNotAllChecked to throw"});
     } catch (e) {
-      test.equal(e.message, "Did not check() all arguments during test");
+      test.equal(e.message, message);
     }
   };
 
-  doesntCheckAllArguments(function () {}, undefined);
-  doesntCheckAllArguments(function () {}, null);
-  doesntCheckAllArguments(function () {}, 1);
-  doesntCheckAllArguments(function () {
+  var tooMany = "Passed too many arguments to function test";
+  var yUnchecked = "Some arguments (y) left unchecked during test";
+
+  doesntCheckAllArguments(tooMany, function () {}, undefined);
+  doesntCheckAllArguments(tooMany, function () {}, null);
+  doesntCheckAllArguments(tooMany, function () {}, 1);
+  doesntCheckAllArguments(tooMany, function () {
     check(_.toArray(arguments).slice(1), [String]);
   }, 1, "asdf", "foo");
-  doesntCheckAllArguments(function (x, y) {
+  doesntCheckAllArguments(yUnchecked, function (x, y) {
     check(x, Boolean);
   }, true, false);
   // One "true" check doesn't count for all.
-  doesntCheckAllArguments(function (x, y) {
+  doesntCheckAllArguments(yUnchecked, function (x, y) {
     check(x, Boolean);
   }, true, true);
   // For non-primitives, we really do require that each arg gets checked.
-  doesntCheckAllArguments(function (x, y) {
+  doesntCheckAllArguments(yUnchecked, function (x, y) {
     check(x, [Boolean]);
     check(x, [Boolean]);
   }, [true], [true]);


### PR DESCRIPTION
Instead of reporting "Did not check() all arguments during setLocation" I report something like "Some arguments (id, name, location) left unchecked during setLocation"

I convert the function to a string and run a regex on it. The regex has been lifted from the `argumentNames` function in the battle tested [Prototype.js](https://ajax.googleapis.com/ajax/libs/prototype/1.7.1.0/prototype.js). Since checks are only run on the server, the variable names are not uglified.
