### PR TITLE
Allow setting custom title

### DIFF
--- a/packages/boilerplate-generator/boilerplate-generator.js
+++ b/packages/boilerplate-generator/boilerplate-generator.js
@@ -54,6 +54,7 @@ Boilerplate.prototype._generateBoilerplateFromManifestAndSource =
       js: [],
       head: '',
       body: '',
+      title: '',
       meteorManifest: JSON.stringify(manifest)
     };
 

--- a/packages/boilerplate-generator/boilerplate_web.browser.html
+++ b/packages/boilerplate-generator/boilerplate_web.browser.html
@@ -1,5 +1,6 @@
 <html {{htmlAttributes}}>
 <head>
+{{#if title}}<title>{{title}}</title>{{/if}}
 {{#each css}}  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="{{../bundledJsCssPrefix}}{{url}}">{{/each}}
 
 {{#if inlineScriptsAllowed}}


### PR DESCRIPTION
Allow setting custom title in the HTML output sent by the server. This allows better identification of the pages before they are processed by the JavaScript. (For example, if JavaScript fails for some reason.)
