### PR TITLE
Improve HTML templates of 'parties' and 'clock' examples

### DIFF
--- a/examples/clock/client/clock.html
+++ b/examples/clock/client/clock.html
@@ -3,33 +3,21 @@
 </head>
 
 <body>
-  <svg xmlns="http://www.w3.org/2000/svg"
-       width="350" height="350"
-       viewBox="-110 -110 220 220"
-       style="display: block; margin: 0 auto;">
+  <svg xmlns="http://www.w3.org/2000/svg" width="350" height="350" viewBox="-110 -110 220 220" style="display: block; margin: 0 auto;">
 
     <!-- bounding circle -->
-    <circle style="stroke: black; fill: #eee;"
-            cx="0" cy="0" r="100"/>
+    <circle style="stroke: black; fill: #eee;" cx="0" cy="0" r="100"/>
 
     <!-- hour, minute and second hands -->
     {{#with handData}}
-      <line {{radial hourDegrees 0 .55}}
-            style="stroke-width: 6px;
-                   stroke: green;" />
-      <line {{radial minuteDegrees 0 .85}}
-            style="stroke-width: 4px;
-                   stroke: blue;" />
-      <line {{radial secondDegrees 0 .95}}
-            style="stroke-width: 2px;
-                   stroke: red;" />
+      <line {{radial hourDegrees 0 .55}} style="stroke-width: 6px; stroke: green;" />
+      <line {{radial minuteDegrees 0 .85}} style="stroke-width: 4px; stroke: blue;" />
+      <line {{radial secondDegrees 0 .95}} style="stroke-width: 2px; stroke: red;" />
     {{/with}}
 
     <!-- tick marks -->
     {{#each hours}}
-      <line {{radial degrees 0.9 1}}
-            style="stroke-width: 3px;
-                   stroke: black;" />
+      <line {{radial degrees 0.9 1}} style="stroke-width: 3px; stroke: black;" />
     {{/each}}
   </svg>
 </body>

--- a/examples/parties/client/parties.html
+++ b/examples/parties/client/parties.html
@@ -80,11 +80,11 @@
         <div class="rsvp-buttons">
           {{#if currentUser}}
             <input type="button" value="I'm going!"
-                   class="btn btn-small rsvp_yes {{maybeChosen "yes"}}">
+                   class="btn btn-small rsvp_yes {{maybeChosen 'yes'}}">
             <input type="button" value="Maybe"
-                   class="btn btn-small rsvp_maybe {{maybeChosen "maybe"}}">
+                   class="btn btn-small rsvp_maybe {{maybeChosen 'maybe'}}">
             <input type="button" value="No"
-                   class="btn btn-small rsvp_no {{maybeChosen "no"}}">
+                   class="btn btn-small rsvp_no {{maybeChosen 'no'}}">
           {{else}}
             <i>Sign in to RSVP for this party.</i>
           {{/if}}


### PR DESCRIPTION
- Change double quotes to single quotes inside `class` tags in parties example
- Don't split `line`, `circle` and `svg` tags in clock example

The reason behind these changes is to make it simpler to process templates' code when it's getting converted to, say, JADE. I've tried many different HTML pre-processors, and none of them liked split `style` tag attributes. Also double quotes inside double quotes without escaping is certainly something that is broken, and even GitHub's syntax highlighter doesn't like it.
