### PR TITLE
Finally remove this debug message

### DIFF
--- a/packages/accounts-ui-unstyled/login_buttons_dialogs.html
+++ b/packages/accounts-ui-unstyled/login_buttons_dialogs.html
@@ -5,8 +5,6 @@
   {{> _justVerifiedEmailDialog}}
   {{> _configureLoginServiceDialog}}
   {{> _configureLoginOnDesktopDialog}}
-
-  <!-- if we're not showing a dropdown, we need some other place to show messages -->
   {{> _loginButtonsMessagesDialog}}
 </body>
 


### PR DESCRIPTION
<!-- if we're not showing a dropdown, we need some other place to show messages -->

This is  injected into the DOM since version 0.6 or whatever. Should be removed.
-> https://twitter.com/discovermeteor/status/331885057289617408