### PR TITLE
Excluded appcache paths are being counted by sizeCheck function

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -178,7 +178,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
 var sizeCheck = function() {
   var totalSize = 0;
   _.each(WebApp.clientProgram.manifest, function (resource) {
-    if (resource.where === 'client') {
+    if (resource.where === 'client' && resource.cacheable) {
       totalSize += resource.size;
     }
   });


### PR DESCRIPTION
I noticed as I was adding paths to exclude from the cache the calculated total wouldn't change to reflect this.

Edit: Sorry. Ignore the PR.
