### PR TITLE
Fix comment in srp.js

### DIFF
--- a/packages/srp/srp.js
+++ b/packages/srp/srp.js
@@ -165,7 +165,7 @@ SRP.Client.prototype.verifyConfirmation = function (confirmation) {
 
 
 /**
- * Generate a new SRP server object. Password is the plaintext password.
+ * Generate a new SRP server object.
  *
  * options is optional and can include:
  * - b: server's private ephemeral value. String or


### PR DESCRIPTION
Remove "Password is the plaintext password." comment from SRP Server. Likely a cut and paste error, as SRP server is never passed the plaintext password.
