### PR TITLE
Add no-ops for Meteor.publish, methods, and onConnection if no webapp - fixes #3529

### DIFF
--- a/packages/ddp/server_convenience.js
+++ b/packages/ddp/server_convenience.js
@@ -24,6 +24,13 @@ if (Package.webapp) {
   Meteor.server = null;
   Meteor.refresh = function (notification) {
   };
+
+  // Make these empty/no-ops too, so that non-webapp apps can still
+  // depend on/use packages that use those functions.
+  _.each(['publish', 'methods', 'onConnection'],
+      function (name) {
+        Meteor[name] = function () { };
+      });
 }
 
 // Meteor.server used to be called Meteor.default_server. Provide


### PR DESCRIPTION
Hey,

Contributor agreement already signed, coding guidelines followed. This is the first part of the following old pr split:

https://github.com/meteor/meteor/pull/2173

