### PR TITLE
Try to fix #1707

### DIFF
--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -425,7 +425,7 @@ LocalCollection._f = {
 
   // deep equality test: use for literal document and array matches
   _equal: function (a, b) {
-    if (typeof a.test === 'function') {
+    if (a instanceof RegExp) {
       return a.test(b);
     }
     return EJSON.equals(a, b, {keyOrderSensitive: true});


### PR DESCRIPTION
Current did not work on the client - `find`/`findOne` returned `undefined`:

``` js
var coll = new Meteor.Collection("test");
coll.insert({title: "foo"});

coll.findOne({$or: [{title: {$in: [/foo/]}}]}); // returned undefined
on client
```

`EJSON.equals` does a correct 1:1 compare resulting in:

``` js
EJSON.equals("foo", "foo"); // True
EJSON.equals(/foo/, /foo/); // True
EJSON.equals(/foo/, "foo"); // False
```

So the change is applied to `LocalCollection._f._equal` as a simple
test if `operandElt` is a regex - _Not sure if we should crawl `b` in
`_equal` (in case of an object)_
