### PR TITLE
enable meteor show w/o arguments

### DIFF
--- a/tools/commands-packages-query.js
+++ b/tools/commands-packages-query.js
@@ -1082,11 +1082,12 @@ main.registerCommand({
       );
       process.exit(1);
     }
+    // Use the projectContext to get the name of the package.
     var currentVersion =
           projectContext.localCatalog.getVersionBySourceRoot(options.packageDir);
     name = currentVersion.packageName;
-    version = currentVersion.version;
-    fullName = name + "@" + version;
+    version = "local";
+    fullName = name + "@local";
   }
   var query = null;
 

--- a/tools/commands-packages-query.js
+++ b/tools/commands-packages-query.js
@@ -1042,7 +1042,7 @@ _.extend(ReleaseQuery.prototype, {
 main.registerCommand({
   name: 'show',
   pretty: true,
-  minArgs: 1,
+  minArgs: 0,
   maxArgs: 1,
   usesPackage: true,
   options: {
@@ -1053,21 +1053,42 @@ main.registerCommand({
     new catalog.Refresh.OnceAtStart(
         { maxAge: DEFAULT_MAX_AGE_MS, ignoreErrors: true })
 }, function (options) {
-  // The foo@bar API means that we have to do some string parsing to figure out
-  // if we want a particular version.
-  var itemName = options.args[0];
-  var splitArgs = itemName.split('@');
-  var name = splitArgs[0];
-  var version = (splitArgs.length > 1) ? splitArgs[1] : null;
-  if (splitArgs.length > 2) {
-    Console.error("Invalid request format: " + itemName);
-    process.exit(1);
-  }
-  var query = null;
-
+  var fullName;
+  var name;
+  var version;
   // Because of the new projectContext interface, we need to initialize the
   // project context in order to load the local catalog. This is not ideal.
   var projectContext = getTempContext(options);
+
+  // If the user specified a query, process it.
+  if (! _.isEmpty(options.args)) {
+    // The foo@bar API means that we have to do some string parsing to figure out
+    // if we want a particular version.
+    fullName = options.args[0];
+    var splitArgs = fullName.split('@');
+    name = splitArgs[0];
+    version = (splitArgs.length > 1) ? splitArgs[1] : null;
+    if (splitArgs.length > 2) {
+      Console.error("Invalid request format: " + fullName);
+      process.exit(1);
+    }
+  } else {
+    if (! options.packageDir) {
+      // Letting the user run 'meteor show' without arguments from a package
+      // directory is a pleasant shortcut, but the default should be specifying
+      // a query.
+      Console.error(
+        "Please specify a package or release name to show information about it."
+      );
+      process.exit(1);
+    }
+    var currentVersion =
+          projectContext.localCatalog.getVersionBySourceRoot(options.packageDir);
+    name = currentVersion.packageName;
+    version = currentVersion.version;
+    fullName = name + "@" + version;
+  }
+  var query = null;
 
   // First, we need to figure out if we are dealing with a package, or a
   // release. We don't want to rely on capitalization conventions, so we will
@@ -1107,7 +1128,7 @@ main.registerCommand({
   // couldn't gather any data about our request, then the item that we are
   // looking for does not exist.
   if (! query || ! query.data) {
-    return itemNotFound(itemName);
+    return itemNotFound(fullName);
   }
 
   query.print({ ejson: !! options.ejson });

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -679,10 +679,16 @@ Options:
 Show detailed information about a release or package.
 Usage: meteor show <name> [--show-all] [--ejson]
        meteor show <name@version> [--ejson]
+       meteor show [--ejson]
 
 Show detailed information on a specific package or release, including
 a list of available versions. Use <name>@<version> to get more information
 about a specific version of a package or release.
+
+Meteor show works on packages built locally from source, as well as remote
+packages stored on the server. Use '<name>@local' to see information from a
+local version. Running from a package source directory with no arguments will
+show information for that package version.
 
 By default, Meteor will not show more than five versions, and will not
 show experimental release versions. Meteor will also hide packages that

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -1249,6 +1249,16 @@ selftest.define("show and search local overrides server",
     run.waitSecs(15);
     run.match(summary);
     run.expectExit(0);
+
+    // Test that running without any arguments still gives us the local version.
+    run = s.run("show");
+    run.match("Package: " + fullPackageName + "\n");
+    run.match("Version: " + "1.0.0" + "\n");
+    run.match("Summary: " + summary + "\n");
+    run.match("Directory:\n" + packageDir + "\n");
+    run.read("\n" + summary + "\n\n");
+    run.read("\n" + addendum + "\n");
+    run.expectEnd(0);
   });
 
   // When we run outside of the package directory, we do not see the local

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -1130,8 +1130,20 @@ selftest.define("show local package w/o version",  function () {
       version: "local",
       directory: packageDir
     });
+
+    // Test that running without any arguments also shows this package.
+    var run = s.run("show");
+    run.match("Package: " + name + "\n");
+    run.match("Version: " + "local"  + "\n");
+    run.match("Directory:\n" + packageDir + "\n");
+    run.expectExit(0);
   });
 
+  // Test that running without any arguments outside of a package does not
+  // work.
+  var run = s.run("show");
+  run.matchErr("specify a package or release name");
+  run.expectExit(1);
 });
 
 // Return a formatted string of today’s date.


### PR DESCRIPTION
This is a thing that I wanted to try -- running 'meteor show' in a
package directory shows you that version's data.
- You might want to run 'meteor show' to get export or dependency
  information on a local package, instead of looking through the
  package.js file.

- Before publishing your package, or updating its metadata, you might
  want to make really sure that its longform description looks good
  in 'meteor show'. Hopefully it does! I would want to check.

Running 'meteor show <name>@local' from a package directory feels
slightly janky to me.
- Other commands in the publiction workflow read 'package.js' to figure
  out your package name. It feels weird to type it out.
- Many package names don't correspond to the directory name. It is good
  to help the user spend less time inspecting package.js files for
  obvious information.

This has bothered me a lot during testing, which is not a normal workflow.
I might be somewhat biased here, in a way that normal users would not be.

There is a minor inefficiency around retrieving a local version record twice,
but I think that it is worth it for code simplicity/readability/etc.