### PR TITLE
Configure LESS options from an external .lessrc file

### DIFF
--- a/docs/client/packages/less.html
+++ b/docs/client/packages/less.html
@@ -10,6 +10,8 @@ With the `less` package installed, `.less` files in your application are
 automatically compiled to CSS and the results are included in the client CSS
 bundle.
 
+You can set options for LESS by creating a file called `.lessrc` in your application's root directory. `.lessrc` should be a valid JSON file containing the options you would like to pass to the compiler.
+
 {{#note}}
 If you want to `@import` a file, give it the extension `.lessimport`
 to prevent Meteor from processing it independently.

--- a/packages/less/.lessrc
+++ b/packages/less/.lessrc
@@ -1,0 +1,3 @@
+{
+	"paths": ["less_tests_config"]
+}

--- a/packages/less/less_tests.js
+++ b/packages/less/less_tests.js
@@ -2,7 +2,7 @@
 Tinytest.add("less - presence", function(test) {
 
   var d = OnscreenDiv(Meteor.render(function() {
-    return '<p class="less-dashy-left-border"></p>'; }));
+    return '<p class="less-dashy-dotty-double-border"></p>'; }));
   d.node().style.display = 'block';
 
   var p = d.node().firstChild;
@@ -10,6 +10,9 @@ Tinytest.add("less - presence", function(test) {
 
   // test @import
   test.equal(getStyleProperty(p, 'border-right-style'), "dotted");
+
+  // test .lessrc config
+  test.equal(getStyleProperty(p, 'border-bottom-style'), "double");
 
   d.kill();
 });

--- a/packages/less/less_tests.less
+++ b/packages/less/less_tests.less
@@ -1,10 +1,12 @@
 @import "less_tests_constants.lessimport";
+@import "less_tests_config.lessimport";
 
 #less-tests { zoom: 1; /* prop this rule open */ }
 
 @dashy: dashed;
 
-.less-dashy-left-border {
+.less-dashy-dotty-double-border {
   border-left: @dashy;
   border-right: @external-dotty;
+  border-bottom: @config-double;
 }

--- a/packages/less/less_tests_config/less_tests_config.lessimport
+++ b/packages/less/less_tests_config/less_tests_config.lessimport
@@ -1,0 +1,2 @@
+// This should import if the path is defined in .lessrc file
+@config-double: double;


### PR DESCRIPTION
I needed a simple way to configure the LESS compiler for my application, so I added support for declaring options in a .lessrc file in the project directory. Inspired by @jonschlinkert's implementation in [assemble-less](https://github.com/assemble/assemble-less#lessrc).

I use the config file to predefine additional paths for my imports and enable compression, etc. This could also be useful for enabling/disabling source maps once the dependency gets bumped to the new version (#1565).
