### PR TITLE
Plugin.registerCommand

### DIFF
--- a/docs/client/api.html
+++ b/docs/client/api.html
@@ -3578,6 +3578,7 @@ package is exported to.
 
 {{> autoApiBox "Package.registerBuildPlugin"}}
 {{> autoApiBox "Plugin.registerSourceHandler"}}
+{{> autoApiBox "Plugin.registerCommand"}}
 
 <h3 id="packagetests"><span>Unit Tests</span></h3>
 

--- a/docs/client/names.json
+++ b/docs/client/names.json
@@ -157,6 +157,7 @@
   "PackageAPI#versionsFrom",
   "Plugin",
   "Plugin.registerSourceHandler",
+  "Plugin.registerCommand",
   "ReactiveVar",
   "ReactiveVar#get",
   "ReactiveVar#set",

--- a/tools/main.js
+++ b/tools/main.js
@@ -965,6 +965,11 @@ Fiber(function () {
     });
   }
 
+  // Register commands exported by plugins
+  _.each(project.project.getCommands(), function(options) {
+    main.registerCommand(options, options.func);
+  });
+
   // OK, if not one of those, the first (non-'--') argument(s) should
   // name the command.
   if (! command) {

--- a/tools/project.js
+++ b/tools/project.js
@@ -570,6 +570,32 @@ _.extend(Project.prototype, {
     return archs;
   },
 
+  // Returns a map of all commands registered by the plugins of this project
+  getCommands: function () {
+    var self = this;
+    var pluginCommands = {};
+    buildmessage.capture(function() {
+      var allPackages = self.getConstraints();
+      var packageLoader = self.getPackageLoader();
+      _.each(allPackages, function(version, pkgName) {
+        _.each(packageLoader.getPackage(pkgName).getCommands(),
+               function(command, commandName) {
+
+          if (_.has(pluginCommands, commandName)) {
+            buildmessage.error("conflict: two packages are both trying to " +
+              "register the " + commandName + " command");
+            // Recover by just going with the first command we saw
+            return;
+          }
+
+          pluginCommands[commandName] = command;
+        });
+      });
+    });
+
+    return pluginCommands;
+  },
+
   // Returns the file path to the .meteor/cordova-plugins file, containing the
   // Cordova plugins dependencies for this specific project.
   _getCordovaPluginsFile: function () {


### PR DESCRIPTION
Hello,

The documentation defines Meteor as two things: a library of packages that aims to provide features to your app, and a command-line tool to build one (or several) app(s) for different targets. Although it's not yet a public thing, there is also the concept of a “plugin” which is a package that extends the command-line tool. Currently the only plugin method is

``` js
Plugin.registerSourceHandler(extension, [options], handler)
```

This is used by packages like coffeescript, spacebars, less, stylus, harmony, etc. to auto-compile some specific files and add them to the bundle. This PR introduces a new plugin method:

``` js
Plugin.registerCommand(name, [options], action)
```

As the method name says, this method allows packages to register new command-line operations. It will be useful for test systems (velocity), code-generator/scaffolding tools (em), wrapped database administration, etc.

For instance the `em` package could register:

``` js
Plugin.registerCommand("em init", function () { /* do something */ });
```

And then a user could simply:

``` sh
$ meteor add eventedmind:em
$ meteor em init
```

The exposed API is similar to what is used internally for meteor core commands, and thus allows the same level of features (sub-commands, options...).
