### PR TITLE
Potential starting point for a fix for #2668

### DIFF
--- a/packages/mongo/oplog_observe_driver.js
+++ b/packages/mongo/oplog_observe_driver.js
@@ -110,6 +110,8 @@ OplogObserveDriver = function (options) {
             // on waiting for oplog entries to catch up) because that will block
             // onOplogEntry!
             self._needToPollQuery();
+          } else if (notification.pollQuery) {
+            self._pollQuery();
           } else {
             // All other operators should be handled depending on phase
             if (self._phase === PHASE.QUERYING)


### PR DESCRIPTION
Addresses issue #2668.

oplog tailor stops itself when more than 2000 records (might be a good idea to make this app configurable) are ahead of the current document. When it turns itself back on it tells all active cursors to re-poll themselves. _doneQuerying throws "Phase unexpectedly STEADY" error when polling occurs, I can't seem to figure out how/why that's happening.

I'm not sure what kind of bugs this may introduce, there's a lot going on there that I didn't take the time to figure out 100%, but I've tested it locally throwing over 150k operations at it one at a time (for loop), and in a big batch (remove) and it's stood up 100%. There is an exception being thrown that I can't for the life of me figure out, somehow the phase gets set back to STEADY when calling _pollQuery. But it doesn't not appear to be affecting anything at all.

I'm excited to hear any comments and concerns.
