### PR TITLE
Include .meteorignore regexes to ignoreFiles on bundle

### DIFF
--- a/tools/bundler.js
+++ b/tools/bundler.js
@@ -1708,7 +1708,7 @@ exports.bundle = function (options) {
     };
 
     var makeIgnoreFilesList = function() {
-      var ignoreFilesList = ignoreFiles;
+      var ignoreFilesList = _.clone(ignoreFiles);
       var listPath = path.join(appDir, '.meteorignore');
 
       // Include each line of ".meteorignore" file into ignoreFilesList


### PR DESCRIPTION
Easy way to offer big flexibility while not changing current functionality,
for a commonly needed feature:
- http://stackoverflow.com/questions/20692534/how-to-exclude-files-from-meteors-generation-of-app
- http://stackoverflow.com/questions/10423430/ignoring-files-in-a-meteor-js-project-directory
- http://stackoverflow.com/questions/16644780/how-to-exclude-directories-files-from-meteors-bundler
- http://stackoverflow.com/questions/23802923/how-to-make-meteor-ignore-files
- http://stackoverflow.com/questions/16160295/how-to-ignore-a-file-in-meteor-js
