### PR TITLE
Respond to proxy requests properly (try fix #1212)

### DIFF
--- a/packages/routepolicy/routepolicy.js
+++ b/packages/routepolicy/routepolicy.js
@@ -96,6 +96,10 @@ _.extend(RoutePolicyConstructor.prototype, {
     // TODO overlapping prefixes, e.g. /foo/ and /foo/bar/
     self.urlPrefixTypes[urlPrefix] = type;
   },
+  
+  isValidUrl: function(url) {
+    return (url.charAt(0) === '/');
+  },
 
   classify: function (url) {
     var self = this;

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -155,6 +155,10 @@ var appUrl = function (url) {
   if (url === '/app.manifest')
     return false;
 
+  //Serve ordinary html if this is a weird bot request
+  if (RoutePolicy.isProxyUrl(url))
+    return true;
+  
   // Avoid serving app HTML for declared routes such as /sockjs/.
   if (RoutePolicy.classify(url))
     return false;

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -155,10 +155,6 @@ var appUrl = function (url) {
   if (url === '/app.manifest')
     return false;
 
-  //Serve ordinary html if this is a weird bot request
-  if (RoutePolicy.isProxyUrl(url))
-    return true;
-  
   // Avoid serving app HTML for declared routes such as /sockjs/.
   if (RoutePolicy.classify(url))
     return false;
@@ -531,6 +527,13 @@ var runWebAppServer = function () {
   });
 
   app.use(function (req, res, next) {
+    if (!RoutePolicy.isValidUrl(req.url)) {
+      res.writeHead(500, {'Content-Type': 'text/html'});
+      res.write("Invalid Request");
+      res.end();
+      return undefined
+    }
+    
     if (! appUrl(req.url))
       return next();
 


### PR DESCRIPTION
Try to fix #1212 by responding to a proxy request with an `Invalid Request` error on the browser end instead of no error and an error on the server logs.