### PR TITLE
Validate number of colons in package name on create

### DIFF
--- a/packages/package-version-parser/package-version-parser-tests.js
+++ b/packages/package-version-parser/package-version-parser-tests.js
@@ -29,7 +29,6 @@ Tinytest.add("package-version-parser - validatePackageName", function (test) {
   badName("-x", /not begin with a hyphen/);
   badName("--x", /not begin with a hyphen/);
   badName("0.0", /must contain/);
-  badName("a:a:a", /more than one colon/);
   badName(":a", /start or end with a colon/);
   badName("a:", /start or end with a colon/);
 

--- a/packages/package-version-parser/package-version-parser.js
+++ b/packages/package-version-parser/package-version-parser.js
@@ -394,10 +394,6 @@ PV.validatePackageName = function (packageName, options) {
   // (There is already a package ending with a `-` and one with two consecutive `-`
   // in troposphere, though they both look like typos.)
 
-  if (packageName.split(":").length > 2) {
-    throwVersionParserError("Package names may not have more than one colon.");
-  }
-
   if (packageName[0] === ":" || __.last(packageName) === ":") {
     throwVersionParserError("Package names may not start or end with a colon.");
   }

--- a/tools/commands.js
+++ b/tools/commands.js
@@ -491,6 +491,18 @@ main.registerCommand({
     var fsName = packageName;
     if (packageName.indexOf(":") !== -1) {
       var split = packageName.split(":");
+
+      if (split.length > 2) {
+        // It may seem like this check should be inside package version parser's
+        // validatePackageName, but we decided to name test packages like this:
+        // local-test:prefix:name, so we have to support building packages
+        // with at least two colons. Therefore we will at least try to
+        // discourage people from putting a ton of colons in their package names
+        // here.
+        Console.error(packageName +
+          ": Package names may not have more than one colon.");
+      }
+
       fsName = split[1];
     }
 


### PR DESCRIPTION
Instead of in the general package version parser