### PR TITLE
You can use Template.currentData inside template.autorun

### DIFF
--- a/docs/client/full-api/api/templates.md
+++ b/docs/client/full-api/api/templates.md
@@ -151,8 +151,9 @@ Access is read-only and non-reactive.
 
 You can use `this.autorun` from a [`created`](#template_created) or
 [`rendered`](#template_rendered) callback to reactively update the DOM
-or the template instance.  The Computation is automatically stopped
-when the template is destroyed.
+or the template instance.  You can use `Template.currentData()` inside
+of this callback to access reactive data context of the template instance.
+The Computation is automatically stopped when the template is destroyed.
 
 Alias for `template.view.autorun`.
 


### PR DESCRIPTION
I think it is important to stress that you can use Template.currentData inside template.autorun, because you cannot use it inside Tracker.autorun, it throws an error that current view does not exist.