### PR TITLE
accounts-password: allow createUser without also logging in

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -1685,8 +1685,8 @@ include a turn-key user interface for password-based sign-in.
 {{> api_box accounts_createUser}}
 
 On the client, this function logs in as the newly created user on
-successful completion. On the server, it returns the newly created user
-id.
+successful completion, unless the `suppressLogin` option is set to
+`true`.  On the server, it returns the newly created user id.
 
 On the client, you must pass `password` and one of `username` or `email`
 &mdash; enough information for the user to be able to log in again

--- a/docs/client/api.js
+++ b/docs/client/api.js
@@ -1173,6 +1173,11 @@ Template.api.accounts_config = {
       name: "loginExpirationInDays",
       type: "Number",
       descr: "The number of days from when a user logs in until their token expires and they are logged out. Defaults to 90. Set to `null` to disable login expiration."
+    },
+    {
+      name: "restrictClientAccountCreation",
+      type: "Function",
+      descr: "If set, allow calls to [`createUser`](#accounts_createuser) from the client only if this predicate function returns true. The function is called with one argument: the `userId` of the connection calling `createUser`."
     }
   ]
 };
@@ -1263,6 +1268,11 @@ Template.api.accounts_createUser = {
       name: "profile",
       type: "Object",
       descr: "The user's profile, typically including the `name` field."
+    },
+    {
+      name: "suppressLogin",
+      type: "Boolean",
+      descr: "Do not log in as the newly created user.  Defaults to `false`."
     }
   ]
 };

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -62,6 +62,7 @@ Accounts.callLoginMethod = function (options) {
   options = _.extend({
     methodName: 'login',
     methodArguments: [],
+    suppressLogin: false,
     _suppressLoggingIn: false
   }, options);
   // Set defaults for callback arguments to no-op functions; make sure we
@@ -158,7 +159,8 @@ Accounts.callLoginMethod = function (options) {
     }
 
     // Make the client logged in. (The user data should already be loaded!)
-    makeClientLoggedIn(result.id, result.token, result.tokenExpires);
+    if (!options.suppressLogin)
+      makeClientLoggedIn(result.id, result.token, result.tokenExpires);
     onceUserCallback();
   };
 

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -55,7 +55,8 @@ Accounts.config = function(options) {
 
   // validate option keys
   var VALID_KEYS = ["sendVerificationEmail", "forbidClientAccountCreation",
-                    "restrictCreationByEmailDomain", "loginExpirationInDays"];
+                    "restrictCreationByEmailDomain", "loginExpirationInDays",
+                    "restrictClientAccountCreation"];
   _.each(_.keys(options), function (key) {
     if (!_.contains(VALID_KEYS, key)) {
       throw new Error("Accounts.config: Invalid key: " + key);

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -58,6 +58,7 @@ Accounts.createUser = function (options, callback) {
   Accounts.callLoginMethod({
     methodName: 'createUser',
     methodArguments: [options],
+    suppressLogin: options.suppressLogin,
     userCallback: callback
   });
 };


### PR DESCRIPTION
For some applications, the developer may want to ensure that all
accounts are created by an administrator.  This is hard to do in
Meteor right now, for two reasons:
- Either Accounts.createUser() is accessible for everyone (i.e., when
  forbidClientAccountCreation is false), or it is prohibited for everyone,
  including to the administrator.
- If the administrator calls Accounts.createUser(), the userId is set to
  the newly created user, both on the client and on the server, which has
  the unfortunate effect of logging out the administrator.

This patch fixes the above two problems, and updates the documentation:
- Accounts.config() now takes an option restrictClientAccountCreation,
  which controls when createUser() calls from the client are accepted,
  based on the userId of the connection invoking createUser.
- Accounts.createUser() now takes an option suppressLogin, which avoids
  switching to the newly created user's userId.
