### PR TITLE
Fixing binary Meteor.http content. See #451

### DIFF
--- a/packages/http/httpcall_server.js
+++ b/packages/http/httpcall_server.js
@@ -75,7 +75,7 @@ var _call = function(method, url, options, callback) {
   var req_options = {
     url: new_url,
     method: method,
-    encoding: "utf8",
+    encoding: _.isUndefined(options._encoding) ? "utf8" : options._encoding,
     jar: false,
     timeout: options.timeout,
     body: content,


### PR DESCRIPTION
A new take on #451 and #851. This time made against devel branch. And also using prefixed option, to make sure it is clear it is undocumented feature. By that I would like to address concerns raised by @glasser in #851, that HTTP should in final version be returning EJSON objects on both client and server and not different objects types.

So this would make life much easier until an official solution is made.
