### PR TITLE
bumped less npm dependency to version 1.5.0

### DIFF
--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -8,7 +8,7 @@ Package._transitional_registerBuildPlugin({
   sources: [
     'plugin/compile-less.js'
   ],
-  npmDependencies: {"less": "1.3.3"}
+  npmDependencies: {"less": "1.5.0"}
 });
 
 Package.on_test(function (api) {


### PR DESCRIPTION
see issue #1556
`less` tests are passing with v1.5.0
