### PR TITLE
Fix #4088

### DIFF
--- a/tools/package-source.js
+++ b/tools/package-source.js
@@ -982,6 +982,11 @@ _.extend(PackageSource.prototype, {
         npmDependencies = null;
         cordovaDependencies = null;
       }
+      
+      // Fill in files for wildcard source selectors
+      _.each(compiler.ALL_ARCHES, function (arch) {
+        api.sources[arch] = files.updateWildcardSelectors(self.sourceRoot, api.sources[arch]);
+      });
     }
 
     // By the way, you can't depend on yourself.


### PR DESCRIPTION
Add feature #4088 “Package api.addFiles accept wildcards / folders”

Adding:
* `files.updateWildcardSelectors`
* Applied this in `package-source`

Reference: https://github.com/MeteorCommunity/discussions/issues/7

Notes: This is for now just for discussion, eg. if this should be added
if so where / if it should work recursively / etc.

There is no tests / changes to documentation yet

Kind regards Morten