### PR TITLE
Use a try/catch block to check for localStorage - fixes #1291, fixes #1688.

### DIFF
--- a/packages/localstorage/localstorage.js
+++ b/packages/localstorage/localstorage.js
@@ -1,32 +1,33 @@
 // Meteor._localStorage is not an ideal name, but we can change it later.
 
-if (window.localStorage) {
-  // Let's test to make sure that localStorage actually works. For example, in
-  // Safari with private browsing on, window.localStorage exists but actually
-  // trying to use it throws.
+// Let's test to make sure that localStorage actually works. For example, in
+// Safari with private browsing on, window.localStorage exists but actually
+// trying to use it throws.
+// Accessing window.localStorage can also immediately throw an error in IE (#1291).
 
-  var key = '_localstorage_test_' + Random.id();
-  var retrieved;
-  try {
+var key = '_localstorage_test_' + Random.id();
+var retrieved;
+try {
+  if (window.localStorage) {
     window.localStorage.setItem(key, key);
     retrieved = window.localStorage.getItem(key);
     window.localStorage.removeItem(key);
-  } catch (e) {
-    // ... ignore
   }
-  if (key === retrieved) {
-    Meteor._localStorage = {
-      getItem: function (key) {
-        return window.localStorage.getItem(key);
-      },
-      setItem: function (key, value) {
-        window.localStorage.setItem(key, value);
-      },
-      removeItem: function (key) {
-        window.localStorage.removeItem(key);
-      }
-    };
-  }
+} catch (e) {
+  // ... ignore
+}
+if (key === retrieved) {
+  Meteor._localStorage = {
+    getItem: function (key) {
+      return window.localStorage.getItem(key);
+    },
+    setItem: function (key, value) {
+      window.localStorage.setItem(key, value);
+    },
+    removeItem: function (key) {
+      window.localStorage.removeItem(key);
+    }
+  };
 }
 
 if (!Meteor._localStorage) {


### PR DESCRIPTION
Accessing `window.localStorage` can immediately throw an exception, which needs to be caught.
For more information, see http://www.w3.org/TR/webstorage/#dom-localstorage.

See also http://mathiasbynens.be/notes/localstorage-pattern#comment-9.

I've tested this on my corporate PC running IE11 which was failing to load Meteor apps before. I think it is hard to add a test for `window.localStorage` throwing, but it should be an otherwise fairly innocuous change.
