### PR TITLE
Allow OAuth1 callback to specify query string parameters

### DIFF
--- a/packages/oauth1/oauth1_binding.js
+++ b/packages/oauth1/oauth1_binding.js
@@ -28,7 +28,7 @@ OAuth1Binding.prototype.prepareRequestToken = function(callbackUrl) {
   var response = self._call('POST', self._urls.requestToken, headers);
   var tokens = querystring.parse(response.content);
 
-  if (!tokens.oauth_callback_confirmed)
+  if (! tokens.oauth_callback_confirmed)
     throw _.extend(new Error("oauth_callback_confirmed false when requesting oauth1 token"),
                              {response: response});
 
@@ -76,7 +76,7 @@ OAuth1Binding.prototype.call = function(method, url, params, callback) {
     oauth_token: self.accessToken
   });
 
-  if(!params) {
+  if(! params) {
     params = {};
   }
 
@@ -162,7 +162,7 @@ OAuth1Binding.prototype._call = function(method, url, headers, params, callback)
         Authorization: authString
       }
     }, callback && function (error, response) {
-      if (!error) {
+      if (! error) {
         response.nonce = headers.oauth_nonce;
       }
       callback(error, response);

--- a/packages/oauth1/oauth1_server.js
+++ b/packages/oauth1/oauth1_server.js
@@ -4,7 +4,7 @@ var url = Npm.require("url");
 OAuth._requestHandlers['1'] = function (service, query, res) {
 
   var config = ServiceConfiguration.configurations.findOne({service: service.serviceName});
-  if (!config) {
+  if (! config) {
     throw new ServiceConfiguration.ConfigError(service.serviceName);
   }
 
@@ -50,7 +50,7 @@ OAuth._requestHandlers['1'] = function (service, query, res) {
     // Get the user's request token so we can verify it and clear it
     var requestTokenInfo = OAuth._retrieveRequestToken(query.state);
 
-    if (!requestTokenInfo) {
+    if (! requestTokenInfo) {
       throw new Error("Unable to retrieve request token");
     }
 


### PR DESCRIPTION
They are then parsed and provided to underlying HTTP package. We have to parse them so that signing of requests works properly. In addition, nonce used in the request is stored in the response so that user can verify JWT payloads returned from the server.
