### PR TITLE
Add git infos for 'meteor --version' when running meteor from checkout

### DIFF
--- a/tools/commands.js
+++ b/tools/commands.js
@@ -111,7 +111,8 @@ main.registerCommand({
   }
 
   if (release.current.isCheckout()) {
-    Console.stderr.write("Unreleased (running from a checkout)\n");
+    var gitLog = files.runGitInCheckout('log', '--format=(commit %h)%d', '-n 1');
+    Console.error("Unreleased (running from a checkout) " + gitLog + "\n");
     return 1;
   }
 


### PR DESCRIPTION
The changes will show additional information extracted from ```git status``` when calling ```meteor --version``` from git checkout.

Old output:
```
Unreleased (running from a checkout)
```

New output:
```
Unreleased (running from a checkout) [BRANCH release-1.0-universal...origin/release-1.0-universal]
```
```
Unreleased (running from a checkout) [HEAD detached at release/METEOR@0.9.1]
```
