### PR TITLE
Adds loginHint parameter to Meteor.loginWithGoogle() 

### DIFF
--- a/packages/accounts-oauth/oauth_client.js
+++ b/packages/accounts-oauth/oauth_client.js
@@ -10,7 +10,7 @@
  * @param {String[]} options.requestPermissions A list of permissions to request from the user.
  * @param {Boolean} options.requestOfflineToken If true, asks the user for permission to act on their behalf when offline. This stores an additional offline token in the `services` field of the user document. Currently only supported with Google.
  * @param {Boolean} options.forceApprovalPrompt If true, forces the user to approve the app's permissions, even if previously approved. Currently only supported with Google.
- * @param {String} options.userEmail An email address that the external service will use to pre-fill the login prompt. Currently only supported with Meteor developer accounts.
+ * @param {String} options.loginHint An email address that the external service will use to pre-fill the login prompt. Currently only supported with Meteor developer accounts and Google accounts.
  * @param {String} options.loginStyle Login style ("popup" or "redirect", defaults to the login service configuration).  The "popup" style opens the login page in a separate popup window, which is generally preferred because the Meteor application doesn't need to be reloaded.  The "redirect" style redirects the Meteor application's window to the login page, and the login service provider redirects back to the Meteor application which is then reloaded.  The "redirect" style can be used in situations where a popup window can't be opened, such as in a mobile UIWebView.  The "redirect" style however relies on session storage which isn't available in Safari private mode, so the "popup" style will be forced if session storage can't be used.
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  */

--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -56,6 +56,10 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
     loginUrl += '&hd=' + encodeURIComponent(Accounts._options.restrictCreationByEmailDomain);
   }
 
+  if (options.loginHint) {
+    loginUrl += '&login_hint=' + encodeURIComponent(options.loginHint);
+  }
+
   OAuth.launchLogin({
     loginService: "google",
     loginStyle: loginStyle,

--- a/packages/meteor-developer/meteor_developer_client.js
+++ b/packages/meteor-developer/meteor_developer_client.js
@@ -29,8 +29,14 @@ var requestCredential = function (options, credentialRequestCompleteCallback) {
         "&response_type=code&" +
         "client_id=" + config.clientId;
 
-  if (options && options.userEmail)
-    loginUrl += '&user_email=' + encodeURIComponent(options.userEmail);
+
+  /**
+   * @deprecated in 1.0.0
+   */
+  if (options.userEmail && !options.loginHint) options.loginHint = options.userEmail;
+
+  if (options && options.loginHint)
+    loginUrl += '&user_email=' + encodeURIComponent(options.loginHint);
 
   loginUrl += "&redirect_uri=" + OAuth._redirectUri('meteor-developer', config);
 


### PR DESCRIPTION
Adds loginHint parameter to Meteor.loginWithGoogle() to hint Google OAuth to select the account we want.

Fixes https://github.com/meteor/meteor/issues/2422.