### PR TITLE
docs: add web.browser and web.cordova as architecture possibilities to package.js

### DIFF
--- a/tools/package-source.js
+++ b/tools/package-source.js
@@ -1102,7 +1102,7 @@ _.extend(PackageSource.prototype, {
          * or `my:forms@1.0.0 || =2.0.1` (`my:forms` at `1.x.y`, or exactly `2.0.1`).
          * @param {String} [architecture] If you only use the package on the
          * server (or the client), you can pass in the second argument (e.g.,
-         * `'server'` or `'client'`) to specify what architecture the package is
+         * `'server'`, `'client'`, 'web.browser', 'web.cordova') to specify what architecture the package is
          * used with.
          * @param {Object} [options]
          * @param {Boolean} options.weak Establish a weak dependency on a
@@ -1227,7 +1227,7 @@ _.extend(PackageSource.prototype, {
          * @summary Specify the source code for your package.
          * @locus package.js
          * @param {String|String[]} filename Name of the source file, or array of strings of source file names.
-         * @param {String} [architecture] If you only want to export the file on the server (or the client), you can pass in the second argument (e.g., 'server' or 'client') to specify what architecture the file is used with.
+         * @param {String} [architecture] If you only want to export the file on the server (or the client), you can pass in the second argument (e.g., 'server', 'client', 'web.browser', 'web.cordova') to specify what architecture the file is used with.
          */
         addFiles: function (paths, arch, fileOptions) {
           paths = toArray(paths);
@@ -1308,7 +1308,7 @@ _.extend(PackageSource.prototype, {
          * @summary Export package-level variables in your package. The specified variables (declared without `var` in the source code) will be available to packages that use this package.
          * @locus package.js
          * @param {String} exportedObject Name of the object.
-         * @param {String} [architecture] If you only want to export the object on the server (or the client), you can pass in the second argument (e.g., 'server' or 'client') to specify what architecture the export is used with.
+         * @param {String} [architecture] If you only want to export the object on the server (or the client), you can pass in the second argument (e.g., 'server', 'client', 'web.browser', 'web.cordova') to specify what architecture the export is used with.
          */
         export: function (symbols, arch, options) {
           // Support `api.export("FooTest", {testOnly: true})` without


### PR DESCRIPTION
docs: add web.browser and web.cordova as architecture possibilities in package.js 's   api.use, api.addFiles and api.export
