### PR TITLE
Allow access to Tinytest internals to be able to extend it

### DIFF
--- a/packages/tinytest/tinytest.js
+++ b/packages/tinytest/tinytest.js
@@ -620,3 +620,8 @@ Tinytest._debugTest = function (cookie, onReport, onComplete) {
 // done.  This is used to provide a live display of the current
 // running client test on the test results page.
 Tinytest._onCurrentClientTest = function (name) {};
+
+Tinytest._TestCaseResults = TestCaseResults;
+Tinytest._TestCase = TestCase;
+Tinytest._TestManager = TestManager;
+Tinytest._TestRun = TestRun;


### PR DESCRIPTION
So we are building an improved version of Tinytest, which has some setup and tearing down capabilities, and would like just to extend Tinytest. So I am proposing that those internals are exposed, but clearly marked as internal with `_`.