### PR TITLE
Make meteor create --package not use prefix

### DIFF
--- a/History.md
+++ b/History.md
@@ -186,16 +186,15 @@
 * After killing existing `mongod` servers, also clear the `mongod.lock` file.
 
 * Stricter validation for package names: they cannot begin with a hyphen, end
-  with a dot, or contain two consecutive dots.  (No packages on Atmosphere fail
+  with a dot, contain two consecutive dots, contain more than one colon, or
+  start or end with a colon.  (No packages on Atmosphere fail
   this validation.)
 
 * `meteor create --package` now no longer creates a directory with the full
   name of the package, since Windows file systems cannot have colon characters
   in file paths. Instead, the command now creates a directory named the same
   as the second part of the package name after the colon (without the username
-  prefix). Using the `meteor create --package` command to create a package
-  with more than one colon in the name is now disallowed and displays an error
-  message.
+  prefix).
 
 
 ### Meteor Mobile

--- a/History.md
+++ b/History.md
@@ -189,6 +189,13 @@
   with a dot, or contain two consecutive dots.  (No packages on Atmosphere fail
   this validation.)
 
+* `meteor create --package` now no longer creates a directory with the full
+  name of the package, since Windows file systems cannot have colon characters
+  in file paths. Instead, the command now creates a directory named the same
+  as the second part of the package name after the colon (without the username
+  prefix). Using the `meteor create --package` command to create a package
+  with more than one colon in the name is now disallowed and displays an error
+  message.
 
 
 ### Meteor Mobile

--- a/packages/package-version-parser/package-version-parser-tests.js
+++ b/packages/package-version-parser/package-version-parser-tests.js
@@ -29,6 +29,9 @@ Tinytest.add("package-version-parser - validatePackageName", function (test) {
   badName("-x", /not begin with a hyphen/);
   badName("--x", /not begin with a hyphen/);
   badName("0.0", /must contain/);
+  badName("a:a:a", /more than one colon/);
+  badName(":a", /start or end with a colon/);
+  badName("a:", /start or end with a colon/);
 
   // these are ok
   PackageVersion.validatePackageName('x-');

--- a/packages/package-version-parser/package-version-parser.js
+++ b/packages/package-version-parser/package-version-parser.js
@@ -393,6 +393,14 @@ PV.validatePackageName = function (packageName, options) {
   }
   // (There is already a package ending with a `-` and one with two consecutive `-`
   // in troposphere, though they both look like typos.)
+
+  if (packageName.split(":").length > 2) {
+    throwVersionParserError("Package names may not have more than one colon.");
+  }
+
+  if (packageName[0] === ":" || __.last(packageName) === ":") {
+    throwVersionParserError("Package names may not start or end with a colon.");
+  }
 };
 
 var throwVersionParserError = function (message) {

--- a/tools/commands.js
+++ b/tools/commands.js
@@ -564,7 +564,7 @@ main.registerCommand({
     // where it was created.
     Console.info(
       packageName + ": created in",
-      Console.path(displayPackageDir + "/")
+      Console.path(displayPackageDir)
     );
 
     return 0;

--- a/tools/commands.js
+++ b/tools/commands.js
@@ -486,7 +486,21 @@ main.registerCommand({
     utils.validatePackageNameOrExit(
       packageName, {detailedColonExplanation: true});
 
-    var fsName = colonConverter.convert(packageName);
+    // When we create a package, avoid introducing a colon into the file system
+    // by naming the directory after the package name without the prefix.
+    var fsName = packageName;
+    if (packageName.indexOf(":") !== -1) {
+      var split = packageName.split(":");
+
+      if (split.length > 2) {
+        Console.error(packageName +
+          ": Package name can't have more than one colon.");
+        return 1;
+      }
+
+      fsName = split[1];
+    }
+
     var packageDir;
     if (options.appDir) {
       packageDir = files.pathResolve(options.appDir, 'packages', fsName);
@@ -549,8 +563,8 @@ main.registerCommand({
     // match the name of the package exactly, therefore we should tell people
     // where it was created.
     Console.info(
-      packageName + ": created in ",
-      Console.path(displayPackageDir)
+      packageName + ": created in",
+      Console.path(displayPackageDir + "/")
     );
 
     return 0;

--- a/tools/commands.js
+++ b/tools/commands.js
@@ -491,13 +491,6 @@ main.registerCommand({
     var fsName = packageName;
     if (packageName.indexOf(":") !== -1) {
       var split = packageName.split(":");
-
-      if (split.length > 2) {
-        Console.error(packageName +
-          ": Package name can't have more than one colon.");
-        return 1;
-      }
-
       fsName = split[1];
     }
 

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -742,7 +742,7 @@ selftest.define("package skeleton creates correct versionsFrom", function () {
   var s = new Sandbox({ warehouse: { v1: { recommended: true } } });
   var token = utils.randomToken();
   var fullPackageName = "test:" + token;
-  var fsPackageName = "test_" + token;
+  var fsPackageName = token;
 
   var run = s.run("create", "--package", fullPackageName);
   run.waitSecs(15);

--- a/tools/tests/publish.js
+++ b/tools/tests/publish.js
@@ -16,7 +16,7 @@ selftest.define("create-publish-and-search",
   testUtils.login(s, username, password);
   var packageName = utils.randomToken();
   var fullPackageName = username + ":" + packageName;
-  var fsPackageName = username + "_" + packageName;
+  var fsPackageName = packageName;
   var githubUrl = "http://github.com/foo/bar";
   var summary = "Package for test";
 


### PR DESCRIPTION
It used to create a directory with an underscore instead of a colon
Now, it just removes the prefix.

In cases where the name of the package has more than one colon, we report an
error.