### PR TITLE
asking for password on stderr instead of stdout so `meteor mongo --url` can be used in scripts

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -358,7 +358,7 @@ var with_password = function (site, callback) {
       callback();
 
     } else {
-      process.stdout.write("Password: ");
+      process.stderr.write("Password: ");
       read_password(callback);
     }
   });


### PR DESCRIPTION
`meteor mongo --url` doesn't work inside of a third-party script.  

For example: `MONGO_URL=$(meteor mongo --url yoursite.meteor.com)`  If the site requires a password, deploy.sh asks the user for the password (via stdout).  The CLI user never sees the prompt, however, since stdout is being saved into $MONGO_URL.  

`sudo`, among others, solves this problem by requesting the password on stderr (http://www.sudo.ws/repos/sudo/file/900a304f9548/src/tgetpass.c).

I figured out a workaround, but it's pretty ugly - the right thing to do (according to sudo, at least) is just to use stderr for prompts like these.

For context, the script I'm writing: https://github.com/AlexeyMK/meteor-download/blob/master/download.sh
