### PR TITLE
Switch the 'unreachable' url from http://asdf.asdf to http://0.0.0.0

### DIFF
--- a/packages/http/httpcall_tests.js
+++ b/packages/http/httpcall_tests.js
@@ -89,12 +89,16 @@ testAsyncMulti("httpcall - errors", [
       test.isFalse(result);
       test.isFalse(error.response);
     };
-    HTTP.call("GET", "http://asfd.asfd/", expect(unknownServerCallback));
+
+    // 0.0.0.0 is an illegal IP address, and thus should always give an error.
+    // If your ISP is intercepting DNS misses and serving ads, an obviously
+    // invalid URL (http://asdf.asdf) might produce an HTTP response.
+    HTTP.call("GET", "http://0.0.0.0/", expect(unknownServerCallback));
 
     if (Meteor.isServer) {
       // test sync version
       try {
-        var unknownServerResult = HTTP.call("GET", "http://asfd.asfd/");
+        var unknownServerResult = HTTP.call("GET", "http://0.0.0.0/");
         unknownServerCallback(undefined, unknownServerResult);
       } catch (e) {
         unknownServerCallback(e, e.response);


### PR DESCRIPTION
Some ISPs / proxies serve a valid HTTP response on any DNS miss, but
we are trying to test an unreachable server.
