### PR TITLE
Issue 3797 fix

### DIFF
--- a/packages/html-tools/parse.js
+++ b/packages/html-tools/parse.js
@@ -170,6 +170,8 @@ getContent = HTMLTools.Parse.getContent = function (scanner, shouldStopFunc) {
               attrs.value = textareaValue;
             }
           }
+        } else if (token.n === 'script') {
+          content = getRawText(scanner, token.n, shouldStopFunc);
         } else {
           content = getContent(scanner, shouldStopFunc);
         }

--- a/packages/html-tools/parse_tests.js
+++ b/packages/html-tools/parse_tests.js
@@ -13,6 +13,7 @@ var A = HTML.A;
 var DIV = HTML.DIV;
 var P = HTML.P;
 var TEXTAREA = HTML.TEXTAREA;
+var SCRIPT = HTML.SCRIPT;
 
 Tinytest.add("html-tools - parser getContent", function (test) {
 
@@ -149,6 +150,8 @@ Tinytest.add("html-tools - parser getContent", function (test) {
   succeed('<br x="\r\r">', BR({x:'\n\n'}));
   succeed('<br x=y\r>', BR({x:'y'}));
   fatal('<br x=\r>');
+  succeed('<script>var x="<div>";</script>',SCRIPT('var x="<div>";'));
+  succeed('<script>var x=1 && 0;</script>',SCRIPT('var x=1 && 0;'));
 });
 
 Tinytest.add("html-tools - parseFragment", function (test) {
@@ -365,5 +368,4 @@ Tinytest.add("html-tools - getTemplateTag", function (test) {
   succeed('<textarea {{a}} x=1 {{b}}></textarea>',
           TEXTAREA(Attrs({x:"1"}, TemplateTag({stuff: 'a'}),
                          TemplateTag({stuff: 'b'}))));
-
 });

--- a/packages/html-tools/parse_tests.js
+++ b/packages/html-tools/parse_tests.js
@@ -368,4 +368,5 @@ Tinytest.add("html-tools - getTemplateTag", function (test) {
   succeed('<textarea {{a}} x=1 {{b}}></textarea>',
           TEXTAREA(Attrs({x:"1"}, TemplateTag({stuff: 'a'}),
                          TemplateTag({stuff: 'b'}))));
+
 });


### PR DESCRIPTION
Fix/Workaround for issue:
https://github.com/meteor/meteor/issues/3797

It will still not be able to parse end script tags inside quoted strings, but at least it will work in most scenarios
