### PR TITLE
Add more support for file upload in `http.call`

### DIFF
--- a/packages/http/httpcall_client.js
+++ b/packages/http/httpcall_client.js
@@ -99,6 +99,10 @@ HTTP.call = function(method, url, options, callback) {
       }, options.timeout);
     };
 
+    // Allow option onProgress
+    if (typeof options.onProgress === 'function')
+      xhr.upload.onprogress = options.onProgress;
+
     // callback on complete
     xhr.onreadystatechange = function(evt) {
       if (xhr.readyState === 4) { // COMPLETE


### PR DESCRIPTION
This pr consists of two commits:
1. Have the `HTTP.call` return the xhr handle - this gives the users a handle eg. to `abort` an upload
2. Allow the user to add a `onProgress` event callback via `options` - This has to be done before `xhr.send`

If you will take this pr I would update the documentation
