### PR TITLE
Do not "throw" error if dependency is weak

### DIFF
--- a/tools/packages.js
+++ b/tools/packages.js
@@ -254,7 +254,9 @@ _.extend(Slice.prototype, {
       _.each(self[field], function (u) {
         var pkg = self.pkg.library.get(u.package, /* throwOnError */ false);
         if (! pkg) {
-          buildmessage.error("no such package: '" + u.package + "'");
+          if (! u.weak) {
+            buildmessage.error("no such package: '" + u.package + "'");
+          }
           // recover by omitting this package from the field
         } else
           scrubbed.push(u);


### PR DESCRIPTION
I understand that the packaging system will be refactored before 1.0, but for now this should be a satisfactory workaround for the long-standing issue #1358.
