### PR TITLE
Missing a period(.) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the app:
     ../meteor
 
 You'll then be able to read the docs locally in your browser at
-`http://localhost:3000/`
+`http://localhost:3000/`.
 
 Note that if you run Meteor from a git checkout, you cannot pin apps to specific
 Meteor releases or run using different Meteor releases using `--release`.


### PR DESCRIPTION
Entire document has sentences ending in periods except for this one (including the ones ending in quotes).
