### PR TITLE
Clean up parsing/writing of cordovaDependencies

### DIFF
--- a/tools/isopack.js
+++ b/tools/isopack.js
@@ -724,8 +724,6 @@ _.extend(Isopack.prototype, {
                           JSON.stringify(resource.type));
       });
 
-      self.cordovaDependencies = mainJson.cordovaDependencies || null;
-
       self.unibuilds.push(new Unibuild(self, {
         name: unibuildMeta.name,
         arch: unibuildMeta.arch,
@@ -735,10 +733,11 @@ _.extend(Isopack.prototype, {
         nodeModulesPath: nodeModulesPath,
         prelinkFiles: prelinkFiles,
         packageVariables: unibuildJson.packageVariables || [],
-        resources: resources,
-        cordovaDependencies: unibuildJson.cordovaDependencies
+        resources: resources
       }));
     });
+
+    self.cordovaDependencies = mainJson.cordovaDependencies || null;
 
     _.each(mainJson.tools, function (toolMeta) {
       toolMeta.rootDir = dir;
@@ -808,8 +807,7 @@ _.extend(Isopack.prototype, {
           pluginProviderPackages: self.pluginProviderPackageDirs,
           source: options.buildOfPath || undefined,
           buildTimeDirectDependencies: buildTimeDirectDeps,
-          buildTimePluginDependencies: buildTimePluginDeps,
-          cordovaDependencies: self.cordovaDependencies
+          buildTimePluginDependencies: buildTimePluginDeps
         };
       }
 


### PR DESCRIPTION
As far as I understand, cordovaDependencies exist in these places:
- On an entire package (not an individual unibuild), as stored in the
  main JSON blob (isopack.json)
- On a target (combination of many packages), as stored in the star

This commit removes some stray code where they show up in other places:
- A field (which is never written) is read from the individual unibuild
  JSON file and passed to the Unibuild constructor, which does not
  expect it.
- A field (which is never read) is written to the buildinfo.json file.

Also, an assignment to Isopack.cordovaDependencies is pulled out of a
loop.

@Slava Can you confirm that these changes are correct?
