### PR TITLE
using Meteor._relativeToSiteRootUrl for CSS reload

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -127,10 +127,7 @@ Autoupdate._retrySubscription = function () {
                 newLink.setAttribute("rel", "stylesheet");
                 newLink.setAttribute("type", "text/css");
                 newLink.setAttribute("class", "__meteor-css__");
-                newLink.setAttribute(
-                  "href",
-                  (__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || "")
-                    + css.url);
+                newLink.setAttribute("href", Meteor._relativeToSiteRootUrl(css.url));
                 attachStylesheetLink(newLink);
               });
             } else {


### PR DESCRIPTION
Fixing the same problem as #3111 and #3450, just this one is implemented using `Meteor._relativeToSiteRootUrl`

The problem I see with using `Meteor.absoluteUrl` is that we have to think about `https` vs `http` and using `127.0.0.1` vs `localhost` b/c it's an absolute url, rather than a relative one.