### PR TITLE
Don't limit test helpers only to tests

### DIFF
--- a/packages/test-helpers/package.js
+++ b/packages/test-helpers/package.js
@@ -22,7 +22,7 @@ Package.onUse(function (api) {
     'focusElement', 'simulateEvent', 'getStyleProperty', 'canonicalizeHtml',
     'renderToDiv',
     'withCallbackLogger', 'testAsyncMulti', 'simplePoll',
-    'makeTestConnection', 'DomUtils'], {testOnly: true});
+    'makeTestConnection', 'DomUtils']);
 
   api.addFiles('try_all_permutations.js');
   api.addFiles('async_multi.js');


### PR DESCRIPTION
This allows other packages to extend/wrap existing test helpers (like `testAsyncMulti`).