### PR TITLE
Give environmental variables precedence when sending emails over the galaxy config

### DIFF
--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -39,8 +39,8 @@ var maybeMakePool = function () {
   var poolFuture = new Future();
   AppConfig.configurePackage('email', function (config) {
     // TODO: allow reconfiguration.
-    if (!smtpPool && (config.url || process.env.MAIL_URL)) {
-      smtpPool = makePool(config.url || process.env.MAIL_URL);
+    if (!smtpPool && (process.env.MAIL_URL || config.url)) {
+      smtpPool = makePool(process.env.MAIL_URL || config.url);
     }
     poolFuture.return();
   });


### PR DESCRIPTION
The commit https://github.com/meteor/meteor/commit/6db81808fad88d30dbbe22729b6aac835564910c broke the ability to set a custom SMTP server with meteor deploy hosting and presumably galaxy hosted apps too:

The section of the docs goes

> For apps deployed with meteor deploy, MAIL_URL defaults to an account (provided by Mailgun) which allows  apps to send up to 200 emails per day; you may override this default by assigning to process.env.MAIL_URL before your first call to Email.send.

So here the precedence is just re-ordered and environmental variables take precedence over a galaxy configuration.
