### PR TITLE
Update outdated README.md

### DIFF
--- a/packages/reactive-dict/README.md
+++ b/packages/reactive-dict/README.md
@@ -5,7 +5,7 @@ datatype for use with
 [tracker](https://atmospherejs.com/meteor/tracker). It provides all of
 the functionality of the `Session` object documented in the [main
 Meteor docs](https://docs.meteor.com/#session), such as reactive
-`get`, `set`, and `equals` functions, except that its contents are not
+`get`, `set`, and `equals` functions, which contents are
 saved across Hot Code Push client code updates.
 
 Example usage:


### PR DESCRIPTION
ReactiveDict's have been able to migrate since: https://github.com/meteor/meteor/commit/624035fab8fb27b1d4f5d884518d92dd3d52e5e0

See [session](https://github.com/meteor/meteor/blob/devel/packages/session/session.js) as an example.