### PR TITLE
Allow METEOR_SETTINGS to be used as fallback if no --settings command line option is given

### DIFF
--- a/tools/run-app.js
+++ b/tools/run-app.js
@@ -175,8 +175,6 @@ _.extend(AppProcess.prototype, {
     }
     if (self.settings) {
       env.METEOR_SETTINGS = self.settings;
-    } else {
-      delete env.METEOR_SETTINGS;
     }
     if (self.listenHost) {
       env.BIND_IP = self.listenHost;


### PR DESCRIPTION
As several (false) bug reports and SO questions are suggesting, it is
not clear why setting up the environment of a meteor application differs
greatly in a typical development scenario versus the bundled production
deployment scenario.

Formerly it was possible to pass METEOR_SETTINGS as environment variable
to not only the bundled application, but also to `meteor run`.

This was reverted in the following commit:
https://github.com/meteor/meteor/commit/24682fd7f44

I don't know if that was intentional, but I strongly propose to
re-enable this behaviour. This is what this commit is about.

The benefits would be:

- The --settings command-line option still has precedence, but
  METEOR_SETTINGS environment variable may act as fallback

- It allows to have one way of dealing with application specific
  configuration values, regardless of the environment
  (production/staging/development)

Example:

     $ export METEOR_SETTINGS="$(cat dev-settings.json)"

When modifying the name of the settings file appropriately,
this approach can be used in all environments.