### PR TITLE
Make tool compatible with both old and new OAuth servers

### DIFF
--- a/packages/oauth/oauth_common.js
+++ b/packages/oauth/oauth_common.js
@@ -6,6 +6,8 @@ OAuth._redirectUri = function (serviceName, config, params, absoluteUrlOptions) 
   // detect whether we need to be backwards compatible by checking for
   // the absence of the `loginStyle` field, which wasn't used in the
   // code which had the "?close" argument.
+  // This logic is duplicated in the tool so that the tool can do OAuth
+  // flow with <= 0.9.0 servers (tools/auth.js).
   var query = config.loginStyle ? null : "close";
 
   // Clone because we're going to mutate 'params'. The 'cordova' and

--- a/tools/auth.js
+++ b/tools/auth.js
@@ -1120,7 +1120,23 @@ exports.loginWithTokenOrOAuth = function (conn, accountsConfiguration,
 
   // Either we didn't have an existing token, or it didn't work. Do an
   // OAuth flow to log in.
-  var redirectUri = url + '/_oauth/meteor-developer?close';
+  var redirectUri = url + '/_oauth/meteor-developer';
+
+  // Duplicate login from packages/oauth/oauth_common.js. If we are
+  // authenticating against a <=0.9.0 app server, then the app server
+  // uses a redirect URL with a "?close" query parameter, and we have to
+  // match the server's redirect URL. After 0.9.0, we deprecated the
+  // "?close" query parameter, so >0.9.0 app servers will use a redirect
+  // URL with no query parameters. The app server uses the presence of
+  // the 'loginStyle' configuration option to decide whether its
+  // configuration is new-style or old-style, so we use that option here
+  // to match the server's redirect URL.
+  //
+  // tl;dr this code is for compatibility with app servers that did
+  // their oauth configuration with <= 0.9.0.
+  if (! accountsConfiguration.loginStyle) {
+    redirectUri = redirectUri + "?close";
+  }
   loginResult = oauthFlow(conn, {
     clientId: clientId,
     redirectUri: redirectUri,

--- a/tools/auth.js
+++ b/tools/auth.js
@@ -1123,17 +1123,17 @@ exports.loginWithTokenOrOAuth = function (conn, accountsConfiguration,
   var redirectUri = url + '/_oauth/meteor-developer';
 
   // Duplicate logic from packages/oauth/oauth_common.js. If we are
-  // authenticating against a <=0.9.0 app server, then the app server
+  // authenticating against a <0.9.2 app server, then the app server
   // uses a redirect URL with a "?close" query parameter, and we have to
-  // match the server's redirect URL. After 0.9.0, we deprecated the
-  // "?close" query parameter, so >0.9.0 app servers will use a redirect
+  // match the server's redirect URL. After 0.9.2, we deprecated the
+  // "?close" query parameter, so >0.9.2 app servers will use a redirect
   // URL with no query parameters. The app server uses the presence of
   // the 'loginStyle' configuration option to decide whether its
   // configuration is new-style or old-style, so we use that option here
   // to match the server's redirect URL.
   //
   // In other words: this code is for compatibility with app servers
-  // that did their oauth configuration with <= 0.9.0.
+  // that did their oauth configuration with <0.9.2.
   if (! accountsConfiguration.loginStyle) {
     redirectUri = redirectUri + "?close";
   }

--- a/tools/auth.js
+++ b/tools/auth.js
@@ -1122,7 +1122,7 @@ exports.loginWithTokenOrOAuth = function (conn, accountsConfiguration,
   // OAuth flow to log in.
   var redirectUri = url + '/_oauth/meteor-developer';
 
-  // Duplicate login from packages/oauth/oauth_common.js. If we are
+  // Duplicate logic from packages/oauth/oauth_common.js. If we are
   // authenticating against a <=0.9.0 app server, then the app server
   // uses a redirect URL with a "?close" query parameter, and we have to
   // match the server's redirect URL. After 0.9.0, we deprecated the
@@ -1132,8 +1132,8 @@ exports.loginWithTokenOrOAuth = function (conn, accountsConfiguration,
   // configuration is new-style or old-style, so we use that option here
   // to match the server's redirect URL.
   //
-  // tl;dr this code is for compatibility with app servers that did
-  // their oauth configuration with <= 0.9.0.
+  // In other words: this code is for compatibility with app servers
+  // that did their oauth configuration with <= 0.9.0.
   if (! accountsConfiguration.loginStyle) {
     redirectUri = redirectUri + "?close";
   }


### PR DESCRIPTION
@Slava I can't remember if this was ever officially reviewed -- can you look at it? This is the tool change (already on the windows branch) that makes it so that new OAuth apps don't have to have "?close" in order for the tool to talk to them. Tested manually against a local package server with old- and new-style configuration.

Also @Slava I can't figure out how to add you to phabricator :(