### PR TITLE
Cleanup Minimongo.Matcher instantiation

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -96,10 +96,10 @@ LocalCollection.Cursor = function (collection, selector, options) {
   if (LocalCollection._selectorIsId(selector)) {
     // stash for fast path
     self._selectorId = selector;
-    self.matcher = new Minimongo.Matcher(selector, self);
+    self.matcher = new Minimongo.Matcher(selector);
   } else {
     self._selectorId = undefined;
-    self.matcher = new Minimongo.Matcher(selector, self);
+    self.matcher = new Minimongo.Matcher(selector);
     if (self.matcher.hasGeoQuery() || options.sort) {
       self.sorter = new Minimongo.Sorter(options.sort || [],
                                          { matcher: self.matcher });
@@ -641,7 +641,7 @@ LocalCollection.prototype.remove = function (selector, callback) {
     return result;
   }
 
-  var matcher = new Minimongo.Matcher(selector, self);
+  var matcher = new Minimongo.Matcher(selector);
   var remove = [];
   self._eachPossiblyMatchingDoc(selector, function (doc, id) {
     if (matcher.documentMatches(doc).result)
@@ -697,7 +697,7 @@ LocalCollection.prototype.update = function (selector, mod, options, callback) {
   }
   if (!options) options = {};
 
-  var matcher = new Minimongo.Matcher(selector, self);
+  var matcher = new Minimongo.Matcher(selector);
 
   // Save the original results of any query that we might need to
   // _recomputeResults on, because _modifyAndNotify will mutate the objects in


### PR DESCRIPTION
We've actually been wrapping our head over passing collection to Minimongo.Matcher before realizing that it doesn't really use the second argument.