### PR TITLE
Fix clientHash call in appcache.

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -81,7 +81,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
 
   if (Package.autoupdate) {
     var version = Package.autoupdate.Autoupdate.autoupdateVersion;
-    if (version !== WebApp.clientHash)
+    if (version !== WebApp.clientHash())
       manifest += "# " + version + "\n";
   }
 


### PR DESCRIPTION
Appcache was broken because it output the _function_ `WebApp.clientHash` instead of its return value. fixes #2661
