### PR TITLE
Use per-message websocket compression

### DIFF
--- a/packages/ddp/.npm/package/npm-shrinkwrap.json
+++ b/packages/ddp/.npm/package/npm-shrinkwrap.json
@@ -1,18 +1,26 @@
 {
   "dependencies": {
     "faye-websocket": {
-      "version": "0.8.1",
+      "version": "0.9.2",
       "dependencies": {
         "websocket-driver": {
-          "version": "0.4.0"
+          "version": "0.5.1",
+          "dependencies": {
+            "websocket-extensions": {
+              "version": "0.1.0"
+            }
+          }
         }
       }
     },
+    "permessage-deflate": {
+      "version": "0.1.2"
+    },
     "sockjs": {
-      "version": "0.3.11",
+      "version": "0.3.12",
       "dependencies": {
         "node-uuid": {
-          "version": "1.4.1"
+          "version": "1.4.2"
         }
       }
     }

--- a/packages/ddp/package.js
+++ b/packages/ddp/package.js
@@ -12,8 +12,9 @@ Package.describe({
 // will prevent a second copy of faye-websocket from being installed inside
 // sockjs.)
 Npm.depends({
-  "faye-websocket": "0.8.1",
-  sockjs: "0.3.11"
+  "faye-websocket": "0.9.2",
+  "permessage-deflate": "0.1.2",
+  sockjs: "0.3.12"
 });
 
 Package.onUse(function (api) {

--- a/packages/ddp/stream_client_nodejs.js
+++ b/packages/ddp/stream_client_nodejs.js
@@ -130,9 +130,13 @@ _.extend(LivedataTest.ClientStream.prototype, {
     // require the module if we actually create a server-to-server
     // connection.
     var FayeWebSocket = Npm.require('faye-websocket');
+    var deflate = Npm.require('permessage-deflate');
 
     var targetUrl = toWebsocketUrl(self.endpoint);
-    var fayeOptions = { headers: self.headers };
+    var fayeOptions = {
+      headers: self.headers,
+      extensions: [deflate]
+    };
     var proxyUrl = self._getProxyUrl(targetUrl);
     if (proxyUrl) {
       fayeOptions.proxy = { origin: proxyUrl };


### PR DESCRIPTION
By default, we attempt to use this for every websocket message on both
client and server.

On the server, we provide the SERVER_WEBSOCKET_COMPRESSION environment
variable to control compression. If $SERVER_WEBSOCKET_COMPRESSION is
set, then it must be valid JSON. If it represents a falsey value, then
we do not use permessage-deflate at all; otherwise, the JSON value is
used as an argument to deflate's configure method; see
https://github.com/faye/permessage-deflate-node/blob/master/README.md

We do not provide a way to use it only on some messages. The underlying
spec allows this but permessage-deflate does not; see
https://github.com/faye/permessage-deflate-node/issues/2

We do not provide a mechanism to control compression parameters on the
client side.  The assumption is that the common reason to care about
compression parameters is to control server per-connection memory
usage. (The noContextTakeover configuration parameter should save some
memory and still allow for some compression, for example.)