### PR TITLE
Put range.removed code in a Deps.nonreactive callback

### DIFF
--- a/packages/ui/render.js
+++ b/packages/ui/render.js
@@ -256,8 +256,10 @@ UI.render = function (kind, parentComponent) {
   range.removed = function () {
     inst.isDestroyed = true;
     if (inst.destroyed) {
-      updateTemplateInstance(inst);
-      inst.destroyed.call(inst.templateInstance);
+      Deps.nonreactive(function () {
+        updateTemplateInstance(inst);
+        inst.destroyed.call(inst.templateInstance);
+      });
     }
   };
 


### PR DESCRIPTION
@avital, @dgreensp
cc @tmeasday

When a range is removed, if the component instance has a destroyed callback
defined, updateTemplateInstance is called and the destroyed callback is called
in the context of the updated templateInstance. updateTemplateInstance calls
getComonentData() which can create a reactive dependency. This doesn't seem
necessary since we're removing the range and causes problems for iron-router.

The problem surfaced in iron-router in combination with using the {{#each
helper. The each helper is currently the only builtin that adds a destroyed
callback. If a previous layout used "{{#each" and a new layout rendered, the
previous range would be removed inside the new computation. If the data context then invalidated the computation, the new layout would render again.
