### PR TITLE
Match OAuth._loginStyle param to service name

### DIFF
--- a/packages/meteor-developer/meteor_developer_client.js
+++ b/packages/meteor-developer/meteor_developer_client.js
@@ -20,7 +20,7 @@ var requestCredential = function (options, credentialRequestCompleteCallback) {
 
   var credentialToken = Random.secret();
 
-  var loginStyle = OAuth._loginStyle('facebook', config, options);
+  var loginStyle = OAuth._loginStyle('meteor-developer', config, options);
 
   var loginUrl =
         MeteorDeveloperAccounts._server +


### PR DESCRIPTION
Why is there a service parameter? It is not used.
