### PR TITLE
Fixed Accounts.onLoginFailure link for the API docs.

### DIFF
--- a/docs/client/full-api/tableOfContents.js
+++ b/docs/client/full-api/tableOfContents.js
@@ -127,7 +127,7 @@ var toc = [
       "Accounts.onCreateUser",
       "Accounts.validateLoginAttempt",
       "Accounts.onLogin",
-      {name: "Accounts.onLoginFailure", id: "accounts_onlogin"}
+      "Accounts.onLoginFailure"
     ],
 
     {name: "Passwords", id: "accounts_passwords"}, [
@@ -390,4 +390,3 @@ Template.nav_section.helpers({
     return this.depth === n;
   }
 });
-


### PR DESCRIPTION
This is a simple fix for the the Accounts.onLoginFailure link (in the api docs) pointing to the Accounts.onLogin's id, instead of it's own.

I signed the contributor's agreement, based this off the devel branch, and put in my actual name and email into the git config user.name and user.email. I think that's everything I needed to do.

Let me know if there is anything else that needs to be done. Thanks.
