### PR TITLE
Format deploy console messages to include http:// protocol

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -386,7 +386,7 @@ var bundleAndDeploy = function (options) {
   var buildDir = path.join(options.appDir, '.meteor', 'local', 'build_tar');
   var bundlePath = path.join(buildDir, 'bundle');
 
-  Console.stdout.write('Deploying to ' + site + '. Bundling...\n');
+  Console.stdout.write('Deploying to http://' + site + '. Bundling...\n');
 
   var settings = null;
   var messages = buildmessage.capture({
@@ -452,7 +452,7 @@ var bundleAndDeploy = function (options) {
   var deployedAt = require('url').parse(result.payload.url);
   var hostname = deployedAt.hostname;
 
-  Console.stdout.write('Now serving at ' + hostname + '\n');
+  Console.stdout.write('Now serving at http://' + hostname + '\n');
   files.rm_recursive(buildDir);
 
   if (! hostname.match(/meteor\.com$/)) {


### PR DESCRIPTION
This is a fix to a personal annoyance I have with the `meteor deploy` command. The messages that the `deploy` command prints into the console have the deploy URL without the protocol, so they aren't interpreted as links by the terminal emulator.

This is just a simple fix to add the protocol to the console messages, nothing more.

Before: `Now serving at mue-staging.meteor.com`
After: `Now serving at http://mue-staging.meteor.com` (which gets linked by the terminal emulator)

I'm not sure if the message should use the `http` or `https` protocol, but I decided on `http` because it's less prone to breakage and you can always access the SSL version yourself.
