### PR TITLE
Lowercased the email address before saving in db

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -706,7 +706,7 @@ var createUser = function (options) {
   if (username)
     user.username = username;
   if (email)
-    user.emails = [{address: email, verified: false}];
+    user.emails = [{address: email.toLowerCase(), verified: false}];
 
   return Accounts.insertUserDoc(options, user);
 };


### PR DESCRIPTION
Prevents a scenario in which the user, by accident or intentionally, creates and account with 1 or more uppercase letters in the email address. According to: http://stackoverflow.com/questions/9807909/are-email-addresses-case-sensitive it's ok to treat email as non-case sensitive, from a user perspective it makes no sense at all.

Some websites, even today, don't treat emails as case sensitive which might lead to bad UX. On some websites, I only noticed this issue because I forgot my password and the service told me that my email doesn't exists. I had an email on my Inbox from this server, copy pasted and worked. Then I noticed that, by accident, the first letter was uppercase.

