### PR TITLE
Change Meteor.absoluteUrl to strip query strings

### DIFF
--- a/packages/meteor/url_common.js
+++ b/packages/meteor/url_common.js
@@ -20,6 +20,12 @@ Meteor.absoluteUrl = function (path, options) {
   if (!url)
     throw new Error("Must pass options.rootUrl or set ROOT_URL in the server environment");
 
+  // Remove query string from url, if any
+  var queryIndex = url.indexOf('?');
+  if (queryIndex >= 0) {
+    url = url.substring(0, queryIndex);
+  }
+
   if (!/^http[s]?:\/\//i.test(url)) // url starts with 'http://' or 'https://'
     url = 'http://' + url; // we will later fix to https if options.secure is set
 

--- a/packages/meteor/url_tests.js
+++ b/packages/meteor/url_tests.js
@@ -59,6 +59,10 @@ Tinytest.add("absolute-url - basics", function(test) {
     test.equal(Meteor.absoluteUrl('foo', {rootUrl: prefix + 'foo.localhost.com',
                                           replaceLocalhost: true}),
                'http://foo.localhost.com/foo');
+
+    // Test appending to a root URL that contains a query string
+    test.equal(Meteor.absoluteUrl('foo', {rootUrl: prefix + 'asdf.com/?mocha=true'}),
+               'http://asdf.com/foo');
   });
 });
 


### PR DESCRIPTION
Change Meteor.relativeUrl function to string query strings from the root URL.

In particular, this fixes an issue with using Meteor.relativeUrl in Mocha Velocity tests as the root url gets ?mocha=true appended to it in the mirror server.