### PR TITLE
FIX for live CSS reload when using ROOT_URL

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -127,7 +127,7 @@ Autoupdate._retrySubscription = function () {
                 newLink.setAttribute("rel", "stylesheet");
                 newLink.setAttribute("type", "text/css");
                 newLink.setAttribute("class", "__meteor-css__");
-                newLink.setAttribute("href", css.url);
+                newLink.setAttribute("href", Meteor.absoluteUrl(css.url));
                 attachStylesheetLink(newLink);
               });
             } else {


### PR DESCRIPTION
When using ROOT_URL the live css reload breaks. This simple fix resolves that issue.