### PR TITLE
POC for adding hooks to boilerplate generation for loading page and/or SSR

### DIFF
--- a/packages/boilerplate-generator/boilerplate_web.browser.html
+++ b/packages/boilerplate-generator/boilerplate_web.browser.html
@@ -21,8 +21,10 @@
 {{/each}}
 
 {{{head}}}
+{{{dynamicHead}}}
 </head>
 <body>
 {{{body}}}
+{{{dynamicBody}}}
 </body>
 </html>

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -109,7 +109,7 @@ WebApp.categorizeRequest = function (req) {
   return _.extend({
     browser: identifyBrowser(req.headers['user-agent']),
     url: url.parse(req.url, true)
-  }, _.pick(req, 'head', 'body'));
+  }, _.pick(req, 'dynamicHead', 'dynamicBody'));
 };
 
 // HTML attribute hooks: functions to be called to determine any attributes to
@@ -244,7 +244,7 @@ var boilerplateByArch = {};
 // XXX so far this function is always called with arch === 'web.browser'
 var memoizedBoilerplate = {};
 var getBoilerplate = function (request, arch) {
-  var useMemoized = ! (request.head || request.body);
+  var useMemoized = ! (request.dynamicHead || request.dynamicBody);
   var htmlAttributes = getHtmlAttributes(request);
   
   if (useMemoized) {
@@ -268,7 +268,7 @@ var getBoilerplate = function (request, arch) {
   
   var boilerplateOptions = _.extend({ 
     htmlAttributes: htmlAttributes 
-  }, _.pick(request, 'head', 'body'));
+  }, _.pick(request, 'dynamicHead', 'dynamicBody'));
   
   return boilerplateByArch[arch].toHTML(boilerplateOptions);
 };

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -106,10 +106,10 @@ var identifyBrowser = function (userAgentString) {
 WebAppInternals.identifyBrowser = identifyBrowser;
 
 WebApp.categorizeRequest = function (req) {
-  return {
+  return _.extend({
     browser: identifyBrowser(req.headers['user-agent']),
     url: url.parse(req.url, true)
-  };
+  }, _.pick(req, 'head', 'body'));
 };
 
 // HTML attribute hooks: functions to be called to determine any attributes to
@@ -235,30 +235,42 @@ WebApp._timeoutAdjustmentRequestCallback = function (req, res) {
 var boilerplateByArch = {};
 
 // Given a request (as returned from `categorizeRequest`), return the
-// boilerplate HTML to serve for that request. Memoizes on HTML
-// attributes (used by, eg, appcache) and whether inline scripts are
-// currently allowed.
+// boilerplate HTML to serve for that request.
+//
+// If a previous connect middleware has rendered content for the head or body,
+// returns the boilerplate with that content patched in otherwise
+// memoizes on HTML attributes (used by, eg, appcache) and whether inline 
+// scripts are currently allowed.
 // XXX so far this function is always called with arch === 'web.browser'
 var memoizedBoilerplate = {};
 var getBoilerplate = function (request, arch) {
-
+  var useMemoized = ! (request.head || request.body);
   var htmlAttributes = getHtmlAttributes(request);
-
-  // The only thing that changes from request to request (for now) are
-  // the HTML attributes (used by, eg, appcache) and whether inline
-  // scripts are allowed, so we can memoize based on that.
-  var memHash = JSON.stringify({
-    inlineScriptsAllowed: inlineScriptsAllowed,
-    htmlAttributes: htmlAttributes,
-    arch: arch
-  });
-
-  if (! memoizedBoilerplate[memHash]) {
-    memoizedBoilerplate[memHash] = boilerplateByArch[arch].toHTML({
-      htmlAttributes: htmlAttributes
+  
+  if (useMemoized) {
+    // The only thing that changes from request to request (unless extra 
+    // content is added to the head or body) are the HTML attributes 
+    // (used by, eg, appcache) and whether inline scripts are allowed, so we 
+    // can memoize based on that.
+    var memHash = JSON.stringify({
+      inlineScriptsAllowed: inlineScriptsAllowed,
+      htmlAttributes: htmlAttributes,
+      arch: arch
     });
+
+    if (! memoizedBoilerplate[memHash]) {
+      memoizedBoilerplate[memHash] = boilerplateByArch[arch].toHTML({
+        htmlAttributes: htmlAttributes
+      });
+    }
+    return memoizedBoilerplate[memHash];
   }
-  return memoizedBoilerplate[memHash];
+  
+  var boilerplateOptions = _.extend({ 
+    htmlAttributes: htmlAttributes 
+  }, _.pick(request, 'head', 'body'));
+  
+  return boilerplateByArch[arch].toHTML(boilerplateOptions);
 };
 
 WebAppInternals.generateBoilerplateInstance = function (arch,


### PR DESCRIPTION
This PR represents the minimum changes to `webapp` that would enable other connect handlers to inject content into the `HEAD` and `BODY` of the boilerplate, effectively enabling packages to implement a loading page or server side rendering. I'm not expecting this PR to be merged as is, rather to form a starting point for a discussion on how we can get something like this into core. Happy to do the work, would just like MDG's guidance and blessing on best to move forward.

A clear example of how this is used is here: https://github.com/percolatestudio/react-leaderboard/blob/master/react-leaderboard.jsx#L162-L168 .

Currently Meteor provides no way for user code to modify the contents of the boilerplate html. This makes it difficult/hacky to serve a loading page or content rendered from the server.
