### PR TITLE
Fix so that it is really possible to pass null to disable transformation in validators

### DIFF
--- a/packages/mongo-livedata/collection.js
+++ b/packages/mongo-livedata/collection.js
@@ -549,7 +549,7 @@ Meteor.Collection.ObjectID = LocalCollection._ObjectID;
         if (!(options[name] instanceof Function)) {
           throw new Error(allowOrDeny + ": Value for `" + name + "` must be a function");
         }
-        if (self._transform)
+        if (self._transform && options.transform !== null)
           options[name].transform = self._transform;
         if (options.transform)
           options[name].transform = Deps._makeNonreactive(options.transform);


### PR DESCRIPTION
In documentation it is written that you can pass `null` to disable transformation for validators, but this does not really work. This pull request fixes that.
