### PR TITLE
Read package metadata from meteor-package.js

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 ## v.NEXT
 
+* Rename package.js to meteor-package.js to avoid conflicts.
+
 * Spacebars: Allow curly braces to be escaped, with special
   sequences `{{|` and `{{{|` to insert a literal `{{` or `{{{`.
 

--- a/docs/client/full-api/api/packagejs.md
+++ b/docs/client/full-api/api/packagejs.md
@@ -1,13 +1,13 @@
 {{#template name="apiPackagejs"}}
 
-<h2 id="packagejs"><span>Package.js</span></h2>
+<h2 id="meteorpackagejs"><span>meteor-package.js</span></h2>
 
-{{#markdown}} A package is a directory containing a package.js file, which
+{{#markdown}} A package is a directory containing a `meteor-package.js` file, which
 contains roughly three major sections: a basic description, a package
 definition, and a test definition. By default, the directory name is the name of
 the package.
 
-The `package.js` file below is an example of how to use the packaging API. The
+The `meteor-package.js` file below is an example of how to use the packaging API. The
 rest of this section will explain the specific API commands in greater detail.
 
 
@@ -99,8 +99,8 @@ the package that you have just created. For example, if your package is the
 package.
 
 If you used `meteor create` to set up your package, Meteor will create the
-required scaffolding in `package.js`, and you'll only need to add unit test code
-in the `_test.js` file that was created.
+required scaffolding in `meteor-package.js`, and you'll only need to add unit test
+code in the `_test.js` file that was created.
 {{/markdown}}
 
 {{> autoApiBox "Package.onTest"}}
@@ -110,7 +110,7 @@ in the `_test.js` file that was created.
 
 {{#markdown}}
 Meteor packages can include NPM packages and Cordova plugins by using
-`Npm.depends` and `Cordova.depends` in the `package.js` file.
+`Npm.depends` and `Cordova.depends` in the `meteor-package.js` file.
 {{/markdown}}
 
 {{> autoApiBox "Npm.depends"}}

--- a/docs/client/full-api/concepts.html
+++ b/docs/client/full-api/concepts.html
@@ -256,11 +256,11 @@ of features. You can also publish the packages and use them in multiple apps
 with `meteor add`.
 
 ```bash
-packages/apples/package.js     # files, dependencies, exports for apple feature
-packages/apples/<anything>.js  # file loading is controlled by package.js
+packages/apples/meteor-package.js   # files, dependencies, exports for apple feature
+packages/apples/<anything>.js       # file loading is controlled by meteor-package.js
 
-packages/oranges/package.js    # files, dependencies, exports for orange feature
-packages/oranges/<anything>.js # file loading is controlled by package.js
+packages/oranges/meteor-package.js  # files, dependencies, exports for orange feature
+packages/oranges/<anything>.js      # file loading is controlled by meteor-package.js
 ```
 
 {{/markdown}}
@@ -899,12 +899,12 @@ the `email` package requires a `MAIL_URL` environment variable.
 
   <h2 id="writingpackages">Writing packages</h2>
 
-Writing Meteor packages is easy. To initialize a meteor package, run
+Writing Meteor packages is easy. To initialize a Meteor package, run
 `meteor create --package username:packagename`, where `username` is your Meteor
 Developer username. This will create a package from scratch and prefill the
-directory with a package.js control file and some javascript. By default, Meteor
-will take the package name from the name of the directory that contains the
-package.js file.
+directory with a [`meteor-package.js`](#meteorpackagejs) control file and some
+JavaScript. By default, Meteor will take the package name from the name of the
+directory that contains the `meteor-package.js` file.
 
 Meteor promises repeatable builds for both packages and applications. This means
 that, if you built your package on a machine, then checked the code into a
@@ -933,7 +933,7 @@ number has three parts separated by dots: major version, minor version and patch
 Additionally, because some meteor packages wrap external libraries,
 Meteor supports the convention of using `_` to denote a wrap number.
 
-You can read more about [`package.js`](#packagejs) files in the API
+You can read more about [`meteor-package.js`](#meteorpackagejs) files in the API
 section.
 
 A word on testing: since testing is an important part of the development process,
@@ -947,8 +947,8 @@ test and run your app as usual. Meteor will detect and respond to changes to
 your local package, just as it does to your app files.
 
 * Unit tests are run with the command [`meteor test-packages
-package-name`](#meteortestpackages). As described in the [`package.js`](#packagejs)
-section, you can use the `package.js` file to specify where your unit tests are
+package-name`](#meteortestpackages). As described in the [`meteor-package.js`](#meteorpackagejs)
+section, you can use the `meteor-package.js` file to specify where your unit tests are
 located. If you have a repository that contains only the package source, you can
 test your package by specifying the path to the package directory (which must
 contain a slash), such as `meteor test-packages ./`.

--- a/docs/client/full-api/tableOfContents.js
+++ b/docs/client/full-api/tableOfContents.js
@@ -278,7 +278,7 @@ var toc = [
       {name: "Assets.getBinary", id: "assets_getBinary"}
     ],
 
-    {name: "package.js", id: "packagejs"}, [
+    {name: "meteor-package.js", id: "meteorpackagejs"}, [
       {name: "Package.describe", id: "packagedescription"},
       {name: "Package.onUse", id: "packagedefinition"}, [
         {name: "api.versionsFrom", id: "pack_versions"},

--- a/packages/launch-screen/default-behavior.js
+++ b/packages/launch-screen/default-behavior.js
@@ -1,6 +1,6 @@
 // Hold launch screen on app load. This reflects the fact that Meteor
 // mobile apps that use this package always start with a launch screen
-// visible. (see XXX comment at the top of package.js for more
+// visible. (see XXX comment at the top of meteor-package.js for more
 // details)
 var handle = LaunchScreen.hold();
 
@@ -13,7 +13,7 @@ Meteor.startup(function () {
     // XXX Instead of doing this here, this code should be in
     // iron:router directly. Note that since we're in a
     // `Meteor.startup` block it's ok that we don't have a
-    // weak dependency on iron:router in package.js.
+    // weak dependency on iron:router in meteor-package.js.
     Package['iron:router'].Router.onAfterAction(function () {
       handle.release();
     });

--- a/scripts/admin/bump-all-version-numbers.js
+++ b/scripts/admin/bump-all-version-numbers.js
@@ -6,7 +6,7 @@ var _ = require("../../packages/underscore/underscore.js")._;
 var packageNames = _.rest(process.argv, 2);
 
 _.each(packageNames, function (name) {
-  // name = "packages/" + name + "/package.js";
+  // name = "packages/" + name + "/meteor-package.js";
 
   var content = fs.readFileSync(name, {encoding: "utf-8"});
 

--- a/tools/bundler.js
+++ b/tools/bundler.js
@@ -688,11 +688,10 @@ _.extend(Target.prototype, {
         if (_.contains(["js", "css"], resource.type)) {
           if (resource.type === "css" && ! isWeb)
             // XXX might be nice to throw an error here, but then we'd
-            // have to make it so that package.js ignores css files
+            // have to make it so that meteor-package.js ignores CSS files
             // that appear in the server directories in an app tree
 
-            // XXX XXX can't we easily do that in the css handler in
-            // meteor.js?
+            // XXX XXX can't we easily do that in the CSS handler?
             return;
 
           var f = new File({ info: 'resource ' + resource.servePath, data: resource.data, cacheable: false});

--- a/tools/catalog-local.js
+++ b/tools/catalog-local.js
@@ -210,15 +210,17 @@ _.extend(LocalCatalog.prototype, {
           return;
 
         // Consider a directory to be a package source tree if it contains
-        // 'package.js'. (We used to support isopacks in localPackageSearchDirs,
+        // 'meteor-package.js', with a backward compatibility fallback to 'package.js'.
+        // (We used to support isopacks in localPackageSearchDirs,
         // but no longer.)
-        if (fs.existsSync(path.join(packageDir, 'package.js'))) {
+        if (fs.existsSync(path.join(packageDir, 'meteor-package.js'))
+          || fs.existsSync(path.join(packageDir, 'package.js'))) {  // TODO deprecate
           // Let earlier package directories override later package
           // directories.
 
           // We don't know the name of the package, so we can't deal with
           // duplicates yet. We are going to have to rely on the fact that we
-          // are putting these in in order, to be processed in order.
+          // are putting these in order, to be processed in order.
           self.effectiveLocalPackageDirs.push(packageDir);
         }
       });
@@ -276,8 +278,8 @@ _.extend(LocalCatalog.prototype, {
           return;
         }
 
-        // Now that we have initialized the package from package.js, we know its
-        // name.
+        // Now that we have initialized the package from meteor-package.js, we
+        // know its name.
         var name = packageSource.name;
 
         // We should only have one package dir for each name; in this case, we
@@ -468,8 +470,13 @@ _.extend(LocalCatalog.prototype, {
         include: [/\/$/]
       });
       _.each(packages, function (p) {
-        watch.readAndWatchFile(watchSet,
-                               path.join(packageDir, p, 'package.js'));
+        // Watch the package metadata file. TODO deprecate package.js
+        if (fs.existsSync(path.join(packageDir, p, 'meteor-package.js')))
+          watch.readAndWatchFile(watchSet,
+                                 path.join(packageDir, p, 'meteor-package.js'));
+        else
+          watch.readAndWatchFile(watchSet,
+                                 path.join(packageDir, p, 'package.js'));
       });
     });
   },

--- a/tools/commands-packages.js
+++ b/tools/commands-packages.js
@@ -519,7 +519,7 @@ main.registerCommand({
         // versions of Meteor will just try to spingboard anyway.
         //
         // This is kind of a transitional hack. Going forward, there are several
-        // ways to fix this -- we could introduct some sort of local records (so
+        // ways to fix this -- we could introduce some sort of local records (so
         // we could create a temporary release record and run meteor from
         // there), or we can teach meteor to just run from a tool, instead of a
         // release. I like the latter better from a conceptual standpoint (why
@@ -575,7 +575,7 @@ main.registerCommand({
       officialBuild: true
     }).isopack;
     if (buildmessage.jobHasMessages())
-      return;
+      return;  // XXX this is the last statement of the function anyway
   });
 
   if (messages.hasMessages()) {
@@ -803,9 +803,11 @@ main.registerCommand({
           // in a release.
           var packageDir = path.resolve(path.join(localPackageDir, item));
           // Consider a directory to be a package source tree if it
-          // contains 'package.js'. (We used to support isopacks in
+          // contains 'meteor-package.js'. (We used to support isopacks in
           // local package directories, but no longer.)
-          if (fs.existsSync(path.join(packageDir, 'package.js'))) {
+          if (fs.existsSync(path.join(packageDir, 'meteor-package.js'))
+            || fs.existsSync(path.join(packageDir, 'package.js'))  // TODO deprecate
+          ) {
             var packageSource = new PackageSource(catalog.complete);
             buildmessage.enterJob(
               { title: "Building package " + item },
@@ -897,9 +899,9 @@ main.registerCommand({
                           oldVersion,
                           compileResult.isopack.buildArchitectures());
 
-                  // If the version number mentioned in package.js exists, but
-                  // there's no build of this architecture, then either the old
-                  // version was only semi-published, or you've added some
+                  // If the version number mentioned in meteor-package.js exists,
+                  // but there's no build of this architecture, then either the
+                  // old version was only semi-published, or you've added some
                   // platform-specific dependencies but haven't bumped the
                   // version number yet; either way, you should probably bump
                   // the version number.
@@ -924,7 +926,7 @@ main.registerCommand({
                     // has changed -- maybe our source files, or a buildId of
                     // one of our build-time dependencies. There might be a
                     // false positive here (for example, we added some comments
-                    // to a package.js file somewhere), but, for now, we would
+                    // to a meteor-package.js file somewhere), but, for now, we would
                     // rather err on the side of catching this issue and forcing
                     // a more thorough check.
                     buildmessage.error("Something changed in package " + item

--- a/tools/files.js
+++ b/tools/files.js
@@ -88,7 +88,8 @@ files.findAppDir = function (filepath) {
 files.findPackageDir = function (filepath) {
   var isPackageDir = function (filepath) {
     try {
-      return fs.statSync(path.join(filepath, 'package.js')).isFile();
+      return fs.statSync(path.join(filepath, 'meteor-package.js')).isFile() ||
+        fs.statSync(path.join(filepath, 'package.js')).isFile();  // TODO deprecate
     } catch (e) {
       return false;
     }

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -598,9 +598,9 @@ Publish a new version of a package to the package server.
 Usage: meteor publish [--create]
 
 Publishes a new version of a local package to the package server. Must be run
-from the directory containing the package. Reads the package.js file for version
-information, builds the package and sends both the package source and the built
-version of the package to the package server.
+from the directory containing the package. Reads the meteor-package.js file for
+version information, builds the package and sends both the package source and the
+built version of the package to the package server.
 
 This will only create one build of the package. If your package has multiple
 builds for different OS architectures, it will create a build for this machine's

--- a/tools/isopack.js
+++ b/tools/isopack.js
@@ -46,7 +46,7 @@ var Unibuild = function (isopack, options) {
   self.implies = options.implies || [];
 
   // This WatchSet will end up having the watch items from the
-  // SourceArch (such as package.js or .meteor/packages), plus all of
+  // SourceArch (such as meteor-package.js or .meteor/packages), plus all of
   // the actual source files for the unibuild (including items that we
   // looked at to find the source files, such as directories we
   // scanned).
@@ -268,7 +268,7 @@ var Isopack = function () {
   // XXX this is likely to change once we have build versions
   //
   // A WatchSet for the full transitive dependencies for all plugins in this
-  // package, as well as this package's package.js. If any of these dependencies
+  // package, as well as this package's meteor-package.js. If any of these dependencies
   // change, our plugins need to be rebuilt... but also, any package that
   // directly uses this package needs to be rebuilt in case the change to
   // plugins affected compilation.

--- a/tools/npm-discards.js
+++ b/tools/npm-discards.js
@@ -7,7 +7,7 @@ var hasOwn = Object.prototype.hasOwnProperty;
 // This class encapsulates a structured specification of files and
 // directories that should be stripped from the node_modules directories
 // of Meteor packages during `meteor build`, as requested by calling
-// `Npm.discard` in package.js files.
+// `Npm.discard` in meteor-package.js files.
 function NpmDiscards() {
   assert.ok(this instanceof NpmDiscards);
   this.discards = {};

--- a/tools/package-client.js
+++ b/tools/package-client.js
@@ -231,7 +231,10 @@ var bundleSource = function (isopack, includeSources, packageDir) {
     return null;
   }
 
-  includeSources.push('package.js');
+  if (fs.existsSync(path.join(packageDir, 'meteor-package.js')))
+    includeSources.push('meteor-package.js');
+  else
+    includeSources.push('package.js');  // TODO deprecate
   if (fs.existsSync(path.join(packageDir, '.npm/package/npm-shrinkwrap.json'))) {
     includeSources.push('.npm/package/npm-shrinkwrap.json');
   }
@@ -424,7 +427,7 @@ exports.publishPackage = function (packageSource, compileResult, conn, options) 
   // to be wrong)
   if (!packageSource.metadata.summary) {
     Console.stderr.write("Please describe what your package does. \n");
-    Console.stderr.write("Set a summary in Package.describe in package.js. \n");
+    Console.stderr.write("Set a summary in Package.describe in meteor-package.js. \n");
     return 1;
   }
 

--- a/tools/package-source.js
+++ b/tools/package-source.js
@@ -173,7 +173,7 @@ var SourceArch = function (pkg, options) {
   // Files and directories that we want to monitor for changes in
   // development mode, as a watch.WatchSet. In the latest refactoring
   // of the code, this does not include source files or directories,
-  // but only control files such as package.js and .meteor/packages,
+  // but only control files such as meteor-package.js and .meteor/packages,
   // since the rest are not determined until compile time.
   self.watchSet = options.watchSet || new watch.WatchSet;
 
@@ -232,7 +232,7 @@ var PackageSource = function (catalog) {
   self.pluginInfo = {};
 
   // Analogous to watchSet in SourceArch but for plugins. At this
-  // stage will typically contain just 'package.js'.
+  // stage will typically contain just 'meteor-package.js'.
   self.pluginWatchSet = new watch.WatchSet;
 
   // npm packages used by this package (on os.* architectures only).
@@ -262,8 +262,8 @@ var PackageSource = function (catalog) {
   self.dependencyVersions = {dependencies: {}, pluginDependencies: {}};
 
   // If this package has a corresponding test package (for example,
-  // underscore-test), defined in the same package.js file, store its value
-  // here.
+  // underscore-test), defined in the same meteor-package.js file, store its
+  // value here.
   self.testName = null;
 
   // Test packages are dealt with differently in the linker (and not published
@@ -291,8 +291,8 @@ var PackageSource = function (catalog) {
   // If this is true, the package source comes from the package server, and
   // should be treated as immutable. The only reason that we have it is so we
   // can build it, and we should expect to use exactly the same inputs
-  // (package.js and version lock file) as we did when it was created. If we
-  // ever need to modify it, we should throw instead.
+  // (meteor-package.js and version lock file) as we did when it was created.
+  // If we ever need to modify it, we should throw instead.
   self.immutable = false;
 
   // Is this a core package? Core packages don't record version files, because
@@ -306,7 +306,7 @@ var PackageSource = function (catalog) {
   // Alternatively, we can also specify noVersionFile directly. Useful for not
   // recording version files for js images of plugins, since those go into the
   // overall package versions file (if one exists). In the future, we can make
-  // this option transparent to the user in package.js.
+  // this option transparent to the user in meteor-package.js.
   self.noVersionFile = false;
 
   // The list of archs that we can target. Doesn't include 'web' because
@@ -396,10 +396,10 @@ _.extend(PackageSource.prototype, {
     self.noVersionFile = options.noVersionFile;
   },
 
-  // Initialize a PackageSource from a package.js-style package directory. Uses
-  // the name field provided and the name/test fields in the package.js file to
-  // figre out if this is a test package (load from on_test) or a use package
-  // (load from on_use).
+  // Initialize a PackageSource from a meteor-package.js-style package directory.
+  // Uses the name field provided and the name/test fields in the
+  // meteor-package.js file to figure out if this is a test package (load from
+  // onTest) or a use package (load from onUse).
   //
   // name: name of the package.
   // dir: location of directory on disk.
@@ -420,8 +420,8 @@ _.extend(PackageSource.prototype, {
     options = options || {};
 
     // If we know what package we are initializing, we pass in a
-    // name. Otherwise, we are intializing the base package specified by 'name:'
-    // field in Package.Describe. In that case, it is clearly not a test
+    // name. Otherwise, we are initializing the base package specified by the
+    // 'name:' field in Package.describe. In that case, it is clearly not a test
     // package. (Though we could be initializing a specific package without it
     // being a test, for a variety of reasons).
     if (options.name) {
@@ -446,27 +446,27 @@ _.extend(PackageSource.prototype, {
     var npmDependencies = null;
     var cordovaDependencies = null;
 
-    var packageJsPath = path.join(self.sourceRoot, 'package.js');
+    var packageJsPath = path.join(self.sourceRoot, 'meteor-package.js');
     var code = fs.readFileSync(packageJsPath);
     var packageJsHash = watch.sha1(code);
 
     var releaseRecords = [];
     var hasTests = false;
 
-    // Any package that depends on us needs to be rebuilt if our package.js file
-    // changes, because a change to package.js might add or remove a plugin,
-    // which could change a file from being handled by extension vs treated as
-    // an asset.
+    // Any package that depends on us needs to be rebuilt if our meteor-package.js
+    // file changes, because a change to meteor-package.js might add or remove a
+    // plugin, which could change a file from being handled by extension vs.
+    // treated as an asset.
     self.pluginWatchSet.addFile(packageJsPath, packageJsHash);
 
-    // == 'Package' object visible in package.js ==
+    // == 'Package' object visible in meteor-package.js ==
 
     /**
      * @global
      * @name  Package
-     * @summary The Package object in package.js
+     * @summary The Package object in meteor-package.js
      * @namespace
-     * @locus package.js
+     * @locus meteor-package.js
      */
     var Package = {
       // Set package metadata. Options:
@@ -478,7 +478,7 @@ _.extend(PackageSource.prototype, {
 
       /**
        * @summary Provide basic package information.
-       * @locus package.js
+       * @locus meteor-package.js
        * @memberOf Package
        * @param {Object} options
        * @param {String} options.summary A concise 1-2 sentence description of
@@ -525,7 +525,7 @@ _.extend(PackageSource.prototype, {
 
       /**
        * @summary Define package dependencies and expose package methods.
-       * @locus package.js
+       * @locus meteor-package.js
        * @memberOf Package
        * @param {Function} func A function that takes in the package control 'api' object, which keeps track of dependencies and exports.
        */
@@ -550,7 +550,7 @@ _.extend(PackageSource.prototype, {
 
       /**
        * @summary Define dependencies and expose package methods for unit tests.
-       * @locus package.js
+       * @locus meteor-package.js
        * @memberOf Package
        * @param {Function} func A function that takes in the package control 'api' object, which keeps track of dependencies and exports.
        */
@@ -619,7 +619,7 @@ _.extend(PackageSource.prototype, {
        * are NPM package names, and the keys are the version numbers of
        * required NPM packages, just like in [Npm.depends](#Npm-depends).
        * @memberOf Package
-       * @locus package.js
+       * @locus meteor-package.js
        */
       registerBuildPlugin: function (options) {
         // Tests don't have plugins; plugins initialized in the control file
@@ -673,12 +673,12 @@ _.extend(PackageSource.prototype, {
       }
     };
 
-    // == 'Npm' object visible in package.js ==
+    // == 'Npm' object visible in meteor-package.js ==
 
     /**
      * @namespace Npm
      * @global
-     * @summary The Npm object in package.js and package source files.
+     * @summary The Npm object in meteor-package.js and package source files.
      */
     var Npm = {
       /**
@@ -691,7 +691,7 @@ _.extend(PackageSource.prototype, {
        * ```js
        * Npm.depends({moment: "2.8.3"});
        * ```
-       * @locus package.js
+       * @locus meteor-package.js
        * @memberOf  Npm
        */
       depends: function (_npmDependencies) {
@@ -770,12 +770,12 @@ _.extend(PackageSource.prototype, {
       }
     };
 
-    // == 'Cordova' object visible in package.js ==
+    // == 'Cordova' object visible in meteor-package.js ==
 
     /**
      * @namespace Cordova
      * @global
-     * @summary The Cordova object in package.js.
+     * @summary The Cordova object in meteor-package.js.
      */
     var Cordova = {
       /**
@@ -808,7 +808,7 @@ _.extend(PackageSource.prototype, {
        * });
        * ```
        *
-       * @locus package.js
+       * @locus meteor-package.js
        * @memberOf  Cordova
        */
       depends: function (_cordovaDependencies) {
@@ -843,12 +843,12 @@ _.extend(PackageSource.prototype, {
         }
 
         cordovaDependencies = _cordovaDependencies;
-      },
+      }
     };
 
     try {
       files.runJavaScript(code.toString('utf8'), {
-        filename: 'package.js',
+        filename: 'meteor-package.js',
         symbols: { Package: Package, Npm: Npm, Cordova: Cordova }
       });
     } catch (e) {
@@ -857,7 +857,7 @@ _.extend(PackageSource.prototype, {
       buildmessage.exception(e);
 
       // Could be a syntax error or an exception. Recover by
-      // continuing as if package.js is empty. (Pressing on with
+      // continuing as if meteor-package.js is empty. (Pressing on with
       // whatever handlers were registered before the exception turns
       // out to feel pretty disconcerting -- definitely violates the
       // principle of least surprise.) Leave the metadata if we have
@@ -1076,7 +1076,7 @@ _.extend(PackageSource.prototype, {
          * @memberOf PackageAPI
          * @instance
          * @summary Depend on package `packagename`.
-         * @locus package.js
+         * @locus meteor-package.js
          * @param {String|String[]} packageNames Packages being depended on.
          * Package names may be suffixed with an @version tag.
          *
@@ -1162,7 +1162,7 @@ _.extend(PackageSource.prototype, {
         /**
          * @memberOf PackageAPI
          * @summary Give users of this package access to another package (by passing  in the string `packagename`) or a collection of packages (by passing in an  array of strings [`packagename1`, `packagename2`]
-         * @locus package.js
+         * @locus meteor-package.js
          * @instance
          * @param {String|String[]} packageSpecs Name of a package, or array of package names, with an optional @version component for each.
          */
@@ -1213,7 +1213,7 @@ _.extend(PackageSource.prototype, {
          * @memberOf PackageAPI
          * @instance
          * @summary Specify the source code for your package.
-         * @locus package.js
+         * @locus meteor-package.js
          * @param {String|String[]} filename Name of the source file, or array of strings of source file names.
          * @param {String} [architecture] If you only want to export the file on the server (or the client), you can pass in the second argument (e.g., 'server' or 'client') to specify what architecture the file is used with.
          */
@@ -1239,7 +1239,7 @@ _.extend(PackageSource.prototype, {
          * @memberOf PackageAPI
          * @instance
          * @summary Use versions of core packages from a release. Unless provided, all packages will default to the versions released along with `meteorRelease`. This will save you from having to figure out the exact versions of the core packages you want to use. For example, if the newest release of meteor is `METEOR@0.9.0` and it includes `jquery@1.0.0`, you can write `api.versionsFrom('METEOR@0.9.0')` in your package, and when you later write `api.use('jquery')`, it will be equivalent to `api.use('jquery@1.0.0')`. You may specify an array of multiple releases, in which case the default value for constraints will be the "or" of the versions from each release: `api.versionsFrom(['METEOR@0.9.0', 'METEOR@0.9.5'])` may cause `api.use('jquery')` to be interpreted as `api.use('jquery@1.0.0 || 2.0.0')`.
-         * @locus package.js
+         * @locus meteor-package.js
          * @param {String | String[]} meteorRelease Specification of a release: track@version. Just 'version' (e.g. `"0.9.0"`) is sufficient if using the default release track `METEOR`.
          */
         versionsFrom: function (releases) {
@@ -1296,7 +1296,7 @@ _.extend(PackageSource.prototype, {
          * @memberOf PackageAPI
          * @instance
          * @summary Export package-level variables in your package. The specified variables (declared without `var` in the source code) will be available to packages that use this package.
-         * @locus package.js
+         * @locus meteor-package.js
          * @param {String} exportedObject Name of the object.
          * @param {String} [architecture] If you only want to export the object on the server (or the client), you can pass in the second argument (e.g., 'server' or 'client') to specify what architecture the export is used with.
          */

--- a/tools/selftest.js
+++ b/tools/selftest.js
@@ -558,14 +558,14 @@ _.extend(Sandbox.prototype, {
   },
 
   // Copy the contents of one file to another.  In these series of tests, we often
-  // want to switch contents of package.js files. It is more legible to copy in
-  // the backup file rather than trying to write into it manually.
+  // want to switch contents of meteor-package.js files. It is more legible to
+  // copy in the backup file rather than trying to write into it manually.
   cp: function(from, to) {
     var self = this;
     var contents = self.read(from);
     if (!contents) {
       throw new Error("File " + from + " does not exist.");
-    };
+    }
     self.write(to, contents);
   },
 

--- a/tools/server/boot.js
+++ b/tools/server/boot.js
@@ -116,7 +116,7 @@ Fiber(function () {
           // XXX better message
           throw new Error(
             "Can't find npm module '" + name +
-              "'. Did you forget to call 'Npm.depends' in package.js " +
+              "'. Did you forget to call 'Npm.depends' in meteor-package.js " +
               "within the '" + packageName + "' package?");
           }
       }

--- a/tools/tests/cordova-plugins.js
+++ b/tools/tests/cordova-plugins.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var path = require('path');
 
 // Copy the contents of one file to another.  In these series of tests, we often
-// want to switch contents of package.js files. It is more legible to copy in
+// want to switch contents of meteor-package.js files. It is more legible to copy in
 // the backup file rather than trying to write into it manually.
 //
 // XXX: Surely there is a function for this in fs?
@@ -16,7 +16,7 @@ var copyFile = function(from, to, sand) {
   var contents = sand.read(from);
   if (!contents) {
     throw new Error("File " + from + " does not exist.");
-  };
+  }
   sand.write(to, contents);
 };
 
@@ -120,11 +120,11 @@ selftest.define("change cordova plugins", function () {
   run.match("restarted");
 
   // Change something in the plugin.
-  s.cp('packages/contains-cordova-plugin/package2.js', 'packages/contains-cordova-plugin/package.js');
+  s.cp('packages/contains-cordova-plugin/package2.js', 'packages/contains-cordova-plugin/meteor-package.js');
   run.waitSecs(2);
   run.match("restarted");
 
-  s.cp('packages/contains-cordova-plugin/package3.js', 'packages/contains-cordova-plugin/package.js');
+  s.cp('packages/contains-cordova-plugin/package3.js', 'packages/contains-cordova-plugin/meteor-package.js');
   run.waitSecs(2);
   run.match("exact version");
 });

--- a/tools/tests/old/test-bundler-npm.js
+++ b/tools/tests/old/test-bundler-npm.js
@@ -65,7 +65,7 @@ var updateTestPackage = function (npmDependencies) {
   if (!fs.existsSync(testPackageDir))
     fs.mkdirSync(testPackageDir);
 
-  fs.writeFileSync(path.join(testPackageDir, 'package.js'),
+  fs.writeFileSync(path.join(testPackageDir, 'meteor-package.js'),
                    "Package.describe({version: '1.0.0'});\n"
                    + "\n"
                    + "Npm.depends(" + JSON.stringify(npmDependencies) + ");"

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -204,7 +204,7 @@ selftest.define("change packages during hot code push", [], function () {
   // package2.js contains an onUse call that tells it to use accounts-base (a
   // core package that is not already included in the app)
   s.cp('packages/contains-plugin/package2.js',
-         'packages/contains-plugin/package.js');
+         'packages/contains-plugin/meteor-package.js');
   run.waitSecs(2);
   run.match("edit");
   run.match("foobar!");
@@ -217,7 +217,7 @@ selftest.define("change packages during hot code push", [], function () {
 
   // Add packages to sub-programs of an app. Make sure that the correct change
   // is propagated to its versions file.
-  s.cp('programs/empty/package2.js', 'programs/empty/package.js');
+  s.cp('programs/empty/package2.js', 'programs/empty/meteor-package.js');
 
   run.waitSecs(2);
   run.match("restarted");
@@ -247,16 +247,16 @@ selftest.define("change packages during hot code push", [], function () {
   run.match("running at");
   run.match("localhost");
 
-  // How about breaking and fixing a package.js?
+  // How about breaking and fixing a meteor-package.js?
   s.cd("packages/shout-something", function () {
-    var packageJs = s.read("package.js");
-    s.write("package.js", "]");
+    var packageJs = s.read("meteor-package.js");
+    s.write("meteor-package.js", "]");
     run.waitSecs(3);
     run.match("=> Errors prevented startup");
-    run.match("package.js:1:1: Unexpected token ]");
+    run.match("meteor-package.js:1:1: Unexpected token ]");
     run.match("Waiting for file change");
 
-    s.write("package.js", packageJs);
+    s.write("meteor-package.js", packageJs);
     run.waitSecs(3);
     run.match("restarting");
     run.match("restarted");
@@ -352,7 +352,7 @@ selftest.define("add packages to app", ["net"], function () {
 
   // Add packages to sub-programs of an app. Make sure that the correct change
   // is propagated to its versions file.
-  s.cp('programs/empty/package2.js', 'programs/empty/package.js');
+  s.cp('programs/empty/package2.js', 'programs/empty/meteor-package.js');
 
   // Don't add the file to packages.
   run = s.run("list");
@@ -504,11 +504,11 @@ selftest.define("sync local catalog", ["slow", "net", "test-package-server"],  f
   var newPack = username + ":" + packageName + "-b";
   s.createPackage(newPack, "package-of-two-versions");
   s.cd(newPack, function() {
-    var packOpen = s.read("package.js");
+    var packOpen = s.read("meteor-package.js");
     packOpen = packOpen + "\nPackage.onUse(function(api) { \n" +
       "api.versionsFrom(\"" + releaseTrack + "@0.9\");\n" +
       "api.use(\"" + fullPackageName + "\"); });";
-    s.write("package.js", packOpen);
+    s.write("meteor-package.js", packOpen);
   });
 
   // Clear the local data cache by deleting the data.json file that we are
@@ -600,11 +600,11 @@ selftest.define("release track defaults to METEOR",
   var newPack = fullPackageName;
   s.createPackage(newPack, "package-of-two-versions");
   s.cd(newPack, function() {
-    var packOpen = s.read("package.js");
+    var packOpen = s.read("meteor-package.js");
     packOpen = packOpen + "\nPackage.onUse(function(api) { \n" +
       "api.versionsFrom(\"" + releaseVersion + "\");\n" +
       "api.use(\"" + fullPackageName + "\"); });";
-    s.write("package.js", packOpen);
+    s.write("meteor-package.js", packOpen);
   });
 
   // Try to publish the package. The error message should demonstrate
@@ -797,7 +797,7 @@ selftest.define("talk to package server with expired or no accounts token",
 // command to fail because the currently logged-in user is not an
 // authorized maintainer of the package.
 var changeVersionAndPublish = function (s, expectAuthorizationFailure) {
-  var packageJs = s.read("package.js");
+  var packageJs = s.read("meteor-package.js");
   // XXX Hack
   var versionMatch = packageJs.match(/version: \'(\d\.\d\.\d)\'/);
   if (! versionMatch) {
@@ -807,7 +807,7 @@ var changeVersionAndPublish = function (s, expectAuthorizationFailure) {
   var versionParts = version.split(".");
   versionParts[0] = parseInt(versionParts[0]) + 1;
   packageJs = packageJs.replace(version, versionParts.join("."));
-  s.write("package.js", packageJs);
+  s.write("meteor-package.js", packageJs);
 
   var run = s.run("publish");
   run.waitSecs(60);
@@ -898,14 +898,14 @@ selftest.define("add package with no builds", ["net", "test-package-server"], fu
 
   s.cd(fullPackageName, function () {
     // Add a binary dependency.
-    var packageJs = s.read("package.js");
+    var packageJs = s.read("meteor-package.js");
     // XXX HACK: prepend Npm.depends to the first 'api.addFiles'
     packageJs = packageJs.replace(
       "api.addFiles",
       "Npm.depends({ bcrypt: '0.7.7' });\n  api.addFiles"
     );
 
-    s.write("package.js", packageJs);
+    s.write("meteor-package.js", packageJs);
 
     run = s.run("publish", "--create");
     run.waitSecs(60);
@@ -933,9 +933,9 @@ selftest.define("package skeleton creates correct versionsFrom", function () {
   run.expectExit(0);
 
   s.cd(fullPackageName);
-  var packageJs = s.read("package.js");
+  var packageJs = s.read("meteor-package.js");
   if (! packageJs.match(/api.versionsFrom\('v1'\);/)) {
-    selftest.fail("package.js missing correct 'api.versionsFrom':\n" +
+    selftest.fail("meteor-package.js missing correct 'api.versionsFrom':\n" +
                   packageJs);
   }
 });

--- a/tools/tests/publish.js
+++ b/tools/tests/publish.js
@@ -24,11 +24,11 @@ selftest.define("publish-and-search",
   var noPack = fullPackageName + "2";
   s.createPackage(noPack, "package-of-two-versions");
   s.cd(noPack, function() {
-    var packOpen = s.read("package.js");
+    var packOpen = s.read("meteor-package.js");
     packOpen = packOpen + "\nPackage.onUse(function(api) { \n" +
       "api.versionsFrom(\"THIS-RELEASE-DOES-NOT-EXIST@0.9\");\n" +
       " });";
-    s.write("package.js", packOpen);
+    s.write("meteor-package.js", packOpen);
     run = s.run("publish", "--create");
     run.waitSecs(20);
     run.matchErr("Unknown release");
@@ -43,10 +43,10 @@ selftest.define("publish-and-search",
   s.cd(fullPackageName);
 
   // set a github URL in the package
-  var packageJsContents = s.read("package.js");
+  var packageJsContents = s.read("meteor-package.js");
   var newPackageJsContents = packageJsContents.replace(
       /git: \'.*\'/, "git: \'" + githubUrl + "\'");
-  s.write("package.js", newPackageJsContents);
+  s.write("meteor-package.js", newPackageJsContents);
 
   run = s.run("publish");
   run.waitSecs(15);
@@ -79,7 +79,7 @@ selftest.define("publish-and-search",
 
   s.createPackage(fullPackageName, "package-of-two-versions");
   s.cd(fullPackageName, function() {
-    s.write("package.js", minPack);
+    s.write("meteor-package.js", minPack);
     // If we manage to publish without the --create flag, that's probably an
     // indicator that we are reading the directory instead of the override, or,
     // in any case, that we can't rely on the rest of this test working.
@@ -181,7 +181,7 @@ selftest.define("list-with-a-new-version",
   });
 
   // Change the package to increment version and publish the new package.
-  s.cp(fullPackageName+'/package2.js', fullPackageName+'/package.js');
+  s.cp(fullPackageName+'/package2.js', fullPackageName+'/meteor-package.js');
   s.cd(fullPackageName, function () {
     run = s.run("publish");
     run.waitSecs(15);
@@ -234,7 +234,7 @@ selftest.define("list-with-a-new-version",
   });
 
   // Now publish an 1.0.4-rc4.
-  s.cp(fullPackageName+'/packagerc.js', fullPackageName+'/package.js');
+  s.cp(fullPackageName+'/packagerc.js', fullPackageName+'/meteor-package.js');
   s.cd(fullPackageName, function () {
     run = s.run("publish");
     run.waitSecs(15);
@@ -310,7 +310,7 @@ selftest.define("do-not-update-to-rcs",
   });
 
   // Change the package to increment version and publish the new package.
-  s.cp(fullPackageName+'/package2.js', fullPackageName+'/package.js');
+  s.cp(fullPackageName+'/package2.js', fullPackageName+'/meteor-package.js');
   s.cd(fullPackageName, function () {
     run = s.run("publish");
     run.waitSecs(15);
@@ -319,7 +319,7 @@ selftest.define("do-not-update-to-rcs",
   });
 
   // Now publish an 1.0.4-rc.3.
-  s.cp(fullPackageName+'/packagerc.js', fullPackageName+'/package.js');
+  s.cp(fullPackageName+'/packagerc.js', fullPackageName+'/meteor-package.js');
   s.cd(fullPackageName, function () {
     run = s.run("publish");
     run.waitSecs(15);
@@ -382,7 +382,7 @@ selftest.define("do-not-update-to-rcs",
   });
 
   // Now publish an 1.0.4-rc.4.
-  s.cp(fullPackageName+'/packagerc2.js', fullPackageName+'/package.js');
+  s.cp(fullPackageName+'/packagerc2.js', fullPackageName+'/meteor-package.js');
   s.cd(fullPackageName, function () {
     run = s.run("publish");
     run.waitSecs(15);
@@ -429,7 +429,7 @@ selftest.define("package-depends-on-either-version",
 
   // Then, we publish fullPackageNameDep at 2.0.
   s.cd(fullPackageNameDep, function() {
-    s.cp("package3.js", "package.js");
+    s.cp("package3.js", "meteor-package.js");
     run = s.run("publish");
     run.waitSecs(20);
     run.match("Done");
@@ -440,12 +440,12 @@ selftest.define("package-depends-on-either-version",
   var fullPackageAnother = username + ":" + another;
   s.createPackage(fullPackageAnother, "package-of-two-versions");
   s.cd(fullPackageAnother, function() {
-    var packOpen = s.read("package.js");
+    var packOpen = s.read("meteor-package.js");
    packOpen = packOpen + "\nPackage.onUse(function(api) { \n" +
       "api.use(\"" + fullPackageNameDep +
       "@1.0.0 || 2.0.0\");\n" +
       " });";
-    s.write("package.js", packOpen);
+    s.write("meteor-package.js", packOpen);
     run = s.run("publish", "--create");
     run.waitSecs(20);
     run.match("Done");

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -479,7 +479,7 @@ exports.isUrlWithSha = function (x) {
 // It does not support the wrap number syntax.
 exports.ensureOnlyExactVersions = function (dependencies) {
   _.each(dependencies, function (version, name) {
-    // We want a given version of a smart package (package.js +
+    // We want a given version of a smart package (meteor-package.js +
     // .npm/npm-shrinkwrap.json) to pin down its dependencies precisely, so we
     // don't want anything too vague. For now, we support semvers and urls that
     // name a specific commit by SHA.

--- a/tools/warehouse.js
+++ b/tools/warehouse.js
@@ -109,9 +109,9 @@ _.extend(warehouse, {
 
   packageExistsInWarehouse: function (name, version) {
     // A package exists if its directory exists. (We used to look for a
-    // particular file name ("package.js") inside the directory, but since we
-    // always install packages by untarring to a temporary directory and
-    // renaming atomically, we shouldn't worry about partial packages.)
+    // particular file name ('meteor-package.js') inside the directory, but
+    // since we always install packages by untarring to a temporary directory
+    // and renaming atomically, we shouldn't worry about partial packages.)
     return fs.existsSync(
       path.join(warehouse.getWarehouseDir(), 'packages', name, version));
   },


### PR DESCRIPTION
... instead of package.js. Meteor-core thread:
https://groups.google.com/forum/#!topic/meteor-core/-qbP-ttPLS8

TODO: the following files need review in particular:
- tools/tests/old/cli-test.sh
- tools/bundler.js, lines 2041-49
- scripts/admin/jsdoc/jsdoc-conf.json
- tools/package-source.js. lines 453, 858
- docs/client/data.js needs to be regenerated

`package.js` files throughout the repo should be `git mv`ed to `meteor-package.js`
