### PR TITLE
Prevent unwanted exceptions from disrupting meteor client

### DIFF
--- a/packages/liverange/liverange.js
+++ b/packages/liverange/liverange.js
@@ -317,6 +317,12 @@ LiveRange.prototype.visit = function(visitRange, visitNode) {
 
   var recurse = function(start, end, startRangeSkip) {
     var startIndex = startRangeSkip || 0;
+    
+    if (!end || !end.nextSibling) {
+      Meteor._debug('empty end-range detected in liveRange.prototype.visit - recurse()');
+      return;
+    }
+    
     var after = end.nextSibling;
     for(var n = start; n && n !== after; n = n.nextSibling) {
       var startData = n[tag] && n[tag][0];


### PR DESCRIPTION
Without this error check on the end parameter, liverange.js throws unwanted exceptions, causing meteor client to go into a broken state and misbehave.

Instead of just quietly swallowing this condition, I've opted to still print a warning during debug mode.
