### PR TITLE
Print exception message (in fiber_stubs_client.js)

### DIFF
--- a/packages/meteor/fiber_stubs_client.js
+++ b/packages/meteor/fiber_stubs_client.js
@@ -46,7 +46,7 @@ _.extend(Meteor._SynchronousQueue.prototype, {
             // for.
             throw e;
           } else {
-            Meteor._debug("Exception in queued task: " + e.stack);
+            Meteor._debug("Exception in queued task: " + e.message + e.stack);
           }
         }
       }


### PR DESCRIPTION
It would make it easier to debug one's code without having to use the debugger (from personal experience just now). Sorry for the sloppy branch name.
