### PR TITLE
Ejson improvements

### DIFF
--- a/packages/ejson/custom_models.js
+++ b/packages/ejson/custom_models.js
@@ -47,10 +47,6 @@ Person.prototype = {
     return EJSON.stringify(this) == EJSON.stringify(other);
   },
 
-  typeName: function () {
-    return "Person";
-  },
-
   toEJSONValue: function () {
     return {
       name: this.name,
@@ -63,10 +59,11 @@ Person.prototype = {
 _.extend(Person, {
   fromEJSONValue: function(value) {
     return new Person(value.name, value.dob, value.address);
-  }
+  },
+  typeName: 'Person'
 });
 
-EJSON.addType("Person", Person);
+EJSON.addType(Person);
 
 _.extend(EJSONTest, {
   Address: Address,

--- a/packages/ejson/custom_models.js
+++ b/packages/ejson/custom_models.js
@@ -30,6 +30,45 @@ EJSON.addType("Address", function fromJSONValue(value) {
   return new Address(value.city, value.state);
 });
 
+function Person (name, dob, address) {
+  this.name = name;
+  this.dob = dob;
+  this.address = address;
+}
+
+Person.prototype = {
+  constructor: Person,
+
+  clone: function () {
+    return new Person(this.name, this.dob, this.address);
+  },
+
+  equals: function (other) {
+    return EJSON.stringify(this) == EJSON.stringify(other);
+  },
+
+  typeName: function () {
+    return "Person";
+  },
+
+  toEJSONValue: function () {
+    return {
+      name: this.name,
+      dob: this.dob,
+      address: this.address
+    };
+  }
+}
+
+_.extend(Person, {
+  fromEJSONValue: function(value) {
+    return new Person(value.name, value.dob, value.address);
+  }
+});
+
+EJSON.addType("Person", Person);
+
 _.extend(EJSONTest, {
-  Address: Address
+  Address: Address,
+  Person: Person
 });

--- a/packages/ejson/custom_models.js
+++ b/packages/ejson/custom_models.js
@@ -1,0 +1,35 @@
+function Address (city, state) {
+  this.city = city;
+  this.state = state;
+}
+
+Address.prototype = {
+  constructor: Address,
+
+  clone: function () {
+    return new Address(this.city, this.state);
+  },
+
+  equals: function (other) {
+    return EJSON.stringify(this) == EJSON.stringify(other);
+  },
+
+  typeName: function () {
+    return "Address";
+  },
+
+  toJSONValue: function () {
+    return {
+      city: this.city,
+      state: this.state
+    };
+  }
+}
+
+EJSON.addType("Address", function fromJSONValue(value) {
+  return new Address(value.city, value.state);
+});
+
+_.extend(EJSONTest, {
+  Address: Address
+});

--- a/packages/ejson/custom_models.js
+++ b/packages/ejson/custom_models.js
@@ -6,10 +6,6 @@ function Address (city, state) {
 Address.prototype = {
   constructor: Address,
 
-  clone: function () {
-    return new Address(this.city, this.state);
-  },
-
   equals: function (other) {
     return EJSON.stringify(this) == EJSON.stringify(other);
   },
@@ -38,10 +34,6 @@ function Person (name, dob, address) {
 
 Person.prototype = {
   constructor: Person,
-
-  clone: function () {
-    return new Person(this.name, this.dob, this.address);
-  },
 
   equals: function (other) {
     return EJSON.stringify(this) == EJSON.stringify(other);

--- a/packages/ejson/custom_models.js
+++ b/packages/ejson/custom_models.js
@@ -6,10 +6,6 @@ function Address (city, state) {
 Address.prototype = {
   constructor: Address,
 
-  equals: function (other) {
-    return EJSON.stringify(this) == EJSON.stringify(other);
-  },
-
   typeName: function () {
     return "Address";
   },
@@ -34,10 +30,6 @@ function Person (name, dob, address) {
 
 Person.prototype = {
   constructor: Person,
-
-  equals: function (other) {
-    return EJSON.stringify(this) == EJSON.stringify(other);
-  },
 
   toEJSONValue: function () {
     return {

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -310,6 +310,10 @@ EJSON.equals = function (a, b, options) {
     }
     return true;
   }
+  switch (EJSON._isCustomType(a) + EJSON._isCustomType(b)) {
+    case 1: return false;
+    case 2: return EJSON.equals(EJSON.toJSONValue(a), EJSON.toJSONValue(b));
+  }
   // fall back to structural equality of objects
   var ret;
   if (keyOrderSensitive) {

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -299,6 +299,8 @@ EJSON.equals = function (a, b, options) {
   }
   if (typeof (a.equals) === 'function')
     return a.equals(b, options);
+  if (typeof (b.equals) === 'function')
+    return b.equals(a, options);
   if (a instanceof Array) {
     if (!(b instanceof Array))
       return false;

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -376,6 +376,10 @@ EJSON.clone = function (v) {
   if (typeof v.clone === 'function') {
     return v.clone();
   }
+  // handle other custom types
+  if (EJSON._isCustomType(v)) {
+    return EJSON.fromJSONValue(EJSON.clone(EJSON.toJSONValue(v)), true);
+  }
   // handle other objects
   ret = {};
   _.each(v, function (value, key) {

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -184,3 +184,26 @@ Tinytest.add("ejson - parse", function (test) {
     /argument should be a string/
   );
 });
+
+Tinytest.add("ejson - custom types", function (test) {
+  var testSameConstructors = function (obj, compareWith) {
+    test.equal(obj.constructor, compareWith.constructor);
+    if (typeof obj === 'object') {
+      _.each(obj, function(value, key) {
+        testSameConstructors(value, compareWith[key]);
+      });
+    }
+  }
+  var testReallyEqual = function (obj, compareWith) {
+    test.equal(obj, compareWith);
+    testSameConstructors(obj, compareWith);
+  }
+  var testRoundTrip = function (obj) {
+    var str = EJSON.stringify(obj);
+    var roundTrip = EJSON.parse(str);
+    testReallyEqual(obj, roundTrip);
+  }
+
+  var a = new EJSONTest.Address('Montreal', 'Quebec');
+  testRoundTrip( {address: a} );
+});

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -215,6 +215,9 @@ Tinytest.add("ejson - custom types", function (test) {
 
   var a = new EJSONTest.Address('Montreal', 'Quebec');
   testCustomObject( {address: a} );
+  var nakedA = {city: 'Montreal', state: 'Quebec'};
+  test.notEqual(nakedA, a);
+  test.notEqual(a, nakedA);
 
   var d = new Date;
   var obj = new EJSONTest.Person("John Doe", d, a);

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -77,6 +77,11 @@ Tinytest.add("ejson - NaN and Inf", function (test) {
   ));
 });
 
+Tinytest.add("ejson - undefined", function (test) {
+  test.equal(EJSON.parse("{\"$Undefined\": true}"), undefined);
+  test.equal(undefined, EJSON.parse("{\"$Undefined\": true}"));
+});
+
 Tinytest.add("ejson - clone", function (test) {
   var cloneTest = function (x, identical) {
     var y = EJSON.clone(x);

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -208,11 +208,17 @@ Tinytest.add("ejson - custom types", function (test) {
     var roundTrip = EJSON.parse(str);
     testReallyEqual(obj, roundTrip);
   }
+  var testCustomObject = function (obj) {
+    testRoundTrip(obj);
+    testReallyEqual(obj, EJSON.clone(obj));
+  }
 
   var a = new EJSONTest.Address('Montreal', 'Quebec');
-  testRoundTrip( {address: a} );
+  testCustomObject( {address: a} );
 
   var d = new Date;
   var obj = new EJSONTest.Person("John Doe", d, a);
-  testRoundTrip( obj );
+  var clone = EJSON.clone(obj);
+  clone.address.city = 'Sherbrooke';
+  test.notEqual( obj, clone );
 });

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -206,4 +206,8 @@ Tinytest.add("ejson - custom types", function (test) {
 
   var a = new EJSONTest.Address('Montreal', 'Quebec');
   testRoundTrip( {address: a} );
+
+  var d = new Date;
+  var obj = new EJSONTest.Person("John Doe", d, a);
+  testRoundTrip( obj );
 });

--- a/packages/ejson/package.js
+++ b/packages/ejson/package.js
@@ -16,6 +16,7 @@ Package.on_test(function (api) {
   api.use('ejson', ['client', 'server']);
   api.use(['tinytest', 'underscore']);
 
+  api.add_files('custom_models.js', ['client', 'server']);
   api.add_files('base64_test.js', ['client', 'server']);
   api.add_files('ejson_test.js', ['client', 'server']);
 });

--- a/packages/livedata/livedata_common.js
+++ b/packages/livedata/livedata_common.js
@@ -76,14 +76,14 @@ parseDDP = function (stringMessage) {
 
   _.each(['fields', 'params', 'result'], function (field) {
     if (_.has(msg, field))
-      msg[field] = EJSON._adjustTypesFromJSONValue(msg[field]);
+      msg[field] = EJSON.fromJSONValue(msg[field], true);
   });
 
   return msg;
 };
 
 stringifyDDP = function (msg) {
-  var copy = EJSON.clone(msg);
+  var copy = _.clone(msg);
   // swizzle 'changed' messages from 'fields undefined' rep to 'fields
   // and cleared' rep
   if (_.has(msg, 'fields')) {
@@ -102,7 +102,7 @@ stringifyDDP = function (msg) {
   // adjust types to basic
   _.each(['fields', 'params', 'result'], function (field) {
     if (_.has(copy, field))
-      copy[field] = EJSON._adjustTypesToJSONValue(copy[field]);
+      copy[field] = EJSON.toJSONValue(copy[field]);
   });
   if (msg.id && typeof msg.id !== 'string') {
     throw new Error("Message id is not a string");


### PR DESCRIPTION
Hi!

When playing around with EJSON, I found a couple of things that I thought could be improved. This PR started quite small and grew bigger as I dug deeper. I didn't create individual PRs as the commits are sequential, I hope that's ok.

Here's a detailed discussion of each commit I've broken down this PR in 8 parts, so each can be discussed independently 

0) No test
The first commit simply adds a basic test for custom types.

#### 1) Embedded custom types
The biggest issue is that the API for custom types requires JSON compatible data. Wouldn't it be best if EJSON compatible data could be used instead?

Taking for example a Person class with a 'date of birth' attribute (or an address that is from another custom type), then an implementer must take care of serializing it, e.g.:

    People.prototype.toJSONValue = function() {
        return {
          name: this.name,
          dob: EJSON.toJSONValue(this.dob), // this.dob would not work here
          // etc...
        }
    }

I'm proposing a solution where a function `toEJSONValue` would be able to return an EJSON compatible value. My patch keeps compatibility with `toJSONValue` although I'm not sure how necessary this is. To do so, the factory argument of `addType` can be an object with a function `fromEJSONValue` instead of a factory.

See also [this stack overflow question](http://stackoverflow.com/questions/17598811/can-i-embed-an-ejson-object-inside-another-ejson-object)

#### 2) `typeName` is not DRY.
There are also very few times where I can imagine that the type returned depends on the object itself. If we allow for the function to be at the constructor level, then it's easier to both simplify the API and avoid the duplication of the custom type. Again, compatibility is maintained.

#### 3) Performance.
`EJSON.{to|from}JSONValue` (& thus `stringify`/`parse`) do a deep clone of the object. This means that simple objects, arrays, etc..., are duplicated, but this seems to be avoidable (partly or even completely in some cases like deserializing). This patch fixes that and no longer uses `EJSON.clone` for either serialization or deserialization. It also simplifies the codebase.

#### 4) support for `undefined`
I couldn't see a reason for `undefined` to not be EJSON compatible. In some odd cases, it might be necessary to change all 'undefined' values to something else, or resort to alternative representations like what `stringifyDDP` does. This patch makes `undefined` EJSON compatible.
I didn't remove the extra massaging in `stringifyDDP` and `parseDDP`, not knowing how set in stone the specs for DDP are, but it would simplify the codebase to do so.

#### 5) `clone` redundancy
Implementing `clone` feels to me to be completely redundant with implementing of `{to|from}{E}JSONValue`. This patch makes EJSON.clone work for any EJSON compatible type, even those that won't define a `clone` function. Note that it could be made more efficient if compatibility with `toJSONValue`/JSON factory was removed.

#### 6) `equals` redundancy
The same thing can be said about implementing `equals()`. Indeed, if the result `toEJSONValue` of two objects is the same, then they should be considered equal (since the client and the server will consider them equal), while if they are different, then we can only assume that the objects themselves are different. This patch makes `EJSON.equals` work for any EJSON compatible type, even those that won't define an `equals` function. Again, this could be made more efficient if compatibility with `toJSONValue`/JSON factory was removed.

#### 7) EJSON.equals symmetry
For some values `x` and `y`, it is possible that `EJSON.equals(x,y) !== EJSON.equals(y,x)`. A simple patch fixes this bug.

#### 8) Automatic helper
I would imagine that the implementation of `{to|from}EJSONValue` will be very similar for most custom types and depend solely on which attributes to serialize. It's pretty easy to add a helper to automatically create these functions. Here's a proposal for `EJSON.defineType`.

It reduces the 36 lines of [this example](https://github.com/EventedMind/meteor-create-a-custom-ejson-type/blob/master/app.js#L26-62) to a single line:

    EJSON.registerType(Address, 'Address', ['city', 'state'])

It will also handle automatically attributes that are themselves of custom types, so this simplifies [this answer](http://stackoverflow.com/questions/17598811/can-i-embed-an-ejson-object-inside-another-ejson-object) to a single paragraph...


Before updating the documentation, etc., I thought I should put this PR out for comments and ideally insight from the core team as to the exact direction to aim for.

Thanks
