### PR TITLE
Pass "bare" option when using CoffeeScript as well

### DIFF
--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -149,7 +149,10 @@ var handler = function (compileStep, isLiterate) {
     path: outputFile,
     sourcePath: compileStep.inputPath,
     data: sourceWithMap.source,
-    sourceMap: sourceWithMap.sourceMap
+    sourceMap: sourceWithMap.sourceMap,
+    // XXX eventually get rid of backward-compatibility "raw" name
+    // XXX COMPAT WITH 0.6.4
+    bare: compileStep.fileOptions.bare || compileStep.fileOptions.raw
   });
 };
 


### PR DESCRIPTION
Fix for https://github.com/meteor/meteor/issues/1668.
