### PR TITLE
Upgrade CoffeeScript

### DIFF
--- a/History.md
+++ b/History.md
@@ -27,6 +27,8 @@
   XXX see http://jquery.com/upgrade-guide/1.9/ for incompatibilities
   XXX consider taking 1.11 instead, which was released this week
 
+* Upgrade CoffeeScript from 1.6.3 to 1.7.1.
+
 * `force-ssl`: don't require SSL during `meteor run` in IPv6 environments.
 
 

--- a/packages/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
+++ b/packages/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
@@ -1,7 +1,12 @@
 {
   "dependencies": {
     "coffee-script": {
-      "version": "1.6.3"
+      "version": "1.7.1",
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.5"
+        }
+      }
     },
     "source-map": {
       "version": "0.1.24",

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -8,7 +8,7 @@ Package._transitional_registerBuildPlugin({
   sources: [
     'plugin/compile-coffeescript.js'
   ],
-  npmDependencies: {"coffee-script": "1.6.3", "source-map": "0.1.24"}
+  npmDependencies: {"coffee-script": "1.7.1", "source-map": "0.1.24"}
 });
 
 Package.on_test(function (api) {

--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -10,7 +10,7 @@ var stripExportedVars = function (source, exports) {
   var lines = source.split("\n");
 
   // We make the following assumptions, based on the output of CoffeeScript
-  // 1.6.3.
+  // 1.7.1.
   //   - The var declaration in question is not indented and is the first such
   //     var declaration.  (CoffeeScript only produces one var line at each
   //     scope and there's only one top-level scope.)  All relevant variables


### PR DESCRIPTION
Coffeescript 1.7 has been released this week.
Changes are available here: http://coffeescript.org/#changelog
