### PR TITLE
include oauth_verifier as a header, not a parameter

### DIFF
--- a/packages/oauth1/oauth1_binding.js
+++ b/packages/oauth1/oauth1_binding.js
@@ -4,7 +4,7 @@ var querystring = Npm.require("querystring");
 // An OAuth1 wrapper around http calls which helps get tokens and
 // takes care of HTTP headers
 //
-// @param config {Object} 
+// @param config {Object}
 //   - consumerKey (String): oauth consumer key
 //   - secret (String): oauth consumer secret
 // @param urls {Object}
@@ -48,14 +48,11 @@ OAuth1Binding.prototype.prepareAccessToken = function(query, requestTokenSecret)
     self.accessTokenSecret = requestTokenSecret;
 
   var headers = self._buildHeader({
-    oauth_token: query.oauth_token
+    oauth_token: query.oauth_token,
+    oauth_verifier: query.oauth_verifier
   });
 
-  var params = {
-    oauth_verifier: query.oauth_verifier
-  };
-
-  var response = self._call('POST', self._urls.accessToken, headers, params);
+  var response = self._call('POST', self._urls.accessToken, headers);
   var tokens = querystring.parse(response.content);
 
   self.accessToken = tokens.oauth_token;


### PR DESCRIPTION
Per [RFC 5849](http://tools.ietf.org/html/rfc5849), the POST request for
the access token should not include a body, but instead include the
verifier as part of the "Authorization: OAuth" header.  The current code
is broken for authentication against servers which verify the body of
the POST request (in particular, Fitbit has recently switched to this
verification).
