### PR TITLE
Fix the broken logic of moving elements forward in a sequence (Blaze)

### DIFF
--- a/packages/observe-sequence/observe_sequence.js
+++ b/packages/observe-sequence/observe_sequence.js
@@ -195,13 +195,28 @@ var diffArray = function (lastSeqArray, seqArray, callbacks) {
         before);
     },
     movedBefore: function (id, before) {
+      if (id === before)
+        return;
+
       var prevPosition = posCur[idStringify(id)];
-      var position = before ? posCur[idStringify(before)] : lengthCur - 1;
+      var position = before ? posCur[idStringify(before)] : lengthCur;
+
+      // Moving the item forward. The new element is losing one position as it
+      // was removed from the old position before being inserted at the new
+      // position.
+      // Ex.:   0  *1*  2   3   4
+      //        0   2   3  *1*  4
+      // The original issued callback is "1" before "4".
+      // The position of "1" is 1, the position of "4" is 4.
+      // The generated move is (1) -> (3)
+      if (position > prevPosition) {
+        position--;
+      }
 
       _.each(posCur, function (pos, id) {
-        if (pos >= prevPosition && pos <= position)
+        if (pos > prevPosition && pos < position)
           posCur[id]--;
-        else if (pos <= prevPosition && pos >= position)
+        else if (pos < prevPosition && pos >= position)
           posCur[id]++;
       });
 

--- a/packages/observe-sequence/observe_sequence.js
+++ b/packages/observe-sequence/observe_sequence.js
@@ -198,8 +198,8 @@ var diffArray = function (lastSeqArray, seqArray, callbacks) {
       if (id === before)
         return;
 
-      var prevPosition = posCur[idStringify(id)];
-      var position = before ? posCur[idStringify(before)] : lengthCur;
+      var oldPosition = posCur[idStringify(id)];
+      var newPosition = before ? posCur[idStringify(before)] : lengthCur;
 
       // Moving the item forward. The new element is losing one position as it
       // was removed from the old position before being inserted at the new
@@ -209,24 +209,34 @@ var diffArray = function (lastSeqArray, seqArray, callbacks) {
       // The original issued callback is "1" before "4".
       // The position of "1" is 1, the position of "4" is 4.
       // The generated move is (1) -> (3)
-      if (position > prevPosition) {
-        position--;
+      if (newPosition > oldPosition) {
+        newPosition--;
       }
 
-      _.each(posCur, function (pos, id) {
-        if (pos > prevPosition && pos < position)
+      // Fix up the positions of elements between the old and the new positions
+      // of the moved element.
+      //
+      // There are two cases:
+      //   1. The element is moved forward. Then all the positions in between
+      //   are moved back.
+      //   2. The element is moved back. Then the positions in between *and* the
+      //   element that is currently standing on the moved element's future
+      //   position are moved forward.
+      _.each(posCur, function (elCurPosition, id) {
+        if (oldPosition < elCurPosition && elCurPosition < newPosition)
           posCur[id]--;
-        else if (pos < prevPosition && pos >= position)
+        else if (newPosition <= elCurPosition && elCurPosition < oldPosition)
           posCur[id]++;
       });
 
-      posCur[idStringify(id)] = position;
+      // Finally, update the position of the moved element.
+      posCur[idStringify(id)] = newPosition;
 
       callbacks.movedTo(
         id,
         seqArray[posNew[idStringify(id)]].item,
-        prevPosition,
-        position,
+        oldPosition,
+        newPosition,
         before);
     },
     removed: function (id) {

--- a/packages/observe-sequence/observe_sequence_tests.js
+++ b/packages/observe-sequence/observe_sequence_tests.js
@@ -244,6 +244,82 @@ Tinytest.add('observe-sequence - array to other array, movedTo', function (test)
   ]);
 });
 
+Tinytest.add('observe-sequence - array to other array, movedTo the end', function (test) {
+  var dep = new Tracker.Dependency;
+  var seq = [{_id: "0"}, {_id: "1"}, {_id: "2"}, {_id: "3"}];
+
+  runOneObserveSequenceTestCase(test, function () {
+    dep.depend();
+    return seq;
+  }, function () {
+    seq = [{_id: "0"}, {_id: "2"}, {_id: "3"}, {_id: "1"}];
+    dep.changed();
+  }, [
+    {addedAt: ["0", {_id: "0"}, 0, null]},
+    {addedAt: ["1", {_id: "1"}, 1, null]},
+    {addedAt: ["2", {_id: "2"}, 2, null]},
+    {addedAt: ["3", {_id: "3"}, 3, null]},
+
+    {movedTo: ["1", {_id: "1"}, 1, 3, null]},
+    {changedAt: ["0", {_id: "0"}, {_id: "0"}, 0]},
+    {changedAt: ["1", {_id: "1"}, {_id: "1"}, 3]},
+    {changedAt: ["2", {_id: "2"}, {_id: "2"}, 1]},
+    {changedAt: ["3", {_id: "3"}, {_id: "3"}, 2]}
+  ]);
+});
+
+Tinytest.add('observe-sequence - array to other array, movedTo later position but not the latest #2845', function (test) {
+  var dep = new Tracker.Dependency;
+  var seq = [{_id: "0"}, {_id: "1"}, {_id: "2"}, {_id: "3"}];
+
+  runOneObserveSequenceTestCase(test, function () {
+    dep.depend();
+    return seq;
+  }, function () {
+    seq = [{_id: "1"}, {_id: "2"}, {_id: "0"}, {_id: "3"}];
+    dep.changed();
+  }, [
+    {addedAt: ["0", {_id: "0"}, 0, null]},
+    {addedAt: ["1", {_id: "1"}, 1, null]},
+    {addedAt: ["2", {_id: "2"}, 2, null]},
+    {addedAt: ["3", {_id: "3"}, 3, null]},
+
+    {movedTo: ["0", {_id: "0"}, 0, 2, "3"]},
+
+    {changedAt: ["0", {_id: "0"}, {_id: "0"}, 2]},
+    {changedAt: ["1", {_id: "1"}, {_id: "1"}, 0]},
+    {changedAt: ["2", {_id: "2"}, {_id: "2"}, 1]},
+    {changedAt: ["3", {_id: "3"}, {_id: "3"}, 3]}
+  ]);
+});
+
+Tinytest.add('observe-sequence - array to other array, movedTo earlier position but not the first', function (test) {
+  var dep = new Tracker.Dependency;
+  var seq = [{_id: "0"}, {_id: "1"}, {_id: "2"}, {_id: "3"}, {_id: "4"}];
+
+  runOneObserveSequenceTestCase(test, function () {
+    dep.depend();
+    return seq;
+  }, function () {
+    seq = [{_id: "0"}, {_id: "4"}, {_id: "1"}, {_id: "2"}, {_id: "3"}];
+    dep.changed();
+  }, [
+    {addedAt: ["0", {_id: "0"}, 0, null]},
+    {addedAt: ["1", {_id: "1"}, 1, null]},
+    {addedAt: ["2", {_id: "2"}, 2, null]},
+    {addedAt: ["3", {_id: "3"}, 3, null]},
+    {addedAt: ["4", {_id: "4"}, 4, null]},
+
+    {movedTo: ["4", {_id: "4"}, 4, 1, "1"]},
+
+    {changedAt: ["0", {_id: "0"}, {_id: "0"}, 0]},
+    {changedAt: ["1", {_id: "1"}, {_id: "1"}, 2]},
+    {changedAt: ["2", {_id: "2"}, {_id: "2"}, 3]},
+    {changedAt: ["3", {_id: "3"}, {_id: "3"}, 4]},
+    {changedAt: ["4", {_id: "4"}, {_id: "4"}, 1]}
+  ]);
+});
+
 Tinytest.add('observe-sequence - array to null', function (test) {
   var dep = new Tracker.Dependency;
   var seq = [{_id: "13", foo: 1}, {_id: "37", bar: 2}];


### PR DESCRIPTION
We had a bug in `observe-sequence`, a translation layer between the array diff and the DOM operations.

Can someone from the Blaze team review it for me? @avital @stubailo @dgreensp 