### PR TITLE
Fix packages on Object.prototype extension

### DIFF
--- a/packages/blaze-tools/tojs.js
+++ b/packages/blaze-tools/tojs.js
@@ -140,6 +140,8 @@ ToJSVisitor.def({
 
     var kvStrs = [];
     for (var k in attrsDict) {
+      if (! attrsDict.hasOwnProperty(k))
+        continue;
       if (! HTML.isNully(attrsDict[k]))
         kvStrs.push(toObjectLiteralKey(k) + ': ' +
                     this.visit(attrsDict[k]));

--- a/packages/htmljs/visitors.js
+++ b/packages/htmljs/visitors.js
@@ -165,6 +165,8 @@ HTML.TransformingVisitor.def({
       var attrArgs = [null, null];
       attrArgs.push.apply(attrArgs, arguments);
       for (var k in oldAttrs) {
+        if (! _hasOwnProperty.call(oldAttrs, k))
+          continue;
         var oldValue = oldAttrs[k];
         attrArgs[0] = k;
         attrArgs[1] = oldValue;

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -559,8 +559,7 @@ LocalCollection.prototype.insert = function (doc, callback) {
 
   var queriesToRecompute = [];
   // trigger live queries that match
-  for (var qid in self.queries) {
-    var query = self.queries[qid];
+  _.each(self.queries, function (query, qid) {
     var matchResult = query.matcher.documentMatches(doc);
     if (matchResult.result) {
       if (query.distances && matchResult.distance !== undefined)
@@ -570,7 +569,7 @@ LocalCollection.prototype.insert = function (doc, callback) {
       else
         LocalCollection._insertInResults(query, doc);
     }
-  }
+  });
 
   _.each(queriesToRecompute, function (qid) {
     if (self.queries[qid])
@@ -821,8 +820,7 @@ LocalCollection.prototype._modifyAndNotify = function (
   var self = this;
 
   var matched_before = {};
-  for (var qid in self.queries) {
-    var query = self.queries[qid];
+  _.each(self.queries, function (query, qid) {
     if (query.ordered) {
       matched_before[qid] = query.matcher.documentMatches(doc).result;
     } else {
@@ -830,14 +828,13 @@ LocalCollection.prototype._modifyAndNotify = function (
       // can just do a direct lookup.
       matched_before[qid] = query.results.has(doc._id);
     }
-  }
+  });
 
   var old_doc = EJSON.clone(doc);
 
   LocalCollection._modify(doc, mod, {arrayIndices: arrayIndices});
 
-  for (qid in self.queries) {
-    query = self.queries[qid];
+  _.each(self.queries, function (query, qid) {
     var before = matched_before[qid];
     var afterMatch = query.matcher.documentMatches(doc);
     var after = afterMatch.result;
@@ -861,7 +858,7 @@ LocalCollection.prototype._modifyAndNotify = function (
     } else if (before && after) {
       LocalCollection._updateInResults(query, doc, old_doc);
     }
-  }
+  });
 };
 
 // XXX the sorted-query logic below is laughably inefficient. we'll
@@ -1048,19 +1045,18 @@ LocalCollection.prototype._saveOriginal = function (id, doc) {
 // Pause the observers. No callbacks from observers will fire until
 // 'resumeObservers' is called.
 LocalCollection.prototype.pauseObservers = function () {
+  var self = this;
   // No-op if already paused.
   if (this.paused)
     return;
 
   // Set the 'paused' flag such that new observer messages don't fire.
-  this.paused = true;
+  self.paused = true;
 
   // Take a snapshot of the query results for each query.
-  for (var qid in this.queries) {
-    var query = this.queries[qid];
-
+  _.each(self.queries, function (query) {
     query.resultsSnapshot = EJSON.clone(query.results);
-  }
+  });
 };
 
 // Resume the observers. Observers immediately receive change
@@ -1077,15 +1073,14 @@ LocalCollection.prototype.resumeObservers = function () {
   // observer methods won't actually fire when we trigger them.
   this.paused = false;
 
-  for (var qid in this.queries) {
-    var query = self.queries[qid];
+  _.each(self.queries, function (query) {
     // Diff the current results against the snapshot and send to observers.
     // pass the query object for its observer callbacks.
     LocalCollection._diffQueryChanges(
       query.ordered, query.resultsSnapshot, query.results, query,
       { projectionFn: query.projectionFn });
     query.resultsSnapshot = null;
-  }
+  });
   self._observeQueue.drain();
 };
 

--- a/packages/tinytest/extend_object_prototype.js
+++ b/packages/tinytest/extend_object_prototype.js
@@ -1,0 +1,14 @@
+// While it's not great style to add things to Object.prototype, users sometimes
+// do so. So we should be careful to always use _.each or equivalent methods
+// when iterating over objects. This will help us catch such issues.
+//
+// Add a random property to the Object prototype. This helps us catch
+// failures caused by iterating incorrectly over keys in an
+// object. (See https://github.com/meteor/meteor/issues/3478)
+//
+// Here are some answers for correctly iterating over keys in an
+// object:
+// http://stackoverflow.com/questions/684672/loop-through-javascript-object
+
+Object.prototype.extendedObjectPrototype = function extendedObjectPrototype () {
+};

--- a/packages/tinytest/package.js
+++ b/packages/tinytest/package.js
@@ -17,6 +17,7 @@ Package.onUse(function (api) {
   api.addFiles('model.js');
   api.addFiles('tinytest_client.js', 'client');
   api.addFiles('tinytest_server.js', 'server');
+  api.addFiles('extend_object_prototype.js');
 
   api.export('Tinytest');
 });


### PR DESCRIPTION
**THIS PR IS INCOMPLETE**.  If somebody extends it to something where you can run `meteor test-packages` and see it pass, that would be great!

Adding things to Object.prototype isn't great style, but users sometimes
do it.  Most of Meteor does fine with this because we mostly use
`_.each` and friends for loops, which skip over unowned properties. But
some pieces of Meteor don't do this.

In order to help us fix this, we add a method to Object.prototype
whenever you use tinytest.

XXX This commit does not completely work! `meteor test-packages` still
fails to work.  More changes like it are required.

Fixes #3478.