### PR TITLE
improve showdown package documentation

### DIFF
--- a/docs/client/packages/showdown.html
+++ b/docs/client/packages/showdown.html
@@ -7,10 +7,16 @@
 This package lets you use Markdown in your templates. It's easy: just
 put your markdown inside
 <code>{&#123;#markdown}}</code> ... <code>{&#123;/markdown}}</code>
-tags. You can still use all of the usual Meteor template features
-inside a Markdown block, such `#each`, and you still get reactivity.
+tags. All [Meteor live template](#livehtmltemplates) rules and features
+also apply inside a Markdown block.
 
-<!-- XXX include an example -->
+Example:
+
+    {{#markdown}}I am using __markdown__.{{/markdown}}
+
+outputs
+
+    <p>I am using <strong>markdown</strong>.</p>
 
 {{/markdown}}
 </template>


### PR DESCRIPTION
- fix a grammar bug
- add an example
- use `{{#each}}` instead of `#each` to be consistent with the rest of the API docs
- link back to "Live HTML Templates" section
