### PR TITLE
upsert $addToSet with $each field creation: $each inserted, not executed

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2254,6 +2254,8 @@ Tinytest.add("minimongo - modify", function (test) {
          {a: [1, 2, 3, 4]}); // tested
   modify({a: [1, 2]}, {$addToSet: {a: {b: 12, $each: [3, 1, 4]}}},
          {a: [1, 2, {b: 12, $each: [3, 1, 4]}]}); // tested
+  modify({}, {$addToSet: {a: {$each: []}}}, {a: []});
+  modify({}, {$addToSet: {a: {$each: [1]}}}, {a: [1]});
   modify({a: []}, {$addToSet: {'a.1': 99}}, {a: [null, [99]]});
   modify({a: {}}, {$addToSet: {'a.x': 99}}, {a: {x: [99]}});
 

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -288,21 +288,22 @@ var MODIFIERS = {
     }
   },
   $addToSet: function (target, field, arg) {
+    var isEach = false;
+    if (typeof arg === "object") {
+      //check if first key is '$each'
+      for (var k in arg) {
+        if (k === "$each")
+          isEach = true;
+        break;
+      }
+    }
+    var values = isEach ? arg["$each"] : [arg];
     var x = target[field];
     if (x === undefined)
-      target[field] = [arg];
+      target[field] = values;
     else if (!(x instanceof Array))
       throw MinimongoError("Cannot apply $addToSet modifier to non-array");
     else {
-      var isEach = false;
-      if (typeof arg === "object") {
-        for (var k in arg) {
-          if (k === "$each")
-            isEach = true;
-          break;
-        }
-      }
-      var values = isEach ? arg["$each"] : [arg];
       _.each(values, function (value) {
         for (var i = 0; i < x.length; i++)
           if (LocalCollection._f._equal(value, x[i]))


### PR DESCRIPTION
### Issue

The `$each` modifier is inserted instead of being executed. Occurs when new field is created during upsert with `$addToSet`.

Executing an upsert:

```
{ $addToSet: { array: { $each: [] } } }
```

on an empty object (`{}`) yelds:

```
[{"_id":"wKGTDDytyxBnWA2sy","array":[{"$each":[]}]}]
```

instead of

```
[{"_id":"wKGTDDytyxBnWA2sy","array":[]}]
```
### Raw MongoDB

Executing on raw mongo:

```
db.meteor.addToSet.update({},{ $addToSet: { array: { $each: [] } } }, {upsert:true})
db.meteor.addToSet.find()
```

yelds, as expected:

```
[{"_id":"wKGTDDytyxBnWA2sy","array":[]}]
```
### Reproduction project

https://github.com/rzymek/meteor-issue-addToSet-each-upsert

Also this pull request includes test case, that fails without the fix.
### Implementation

Use the same `$each` handing code when creating a field as when updating one.
