### PR TITLE
typo: mysterious g in deployment docs

### DIFF
--- a/docs/client/full-api/concepts.html
+++ b/docs/client/full-api/concepts.html
@@ -886,7 +886,7 @@ HTTP port for the application to listen on, and the MongoDB endpoint.
 $ cd my_directory
 $ (cd programs/server && npm install)
 $ PORT=3000 MONGO_URL=mongodb://localhost:27017/myapp node main.js
-```g
+```
 
 Some packages might require other environment variables. For example,
 the `email` package requires a `MAIL_URL` environment variable.


### PR DESCRIPTION
Removes the mysterious **g**.

![screen shot 2014-10-29 at 21 26 18](https://cloud.githubusercontent.com/assets/58871/4835071/8c572ff8-5fb3-11e4-90c2-834e3c218ade.png)
