### PR TITLE
Allow a server option to be passed through to sockJS via DDP.connect

### DIFF
--- a/packages/livedata/livedata_connection.js
+++ b/packages/livedata/livedata_connection.js
@@ -9,7 +9,7 @@ if (Meteor.isServer) {
 // Options:
 //   reloadWithOutstanding: is it OK to reload if there are outstanding methods?
 //   onDDPNegotiationVersionFailure: callback when version negotiation fails.
-//   serverIdentifier: Specifies server component of a sockjs url
+//   _sockjsOptions: Specifies options to pass through to the sockjs client
 var Connection = function (url, options) {
   var self = this;
   options = _.extend({
@@ -34,7 +34,7 @@ var Connection = function (url, options) {
   } else {
     self._stream = new LivedataTest.ClientStream(url, {
       retry: options.retry,
-      serverIdentifier: options.serverIdentifier
+      _sockjsOptions: options._sockjsOptions
     });
   }
 

--- a/packages/livedata/stream_client_common.js
+++ b/packages/livedata/stream_client_common.js
@@ -127,8 +127,8 @@ _.extend(LivedataTest.ClientStream.prototype, {
       self._changeUrl(options.url);
     }
 
-    if (options.serverIdentifier) {
-      self.options.serverIdentifier = options.serverIdentifier;
+    if (options._sockjsOptions) {
+      self.options._sockjsOptions = options._sockjsOptions;
     }
 
     if (self.currentStatus.connected) {

--- a/packages/livedata/stream_client_sockjs.js
+++ b/packages/livedata/stream_client_sockjs.js
@@ -147,15 +147,14 @@ _.extend(LivedataTest.ClientStream.prototype, {
     var self = this;
     self._cleanup(); // cleanup the old socket, if there was one.
 
+    var options = _.extend({
+      protocols_whitelist:self._sockjsProtocolsWhitelist()
+    }, self.options._sockjsOptions);
+
     // Convert raw URL to SockJS URL each time we open a connection, so that we
     // can connect to random hostnames and get around browser per-host
     // connection limits.
-    self.socket = new SockJS(
-      toSockjsUrl(self.rawUrl), undefined, {
-        debug: false,
-        protocols_whitelist: self._sockjsProtocolsWhitelist(),
-        server: self.options.serverIdentifier
-      });
+    self.socket = new SockJS(toSockjsUrl(self.rawUrl), undefined, options);
     self.socket.onopen = function (data) {
       self._connected();
     };


### PR DESCRIPTION
This simple change gives us the ability to set the server component of the sockjs url.  The benefit is that we can then have our proxy route to an appropriate server based on the url.  It allows us to make sure all users within a certain group (organization in our case) are routed to the same server, providing them with real-time updates instead of a 10 second delay, without depending on oplog.

Without specifying it, sockjs default to using a random 3 digit number.  e.g. the 518 in: wss://example.com/sockjs/518/es6gmosh/websocket
