### PR TITLE
Added possibility to escape "{{" braces by appending a vertical bar "{{|"

### DIFF
--- a/packages/spacebars-compiler/codegen.js
+++ b/packages/spacebars-compiler/codegen.js
@@ -150,6 +150,8 @@ _.extend(CodeGen.prototype, {
 
           return BlazeTools.EmitCode(includeCode);
         }
+      } else if (tag.type === 'ESCAPE') {
+        return HTML.Raw(tag.value);
       } else {
         // Can't get here; TemplateTag validation should catch any
         // inappropriate tag types that might come out of the parser.

--- a/packages/spacebars-compiler/spacebars_tests.js
+++ b/packages/spacebars-compiler/spacebars_tests.js
@@ -164,6 +164,9 @@ Tinytest.add("spacebars-compiler - stache tags", function (test) {
   run('{{foo "="}}', {type: 'DOUBLE', path: ['foo'],
                         args: [['STRING', '=']]});
 
+  run('{{| asdf', { type: 'ESCAPE', value: '{{' });
+  run('{{{| asdf', { type: 'ESCAPE', value: '{{{' });
+  run('{{{{| asdf', { type: 'ESCAPE', value: '{{{{' });
 });
 
 


### PR DESCRIPTION
see #2052, I've also made it possible to have more than 2 or 3 curly braces escaped, since spacebars would throw an error if you wanted to have more than that
