### PR TITLE
[Docs] Custom events in event maps

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -2390,9 +2390,9 @@ used for arrow keys or modifier keys.
 
 </dl>
 
-Other DOM events are available as well, but for the events above,
-Meteor has taken some care to ensure that they work uniformly in all
-browsers.
+Other DOM events are available as well, including custom events, but for the 
+events above, Meteor has taken some care to ensure that they work uniformly in
+all browsers.
 
 {{/api_box}}
 


### PR DESCRIPTION
I was under the impression before finding #1200 that only the events listed in the docs and perhaps some obscure default browser events could be used in the event map, and events sent by libraries, eg `tap`, had to be listened for separately.
