### PR TITLE
Let `Meteor.call` within `observe` call server methods.

### DIFF
--- a/packages/minimongo/call_in_observe_test.js
+++ b/packages/minimongo/call_in_observe_test.js
@@ -1,0 +1,34 @@
+// This file is a regression test for https://github.com/meteor/meteor/issues/907
+
+Meteor.methods({
+  isRunningOnServer: function () {
+    return Meteor.isServer;
+  },
+  insertIntoLocalCollection: function () {
+    if (Meteor.isClient) {
+      LocalCollection.insert({});
+    }
+  }
+});
+
+if (Meteor.isClient) {
+  var LocalCollection = new Meteor.Collection(null);
+
+  testAsyncMulti("Meteor.call inside observe sends method to server", [
+    function (test, expect) {
+      var done = expect();
+
+      LocalCollection.find().observe({
+        added: function () {
+          Meteor.call("isRunningOnServer", function (err, res) {
+            test.equal(err, undefined);
+            test.equal(res, true);
+            done();
+          });
+        }
+      });
+
+      Meteor.call("insertIntoLocalCollection");
+    }
+  ]);
+}

--- a/packages/minimongo/package.js
+++ b/packages/minimongo/package.js
@@ -38,9 +38,11 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   api.use('minimongo', ['client', 'server']);
   api.use('test-helpers', 'client');
+  api.use('ddp'); // for testing interaction between `Meteor.call` and `observe`
   api.use(['tinytest', 'underscore', 'ejson', 'ordered-dict',
            'random', 'tracker', 'reactive-var', 'mongo-id']);
   api.addFiles('minimongo_tests.js', 'client');
   api.addFiles('wrap_transform_tests.js');
   api.addFiles('minimongo_server_tests.js', 'server');
+  api.addFiles('call_in_observe_test.js');
 });


### PR DESCRIPTION
Since `observe` callbacks fire synchronously, before this change,
then if you run a method on the client that leads to an observe
callback firing, and in that observe callback you call `Meteor.call`,
it would act the same as when you call `Meteor.call` within a method
stub -- that is, it would call the method stub but not send the
method invocation to the server.
