### PR TITLE
Added `button` property to EventMap

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -2308,8 +2308,11 @@ event bubbles.
 {{/dtdd}}
 
 {{#dtdd name="which" type="Number"}}
-For mouse events, the number of the mouse button (1=left, 2=middle, 3=right).
 For key events, a character or key code.
+{{/dtdd}}
+
+{{#dtdd name="button" type="Number"}}
+For mouse events, the number of the mouse button (1=left, 2=middle, 3=right).
 {{/dtdd}}
 
 {{#dtdd "stopPropagation()"}}


### PR DESCRIPTION
`which` property exists only in keyboard events, `button` only in mouse events.
Error seems inherited from jQuery docs https://api.jquery.com/category/events/event-object/
