### PR TITLE
A basic proof-of-concept lazy loading implementation

### DIFF
--- a/packages/webapp/boilerplate.html
+++ b/packages/webapp/boilerplate.html
@@ -4,8 +4,10 @@
 
 {{#if inlineScriptsAllowed}}
 <script type='text/javascript'>__meteor_runtime_config__ = {{meteorRuntimeConfig}};</script>
+<script type="text/javascript">__atmosphere_layers__ = {{atmosphereLayers}};</script>
 {{else}}
 <script type='text/javascript' src='{{rootUrlPathPrefix}}/meteor_runtime_config.js'></script>
+<script type="text/javascript" src='{{rootUrlPathPrefix}}/atmosphere_layers.js'></script>
 {{/if}}
 {{#each js}}  <script type="text/javascript" src="{{../bundledJsCssPrefix}}{{url}}"></script>
 {{/each}}


### PR DESCRIPTION
Dear core team. This is the closest I could get to the long-awaited lazy load feature for meteor. I am aware that these changes are pretty extensive, so I can understand if you decide they're not ready to be merged. I only hope that this PR will encourage you and the community to discuss this problem in details and will result in implementing this important feature in the nearest future. I would be happy to take part in this process.

About this PR. The basic idea is that everything you define under `/client/layers/` gets squashed into independent layers, which you can download on demand. For example, if your project structure looks lie:

```
client
  layers
    dashboard
      admin.html
      admin.js
    someModule
      file1.js
      file2.js
  ...
```

you will get two layers called `dashboard` and `someModule`. They will be served on `/client/layers/dashboard.js` and `/client/layers/module.js` respectively (at least in the development mode), but they won't be included as `<script>` tags in the initial page.

Also packages can define their own layers by specifying it in `fileOptions` object on call to `add_files`, e.g.

``` javascript
api.add_files([ /* ... */ ], 'client', { layer: 'someOptionalFeature' });
```

On the client, there is a global array called `layers` containing a list of all layers defined for the app. Eg.

``` javascript
__atmosphere_layers__ = [
  { name: 'dashboard'  , path: '/client/layers/dashboard?[hash]' },
  { name: 'someModule' , path: '/client/layers/someModule?[hash]' },
  /* ... */
];
```
