### PR TITLE
Add momentum scrolling to documentation

### DIFF
--- a/docs/client/docs.less
+++ b/docs/client/docs.less
@@ -381,6 +381,7 @@ ol {
     height: 100%;
     top: 0;
     overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
 }
 
 .main-content {
@@ -391,6 +392,7 @@ ol {
     z-index: 1;
     background: white;
     overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
     overflow-x: hidden;
     margin-left: 0;
     transition: margin-left 300ms ease-out;


### PR DESCRIPTION
enable momentum scrolling on the documentation page for iOS devices