### PR TITLE
OAuth::Google - Add the option `includeGrantedScopes` to `Meteor.loginWithGoogle`

### DIFF
--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -34,6 +34,7 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
   // https://developers.google.com/accounts/docs/OAuth2WebServer#formingtheurl
   var accessType = options.requestOfflineToken ? 'offline' : 'online';
   var approvalPrompt = options.forceApprovalPrompt ? 'force' : 'auto';
+  var includeGrantedScopes = options.includeGrantedScopes ? 'true' : 'false';
 
   var loginStyle = OAuth._loginStyle('google', config, options);
 
@@ -45,7 +46,8 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
         '&redirect_uri=' + OAuth._redirectUri('google', config) +
         '&state=' + OAuth._stateParam(loginStyle, credentialToken) +
         '&access_type=' + accessType +
-        '&approval_prompt=' + approvalPrompt;
+        '&approval_prompt=' + approvalPrompt +
+        '&include_granted_scopes=' + includeGrantedScopes;
 
   // Use Google's domain-specific login page if we want to restrict creation to
   // a particular email domain. (Don't use it if restrictCreationByEmailDomain

--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -49,15 +49,6 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
         '&approval_prompt=' + approvalPrompt +
         '&include_granted_scopes=' + includeGrantedScopes;
 
-  // Use Google's domain-specific login page if we want to restrict creation to
-  // a particular email domain. (Don't use it if restrictCreationByEmailDomain
-  // is a function.) Note that all this does is change Google's UI ---
-  // accounts-base/accounts_server.js still checks server-side that the server
-  // has the proper email address after the OAuth conversation.
-  if (typeof Accounts._options.restrictCreationByEmailDomain === 'string') {
-    loginUrl += '&hd=' + encodeURIComponent(Accounts._options.restrictCreationByEmailDomain);
-  }
-
   OAuth.launchLogin({
     loginService: "google",
     loginStyle: loginStyle,


### PR DESCRIPTION
[As per the documentation](https://developers.google.com/accounts/docs/OAuth2WebServer#formingtheurl):
If this is provided with the value true, and the authorization request is granted, the authorization will include any previous authorizations granted to this user/application combination for other scopes; see Incremental Authorization.