### PR TITLE
display exports for local packages

### DIFF
--- a/tools/compiler.js
+++ b/tools/compiler.js
@@ -28,6 +28,10 @@ var compiler = exports;
 // update BUILT_BY, though you will need to quit and rerun "meteor run".)
 compiler.BUILT_BY = 'meteor/15';
 
+// This is a list of all possible architectures that a build can target. (Client
+// is expanded into 'web.browser' and 'web.cordova')
+compiler.ALL_ARCHES = [ "os", "web.browser", "web.cordova" ];
+
 compiler.compile = function (packageSource, options) {
   buildmessage.assertInCapture();
 

--- a/tools/package-client.js
+++ b/tools/package-client.js
@@ -569,6 +569,7 @@ exports.publishPackage = function (options) {
         compilerVersion: compiler.BUILT_BY,
         containsPlugins: packageSource.containsPlugins(),
         debugOnly: packageSource.debugOnly,
+        exports: packageSource.getExports(),
         releaseName: release.current.name,
         dependencies: packageDeps
       };

--- a/tools/package-source.js
+++ b/tools/package-source.js
@@ -280,9 +280,6 @@ var PackageSource = function () {
   // specify the correct restrictions at 0.90.
   // XXX: 0.90 package versions.
   self.isCore = false;
-
-  // The list of architectures that this package source can target.
-  self.allArchs = compiler.ALL_ARCHES;
 };
 
 
@@ -903,7 +900,7 @@ _.extend(PackageSource.prototype, {
     var uses = {};
     var implies = {};
 
-    _.each(self.allArchs, function (arch) {
+    _.each(compiler.ALL_ARCHES, function (arch) {
       sources[arch] = [];
       exports[arch] = [];
       uses[arch] = [];
@@ -914,7 +911,7 @@ _.extend(PackageSource.prototype, {
     // that match an element of self.allarchs.
     var forAllMatchingArchs = function (archs, f) {
       _.each(archs, function (arch) {
-        _.each(self.allArchs, function (matchArch) {
+        _.each(compiler.ALL_ARCHES, function (matchArch) {
           if (archinfo.matches(matchArch, arch)) {
             f(matchArch);
           }
@@ -944,12 +941,12 @@ _.extend(PackageSource.prototype, {
 
       var toArchArray = function (arch) {
         if (!(arch instanceof Array)) {
-          arch = arch ? [arch] : self.allArchs;
+          arch = arch ? [arch] : compiler.ALL_ARCHES;
         }
         arch = _.uniq(arch);
         arch = _.map(arch, mapWhereToArch);
         _.each(arch, function (inputArch) {
-          var isMatch = _.any(_.map(self.allArchs, function (actualArch) {
+          var isMatch = _.any(_.map(compiler.ALL_ARCHES, function (actualArch) {
             return archinfo.matches(actualArch, inputArch);
           }));
           if (! isMatch) {
@@ -1276,7 +1273,7 @@ _.extend(PackageSource.prototype, {
         // principle of least surprise to half-run a handler
         // and then continue.
         sources = {};
-        _.each(self.allArchs, function (arch) {
+        _.each(compiler.ALL_ARCHES, function (arch) {
           sources[arch] = [];
         });
 
@@ -1295,7 +1292,7 @@ _.extend(PackageSource.prototype, {
                            " depends on itself.\n");
       }
     };
-    _.each(self.allArchs, function (label) {
+    _.each(compiler.ALL_ARCHES, function (label) {
       _.each(uses[label], doNotDepOnSelf);
       _.each(implies[label], doNotDepOnSelf);
     });
@@ -1330,7 +1327,7 @@ _.extend(PackageSource.prototype, {
 
       // For all implies and uses, fill in the unspecified dependencies from the
       // release.
-      _.each(self.allArchs, function (label) {
+      _.each(compiler.ALL_ARCHES, function (label) {
         uses[label] = _.map(uses[label], setFromRel);
         implies[label] = _.map(implies[label], setFromRel);
       });
@@ -1373,7 +1370,7 @@ _.extend(PackageSource.prototype, {
 
     // Create source architectures, one for the server and one for each web
     // arch.
-    _.each(self.allArchs, function (arch) {
+    _.each(compiler.ALL_ARCHES, function (arch) {
       // Everything depends on the package 'meteor', which sets up
       // the basic environment) (except 'meteor' itself, and js-analyze
       // which needs to be loaded by the linker).
@@ -1442,7 +1439,7 @@ _.extend(PackageSource.prototype, {
 
     var projectWatchSet = projectContext.getProjectWatchSet();
 
-    _.each(self.allArchs, function (arch) {
+    _.each(compiler.ALL_ARCHES, function (arch) {
       // We don't need to build a Cordova SourceArch if there are no Cordova
       // platforms.
       if (arch === 'web.cordova' &&

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -993,11 +993,14 @@ var testShowPackage = function (s, fullPackageName, options) {
   if (options.homepage) {
     run.read("Homepage: " + options.homepage + "\n");
   }
+  if (options.maintainers) {
+    run.read("Maintainers: " + options.maintainers + "\n");
+  }
   if (options.git) {
     run.read("Git: " + options.git + "\n");
   }
-  if (options.maintainers) {
-    run.read("Maintainers: " + options.maintainers + "\n");
+  if (options.exports) {
+    run.read("Exports: " + options.exports + "\n");
   }
   run.read("\n");
   if (_.has(options, "summary")) {
@@ -1057,14 +1060,14 @@ var testShowPackageVersion = function (s, options) {
   if (options.publishedBy) {
     run.match("Published by " + options.publishedBy + " on " + options.publishedOn + "\n");
   }
+  if (options.directory) {
+    run.match("Directory:\n" + options.directory + "\n");
+  }
   if (options.git) {
     run.match("Git: " + options.git + "\n");
   }
-  if (options.directory) {
-    // Because of line wrapping, we will never be able to fit our root path on
-    // the same line as the label (on the 80 character terminal, with sandbox's
-    // super-long paths).
-    run.match("Directory:\n" + options.directory + "\n");
+  if (options.exports) {
+    run.read("Exports: " + options.exports + "\n");
   }
   run.read("\n");
   if (_.has(options, "summary")) {
@@ -1166,6 +1169,33 @@ selftest.define("show and search local package",  function () {
   run.match(name);
   run.match("You can use");
   run.expectExit(0);
+
+  // We can see exports on local packages.
+  s.cd("packages");
+  summary = "This is a test package";
+  name = "my-local-exports";
+  packageDir = files.pathJoin(s.root, "home", "myapp", "packages", name);
+  s.createPackage(name, "package-for-show");
+  s.cd(name, function () {
+    s.cp("package-with-exports.js", "package.js");
+  });
+
+  var exportStr =
+    "A, B (server), C (web.browser, web.cordova)," +
+    " D (web.browser),\n"  + "         " +
+    "E (web.cordova), G (server, web.cordova)";
+  testShowPackage(s, name, {
+    summary: summary,
+    exports: exportStr,
+    versions: [{ version: "1.0.1", directory: packageDir }]
+  });
+  testShowPackageVersion(s, {
+    packageName: name,
+    version: "1.0.1",
+    directory: packageDir,
+    summary: summary,
+    exports: exportStr
+  });
 });
 
 // Make sure that if a package exists both locally, and on the server, 'meteor
@@ -1262,7 +1292,7 @@ selftest.define("show server package",
   testUtils.login(s, username, password);
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName;
-
+  var versions = [];
   // Publish a version the package without git or any dependencies. Make sure
   // that 'show' renders it correctly.
   s.createPackage(fullPackageName, "package-for-show");
@@ -1273,10 +1303,11 @@ selftest.define("show server package",
   });
 
   var summary = "This is a test package";
+  versions.push({ version: "0.9.9", date: today });
   testShowPackage(s, fullPackageName, {
     summary: summary,
     maintainers: username,
-    versions: [{ version: "0.9.9", date: today }]
+    versions: versions
   });
 
   testShowPackageVersion(s, {
@@ -1294,15 +1325,13 @@ selftest.define("show server package",
     run.waitSecs(30);
     run.expectExit(0);
   });
+  versions.push({ version: "1.0.0", date: today });
 
   testShowPackage(s, fullPackageName, {
     summary: summary,
     maintainers: username,
     git: "www.github.com/meteor/meteor",
-    versions: [
-      { version: "0.9.9", date: today },
-      { version: "1.0.0", date: today }
-    ]
+    versions: versions
   });
 
   testShowPackageVersion(s, {
@@ -1313,6 +1342,38 @@ selftest.define("show server package",
     summary: summary,
     git: "www.github.com/meteor/meteor"
   });
+
+  // Publish a version of the package with exports, and see that they show up.
+  s.cd(fullPackageName, function () {
+    s.cp("package-with-exports.js", "package.js");
+    var run = s.run("publish");
+    run.waitSecs(30);
+    run.expectExit(0);
+  });
+  versions.push({ version: "1.0.1", date: today });
+  var exportStr =
+    "A, B (server), C (web.browser, web.cordova)," +
+    " D (web.browser),\n"  + "         " +
+    "E (web.cordova), G (server, web.cordova)";
+
+  testShowPackage(s, fullPackageName, {
+    summary: summary,
+    maintainers: username,
+    exports: exportStr,
+    git: "www.github.com/meteor/meteor",
+    versions: versions
+  });
+
+  testShowPackageVersion(s, {
+    packageName: fullPackageName,
+    version: "1.0.1",
+    publishedBy: username,
+    publishedOn: today,
+    exports: exportStr,
+    summary: summary,
+    git: "www.github.com/meteor/meteor"
+  });
+
   // Publish a version of the package with git that depends on other
   // packages. To do this, we need to publish two other packages (since we don't
   // want to rely on specific packages existing on the test server).
@@ -1334,16 +1395,13 @@ selftest.define("show server package",
     run.expectExit(0);
   });
 
+  var newVersions = _.union(versions, [{ version: "1.2.0", date: today }]);
   var newSummary = "This is a test package with dependencies";
   testShowPackage(s, fullPackageName, {
     summary: newSummary,
     maintainers: username,
     git: "www.github.com/meteor/meteor",
-    versions: [
-      { version: "0.9.9", date: today },
-      { version: "1.0.0", date: today },
-      { version: "1.2.0", date: today }
-    ]
+    versions: newVersions
   });
 
   testShowPackageVersion(s, {
@@ -1370,11 +1428,7 @@ selftest.define("show server package",
     maintainers: username,
     git: "www.github.com/meteor/meteor",
     homepage: "www.meteor.com",
-    versions: [
-      { version: "0.9.9", date: today },
-      { version: "1.0.0", date: today },
-      { version: "1.2.0", date: today }
-    ]
+    versions: newVersions
   });
 
   // Add this package to an app, forcing us to download the isopack. Check that
@@ -1388,16 +1442,13 @@ selftest.define("show server package",
     run.expectExit(0);
   });
 
+  versions.push({ version: "1.2.0", date: today, label: "installed" });
   testShowPackage(s, fullPackageName, {
     summary: newSummary,
     maintainers: username,
     git: "www.github.com/meteor/meteor",
     homepage: "www.meteor.com",
-    versions: [
-      { version: "0.9.9", date: today },
-      { version: "1.0.0", date: today },
-      { version: "1.2.0", date: today, label: "installed" }
-    ]
+    versions: versions
   });
 
   // Publish a pre-release version of the package.
@@ -1415,7 +1466,7 @@ selftest.define("show server package",
   // Neither of these versions should show up.
   var moreAvailable =
     "Some versions of " + fullPackageName + " have been hidden. To see " +
-    "all 4 versions, run\n'meteor show --show-all " + fullPackageName + "'.";
+    "all 5 versions, run\n'meteor show --show-all " + fullPackageName + "'.";
   testShowPackage(s, fullPackageName, {
     summary: newSummary,
     maintainers: username,
@@ -1428,18 +1479,15 @@ selftest.define("show server package",
     addendum: moreAvailable
   });
 
+  newVersions =
+    _.union(versions, [{ version: "1.3.0-rc.1", date: today }]);
   // All the versions will show up when we run with the 'show-all' flag.
   testShowPackage(s, fullPackageName, {
     summary: newSummary,
     maintainers: username,
     git: "www.github.com/meteor/meteor",
     homepage: "www.meteor.com",
-    versions: [
-      { version: "0.9.9", date: today },
-      { version: "1.0.0", date: today },
-      { version: "1.2.0", date: today, label: "installed" },
-      { version: "1.3.0-rc.1", date: today }
-    ],
+    versions: newVersions,
     all: true
   });
 

--- a/tools/tests/packages/package-for-show/package-with-exports.js
+++ b/tools/tests/packages/package-for-show/package-with-exports.js
@@ -1,0 +1,15 @@
+Package.describe({
+  summary: 'This is a test package',
+  version: '1.0.1',
+  git: 'www.github.com/meteor/meteor'
+});
+
+Package.onUse(function(api) {
+  api.export("A");
+  api.export("B", 'server');
+  api.export("C", 'client');
+  api.export("D", "web.browser");
+  api.export("E", "web.cordova");
+  api.export("G", "web.cordova");
+  api.export("G", "server");
+});


### PR DESCRIPTION
Display exports for local packages in ‘meteor show’. (We will eventually display exports for non-local packages as well)

- method to aggregate exports for a package in packageSource (exports are per-architecture).

- get this data from packageSource in PackageQuery for ‘meteor show’. Don’t store it in the
  local catalog — while it is not a particularly expensive operation, it is still more expensive
  than a simple lookup. We really do care about minimizing any sort of computation when we
  are initializing packages, since we want the tool to be fast.

- display the data in ‘meteor show’. It makes sense to line wrap this with the ‘Exports:’ label as a
  bulletPoint (just look at the test to see an example where this improves user experience). Since we
  are doing that, we might as well use that bulletPoint functionality on the other labels as well.

There is also a test. Run ‘meteor self-test show’ to test, or run ‘meteor show’ on a local package
with exports.

The Troposphere counterpoint to this is: https://github.com/meteor/troposphere/pull/5