### PR TITLE
Added missing underscore package dependency.

### DIFF
--- a/packages/url/package.js
+++ b/packages/url/package.js
@@ -5,6 +5,7 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.export('URL');
+  api.use('underscore', ['client', 'server']);
   api.addFiles('url_common.js', ['client', 'server']);
   api.addFiles('url_client.js', 'client');
   api.addFiles('url_server.js', 'server');


### PR DESCRIPTION
Underscore is used in url_common.js, but this dependency is missing in the package's onUse function. It might lead to "_ is not defined" errors, for example when using HTTP.get(). Probably a result of the new package manager being more strict on this...

Trace:
W20141005-21:19:44.608(9)? (STDERR) ReferenceError: _ is not defined
W20141005-21:19:44.608(9)? (STDERR)     at Object.URL._encodeParams (packages/url/url_common.js:10)
W20141005-21:19:44.608(9)? (STDERR)     at buildUrl (packages/url/url_common.js:28)
W20141005-21:19:44.609(9)? (STDERR)     at Object.URL._constructUrl (packages/url/url_server.js:5)
W20141005-21:19:44.609(9)? (STDERR)     at Object._call (packages/http/httpcall_server.js:39)
W20141005-21:19:44.610(9)? (STDERR)     at Object.call (packages/meteor/helpers.js:117)
W20141005-21:19:44.610(9)? (STDERR)     at Object.HTTP.get (packages/http/httpcall_common.js:45)
W20141005-21:19:44.610(9)? (STDERR)     at Object.TumblrFeedAPI.updateFeed (packages/c2o-tumblrfeed/server.js:43)
... etc
