### PR TITLE
add --test flag to Meteor CLI for velociy CI support

### DIFF
--- a/tools/commands.js
+++ b/tools/commands.js
@@ -322,7 +322,10 @@ main.registerCommand({
     });
     var DDP = unipackages.ddp.DDP;
 
-    var ddpConnection = DDP.connect("http://localhost:3000");
+    var hostPort = parseHostPort(options.port);
+    var serverUrl = "http://" + (hostPort.host || "localhost") +
+      ":" + hostPort.port;
+    var ddpConnection = DDP.connect(serverUrl);
 
     var interval = setInterval(function(){
       if (ddpConnection.status().status === "connected"){
@@ -339,9 +342,9 @@ main.registerCommand({
                   var testDesc = msg.fields.framework + " : " +
                     msg.fields.ancestors.join(":") + " => " + msg.fields.name;
                   if(msg.fields.result == "passed"){
-                    console.log("PASSED ", testDesc);
+                    console.log("PASSED", testDesc);
                   } else if (msg.fields.result == "failed"){
-                    console.error("FAILED ", testDesc);
+                    console.error("FAILED", testDesc);
                     console.log(msg.fields.failureStackTrace)
                   }
                 }
@@ -380,12 +383,12 @@ main.registerCommand({
                      report.result === "completed"){
                     setTimeout(function(){
                       if (aggregateResult === "passed"){
-                        console.log("TESTS RAN SUCCESSFULLY :-)")
+                        console.log("TESTS RAN SUCCESSFULLY")
                         //better way to exit here?
                         process.exit(0);
                       }
                       if (aggregateResult === "failed"){
-                        console.log("FAILURE :-(");
+                        console.log("FAILURE");
                         process.exit(1);
                       }
                     }, 2000);

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -50,6 +50,7 @@ Options:
   --settings     Set optional data for Meteor.settings on the server
   --release      Specify the release of Meteor to use
   --program      The program in the app to run (Advanced)
+  --test         Run velocity tests (using phantomjs if necessary) and exit
   --verbose      Print all output from builds logs.
 
 


### PR DESCRIPTION
This code is untested so far, but I thought it'd be worthwhile to create the pull request early so there's a place to hang comments while I work on the proper selftests.

What the --test flag does:
- establish a DDP connection to Meteor
- subscribe to test results
- hit running web server
- exit with appropriate status code after tests have completed
