### PR TITLE
Fix a typo in the API doc

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -1937,7 +1937,7 @@ effects of `created`.  It fires once and is the last callback to fire.
 
 {{> api_box template_events}}
 
-Declare event handers for instances of this template. Multiple calls add
+Declare event handlers for instances of this template. Multiple calls add
 new event handlers in addition to the existing ones.
 
 See [Event Maps](#eventmaps) for a detailed description of the event


### PR DESCRIPTION
I fixed a little typo in the API section of the documentation (Template.myTemplate.events(eventMap)).
