### PR TITLE
Better error message when trying to deserialize a custom EJSON type

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -114,9 +114,9 @@ var builtinConverters = [
     },
     fromJSONValue: function (obj) {
       var typeName = obj.$type;
-      var converter = customTypes[typeName];
-      if (typeof converter !== "function")
+      if (!_.has(customTypes, typeName))
         throw new Error("Custom EJSON type " + typeName + " is not defined");
+      var converter = customTypes[typeName];
       return converter(obj.$value);
     }
   }


### PR DESCRIPTION
Right now the error message just says "undefined is not a function" and takes some time to figure out. This situation can happen when you've stored some data with a custom type defined but are trying to retrieve it without the type defined (or maybe if you defined only on client or server and are trying to send the object back and forth).
