### PR TITLE
Avoids a race condition

### DIFF
--- a/docs/client/full-api/api/accounts.md
+++ b/docs/client/full-api/api/accounts.md
@@ -192,16 +192,17 @@ meteor add service-configuration
 Then, in your app:
 
 ```js
-// first, remove configuration entry in case service is already configured
-ServiceConfiguration.configurations.remove({
-  service: "weibo"
-});
-ServiceConfiguration.configurations.insert({
-  service: "weibo",
-  clientId: "1292962797",
-  loginStyle: "popup",
-  secret: "75a730b58f5691de5522789070c319bc"
-});
+ServiceConfiguration.configurations.update(
+  { service: "weibo" },
+  {
+    $set: {
+      clientId: "1292962797",
+      loginStyle: "popup",
+      secret: "75a730b58f5691de5522789070c319bc"
+    }
+  },
+  { upsert: true }
+);
 ```
 
 Each external service has its own login provider package and login function. For

--- a/examples/localmarket/server/_settings.js
+++ b/examples/localmarket/server/_settings.js
@@ -12,11 +12,13 @@ _.defaults(Meteor.settings, {
   }
 });
 
-ServiceConfiguration.configurations.remove({
-  service: "twitter"
-});
-ServiceConfiguration.configurations.insert({
-  service: "twitter",
-  consumerKey: Meteor.settings.twitter.consumerKey,
-  secret: Meteor.settings.twitter.secret
-});
+ServiceConfiguration.configurations.update(
+    { service: "twitter" },
+    {
+      $set: {
+        consumerKey: Meteor.settings.twitter.consumerKey,
+        secret: Meteor.settings.twitter.secret
+      }
+    },
+    { upsert: true }
+);

--- a/packages/service-configuration/README.md
+++ b/packages/service-configuration/README.md
@@ -3,15 +3,11 @@
 Configure login services. Example:
 
 ```
-// first, remove configuration entry in case service is already configured
-ServiceConfiguration.configurations.remove({
-  service: "weibo"
-});
-ServiceConfiguration.configurations.insert({
-  service: "weibo",
-  clientId: "1292962797",
-  secret: "75a730b58f5691de5522789070c319bc"
-});
+ServiceConfiguration.configurations.update(
+  { service: "weibo" },
+  { $set: { clientId: "1292962797", secret: "75a730b58f5691de5522789070c319bc" } },
+  { upsert: true }
+);
 ```
 
 Read more in the [Meteor


### PR DESCRIPTION
Doing a remove and then an insert means that there is a period of time when there isn't a configuration entry. MongoDB does not have transactions, atomic upserts are used instead. If there are multiple meteor servers backed by one MongoDB database, this race condition could cause user-visible issues.