### PR TITLE
Fix appcache usage of WebApp.clientHash

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -71,7 +71,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
   // So to ensure that the client updates if client resources change,
   // include a hash of client resources in the manifest.
 
-  manifest += "# " + WebApp.clientHash + "\n";
+  manifest += "# " + WebApp.clientHash() + "\n";
 
   // When using the autoupdate package, also include
   // AUTOUPDATE_VERSION.  Otherwise the client will get into an
@@ -81,7 +81,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
 
   if (Package.autoupdate) {
     var version = Package.autoupdate.Autoupdate.autoupdateVersion;
-    if (version !== WebApp.clientHash)
+    if (version !== WebApp.clientHash())
       manifest += "# " + version + "\n";
   }
 


### PR DESCRIPTION
In https://github.com/meteor/meteor/commit/71966f407a651643424ba83d854c658e6a957542#diff-79c5e18978e1bfa64cbb9edb380f2920L214
`WebApp.clientHash` changed from a string to a
function.

This PR fixes the appcache package to call the new function.

With the change to a function being called, the client hash is no
longer cached, and the client hash will be recalculated on each load of
the app manifest file.

I presume the client hash could be cached by the appcache package
because it always uses the default architecture ("web.browser"), but I
didn't make that addition because I wasn't sure if that was correct.
