### PR TITLE
Call correct function on error in fetching assets.

### DIFF
--- a/tools/bundler.js
+++ b/tools/bundler.js
@@ -1259,7 +1259,7 @@ _.extend(JsImage.prototype, {
       };
 
       if (!assets || !_.has(assets, assetPath)) {
-        _.callback(new Error("Unknown asset: " + assetPath));
+        _callback(new Error("Unknown asset: " + assetPath));
       } else {
         var buffer = assets[assetPath];
         var result = encoding ? buffer.toString(encoding) : buffer;


### PR DESCRIPTION
Instead of trying (and failing) to call a function on underscore, call the correct `_callback`.
