### PR TITLE
accounts-password:  'user' object update before passing to email template functions

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -266,13 +266,16 @@ Accounts.sendResetPasswordEmail = function (userId, email) {
 
   var token = Random.secret();
   var when = new Date();
+  var tokenRecord = {
+    token: token,
+    email: email,
+    when: when
+  };
   Meteor.users.update(userId, {$set: {
-    "services.password.reset": {
-      token: token,
-      email: email,
-      when: when
-    }
+    "services.password.reset": tokenRecord
   }});
+  // before passing to template, update user object with new token
+  user.services.password.reset = tokenRecord;
 
   var resetPasswordUrl = Accounts.urls.resetPassword(token);
 
@@ -312,16 +315,18 @@ Accounts.sendEnrollmentEmail = function (userId, email) {
   if (!email || !_.contains(_.pluck(user.emails || [], 'address'), email))
     throw new Error("No such email for user.");
 
-
   var token = Random.secret();
   var when = new Date();
+  var tokenRecord = {
+    token: token,
+    email: email,
+    when: when
+  };
   Meteor.users.update(userId, {$set: {
-    "services.password.reset": {
-      token: token,
-      email: email,
-      when: when
-    }
+    "services.password.reset": tokenRecord
   }});
+  // before passing to template, update user object with new token
+  user.services.password.reset = tokenRecord;
 
   var enrollAccountUrl = Accounts.urls.enrollAccount(token);
 
@@ -442,6 +447,8 @@ Accounts.sendVerificationEmail = function (userId, address) {
   Meteor.users.update(
     {_id: userId},
     {$push: {'services.email.verificationTokens': tokenRecord}});
+  // before passing to template, update user object with new token
+  user.services.email.verificationTokens.push(tokenRecord);
 
   var verifyEmailUrl = Accounts.urls.verifyEmail(tokenRecord.token);
 


### PR DESCRIPTION
I wanted to customise my password reset email, but the 'user' object passed through to 'Accounts.emailTemplates.resetPassword.text' didn't have the latest token data. This fix updates the user object with the new token data before calling the email template functions.
