### PR TITLE
Remove unused Underscore dependency in the Deps package

### DIFF
--- a/packages/deps/package.js
+++ b/packages/deps/package.js
@@ -6,7 +6,6 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
-  api.use('underscore');
   api.export('Deps');
   api.add_files('deps.js');
   api.add_files('deprecated.js');


### PR DESCRIPTION
Underscore is useless since 8805281, cc @dgreensp 
