### PR TITLE
set mongo cursor batchSize

### DIFF
--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -852,7 +852,8 @@ MongoConnection.prototype._createSynchronousCursor = function(
   var mongoOptions = {
     sort: cursorOptions.sort,
     limit: cursorOptions.limit,
-    skip: cursorOptions.skip
+    skip: cursorOptions.skip,
+    batchSize: typeof cursorOptions.batchSize === 'undefined' ? 50000 : cursorOptions.batchSize 
   };
 
   // Do we want a tailable cursor (which only works on capped collections)?


### PR DESCRIPTION
As discussed on #3804, setting a batchSize by default gives massive speed improvements when reading 100,000+ docs from mongo.  The value can be overridden by setting a batchSize in cursor options.  Initiating a cursor with `{batchSize: 0}` reverts to the original behaviour and Mongo default batchSize. 

The [batchsize setting](http://docs.mongodb.org/manual/reference/method/cursor.batchSize/) behaves differently for negative values or 1 and closes the cursor at the end of the first batch.  So maybe such values should be prevented.
