### PR TITLE
create methods for server collections when connection is null

### DIFF
--- a/packages/mongo-livedata/collection.js
+++ b/packages/mongo-livedata/collection.js
@@ -648,7 +648,7 @@ Meteor.Collection.prototype._defineMutationMethods = function() {
   self._prefix = '/' + self._name + '/';
 
   // mutation methods
-  if ( Meteor.isServer || self._connection ) {
+  if( self._connection || Meteor.isServer ){
     var m = {};
 
     _.each(['insert', 'update', 'remove'], function (method) {
@@ -683,7 +683,6 @@ Meteor.Collection.prototype._defineMutationMethods = function() {
           }
 
           // This is the server receiving a method call from the client.
-
           // We don't allow arbitrary selectors in mutations from the client: only
           // single-ID selectors.
           if (method !== 'insert')
@@ -724,11 +723,13 @@ Meteor.Collection.prototype._defineMutationMethods = function() {
     // Minimongo on the server gets no stubs; instead, by default
     // it wait()s until its result is ready, yielding.
     // This matches the behavior of macromongo on the server better.
-    if ( Meteor.isClient || self._connection === Meteor.server)
+    if ( Meteor.isClient ){
       self._connection.methods(m);
+      return;
+    }
 
     //create server methods so client call can succeed when server collection is not backed by db
-    if ( Meteor.isServer && self._connection === null )
+    if ( self._connection === Meteor.server || self._connection === null )
       Meteor.server.methods( m );
   }
 };


### PR DESCRIPTION
Let server collections created with `new Meteor.Collection( 'someName', {connection: null} )` be used from client just like other collections.  Currently the server does not have insert, update, upsert, and remove methods created if the collection is null so calling them from the client will fail.

With this pull request, allow / deny rules still need to be set up for the collection or client calls will still fail just with the 'access denied' error instead of 'method not found' but this is inline with how other server collections work.
