### PR TITLE
showdown package is moved to `markdown` package

### DIFF
--- a/docs/client/full-api/packages/markdown.html
+++ b/docs/client/full-api/packages/markdown.html
@@ -1,7 +1,7 @@
-<template name="pkg_showdown">
+<template name="pkg_markdown">
 {{#markdown}}
 
-## `showdown`
+## `markdown`
 <!-- XXX rename to markdown when we rename the package -->
 
 This package lets you use Markdown in your templates. It's easy: just


### PR DESCRIPTION
I typed

```
meteor add markdown
```

then.
showdown: Moved to the 'markdown' package
