### PR TITLE
added basic attachments handling

### DIFF
--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -147,6 +147,10 @@ Email.send = function (options) {
   _.each(options.headers, function (value, name) {
     mc.addHeader(name, value);
   });
+  
+  _.each(options.attachments, function(attachment){
+    mc.addAttachment(attachment);
+  });
 
   var pool = getPool();
   if (pool) {


### PR DESCRIPTION
now Email.send(options) options support options.attachments, which is assumed to be [] of attachment objects.

see here https://github.com/andris9/mailcomposer#add-attachments for supported attachment object structure.
tested it at my current project. going to propose pull request. 