### PR TITLE
Wrapped helper and template methods with try-catch to prevent exceptions from breaking the whole Meteor app

### DIFF
--- a/packages/handlebars/evaluate-handlebars.js
+++ b/packages/handlebars/evaluate-handlebars.js
@@ -238,7 +238,18 @@ Handlebars.evaluate = function (ast, data, options) {
           args[i] = args[i](); // `this` already bound by eval_value
       if (extra)
         args.push(extra);
-      return values[0].apply(stack.data, args);
+
+      try {
+
+        return values[0].apply(stack.data, args);
+
+      } catch (e) {
+
+        console.error("Exception thrown in helper ["+e+"], returning null. Stack trace: ", e.stack);
+        return null;
+
+      }
+
     };
 
     var values = new Array(params.length);

--- a/packages/templating/deftemplate.js
+++ b/packages/templating/deftemplate.js
@@ -131,23 +131,41 @@ Template.__define__ = function (name, raw_func) {
     var tmpl = name && Template[name] || {};
     var tmplData = tmpl._tmpl_data || {};
 
+    function handleTemplateException(e,method) {
+
+      console.error("Exception thrown in template ["+name+"], method ["+method+"]: ["+e+"], stack trace: ", e.stack);
+
+    }
+
     var html = Spark.labelBranch("Template."+name, function () {
       var html = Spark.createLandmark({
         preserve: tmplData.preserve || {},
         created: function () {
           var template = templateObjFromLandmark(this);
           template.data = data;
-          tmpl.created && tmpl.created.call(template);
+          try {
+            tmpl.created && tmpl.created.call(template);
+          } catch (e) {
+            handleTemplateException(e,"created");
+          }
         },
         rendered: function () {
           var template = templateObjFromLandmark(this);
           template.data = data;
-          tmpl.rendered && tmpl.rendered.call(template);
+          try {
+            tmpl.rendered && tmpl.rendered.call(template);
+          } catch (e) {
+            handleTemplateException(e,"rendered");
+          }
         },
         destroyed: function () {
           // template.data is already set from previous callbacks
-          tmpl.destroyed &&
-            tmpl.destroyed.call(templateObjFromLandmark(this));
+          try {
+            tmpl.destroyed &&
+              tmpl.destroyed.call(templateObjFromLandmark(this));
+          } catch (e) {
+            handleTemplateException(e,"destroyed");
+          }
           delete templateInstanceData[this.id];
         }
       }, function (landmark) {


### PR DESCRIPTION
Re-do of PR #1487 that got broken somehow. Original comment below:

A small bug (like a null dereference) in a helper or template method can break a whole Meteor app (causes a blank screen). Wrapping calls to these methods with try-catch and not allowing exceptions to bubble-up is a good solution.

Please see detailed explanation at https://groups.google.com/forum/#!topic/meteor-talk/O0B6lA-hSUE
