### PR TITLE
Removed extra comma at end of method. Fixes IE7

### DIFF
--- a/packages/livedata/livedata_common.js
+++ b/packages/livedata/livedata_common.js
@@ -45,7 +45,7 @@ _.extend(MethodInvocation.prototype, {
       throw new Error("Can't call setUserId in a method after calling unblock");
     self.userId = userId;
     self._setUserId(userId);
-  },
+  }
 });
 
 parseDDP = function (stringMessage) {


### PR DESCRIPTION
This small fix let's IE7 run meteor again.
