### PR TITLE
Allow runtime modification of accounts-oauth services set

### DIFF
--- a/packages/accounts-oauth/oauth_common.js
+++ b/packages/accounts-oauth/oauth_common.js
@@ -19,6 +19,17 @@ Accounts.oauth.registerService = function (name) {
   }
 };
 
+// Removes a previously registered service.
+// This will disable logging in with this service, and serviceNames() will not
+// contain it.
+// It's worth noting that already logged in users will remain logged in unless
+// you manually expire their sessions.
+Accounts.oauth.deregisterService = function (name) {
+  if (!_.has(services, name))
+    throw new Error("Service not found: " + name);
+  delete services[name];
+};
+
 Accounts.oauth.serviceNames = function () {
   return _.keys(services);
 };

--- a/packages/accounts-oauth/oauth_server.js
+++ b/packages/accounts-oauth/oauth_server.js
@@ -41,6 +41,17 @@ Accounts.registerLoginHandler(function (options) {
     // We tried to login, but there was a fatal error. Report it back
     // to the user.
     throw result;
-  else
+  else {
+    if (!_.contains(Accounts.oauth.serviceNames(), result.serviceName)) {
+      // serviceName was not found in the registered services list.
+      // This could happen because the service never registered itself or
+      // deregisterService was called on it.
+      return { type: "oauth",
+               error: new Meteor.Error(
+                 Accounts.LoginCancelledError.numericError,
+                 "No registered oauth service found for: " + result.serviceName) };
+
+    }
     return Accounts.updateOrCreateUserFromExternalService(result.serviceName, result.serviceData, result.options);
+  }
 });


### PR DESCRIPTION
Hi all,

For Sandstorm.io, we would like the server administrator to be able to dynamically configure which login services are available. We ship an already-built server bundle to users who deploy on their own hardware, so it's inconvenient to tell people to rebuild with different Meteor packages. In fact, we'd like to have an admin UI that allows the administrator to toggle services on and off without even restarting the server. It seems like this is probably a common need for Meteor apps that are designed to have many instances managed by different people.

This PR is a proposal which seems to accomplish what we want, but please let us know if there is a better way.

In this PR, we add a method to remove login services from the registered set, which is most of what we need. We also add a check at login time to reject logins using a deregistered service. Otherwise, because packages like `google` and `github` are always resident in our server even if not enabled, people would presumably be able to log in with them by manually sending the right requests.

It looks like the code in `accounts-base` will already reject calls to `configureLoginService` for a service name not in the `serviceNames()` set, which is great because we wouldn't want arbitrary users to be able to configure services that the admin left disabled (and presumably never configured).

Separately from this PR, it looks like we'll need to forgo the `accounts-{google,github,...}` packages and instead depend directly on `{google,github,...}` and implement the `accounts-oauth` registration part directly. Fortunately this appears to be only a couple lines of code for each service. It would be nice to see this become more controllable in the future, though.

Thoughts?

-Kenton

PS. We'd love to add a test, but this package doesn't appear to have any tests, and it's not really clear how tests should be written. Please let us know if there is a good place to put them.