### PR TITLE
Support for Facebook login from mobile

### DIFF
--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -50,18 +50,7 @@ var getTokenResponse = function (query) {
   try {
     // Request an access token, or request access token info if it was already given
     if (query.accessToken) {
-      var response = HTTP.get(
-        "https://graph.facebook.com/debug_token", {
-          params: {
-            client_id: config.appId,
-            redirect_uri: OAuth._redirectUri('facebook', config),
-            client_secret: OAuth.openSecret(config.secret),
-            input_token: query.accessToken,
-            access_token: query.accessToken
-          }
-        }).content;
-      response = JSON.parse(response);
-      responseContent = "access_token=" + query.accessToken + "&expires=" +
+      responseContent = "access_token=" + query.accessToken + "&expires=5184000000";
         (response.data.expires_at - response.data.issued_at);
     } else {
       responseContent = HTTP.get(

--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -50,7 +50,7 @@ var getTokenResponse = function (query) {
   try {
     // Request an access token, or request access token info if it was already given
     if (query.accessToken) {
-      responseContent = "access_token=" + query.accessToken + "&expires=5184000000";
+      responseContent = "access_token=" + query.accessToken + "&expires=5184000";
     } else {
       responseContent = HTTP.get(
         "https://graph.facebook.com/oauth/access_token", {

--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -51,7 +51,6 @@ var getTokenResponse = function (query) {
     // Request an access token, or request access token info if it was already given
     if (query.accessToken) {
       responseContent = "access_token=" + query.accessToken + "&expires=5184000000";
-        (response.data.expires_at - response.data.issued_at);
     } else {
       responseContent = HTTP.get(
         "https://graph.facebook.com/oauth/access_token", {

--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -4,7 +4,6 @@ var querystring = Npm.require('querystring');
 
 
 OAuth.registerService('facebook', 2, null, function(query) {
-  
 
   var response = getTokenResponse(query);
   var accessToken = response.accessToken;
@@ -62,8 +61,6 @@ var getTokenResponse = function (query) {
           }
         }).content;
       response = JSON.parse(response);
-      console.log(response);
-      console.log(response.data);
       responseContent = "access_token=" + query.accessToken + "&expires=" +
         (response.data.expires_at - response.data.issued_at);
     } else {
@@ -81,7 +78,6 @@ var getTokenResponse = function (query) {
     throw _.extend(new Error("Failed to complete OAuth handshake with Facebook. " + err.message),
                    {response: err.response});
   }
-	console.log(responseContent.data);
 
   // If 'responseContent' parses as JSON, it is an error.
   // XXX which facebook error causes this behvaior?

--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -50,7 +50,7 @@ var getTokenResponse = function (query) {
   try {
     // Request an access token, or request access token info if it was already given
     if (query.accessToken) {
-      responseContent = HTTP.get(
+      var response = HTTP.get(
         "https://graph.facebook.com/debug_token", {
           params: {
             client_id: config.appId,
@@ -59,7 +59,12 @@ var getTokenResponse = function (query) {
             input_token: query.accessToken,
             access_token: query.accessToken
           }
-        }).content
+        }).content;
+      response = JSON.parse(response);
+      console.log(response);
+      console.log(response.data);
+      responseContent = "access_token=" + query.accessToken + "&expires=" +
+        (response.data.expires_at - response.data.issued_at);
     } else {
       responseContent = HTTP.get(
         "https://graph.facebook.com/oauth/access_token", {
@@ -70,10 +75,12 @@ var getTokenResponse = function (query) {
             code: query.code
           }
         }).content;
+    }
   } catch (err) {
     throw _.extend(new Error("Failed to complete OAuth handshake with Facebook. " + err.message),
                    {response: err.response});
   }
+	console.log(responseContent.data);
 
   // If 'responseContent' parses as JSON, it is an error.
   // XXX which facebook error causes this behvaior?

--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -58,11 +58,11 @@ var getTokenResponse = function (query) {
           }
         }).content;
       response = JSON.parse(response);
-			if (response.id == config.appId) {
+	  if (response.id == config.appId) {
         responseContent = "access_token=" + query.accessToken + "&expires=5184000";
-			} else {
-				throw new Error("Failed to complete OAuth handshake with Facebook. The access token's app ID and the server's app ID did not match.");
-			}
+	  } else {
+		throw new Error("Failed to complete OAuth handshake with Facebook. The access token's app ID and the server's app ID did not match.");
+	  }
     } else {
       responseContent = HTTP.get(
         "https://graph.facebook.com/oauth/access_token", {

--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -2,6 +2,7 @@ Facebook = {};
 
 var querystring = Npm.require('querystring');
 
+
 OAuth.registerService('facebook', 2, null, function(query) {
   
 

--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -2,8 +2,8 @@ Facebook = {};
 
 var querystring = Npm.require('querystring');
 
-
 OAuth.registerService('facebook', 2, null, function(query) {
+  
 
   var response = getTokenResponse(query);
   var accessToken = response.accessToken;
@@ -49,8 +49,20 @@ var getTokenResponse = function (query) {
   var responseContent;
   try {
     // Request an access token, or request access token info if it was already given
+    // DDP clients should make a post request sending the accessToken before logging in with oauth credentialtoken/secret
     if (query.accessToken) {
-      responseContent = "access_token=" + query.accessToken + "&expires=5184000";
+      var response = HTTP.get(
+        "https://graph.facebook.com/app", {
+          params: {
+            access_token: query.accessToken
+          }
+        }).content;
+      response = JSON.parse(response);
+			if (response.id == config.appId) {
+        responseContent = "access_token=" + query.accessToken + "&expires=5184000";
+			} else {
+				throw new Error("Failed to complete OAuth handshake with Facebook. The access token's app ID and the server's app ID did not match.");
+			}
     } else {
       responseContent = HTTP.get(
         "https://graph.facebook.com/oauth/access_token", {

--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -2,8 +2,8 @@ Facebook = {};
 
 var querystring = Npm.require('querystring');
 
-
 OAuth.registerService('facebook', 2, null, function(query) {
+  
 
   var response = getTokenResponse(query);
   var accessToken = response.accessToken;
@@ -48,16 +48,28 @@ var getTokenResponse = function (query) {
 
   var responseContent;
   try {
-    // Request an access token
-    responseContent = HTTP.get(
-      "https://graph.facebook.com/oauth/access_token", {
-        params: {
-          client_id: config.appId,
-          redirect_uri: OAuth._redirectUri('facebook', config),
-          client_secret: OAuth.openSecret(config.secret),
-          code: query.code
-        }
-      }).content;
+    // Request an access token, or request access token info if it was already given
+    if (query.accessToken) {
+      responseContent = HTTP.get(
+        "https://graph.facebook.com/debug_token", {
+          params: {
+            client_id: config.appId,
+            redirect_uri: OAuth._redirectUri('facebook', config),
+            client_secret: OAuth.openSecret(config.secret),
+            input_token: query.accessToken,
+            access_token: query.accessToken
+          }
+        }).content
+    } else {
+      responseContent = HTTP.get(
+        "https://graph.facebook.com/oauth/access_token", {
+          params: {
+            client_id: config.appId,
+            redirect_uri: OAuth._redirectUri('facebook', config),
+            client_secret: OAuth.openSecret(config.secret),
+            code: query.code
+          }
+        }).content;
   } catch (err) {
     throw _.extend(new Error("Failed to complete OAuth handshake with Facebook. " + err.message),
                    {response: err.response});


### PR DESCRIPTION
I'm working on adding loginWithOAuth support to the [android](https://github.com/kenyee/android-ddp-client) and [iOS](https://github.com/boundsj/ObjectiveDDP) DDP clients.

I've figured out how to get the pending credentials, etc, set up before login, but the last problem to opening oAuth login for mobile is that mobile oAuth clients (I've only checked Facebook so far, but it looks similar with the other implementations of the oAuth request handlers) send long-term accessTokens instead of short ones.

This pull will add a check for a query.accessToken parameter, and if there is one, skip requesting a new accessToken in favor of requesting the expiration info for the token instead.
