### PR TITLE
Attributes of the type 'xlink:something', used in SVG, should be set usi...

### DIFF
--- a/packages/ui/attrs.js
+++ b/packages/ui/attrs.js
@@ -114,6 +114,20 @@ var ValueHandler = AttributeHandler.extend({
   }
 });
 
+// attributes of the type 'xlink:something' should be set using
+// the correct namespace in order to work
+var XlinkHandler = AttributeHandler.extend({
+  update: function(element, oldValue, value) {
+    var NS = 'http://www.w3.org/1999/xlink';
+    if (value === null) {
+      if (oldValue !== null)
+        element.removeAttributeNS(NS, this.name);
+    } else {
+      element.setAttributeNS(NS, this.name, this.value);
+    }
+  }
+});
+
 // cross-browser version of `instanceof SVGElement`
 var isSVGElement = function (elem) {
   return 'ownerSVGElement' in elem;
@@ -133,6 +147,8 @@ makeAttributeHandler = function (elem, name, value) {
     return new BooleanHandler(name, value);
   } else if (elem.tagName === 'TEXTAREA' && name === 'value') {
     return new ValueHandler(name, value);
+  } else if (name.substring(0,6) === 'xlink:') {
+    return new XlinkHandler(name.substring(6), value);
   } else {
     return new AttributeHandler(name, value);
   }


### PR DESCRIPTION
...ng the correct namespace in order to work. Therefore, a new attribute handler is used to do so for all attributes who's name start with 'xlink:'. 
