### PR TITLE
Make subscriptions handles reactively stop.

### DIFF
--- a/packages/livedata/livedata_connection.js
+++ b/packages/livedata/livedata_connection.js
@@ -528,7 +528,7 @@ _.extend(Connection.prototype, {
         connection: self,
         remove: function() {
           delete this.connection._subscriptions[this.id];
-          this.readyDeps.changed();
+          this.ready && this.readyDeps.changed();
         },
         stop: function() {
           this.connection._send({msg: 'unsub', id: id});

--- a/packages/livedata/livedata_connection_tests.js
+++ b/packages/livedata/livedata_connection_tests.js
@@ -282,14 +282,12 @@ Tinytest.add("livedata stub - reactive subscribe handle correct", function (test
   var rFoo = new ReactiveVar('foo1');
 
   // Subscribe to some subs.
-  var fooHandle;
+  var fooHandle, fooReady;
   var autorunHandle = Deps.autorun(function () {
     fooHandle = conn.subscribe("foo", rFoo.get());
-  });
-
-  var fooReady;
-  var readyAutorunHandle = Deps.autorun(function() {
-    fooReady = fooHandle.ready();
+    Deps.autorun(function() {
+      fooReady = fooHandle.ready();
+    });
   });
 
   var message = JSON.parse(stream.sent.shift());
@@ -354,7 +352,6 @@ Tinytest.add("livedata stub - reactive subscribe handle correct", function (test
   test.isTrue(fooReady);
   
   autorunHandle.stop();
-  readyAutorunHandle.stop();
 });
 
 Tinytest.add("livedata stub - this", function (test) {


### PR DESCRIPTION
Although `handle.ready()` becomes false when the subscription is stopped, it doesn't do so reactively, 
which leads to some difficult to understand issues. My reasoning for why it should:
1. It just seems wrong that `handle.ready()` will now return `false`, but any computations that depend on `handle.ready()` aren't invalidated, and thus still "think" it's `true`.
2. There's a common use case this addresses when setting up handles in an autorun, like so:

```
var handle;
Deps.autorun(function() {
  handle = Meteor.subscribe('foo', Session.get('bar'));
});

// and somewhere else, most likely a helper
Deps.autorun(function() {
  if (handle.ready()) ...
});
```

The issue is that if the handle stops due to the computation invalidating, the `ready()`'s dependency never gets changed. So the second autorun doesn't know that it needs to re-check whether the handle is ready.

This can have a variety of consequences, but the most common is if `Session.get('bar')` changes before the first subscription goes ready, the second autorun will never re-run and it'll appear like the subscription _never_ goes ready.
