### PR TITLE
Allow `spiderable` package to have a customizable `ready`iness callback

### DIFF
--- a/packages/spiderable/phantom_script.js
+++ b/packages/spiderable/phantom_script.js
@@ -15,7 +15,7 @@ var isReady = function () {
       return false;
     }
     Tracker.flush();
-    return DDP._allSubscriptionsReady();
+    return Spiderable.ready();
   });
 };
 

--- a/packages/spiderable/spiderable_client.js
+++ b/packages/spiderable/spiderable_client.js
@@ -16,6 +16,9 @@
 // it then polls until all subscriptions are ready.
 
 Spiderable._initialSubscriptionsStarted = false;
+Spiderable.ready = function(){
+  return DDP._allSubscriptionsReady();
+};
 
 var startupCallbacksDone = function () {
   Spiderable._initialSubscriptionsStarted = true;

--- a/packages/spiderable/spiderable_server.js
+++ b/packages/spiderable/spiderable_server.js
@@ -118,7 +118,7 @@ WebApp.connectHandlers.use(function (req, res, next) {
           if (error && error.code === 127)
             Meteor._debug("spiderable: phantomjs not installed. Download and install from http://phantomjs.org/");
           else
-            Meteor._debug("spiderable: phantomjs failed:", error, "\nstderr:", stderr);
+            Meteor._debug("spiderable: phantomjs failed:", error, "\nstderr:", stderr, "\nstdout:", stdout);
 
           next();
         }


### PR DESCRIPTION
Allow `spiderable` package to have a customizable `ready`iness callback

Also fixes an issue when stdout fails /<html/ match & may have pertinent information

@glasser @n1mmy @Slava 

Thoughts?