### PR TITLE
Clarified load order in docs. Fixes #3431

### DIFF
--- a/docs/client/full-api/concepts.html
+++ b/docs/client/full-api/concepts.html
@@ -185,34 +185,41 @@ in a real app could go.
 
 ### File Load Order
 
-It is best to write your application in such a way that it is insensitive to the
-order in which files are loaded, for example by using
-[Meteor.startup](#meteor_startup), or by moving load order sensitive code into
-[packages](#usingpackages), which can explicitly control both the load order of
-their contents and their load order with respect to other packages. However
-sometimes load order dependencies in your application are unavoidable.
+It is best to write your application in such a way that it is insensitive to
+the order in which files are loaded, for example by using [Meteor.startup](#meteor_startup),
+or by moving load order sensitive code into [packages](#usingpackages),
+which can explicitly control both the load order of their contents and their
+load order with respect to other packages. However, sometimes load order
+dependencies in your application are unavoidable.
 
-When not using special filenames and directories:
+There are several load ordering rules. They are *applied sequentially* to all
+applicable files in the application, in the priority given below:
 
-- Files in subdirectories are loaded before files in parent directories, so that
-files in the deepest subdirectory are loaded first, and files in the root
-directory are loaded last. - Within a directory, files are loaded in
-alphabetical order by filename.
+1. HTML template files are *always* loaded before everything else
+2. Files beginning with `main.` are loaded last
+3. Files inside *any* `/lib/` directory are loaded next
+4. Files with deeper paths are loaded next
+5. Files are then loaded in alphabetical order of the entire path
 
-Below is a complete list of special file and directory names that control file
-load order:
+```js
+nav.html
+main.html
+/client/lib/methods.js
+/client/lib/styles.js
+/lib/feature/styles.js
+/lib/collections.js
+/client/main.js
+```
 
-- **lib**
+For example, the files above are arranged in the correct load order.
+`main.html` is loaded second because HTML templates are always loaded first,
+even if it begins with `main.`, since rule 1 has priority over rule 2.
+However, it will be loaded after `nav.html` because rule 2 has priority over
+rule 5.
 
-    After sorting as described above, all files under directories named `lib`
-    are moved before everything else, preserving their order.
-
-- **main.***
-
-    All files that match `main.*` are moved after everything else, preserving
-    their order.
-
-
+`/client/lib/styles.js` and `/lib/feature/styles.js` have identical load order
+up to rule 4, however, since `client` comes before `lib`alphabetically,
+it will be loaded first.
 
 ### Organizing Your Project
 


### PR DESCRIPTION
In the current documentation, there's no mention of loading template files first, and 'preserving their order' is confusing. I devised a list of rules which is based on `meteor/tools/package-source.js`. I hope it makes the load order much more straight-forward.

This appears to be a common issue, since there are several questions on SO, most prominently https://stackoverflow.com/questions/10693113/ and http://stackoverflow.com/questions/22260038/