### PR TITLE
Fixed a failed check for Tracker.flush() during a Tracker.Computation

### DIFF
--- a/packages/tracker/tracker.js
+++ b/packages/tracker/tracker.js
@@ -263,7 +263,7 @@ Tracker.Computation.prototype._compute = function () {
     withNoYieldsAllowed(self._func)(self);
   } finally {
     setCurrentComputation(previous);
-    inCompute = false;
+    inCompute = previousInCompute;
   }
 };
 

--- a/packages/tracker/tracker_tests.js
+++ b/packages/tracker/tracker_tests.js
@@ -242,6 +242,13 @@ Tinytest.add("tracker - flush", function (test) {
       Tracker.flush(); // illegal to flush from a computation
     });
   });
+
+  test.throws(function () {
+    Tracker.autorun(function () {
+      Tracker.autorun(function () {});
+      Tracker.flush();
+    });
+  });
 });
 
 Tinytest.add("tracker - lifecycle", function (test) {


### PR DESCRIPTION
When the `Tracker.flush()` function is called while a `Tracker.Computation` is running, an error is usually raised. However, a small oversight in the code causes this check to fail after a nested `Tracker.Computation` completes. This could lead to an infinite loop.

This change adds a test proving the existence of the bug and the fix for it.