### PR TITLE
Typo fixes

### DIFF
--- a/docs/client/full-api/concepts.html
+++ b/docs/client/full-api/concepts.html
@@ -805,7 +805,7 @@ debugger, you've got two options:
   don't use the `email` package directly.
 
 When declaring functions, keep in mind that `function x () {}` is just
-shorthard for `var x = function () {}` in JavaScript. Consider these
+shorthand for `var x = function () {}` in JavaScript. Consider these
 examples:
 
     // This is the same as 'var x = function () ...'. So x() is
@@ -885,7 +885,7 @@ HTTP port for the application to listen on, and the MongoDB endpoint.
 $ cd my_directory
 $ (cd programs/server && npm install)
 $ PORT=3000 MONGO_URL=mongodb://localhost:27017/myapp node main.js
-```g
+```
 
 Some packages might require other environment variables. For example,
 the `email` package requires a `MAIL_URL` environment variable.


### PR DESCRIPTION
I noticed two small typos: "shorthard" -> "shorthand", remove lone "g"
