### PR TITLE
Make tinytest/run return rapidly; add a 'done' record to the collection ...

### DIFF
--- a/packages/tinytest/tinytest_client.js
+++ b/packages/tinytest/tinytest_client.js
@@ -30,9 +30,9 @@ Tinytest._runTestsEverywhere = function (onReport, onComplete, pathPrefix) {
         return;
       // This will only work for added & changed messages.
       // hope that is all you get.
-      _.each(msg.fields, function (report) {
-        // Skip the 'done' report (deal with it last)
-        if (_.has(report, 'done')) {
+      _.each(msg.fields, function (report, key) {
+        // Skip the 'complete' report (deal with it last)
+        if (key === 'complete') {
           return;
         }
         _.each(report.events, function (event) {
@@ -41,8 +41,9 @@ Tinytest._runTestsEverywhere = function (onReport, onComplete, pathPrefix) {
         report.server = true;
         onReport(report);
       });
-      // Check if we have the 'done' message
-      if (_.has(msg.fields, 'done')) {
+      // Now that we've processed all the other messages,
+      // check if we have the 'complete' message
+      if (_.has(msg.fields, 'complete')) {
         remoteComplete = true;
         handle.stop();
         Meteor.call('tinytest/clearResults', runId);

--- a/packages/tinytest/tinytest_server.js
+++ b/packages/tinytest/tinytest_server.js
@@ -50,14 +50,11 @@ Meteor.methods({
     };
 
     var onComplete = function() {
-      if (! Fiber.current) {
-        Meteor._debug("Trying to report a test not in a fiber! "+
-                      "You probably forgot to wrap a callback in bindEnvironment.");
-        console.trace();
-      }
+      // We send an object for current and future compatibility,
+      // though we could get away with just sending { complete: true }
       var report = { done: true };
-      var doneKey = 'done';
-      addReport(doneKey, report);
+      var key = 'complete';
+      addReport(key, report);
     };
 
     Tinytest._runTests(onReport, onComplete, pathPrefix);

--- a/packages/tinytest/tinytest_server.js
+++ b/packages/tinytest/tinytest_server.js
@@ -27,12 +27,17 @@ Meteor.methods({
     check(pathPrefix, Match.Optional([String]));
     this.unblock();
 
-    // XXX using private API === lame
-    var path = Npm.require('path');
-    var Future = Npm.require(path.join('fibers', 'future'));
-    var future = new Future;
-
     reportsForRun[runId] = {};
+
+    var addReport = function (key, report) {
+      var fields = {};
+      fields[key] = report;
+      _.each(handlesForRun[runId], function (handle) {
+        handle.changed(Meteor._ServerTestResultsCollection, runId, fields);
+      });
+      // Save for future subscriptions.
+      reportsForRun[runId][key] = report;
+    };
 
     var onReport = function (report) {
       if (! Fiber.current) {
@@ -41,22 +46,21 @@ Meteor.methods({
         console.trace();
       }
       var dummyKey = Random.id();
-      var fields = {};
-      fields[dummyKey] = report;
-      _.each(handlesForRun[runId], function (handle) {
-        handle.changed(Meteor._ServerTestResultsCollection, runId, fields);
-      });
-      // Save for future subscriptions.
-      reportsForRun[runId][dummyKey] = report;
+      addReport(dummyKey, report);
     };
 
     var onComplete = function() {
-      future['return']();
+      if (! Fiber.current) {
+        Meteor._debug("Trying to report a test not in a fiber! "+
+                      "You probably forgot to wrap a callback in bindEnvironment.");
+        console.trace();
+      }
+      var report = { done: true };
+      var doneKey = 'done';
+      addReport(doneKey, report);
     };
 
     Tinytest._runTests(onReport, onComplete, pathPrefix);
-
-    future.wait();
   },
   'tinytest/clearResults': function (runId) {
     check(runId, String);


### PR DESCRIPTION
...to signal completion

Otherwise the DDP call to tinytest/run was blocking client test execution,
in particular Accounts DDP calls won't run concurrently with another DDP call,
even if the first DDP call calls unblock.
