### PR TITLE
Refactor symlinks for tropohouse and tool

### DIFF
--- a/tools/commands-packages.js
+++ b/tools/commands-packages.js
@@ -2450,12 +2450,11 @@ main.registerCommand({
     var toolRecord = _.findWhere(toolIsopack.toolsOnDisk, {arch: osArch});
     if (!toolRecord)
       throw Error("missing tool for " + osArch);
-    files.symlink(
-      files.pathJoin(
+
+    tmpTropo.linkToLatestMeteor(files.pathJoin(
         tmpTropo.packagePath(toolPackage, toolVersion, true),
         toolRecord.path,
-        'meteor'),
-      files.pathJoin(tmpTropo.root, 'meteor'));
+        'meteor'));
 
     files.createTarball(
       tmpTropo.root,

--- a/tools/files.js
+++ b/tools/files.js
@@ -997,7 +997,15 @@ _.extend(files.KeyValueFile.prototype, {
   }
 });
 
-/////// Below here are wrappers of fs.* and path.* functions
+files.getHomeDir = function () {
+  return process.env.HOME || process.env.LOCALAPPDATA || process.env.APPDATA;
+};
+
+files.linkToMeteorScript = function (scriptLocation, linkLocation) {
+  files.symlinkOverSync(scriptLocation, linkLocation);
+};
+
+/////// Below here, functions have been corrected for slashes
 
 var toPosixPath = function (p) {
   p = p.replace(/\\/g, '/');

--- a/tools/isopack.js
+++ b/tools/isopack.js
@@ -184,27 +184,6 @@ _.extend(Unibuild.prototype, {
 // Isopack
 ///////////////////////////////////////////////////////////////////////////////
 
-var convertIsopackFormat = function (data, versionFrom, versionTo) {
-  var convertedData = _.clone(data);
-  if (versionFrom === versionTo) {
-    return convertedData;
-  }
-
-  // XXX COMPAT WITH 0.9.3
-  if (versionFrom === "unipackage-pre2" && versionTo === "isopack-1") {
-    convertedData.builds = convertedData.unibuilds;
-    delete convertedData.unibuilds;
-    return convertedData;
-  } else if (versionFrom === "isopack-1" && versionTo === "unipackage-pre2") {
-    convertedData.unibuilds = convertedData.builds;
-    convertedData.format = "unipackage-pre2";
-    delete convertedData.builds;
-    return convertedData;
-  }
-};
-
-var currentFormat = "isopack-1";
-
 // XXX document
 var Isopack = function () {
   var self = this;
@@ -269,6 +248,75 @@ var Isopack = function () {
   // This is tools to copy from trees on disk. This is used by the
   // isopack-merge code in tropohouse.
   self.toolsOnDisk = [];
+};
+
+Isopack.currentFormat = "isopack-1";
+
+Isopack.convertIsopackFormat = function (data, versionFrom, versionTo) {
+  var convertedData = _.clone(data);
+  if (versionFrom === versionTo) {
+    return convertedData;
+  }
+
+  // XXX COMPAT WITH 0.9.3
+  if (versionFrom === "unipackage-pre2" && versionTo === "isopack-1") {
+    convertedData.builds = convertedData.unibuilds;
+    delete convertedData.unibuilds;
+    return convertedData;
+  } else if (versionFrom === "isopack-1" && versionTo === "unipackage-pre2") {
+    convertedData.unibuilds = convertedData.builds;
+    convertedData.format = "unipackage-pre2";
+    delete convertedData.builds;
+    return convertedData;
+  }
+};
+
+// Read the correct file from isopackDirectory and convert to current format
+// of the isopack metadata. Returns null if there is no package here.
+Isopack.readMetadataFromDirectory = function (isopackDirectory) {
+  var metadata;
+
+  // deal with different versions of "isopack.json", backwards compatible
+  var isopackJsonPath = files.pathJoin(isopackDirectory, "isopack.json");
+  var unipackageJsonPath = files.pathJoin(isopackDirectory, "unipackage.json");
+
+  if (files.exists(isopackJsonPath)) {
+    var isopackJson = JSON.parse(files.readFile(isopackJsonPath));
+
+    if (isopackJson[Isopack.currentFormat]) {
+      metadata = isopackJson[Isopack.currentFormat];
+    } else {
+      // This file is from the future and no longer supports this version
+      throw new Error("Could not find isopack data with format " + Isopack.currentFormat + ".\n" +
+        "This isopack was likely built with a much newer version of Meteor.");
+    }
+  } else if (files.exists(unipackageJsonPath)) {
+    // super old version with different file name
+    // XXX COMPAT WITH 0.9.3
+    if (files.exists(unipackageJsonPath)) {
+      metadata = JSON.parse(files.readFile(unipackageJsonPath));
+
+      // in the old format, builds were called unibuilds
+      // use string to make sure this doesn't get caught in a find/replace
+      metadata.builds = metadata["unibuilds"];
+
+      metadata = Isopack.convertIsopackFormat(metadata,
+        "unipackage-pre2", Isopack.currentFormat);
+    }
+
+    if (metadata.format !== "unipackage-pre2") {
+      // We don't support pre-0.9.0 isopacks, but we do know enough to delete
+      // them if we find them in an isopack cache somehow (rather than crash).
+      if (metadata.format === "unipackage-pre1") {
+        throw new exports.OldIsopackFormatError();
+      }
+
+      throw new Error("Unsupported isopack format: " +
+                      JSON.stringify(metadata.format));
+    }
+  }
+
+  return metadata;
 };
 
 _.extend(Isopack.prototype, {
@@ -529,49 +577,7 @@ _.extend(Isopack.prototype, {
     // realpath'ing dir.
     dir = files.realpath(dir);
 
-    var mainJson;
-
-    // deal with different versions of "isopack.json", backwards compatible
-    var isopackJsonPath = files.pathJoin(dir, "isopack.json");
-    if (files.exists(isopackJsonPath)) {
-      var isopackJson = JSON.parse(files.readFile(isopackJsonPath));
-
-      if (isopackJson[currentFormat]) {
-        mainJson = isopackJson[currentFormat];
-      } else {
-        // This file is from the future and no longer supports this version
-        throw new Error("Could not find isopack data with format " + currentFormat + ".\n" +
-          "This isopack was likely built with a much newer version of Meteor.");
-      }
-    } else {
-      // super old version with different file name
-      // XXX COMPAT WITH 0.9.3
-      var unipackageJsonPath = files.pathJoin(dir, "unipackage.json");
-      if (files.exists(unipackageJsonPath)) {
-        mainJson = JSON.parse(files.readFile(unipackageJsonPath));
-
-        // in the old format, builds were called unibuilds
-        // use string to make sure this doesn't get caught in a find/replace
-        mainJson.builds = mainJson["unibuilds"];
-
-        mainJson = convertIsopackFormat(mainJson,
-          "unipackage-pre2", currentFormat);
-      }
-
-      if (mainJson.format !== "unipackage-pre2") {
-        // We don't support pre-0.9.0 isopacks, but we do know enough to delete
-        // them if we find them in an isopack cache somehow (rather than crash).
-        if (mainJson.format === "unipackage-pre1") {
-          throw new exports.OldIsopackFormatError();
-        }
-
-        throw new Error("Unsupported isopack format: " +
-                        JSON.stringify(mainJson.format));
-      }
-    }
-
-    // done dealing with different versions, below here
-    // mainJson is the data we want
+    var mainJson = Isopack.readMetadataFromDirectory(dir);
 
     // isopacks didn't used to know their name, but they should.
     if (_.has(mainJson, 'name') && name !== mainJson.name) {
@@ -988,7 +994,7 @@ _.extend(Isopack.prototype, {
       // old unipackage.json format/filename
       // XXX COMPAT WITH 0.9.3
       builder.writeJson("unipackage.json",
-        convertIsopackFormat(mainJson, currentFormat, "unipackage-pre2"));
+        Isopack.convertIsopackFormat(mainJson, Isopack.currentFormat, "unipackage-pre2"));
 
       // write several versions of the file
       // add your new format here, and define some stuff
@@ -997,8 +1003,8 @@ _.extend(Isopack.prototype, {
       var isopackJson = {};
       _.each(formats, function (format) {
         // new, extensible format - forwards-compatible
-        isopackJson[format] = convertIsopackFormat(mainJson,
-          currentFormat, format);
+        isopackJson[format] = Isopack.convertIsopackFormat(mainJson,
+          Isopack.currentFormat, format);
       });
 
       // writes one file with all of the new formats, so that it is possible

--- a/tools/selftest.js
+++ b/tools/selftest.js
@@ -141,13 +141,7 @@ var setUpBuiltPackageTropohouse = function () {
   // though some tests will want them to be under
   // 'packages-for-server/test-packages'; we'll fix this in _makeWarehouse.
   tropohouseIsopackCache.eachBuiltIsopack(function (name, isopack) {
-    // XXX we should stop relying on symlinks and just parse isopack.json (we
-    // need to do this for Windows anyway).
-    var directPath = '.' + isopack.version + '.XXX++' +
-          isopack.buildArchitectures();
-    isopack.saveToPath(tropohouse.packagePath(name, directPath));
-    files.symlinkOverSync(directPath,
-                          tropohouse.packagePath(name, isopack.version));
+    tropohouse._saveIsopack(isopack, name);
   });
 };
 

--- a/tools/selftest.js
+++ b/tools/selftest.js
@@ -819,10 +819,10 @@ _.extend(Sandbox.prototype, {
 
     // And a cherry on top
     // XXX this is hacky
-    files.symlink(files.pathJoin(packagesDirectoryName,
-                                  "meteor-tool", toolPackageVersion,
-                                  'meteor-tool-' + archinfo.host(), 'meteor'),
-                  files.pathJoin(self.warehouse, 'meteor'));
+    files.linkToMeteorScript(
+      files.pathJoin(packagesDirectoryName, "meteor-tool", toolPackageVersion,
+        'meteor-tool-' + archinfo.host(), 'meteor'),
+      files.pathJoin(self.warehouse, 'meteor'));
   }
 });
 

--- a/tools/tropohouse.js
+++ b/tools/tropohouse.js
@@ -309,7 +309,7 @@ _.extend(exports.Tropohouse.prototype, {
             {firstIsopack: i === 0});
         });
 
-        self._saveIsopack(isopack, packageName, version);
+        self._saveIsopack(isopack, packageName);
 
         // Clean up old version.
         if (packageLinkTarget) {

--- a/tools/tropohouse.js
+++ b/tools/tropohouse.js
@@ -398,6 +398,6 @@ _.extend(exports.Tropohouse.prototype, {
   linkToLatestMeteor: function (scriptLocation) {
     var self = this;
     var linkPath = files.pathJoin(self.root, 'meteor');
-    files.symlinkOverSync(scriptLocation, linkPath);
+    files.linkToMeteorScript(scriptLocation, linkPath);
   }
 });

--- a/tools/tropohouse.js
+++ b/tools/tropohouse.js
@@ -381,9 +381,9 @@ _.extend(exports.Tropohouse.prototype, {
     return files.readlink(linkPath);
   },
 
-  replaceLatestMeteorSymlink: function (linkText) {
+  linkToLatestMeteor: function (scriptLocation) {
     var self = this;
     var linkPath = files.pathJoin(self.root, 'meteor');
-    files.symlinkOverSync(linkText, linkPath);
+    files.symlinkOverSync(scriptLocation, linkPath);
   }
 });

--- a/tools/tropohouse.js
+++ b/tools/tropohouse.js
@@ -196,31 +196,15 @@ _.extend(exports.Tropohouse.prototype, {
 
     // Figure out what arches (if any) we have loaded for this package version
     // already.
-    var packageLinkFile = self.packagePath(packageName, version);
+    var packagePath = self.packagePath(packageName, version);
     var downloadedArches = [];
-    var packageLinkTarget = null;
-    try {
-      packageLinkTarget = files.readlink(packageLinkFile);
-    } catch (e) {
-      // Complain about anything other than "we don't have it at all". This
-      // includes "not a symlink": The main reason this would not be a symlink
-      // is if it's a directory containing a pre-0.9.0 package (ie, this is a
-      // warehouse package not a tropohouse package). But the versions should
-      // not overlap: warehouse versions are truncated SHAs whereas tropohouse
-      // versions should be semver-like.
-      if (e.code !== 'ENOENT')
-        throw e;
-    }
-    if (packageLinkTarget) {
-      // The symlink will be of the form '.VERSION.RANDOMTOKEN++web.browser+os',
-      // so this strips off the part before the '++'.
-      // XXX maybe we should just read the isopack.json instead of
-      //     depending on the symlink?
-      var archPart = packageLinkTarget.split('++')[1];
-      if (!archPart)
-        throw Error("unexpected symlink target for " + packageName + "@" +
-                    version + ": " + packageLinkTarget);
-      downloadedArches = archPart.split('+');
+
+    // Find out which arches we have by reading the isopack metadata
+    var packageMetadata = Isopack.readMetadataFromDirectory(packagePath);
+
+    // packageMetadata is null if there is no package at packagePath
+    if (packageMetadata) {
+      downloadedArches = _.pluck(packageMetadata.builds, "arch");
     }
 
     var archesToDownload = _.filter(options.architectures, function (requiredArch) {
@@ -256,10 +240,28 @@ _.extend(exports.Tropohouse.prototype, {
         title: "downloading " + packageName + "@" + version + "..."
       }, function() {
         var buildTempDirs = [];
+
+        // XXX on windows we will special case this whole block
+        // Find the previous actual directory of the package
+        var packageLinkTarget = null;
+        try {
+          packageLinkTarget = files.readFile(packagePath);
+        } catch (e) {
+          // Complain about anything other than "we don't have it at all". This
+          // includes "not a symlink": The main reason this would not be a symlink
+          // is if it's a directory containing a pre-0.9.0 package (ie, this is a
+          // warehouse package not a tropohouse package). But the versions should
+          // not overlap: warehouse versions are truncated SHAs whereas tropohouse
+          // versions should be semver-like.
+          if (e.code !== 'ENOENT') {
+            throw e;
+          }
+        }
+
         // If there's already a package in the tropohouse, start with it.
         if (packageLinkTarget) {
           buildTempDirs.push(
-            files.pathResolve(files.pathDirname(packageLinkFile),
+            files.pathResolve(files.pathDirname(packagePath),
                               packageLinkTarget));
         }
         // XXX how does concurrency work here?  we could just get errors if we
@@ -293,7 +295,7 @@ _.extend(exports.Tropohouse.prototype, {
         var combinedDirectory = self.packagePath(
           packageName, newPackageLinkTarget);
         isopack.saveToPath(combinedDirectory);
-        files.symlinkOverSync(newPackageLinkTarget, packageLinkFile);
+        files.symlinkOverSync(newPackageLinkTarget, packagePath);
 
         // Clean up old version.
         if (packageLinkTarget) {

--- a/tools/updater.js
+++ b/tools/updater.js
@@ -197,7 +197,7 @@ var updateMeteorToolSymlink = function () {
     if (!toolRecord)
       throw Error("latest release has no tool?");
 
-    tropohouse.default.replaceLatestMeteorSymlink(
-      files.pathJoin(relativeToolPath, toolRecord.path, 'meteor'));
+    tropohouse.default.linkToLatestMeteor(files.pathJoin(
+      relativeToolPath, toolRecord.path, 'meteor'));
   }
 };


### PR DESCRIPTION
In order to sanely replace the symlink code on Windows, first we need to factor it out into as few places as possible.

1. Now we use the isopack.json file (read with the logic from isopack.js) to find out which arches are downloaded
2. There is a function specifically for making the latest tool symlink, which will be replaced with a non-symlink solution on Windows