### PR TITLE
Extend options with encoding

### DIFF
--- a/packages/http/httpcall_server.js
+++ b/packages/http/httpcall_server.js
@@ -56,7 +56,7 @@ var _call = function(method, url, options, callback) {
 
   _.extend(headers, options.headers || {});
   
-  if (typeof options.encoding !== 'undefined') {
+  if (typeof options.encoding === 'undefined') {
     options.encoding = "utf8";
   }
 


### PR DESCRIPTION
Allow options object to have an encoding property that is used in the req_options. This allows for example options.encoding = null which will return the response content as buffer. In my case this allows me to use this package to save a generated pdf, from a post request to an external website, to file.
