### PR TITLE
Fix #3540 by skipping contentBlock templates on lookup

### DIFF
--- a/packages/spacebars-tests/template_tests.html
+++ b/packages/spacebars-tests/template_tests.html
@@ -1015,3 +1015,15 @@ Hi there!
 <template name="spacebars_template_test_inclusion_with_data_remove_inner">
   <b>{{.}}</b>
 </template>
+
+<!-- issue meteor/meteor #3540 -->
+<template name="spacebars_template_test_template_instance_wrapper_outer">
+  {{#spacebars_template_test_template_instance_wrapper_wrapper}}
+    {{thisShouldOutputHello}}
+  {{/spacebars_template_test_template_instance_wrapper_wrapper}}
+  {{thisShouldOutputHello}}
+</template>
+
+<template name="spacebars_template_test_template_instance_wrapper_wrapper">
+  {{> Template.contentBlock}}
+</template>

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -3067,3 +3067,20 @@ Tinytest.add("spacebars-tests - template_tests - inclusion with data remove (#31
   test.isTrue(parentView.isDestroyed);
   test.equal(canonicalizeHtml(div.innerHTML), "<span></span>");
 });
+
+Template.spacebars_template_test_template_instance_wrapper_outer.helpers({
+  thisShouldOutputHello: function () {
+    return Template.instance().customProp;
+  }
+});
+
+Template.spacebars_template_test_template_instance_wrapper_outer.created = function () {
+  this.customProp = "hello";
+};
+
+Tinytest.add("spacebars-tests - template_tests - custom block helper doesn't break Template.instance() (#3540)", function (test) {
+  var tmpl = Template.spacebars_template_test_template_instance_wrapper_outer;
+
+  var div = renderToDiv(tmpl);
+  test.equal(canonicalizeHtml(div.innerHTML), "hello hello");
+});


### PR DESCRIPTION
Since we decided to implement Template.contentBlock by using `new Template`, the lookup code for `Template.instance()` was returning it instead of the real enclosing template.