### PR TITLE
Document that transforms are ignored in publish functions

### DIFF
--- a/docs/client/api.js
+++ b/docs/client/api.js
@@ -568,7 +568,7 @@ Template.api.find = {
      descr: "(Client only) Default `true`; pass `false` to disable reactivity"},
     {name: "transform",
      type: "Function",
-     descr: "Overrides `transform` on the  [`Collection`](#collections) for this cursor.  Pass `null` to disable transformation."}
+     descr: "Overrides `transform` on the  [`Collection`](#collections) for this cursor.  Pass `null` to disable transformation. Note that on the server, the transform function won't be run if the `find()` is called from a publish functions."}
   ]
 };
 
@@ -600,7 +600,7 @@ Template.api.findone = {
      descr: "(Client only) Default true; pass false to disable reactivity"},
     {name: "transform",
      type: "Function",
-     descr:  "Overrides `transform` on the [`Collection`](#collections) for this cursor.  Pass `null` to disable transformation."
+     descr:  "Overrides `transform` on the [`Collection`](#collections) for this cursor.  Pass `null` to disable transformation. Note that on the server, the transform function won't be run if the `find()` is called from a publish functions."
     }
   ]
 };


### PR DESCRIPTION
Wasted a bunch of time trying to figure out why the transform function was completely ignored by the server-side find() in a publish function.

It would be great if Meteor warned explicitly if a transform function was passed to find() in a publish function.

See also http://stackoverflow.com/questions/18093560/meteor-collection-transform-is-it-done-on-the-server-or-on-the-client-or-it-de
