### PR TITLE
$regex throws incorrect error with an empty string argument

### DIFF
--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -384,7 +384,7 @@ var VALUE_OPERATORS = {
   },
   // $options just provides options for $regex; its logic is inside $regex
   $options: function (operand, valueSelector) {
-    if (!valueSelector.$regex)
+    if (!valueSelector.hasOwnProperty("$regex"))
       throw Error("$options needs a $regex");
     return everythingMatcher;
   },


### PR DESCRIPTION
In 0.7.1.2, a query such as `Foo.find({field: {$regex: "", $options: "i"}})` leads to the following error:

```
Exception from Deps recompute: Error: $options needs a $regex
```

This is because the argument checking logic doesn't account for `$regex` possibly being an empty string. In Mongo, the same query would return all documents for which the field exists.

Discovered by @geekyme in mizzao/meteor-autocomplete#15
