### PR TITLE
Prevent "meteor shell" from stomping Underscore

### DIFF
--- a/tools/server/shell.js
+++ b/tools/server/shell.js
@@ -56,7 +56,7 @@ function onConnection(socket) {
       prompt: "> ",
       terminal: true,
       useColors: true,
-      useGlobal: true,
+      useGlobal: false,
       ignoreUndefined: true,
     });
 


### PR DESCRIPTION
The return value of last REPL command is stored in global._ if the REPL is set to use the global context. So after you run your first REPL command, Underscore is no longer available to Meteor server code as global._ - that variable is now the result of your last REPL command.

See http://stackoverflow.com/questions/10973968/underscore-doesnt-work-in-coffeescripts-console
