### PR TITLE
Sets the process title to "meteor"

### DIFF
--- a/tools/main.js
+++ b/tools/main.js
@@ -2,6 +2,8 @@ var showRequireProfile = ('METEOR_PROFILE_REQUIRE' in process.env);
 if (showRequireProfile)
   require('./profile-require.js').start();
 
+process.title = 'meteor';
+
 var _ = require('underscore');
 var Fiber = require('fibers');
 var files = require('./files.js');


### PR DESCRIPTION
Otherwise the process title is set to e.g.  $HOME/.meteor/tools/858c88b520/bin/node $HOME/.meteor/tools/858c88b520/tools/main.js

I made this change because I want to be able to resurrect meteor
sessions within tmux with
https://github.com/tmux-plugins/tmux-resurrect/

This change ensures that the process title is predictable (always the
same) instead of changing between user accounts, and commit ids.

I have tried to check if this change had any side effects, but could not
find anywhere the process title is used
