### PR TITLE
Both

### DIFF
--- a/tools/packages.js
+++ b/tools/packages.js
@@ -1346,6 +1346,8 @@ _.extend(Package.prototype, {
             where = where ? [where] : allWheres;
           }
           where = _.uniq(where);
+          if (where.length === 1 && where[0] === 'both')
+            where = allWheres;
           var realWhere = _.intersection(where, allWheres);
           if (realWhere.length !== where.length) {
             var badWheres = _.difference(where, allWheres);
@@ -1367,7 +1369,8 @@ _.extend(Package.prototype, {
           // anonymous packages you want to use (eg, app packages)
           //
           // @param where 'client', 'server', or an array of those.
-          // The default is ['client', 'server'].
+          // The shortcut 'both' can be used instead of ['client', 'server'].
+          // The default is 'both'.
           //
           // @param options 'testOnly', boolean.
           //
@@ -1477,7 +1480,8 @@ _.extend(Package.prototype, {
           //
           // @param symbols String (eg "Foo") or array of String
           // @param where 'client', 'server', or an array of those.
-          // The default is ['client', 'server'].
+          // The shortcut 'both' can be used instead of ['client', 'server'].
+          // The default is 'both'.
           // @param options 'testOnly', boolean.
           export: function (symbols, where, options) {
             if (role === "test") {


### PR DESCRIPTION
Please allow `'both'` as an alias to `['client', 'server']`. I realize that not entering any value is even shorter, but that solution is not explicit. TBH, I didn't realize it at first as it wasn't documented... this builds on #1774.

This would avoid having to write `both = ['client', 'server']` like [here](https://github.com/bline/meteor-locale/blob/8b27d61aea1aa737b49192c30492ecb5ae660acb/package.js), [here](https://github.com/BeDifferential/meteor-profile/blob/a87ef01b5cac68ff172ba0ecd4afe9837aa6eb8f/package.js), [here](https://github.com/mindreframer/meteorjs-stuff/blob/f4de16806497006bbe8f849d9a027be983d4bcab/github.com/alanning/meteor-roles/roles/package.js),  [etc](https://github.com/RolandStuder/jeizinen-meteor/blob/d8b8ffe5689fd65f24cedd09ec54df3ea1351933/package.js)...
