### PR TITLE
History.md: improve vNEXT bullet

### DIFF
--- a/History.md
+++ b/History.md
@@ -47,7 +47,7 @@
 * The `accounts-password` `Accounts.emailTemplates` can now specify arbitrary
   email `headers`.  The `from` address can now be set separately on the
   individual templates, and is a function there rather than a static string.
-  #2858 #2854
+  \#2858 #2854
 
 * The return value from a server-side `Meteor.call` or `Meteor.apply` is now a
   clone of what the function returned rather than sharing mutable state.  #3201


### PR DESCRIPTION
"#2858" was interpreted by Markdown as <h1>2858</h1> instead of a mention of GitHub ticket #2858.