### PR TITLE
@font-face added to css minifiers

### DIFF
--- a/packages/minifiers/minification.js
+++ b/packages/minifiers/minification.js
@@ -95,6 +95,13 @@ traverse.page = function(node) {
     + emit('}');
 };
 
+traverse['font-face'] = function(node){
+  return emit('@font-face', node.position, true)
+    + emit('{')
+    + mapVisit(node.declarations)
+    + emit('}');
+};
+
 traverse.rule = function(node) {
   var decls = node.declarations;
   if (!decls.length) return '';


### PR DESCRIPTION
Recently [css-stringify added @font-face support](https://github.com/reworkcss/css-stringify/commit/a7fe6de82e055d41d1c5923ec2ccef06f2a45efa)

Meteor devel branch will fail to run/deploy if you have @font-face in your CSS without this bugfix.
It simply adds font-face support to the minification script.

It's also related to this [issue](https://github.com/meteor/meteor/issues/2028)
