### PR TITLE
Don't force external links to open in a new tab

### DIFF
--- a/docs/client/full-api/docs.js
+++ b/docs/client/full-api/docs.js
@@ -1,9 +1,3 @@
-Meteor.startup(function () {
-  // Make external links open in a new tab.
-  // XXX doesn't work in multipage
-  $('a:not([href^="#"])').attr('target', '_blank');
-});
-
 check_links = function() {
   var body = document.body.innerHTML;
 


### PR DESCRIPTION
Just allow people to decide for themselves whether they want to navigate away to another page or open the link in a new tab using the controls provided them by the browser (eg. cmd-click, or the options in the right click menu).

This also fixes the situation where someone might want to open an external link in the same tab, which is currently made impossible.

Overriding user preference is a bad idea from a usability point of view. Here's a Stack Exchange thread linking to some HCI-backed research advocating against forcing links to open in new tabs: http://ux.stackexchange.com/q/19892/249
