### PR TITLE
Fix {{#each todos}} rendering when !list_id

### DIFF
--- a/examples/todos/client/todos.js
+++ b/examples/todos/client/todos.js
@@ -167,7 +167,7 @@ Template.todos.todos = function () {
 
   var list_id = Session.get('list_id');
   if (!list_id)
-    return {};
+    return [];
 
   var sel = {list_id: list_id};
   var tag_filter = Session.get('tag_filter');


### PR DESCRIPTION
{{#each todos}} rendering was broken when no list was selected, since {{#each}} cannot iterate on "{}" (it only takes lists and falsey values).
This code path is never hit in the todos app as it is shipped, but it can cause problems with people modifying the example code for their own apps.
