### PR TITLE
Fix occurrences of "cd `dirname $0`"

### DIFF
--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd `dirname $0`
+cd "`dirname "$0"`"
 cd ../..
 export METEOR_HOME=`pwd`
 

--- a/scripts/admin/build-package-tarballs.sh
+++ b/scripts/admin/build-package-tarballs.sh
@@ -14,7 +14,7 @@ set -e
 set -u
 
 # cd to top level dir
-cd `dirname $0`
+cd "`dirname "$0"`"
 cd ../..
 export TOPDIR=$(pwd)
 

--- a/scripts/admin/build-release.sh
+++ b/scripts/admin/build-release.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 
 # cd to top level dir
-cd `dirname $0`
+cd "`dirname "$0"`"
 cd ../..
 TOPDIR=$(pwd)
 

--- a/scripts/admin/build-tools-tarballs.sh
+++ b/scripts/admin/build-tools-tarballs.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 
 # cd to top level dir
-cd `dirname $0`
+cd "`dirname "$0"`"
 cd ../..
 TOPDIR=$(pwd)
 

--- a/scripts/admin/build-tools-tree.sh
+++ b/scripts/admin/build-tools-tree.sh
@@ -8,7 +8,7 @@
 set -e
 set -u
 
-cd `dirname $0`/../..
+cd "`dirname "$0"`"/../..
 
 if [ "$TARGET_DIR" == "" ] ; then
     echo 'Must set $TARGET_DIR'

--- a/scripts/admin/copy-dev-bundle-from-jenkins.sh
+++ b/scripts/admin/copy-dev-bundle-from-jenkins.sh
@@ -8,7 +8,7 @@
 set -e
 set -u
 
-cd `dirname $0`
+cd "`dirname "$0"`"
 
 TARGET="s3://com.meteor.static/test/"
 TEST=no

--- a/scripts/admin/deploy-examples.sh
+++ b/scripts/admin/deploy-examples.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-cd `dirname $0`
+cd "`dirname "$0"`"
 cd ../examples
 
 

--- a/scripts/admin/publish-release.sh
+++ b/scripts/admin/publish-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 set -u
-cd `dirname $0`
+cd "`dirname "$0"`"
 DIR="$(pwd)"
 METEOR_DIR="$(pwd)/../.."
 

--- a/scripts/admin/upgrade-to-engine/build-fake-release.sh
+++ b/scripts/admin/upgrade-to-engine/build-fake-release.sh
@@ -10,7 +10,7 @@ set -e
 set -u
 
 # cd to top level dir
-cd `dirname $0`
+cd "`dirname "$0"`"
 cd ../../..
 TOPDIR=$(pwd)
 

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -49,7 +49,7 @@ fi
 PLATFORM="${UNAME}_${ARCH}"
 
 # save off meteor checkout dir as final target
-cd `dirname $0`/..
+cd "`dirname "$0"`"/..
 TARGET_DIR=`pwd`
 
 # Read the bundle version from the meteor shell script.

--- a/tools/tests/old/cli-test.sh
+++ b/tools/tests/old/cli-test.sh
@@ -11,7 +11,7 @@
 
 set -e -x
 
-cd `dirname $0`/../../..
+cd "`dirname "$0"`"/../../..
 
 # METEOR_TOOL_PATH is the path to the 'meteor' that we will use for
 # our tests. There is a vestigal capability to default to running the


### PR DESCRIPTION
They are not safe for spaces in paths. There might be other places to look for trouble.

I've run the following command to produce this commit: (on OS X, copy-and-pasting the below exactly)

```
find . -type f -name '*.sh' -print0  |  # Find all .sh files
    xargs -0 fgrep -H -- '`'         |  # See all places with backticks in them
    fgrep 'cd `dirname $0'           |  # I deemed these problematic (variable assignments are safe)
    cut -d ':' -f 1                  |  # Take the <file> from <file>:<line> produced by "grep -H"
    tr '\n' '\0'                     |  # Also here, spaces can be problematic - always do "xargs -0"!
    xargs -0 -- sed -i '' 's/cd `dirname $0`/cd "`dirname "$0"`"/g'
```

The significance of adding the two levels of "'s can be verified by running the following in your Terminal:

```
$ node -e 'console.log(process.argv.splice(1))' -- `echo 1   2`
[ '1', '2' ]

$ node -e 'console.log(process.argv.splice(1))' -- "`echo 1   2`"
[ '1 2' ]

$ node -e 'console.log(process.argv.splice(1))' -- "`echo "1   2"`"
[ '1   2' ]
```

I have not run or updated any tests, neither before nor after creating this commit.
