### PR TITLE
Template args

### DIFF
--- a/packages/blaze-tools/tokens.js
+++ b/packages/blaze-tools/tokens.js
@@ -19,8 +19,10 @@ var unicodeClass = function (abbrev) {
 };
 
 // Special handlebars-reserved identifiers, usually starting with '@'
-// Other candidates to be in this list: '@last', '@first', '@key'
-var reservedIds = ['@index'];
+var reservedIds = [
+  // special #each-loop variables
+  '@index', '@index_1', '@first', '@last', '@odd', '@even', '@key'
+];
 
 // See ECMA-262 spec, 3rd edition, Section 7.6
 // Match one or more characters that can start an identifier.

--- a/packages/blaze-tools/tokens.js
+++ b/packages/blaze-tools/tokens.js
@@ -21,7 +21,9 @@ var unicodeClass = function (abbrev) {
 // Special handlebars-reserved identifiers, usually starting with '@'
 var reservedIds = [
   // special #each-loop variables
-  '@index', '@index_1', '@first', '@last', '@odd', '@even', '@key'
+  '@index', '@index_1', '@first', '@last', '@odd', '@even', '@key',
+  // a new template inclusion operator
+  '@>'
 ];
 
 // See ECMA-262 spec, 3rd edition, Section 7.6

--- a/packages/blaze-tools/tokens.js
+++ b/packages/blaze-tools/tokens.js
@@ -23,7 +23,9 @@ var reservedIds = [
   // special #each-loop variables
   '@index', '@index_1', '@first', '@last', '@odd', '@even', '@key',
   // a new template inclusion operator
-  '@>'
+  '@>',
+  // special keywords for new templates features
+  '@args', '@state'
 ];
 
 // See ECMA-262 spec, 3rd edition, Section 7.6

--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -130,8 +130,10 @@ var fireCallbacks = function (callbacks, template) {
 // A separate reference to the argsView to have the context where the arguments
 // are evaluated, so we can later re-evaluate them reactively in an autorun.
 var setupArgsForTemplateView = function (view, argsFunc, argsView, formalArgs) {
-  var initArgs = argsFunc();
-  Blaze._attachBindingsToView(_.pick(initArgs, formalArgs), view);
+  Tracker.nonreactive(function () {
+    var initArgs = argsFunc();
+    Blaze._attachBindingsToView(_.pick(initArgs, formalArgs), view);
+  });
   Blaze._attachBindingsToView({
     '@args': argsFunc
   }, view);

--- a/packages/spacebars-compiler/codegen.js
+++ b/packages/spacebars-compiler/codegen.js
@@ -74,7 +74,7 @@ _.extend(CodeGen.prototype, {
             'function () { return ' + code + '; })';
         }
         return BlazeTools.EmitCode(code);
-      } else if (tag.type === 'INCLUSION' || tag.type === 'BLOCKOPEN') {
+      } else if (_.contains(['INCLUSION', 'INCLUSION_ARGS', 'BLOCKOPEN'], tag.type)) {
         var path = tag.path;
         var args = tag.args;
 
@@ -142,16 +142,28 @@ _.extend(CodeGen.prototype, {
           }
 
           var dataCode = self.codeGenInclusionDataFunc(tag.args);
+          var argsCode = null;
+
+          // In the different inclusion type, arguments don't form a
+          // data-context, but rather set the template-level scope.
+          if (tag.type === 'INCLUSION_ARGS') {
+            argsCode = dataCode;
+            dataCode = null;
+          }
+
           var content = (('content' in tag) ?
                          self.codeGenBlock(tag.content) : null);
           var elseContent = (('elseContent' in tag) ?
                              self.codeGenBlock(tag.elseContent) : null);
 
           var includeArgs = [compCode];
-          if (content) {
-            includeArgs.push(content);
-            if (elseContent)
-              includeArgs.push(elseContent);
+          if (content || argsCode) {
+            includeArgs.push(content || 'null');
+            if (elseContent || argsCode) {
+              includeArgs.push(elseContent || 'null');
+              if (argsCode)
+                includeArgs.push(argsCode);
+            }
           }
 
           var includeCode =

--- a/packages/spacebars-compiler/spacebars_tests.js
+++ b/packages/spacebars-compiler/spacebars_tests.js
@@ -99,6 +99,8 @@ Tinytest.add("spacebars-compiler - stache tags", function (test) {
                      args: []});
   run('{{> a.b.c}}', {type: 'INCLUSION', path: ['a', 'b', 'c'],
                       args: []});
+  run('{{@> templ a=b c = d}}', {type: 'INCLUSION_ARGS', path: ['templ'],
+                      args: [['PATH', ['b'], 'a'], ['PATH', ['d'], 'c']]});
 
   run('{{foo.[]/[]}}', {type: 'DOUBLE', path: ['foo', '', ''],
                         args: []});

--- a/packages/spacebars-compiler/templatetag.js
+++ b/packages/spacebars-compiler/templatetag.js
@@ -49,7 +49,7 @@ TemplateTag.prototype = new HTMLTools.TemplateTag;
 TemplateTag.prototype.constructorName = 'SpacebarsCompiler.TemplateTag';
 
 var makeStacheTagStartRegex = function (r) {
-  return new RegExp(r.source + /(?![{>!#/])/.source,
+  return new RegExp(r.source + /(?!([{>!#/]|@>))/.source,
                     r.ignoreCase ? 'i' : '');
 };
 
@@ -64,6 +64,7 @@ var starts = {
   BLOCKCOMMENT: makeStacheTagStartRegex(/^\{\{\s*!--/),
   COMMENT: makeStacheTagStartRegex(/^\{\{\s*!/),
   INCLUSION: makeStacheTagStartRegex(/^\{\{\s*>\s*(?!\s)/),
+  INCLUSION_ARGS: makeStacheTagStartRegex(/^\{\{\s*@>\s*(?!\s)/),
   BLOCKOPEN: makeStacheTagStartRegex(/^\{\{\s*#\s*(?!\s)/),
   BLOCKCLOSE: makeStacheTagStartRegex(/^\{\{\s*\/\s*(?!\s)/)
 };
@@ -244,6 +245,7 @@ TemplateTag.parse = function (scannerOrString) {
   else if (run(starts.BLOCKCOMMENT)) type = 'BLOCKCOMMENT';
   else if (run(starts.COMMENT)) type = 'COMMENT';
   else if (run(starts.INCLUSION)) type = 'INCLUSION';
+  else if (run(starts.INCLUSION_ARGS)) type = 'INCLUSION_ARGS';
   else if (run(starts.BLOCKOPEN)) type = 'BLOCKOPEN';
   else if (run(starts.BLOCKCLOSE)) type = 'BLOCKCLOSE';
   else
@@ -273,7 +275,7 @@ TemplateTag.parse = function (scannerOrString) {
     var result = run(/^\{*\|/);
     tag.value = '{{' + result.slice(0, -1);
   } else {
-    // DOUBLE, TRIPLE, BLOCKOPEN, INCLUSION
+    // DOUBLE, TRIPLE, BLOCKOPEN, INCLUSION, INCLUSION_ARGS
     tag.path = scanPath();
     tag.args = [];
     var foundKwArg = false;

--- a/packages/spacebars-tests/template_tests.html
+++ b/packages/spacebars-tests/template_tests.html
@@ -1095,3 +1095,13 @@ Hi there!
   {{/each}}
 </template>
 
+<template name="spacebars_template_test_template_arguments" args="one two three">
+  {{one}} - {{two}} - {{three}}
+</template>
+
+<template name="spacebars_template_test_template_pass_arguments">
+  {{#let v="variable reference"}}
+    {{@> spacebars_template_test_template_arguments one="my string" two=2 three=v}}
+  {{/let}}
+</template>
+

--- a/packages/spacebars-tests/template_tests.html
+++ b/packages/spacebars-tests/template_tests.html
@@ -1114,3 +1114,13 @@ Hi there!
   {{@> spacebars_template_test_undeclared_args one=1 two=2 three=3}}
 </template>
 
+<template name="spacebars_template_test_at_args_symbol" args="five">
+  {{five}} - {{keyValues @args}}
+</template>
+
+<template name="spacebars_template_test_at_args_symbol_caller">
+  {{#let th=3}}
+    {{@> spacebars_template_test_at_args_symbol one=1 two="two" three=th four=helper five="f"}}
+  {{/let}}
+</template>
+

--- a/packages/spacebars-tests/template_tests.html
+++ b/packages/spacebars-tests/template_tests.html
@@ -1105,3 +1105,12 @@ Hi there!
   {{/let}}
 </template>
 
+<template name="spacebars_template_test_undeclared_args" args="one two">
+  {{!-- three is omited from args formals on purpose --}}
+  {{one}} - {{two}} - {{three}}
+</template>
+
+<template name="spacebars_template_test_undeclared_args_caller">
+  {{@> spacebars_template_test_undeclared_args one=1 two=2 three=3}}
+</template>
+

--- a/packages/spacebars-tests/template_tests.html
+++ b/packages/spacebars-tests/template_tests.html
@@ -1095,13 +1095,13 @@ Hi there!
   {{/each}}
 </template>
 
-<template name="spacebars_template_test_template_arguments" args="one two three">
-  {{one}} - {{two}} - {{three}}
+<template name="spacebars_template_test_template_arguments" args="one two three four">
+  {{one}} - {{two}} - {{three}} - {{four}}
 </template>
 
 <template name="spacebars_template_test_template_pass_arguments">
   {{#let v="variable reference"}}
-    {{@> spacebars_template_test_template_arguments one="my string" two=2 three=v}}
+    {{@> spacebars_template_test_template_arguments one="my string" two=2 three=v four=helper}}
   {{/let}}
 </template>
 

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -3328,7 +3328,7 @@ Tinytest.add("spacebars-tests - template_tests - #each @index", function (test) 
   Blaze.remove(view);
 });
 
-Tinytest.add("spacebars-tests - template_tests - template arguments", function (test) {
+Tinytest.add("spacebars-tests - template_tests - template arguments - basic", function (test) {
   var tmpl = Template.spacebars_template_test_template_pass_arguments;
   var myVar = new ReactiveVar('init');
   tmpl.helpers({
@@ -3343,5 +3343,12 @@ Tinytest.add("spacebars-tests - template_tests - template arguments", function (
   myVar.set('new');
   Tracker.flush();
   test.equal(canonicalizeHtml(div.innerHTML), "my string - 2 - variable reference - new");
+});
+
+Tinytest.add("spacebars-tests - template_tests - template arguments - undeclared args", function (test) {
+  var tmpl = Template.spacebars_template_test_undeclared_args_caller;
+
+  var div = renderToDiv(tmpl);
+  test.equal(canonicalizeHtml(div.innerHTML), "1 - 2 - ");
 });
 

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -3328,3 +3328,10 @@ Tinytest.add("spacebars-tests - template_tests - #each @index", function (test) 
   Blaze.remove(view);
 });
 
+Tinytest.add("spacebars-tests - template_tests - template arguments", function (test) {
+  var tmpl = Template.spacebars_template_test_template_pass_arguments;
+
+  var div = renderToDiv(tmpl);
+  test.equal(canonicalizeHtml(div.innerHTML), "my string - 2 - variable reference");
+});
+

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -3330,8 +3330,18 @@ Tinytest.add("spacebars-tests - template_tests - #each @index", function (test) 
 
 Tinytest.add("spacebars-tests - template_tests - template arguments", function (test) {
   var tmpl = Template.spacebars_template_test_template_pass_arguments;
+  var myVar = new ReactiveVar('init');
+  tmpl.helpers({
+    helper: function () {
+      return myVar.get();
+    }
+  });
 
   var div = renderToDiv(tmpl);
-  test.equal(canonicalizeHtml(div.innerHTML), "my string - 2 - variable reference");
+  test.equal(canonicalizeHtml(div.innerHTML), "my string - 2 - variable reference - init");
+
+  myVar.set('new');
+  Tracker.flush();
+  test.equal(canonicalizeHtml(div.innerHTML), "my string - 2 - variable reference - new");
 });
 

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -3352,3 +3352,27 @@ Tinytest.add("spacebars-tests - template_tests - template arguments - undeclared
   test.equal(canonicalizeHtml(div.innerHTML), "1 - 2 -");
 });
 
+Tinytest.add("spacebars-tests - template_tests - template arguments - @args symbol", function (test) {
+  var tmpl = Template.spacebars_template_test_at_args_symbol_caller;
+  var myVar = new ReactiveVar('init');
+  tmpl.helpers({
+    helper: function () {
+      return myVar.get();
+    }
+  });
+  Template.spacebars_template_test_at_args_symbol.helpers({
+    keyValues: function (obj) {
+      return _.map(obj, function (v, k) {
+        return k + ':' + v;
+      }).join(' ');
+    }
+  });
+
+  var div = renderToDiv(tmpl);
+  test.equal(canonicalizeHtml(div.innerHTML), "f - one:1 two:two three:3 four:init five:f");
+
+  myVar.set('new');
+  Tracker.flush();
+  test.equal(canonicalizeHtml(div.innerHTML), "f - one:1 two:two three:3 four:new five:f");
+});
+

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -3349,6 +3349,6 @@ Tinytest.add("spacebars-tests - template_tests - template arguments - undeclared
   var tmpl = Template.spacebars_template_test_undeclared_args_caller;
 
   var div = renderToDiv(tmpl);
-  test.equal(canonicalizeHtml(div.innerHTML), "1 - 2 - ");
+  test.equal(canonicalizeHtml(div.innerHTML), "1 - 2 -");
 });
 

--- a/packages/spacebars/spacebars-runtime.js
+++ b/packages/spacebars/spacebars-runtime.js
@@ -2,7 +2,8 @@ Spacebars = {};
 
 var tripleEquals = function (a, b) { return a === b; };
 
-Spacebars.include = function (templateOrFunction, contentFunc, elseFunc) {
+Spacebars.include = function (
+  templateOrFunction, contentFunc, elseFunc, argsFunc) {
   if (! templateOrFunction)
     return null;
 
@@ -10,7 +11,7 @@ Spacebars.include = function (templateOrFunction, contentFunc, elseFunc) {
     var template = templateOrFunction;
     if (! Blaze.isTemplate(template))
       throw new Error("Expected template or null, found: " + template);
-    return templateOrFunction.constructView(contentFunc, elseFunc);
+    return templateOrFunction.constructView(contentFunc, elseFunc, argsFunc);
   }
 
   var templateVar = Blaze.ReactiveVar(null, tripleEquals);
@@ -22,7 +23,7 @@ Spacebars.include = function (templateOrFunction, contentFunc, elseFunc) {
     if (! Blaze.isTemplate(template))
       throw new Error("Expected template or null, found: " + template);
 
-    return template.constructView(contentFunc, elseFunc);
+    return template.constructView(contentFunc, elseFunc, argsFunc);
   });
   view.__templateVar = templateVar;
   view.onViewCreated(function () {

--- a/packages/templating/plugin/html_scanner.js
+++ b/packages/templating/plugin/html_scanner.js
@@ -167,9 +167,16 @@ html_scanner = {
         var nameLiteral = JSON.stringify(name);
         var templateDotNameLiteral = JSON.stringify("Template." + name);
 
+        // Options passed to the Template constructor
+        var opts = {};
+        if (attribs.args) {
+          opts.formalArgs = attribs.args.split(/\s+/g);
+        }
+
         results.js += "\nTemplate.__checkName(" + nameLiteral + ");\n" +
           "Template[" + nameLiteral + "] = new Template(" +
-          templateDotNameLiteral + ", " + renderFuncCode + ");\n";
+          templateDotNameLiteral + ", " + renderFuncCode + ", " +
+          JSON.stringify(opts) + ");\n";
       } else {
         // <body>
         if (hasAttribs) {


### PR DESCRIPTION
[Main Proposal](https://meteor.hackpad.com/Blaze-lexical-scope-and-template-arguments-fZP806qG6xQ)

A WIP PR and discussion for the template arguments. This branch is based on the `each-in` branch and `spacebars-template-exprs` branch.

```handlebars
<template name="myTemplate" args="fistName lastName">
  <p>{{firstName}} - {{lastName}}</p>
  <p>All arguments:</p>
  <ul>
    {{#each val in @args}}
        <li>{{@key}}: {{val}}</li>
    {{/each}}
  </ul>
</template>

<template name="main">
  {{@> myTemplate firstName="John" lastName="Doe" age=34 nationality="U.S."}}
</template>
```

Will output:

```html
<p>John - Doe</p>
<p>All arguments</p>
<ul>
  <li>firstName: John</li>
  <li>lastName: Doe</li>
  <li>age: 34</li>
  <li>nationality: U.S.</li>
</ul>
```

What's new:

1. The `@>` operator is the new inclusion with args (as opposed to `>` which is inclusion with the data context). Positional and keyword args are under consideration.
2. `@args` - special keyword to access a dictionary of passed arguments. Keyword args are mapped key-value, positional args are mapped as 0-arg0, 1-arg1. Iterable with `#each`.
3. Template's args signature: defined args will be dumped into scope for matching passed args. Other args, not present in the signature, will be available only in `@args`.
4. `@args` can be accessed in JS helpers as `Template.instance().args.get('x')` to get argument `x`. Similar to `Template.instance().state.get('x')/set('x', y)`.