### PR TITLE
remove require(./commands-packages.js); from main.js

### DIFF
--- a/tools/main.js
+++ b/tools/main.js
@@ -250,7 +250,6 @@ main.registerCommand = function (options, func) {
 // NB: files required up to this point may not define commands
 
 require('./commands.js');
-require('./commands-packages.js');
 
 ///////////////////////////////////////////////////////////////////////////////
 // Long-form help


### PR DESCRIPTION
`commands-packages.js` is required in `commands.js`
I've removed it from main.js to avoid multiple import
