### PR TITLE
Update concepts.html

### DIFF
--- a/docs/client/full-api/concepts.html
+++ b/docs/client/full-api/concepts.html
@@ -805,10 +805,10 @@ debugger, you've got two options:
   don't use the `email` package directly.
 
 When declaring functions, keep in mind that `function x () {}` is just
-shorthand for `var x = function () {}` in JavaScript. Consider these
+shorthand for `var x = function x () {}` in JavaScript. Consider these
 examples:
 
-    // This is the same as 'var x = function () ...'. So x() is
+    // This is the same as 'var x = function x () ...'. So x() is
     // file-scope and can be called only from within this one file.
     function x () { ... }
 


### PR DESCRIPTION
`var x = function () {}` creates a reference to an anonymous function while `var x = function x () {}` creates a reference to a named function. I believe that `function x () {}` is shorthand for the latter.
