### PR TITLE
Make deny, allow example clear as to client/server

### DIFF
--- a/docs/client/basic/sections/collections.md
+++ b/docs/client/basic/sections/collections.md
@@ -233,7 +233,7 @@ For example, we might say that users can only create new posts if the
 impersonate each other.
 
 ```
-// In a file loaded on the client and server
+// In a file loaded on the server (ignored on the client)
 Posts.allow({
   insert: function (userId, post) {
     // can only create posts where you are the author
@@ -284,7 +284,7 @@ For example, if we wanted to override part of our `allow` rule above to exclude
 certain post titles:
 
 ```
-// In a file loaded on the client and server
+// In a file loaded on the server (ignored on the client)
 Posts.deny({
   insert: function (userId, post) {
     // Don't allow posts with a certain title


### PR DESCRIPTION
As per [explanation from Avital Oliver in meteor-talk](https://groups.google.com/forum/#!topic/meteor-talk/ZL5P2a6kNE4), I propose making this change in the doc to make it more clear that the code snippet does not need to reside on _both_ the client and server.

The title of the sections (deny, allow) from the autoApiBox specify "server". The example got me confused as is.
