### PR TITLE
Better parse caller file path in Log._getCallerDetails

### DIFF
--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -96,6 +96,9 @@ Log._getCallerDetails = function (ignoreRegex) {
     if (line.match(/^\s*at eval \(eval/)) {
       return {file: "eval"};
     }
+    else if (line.match(/^\s*at <anonymous>/)) {
+      return {file: "anonymous"};
+    }
 
     // XXX probably wants to be / or .js in case no source maps
     if (line.match(/packages\/logging(?:\/|(?::tests)?\.js)/))


### PR DESCRIPTION
Return whole file path and not just the last segment as only filename is useless in more complex apps with many files which can overlap in filenames. Use browser to parse URL. On the server side it seems there is nothing to be done.
