### PR TITLE
Fix docs example for custom user data publish

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -1586,8 +1586,11 @@ published to the client. You can publish additional fields for the
 current user with:
 
     Meteor.publish(null, function () {
-      return Meteor.users.find({_id: this.userId},
+      if this.userId
+        return Meteor.users.find({_id: this.userId},
                                {fields: {'other': 1, 'things': 1}});
+      else
+        return null
     });
 
 If the autopublish package is installed, information about all users


### PR DESCRIPTION
Since the function is always subscribed to, sometimes the userId would be null, and I think it would be good practice to not invoke a db query you know won't return anything?
