### PR TITLE
Minor adjustments to add blaze and spacebars package references.

### DIFF
--- a/docs/client/full-api/api/templates.md
+++ b/docs/client/full-api/api/templates.md
@@ -418,5 +418,10 @@ Other DOM events are available as well, but for the events above,
 Meteor has taken some care to ensure that they work uniformly in all
 browsers.
 
+{{> apiBoxTitle name="Spacebars" id="spacebars"}}
+
+Spacebars is a Meteor template language inspired by [Handlebars](http://handlebarsjs.com/). It shares some of the spirit and syntax of Handlebars, but it has been tailored to produce reactive Meteor templates when compiled.
+
+For more information about Spacebars, see the [Spacebars README](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md).
 
 {{/template}}

--- a/docs/client/full-api/tableOfContents.js
+++ b/docs/client/full-api/tableOfContents.js
@@ -178,7 +178,8 @@ var toc = [
       "Template.body",
       {name: "{{> Template.dynamic}}", id: "template_dynamic"},
       {type: "spacer"},
-      {name: "Event maps", style: "noncode"}
+      {name: "Event maps", style: "noncode"},
+      {name: "Spacebars", style: "noncode"}
     ],
     "Blaze", [
       "Blaze.render",
@@ -311,12 +312,14 @@ var toc = [
     "appcache",
     "accounts-ui",
     "audit-argument-checks",
+    {name: "blaze", link: "https://atmospherejs.com/meteor/blaze"},
     "coffeescript",
     "jquery",
     "less",
     "markdown",
     "oauth-encryption",
     "random",
+    {name: "spacebars", link: "https://atmospherejs.com/meteor/spacebars"},
     {name: "spiderable", link: "https://atmospherejs.com/meteor/spiderable"},
     "underscore",
     "webapp"

--- a/packages/spacebars/README.md
+++ b/packages/spacebars/README.md
@@ -69,7 +69,7 @@ use one of the following as the first element of a path: `else`, `this`, `true`,
 reserved words like `var` and `for`.
 
 A Spacebars path is a series of one or more identifiers separated by either `.`
-or `/`, such as `foo`, `foo.bar`, `this.name`, `../title`, or `foo.[0]`.
+or `/`, such as `foo`, `foo.bar`, `this.name`, `../title`, or `foo.[0]` (numeric indices must be enclosed in brackets).
 
 ### Name Resolution
 
@@ -509,4 +509,3 @@ following elements:
   page.  It will be compiled to the `Template.body` component. If `<body>` is
   used multiple times (perhaps in different files), the contents of all of the
   `<body>` elements are concatenated.
-


### PR DESCRIPTION
Hi guys - a few minor adjustments to help with #3858 (added spacebars and blaze atmosphere links under the full API TOC packages section, and a small mention of spacebars under templates). Thanks!