### PR TITLE
Prevent error when altering Meteor.Collection

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -25,7 +25,7 @@ The default id generation technique is `'STRING'`.
  */
 Mongo.Collection = function (name, options) {
   var self = this;
-  if (! (self instanceof Mongo.Collection))
+  if (! (self instanceof Mongo.Collection || self instanceof Meteor.Collection))
     throw new Error('use "new" to construct a Mongo.Collection');
 
   if (!name && (name !== null)) {


### PR DESCRIPTION
There are a few popular packages that alter the `Meteor.Collection` constructor. The check in line 28 causes them or a later code to throw the error. Extending the check to allow the collection be an instance of `Meteor.Collection` allows using backward-compatible packages in 0.9.1 applications.
