### PR TITLE
Add HTML5 `main` tag

### DIFF
--- a/packages/htmljs/html.js
+++ b/packages/htmljs/html.js
@@ -307,7 +307,7 @@ HTML.getSymbolName = function (tagName) {
  *
  * An array of all known HTML5 and SVG element names in normalized case.
  */
-HTML.knownElementNames = 'a abbr acronym address applet area article aside audio b base basefont bdi bdo big blockquote body br button canvas caption center cite code col colgroup command data datagrid datalist dd del details dfn dir div dl dt em embed eventsource fieldset figcaption figure font footer form frame frameset h1 h2 h3 h4 h5 h6 head header hgroup hr html i iframe img input ins isindex kbd keygen label legend li link map mark menu meta meter nav noframes noscript object ol optgroup option output p param pre progress q rp rt ruby s samp script section select small source span strike strong style sub summary sup table tbody td textarea tfoot th thead time title tr track tt u ul var video wbr'.split(' ');
+HTML.knownElementNames = 'a abbr acronym address applet area article aside audio b base basefont bdi bdo big blockquote body br button canvas caption center cite code col colgroup command data datagrid datalist dd del details dfn dir div dl dt em embed eventsource fieldset figcaption figure font footer form frame frameset h1 h2 h3 h4 h5 h6 head header hgroup hr html i iframe img input ins isindex kbd keygen label legend li link main map mark menu meta meter nav noframes noscript object ol optgroup option output p param pre progress q rp rt ruby s samp script section select small source span strike strong style sub summary sup table tbody td textarea tfoot th thead time title tr track tt u ul var video wbr'.split(' ');
 // (we add the SVG ones below)
 
 /**


### PR DESCRIPTION
This adds rudimentary support for the HTML5 `main` tag, but there might be additional logic desired for this qualification:

`Note: There must not be more than one <main> element in a document, and it must not be a descendent of an <article>, <aside>, <footer>, <header>, or <nav> element.`

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
