### PR TITLE
Add confirmation for `meteor reset`. `-y` and `--yes` flags skip dialog

### DIFF
--- a/tools/commands.js
+++ b/tools/commands.js
@@ -1016,6 +1016,9 @@ main.registerCommand({
 
 main.registerCommand({
   name: 'reset',
+  options: {
+    'yes': { type: Boolean, short: 'y' }
+  },
   // Doesn't actually take an argument, but we want to print an custom
   // error message if they try to pass one.
   maxArgs: 1,
@@ -1033,6 +1036,23 @@ main.registerCommand({
       Console.command("meteor deploy appname"), Console.options({ indent: 2 }));
     return 1;
   }
+
+  // Project Reset Confirmation Dialog
+  if (options.yes !== true) {
+    Console.warn('meteor reset will delete your local database.');
+
+    var confirmReset = Console.readLine({
+      prompt: "Are you sure (Y/n)? ",
+      stream: process.stderr
+    });
+
+    confirmReset = confirmReset.trim().toLowerCase();
+
+    if (!(confirmReset === 'y' || confirmReset === 'yes')) {
+      Console.info('Project reset cancelled.');
+      return 1;
+    };
+  };
 
   // XXX detect the case where Meteor is running the app, but
   // MONGO_URL was set, so we don't see a Mongo process


### PR DESCRIPTION
Implements feature request #3661 

:warning: Breaking change for scripts that rely on `meteor reset`; use `meteor reset -y` to skip confirmation.
