### PR TITLE
Velocity package ci

### DIFF
--- a/tools/commands.js
+++ b/tools/commands.js
@@ -1258,6 +1258,7 @@ main.registerCommand({
     deploy: { type: String },
     production: { type: Boolean },
     settings: { type: String },
+    velocity: { type: Boolean},
     verbose: { type: Boolean, short: "v" },
 
     // Undocumented. See #Once
@@ -1425,6 +1426,13 @@ main.registerCommand({
       }
     }
     options.extraRunners = runners;
+  }
+
+  if (options['velocity']){
+    var serverUrl = "http://" + (parsedUrl.host || "localhost") +
+          ":" + parsedUrl.port;
+    var velocity = require('./run-velocity.js');
+    velocity.runVelocity(serverUrl);
   }
 
   return runTestAppForPackages(projectContext, options);

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -471,6 +471,7 @@ Options:
   --test-app-path   Set the directory in which to create a temporary app used
                     for tests. Defaults to the system's temporary directory,
                     usually /tmp.
+  --velocity        Execute tests using phantomjs and exit
   --verbose         Print all output from builds logs.
 
 


### PR DESCRIPTION
I've recently been working to bring package level testing to Velocity.

This `--velocity` flag would allow the `test-packages` command to use the same infrastructure set up around the `meteor run --test` command.