### PR TITLE
Mbrewer dev bundle

### DIFF
--- a/scripts/admin/copy-dev-bundle-from-jenkins.sh
+++ b/scripts/admin/copy-dev-bundle-from-jenkins.sh
@@ -41,10 +41,11 @@ aws s3 ls s3://com.meteor.jenkins/$DIRNAME/ | \
 trap - EXIT
 
 for FILE in $(aws s3 ls s3://com.meteor.jenkins/$DIRNAME/ | perl -nlaF/ -e 'print $F[-1]'); do
-   if [[ $(aws s3 ls $TARGET$FILE >/dev/null | wc -l) != 0 ]]; then
-     echo "$TARGET$FILE already exists (maybe from another branch?)"
-     exit 1
-   fi
+  # aws s3 ls returns 0 when it lists nothing
+  if [[ $(aws s3 ls $TARGET$FILE >/dev/null | wc -l) != 0 ]]; then
+    echo "$TARGET$FILE already exists (maybe from another branch?)"
+    exit 1
+  fi
 done
 
 echo Copying to $TARGET

--- a/scripts/admin/copy-dev-bundle-from-jenkins.sh
+++ b/scripts/admin/copy-dev-bundle-from-jenkins.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Requires s3cmd to be installed and an appropriate ~/.s3cfg.
+# Requires awscli to be installed and an appropriate ~/.aws/config.
 # Usage:
 #    scripts/admin/copy-dev-bundle-from-jenkins.sh [--prod] BUILDNUMBER
 # where BUILDNUMBER is the small integer Jenkins build number.
@@ -24,7 +24,7 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-DIRNAME=$(s3cmd ls s3://com.meteor.jenkins/ | perl -nle 'print $1 if m!/(dev-bundle-.+--'$1'--.+)/!')
+DIRNAME=$(aws s3 ls s3://com.meteor.jenkins/ | perl -nle 'print $1 if m!/(dev-bundle-.+--'$1'--.+)/!')
 
 if [ -z "$DIRNAME" ]; then
     echo "build not found" 1>&2
@@ -35,17 +35,17 @@ echo Found build $DIRNAME
 
 trap "echo Found surprising number of tarballs." EXIT
 # Check to make sure the proper number of each kind of file is there.
-s3cmd ls s3://com.meteor.jenkins/$DIRNAME/ | \
+aws s3 ls s3://com.meteor.jenkins/$DIRNAME/ | \
   perl -nle 'if (/\.tar\.gz/) { ++$TAR } else { die "something weird" }  END { exit !($TAR == 4) }'
 
 trap - EXIT
 
-for FILE in $(s3cmd ls s3://com.meteor.jenkins/$DIRNAME/ | perl -nlaF/ -e 'print $F[-1]'); do
-   if s3cmd info $TARGET$FILE >/dev/null 2>&1; then
+for FILE in $(aws s3 ls s3://com.meteor.jenkins/$DIRNAME/ | perl -nlaF/ -e 'print $F[-1]'); do
+   if [[ $(aws s3 ls $TARGET$FILE >/dev/null | wc -l) != 0 ]]; then
      echo "$TARGET$FILE already exists (maybe from another branch?)"
      exit 1
    fi
 done
 
 echo Copying to $TARGET
-s3cmd -P cp -r s3://com.meteor.jenkins/$DIRNAME/ $TARGET
+aws s3 cp --acl public-read --recursive s3://com.meteor.jenkins/$DIRNAME/ $TARGET

--- a/scripts/admin/copy-windows-installer-from-jenkins.sh
+++ b/scripts/admin/copy-windows-installer-from-jenkins.sh
@@ -29,6 +29,7 @@ fi
 
 echo Found build "$DIRNAME"
 
+# aws s3 ls returns 0 when it lists nothing
 if [[ $(aws s3 ls "s3://com.meteor.jenkins/$DIRNAME/InstallMeteor.exe" | wc -l) == 0 ]] then
   echo "InstallMeteor.exe wasn't found in $DIRNAME, did Jenkins job fail?"
   exit 1

--- a/scripts/admin/copy-windows-installer-from-jenkins.sh
+++ b/scripts/admin/copy-windows-installer-from-jenkins.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run this script on Mac/Linux, not on Windows
-# Requires s3cmd to be installed and an appropriate ~/.s3cfg.
+# Requires awscli to be installed and an appropriate ~/.aws/config.
 # Usage:
 #    scripts/admin/copy-windows-installer-from-jenkins.sh BUILDNUMBER
 # where BUILDNUMBER is the small integer Jenkins build number.
@@ -19,7 +19,7 @@ if [ $# -ne 1 ]; then
 fi
 
 # installer-windows--${METEOR_RELEASE}--${BUILD_ID}--${BUILD_NUMBER}--${GIT_COMMIT}
-DIRNAME=$(s3cmd ls s3://com.meteor.jenkins/ | perl -nle 'print $1 if m!/(installer-windows--.+--.+--'$1'--.+)/!')
+DIRNAME=$(aws s3 ls s3://com.meteor.jenkins/ | perl -nle 'print $1 if m!/(installer-windows--.+--.+--'$1'--.+)/!')
 RELEASE=$(echo $DIRNAME | perl -pe 's/^installer-windows--(.+)--.+--.+--.+$/$1/')
 
 if [ -z "$DIRNAME" ]; then
@@ -29,11 +29,10 @@ fi
 
 echo Found build "$DIRNAME"
 
-if ! s3cmd info "s3://com.meteor.jenkins/$DIRNAME/InstallMeteor.exe"
-then
+if [[ $(aws s3 ls "s3://com.meteor.jenkins/$DIRNAME/InstallMeteor.exe" | wc -l) == 0 ]] then
   echo "InstallMeteor.exe wasn't found in $DIRNAME, did Jenkins job fail?"
   exit 1
 fi
 
-s3cmd -P cp -r "s3://com.meteor.jenkins/$DIRNAME/" "$TARGET$RELEASE/"
+aws s3 cp --acl public-read --recursive "s3://com.meteor.jenkins/$DIRNAME/" "$TARGET$RELEASE/"
 


### PR DESCRIPTION
Port from s3cfg to awscli.

   This serves 3 purposes
    1) aws cli can do a lot more things, so this is fewer tools we have to use
    2) this uses the same key format as we're already using for everything else
    3) because of key format, we can easily switch to everyone using their own keys
    
    Note that after this is committed you will have to set up aws cli to use this script.
    See: https://mdg.hackpad.com/Operational-Suggestions-and-tips-EZFrKK81iHf#:h=AWS-management
