### PR TITLE
Don’t apply the CDN prefix on cordova. For #3278

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -326,6 +326,17 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
     additionalOptions.runtimeConfigOverrides || {}
   );
 
+  var jsCssPrefix;
+  if (arch === 'web.cordova') {
+    // in cordova we serve assets up directly from disk so it doesn't make
+    // sense to use the prefix (ordinarily something like a CDN) and go out 
+    // to the internet for those files.
+    jsCssPrefix = '';
+  } else {
+    jsCssPrefix = bundledJsCssPrefix ||
+      __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
+  }
+
   return new Boilerplate(arch, manifest,
     _.extend({
       pathMapper: function (itemPath) {
@@ -342,8 +353,7 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
         ),
         meteorRuntimeConfig: JSON.stringify(runtimeConfig),
         rootUrlPathPrefix: __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '',
-        bundledJsCssPrefix: bundledJsCssPrefix ||
-          __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '',
+        bundledJsCssPrefix: jsCssPrefix,
         inlineScriptsAllowed: WebAppInternals.inlineScriptsAllowed(),
         inline: additionalOptions.inline
       }


### PR DESCRIPTION
Cordova serves assets directly from the device so it doesn’t make sense to hit the CDN for them. Beside it causes issues because they are served from /__cordova anyway.
