### PR TITLE
mentions Blaze.render instead of UI.render in the error message

### DIFF
--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -508,7 +508,7 @@ Blaze.renderWithData = function (content, data, parentElement, nextNode, parentV
 
 Blaze.remove = function (view) {
   if (! (view && (view._domrange instanceof Blaze._DOMRange)))
-    throw new Error("Expected template rendered with UI.render");
+    throw new Error("Expected template rendered with Blaze.render");
 
   if (! view.isDestroyed) {
     var range = view._domrange;


### PR DESCRIPTION
The error message for Blaze.remove mentions UI.render. I've update it to Blaze.render.

The error message for Blaze.insert also metions UI.render, but it's deprecated, so I didn't update it
