### PR TITLE
Better documentation for callbacks taking arguments

### DIFF
--- a/docs/client/api-box.js
+++ b/docs/client/api-box.js
@@ -59,7 +59,7 @@ var typeNameTranslation = {
 
 Template.autoApiBox.helpers({
   apiData: apiData,
-  typeNames: function (nameList) {
+  typeNames: function typeNames (nameList) {
     // change names if necessary
     nameList = _.map(nameList, function (name) {
       // decode the "Array.<Type>" syntax
@@ -81,6 +81,10 @@ Template.autoApiBox.helpers({
 
       if (typeNameTranslation.hasOwnProperty(name)) {
         return typeNameTranslation[name];
+      }
+
+      if (DocsData[name]) {
+        return typeNames(DocsData[name].type);
       }
 
       return name;

--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -2765,6 +2765,34 @@ DocsData = {
     "scope": "static",
     "summary": "Send an HTTP `PUT` request. Equivalent to calling [`HTTP.call`](#http_call) with \"PUT\" as the first argument."
   },
+  "IterationCallback": {
+    "kind": "typedef",
+    "longname": "IterationCallback",
+    "name": "IterationCallback",
+    "params": [
+      {
+        "name": "doc",
+        "type": {
+          "names": [
+            "Object"
+          ]
+        }
+      },
+      {
+        "name": "index",
+        "type": {
+          "names": [
+            "Number"
+          ]
+        }
+      }
+    ],
+    "type": {
+      "names": [
+        "function"
+      ]
+    }
+  },
   "Match": {
     "kind": "namespace",
     "longname": "Match",
@@ -4231,6 +4259,15 @@ DocsData = {
     "name": "count",
     "options": [],
     "params": [],
+    "returns": [
+      {
+        "type": {
+          "names": [
+            "Number"
+          ]
+        }
+      }
+    ],
     "scope": "instance",
     "summary": "Returns the number of documents that match a query."
   },
@@ -4267,7 +4304,7 @@ DocsData = {
         "name": "callback",
         "type": {
           "names": [
-            "function"
+            "IterationCallback"
           ]
         }
       },
@@ -4298,7 +4335,7 @@ DocsData = {
         "name": "callback",
         "type": {
           "names": [
-            "function"
+            "IterationCallback"
           ]
         }
       },
@@ -5399,7 +5436,11 @@ DocsData = {
     "params": [],
     "returns": [
       {
-        "description": "<p>Blaze.TemplateInstance</p>"
+        "type": {
+          "names": [
+            "Blaze.TemplateInstance"
+          ]
+        }
       }
     ],
     "scope": "static",
@@ -5675,7 +5716,7 @@ DocsData = {
         "name": "runFunc",
         "type": {
           "names": [
-            "function"
+            "TrackerComputationFunction"
           ]
         }
       }
@@ -5758,6 +5799,25 @@ DocsData = {
     ],
     "scope": "static",
     "summary": "Registers a new [`onInvalidate`](#computation_oninvalidate) callback on the current computation (which must exist), to be called immediately when the current computation is invalidated or stopped."
+  },
+  "TrackerComputationFunction": {
+    "kind": "typedef",
+    "longname": "TrackerComputationFunction",
+    "name": "TrackerComputationFunction",
+    "params": [
+      {
+        "type": {
+          "names": [
+            "Tracker.Computation"
+          ]
+        }
+      }
+    ],
+    "type": {
+      "names": [
+        "function"
+      ]
+    }
   },
   "check": {
     "kind": "function",

--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -5595,6 +5595,27 @@ DocsData = {
     "scope": "instance",
     "summary": "True if this computation has been stopped."
   },
+  "Tracker.ComputationFunction": {
+    "kind": "typedef",
+    "longname": "Tracker.ComputationFunction",
+    "memberof": "Tracker",
+    "name": "ComputationFunction",
+    "params": [
+      {
+        "type": {
+          "names": [
+            "Tracker.Computation"
+          ]
+        }
+      }
+    ],
+    "scope": "static",
+    "type": {
+      "names": [
+        "function"
+      ]
+    }
+  },
   "Tracker.Dependency": {
     "instancename": "dependency",
     "kind": "class",
@@ -5716,7 +5737,7 @@ DocsData = {
         "name": "runFunc",
         "type": {
           "names": [
-            "TrackerComputationFunction"
+            "Tracker.ComputationFunction"
           ]
         }
       }
@@ -5799,25 +5820,6 @@ DocsData = {
     ],
     "scope": "static",
     "summary": "Registers a new [`onInvalidate`](#computation_oninvalidate) callback on the current computation (which must exist), to be called immediately when the current computation is invalidated or stopped."
-  },
-  "TrackerComputationFunction": {
-    "kind": "typedef",
-    "longname": "TrackerComputationFunction",
-    "name": "TrackerComputationFunction",
-    "params": [
-      {
-        "type": {
-          "names": [
-            "Tracker.Computation"
-          ]
-        }
-      }
-    ],
-    "type": {
-      "names": [
-        "function"
-      ]
-    }
   },
   "check": {
     "kind": "function",

--- a/docs/client/names.json
+++ b/docs/client/names.json
@@ -213,6 +213,7 @@
   "Tracker.Computation#onInvalidate",
   "Tracker.Computation#stop",
   "Tracker.Computation#stopped",
+  "Tracker.ComputationFunction",
   "Tracker.Dependency",
   "Tracker.Dependency#changed",
   "Tracker.Dependency#depend",
@@ -224,7 +225,6 @@
   "Tracker.flush",
   "Tracker.nonreactive",
   "Tracker.onInvalidate",
-  "TrackerComputationFunction",
   "check",
   "currentUser",
   "loggingIn"

--- a/docs/client/names.json
+++ b/docs/client/names.json
@@ -99,6 +99,7 @@
   "HTTP.get",
   "HTTP.post",
   "HTTP.put",
+  "IterationCallback",
   "Match",
   "Match.test",
   "Meteor",
@@ -223,6 +224,7 @@
   "Tracker.flush",
   "Tracker.nonreactive",
   "Tracker.onInvalidate",
+  "TrackerComputationFunction",
   "check",
   "currentUser",
   "loggingIn"

--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -475,7 +475,7 @@ Template.prototype.events = function (eventMap) {
  * @memberOf Template
  * @summary The [template instance](#template_inst) corresponding to the current template helper, event handler, callback, or autorun.  If there isn't one, `null`.
  * @locus Client
- * @returns Blaze.TemplateInstance
+ * @returns {Blaze.TemplateInstance}
  */
 Template.instance = function () {
   return Template._currentTemplateInstanceFunc

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -144,12 +144,17 @@ LocalCollection.prototype.findOne = function (selector, options) {
 };
 
 /**
+ * @callback IterationCallback
+ * @param {Object} doc
+ * @param {Number} index
+ */
+/**
  * @summary Call `callback` once for each matching document, sequentially and synchronously.
  * @locus Anywhere
  * @method  forEach
  * @instance
  * @memberOf Mongo.Cursor
- * @param {Function} callback Function to call. It will be called with three arguments: the document, a 0-based index, and <em>cursor</em> itself.
+ * @param {IterationCallback} callback Function to call. It will be called with three arguments: the document, a 0-based index, and <em>cursor</em> itself.
  * @param {Any} [thisArg] An object which will be the value of `this` inside `callback`.
  */
 LocalCollection.Cursor.prototype.forEach = function (callback, thisArg) {
@@ -185,7 +190,7 @@ LocalCollection.Cursor.prototype.getTransform = function () {
  * @method map
  * @instance
  * @memberOf Mongo.Cursor
- * @param {Function} callback Function to call. It will be called with three arguments: the document, a 0-based index, and <em>cursor</em> itself.
+ * @param {IterationCallback} callback Function to call. It will be called with three arguments: the document, a 0-based index, and <em>cursor</em> itself.
  * @param {Any} [thisArg] An object which will be the value of `this` inside `callback`.
  */
 LocalCollection.Cursor.prototype.map = function (callback, thisArg) {
@@ -220,6 +225,7 @@ LocalCollection.Cursor.prototype.fetch = function () {
  * @method  count
  * @instance
  * @locus Anywhere
+ * @returns {Number}
  */
 LocalCollection.Cursor.prototype.count = function () {
   var self = this;

--- a/packages/tracker/tracker.js
+++ b/packages/tracker/tracker.js
@@ -453,13 +453,13 @@ Tracker.flush = function (_opts) {
 // so that it is stopped if the current computation is invalidated.
 
 /**
- * @callback TrackerComputationFunction
+ * @callback Tracker.ComputationFunction
  * @param {Tracker.Computation}
  */
 /**
  * @summary Run a function now and rerun it later whenever its dependencies change. Returns a Computation object that can be used to stop or observe the rerunning.
  * @locus Client
- * @param {TrackerComputationFunction} runFunc The function to run. It receives one argument: the Computation object that will be returned.
+ * @param {Tracker.ComputationFunction} runFunc The function to run. It receives one argument: the Computation object that will be returned.
  * @returns {Tracker.Computation}
  */
 Tracker.autorun = function (f) {

--- a/packages/tracker/tracker.js
+++ b/packages/tracker/tracker.js
@@ -453,9 +453,13 @@ Tracker.flush = function (_opts) {
 // so that it is stopped if the current computation is invalidated.
 
 /**
+ * @callback TrackerComputationFunction
+ * @param {Tracker.Computation}
+ */
+/**
  * @summary Run a function now and rerun it later whenever its dependencies change. Returns a Computation object that can be used to stop or observe the rerunning.
  * @locus Client
- * @param {Function} runFunc The function to run. It receives one argument: the Computation object that will be returned.
+ * @param {TrackerComputationFunction} runFunc The function to run. It receives one argument: the Computation object that will be returned.
  * @returns {Tracker.Computation}
  */
 Tracker.autorun = function (f) {

--- a/scripts/admin/jsdoc/docdata-jsdoc-template/publish.js
+++ b/scripts/admin/jsdoc/docdata-jsdoc-template/publish.js
@@ -67,6 +67,15 @@
       }
     });
 
+    // Callback descriptions are going to be embeded into Function descriptions
+    // when they are used as arguments, so we always attach them to reference
+    // them later.
+    var callbacks = helper.find(data, {kind: "typedef"});
+    _.each(callbacks, function (cb) {
+      delete cb.comment;
+      addToData(cb.longname, cb);
+    });
+
     var functions = helper.find(data, {kind: "function"});
     var constructors = helper.find(data, {kind: "class"});
 

--- a/scripts/admin/jsdoc/docdata-jsdoc-template/publish.js
+++ b/scripts/admin/jsdoc/docdata-jsdoc-template/publish.js
@@ -37,7 +37,7 @@
     data.___id = undefined;
     data.___s = undefined;
     data.tags = undefined;
-    
+
     names.push(location);
     dataContents[location] = data;
   };


### PR DESCRIPTION
This PR makes it possible to use JSDoc's `@callback` directives to declare a specific type of callbacks with specific arguments types.

So far, we still hide the extra arguments in the docs app, but it should be easier to implement with this PR.

(+ it contains some improvements to internal docs)

cc @stubailo 