### PR TITLE
ddp match optimisation

### DIFF
--- a/packages/ddp/crossbar.js
+++ b/packages/ddp/crossbar.js
@@ -87,6 +87,12 @@ _.extend(DDPServer._Crossbar.prototype, {
   //    (a targeted write to a collection does not match a targeted query
   //     targeted at a different document)
   _matches: function (notification, trigger) {
+    if (notification.collection && trigger.collection && notification.collection !== trigger.collection) {
+      return false;
+    }
+    if (notification.id && trigger.id && notification.id !== trigger.id) {
+      return false;
+    }
     return _.all(trigger, function (triggerValue, key) {
       return !_.has(notification, key) ||
         EJSON.equals(triggerValue, notification[key]);

--- a/packages/ddp/crossbar.js
+++ b/packages/ddp/crossbar.js
@@ -87,12 +87,25 @@ _.extend(DDPServer._Crossbar.prototype, {
   //    (a targeted write to a collection does not match a targeted query
   //     targeted at a different document)
   _matches: function (notification, trigger) {
-    if (notification.collection && trigger.collection && notification.collection !== trigger.collection) {
+    
+    if (typeof(notification.collection) === 'string' &&
+        typeof(trigger.collection) === 'string' &&
+        notification.collection !== trigger.collection) {
       return false;
     }
-    if (notification.id && trigger.id && notification.id !== trigger.id) {
+    
+    if (typeof(notification.id) === 'string' &&
+        typeof(trigger.id) === 'string' &&
+        notification.id !== trigger.id) {
       return false;
     }
+    
+    if (notification.id instanceof LocalCollection._ObjectID &&
+        trigger.id instanceof LocalCollection._ObjectID &&
+        ! notification.id.equals(trigger.id)) {
+      return false;
+    }
+    
     return _.all(trigger, function (triggerValue, key) {
       return !_.has(notification, key) ||
         EJSON.equals(triggerValue, notification[key]);


### PR DESCRIPTION
Hi,

We have ~100 write ops per second production site and this change helped me to speed up oplog tailing and reduce cpu usage in factor of 10.  Before this change the bottle neck of mongo updates were meteor but now it seems it can keep up with mongo changes and the bottleneck is db.

It seems to work ok so far but can there be any side effect of this optimisation?

Thanks,
Reio