### PR TITLE
Fix the typeof check

### DIFF
--- a/packages/blaze/preamble.js
+++ b/packages/blaze/preamble.js
@@ -22,7 +22,7 @@ Blaze._escape = (function() {
 Blaze._warn = function (msg) {
   msg = 'Warning: ' + msg;
 
-  if ((typeof 'Log' !== 'undefined') && Log && Log.warn)
+  if ((typeof Log !== 'undefined') && Log && Log.warn)
     Log.warn(msg); // use Meteor's "logging" package
   else if ((typeof 'console' !== 'undefined') && console.log)
     console.log(msg);


### PR DESCRIPTION
Encountered this bug when I tried to update an app to 0.9.4 RC and it began generating Blaze warnings about the deprecated old-style helper.

The problem is that the type of the string `'Log'` is being checked rather than the value of the `Log` variable, which obviously returns true, and then the code breaks on the `&& Log` check, which is undefined.
