### PR TITLE
made query parameter available to oauth1 services

### DIFF
--- a/packages/oauth1/oauth1_server.js
+++ b/packages/oauth1/oauth1_server.js
@@ -67,7 +67,7 @@ OAuth._requestHandlers['1'] = function (service, query, res) {
       oauthBinding.prepareAccessToken(query, requestTokenInfo.requestTokenSecret);
 
       // Run service-specific handler.
-      var oauthResult = service.handleOauthRequest(oauthBinding, query);
+      var oauthResult = service.handleOauthRequest(oauthBinding, { query: query });
 
       var credentialToken = OAuth._credentialTokenFromQuery(query);
       credentialSecret = Random.secret();


### PR DESCRIPTION
In order to get the accounts_quickbooks and associated quickbooks package working, I had to get access to this realmId parameter that comes back in the oauth request.  This seemed like simple and safe way to do it (and the oauth2 code already has access to the query parameter).
