### PR TITLE
fix link to update operators in MongoDB manual

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -1347,7 +1347,7 @@ supported by [validated updates](#allow).)
     Users.update({_id: "123"}, {name: "Alice", friends: ["Bob"]});
 
 See the [full list of
-modifiers](http://www.mongodb.org/display/DOCS/Updating#Updating-ModifierOperations).
+modifiers](http://docs.mongodb.org/manual/reference/operator/update/).
 
 
 {{> apiBoxTitle name="Sort Specifiers" id="sortspecifiers"}}


### PR DESCRIPTION
Related note: I think the MongoDB folks say "update operators" where they used to say "update modifiers", so we may want to follow their lead.
