### PR TITLE
Allow overriding templates

### DIFF
--- a/packages/templating/plugin/html_scanner.js
+++ b/packages/templating/plugin/html_scanner.js
@@ -165,8 +165,10 @@ html_scanner = {
         var templateDotNameLiteral = JSON.stringify("Template." + name);
 
         results.js += "\nTemplate.__checkName(" + nameLiteral + ");\n" +
+          "if (!Template.__maybeOverride(" + nameLiteral +
+          ", " + renderFuncCode + ")) {\n" +
           "Template[" + nameLiteral + "] = new Template(" +
-          templateDotNameLiteral + ", " + renderFuncCode + ");\n";
+          templateDotNameLiteral + ", " + renderFuncCode + ");\n}\n";
       } else {
         // <body>
         if (hasAttribs)

--- a/packages/templating/scanner_tests.js
+++ b/packages/templating/scanner_tests.js
@@ -34,9 +34,11 @@ Tinytest.add("templating - html scanner", function (test) {
     // '"hello"' into '"Template.hello"'
     var viewName = templateName.slice(0, 1) + 'Template.' + templateName.slice(1);
 
-    return '\nTemplate.__checkName(' + templateName + ');\nTemplate[' + templateName +
-      '] = new Template(' + viewName +
-      ', (function() {\n  var view = this;\n  return ' + content + ';\n}));\n';
+    return '\nTemplate.__checkName(' + templateName + ');\n' +
+      'if (!Template.__maybeOverride(' + templateName +
+      ', (function() {\n  var view = this;\n  return ' + content + ';\n}))) {\n' +
+      'Template[' + templateName + '] = new Template(' + viewName +
+      ', (function() {\n  var view = this;\n  return ' + content + ';\n}));\n}\n';
   };
 
   var checkResults = function(results, expectJs, expectHead) {

--- a/packages/templating/templating.js
+++ b/packages/templating/templating.js
@@ -10,22 +10,33 @@ Template = Blaze.Template;
 
 var RESERVED_TEMPLATE_NAMES = "__proto__ name".split(" ");
 
-// Check for duplicate template names and illegal names that won't work.
+// Check for illegal names that won't work.
 Template.__checkName = function (name) {
   // Some names can't be used for Templates. These include:
   //  - Properties Blaze sets on the Template object.
   //  - Properties that some browsers don't let the code to set.
   //    These are specified in RESERVED_TEMPLATE_NAMES.
-  if (name in Template || _.contains(RESERVED_TEMPLATE_NAMES, name)) {
-    if ((Template[name] instanceof Template) && name !== "body")
-      throw new Error("There are multiple templates named '" + name + "'. Each template needs a unique name.");
+  if (_.contains(RESERVED_TEMPLATE_NAMES, name)) {
     throw new Error("This template name is reserved: " + name);
   }
+};
+
+Template.__maybeOverride = function (name, renderFunc) {
+  if (name in Template && (Template[name] instanceof Template) && name !== "body") {
+    // We create a Template object to verify if everything looks good,
+    // but then we just use its renderFunction to override it in the
+    // original Template object.
+    var template = new Template("Template." + name, renderFunc);
+    Template[name].renderFunction = template.renderFunction;
+    return true;
+  }
+  return false;
 };
 
 // XXX COMPAT WITH 0.8.3
 Template.__define__ = function (name, renderFunc) {
   Template.__checkName(name);
+  if (Template.__maybeOverride(name, renderFunc)) return;
   Template[name] = new Template("Template." + name, renderFunc);
   // Exempt packages built pre-0.9.0 from warnings about using old
   // helper syntax, because we can.  It's not very useful to get a


### PR DESCRIPTION
Allow overriding templates.

Maybe there should be an argument to template, to say that you know that you are overriding a template. Something like `<template override=true>` or something. Otherwise an error could be thrown. For now it just silently allows it.

Or, you should not be able to define the same template multiple times inside the package, but the app can override the template defined in a package (or another package can redefine the template from some other package)

Related #2833.
