### PR TITLE
Docs - add extra note about enabling internal packages

### DIFF
--- a/docs/client/full-api/concepts.html
+++ b/docs/client/full-api/concepts.html
@@ -916,7 +916,8 @@ Writing Meteor packages is easy. To initialize a meteor package, run
 Developer username. This will create a package from scratch and prefill the
 directory with a package.js control file and some javascript. By default, Meteor
 will take the package name from the name of the directory that contains the
-package.js file.
+package.js file. Don't forget to `meteor add username:package`, even if it is 
+internal, in order to enable it.
 
 Meteor promises repeatable builds for both packages and applications. This means
 that, if you built your package on a machine, then checked the code into a


### PR DESCRIPTION
This simply adds an extra note to the 'writing packages' section of the docs which states that you should `meteor add` an internal package to enable it. I ran into this issue and banged my head for a while last night wondering why an internal package was not exposing a template / exported object to the rest of my app. The issue was that I did not `meteor add` it since I assumed that because it was internal source code I did not have to.