### PR TITLE
change nav width

### DIFF
--- a/docs/client/docs.css
+++ b/docs/client/docs.css
@@ -483,7 +483,7 @@ pre {
         margin-left: 330px; /* nav width + padding */
     }
     #nav {
-        width: 270px;
+        width: 290px;
     }
     .github-ribbon {
         display: block;


### PR DESCRIPTION
270px causing weird line breake on hovering over long names of api endpoints (eg Accounts.sendResetPasswordEmail)

note: in @media min-width: 768px the width of 200px causes the same problem. an overall rework on the doc styling should fall under consideration