### PR TITLE
Adds Alternative X_FORWARDED_PROTO header used by haproxy loadbalancer (Rightscale)

### DIFF
--- a/packages/force-ssl/force_ssl_server.js
+++ b/packages/force-ssl/force_ssl_server.js
@@ -33,8 +33,10 @@ httpServer.addListener('request', function (req, res) {
   // Determine if the connection was over SSL at any point. Either we
   // received it as SSL, or a proxy did and translated it for us.
   var isSsl = req.connection.pair ||
-      (req.headers['x-forwarded-proto'] &&
-       req.headers['x-forwarded-proto'].indexOf('https') !== -1);
+      ( ( req.headers['x-forwarded-proto'] &&                                                             
+       req.headers['x-forwarded-proto'].indexOf('https') !== -1) ||                                     
+       (req.headers['X_FORWARDED_PROTO'] &&                                                             
+       req.headers['X_FORWARDED_PROTO'].indexOf('https') !== -1) );
 
   if (!isLocal && !isSsl) {
     // connection is not cool. send a 302 redirect!


### PR DESCRIPTION
We are in the process of deploying a Meteor App to production at a Fortune 100 co with a *rigid* DevOps policy (no changes to existing infrastructure). The HAPROXY managed by RightScale uses the Capitalised_underscore_separated header **X_FORWARDED_PROTO** for re-routing traffic to application servers. This simple change to force-ssl will allow other apps to deploy using HAPROXY without any modification. (Thanks!)