### PR TITLE
Add SMTP envelope to Email

### DIFF
--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -70,7 +70,6 @@ EmailTest.restoreOutputStream = function () {
 
 var devModeSend = function (mc) {
   var devmode_mail_id = next_devmode_mail_id++;
-
   var stream = output_stream;
 
   // This approach does not prevent other writers to stdout from interleaving.
@@ -137,6 +136,7 @@ EmailTest.hookSend = function (f) {
  * @param {String} [options.subject]  "Subject:" line
  * @param {String} [options.text|html] Mail body (in plain text or HTML)
  * @param {Object} [options.headers] Dictionary of custom headers
+ * @param {String} [options.envelope] SMTP envelope
  */
 Email.send = function (options) {
   for (var i = 0; i < sendHooks.length; i++)
@@ -145,10 +145,7 @@ Email.send = function (options) {
 
   var mc = new MailComposer();
 
-  // setup message data
-  // XXX support attachments (once we have a client/server-compatible binary
-  //     Buffer class)
-  mc.setMessageOption({
+  var messageOption = {
     from: options.from,
     to: options.to,
     cc: options.cc,
@@ -157,7 +154,16 @@ Email.send = function (options) {
     subject: options.subject,
     text: options.text,
     html: options.html
-  });
+  };
+
+  if (_.has(options, "envelope")) {
+    messageOption.envelope = options.envelope;
+  }
+
+  // setup message data
+  // XXX support attachments (once we have a client/server-compatible binary
+  //     Buffer class)
+  mc.setMessageOption(messageOption);
 
   _.each(options.headers, function (value, name) {
     mc.addHeader(name, value);

--- a/packages/email/email_tests.js
+++ b/packages/email/email_tests.js
@@ -8,6 +8,7 @@ Tinytest.add("email - dev mode smoke test", function (test) {
     var stream = new streamBuffers.WritableStreamBuffer;
     EmailTest.overrideOutputStream(stream);
     Email.send({
+      envelope: {'from': 'somefoo@example.com'},
       from: "foo@example.com",
       to: "bar@example.com",
       cc: ["friends@example.com", "enemies@example.com"],


### PR DESCRIPTION
This little one fix the #3388. Note: I can't test the envelope created, cause Email doesn't have an exposed method to access MailComposer.getEnvelope() and it is used internally in SMTP client. I just add it to test to make sure it doesn't impact actual behavior
