### PR TITLE
Add command line h1 to docs

### DIFF
--- a/docs/client/commandline.html
+++ b/docs/client/commandline.html
@@ -2,7 +2,7 @@
 <div>
 {{#markdown}}
 
-{{#api_section "commandline"}}Command line{{/api_section}}
+<h1 id="commandline">Command line</h1>
 
 <!-- XXX some intro text? -->
 


### PR DESCRIPTION
I'm assuming the api_section is unnecessary as it's not included in other parts of the docs.
