### PR TITLE
Bugfix localmarket

### DIFF
--- a/examples/localmarket/client/templates/app-body.js
+++ b/examples/localmarket/client/templates/app-body.js
@@ -43,7 +43,7 @@ Meteor.startup(function () {
 
   // Only show the connection error box if it has been 5 seconds since
   // the app started
-  setTimeout(function () {
+  connErrorTimeout = setTimeout(function () {
     // Launch screen handle created in lib/router.js
     dataReadyHold.release();
 

--- a/examples/localmarket/lib/router.js
+++ b/examples/localmarket/lib/router.js
@@ -26,7 +26,10 @@ HomeController = RouteController.extend({
   onBeforeAction: function() {
     Meteor.subscribe('latestActivity', function() {
       dataReadyHold.release();
-      clearTimeout(connErrorTimeout);
+      if(connErrorTimeout) {
+        clearTimeout(connErrorTimeout);
+        connErrorTimeout = null;
+      };
     });
   }
 });

--- a/examples/localmarket/lib/router.js
+++ b/examples/localmarket/lib/router.js
@@ -2,6 +2,7 @@ var feedSubscription;
 
 // Handle for launch screen possibly dismissed from app-body.js
 dataReadyHold = null;
+connErrorTimeout = null;
 
 // Global subscriptions
 if (Meteor.isClient) {
@@ -25,6 +26,7 @@ HomeController = RouteController.extend({
   onBeforeAction: function() {
     Meteor.subscribe('latestActivity', function() {
       dataReadyHold.release();
+      clearTimeout(connErrorTimeout);
     });
   }
 });


### PR DESCRIPTION
Fixed a small bug in the localmarket example app, which btw is pretty awesome.
The timeout that flags connection errors is never cleared. As a result, the Session value for 'showConnectionIssue' always evaluated to true. 