### PR TITLE
Add Twitter Options: forceLogin and requestPermissions

### DIFF
--- a/packages/oauth1/oauth1_binding.js
+++ b/packages/oauth1/oauth1_binding.js
@@ -17,14 +17,21 @@ OAuth1Binding = function(config, urls) {
   this._urls = urls;
 };
 
-OAuth1Binding.prototype.prepareRequestToken = function(callbackUrl) {
+OAuth1Binding.prototype.prepareRequestToken = function(options, callbackUrl) {
   var self = this;
 
-  var headers = self._buildHeader({
-    oauth_callback: callbackUrl
-  });
+  // support both (options, callback) and (callback).
+  if (!callbackUrl && typeof options === 'function') {
+    callbackUrl = options;
+    options = {};
+  }
 
-  var response = self._call('POST', self._urls.requestToken, headers);
+  var headers = self._buildHeader({ oauth_callback: callbackUrl });
+
+  // Options are passed as params, without any further processing
+  var params = options;
+
+  var response = self._call('POST', self._urls.requestToken, headers, params);
   var tokens = querystring.parse(response.content);
 
   if (!tokens.oauth_callback_confirmed)

--- a/packages/oauth1/oauth1_server.js
+++ b/packages/oauth1/oauth1_server.js
@@ -17,12 +17,20 @@ Oauth._requestHandlers['1'] = function (service, query, res) {
   if (query.requestTokenAndRedirect) {
     // step 1 - get and store a request token
 
+    requestTokenOptions = {};
+    if(query.requestTokenOptions) {
+      var requestTokenParamNames = query.requestTokenOptions.split(',');
+      _.each(requestTokenParamNames, function(paramName) {
+        requestTokenOptions[paramName] = query[paramName];
+      });
+    }
+
     // Get a request token to start auth process
-    oauthBinding.prepareRequestToken(query.requestTokenAndRedirect);
+    oauthBinding.prepareRequestToken(requestTokenOptions, query.requestTokenAndRedirect);
 
     // Keep track of request token so we can verify it on the next step
     requestTokens[query.state] = {
-      requestToken: oauthBinding.requestToken, 
+      requestToken: oauthBinding.requestToken,
       requestTokenSecret: oauthBinding.requestTokenSecret
     };
 
@@ -32,6 +40,14 @@ Oauth._requestHandlers['1'] = function (service, query, res) {
       redirectUrl = urls.authenticate(oauthBinding);
     } else {
       redirectUrl = urls.authenticate + '?oauth_token=' + oauthBinding.requestToken;
+    }
+
+    // Add any authenticationOption parameters to the URL
+    if (query.authenticationOptions) {
+      var authenticationOptionParamNames = query.authenticationOptions.split(',');
+      _.each(authenticationOptionParamNames, function(paramName) {
+        redirectUrl += '&' + paramName + '=' + query[paramName];
+      });
     }
 
     // redirect to provider login, which will redirect back to "step 2" below

--- a/packages/twitter/twitter_client.js
+++ b/packages/twitter/twitter_client.js
@@ -1,16 +1,25 @@
 Twitter = {};
 
 // Request Twitter credentials for the user
-// @param options {optional}  XXX support options.requestPermissions
+// @param options {optional Object} with fields:
+// - requestPermissions {'read' or 'write'}
+//     Request a specific permission level from Twitter (Twitter's x_auth_access_type)
+//     If you nead RWD, leave this blank, and configure it in your Twitter app config
+// - forceLogin {Boolean}
+//     If true, tells Twitter to prompt for a new login
 // @param credentialRequestCompleteCallback {Function} Callback function to call on
 //   completion. Takes one argument, credentialToken on success, or Error on
 //   error.
 Twitter.requestCredential = function (options, credentialRequestCompleteCallback) {
-  // support both (options, callback) and (callback).
+  // Support both (options, callback) and (callback).
   if (!credentialRequestCompleteCallback && typeof options === 'function') {
     credentialRequestCompleteCallback = options;
     options = {};
   }
+
+  // If options is null or undefined, default it to an empty object
+  if (!options)
+    options = {};
 
   var config = ServiceConfiguration.configurations.findOne({service: 'twitter'});
   if (!config) {
@@ -33,5 +42,28 @@ Twitter.requestCredential = function (options, credentialRequestCompleteCallback
         + encodeURIComponent(callbackUrl)
         + '&state=' + credentialToken;
 
+  // Prepare authentication options
+  var authenticationOptions = [];
+
+  if (options.forceLogin === true) {
+    url += '&force_login=true';
+    authenticationOptions.push('force_login');
+  }
+
+  if (authenticationOptions.length > 0)
+    url += '&authenticationOptions=' + authenticationOptions.join(',');
+
+  // Prepare request token options
+  var requestTokenOptions = [];
+
+  if (options.requestPermissions) {
+    url += '&x_auth_access_type=' + options.requestPermissions;
+    requestTokenOptions.push('x_auth_access_type');
+  }
+
+  if (requestTokenOptions.length > 0)
+    url += '&requestTokenOptions=' + requestTokenOptions.join(',');
+
+  // Initiate the login
   Oauth.initiateLogin(credentialToken, url, credentialRequestCompleteCallback);
 };


### PR DESCRIPTION
This PR preserves backwards compatibility. It adds two options to the Twitter package. When requesting a credential, there are now two options.

The forceLogin option means force_login gets passed through to Twitter, telling it to present the authentication form as a login form, disregarding any user currently signed in to Twitter.com at the time.

The requestPermissions option allows an app to specify a lower permission level if it doesn't want use the one the app is configured with at dev.twitter.com. Valid options are 'read' and 'write'.

Closes #616, #1564
