### PR TITLE
Make 'pretty: true' to the default for commands

### DIFF
--- a/tools/commands-cordova.js
+++ b/tools/commands-cordova.js
@@ -2846,7 +2846,6 @@ main.registerCommand({
   minArgs: 1,
   maxArgs: Infinity,
   requiresApp: true,
-  pretty: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   cordova.setVerboseness(options.verbose);
@@ -2975,7 +2974,6 @@ main.registerCommand({
 main.registerCommand({
   name: 'list-platforms',
   requiresApp: true,
-  pretty: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   var projectContext = new projectContextModule.ProjectContext({
@@ -3021,7 +3019,6 @@ main.registerCommand({
 
 main.registerCommand({
   name: 'android-launch',
-  pretty: true,
   options: {
     verbose: { type: Boolean, short: "v" }
   },
@@ -3063,7 +3060,6 @@ var openUrl = function (url) {
 
 main.registerCommand({
   name: 'install-sdk',
-  pretty: true,
   options: {
     verbose: { type: Boolean, short: "v" }
   },

--- a/tools/commands-packages.js
+++ b/tools/commands-packages.js
@@ -119,7 +119,6 @@ var formatArchitecture = function (s) {
 // whenever necessary!
 main.registerCommand({
   name: '--get-ready',
-  pretty: true,
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: false })
 }, function (options) {
   // If we're in an app, make sure that we can build the current app. Otherwise
@@ -162,7 +161,6 @@ main.registerCommand({
 // builds and downloads packages used by the current app.
 main.registerCommand({
   name: '--prepare-app',
-  pretty: true,
   requiresApp: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
@@ -182,7 +180,6 @@ main.registerCommand({
 
 main.registerCommand({
   name: 'publish',
-  pretty: true,
   minArgs: 0,
   maxArgs: 0,
   options: {
@@ -416,7 +413,6 @@ main.registerCommand({
   name: 'publish-for-arch',
   minArgs: 1,
   maxArgs: 1,
-  pretty: true,
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: false })
 }, function (options) {
   // argument processing
@@ -596,7 +592,6 @@ main.registerCommand({
     'create-track': { type: Boolean, required: false },
     'from-checkout': { type: Boolean, required: false }
   },
-  pretty: true,
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: false })
 }, function (options) {
   try {
@@ -1032,7 +1027,6 @@ main.registerCommand({
 
 main.registerCommand({
   name: 'show',
-  pretty: true,
   minArgs: 1,
   maxArgs: 1,
   options: {
@@ -1221,7 +1215,6 @@ main.registerCommand({
 
 main.registerCommand({
   name: 'search',
-  pretty: true,
   minArgs: 0, // So we can provide specific help
   maxArgs: 1,
   options: {
@@ -1377,7 +1370,6 @@ main.registerCommand({
 main.registerCommand({
   name: 'list',
   requiresApp: true,
-  pretty: true,
   options: {
   },
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: true })
@@ -1781,7 +1773,6 @@ main.registerCommand({
   requiresRelease: false,
   minArgs: 0,
   maxArgs: Infinity,
-  pretty: true,
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: true })
 }, function (options) {
   // If you are specifying packaging individually, you probably don't want to
@@ -1898,7 +1889,6 @@ main.registerCommand({
   minArgs: 1,
   maxArgs: 1,
   requiresApp: true,
-  pretty: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   var projectContext = new projectContextModule.ProjectContext({
@@ -1926,7 +1916,6 @@ main.registerCommand({
   minArgs: 1,
   maxArgs: Infinity,
   requiresApp: true,
-  pretty: true,
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: true })
 }, function (options) {
   var projectContext = new projectContextModule.ProjectContext({
@@ -2107,7 +2096,6 @@ main.registerCommand({
   minArgs: 1,
   maxArgs: Infinity,
   requiresApp: true,
-  pretty: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   var projectContext = new projectContextModule.ProjectContext({
@@ -2199,7 +2187,6 @@ main.registerCommand({
 
 main.registerCommand({
   name: 'refresh',
-  pretty: true,
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: false })
 }, function (options) {
   // We already did it!
@@ -2315,7 +2302,6 @@ main.registerCommand({
   minArgs: 2,
   maxArgs: 2,
   hidden: true,
-  pretty: true,
 
   // In this function, we want to use the official catalog everywhere, because
   // we assume that all packages have been published (along with the release

--- a/tools/commands.js
+++ b/tools/commands.js
@@ -82,6 +82,7 @@ var showInvalidArchMsg = function (arch) {
 main.registerCommand({
   name: '--arch',
   requiresRelease: false,
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   var archinfo = require('./archinfo.js');
@@ -96,6 +97,7 @@ main.registerCommand({
 main.registerCommand({
   name: '--version',
   requiresRelease: false,
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   if (release.current === null) {
@@ -121,6 +123,7 @@ main.registerCommand({
 main.registerCommand({
   name: '--long-version',
   requiresRelease: false,
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   if (files.inCheckout()) {
@@ -141,6 +144,7 @@ main.registerCommand({
 main.registerCommand({
   name: '--requires-release',
   requiresRelease: true,
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   return 0;
@@ -151,7 +155,6 @@ main.registerCommand({
 ///////////////////////////////////////////////////////////////////////////////
 
 var runCommandOptions = {
-  pretty: true,
   requiresApp: true,
   maxArgs: Infinity,
   options: {
@@ -376,6 +379,7 @@ main.registerCommand(_.extend(
 
 main.registerCommand({
   name: 'shell',
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   if (!options.appDir) {
@@ -401,7 +405,6 @@ main.registerCommand({
     example: { type: String },
     package: { type: Boolean }
   },
-  pretty: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
 
@@ -633,7 +636,6 @@ var buildCommands = {
     "mobile-port": { type: String },
     verbose: { type: Boolean, short: "v" }
   },
-  pretty: true,
   catalogRefresh: new catalog.Refresh.Never()
 };
 
@@ -871,6 +873,7 @@ main.registerCommand({
   requiresApp: function (options) {
     return options.args.length === 0;
   },
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   var mongoUrl;
@@ -981,7 +984,6 @@ main.registerCommand({
 
 main.registerCommand({
   name: 'deploy',
-  pretty: true,
   minArgs: 1,
   maxArgs: 1,
   options: {
@@ -1157,6 +1159,11 @@ main.registerCommand({
     remove: { type: String, short: "r" },
     list: { type: Boolean }
   },
+  pretty: function (options) {
+    // pretty if we're mutating; plain if we're listing (which is more likely to
+    // be used by scripts)
+    return options.add || options.remove;
+  },
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
 
@@ -1245,7 +1252,6 @@ main.registerCommand({
 main.registerCommand({
   name: 'test-packages',
   maxArgs: Infinity,
-  pretty: true,
   options: {
     port: { type: String, short: "p", default: DEFAULT_PORT },
     'http-proxy-port': { type: String },
@@ -1540,7 +1546,6 @@ main.registerCommand({
   name: 'rebuild',
   maxArgs: Infinity,
   hidden: true,
-  pretty: true,
   requiresApp: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
@@ -1596,7 +1601,8 @@ main.registerCommand({
 
 main.registerCommand({
   name: 'whoami',
-  catalogRefresh: new catalog.Refresh.Never()
+  catalogRefresh: new catalog.Refresh.Never(),
+  pretty: false
 }, function (options) {
   return auth.whoAmICommand(options);
 });
@@ -1632,6 +1638,7 @@ main.registerCommand({
   name: 'admin list-organizations',
   minArgs: 0,
   maxArgs: 0,
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
 
@@ -1686,6 +1693,11 @@ main.registerCommand({
     add: { type: String },
     remove: { type: String },
     list: { type: Boolean }
+  },
+  pretty: function (options) {
+    // pretty if we're mutating; plain if we're listing (which is more likely to
+    // be used by scripts)
+    return options.add || options.remove;
   },
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
@@ -1842,6 +1854,7 @@ main.registerCommand({
   name: 'list-sites',
   minArgs: 0,
   maxArgs: 0,
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   auth.pollForRegistrationCompletion();
@@ -1871,6 +1884,7 @@ main.registerCommand({
     // 15. (MDG can reserve machines for longer than that.)
     minutes: { type: Number, required: false }
   },
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
 
@@ -1999,6 +2013,7 @@ main.registerCommand({
   },
   maxArgs: 2,
   hidden: true,
+  pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   var p = function (key) {


### PR DESCRIPTION
It was already set for most common commands, and was unnecessarily not
set for others.

The following commands are remaining "pretty: false":

- Commands that just print machine-parseable text: --version, --arch,
  admin members (without --add or --remove), mongo --url,
  authorized (without --add or --remove), whoami, list-organizations, list-sites
- Commands that just switch over to another codebase's interactive
  command: mongo without --url, admin get-machine, shell

The following commands used to be implicitly "pretty: false" and now
will be pretty:

- A bunch of troposphere admin commands: set-banners, recommend-release,
  change-homepage, set-unmigrated, set-latest-readme
- A few accounts/deploy related commands: logs, claim, login, logout
- remove-platform, reset, self-test
- admin maintainers (which unlike admin members and authorized prints an
  English header before the user list; maybe this is a mistake)

Fixes #3162.