### PR TITLE
Use Meteor._setImmediate instead of setTimeout with 0

### DIFF
--- a/packages/tracker/tracker.js
+++ b/packages/tracker/tracker.js
@@ -104,7 +104,11 @@ var afterFlushCallbacks = [];
 
 var requireFlush = function () {
   if (! willFlush) {
-    setTimeout(Tracker.flush, 0);
+    // We want this code to work without Meteor, see debugFunc above
+    if (typeof Meteor !== "undefined")
+      Meteor._setImmediate(Tracker.flush);
+    else
+      setTimeout(Tracker.flush, 0);
     willFlush = true;
   }
 };


### PR DESCRIPTION
Currently setTimeout 0 is used on the invalidate to trigger the Tracker.flush, it should be better to use Meteor._setInmediate instead

https://github.com/meteor/meteor/issues/3880