### PR TITLE
Allow usage of hashPassword outside of accounts-password package.

### DIFF
--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -49,7 +49,7 @@ Meteor.loginWithPassword = function (selector, password, callback) {
   });
 };
 
-var hashPassword = function (password) {
+Accounts.hashPassword = function (password) {
   return {
     digest: SHA256(password),
     algorithm: "sha-256"
@@ -93,7 +93,7 @@ Accounts.createUser = function (options, callback) {
     throw new Error("Must set options.password");
 
   // Replace password with the hashed password.
-  options.password = hashPassword(options.password);
+  options.password = Accounts.hashPassword(options.password);
 
   Accounts.callLoginMethod({
     methodName: 'createUser',


### PR DESCRIPTION
Since `sha` is an internal package and hashPassword is a private function that isn't exported, I have no clean way to hash a password before sending it to the server if I want to call createUser on the server side.

This seems less than ideal to force everyone to call Accounts.createUser client side.  Perhaps exposing Accounts.hashPassword would be cleaner for other account packages.