### PR TITLE
Removed no longer needed hack

### DIFF
--- a/packages/less/plugin/compile-less.js
+++ b/packages/less/plugin/compile-less.js
@@ -44,7 +44,7 @@ Plugin.registerSourceHandler("less", function (compileStep) {
     compileStep.error({
       message: "Less compiler error: " + e.message,
       sourcePath: e.filename || compileStep.inputPath,
-      line: e.line - 1,  // dunno why, but it matches
+      line: e.line,
       column: e.column + 1
     });
     return;


### PR DESCRIPTION
The hack done here: https://github.com/meteor/meteor/blob/devel/packages/less/plugin/compile-less.js#L47
 now backfires on my system and is reporting a line number one less than the actual error. I don't know when this behaviour has changed, but I have tested this in multiple scenarios.

(I also see that the less library package is a bit outdated.)
