### PR TITLE
Update safety checks

### DIFF
--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -514,10 +514,20 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
 };
 
 var isModificationMod = function (mod) {
-  for (var k in mod)
-    if (k.substr(0, 1) === '$')
-      return true;
-  return false;
+  var isReplace = false;
+  var isModify = false;
+  for (var k in mod) {
+    if (k.substr(0, 1) === '$') {
+      isModify = true;
+    } else {
+      isReplace = true;
+    }
+  }
+  if (isModify && isReplace) {
+    throw new Error(
+      "Update parameter cannot have both modifier and non-modifier fields.");
+  }
+  return isModify;
 };
 
 var NUM_OPTIMISTIC_TRIES = 3;

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -3068,7 +3068,7 @@ Meteor.isServer && testAsyncMulti("mongo-livedata - update with replace forbidde
 
     test.throws(function () {
       c.update(id, { foo3: "bar3", $set: { blah: 1 } });
-    }, "cannot be mixed");
+    }, "cannot have both modifier and non-modifier fields");
     test.equal(c.findOne(id), { _id: id, foo2: "bar2" });
   }
 ]);


### PR DESCRIPTION
A couple safety checks for updates:
- Disallow EJSON custom types and anything other than plain objects for replacement updates. This matches a check that we do in `insert`.
- Throw an error if you try to update with a modifier that looks like this: `{ foo: 'bar', $set: { foo: 'bar' } }`. This is illegal according to mongodb anyway, so this is just an extra safety check (and a reassurance that we'll continue enforcing this even if mongodb changes its behavior someday).

@n1mmy, @glasser: could you please take a look?
