### PR TITLE
Set testing to automatically be run once.

### DIFF
--- a/tools/commands.js
+++ b/tools/commands.js
@@ -372,6 +372,7 @@ function doRunCommand (options) {
   //
   // NOTE: this calls process.exit() when testing is done.
   if (options['test']){
+    options.once = true;
     var serverUrl = "http://" + (parsedUrl.host || "localhost") +
           ":" + parsedUrl.port;
     var velocity = require('./run-velocity.js');


### PR DESCRIPTION
Right now you have to issue --test --once to get it to work the way a CI environment needs. That isn't expected and seems confusing to users. The velocity team decided this is the best way to handle that.