### PR TITLE
resolve dependency of `google` package on `Accounts`.

### DIFF
--- a/packages/accounts-google/google.js
+++ b/packages/accounts-google/google.js
@@ -5,7 +5,16 @@ if (Meteor.isClient) {
     // support a callback without options
     if (! callback && typeof options === "function") {
       callback = options;
-      options = null;
+      options = {};
+    }
+
+    // Use Google's domain-specific login page if we want to restrict creation to
+    // a particular email domain. (Don't use it if restrictCreationByEmailDomain
+    // is a function.) Note that all this does is change Google's UI ---
+    // accounts-base/accounts_server.js still checks server-side that the server
+    // has the proper email address after the OAuth conversation.
+    if (typeof Accounts._options.restrictCreationByEmailDomain === 'string') {
+      options.hostedDomain = Accounts._options.restrictCreationByEmailDomain;
     }
 
     var credentialRequestCompleteCallback = Accounts.oauth.credentialRequestCompleteHandler(callback);

--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -47,13 +47,9 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
         '&access_type=' + accessType +
         '&approval_prompt=' + approvalPrompt;
 
-  // Use Google's domain-specific login page if we want to restrict creation to
-  // a particular email domain. (Don't use it if restrictCreationByEmailDomain
-  // is a function.) Note that all this does is change Google's UI ---
-  // accounts-base/accounts_server.js still checks server-side that the server
-  // has the proper email address after the OAuth conversation.
-  if (typeof Accounts._options.restrictCreationByEmailDomain === 'string') {
-    loginUrl += '&hd=' + encodeURIComponent(Accounts._options.restrictCreationByEmailDomain);
+  // limits sign-in to a particular google apps hosted domain
+  if (options.hostedDomain) {
+    loginUrl += '&hd=' + encodeURIComponent(options.hostedDomain);
   }
 
   OAuth.launchLogin({


### PR DESCRIPTION
Fix for Issue #3903 -

Google.requestCredential now takes parameter `options.hostedDomain` to limit sign-in to a particular google apps hosted domain. Instead of directly reading from `Accounts._options. restrictCreationByEmailDomain `