### PR TITLE
Print when we're listening, for use in automated browser tests

### DIFF
--- a/packages/test-in-browser/package.js
+++ b/packages/test-in-browser/package.js
@@ -28,5 +28,8 @@ Package.on_use(function (api) {
 
   api.use('autoupdate', 'server', {weak: true});
   api.use('random', 'server');
-  api.add_files('autoupdate.js', 'server');
+  api.add_files([
+    'autoupdate.js',
+    'reporter.js'
+  ], 'server');
 });

--- a/packages/test-in-browser/reporter.js
+++ b/packages/test-in-browser/reporter.js
@@ -1,0 +1,6 @@
+// provide some notification we're started. This is to allow use
+// in automated scripts with `meteor run --once` which does not
+// print when the proxy is listening.
+Meteor.startup(function () {
+  Meteor._debug("test-in-browser listening");
+});


### PR DESCRIPTION
Similar to #1884, for testing with [Sauce Labs](https://saucelabs.com) which run tests directly in the browser, we need to know when Meteor is ready so that we can start running tests. But we also want `--once` so that Meteor fails fast if there are errors.