### PR TITLE
Add spiderable support for hash fragments

### DIFF
--- a/packages/spiderable/phantom_script.js
+++ b/packages/spiderable/phantom_script.js
@@ -37,4 +37,3 @@ setInterval(function() {
     phantom.exit();
   }
 }, 100);
-

--- a/packages/spiderable/spiderable_server.js
+++ b/packages/spiderable/spiderable_server.js
@@ -26,6 +26,7 @@ Spiderable._urlForPhantom = function (siteAbsoluteUrl, requestUrl) {
   // reassembling url without escaped fragment if exists
   var parsedUrl = urlParser.parse(requestUrl);
   var parsedQuery = querystring.parse(parsedUrl.query);
+  var escapedFragment = parsedQuery['_escaped_fragment_'];
   delete parsedQuery['_escaped_fragment_'];
 
   var parsedAbsoluteUrl = urlParser.parse(siteAbsoluteUrl);
@@ -41,6 +42,10 @@ Spiderable._urlForPhantom = function (siteAbsoluteUrl, requestUrl) {
   parsedAbsoluteUrl.query = parsedQuery;
   // `url.format` will only use `query` if `search` is absent
   parsedAbsoluteUrl.search = null;
+
+  if (escapedFragment !== undefined && escapedFragment !== null && escapedFragment.length > 0) {
+    parsedAbsoluteUrl.hash = '!' + decodeURIComponent(escapedFragment);
+  }
 
   return urlParser.format(parsedAbsoluteUrl);
 };

--- a/packages/spiderable/spiderable_tests.js
+++ b/packages/spiderable/spiderable_tests.js
@@ -3,37 +3,52 @@ var url = Npm.require("url");
 Tinytest.add("spiderable - phantom url generation", function (test, expect) {
   var absUrl = "http://example.com";
   _.each([
+    // Requests resulting from `<meta name="fragment" content="!">`
+    // will have an `_escaped_fragment_` which is present but blank,
+    // which we want to represent as having no hash fragment
+    // parameter.  (Note this means we cannot distinguish between `/`
+    // and `/#!`).
+    {
+      requestUrl: "/?_escaped_fragment_=",
+      expected: "/"
+    },
+    // Test that a nonempty fragment is tunneled through to the generated URL
     {
       requestUrl: "/?_escaped_fragment_=1",
-      expected: "/"
+      expected: "/#!1"
+    },
+    // Test decoding the encoded escaped fragment.
+    {
+      requestUrl: "/?_escaped_fragment_=abc%3D123%26def%3D456",
+      expected: "/#!abc=123&def=456"
     },
     // Test that query strings are preserved
     {
       requestUrl: "/?_escaped_fragment_=1&foo=bar",
-      expected: "/?foo=bar"
+      expected: "/?foo=bar#!1"
     },
     {
       requestUrl: "/?foo=bar&_escaped_fragment_=1",
-      expected: "/?foo=bar"
+      expected: "/?foo=bar#!1"
     },
     // Test that paths are preserved
     {
       requestUrl: "/foo/bar?_escaped_fragment_=1",
-      expected: "/foo/bar"
+      expected: "/foo/bar#!1"
     },
     {
       requestUrl: "/foo/bar?_escaped_fragment_=1&foo=bar",
-      expected: "/foo/bar?foo=bar"
+      expected: "/foo/bar?foo=bar#!1"
     },
     // Test with a path on the site's absolute url
     {
       requestUrl: "/foo/bar?_escaped_fragment_=1",
-      expected: "/foo/bar",
+      expected: "/foo/bar#!1",
       absUrl: "http://example.com/foo"
     },
     {
       requestUrl: "/bar?_escaped_fragment_=1",
-      expected: "/bar",
+      expected: "/bar#!1",
       absUrl: "http://example.com/foo"
     }
   ], function (testCase) {


### PR DESCRIPTION
Since the browser application cache appears not to support URL path
routes in a non-buggy way (see
https://github.com/meteor/meteor/pull/2926), applications using the
appcache package will want to use hash fragment routes instead.

This PR adds support to the spiderable package for hash fragment
routes.  An original URL such as `http://example.com/#!a=1&b=2` will
be encoded by a search engine as an escaped fragment, decoded by the
spiderable package, passed through to the phantomjs process, and
appear to the phantom client as `#!a=1&b=2` in `window.location.hash`
(the same as when the original URL is opened in a regular browser).