### PR TITLE
Replaced process.nextTick with setImmediate in _SynchronousQueue

### DIFF
--- a/packages/meteor/fiber_helpers.js
+++ b/packages/meteor/fiber_helpers.js
@@ -123,7 +123,7 @@ _.extend(Meteor._SynchronousQueue.prototype, {
       return;
 
     self._runningOrRunScheduled = true;
-    process.nextTick(function () {
+    setImmediate(function () {
       Fiber(function () {
         self._run();
       }).run();


### PR DESCRIPTION
To fix issue [2299](https://github.com/meteor/meteor/issues/2299) - event loop starvation caused by `process.nextTick`.
