### PR TITLE
Add project root to less import paths

### DIFF
--- a/packages/less/plugin/compile-less.js
+++ b/packages/less/plugin/compile-less.js
@@ -12,7 +12,7 @@ Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileSte
     // we don't have to use Futures and (b) errors thrown by bugs in less
     // actually get caught.
     syncImport: true,
-    paths: [path.dirname(compileStep._fullInputPath)] // for @import
+    paths: [process.cwd(), path.dirname(compileStep._fullInputPath)] // for @import
   };
 
   var parser = new less.Parser(options);


### PR DESCRIPTION
Adding this enables the ability to import relative to the project rather than relative to each individual file. See brief discussion [here](https://github.com/Nemo64/meteor-bootstrap/issues/28#issuecomment-68387702)

It may be interesting to expose this Less setting through a configuration file such as the [fourseven:scss](https://github.com/fourseven/meteor-scss/blob/master/plugin/compile-scss.js#L26) package does through an `scss.json` file in the project root folder.