### PR TITLE
Local reactive template state

### DIFF
--- a/packages/blaze/package.js
+++ b/packages/blaze/package.js
@@ -12,6 +12,7 @@ Package.onUse(function (api) {
   api.imply('htmljs');
   api.use('observe-sequence');
   api.use('reactive-var');
+  api.use('reactive-dict');
 
   api.addFiles([
     'preamble.js'

--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -277,6 +277,12 @@ Blaze.TemplateInstance = function (view) {
   this._allSubsReady = false;
 
   this._subscriptionHandles = {};
+
+  /**
+   * A Reactive Dict for storing local template state.
+   * @type {ReactiveDict}
+   */
+  this.state = new ReactiveDict();
 };
 
 /**

--- a/packages/reactive-dict/package.js
+++ b/packages/reactive-dict/package.js
@@ -5,8 +5,6 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use(['underscore', 'tracker', 'ejson']);
-  // If we are loading mongo-livedata, let you store ObjectIDs in it.
-  api.use('mongo', {weak: true});
   api.export('ReactiveDict');
   api.addFiles('reactive-dict.js');
   api.addFiles('migration.js');

--- a/packages/reactive-dict/reactive-dict.js
+++ b/packages/reactive-dict/reactive-dict.js
@@ -94,8 +94,8 @@ _.extend(ReactiveDict.prototype, {
 
     // Mongo.ObjectID is in the 'mongo' package
     var ObjectID = null;
-    if (typeof Mongo !== 'undefined') {
-      ObjectID = Mongo.ObjectID;
+    if (typeof Package.mongo !== 'undefined') {
+      ObjectID = Package.mongo.Mongo.ObjectID;
     }
 
     // We don't allow objects (or arrays that might include objects) for

--- a/packages/spacebars-compiler/codegen.js
+++ b/packages/spacebars-compiler/codegen.js
@@ -29,7 +29,8 @@ var builtInTemplateMacros = {
   // implements the dynamic template feature.
   'dynamic': 'Template.__dynamic',
 
-  'subscriptionsReady': 'view.templateInstance().subscriptionsReady()'
+  'subscriptionsReady': 'view.templateInstance().subscriptionsReady()',
+  'state': '_.bind(view.templateInstance().state.get, view.templateInstance().state)'
 };
 
 // A "reserved name" can't be used as a <template> name.  This

--- a/packages/spacebars-tests/template_tests.html
+++ b/packages/spacebars-tests/template_tests.html
@@ -1046,3 +1046,7 @@ Hi there!
     {{subscribingHelper2}}
   {{/if}}
 </template>
+
+<template name="spacebars_template_test_local_template_state">
+  {{Template.state "x"}}
+</template>

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -3214,3 +3214,14 @@ testAsyncMulti("spacebars-tests - template_tests - template-level subscriptions 
     trueThenFalse.set(false);
   }
 ]);
+
+Tinytest.add("spacebars-tests - template_tests - local template state", function (test) {
+  var tmpl = Template.spacebars_template_test_local_template_state;
+
+  tmpl.onCreated(function () {
+    this.state.set("x", 5);
+  });
+
+  var div = renderToDiv(tmpl);
+  test.equal(canonicalizeHtml(div.innerHTML), "5");
+});


### PR DESCRIPTION
You can now use `Template.instance().state` to store local reactive data for your template. There is also a `Template.state` built-in helper that you can use to access it without defining a new helper.

to do:
1. Add serialization hooks for migration
2. Refactor reactive dict to not always serialize things