### PR TITLE
Increase the stdout/stderr buffer for npm install

### DIFF
--- a/tools/meteor-npm.js
+++ b/tools/meteor-npm.js
@@ -357,7 +357,7 @@ var runNpmCommand = function (args, cwd) {
   var future = new Future;
   var child_process = require('child_process');
   child_process.execFile(
-    npmPath, args, { cwd: cwd }, function (err, stdout, stderr) {
+    npmPath, args, { cwd: cwd, maxBuffer: 10 * 1024 * 1024 }, function (err, stdout, stderr) {
     if (meteorNpm._printNpmCalls)
       process.stdout.write(err ? 'failed\n' : 'done\n');
 


### PR DESCRIPTION
Otherwise for some npm packages which output a lot during install, installation simply fails with no clear error message. node.js kills the process and there is no information about that in anything Meteor prints out: "maxBuffer specifies the largest amount of data allowed on stdout or stderr - if this value is exceeded then the child process is killed."