### PR TITLE
Allow more direct access to specific template methods

### DIFF
--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -38,13 +38,13 @@ var Template = Blaze.Template;
 
 var HelperMap = function () {};
 HelperMap.prototype.get = function (name) {
-  return this[' '+name];
+  return this[name];
 };
 HelperMap.prototype.set = function (name, helper) {
-  this[' '+name] = helper;
+  this[name] = helper;
 };
 HelperMap.prototype.has = function (name) {
-  return (' '+name) in this;
+  return (name) in this;
 };
 
 /**


### PR DESCRIPTION
With the now deprecated Template declaration syntax, you could directly access template methods:

``` javascript
Template.myTemplate.myMethod = function() {
  return 'result'
}

Template.myTemplate.myMethod() // outputs 'result'
```

With the prefered way to declare helpers, you cannot directly access them:

``` javascript
Template.myTemplate.helpers({
  myMethod: function() {
    return 'result'
  }
})

Template.myTemplate.myMethod() // outputs undefined

// you have to call the method either through a getter
Template.myTemplate.__helpers.get('myMethod')()

// or though a hack
Template.myTemplate.__helpers[' myMethod']() // notice the empty space before 'myMethod'
```

This PR would allow to call it on a more direct way:

``` javacript
Template.myTemplate.__helpers.myMethod()
```

Is there a reason for adding the white spaces before the argument names on `HelperMap.prototype.set`?