### PR TITLE
fixed 'make list public/private' language to accurately reflect the action being performed

### DIFF
--- a/examples/todos/client/templates/lists-show.html
+++ b/examples/todos/client/templates/lists-show.html
@@ -31,9 +31,9 @@
           <div class="options-web">
             <a class="js-toggle-list-privacy nav-item">
               {{#if userId}}
-                <span class="icon-lock" title="Make list private"></span>
+                <span class="icon-lock" title="Make list public"></span>
               {{else}}
-                <span class="icon-unlock" title="Make list public"></span>
+                <span class="icon-unlock" title="Make list private"></span>
               {{/if}}
             </a>
 


### PR DESCRIPTION
The language was backwards, I simply changed the hover text.

fixes #3376 
