### PR TITLE
Clock example uses old API

### DIFF
--- a/examples/clock/client/clock.js
+++ b/examples/clock/client/clock.js
@@ -2,7 +2,7 @@ Meteor.setInterval(function () {
   Session.set('time', new Date());
 }, 1000);
 
-UI.body.helpers({
+Template.body.helpers({
 
   hours: _.range(0, 12),
 


### PR DESCRIPTION
Clock example uses old API (UI). Actual documentation contains only 'Template.body' way
