### PR TITLE
Fixes #2097 - null !== undefined leads to overwriting client supplied _id on validated insert

### DIFF
--- a/packages/mongo-livedata/collection.js
+++ b/packages/mongo-livedata/collection.js
@@ -772,6 +772,11 @@ Meteor.Collection.prototype._validatedInsert = function (userId, doc,
                                                          generatedId) {
   var self = this;
 
+  // This parameter is optional. Default value is null
+  if (generatedId === undefined) {
+    generatedId = null;
+  }
+
   // call user validators.
   // Any deny returns true means denied.
   if (_.any(self._validators.insert.deny, function(validator) {


### PR DESCRIPTION
Fixes https://github.com/meteor/meteor/issues/2097

null !== undefined leads to always overwriting client supplied `_id` with `undefined` for validated inserts, which led mongodb to create a new _id value for each such document.
