### PR TITLE
`show` command doesn't have a `maintainer` option

### DIFF
--- a/tools/help.txt
+++ b/tools/help.txt
@@ -649,7 +649,6 @@ are known to not be compatible with Meteor 0.9.0 and later. If you
 want to see those versions anyway, use the --show-old option.
 
 Options:
-  --maintainer    filter by authorized maintainer
   --show-old      show versions incompatible with Meteor 0.9.0 and later.
 
 


### PR DESCRIPTION
Proof: https://github.com/meteor/meteor/blob/bd3b61a571a7e7294baac492c0e6cafc0189fc1f/tools/commands-packages.js#1035-1037
