### PR TITLE
Specify what happens if a String is passed to find/findOne

### DIFF
--- a/docs/client/api.js
+++ b/docs/client/api.js
@@ -546,7 +546,7 @@ Template.api.find = {
     {name: "selector",
      type: "Mongo selector, or String",
      type_link: "selectors",
-     descr: "The query"}
+     descr: "The query, if a selector. If a String is passed, it will be compared against the `_id` field."}
   ],
   options: [
     {name: "sort",
@@ -581,7 +581,7 @@ Template.api.findone = {
     {name: "selector",
      type: "Mongo selector, or String",
      type_link: "selectors",
-     descr: "The query"}
+     descr: "The query, if a selector. If a String is passed, it will be compared against the `_id` field."}
   ],
   options: [
     {name: "sort",


### PR DESCRIPTION
Doesn't look like it has been specified that a String passed to find() or findOne() is equivalent to {_id: string}
