### PR TITLE
Export FastClick to all clients

### DIFF
--- a/packages/fastclick/package.js
+++ b/packages/fastclick/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
-  api.export('FastClick', 'web.cordova');
+  api.export('FastClick', 'web');
 
-  api.addFiles(['pre.js', 'fastclick.js', 'post.js'], 'web.cordova');
+  api.addFiles(['pre.js', 'fastclick.js', 'post.js'], 'web');
 });


### PR DESCRIPTION
Remove the 300ms click delay on mobile web browsers in addition to Cordova builds. FastClick will ignore desktop / non-touchscreen browsers.

This commit resolves #2755 
