### PR TITLE
Document possibility of repeat calls to a method

### DIFF
--- a/docs/client/full-api/api/methods.md
+++ b/docs/client/full-api/api/methods.md
@@ -66,6 +66,13 @@ Since methods usually expect particular types as arguments,
 use [`check`](#check) liberally to ensure your method arguments have
 the correct [types and structure](#matchpatterns).
 
+If a client calls a method and is disconnected before it receives a response,
+it will re-call the method when it reconnects. This means that a client may
+call a method multiple times when it only means to call it once. If this
+behavior is problematic for your method, consider attaching a unique ID
+to each method call on the client, and checking on the server whether a call
+with this ID has already been made.
+
 {{> autoApiBox "MethodInvocation#userId"}}
 
 The user id is an arbitrary string &mdash; typically the id of the user record


### PR DESCRIPTION
On re-connect, clients re-try methods that haven't received a response, which means that methods might be called multiple times. This is important to document so users know to guard against this behavior if a method has dangerous side-effects.

See issue #2407.
