### PR TITLE
Changed Collection.find(selector) to be optional. Added a warning block ...

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -778,6 +778,12 @@ invalidations in reactive computations using this cursor. Careful use
 of `fields` allows for more fine-grained reactivity for computations
 that don't depend on an entire document.
 
+{{#warning}}
+`Collection.find()` (return all docs) behaves differently from
+`Collection.find(undefined)` (return 0 docs).  so be
+careful about the length of arguments.
+{{/warning}}
+
 {{> api_box findone}}
 
 Equivalent to `find(selector, options).fetch()[0]` with

--- a/docs/client/api.js
+++ b/docs/client/api.js
@@ -545,7 +545,7 @@ Template.api.meteor_collection = {
 
 Template.api.find = {
   id: "find",
-  name: "<em>collection</em>.find(selector, [options])",
+  name: "<em>collection</em>.find([selector], [options])",
   locus: "Anywhere",
   descr: ["Find the documents in a collection that match the selector."],
   args: [
@@ -580,7 +580,7 @@ Template.api.find = {
 
 Template.api.findone = {
   id: "findone",
-  name: "<em>collection</em>.findOne(selector, [options])",
+  name: "<em>collection</em>.findOne([selector], [options])",
   locus: "Anywhere",
   descr: ["Finds the first document that matches the selector, as ordered by sort and skip options."],
   args: [


### PR DESCRIPTION
...that was in the inline code in collection.js but wasn't in the documentation about using () vs. (null). Fixes issue #2523.
