### PR TITLE
Apply fields projection on documents before diffing them for Minimongo's...

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -879,7 +879,10 @@ LocalCollection._removeFromResults = function (query, doc) {
 LocalCollection._updateInResults = function (query, doc, old_doc) {
   if (!EJSON.equals(doc._id, old_doc._id))
     throw new Error("Can't change a doc's _id while updating");
-  var changedFields = LocalCollection._makeChangedFields(doc, old_doc);
+  var projectionFn = query.projectionFn || _.identity;
+  var changedFields = LocalCollection._makeChangedFields(
+    projectionFn(doc), projectionFn(old_doc));
+
   if (!query.ordered) {
     if (!_.isEmpty(changedFields)) {
       query.changed(doc._id, changedFields);


### PR DESCRIPTION
Apply fields projection on documents before diffing them for Minimongo's `changed` event.

This change actually introduces another layer of projections before diffing, in
addition to more projection after the diffing, on the result.

I didn't figure out why, but the tests fail if you remove either of them.

Adds tests. Fixes #2254.

@glasser, can you CR this please?