### PR TITLE
Feature request - Add server time to client

### DIFF
--- a/packages/livedata/livedata_connection.js
+++ b/packages/livedata/livedata_connection.js
@@ -174,6 +174,21 @@ var Connection = function (url, options) {
     });
   }
 
+  // Client/server time/date difference inclusive transport time
+  var clientServerTimeDiff = 0;
+
+  // Calculate the client server time/date difference
+  var calculateTimeDiff = function(serverTime) {
+    if (typeof serverTime !== 'undefined') {
+      clientServerTimeDiff = serverTime - Date.now();
+    }
+  };
+
+  // Return the current time/date added the client server difference
+  self.serverTime = function() {
+    return new Date( Date.now() + clientServerTimeDiff );
+  };
+
   var onMessage = function (raw_msg) {
     try {
       var msg = parseDDP(raw_msg);
@@ -188,6 +203,7 @@ var Connection = function (url, options) {
     }
 
     if (msg.msg === 'connected') {
+      calculateTimeDiff(msg.serverTime);
       self._version = self._versionSuggestion;
       options.onConnected();
       self._livedata_connected(msg);

--- a/packages/livedata/livedata_server.js
+++ b/packages/livedata/livedata_server.js
@@ -252,6 +252,7 @@ var Session = function (server, version, socket) {
   self._pendingReady = [];
 
   socket.send(stringifyDDP({msg: 'connected',
+                            serverTime: Date.now(),
                             session: self.id}));
   // On initial connect, spin up all the universal publishers.
   Fiber(function () {


### PR DESCRIPTION
- Added server time on connect
- Added a server time getter eg. `Meteor.connection.serverTime()` returns sever Date object

_The clientServerTimeDiff could be persisted in localstorage_

It would allow the user to timestamp data on the client but with the server relative time using `Meteor.connection.serverTime();`
