### PR TITLE
Tracker profiler package

### DIFF
--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -20,7 +20,7 @@ Blaze.With = function (data, contentFunc) {
       // `data` is a reactive function
       view.autorun(function () {
         view.dataVar.set(data());
-      }, view.parentView);
+      }, view.parentView, 'setData');
     } else {
       view.dataVar.set(data);
     }
@@ -48,7 +48,7 @@ Blaze.If = function (conditionFunc, contentFunc, elseFunc, _not) {
     this.autorun(function () {
       var cond = Blaze._calculateCondition(conditionFunc());
       conditionVar.set(_not ? (! cond) : cond);
-    }, this.parentView);
+    }, this.parentView, 'condition');
   });
 
   return view;
@@ -96,7 +96,7 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
     // passing argFunc straight to ObserveSequence).
     eachView.autorun(function () {
       eachView.argVar.set(argFunc());
-    }, eachView.parentView);
+    }, eachView.parentView, 'collection');
 
     eachView.stopHandle = ObserveSequence.observe(function () {
       return eachView.argVar.get();

--- a/packages/blaze/materializer.js
+++ b/packages/blaze/materializer.js
@@ -83,7 +83,8 @@ Blaze._DOMMaterializer.def({
       };
       var updaterComputation;
       if (self.parentView) {
-        updaterComputation = self.parentView.autorun(updateAttributes);
+        updaterComputation =
+          self.parentView.autorun(updateAttributes, undefined, 'updater');
       } else {
         updaterComputation = Tracker.nonreactive(function () {
           return Tracker.autorun(function () {

--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -140,7 +140,7 @@ Blaze.View.prototype.onViewDestroyed = function (cb) {
 /// callback.  Autoruns that update the DOM should be started
 /// from either onViewCreated (guarded against the absence of
 /// view._domrange), or onViewReady.
-Blaze.View.prototype.autorun = function (f, _inViewScope) {
+Blaze.View.prototype.autorun = function (f, _inViewScope, displayName) {
   var self = this;
 
   // The restrictions on when View#autorun can be called are in order
@@ -174,18 +174,35 @@ Blaze.View.prototype.autorun = function (f, _inViewScope) {
     throw new Error("Can't call View#autorun from a Tracker Computation; try calling it from the created or rendered callback");
   }
 
-  var templateInstanceFunc = Blaze.Template._currentTemplateInstanceFunc;
+  // Each local variable allocate additional space on each frame of the
+  // execution stack. When too many variables are allocated on stack, you can
+  // run out of memory on stack running a deep recursion (which is typical for
+  // Blaze functions) and get stackoverlow error. (The size of the stack varies
+  // between browsers).
+  // The trick we use here is to allocate only one variable on stack `locals`
+  // that keeps references to all the rest. Since locals is allocated on heap,
+  // we don't take up any space on the stack.
+  var locals = {};
+  locals.templateInstanceFunc = Blaze.Template._currentTemplateInstanceFunc;
 
-  var c = Tracker.autorun(function viewAutorun(c) {
+  locals.f = function viewAutorun(c) {
     return Blaze._withCurrentView(_inViewScope || self, function () {
-      return Blaze.Template._withTemplateInstanceFunc(templateInstanceFunc, function () {
+      return Blaze.Template._withTemplateInstanceFunc(locals.templateInstanceFunc, function () {
         return f.call(self, c);
       });
     });
-  });
-  self.onViewDestroyed(function () { c.stop(); });
+  };
 
-  return c;
+  // Give the autorun function a better name for debugging and profiling.
+  // The `displayName` property is not part of the spec but browsers like Chrome
+  // and Firefox prefer it in debuggers over the name function was declared by.
+  locals.f.displayName =
+    (self.name || 'anonymous') + ':' + (displayName || 'anonymous');
+  locals.c = Tracker.autorun(locals.f);
+
+  self.onViewDestroyed(function () { locals.c.stop(); });
+
+  return locals.c;
 };
 
 Blaze.View.prototype._errorIfShouldntCallSubscribe = function () {
@@ -305,7 +322,7 @@ Blaze._materializeView = function (view, parentView) {
       Tracker.onInvalidate(function () {
         domrange.destroyMembers();
       });
-    });
+    }, undefined, ':materialize');
 
     var teardownHook = null;
 

--- a/packages/spacebars-compiler/codegen.js
+++ b/packages/spacebars-compiler/codegen.js
@@ -69,7 +69,8 @@ _.extend(CodeGen.prototype, {
           // Reactive attributes are already wrapped in a function,
           // and there's no fine-grained reactivity.
           // Anywhere else, we need to create a View.
-          code = 'Blaze.View(function () { return ' + code + '; })';
+          code = 'Blaze.View("lookup:' + tag.path.join('.') + '", ' +
+            'function () { return ' + code + '; })';
         }
         return BlazeTools.EmitCode(code);
       } else if (tag.type === 'INCLUSION' || tag.type === 'BLOCKOPEN') {


### PR DESCRIPTION
WIP.

- Expose references to computations in Tracker.
- Introduce a package called `tracker-profiler` that counts recomputations of every computation.
- Give Blaze autoruns descriptive names in the [`displayName`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName) field.
- Spacebars generator should give more descriptive names to the views generated for helpers and other symbols (or identifier paths).

@avital