### PR TITLE
Add option to `meteor bundle` to output a directory.

### DIFF
--- a/tools/commands.js
+++ b/tools/commands.js
@@ -649,6 +649,7 @@ main.registerCommand({
   requiresApp: true,
   options: {
     debug: { type: Boolean },
+    directory: { type: Boolean },
     // Undocumented
     'for-deploy': { type: Boolean }
   }
@@ -664,8 +665,9 @@ main.registerCommand({
   // machines, but worth it for humans)
 
   var buildDir = path.join(options.appDir, '.meteor', 'local', 'build_tar');
-  var bundlePath = path.join(buildDir, 'bundle');
   var outputPath = path.resolve(options.args[0]); // get absolute path
+  var bundlePath = options['directory'] ?
+      outputPath : path.join(buildDir, 'bundle');
 
   var bundler = require(path.join(__dirname, 'bundler.js'));
   var bundleResult = bundler.bundle({
@@ -682,11 +684,13 @@ main.registerCommand({
     return 1;
   }
 
-  try {
-    files.createTarball(path.join(buildDir, 'bundle'), outputPath);
-  } catch (err) {
-    console.log(JSON.stringify(err));
-    process.stderr.write("Couldn't create tarball\n");
+  if (!options['directory']) {
+    try {
+      files.createTarball(path.join(buildDir, 'bundle'), outputPath);
+    } catch (err) {
+      console.log(JSON.stringify(err));
+      process.stderr.write("Couldn't create tarball\n");
+    }
   }
   files.rm_recursive(buildDir);
 });

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -116,7 +116,9 @@ includes everything necessary to run the application. See README in
 the tarball for details.
 
 Options:
-  --debug  bundle in debug mode (don't minify, etc)
+  --debug      bundle in debug mode (don't minify, etc)
+  --directory  output a directory (rather than a tarball). If the output
+               location exists, it will be recursively deleted first.
 
 
 >>> mongo


### PR DESCRIPTION
This is useful when the output tarball would just be unpacked immediately
anyway, e.g. because it is part of a larger build process. This shaves
eight seconds off my build. :)
