### PR TITLE
Added clear() and all() to reactive-dict

### DIFF
--- a/packages/reactive-dict/package.js
+++ b/packages/reactive-dict/package.js
@@ -14,4 +14,6 @@ Package.onUse(function (api) {
 
 Package.onTest(function (api) {
   api.use('tinytest');
+  api.use('reactive-dict');
+  api.addFiles('reactive-dict-tests.js');
 });

--- a/packages/reactive-dict/reactive-dict-tests.js
+++ b/packages/reactive-dict/reactive-dict-tests.js
@@ -1,0 +1,44 @@
+Tinytest.add('ReactiveDict - all() works', function (test) {
+  var all = {}, dict = new ReactiveDict;
+  Tracker.autorun(function() {
+    all = dict.all();
+  });
+  
+  test.equal(all, {});
+  
+  dict.set('foo', 'bar');
+  Tracker.flush();
+  test.equal(all, {foo: 'bar'});
+});
+
+
+Tinytest.add('ReactiveDict - clear() works', function (test) {
+  var dict = new ReactiveDict;
+  dict.set('foo', 'bar');
+  
+  var val, equals, equalsUndefined, all;
+  Tracker.autorun(function() {
+    val = dict.get('foo');
+  });
+  Tracker.autorun(function() {
+    equals = dict.equals('foo', 'bar');
+  });
+  Tracker.autorun(function() {
+    equalsUndefined = dict.equals('foo', undefined);
+  });
+  Tracker.autorun(function() {
+    all = dict.all();
+  });
+  
+  test.equal(val, 'bar');
+  test.equal(equals, true);
+  test.equal(equalsUndefined, false);
+  test.equal(all, {foo: 'bar'});
+  
+  dict.clear();
+  Tracker.flush();
+  test.isUndefined(val);
+  test.equal(equals, false);
+  test.equal(equalsUndefined, true);
+  test.equal(all, {});
+});

--- a/packages/reactive-dict/reactive-dict.js
+++ b/packages/reactive-dict/reactive-dict.js
@@ -11,6 +11,10 @@ var parse = function (serialized) {
   return EJSON.parse(serialized);
 };
 
+var changed = function (v) {
+  v && v.changed();
+};
+
 // XXX COMPAT WITH 0.9.1 : accept migrationData instead of dictName
 ReactiveDict = function (dictName) {
   // this.keys: key -> value
@@ -31,6 +35,7 @@ ReactiveDict = function (dictName) {
     this.keys = {};
   }
 
+  this.allDeps = new Tracker.Dependency;
   this.keyDeps = {}; // key -> Dependency
   this.keyValueDeps = {}; // key -> Dependency
 };
@@ -59,10 +64,7 @@ _.extend(ReactiveDict.prototype, {
       return;
     self.keys[key] = value;
 
-    var changed = function (v) {
-      v && v.changed();
-    };
-
+    self.allDeps.changed();
     changed(self.keyDeps[key]);
     if (self.keyValueDeps[key]) {
       changed(self.keyValueDeps[key][oldSerializedValue]);
@@ -135,6 +137,31 @@ _.extend(ReactiveDict.prototype, {
     var oldValue = undefined;
     if (_.has(self.keys, key)) oldValue = parse(self.keys[key]);
     return EJSON.equals(oldValue, value);
+  },
+  
+  all: function() {
+    this.allDeps.depend();
+    var ret = {};
+    _.each(this.keys, function(value, key) {
+      ret[key] = parse(value);
+    });
+    return ret;
+  },
+  
+  clear: function() {
+    var self = this;
+    
+    var oldKeys = self.keys;
+    self.keys = {};
+    
+    self.allDeps.changed();
+    
+    _.each(oldKeys, function(value, key) {
+      changed(self.keyDeps[key]);
+      changed(self.keyValueDeps[key][value]);
+      changed(self.keyValueDeps[key]['undefined']);
+    });
+    
   },
 
   _setObject: function (object) {


### PR DESCRIPTION
Added a `clear()` and an `all()` method to the `ReactiveDict`.

The second returns a dictionary with all values, and depends on every key (both current and future). Added tests for the two.

A couple of notes:

1. Could add a `.unset(key)` and use it in `.clear`. Haven't needed that yet.

2. Not sure if unsetting a key should invalidate `equals(key, undefined)`?