### PR TITLE
Use indexOf for string matching.  Why can't we test tinytest?

### DIFF
--- a/packages/tinytest/tinytest.js
+++ b/packages/tinytest/tinytest.js
@@ -255,11 +255,9 @@ _.extend(TestCaseResults.prototype, {
     else if (typeof s === "object")
       pass = v in s;
     else if (typeof s === "string")
-      for (var i = 0; i < s.length; i++)
-        if (s.charAt(i) === v) {
-          pass = true;
-          break;
-        }
+      if (s.indexOf(v) > -1) {
+        pass = true;
+      }
     else
       /* fail -- not something that contains other things */;
     if (pass)


### PR DESCRIPTION
We noticed that the current implementation of the include assertion method for strings just checks for matching of one letter.  This is sub-optimal as I don't see any actual string matching case where you care about 1 letter.

Instead let's use indexOf and test that it is greater than -1, which only returns -1 if we don't find a match of a substring within a string.  Anything greater than -1 means we found a substring match in the string.

/cc @ryw
