### PR TITLE
upload README files to Isobuild; change package skeleton

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUNDLE_VERSION=0.3.76
+BUNDLE_VERSION=0.3.83
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -35,6 +35,7 @@ var packageJson = {
     "http-proxy": "1.6.0",
     "wordwrap": "0.0.2",
     "moment": "2.8.4",
+    "commonmark": "0.15.0",
     // XXX We ought to be able to get this from the copy in js-analyze rather
     // than in the dev bundle.)
     esprima: "1.2.2",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -35,6 +35,9 @@ var packageJson = {
     "http-proxy": "1.6.0",
     "wordwrap": "0.0.2",
     "moment": "2.8.4",
+    // XXX: When we update this, see if it fixes this Github issue:
+    // https://github.com/jgm/CommonMark/issues/276 . If it does, remove the
+    // workaround from the tool.
     "commonmark": "0.15.0",
     // XXX We ought to be able to get this from the copy in js-analyze rather
     // than in the dev bundle.)

--- a/tools/catalog-local.js
+++ b/tools/catalog-local.js
@@ -308,6 +308,7 @@ _.extend(LocalCatalog.prototype, {
             version: packageSource.version,
             publishedBy: null,
             description: packageSource.metadata.summary,
+            git: packageSource.metadata.git,
             dependencies: packageSource.getDependencyMetadata(),
             source: null,
             lastUpdated: null,

--- a/tools/commands-packages-query.js
+++ b/tools/commands-packages-query.js
@@ -451,10 +451,11 @@ _.extend(PackageQuery.prototype, {
     }
 
     var readmeInfo;
-    main.captureAndExit("=> Errors while reading local packages:", function () {
-      buildmessage.enterJob("reading " + data["directory"], function () {
+    main.captureAndExit(
+      "=> Errors while reading local packages:",
+      "reading " + data["directory"],
+       function () {
         readmeInfo = packageSource.processReadme();
-      });
     });
     if (readmeInfo) {
       data["description"] = readmeInfo.excerpt;

--- a/tools/commands-packages.js
+++ b/tools/commands-packages.js
@@ -272,7 +272,7 @@ main.registerCommand({
   if (options.update && options["existing-version"]) {
     Console.error(
       "The --update option implies that the version already exists.",
-      "You do not need to use the --exising-version flag with --update.");
+      "You do not need to use the --existing-version flag with --update.");
     return 1;
   }
 

--- a/tools/commands-packages.js
+++ b/tools/commands-packages.js
@@ -204,10 +204,9 @@ var updatePackageMetadata = function (packageSource, conn) {
     // You are still not allowed to upload a blank README.md.
     if (readmeInfo && readmeInfo.hash === files.blankHash) {
       Console.error(
-        "Please fill it out your documentation file! If you don't want to",
-        "update new documentation, you can remove it out from the package",
-        "description, or set 'documentation: null' in your Package.describe",
-        "to remove it entirely");
+        "Your documentation file is blank, so users may have trouble",
+        "figuring out how to use your package. Please fill it out, or",
+        "set 'documentation: null' in your Package.describe.");
       return 1;
     };
 

--- a/tools/files.js
+++ b/tools/files.js
@@ -306,6 +306,8 @@ files.fileHash = function (filename) {
   return fut.wait();
 };
 
+// This is the result of running fileHash on a blank file.
+files.blankHash = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
 
 // Returns a base64 SHA256 hash representing a tree on disk. It is not sensitive
 // to modtime, uid/gid, or any permissions bits other than the current-user-exec
@@ -1194,4 +1196,3 @@ files.pathwatcherWatch = function () {
   var pathwatcher = require('pathwatcher');
   return pathwatcher.watch.apply(pathwatcher, args);
 };
-

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -595,6 +595,7 @@ Options:
 Publish a new version of a package to the package server.
 
 Usage: meteor publish [--create]
+       meteor publish --update
 
 Publishes a new version of a local package to the package server. Must be run
 from the directory containing the package. Reads the package.js file for version
@@ -602,18 +603,23 @@ information, builds the package and sends both the package source and the built
 version of the package to the package server.
 
 This will only create one build of the package. If your package has multiple
-builds for different OS architectures, it will create a build for this machine's
-architecture. To publish a different build for the same version, run
-publish-for-arch.
+builds for different OS architectures, it will ask you to use the Meteor build
+farm to create a build per each supported architecture. To publish a different
+build for the same version, run publish-for-arch.
 
 This will mark you as the only maintainer of the package. If you need to change
-maintainers and other metadata about this package & package version, take a look
-at the admin commands.
+package maintainers or add a homepage, take a look at the admin commands.
+
+Change the metadata for a given version of a package by running with the
+--update flag. That will set the git url, version summary, longform description
+and documentation in the database to their new values. You can use 'meteor show'
+to preview the results.
 
 Pass --create to create a new package.
 
 Options:
   --create   publish a new package
+  --update   changed metadata of a previously published version
 
 
 >>> publish-for-arch

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -602,13 +602,16 @@ from the directory containing the package. Reads the package.js file for version
 information, builds the package and sends both the package source and the built
 version of the package to the package server.
 
-This will only create one build of the package. If your package has multiple
-builds for different OS architectures, it will ask you to use the Meteor build
-farm to create a build per each supported architecture. To publish a different
-build for the same version, run publish-for-arch.
+This will create at most one build of the package. If the package has an
+OS-dependent binary component, publishing will only register metadata about the
+package. To actually publish the package builds, use `admin get-machine`
+and `publish-for-arch`. Packages with no published builds cannot be added
+to applications.
 
-This will mark you as the only maintainer of the package. If you need to change
-package maintainers or add a homepage, take a look at the admin commands.
+This will mark you as the only maintainer of the package. You can use
+'admin maintainers' to change package maintainers. Use 'admin change-homepage'
+to change the package homepage. You can run 'help admin' to learn more about
+admin commands.
 
 Change the metadata for a given version of a package by running with the
 --update flag. That will set the git url, version summary, longform description

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -604,14 +604,13 @@ version of the package to the package server.
 
 This will create at most one build of the package. If the package has an
 OS-dependent binary component, publishing will only register metadata about the
-package. To actually publish the package builds, use `admin get-machine`
-and `publish-for-arch`. Packages with no published builds cannot be added
+package. To actually publish the package builds, use `meteor admin get-machine`
+and `meteor publish-for-arch`. Packages with no published builds cannot be added
 to applications.
 
 This will mark you as the only maintainer of the package. You can use
-'admin maintainers' to change package maintainers. Use 'admin change-homepage'
-to change the package homepage. You can run 'help admin' to learn more about
-admin commands.
+'meteor admin maintainers' to change package maintainers. For more information
+about admin commands, run 'meteor help admin'.
 
 Change the metadata for a given version of a package by running with the
 --update flag. That will set the git url, version summary, longform description

--- a/tools/package-client.js
+++ b/tools/package-client.js
@@ -455,13 +455,18 @@ exports.updatePackageMetadata = function (options) {
   }
 
   var dataToUpdate = {
-    git: packageSource.metadata.git,
-    summary: packageSource.metadata.summary,
+    git: packageSource.metadata.git || "",
+    description: packageSource.metadata.summary,
     longDescription: readmeInfo.excerpt
   };
 
   // Check that the metadata fits under the established limits, and give helpful
   // feedback.
+  if (! dataToUpdate["description"]) {
+    buildmessage.error("Please provide a short description to use in 'meteor search'");
+    return;
+  }
+
   if (dataToUpdate["description"] &&
       dataToUpdate["description"].length > 100) {
     buildmessage.error("Summary must be under 100 chars.");
@@ -587,6 +592,15 @@ exports.publishPackage = function (options) {
       "set 'documentation: null' in your Package.describe");
     return;
   }
+  if (readmeInfo && readmeInfo.excerpt.length > 1500) {
+    buildmessage.error(
+      "Longform package description is too long. Meteor uses the section of",
+      "the Markdown documentation file between the first and second",
+      "headings. That section must be less than 1500 characters long.");
+    return;
+  }
+
+
   // We don't let the user upload a blank README for UX reasons, but we would
   // prefer that the server move to a world with 'readme' files for everything
   // in the future. This helps unite these interfaces, and makes our code easier

--- a/tools/package-client.js
+++ b/tools/package-client.js
@@ -494,7 +494,7 @@ exports.updatePackageMetadata = function (options) {
     var uploadInfo =
           callPackageServerBM(conn, "createReadme", versionIdentifier);
     if (! uploadInfo) return;
-    if (! uploadFile(uploadInfo.url, readmePath) < 0) return;
+    if (! uploadFile(uploadInfo.url, readmePath)) return;
     callPackageServerBM(
       conn, "publishReadme", uploadInfo.uploadToken, { hash: readmeInfo.hash });
   });

--- a/tools/package-source.js
+++ b/tools/package-source.js
@@ -111,7 +111,7 @@ var getExcerptFromReadme = function (text) {
   // Don't waste time parsing if the document is empty.
   if (! text) return "";
 
-  // Split into linesarse with Commonmark.
+  // Split into lines with Commonmark.
   var commonmark = require('commonmark');
   var reader = new commonmark.DocParser();
   var parsed = reader.parse(text);

--- a/tools/package-source.js
+++ b/tools/package-source.js
@@ -139,9 +139,9 @@ var getExcerptFromReadme = function (text) {
       // that we are done.
       return true;
     } else if (isHeader) {
-      // We are going to take the first text that we encounter under the first
-      // two headers. Beyond that, if we don't encounter anything, we won't
-      // excerpt it.
+      // We are going to take the first text that we encounter under either of
+      // the first two headers. Beyond that, if we don't encounter anything, we
+      // won't excerpt it.
       headerNum++;
       if (headerNum > 2) {
         return true;

--- a/tools/package-source.js
+++ b/tools/package-source.js
@@ -1813,6 +1813,7 @@ _.extend(PackageSource.prototype, {
       return null;
     }
 
+    // To ensure atomicity, we want to copy the README to a temporary file.
     var ret = {};
     ret.path =
       files.pathJoin(self.sourceRoot, self.metadata.documentation);
@@ -1846,9 +1847,12 @@ _.extend(PackageSource.prototype, {
       return null;
     }
 
-    ret.hash = files.fileHash(ret.path);
-    ret.excerpt = getExcerptFromReadme(fullReadme.toString());
-    return ret;
+    var text = fullReadme.toString();
+    return {
+      contents: text,
+      hash: utils.sha256(text),
+      excerpt: getExcerptFromReadme(text)
+    };
   },
 
   // If dependencies aren't consistent across unibuilds, return false and

--- a/tools/skel-pack/package.js
+++ b/tools/skel-pack/package.js
@@ -1,8 +1,13 @@
 Package.describe({
   name: '~name~',
-  summary: ' /* Fill me in! */ ',
-  version: '1.0.0',
-  git: ' /* Fill me in! */ '
+  // Brief, one-line summary of the package.
+  summary: '',
+  version: '0.0.1',
+  // By default, Meteor will default to using README.md for documentation. Use
+  // this override to specify a different file, or 'null' to specify no
+  // documentation at all.
+  documentation: 'README.md',
+  git: ''
 });
 
 Package.onUse(function(api) {

--- a/tools/skel-pack/package.js
+++ b/tools/skel-pack/package.js
@@ -3,9 +3,8 @@ Package.describe({
   // Brief, one-line summary of the package.
   summary: '',
   version: '0.0.1',
-  // By default, Meteor will default to using README.md for documentation. Use
-  // this override to specify a different file, or 'null' to specify no
-  // documentation at all.
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
   documentation: 'README.md',
   git: ''
 });

--- a/tools/tests/cordova-platforms.js
+++ b/tools/tests/cordova-platforms.js
@@ -9,7 +9,6 @@ selftest.define("add cordova platforms", function () {
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
 
   run = s.run("run", "android");
   run.matchErr("Please add the Android platform to your project first");

--- a/tools/tests/cordova-plugins.js
+++ b/tools/tests/cordova-plugins.js
@@ -99,7 +99,6 @@ selftest.define("change cordova plugins", function () {
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   run = s.run();
   run.waitSecs(5);
   run.match("myapp");
@@ -142,7 +141,6 @@ selftest.define("add cordova plugins", ["slow"], function () {
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   s.set("METEOR_OFFLINE_CATALOG", "t");
 
   run = s.run("remove", "meteor-platform");
@@ -473,7 +471,6 @@ selftest.define("cordova plugins in star.json, direct and transitive", ["slow"],
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   s.set("METEOR_OFFLINE_CATALOG", "t");
 
   run = s.run("add-platform", "android");

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -1089,9 +1089,7 @@ var testShowPackageVersion =  selftest.markStack(function (s, options) {
 // 'name@local' gives that local version.
 selftest.define("show local package w/o version",  function () {
   var s = new Sandbox();
-  // We rely on this package not existing on the server. It doesn't have a
-  // prefix (or a meaningful name), so it is a reasonably safe assumption.
-  var name = "my-local-package";
+  var name = "my-local-package" + utils.randomToken();
 
   // Create a package without version or summary; check that we can show its
   // information without crashing.
@@ -1125,9 +1123,7 @@ selftest.define("show and search local package",  function () {
   // Setup: create an app, containing a package. This local package should show
   // up in the results of `meteor show` and `meteor search`.
   var s = new Sandbox();
-  // We rely on this package not existing on the server. It doesn't have a
-  // prefix (or a meaningful name), so it is a reasonably safe assumption.
-  var name = "my-local-package";
+  var name = "my-local-package" + utils.randomToken();
   s.createApp("myapp", "empty");
   s.cd("myapp");
   s.mkdir("packages");
@@ -1965,9 +1961,7 @@ selftest.define("show package w/many versions",
 // that's covered in a different test.
 selftest.define("show readme excerpt",  function () {
   var s = new Sandbox();
-  // We rely on this package not existing on the server. It doesn't have a
-  // prefix (or a meaningful name), so it is a reasonably safe assumption.
-  var name = "my-local-package";
+  var name = "my-local-package" + utils.randomToken();
 
   // Create a package without version or summary; check that we can show its
   // information without crashing.

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -2060,27 +2060,12 @@ selftest.define("show readme excerpt",  function () {
   // Some formatting in the text.
   var excerpt =
         "Here is a code sample:" + "\n\n" +
-        "```foobar\nand foobar```";
+        "```foobar and foobar```";
   readme =
     "Heading" + "\n" +
     "========" + "\n" + "\n" +
     excerpt + "\n\n" +
     "# Subheading" + "\n" + "\n" +
-    "## Another subheading" + "\n" + "\n" +
-    "You should not see this line!";
-  s.write("README.md", readme);
-  testShowPackage(
-    s, name, _.extend({ description: excerpt }, basePackageInfo));
-  testShowPackageVersion(
-    s, _.extend({ description: excerpt }, baseVersionInfo));
-
-  // Some formatting in the text that we are going to skip.
-  readme =
-    "Heading" + "\n" +
-    "========" + "\n" + "\n" +
-    "# Subheading" + "\n" + "\n" +
-    "![skip this image!] \n" +
-    excerpt + "\n\n" +
     "## Another subheading" + "\n" + "\n" +
     "You should not see this line!";
   s.write("README.md", readme);
@@ -2194,7 +2179,7 @@ selftest.define("show server readme",
     staging = staging.replace(/~summary~/g, summary);
     var current = staging.replace(/~version~/g, "1.0.0");
     s.write("package.js", current.replace(/~documentation~/g, "'MINE.md'"));
-    s.write("MINE.md", "Foobar\n====\nNew test!\n#Something\n");
+    s.write("MINE.md", "Foobar\n====\nNew test!\n\n# Something\n");
     publish();
   });
   testShowPackageVersion(s, {
@@ -2263,7 +2248,7 @@ selftest.define("show server readme",
     var longReadme = Array(75).join(" please do not read me! ");
     s.write("long", "Heading\n===\n" + longReadme);
     run = s.run("publish");
-    run.matchErr("Documentation snippet is too long");
+    run.matchErr("Longform package description is too long");
     run.expectExit(1);
   });
 
@@ -2528,7 +2513,7 @@ selftest.define("update package metadata",
     s.write("longReadme.md", "Heading\n===\n" + longDesc);
 
     var run = s.run("publish", "--update");
-    run.matchErr("Documentation snippet is too long.");
+    run.matchErr("Longform package description is too long.");
     run.expectExit(1);
   });
 

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -2022,29 +2022,6 @@ selftest.define("show readme excerpt",  function () {
   testShowPackageVersion(
     s, _.extend({ description: "foobaz" }, baseVersionInfo));
 
-  // Top heading, sub heading, sub heading, text. No text should show up! The
-  // user is intentionally skipping a section.
-  readme =
-    "Heading" + "\n" +
-    "========" + "\n" + "\n" +
-    "## Subheading" + "\n" + "\n" +
-    "## Another subheading" + "\n" + "\n" +
-    "You should not see this line!";
-  s.write("README.md", readme);
-  testShowPackage(s, name, basePackageInfo);
-  testShowPackageVersion(s, baseVersionInfo);
-
-  // Same as above, but with more weird subheadings.
-  readme =
-    "Heading" + "\n" +
-    "========" + "\n" + "\n" +
-    "# Subheading" + "\n" + "\n" +
-    "## Another subheading" + "\n" + "\n" +
-    "You should not see this line!";
-  s.write("README.md", readme);
-  testShowPackage(s, name, basePackageInfo);
-  testShowPackageVersion(s, baseVersionInfo);
-
   // Some formatting in the text.
   var excerpt =
         "Here is a code sample:" + "\n\n" +
@@ -2239,10 +2216,9 @@ selftest.define("show server readme",
     run.expectExit(1);
   });
 
-  // If you didn't format things properly, we will still publish, but you might
-  // not have an excerpt.
+  // If you didn't format things properly, we will still publish and use that as
+  // an excerpt.
   s.cd(fullPackageName, function () {
-    // README is blank.
     var current = staging.replace(/~version~/g, "1.0.0_2");
     s.write("package.js", current.replace(/~documentation~/g, "'unformat'"));
     s.write("unformat", "I did not format this readme");
@@ -2253,6 +2229,7 @@ selftest.define("show server readme",
     git: git,
     packageName: fullPackageName,
     version:  "1.0.0_2",
+    description: "I did not format this readme",
     publishedBy: username,
     publishedOn: today
   });
@@ -2260,6 +2237,7 @@ selftest.define("show server readme",
     summary: summary,
     git: git,
     maintainers: username,
+    description: "I did not format this readme",
     versions: [
       { version: "0.9.9", date: today },
       { version: "1.0.0", date: today },

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -157,7 +157,6 @@ selftest.define("change packages during hot code push", [], function () {
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   run = s.run();
   run.waitSecs(5);
   run.match("myapp");
@@ -264,7 +263,6 @@ selftest.define("add packages to app", [], function () {
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   s.set("METEOR_OFFLINE_CATALOG", "t");
 
   // This has legit version syntax, but accounts-base started with 1.0.0 and is
@@ -375,8 +373,7 @@ selftest.define("add packages client archs", function (options) {
     // Starting a run
     s.createApp("myapp", "package-tests");
     s.cd("myapp");
-    s.set("METEOR_TEST_TMP", files.mkdtemp());
-    s.set("METEOR_OFFLINE_CATALOG", "t");
+      s.set("METEOR_OFFLINE_CATALOG", "t");
 
     var outerRun = s.run("add", "say-something-client-targets");
     outerRun.match(/say-something-client-targets.*added,/);
@@ -440,7 +437,6 @@ selftest.define("sync local catalog", ["slow", "net", "test-package-server"],  f
   var s = new Sandbox();
   var run;
 
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName + "-a";
@@ -544,7 +540,6 @@ selftest.define("release track defaults to METEOR",
                 ["net", "test-package-server", "checkout"], function () {
 
   var s = new Sandbox();
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName;
@@ -668,7 +663,6 @@ selftest.define("package specifying a name",
   // Starting a run; introducing a new package overriding a core package.
   s.createApp("myapp", "package-tests");
   s.cd("myapp");
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   run = s.run("add", "accounts-base");
   run.waitSecs(40);
   run.match("accounts-base");
@@ -1181,7 +1175,6 @@ selftest.define("show and search local overrides server",
   var today = longformToday();
   var run;
 
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName;
@@ -1257,7 +1250,6 @@ selftest.define("show server package",
   var today = longformToday();
 
   var s = new Sandbox();
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName;
@@ -1464,7 +1456,6 @@ selftest.define("show server package",
 selftest.define("show rc-only package",
   ['net', 'test-package-server', 'slow'], function () {
   var s = new Sandbox();
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName;
@@ -1626,7 +1617,6 @@ selftest.define("show release",
   ['net', 'test-package-server', 'slow'], function () {
 
   var s = new Sandbox();
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
 
   // Technically, this could make our test a little flaky if run at exactly
@@ -1787,7 +1777,6 @@ selftest.define("show release w/o recommended versions",
   ['net', 'test-package-server', 'slow'], function () {
 
   var s = new Sandbox();
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
 
   // Technically, this could make our test a little flaky if run at exactly
@@ -1864,7 +1853,6 @@ selftest.define("show package w/many versions",
   ['net', 'test-package-server', 'slow'], function () {
 
   var s = new Sandbox();
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
 
   // Technically, this could make our test a little flaky if run at exactly
@@ -2125,7 +2113,6 @@ selftest.define("show server readme",
   ['net', 'test-package-server', 'slow'], function () {
 
   var s = new Sandbox();
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
 
   // Technically, this could make our test a little flaky if run at exactly
@@ -2289,7 +2276,6 @@ selftest.define("update package metadata",
   ['net', 'test-package-server', 'slow'], function () {
 
   var s = new Sandbox();
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
   testUtils.login(s, username, password);
 
   // Technically, this could make our test a little flaky if run at exactly

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -2466,15 +2466,17 @@ selftest.define("update package metadata",
     run.matchErr("Summary must be under");
     run.expectExit(1);
 
-    // Blank summary can still work, for now, but doesn't actually update the
-    // summary.
+    // Blank summary.
     staging = s.read("package-customizable.js");
     staging = staging.replace(/~git~/g, git);
     staging = staging.replace(/~summary~/g, "");
     staging = staging.replace(/~version~/g, "0.9.9");
     staging = staging.replace(/~documentation~/g, "null");
     s.write("package.js", staging);
-    update();
+    run = s.run("publish", "--update");
+    run.matchErr("Please provide");
+    run.expectExit(1);
+
   });
   testShowPackageVersion(s, _.extend({
     summary: summary,

--- a/tools/tests/packages/fake-accounts-base/package.js
+++ b/tools/tests/packages/fake-accounts-base/package.js
@@ -2,7 +2,8 @@
 // by using the name attribute in Package.describe.
 
 Package.describe({
-  name: "accounts-base"
+  name: "accounts-base",
+  documentation: null
 });
 
 Package.onUse(function(api) {

--- a/tools/tests/packages/package-for-show/README.md
+++ b/tools/tests/packages/package-for-show/README.md
@@ -1,0 +1,11 @@
+## Package for show
+
+Test package.
+
+# First heading
+
+Something here, but we should never see it.
+
+# second heading
+
+Something here too, but we do not care.

--- a/tools/tests/packages/package-for-show/completely-empty-package.js
+++ b/tools/tests/packages/package-for-show/completely-empty-package.js
@@ -1,2 +1,3 @@
 Package.describe({
+  documentation: null
 });

--- a/tools/tests/packages/package-for-show/package-customizable.js
+++ b/tools/tests/packages/package-for-show/package-customizable.js
@@ -1,0 +1,6 @@
+Package.describe({
+  summary: '~summary~',
+  version: '~version~',
+  git: '~git~',
+  documentation: ~documentation~
+});

--- a/tools/tests/packages/package-for-show/package-rc-version.js
+++ b/tools/tests/packages/package-for-show/package-rc-version.js
@@ -1,5 +1,6 @@
 Package.describe({
   summary: 'This is a pre-release version of this package!',
   version: '1.3.0-rc.1',
-  git: 'www.github.com/fake-user/meteor'
+  git: 'www.github.com/fake-user/meteor',
+  documentation: null
 });

--- a/tools/tests/packages/package-for-show/package-with-deps.js
+++ b/tools/tests/packages/package-for-show/package-with-deps.js
@@ -1,7 +1,8 @@
 Package.describe({
   summary: 'This is a test package with dependencies',
   version: '1.2.0',
-  git: 'www.github.com/meteor/meteor'
+  git: 'www.github.com/meteor/meteor',
+  documentation: null
 });
 
 Package.onUse(function(api) {

--- a/tools/tests/packages/package-for-show/package-with-git.js
+++ b/tools/tests/packages/package-for-show/package-with-git.js
@@ -1,5 +1,6 @@
 Package.describe({
   summary: 'This is a test package',
   version: '1.0.0',
-  git: 'www.github.com/meteor/meteor'
+  git: 'www.github.com/meteor/meteor',
+  documentation: null
 });

--- a/tools/tests/packages/package-of-two-versions/package-version.js
+++ b/tools/tests/packages/package-of-two-versions/package-version.js
@@ -1,4 +1,5 @@
 Package.describe({
   summary: "Test package.",
-  version: "~version~"
+  version: "~version~",
+  documentation: null
 });

--- a/tools/tests/packages/package-of-two-versions/package.js
+++ b/tools/tests/packages/package-of-two-versions/package.js
@@ -1,4 +1,5 @@
 Package.describe({
   summary: "Test package.",
-  version: "1.0.0"
+  version: "1.0.0",
+  documentation: null
 });

--- a/tools/tests/packages/package-with-npm/package.js
+++ b/tools/tests/packages/package-with-npm/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   summary: "Test package with a binary npm dependency",
-  version: "1.0.0"
+  version: "1.0.0",
+  documentation: null
 });
 
-// bcrypt is an npm package that 
+// bcrypt is an npm package that
 // has different binaries for differnet architectures.
 Npm.depends({
   bcrypt: '0.7.7'
 });
-

--- a/tools/tests/publish.js
+++ b/tools/tests/publish.js
@@ -6,7 +6,7 @@ var stats = require('../stats.js');
 var Sandbox = selftest.Sandbox;
 var files = require('../files.js');
 
-selftest.define("publish-and-search",
+selftest.define("create-publish-and-search",
     ["slow", "net", "test-package-server", "checkout"], function () {
   var s = new Sandbox;
 
@@ -17,6 +17,7 @@ selftest.define("publish-and-search",
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName;
   var githubUrl = "http://github.com/foo/bar";
+  var summary = "Package for test";
 
   // Create a package that has a versionsFrom for a nonexistent release and see
   // that we throw on it.
@@ -41,11 +42,16 @@ selftest.define("publish-and-search",
 
   s.cd(fullPackageName);
 
-  // set a github URL in the package
+  // set a github URL & summary in the package
   var packageJsContents = s.read("package.js");
   var newPackageJsContents = packageJsContents.replace(
       /git: \'.*\'/, "git: \'" + githubUrl + "\'");
+  newPackageJsContents = newPackageJsContents.replace(
+      /summary: \'.*\'/, "summary: \'" + summary + "\'");
   s.write("package.js", newPackageJsContents);
+
+  // Write some documentation.
+  s.write("README.md", "Heading\n==\nDocs here");
 
   run = s.run("publish");
   run.waitSecs(15);
@@ -65,7 +71,7 @@ selftest.define("publish-and-search",
   run = s.run("show", fullPackageName);
   run.waitSecs(15);
   run.expectExit(0);
-  run.match("Maintained");
+  run.match("Git");
   run.match(githubUrl);
 
   // name override.
@@ -74,6 +80,7 @@ selftest.define("publish-and-search",
   var minPack = " Package.describe({ " +
     "summary: 'Test package: " + packageName + "'," +
     "version: '1.0.1'," +
+    "documentation: null," +
     "name: '" + newPackageName + "'});";
 
   s.createPackage(fullPackageName, "package-of-two-versions");
@@ -84,7 +91,6 @@ selftest.define("publish-and-search",
     // in any case, that we can't rely on the rest of this test working.
     run = s.run("publish");
     run.waitSecs(15);
-    run.match("Reading package...\n");
     run.matchErr("There is no package named " + newPackageName);
     run.expectExit(1);
 
@@ -98,7 +104,7 @@ selftest.define("publish-and-search",
   run = s.run("show", newPackageName);
   run.waitSecs(15);
   run.expectExit(0);
-  run.match("package: " + packageName);
+  run.match("Package: " + newPackageName);
 });
 
 selftest.define("publish-one-arch",
@@ -112,14 +118,10 @@ selftest.define("publish-one-arch",
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName;
 
-  var run = s.run("create", "--package", fullPackageName);
-  run.waitSecs(15);
-  run.expectExit(0);
-  run.match(fullPackageName);
-
+  s.createPackage(fullPackageName, "package-of-two-versions");
   s.cd(fullPackageName);
 
-  run = s.run("publish", "--create");
+  var run = s.run("publish", "--create");
   run.waitSecs(15);
   run.expectExit(0);
   run.match("Published");

--- a/tools/tests/publish.js
+++ b/tools/tests/publish.js
@@ -459,7 +459,6 @@ selftest.define("package-depends-on-either-version",
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");
-  s.set("METEOR_TEST_TMP", files.mkdtemp());
 
   run = s.run("add", fullPackageNameDep + "@=1.0.0");
   run.match(fullPackageNameDep);

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -681,3 +681,11 @@ exports.explainIfRefreshFailed = function () {
       "Please connect to the internet and try again.");
   }
 };
+
+// Returns a sha256 hash of a given string.
+exports.sha256 = function (contents) {
+  var crypto = require('crypto');
+  var hash = crypto.createHash('sha256');
+  hash.update(contents);
+  return hash.digest('base64');
+};


### PR DESCRIPTION
This commit is based on the following design document:
https://mdg.hackpad.com/Creating-and-Updating-Docs-0ZyyDcSZDxp,
and some other stuff from here: https://mdg.hackpad.com/Meteor-Long-Description-wGZ1vIOwVlF.

It does the following:

- Allow the user to specify package documentation in Package.Describe.
We will take the README.md file by default, to make the transition easier.
Users can specify ‘documentation: null’ to not submit a README.md

- From that documentation, extract the section between the first and second header
to use as the long form description for the package.

- Upload the documentation to the server at publish-time. Allow metadata changes with ‘publish —update’.

- Change the default package skeleton to include the README.md file.
Also, changes the skeleton to have fewer useless placeholders in Package.describe values.

-  Fix a minor bug where Git did not show up when running ‘meteor show’ on local packages.

A note on ‘documentation: null’ and blank documentation — we don’t let maintainers upload
blank README.md files, because we want to encourage people to fill them out. (Instead,
we allow a ‘documentation: null’ as an override) This is a UX issue!  It is not a technical thing.

Right now, when ‘documentation: null’, Meteor interprets that to mean ‘upload a blank README’*.
Why? Well, the alternative, is to allow the user to just remove the documentation documentation
field from the version record. To do that, we need a ‘removeReadme’ method on Troposphere.

That’s easy, but I think it is wrong:

- In the future, we want all package versions to have a README.md.
They are mostly optional right now because we want to make this transition painless for our users.

- This means that we want to move the server towards a world where records have READMEs.
Allowing that field to be removed, post-factum, moves us say from that world. It also keeps
alive bad abstractions (look at Git if there is no readme) and makes our lives slightly harder
to reason about (absolutes like ‘always uploads a readme after this version of Meteor’
and ‘always has a README’ are easier to deal with).

- Clearly, uploading a blank is a hack. With any hack, it is important to think about
when we will eliminate it. In this case, it is a hack around the UX. This is, for example,
because the UX allows you to not have documentation in the first place. We will almost certainly
think about this again when we deal with the new project control file. Similarly, the UX does not
allow you to upload blank documentation yourself. That’s because of the package skeleton and various
UX issues in package creation that, once again, will be re-examined with project control files.

- If, later, if turns out that I am wrong, this hack is confined to the tool and uses APIs that
we don’t intend to change (too much). So, removing it and putting in a Troposphere method is cheap.

- Making a method on Troposphere is less of a hack. It could stay that way forever.
But I don’t think that it will — instead, we will come to a world where we need to
deprecate that method, and move towards non-optional documentation and it is a lot harder to do.

So, that’s why I did it. But it is kind of crazy, and not as smooth as I like my
abstractions and abstraction seams to be. A second opinion would be greatly appreciated.

*: this is something we can optimize to be cheap in the far future, if we care.