### PR TITLE
Restore the value of an environment variable properly if a withValue call yields.

### DIFF
--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -55,7 +55,11 @@ _.extend(Meteor.EnvironmentVariable.prototype, {
       currentValues[this.slot] = value;
       var ret = func();
     } finally {
+      // func may yield, and a bindEnvironment will replace the object
+      // in _meteor_dynamics, so make sure we actually save the
+      // original values back
       currentValues[this.slot] = saved;
+      Fiber.current._meteor_dynamics = currentValues;
     }
 
     return ret;


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/meteor-core/DQ8Oc5s6phs.

To summarize, if `func()` yields, then `currentValues` may no longer point to `Fiber.current._meteor_dynamics`. So we need to make sure it does, otherwise `currentValues[this.slot] = saved` will be a no-op, and the existing value of the environment variable will persist.

This would rarely cause issues, but it could be troublesome for code that checks an environment variable to see if it's defined or not, and thinks it is when it actually isn't.
