### PR TITLE
Change cursor to pointer on checkbox hover

### DIFF
--- a/examples/todos/client/stylesheets/globals/list-items.import.less
+++ b/examples/todos/client/stylesheets/globals/list-items.import.less
@@ -7,7 +7,10 @@
   height: 3rem;
   width: 100%;
 
-  .checkbox { .flex(0, 0, 44px); }
+  .checkbox {
+    .flex(0, 0, 44px);
+    cursor: pointer;
+  }
   input[type="text"] { .flex(1); }
   .delete-item { .flex(0, 0, 3rem); }
 


### PR DESCRIPTION
It would eventually be ideal to give the `input` element `opacity: 0` so that it's still focusable, but this makes it a bit easier to use the Todo example with the mouse, giving the user the indication that they can click the checkbox.

It's the little things. :)