### PR TITLE
Tools doc

### DIFF
--- a/tools/packages.js
+++ b/tools/packages.js
@@ -1366,6 +1366,11 @@ _.extend(Package.prototype, {
           // used. Can also take literal package objects, if you have
           // anonymous packages you want to use (eg, app packages)
           //
+          // @param where 'client', 'server', or an array of those.
+          // The default is ['client', 'server'].
+          //
+          // @param options 'testOnly', boolean.
+          //
           // options can include:
           //
           // - role: defaults to "use", but you could pass something
@@ -1471,7 +1476,8 @@ _.extend(Package.prototype, {
           // Export symbols from this package.
           //
           // @param symbols String (eg "Foo") or array of String
-          // @param where 'client', 'server', or an array of those
+          // @param where 'client', 'server', or an array of those.
+          // The default is ['client', 'server'].
           // @param options 'testOnly', boolean.
           export: function (symbols, where, options) {
             if (role === "test") {


### PR DESCRIPTION
Small fix to document the `where` parameter for packages (and fix a trailing whitespace).
