### PR TITLE
Update Google oauth scopes.  The previous ones were deprecated.

### DIFF
--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -23,8 +23,8 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
   var credentialToken = Random.id();
 
   // always need this to get user id from google.
-  var requiredScope = ['https://www.googleapis.com/auth/userinfo.profile'];
-  var scope = ['https://www.googleapis.com/auth/userinfo.email'];
+  var requiredScope = ['profile'];
+  var scope = ['email'];
   if (options.requestPermissions)
     scope = options.requestPermissions;
   scope = _.union(scope, requiredScope);


### PR DESCRIPTION
Google has documented the deprecation here: https://developers.google.com/+/api/oauth

In my basic testing, these new scopes return the same fields that the Google package was already utilizing.
