### PR TITLE
Fix Meteor._inherits to copy Parent static properties

### DIFF
--- a/packages/meteor/helpers.js
+++ b/packages/meteor/helpers.js
@@ -119,10 +119,13 @@ _.extend(Meteor, {
   //   _.extend(ClassB.prototype, { ... })
   // Inspired by CoffeeScript's `extend` and Google Closure's `goog.inherits`.
   _inherits: function (Child, Parent) {
-    // copy static fields
-    _.each(Parent, function (prop, field) {
-      Child[field] = prop;
-    });
+    // copy Parent static properties
+    for (var key in Parent) {
+      // make sure we only copy hasOwnProperty properties vs. prototype
+      // properties
+      if (_.has(Parent, key))
+        Child[key] = Parent[key];
+    }
 
     // a middle member of prototype chain: takes the prototype from the Parent
     var Middle = function () {

--- a/packages/meteor/helpers_test.js
+++ b/packages/meteor/helpers_test.js
@@ -74,6 +74,22 @@ Tinytest.add("environment - helpers", function (test) {
   x = {a: 12};
   Meteor._delete(x, "a");
   test.equal(x, {});
+
+  /*** inherits ***/
+  var Parent = function () {};
+  Parent.parentStaticProp = true;
+  Parent.prototype.parentProp = true;
+
+  var Child = function () {};
+  Meteor._inherits(Child, Parent);
+
+  Child.prototype.childProp = true;
+
+  test.isTrue(Child.parentStaticProp, 'parent static props not copied');
+  test.equal(Child.__super__, Parent.prototype, '__super__ not set');
+
+  var c = new Child;
+  test.isTrue(c.parentProp, 'prototype chain not hooked up correctly');
 });
 
 Tinytest.add("environment - startup", function (test) {


### PR DESCRIPTION
**Problem**
Meteor._inherits does not copy parent function properties to the child function.

Example:

``` javascript
Parent = function () {};
Parent.someStaticProp = true;

Child = function () {};
Meteor._inherits(Child, Parent);

// expect Child.someStaticProp => true
```

The reason is the _.each helper does not properly iterate over function properties because it uses the length property for the iteration. But functions also have a length property which tells you the function arity (how many args).

**Solution:**
Don't use _.each to copy parent properties to the child function. Instead,
iterate directly and copy hasOwn properties to the child function.

An alternative solution is to make the _.each helper work properly with
functions in the underscore package.
