### PR TITLE
PhantomJS doesn't serialize node values, attributes (like value) must be...

### DIFF
--- a/packages/blaze/attrs.js
+++ b/packages/blaze/attrs.js
@@ -171,8 +171,14 @@ var BooleanHandler = AttributeHandler.extend({
   }
 });
 
+var origUpdate = AttributeHandler.prototype.update;
 var ValueHandler = AttributeHandler.extend({
   update: function (element, oldValue, value) {
+    var self = this;
+    var args = arguments;
+
+    origUpdate.apply(self, args);
+
     if (value !== element.value)
       element.value = value;
   }


### PR DESCRIPTION
PhantomJS doesn't serialize node values, attributes like `value` must be set.

This is partially related to #3824 but is entirely it's own issue.

PhantomJS; specifically [page.content](https://github.com/meteor/meteor/blob/devel/packages/spiderable/phantom_script.js#L23) doesn't serialize some values from the DOM node to HTML content, the issue is that the attributes must also be set on the tag as well [like so here](https://github.com/meteor/meteor/blob/devel/packages/blaze/attrs.js#L39-L44)

The reason for this pull request is to fix the immediate problem of `input`s `value`s attribute not being sent via `spiderable` package, but a second pair of eyes or someone more versed with blaze should ensure other attributes are being properly serialized by blame/phantomjs.

Cheers!
