### PR TITLE
show implied packages

### DIFF
--- a/tools/tests/packages/package-for-show/package-with-implies.js
+++ b/tools/tests/packages/package-for-show/package-with-implies.js
@@ -1,0 +1,15 @@
+Package.describe({
+  summary: 'This is a test package',
+  version: '1.2.1',
+  git: 'www.github.com/meteor/meteor'
+});
+
+Package.onUse(function(api) {
+  api.imply("~A~@1.0.0");
+  api.imply("~B~@1.0.0", 'server');
+  api.imply("~C~@1.0.0", 'client');
+  api.imply("~D~@1.0.0", 'web.browser');
+  api.imply("~E~@1.0.0", 'web.cordova');
+  api.imply("~G~@1.0.0", 'web.cordova');
+  api.imply("~G~@1.0.0", 'server');
+});


### PR DESCRIPTION
In 'meteor show', display the list of packages implied by a package/version.

Implied exports are part of the package's exports, especially for an umbrealla
package like 'meteor-platform' or 'cfs:standard-packages'. However, we can't
tell you the exact exports (ex: "Mongo") without running the constraint solver
(because we don't know what version of the implied package you will end up with).

Showing implies also makes umbrella packages like 'meteor-platform' and
'cfs:standard-packages' more obvious -- the user can tell what is going on with the
package much better.