### PR TITLE
Fix Css autoupdate for pages with ROOT_URL_PATH_PREFIX set

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -127,7 +127,7 @@ Autoupdate._retrySubscription = function () {
                 newLink.setAttribute("rel", "stylesheet");
                 newLink.setAttribute("type", "text/css");
                 newLink.setAttribute("class", "__meteor-css__");
-                newLink.setAttribute("href", css.url);
+                newLink.setAttribute("href", __meteor_runtime_config__.ROOT_URL_PATH_PREFIX + css.url);
                 attachStylesheetLink(newLink);
               });
             } else {


### PR DESCRIPTION
Hi, I fixed an issue which broke the CSS autoupdate for me for a few months now. I thought it would be a different problem, some dynamic javascript required to properly init the template or somesuch, but today I decided to check for the source of the problem.

It seems like I found it, it is similar to this one: https://github.com/meteor/meteor/commit/0f4f77f8a20f34a035cfd2bce57041bfe170877f which got patched the same way.

The fix works for me, i tried it for projects without a ROOT_URL set as well, please check and, if possible, include it into the core! :)

Best wishes

Daniel