### PR TITLE
Refactor reactive dict into a serializing and non-serializing version

### DIFF
--- a/packages/reactive-dict/package.js
+++ b/packages/reactive-dict/package.js
@@ -7,8 +7,13 @@ Package.onUse(function (api) {
   api.use(['underscore', 'tracker', 'ejson']);
   // If we are loading mongo-livedata, let you store ObjectIDs in it.
   api.use('mongo', {weak: true});
+
   api.export('ReactiveDict');
+  api.export('SerializingReactiveDict');
+
   api.addFiles('reactive-dict.js');
+  api.addFiles("serializing-reactive-dict.js");
+
   api.addFiles('migration.js');
 });
 

--- a/packages/reactive-dict/reactive-dict-tests.js
+++ b/packages/reactive-dict/reactive-dict-tests.js
@@ -1,116 +1,137 @@
 Tinytest.add('ReactiveDict - all() works', function (test) {
-  var all = {}, dict = new ReactiveDict;
-  Tracker.autorun(function() {
-    all = dict.all();
+  _.each([SerializingReactiveDict, ReactiveDict], function (type) {
+    var all = {}, dict = new type();
+    Tracker.autorun(function() {
+      all = dict.all();
+    });
+    
+    test.equal(all, {});
+    
+    dict.set('foo', 'bar');
+
+    Tracker.flush();
+
+    test.equal(all, {foo: 'bar'});
   });
-  
-  test.equal(all, {});
-  
-  dict.set('foo', 'bar');
-  Tracker.flush();
-  test.equal(all, {foo: 'bar'});
 });
 
 Tinytest.add('ReactiveDict - clear() works', function (test) {
-  var dict = new SerializingReactiveDict();
-  dict.set('foo', 'bar');
-  
-  var val, equals, equalsUndefined, all;
-  Tracker.autorun(function() {
-    val = dict.get('foo');
+  _.each([SerializingReactiveDict, ReactiveDict], function (type) {
+    var dict = new type();
+
+    dict.set('foo', 'bar');
+    
+    var val, equals, equalsUndefined, all;
+    Tracker.autorun(function() {
+      val = dict.get('foo');
+    });
+
+    Tracker.autorun(function() {
+      all = dict.all();
+    });
+
+    if (type === SerializingReactiveDict) {
+      Tracker.autorun(function() {
+        equals = dict.equals('foo', 'bar');
+      });
+
+      Tracker.autorun(function() {
+        equalsUndefined = dict.equals('foo', undefined);
+      });
+    }
+    
+    test.equal(val, 'bar');
+    test.equal(all, {foo: 'bar'});
+
+    if (type === SerializingReactiveDict) {
+      test.equal(equals, true);
+      test.equal(equalsUndefined, false);
+    }
+    
+    dict.clear();
+    Tracker.flush();
+
+    test.isUndefined(val);
+    test.equal(all, {});
+    
+    if (type === SerializingReactiveDict) {
+      test.equal(equals, false);
+      test.equal(equalsUndefined, true);
+    }
   });
-  Tracker.autorun(function() {
-    equals = dict.equals('foo', 'bar');
-  });
-  Tracker.autorun(function() {
-    equalsUndefined = dict.equals('foo', undefined);
-  });
-  Tracker.autorun(function() {
-    all = dict.all();
-  });
-  
-  test.equal(val, 'bar');
-  test.equal(equals, true);
-  test.equal(equalsUndefined, false);
-  test.equal(all, {foo: 'bar'});
-  
-  dict.clear();
-  Tracker.flush();
-  test.isUndefined(val);
-  test.equal(equals, false);
-  test.equal(equalsUndefined, true);
-  test.equal(all, {});
 });
 
-var reactiveDict = new ReactiveDict();
 
 Tinytest.add('ReactiveDict - setDefault', function (test) {
-  reactiveDict.setDefault('def', "argyle");
-  test.equal(reactiveDict.get('def'), "argyle");
-  reactiveDict.set('def', "noodle");
-  test.equal(reactiveDict.get('def'), "noodle");
-  reactiveDict.set('nondef', "potato");
-  test.equal(reactiveDict.get('nondef'), "potato");
-  reactiveDict.setDefault('nondef', "eggs");
-  test.equal(reactiveDict.get('nondef'), "potato");
-  // This is so the test passes the next time, after hot code push.  I know it
-  // doesn't return it to the completely untouched state, but we don't have
-  // reactiveDict.clear() yet.  When we do, this should be that.
-  delete reactiveDict.keys['def'];
-  delete reactiveDict.keys['nondef'];
+  _.each([SerializingReactiveDict, ReactiveDict], function (type) {
+    var reactiveDict = new type();
+
+    reactiveDict.setDefault('def', "argyle");
+    test.equal(reactiveDict.get('def'), "argyle");
+    reactiveDict.set('def', "noodle");
+    test.equal(reactiveDict.get('def'), "noodle");
+    reactiveDict.set('nondef', "potato");
+    test.equal(reactiveDict.get('nondef'), "potato");
+    reactiveDict.setDefault('nondef', "eggs");
+    test.equal(reactiveDict.get('nondef'), "potato");
+  });
 });
 
 Tinytest.add('ReactiveDict - get/set types', function (test) {
+  // Test that initial value is undefined
+  var reactiveDict = new ReactiveDict();
   test.equal(reactiveDict.get('u'), undefined);
 
-  reactiveDict.set('u', undefined);
-  test.equal(reactiveDict.get('u'), undefined);
+  var serializingReactiveDict = new ReactiveDict();
+  test.equal(serializingReactiveDict.get('u'), undefined);
 
-  reactiveDict.set('n', null);
-  test.equal(reactiveDict.get('n'), null);
+  // Test that a bunch of types can be get and set properly
+  var testGetAndSet = function (value) {
+    var baseRD = new ReactiveDict();
+    var serializingRD = new SerializingReactiveDict();
 
-  reactiveDict.set('t', true);
-  test.equal(reactiveDict.get('t'), true);
+    baseRD.set("key", value);
+    test.equal(baseRD.get("key"), value);
 
-  reactiveDict.set('f', false);
-  test.equal(reactiveDict.get('f'), false);
+    serializingRD.set("key", value);
+    test.equal(serializingRD.get("key"), value);
+  };
 
-  reactiveDict.set('num', 0);
-  test.equal(reactiveDict.get('num'), 0);
-
-  reactiveDict.set('str', 'true');
-  test.equal(reactiveDict.get('str'), 'true');
-
-  reactiveDict.set('arr', [1, 2, {a: 1, b: [5, 6]}]);
-  test.equal(reactiveDict.get('arr'), [1, 2, {b: [5, 6], a: 1}]);
-
-  reactiveDict.set('obj', {a: 1, b: [5, 6]});
-  test.equal(reactiveDict.get('obj'), {b: [5, 6], a: 1});
-
-  reactiveDict.set('date', new Date(1234));
-  test.equal(reactiveDict.get('date'), new Date(1234));
-
-  reactiveDict.set('oid', new Mongo.ObjectID('ffffffffffffffffffffffff'));
-  test.equal(reactiveDict.get('oid'),  new Mongo.ObjectID('ffffffffffffffffffffffff'));
+  _.each([
+    undefined,
+    null,
+    true,
+    false,
+    0,
+    "true",
+    [1, 2, {a: 1, b: [5, 6]}],
+    {a: 1, b: [5, 6]},
+    new Date(1234),
+    new Mongo.ObjectID('ffffffffffffffffffffffff')
+  ], testGetAndSet);
 });
 
 Tinytest.add('ReactiveDict - context invalidation for get', function (test) {
-  var xGetExecutions = 0;
-  Tracker.autorun(function () {
-    ++xGetExecutions;
-    reactiveDict.get('x');
+  _.each([SerializingReactiveDict, ReactiveDict], function (type) {
+    var reactiveDict = new type();
+
+    var xGetExecutions = 0;
+    Tracker.autorun(function () {
+      ++xGetExecutions;
+      reactiveDict.get('x');
+    });
+    test.equal(xGetExecutions, 1);
+    reactiveDict.set('x', 1);
+    // Invalidation shouldn't happen until flush time.
+    test.equal(xGetExecutions, 1);
+    Tracker.flush();
+    test.equal(xGetExecutions, 2);
+    // Setting to the same value doesn't re-run.
+    reactiveDict.set('x', 1);
+    Tracker.flush();
+    test.equal(xGetExecutions, 2);
+    reactiveDict.set('x', '1');
+    Tracker.flush();
+    test.equal(xGetExecutions, 3);
   });
-  test.equal(xGetExecutions, 1);
-  reactiveDict.set('x', 1);
-  // Invalidation shouldn't happen until flush time.
-  test.equal(xGetExecutions, 1);
-  Tracker.flush();
-  test.equal(xGetExecutions, 2);
-  // Setting to the same value doesn't re-run.
-  reactiveDict.set('x', 1);
-  Tracker.flush();
-  test.equal(xGetExecutions, 2);
-  reactiveDict.set('x', '1');
-  Tracker.flush();
-  test.equal(xGetExecutions, 3);
 });

--- a/packages/reactive-dict/reactive-dict-tests.js
+++ b/packages/reactive-dict/reactive-dict-tests.js
@@ -11,9 +11,8 @@ Tinytest.add('ReactiveDict - all() works', function (test) {
   test.equal(all, {foo: 'bar'});
 });
 
-
 Tinytest.add('ReactiveDict - clear() works', function (test) {
-  var dict = new ReactiveDict;
+  var dict = new SerializingReactiveDict();
   dict.set('foo', 'bar');
   
   var val, equals, equalsUndefined, all;
@@ -41,4 +40,77 @@ Tinytest.add('ReactiveDict - clear() works', function (test) {
   test.equal(equals, false);
   test.equal(equalsUndefined, true);
   test.equal(all, {});
+});
+
+var reactiveDict = new ReactiveDict();
+
+Tinytest.add('ReactiveDict - setDefault', function (test) {
+  reactiveDict.setDefault('def', "argyle");
+  test.equal(reactiveDict.get('def'), "argyle");
+  reactiveDict.set('def', "noodle");
+  test.equal(reactiveDict.get('def'), "noodle");
+  reactiveDict.set('nondef', "potato");
+  test.equal(reactiveDict.get('nondef'), "potato");
+  reactiveDict.setDefault('nondef', "eggs");
+  test.equal(reactiveDict.get('nondef'), "potato");
+  // This is so the test passes the next time, after hot code push.  I know it
+  // doesn't return it to the completely untouched state, but we don't have
+  // reactiveDict.clear() yet.  When we do, this should be that.
+  delete reactiveDict.keys['def'];
+  delete reactiveDict.keys['nondef'];
+});
+
+Tinytest.add('ReactiveDict - get/set types', function (test) {
+  test.equal(reactiveDict.get('u'), undefined);
+
+  reactiveDict.set('u', undefined);
+  test.equal(reactiveDict.get('u'), undefined);
+
+  reactiveDict.set('n', null);
+  test.equal(reactiveDict.get('n'), null);
+
+  reactiveDict.set('t', true);
+  test.equal(reactiveDict.get('t'), true);
+
+  reactiveDict.set('f', false);
+  test.equal(reactiveDict.get('f'), false);
+
+  reactiveDict.set('num', 0);
+  test.equal(reactiveDict.get('num'), 0);
+
+  reactiveDict.set('str', 'true');
+  test.equal(reactiveDict.get('str'), 'true');
+
+  reactiveDict.set('arr', [1, 2, {a: 1, b: [5, 6]}]);
+  test.equal(reactiveDict.get('arr'), [1, 2, {b: [5, 6], a: 1}]);
+
+  reactiveDict.set('obj', {a: 1, b: [5, 6]});
+  test.equal(reactiveDict.get('obj'), {b: [5, 6], a: 1});
+
+  reactiveDict.set('date', new Date(1234));
+  test.equal(reactiveDict.get('date'), new Date(1234));
+
+  reactiveDict.set('oid', new Mongo.ObjectID('ffffffffffffffffffffffff'));
+  test.equal(reactiveDict.get('oid'),  new Mongo.ObjectID('ffffffffffffffffffffffff'));
+});
+
+Tinytest.add('ReactiveDict - context invalidation for get', function (test) {
+  var xGetExecutions = 0;
+  Tracker.autorun(function () {
+    ++xGetExecutions;
+    reactiveDict.get('x');
+  });
+  test.equal(xGetExecutions, 1);
+  reactiveDict.set('x', 1);
+  // Invalidation shouldn't happen until flush time.
+  test.equal(xGetExecutions, 1);
+  Tracker.flush();
+  test.equal(xGetExecutions, 2);
+  // Setting to the same value doesn't re-run.
+  reactiveDict.set('x', 1);
+  Tracker.flush();
+  test.equal(xGetExecutions, 2);
+  reactiveDict.set('x', '1');
+  Tracker.flush();
+  test.equal(xGetExecutions, 3);
 });

--- a/packages/reactive-dict/reactive-dict.js
+++ b/packages/reactive-dict/reactive-dict.js
@@ -7,6 +7,7 @@ changed = function (v) {
 
 ReactiveDict = function (dictName) {
   // this.keys: key -> value
+  // XXX COMPAT WITH 0.9.1 : accept migrationData instead of dictName
   if (dictName) {
     return new SerializingReactiveDict(dictName);
   }

--- a/packages/reactive-dict/reactive-dict.js
+++ b/packages/reactive-dict/reactive-dict.js
@@ -1,50 +1,62 @@
-// XXX come up with a serialization method which canonicalizes object key
-// order, which would allow us to use objects as values for equals.
-var stringify = function (value) {
-  if (value === undefined)
-    return 'undefined';
-  return EJSON.stringify(value);
-};
-var parse = function (serialized) {
-  if (serialized === undefined || serialized === 'undefined')
-    return undefined;
-  return EJSON.parse(serialized);
+// Helper function to call changed on a key that might not exist
+changed = function (v) {
+  if (v) {
+    v.changed();
+  }
 };
 
-var changed = function (v) {
-  v && v.changed();
-};
-
-// XXX COMPAT WITH 0.9.1 : accept migrationData instead of dictName
 ReactiveDict = function (dictName) {
   // this.keys: key -> value
   if (dictName) {
-    if (typeof dictName === 'string') {
-      // the normal case, argument is a string name.
-      // _registerDictForMigrate will throw an error on duplicate name.
-      ReactiveDict._registerDictForMigrate(dictName, this);
-      this.keys = ReactiveDict._loadMigratedDict(dictName) || {};
-    } else if (typeof dictName === 'object') {
-      // back-compat case: dictName is actually migrationData
-      this.keys = dictName;
-    } else {
-      throw new Error("Invalid ReactiveDict argument: " + dictName);
-    }
-  } else {
-    // no name given; no migration will be performed
-    this.keys = {};
+    return new SerializingReactiveDict(dictName);
   }
 
-  this.allDeps = new Tracker.Dependency;
-  this.keyDeps = {}; // key -> Dependency
-  this.keyValueDeps = {}; // key -> Dependency
+  // Actual data storage
+  this.keys = {};
+
+  // Used for .get to fire a change when the value changes
+  this.keyDeps = {};
+
+  // Used for .clear and .all
+  this.allDeps = new Tracker.Dependency();
+
+  // Save the result of converting an undefined
+  this._identity = this._convert(undefined);
 };
 
 _.extend(ReactiveDict.prototype, {
-  // set() began as a key/value method, but we are now overloading it
-  // to take an object of key/value pairs, similar to backbone
-  // http://backbonejs.org/#Model-set
+  /**
+   * Convert incoming values to a desired representation for internal storage
+   * @param  {Object} value Anything the user puts in
+   * @return {Object}       The object that will be stored in the internal
+   * data structure of the ReactiveDict
+   */
+  _convert: function (value) {
+    // No-op in the base class, override this to modify incoming values, for
+    // example to serialize them
+    return value;
+  },
 
+  // The opposite of _convert
+  _unConvert: function (convertedValue) {
+    return convertedValue;
+  },
+
+  /**
+   * Compare two internally stored values
+   * @param  {Object} l A value of the form returned by _convert
+   * @param  {Object} r A value of the form returned by _convert
+   * @return {Boolean} True if the items should be considered equal 
+   */
+  _equals: function (l, r) {
+    return _.isEqual(l, r);
+  },
+
+  /**
+   * Set a value
+   * @param {String} key   The key
+   * @param {Object} value Any value
+   */
   set: function (keyOrObject, value) {
     var self = this;
 
@@ -56,24 +68,35 @@ _.extend(ReactiveDict.prototype, {
     // and we resume with the rest of the function
     var key = keyOrObject;
 
-    value = stringify(value);
+    value = self._convert(value);
 
-    var oldSerializedValue = 'undefined';
-    if (_.has(self.keys, key)) oldSerializedValue = self.keys[key];
-    if (value === oldSerializedValue)
+    var oldValue = self._identity;
+    if (_.has(self.keys, key)) {
+      oldValue = self.keys[key];
+    }
+
+    if (self._equals(value, oldValue)) {
+      // Do nothing, the set has no effect
       return;
+    }
+
     self.keys[key] = value;
 
     self.allDeps.changed();
     changed(self.keyDeps[key]);
-    if (self.keyValueDeps[key]) {
-      changed(self.keyValueDeps[key][oldSerializedValue]);
-      changed(self.keyValueDeps[key][value]);
-    }
+  },
+
+  _setObject: function (object) {
+    var self = this;
+
+    _.each(object, function (value, key){
+      self.set(key, value);
+    });
   },
 
   setDefault: function (key, value) {
     var self = this;
+
     // for now, explicitly check for undefined, since there is no
     // ReactiveDict.clear().  Later we might have a ReactiveDict.clear(), in which case
     // we should check if it has the key.
@@ -86,104 +109,46 @@ _.extend(ReactiveDict.prototype, {
     var self = this;
     self._ensureKey(key);
     self.keyDeps[key].depend();
-    return parse(self.keys[key]);
+    return self._unConvert(self.keys[key]);
   },
 
   equals: function (key, value) {
-    var self = this;
-
-    // Mongo.ObjectID is in the 'mongo' package
-    var ObjectID = null;
-    if (typeof Mongo !== 'undefined') {
-      ObjectID = Mongo.ObjectID;
-    }
-
-    // We don't allow objects (or arrays that might include objects) for
-    // .equals, because JSON.stringify doesn't canonicalize object key
-    // order. (We can make equals have the right return value by parsing the
-    // current value and using EJSON.equals, but we won't have a canonical
-    // element of keyValueDeps[key] to store the dependency.) You can still use
-    // "EJSON.equals(reactiveDict.get(key), value)".
-    //
-    // XXX we could allow arrays as long as we recursively check that there
-    // are no objects
-    if (typeof value !== 'string' &&
-        typeof value !== 'number' &&
-        typeof value !== 'boolean' &&
-        typeof value !== 'undefined' &&
-        !(value instanceof Date) &&
-        !(ObjectID && value instanceof ObjectID) &&
-        value !== null)
-      throw new Error("ReactiveDict.equals: value must be scalar");
-    var serializedValue = stringify(value);
-
-    if (Tracker.active) {
-      self._ensureKey(key);
-
-      if (! _.has(self.keyValueDeps[key], serializedValue))
-        self.keyValueDeps[key][serializedValue] = new Tracker.Dependency;
-
-      var isNew = self.keyValueDeps[key][serializedValue].depend();
-      if (isNew) {
-        Tracker.onInvalidate(function () {
-          // clean up [key][serializedValue] if it's now empty, so we don't
-          // use O(n) memory for n = values seen ever
-          if (! self.keyValueDeps[key][serializedValue].hasDependents())
-            delete self.keyValueDeps[key][serializedValue];
-        });
-      }
-    }
-
-    var oldValue = undefined;
-    if (_.has(self.keys, key)) oldValue = parse(self.keys[key]);
-    return EJSON.equals(oldValue, value);
-  },
-  
-  all: function() {
-    this.allDeps.depend();
-    var ret = {};
-    _.each(this.keys, function(value, key) {
-      ret[key] = parse(value);
-    });
-    return ret;
-  },
-  
-  clear: function() {
-    var self = this;
-    
-    var oldKeys = self.keys;
-    self.keys = {};
-    
-    self.allDeps.changed();
-    
-    _.each(oldKeys, function(value, key) {
-      changed(self.keyDeps[key]);
-      changed(self.keyValueDeps[key][value]);
-      changed(self.keyValueDeps[key]['undefined']);
-    });
-    
-  },
-
-  _setObject: function (object) {
-    var self = this;
-
-    _.each(object, function (value, key){
-      self.set(key, value);
-    });
+    // In the base class, there is no efficient way to do .equals, so we only do
+    // it in the serializing variants
+    throw new Error(".equals is not implemented on this object.");
   },
 
   _ensureKey: function (key) {
     var self = this;
     if (!(key in self.keyDeps)) {
-      self.keyDeps[key] = new Tracker.Dependency;
-      self.keyValueDeps[key] = {};
+      self.keyDeps[key] = new Tracker.Dependency();
     }
   },
 
-  // Get a JSON value that can be passed to the constructor to
-  // create a new ReactiveDict with the same contents as this one
-  _getMigrationData: function () {
-    // XXX sanitize and make sure it's JSONible?
-    return this.keys;
+  /**
+   * Return all of the keys/values of the ReactiveDict as a plain object, and
+   * register a dependency on any changes to the dictionary.
+   */
+  all: function () {
+    var self = this;
+
+    self.allDeps.depend();
+
+    var unConverted = {};
+    _.each(self.keys, function (value, key) {
+      unConverted[key] = self._unConvert(value);
+    });
+
+    return unConverted;
+  },
+
+  clear: function () {
+    var self = this;
+
+    _.each(self.keys, function (value, key) {
+      self.set(key, undefined);
+    });
+
+    self.keys = {};
   }
 });

--- a/packages/reactive-dict/serializing-reactive-dict.js
+++ b/packages/reactive-dict/serializing-reactive-dict.js
@@ -1,0 +1,117 @@
+SerializingReactiveDict = function (dictName) {
+  ReactiveDict.call(this);
+
+  // Used for .equals to make sure we only fire a change when the equality state
+  // changes
+  this.keyValueDeps = {};
+
+  // this.keys: key -> value
+  if (dictName) {
+    if (typeof dictName === 'string') {
+      // the normal case, argument is a string name.
+      // _registerDictForMigrate will throw an error on duplicate name.
+      ReactiveDict._registerDictForMigrate(dictName, this);
+      this.keys = ReactiveDict._loadMigratedDict(dictName) || {};
+    } else if (typeof dictName === 'object') {
+      // XXX COMPAT WITH 0.9.1 : accept migrationData instead of dictName
+      this.keys = dictName;
+    } else {
+      throw new Error("Invalid SerializingReactiveDict argument: " + dictName);
+    }
+  }
+};
+
+Meteor._inherits(SerializingReactiveDict, ReactiveDict);
+
+_.extend(SerializingReactiveDict.prototype, {
+  _convert: function (value) {
+    // XXX come up with a serialization method which canonicalizes object key
+    // order, which would allow us to use objects as values for equals.
+    if (value === undefined) {
+      return 'undefined';
+    }
+
+    return EJSON.stringify(value);
+  },
+  _unConvert: function (serialized) {
+    if (serialized === undefined || serialized === 'undefined') {
+      return undefined;
+    }
+
+    return EJSON.parse(serialized);
+  },
+  set: function (key, value) {
+    var self = this;
+    var oldValue = this.keys[key];
+
+    ReactiveDict.prototype.set.call(this, key, value);
+
+    if (self.keyValueDeps[key]) {
+      changed(self.keyValueDeps[key][oldValue]);
+      changed(self.keyValueDeps[key][value]);
+    }
+  },
+  equals: function (key, value) {
+    var self = this;
+
+    // Mongo.ObjectID is in the 'mongo' package
+    var ObjectID = null;
+    if (typeof Package.mongo !== 'undefined') {
+      ObjectID = Package.mongo.Mongo.ObjectID;
+    }
+
+    // We don't allow objects (or arrays that might include objects) for
+    // .equals, because JSON.stringify doesn't canonicalize object key
+    // order. (We can make equals have the right return value by parsing the
+    // current value and using EJSON.equals, but we won't have a canonical
+    // element of keyValueDeps[key] to store the dependency.) You can still use
+    // "EJSON.equals(reactiveDict.get(key), value)".
+    //
+    // XXX we could allow arrays as long as we recursively check that there
+    // are no objects
+    if (typeof value !== 'string' &&
+        typeof value !== 'number' &&
+        typeof value !== 'boolean' &&
+        typeof value !== 'undefined' &&
+        !(value instanceof Date) &&
+        !(ObjectID && value instanceof ObjectID) &&
+        value !== null)
+      throw new Error("ReactiveDict.equals: value must be scalar");
+
+    var serializedValue = self._convert(value);
+
+    if (Tracker.active) {
+      self._ensureKey(key);
+
+      if (! _.has(self.keyValueDeps[key], serializedValue))
+        self.keyValueDeps[key][serializedValue] = new Tracker.Dependency;
+
+      var isNew = self.keyValueDeps[key][serializedValue].depend();
+      if (isNew) {
+        Tracker.onInvalidate(function () {
+          // clean up [key][serializedValue] if it's now empty, so we don't
+          // use O(n) memory for n = values seen ever
+          if (! self.keyValueDeps[key][serializedValue].hasDependents())
+            delete self.keyValueDeps[key][serializedValue];
+        });
+      }
+    }
+
+    var oldValue = undefined;
+    if (_.has(self.keys, key)) oldValue = self._unConvert(self.keys[key]);
+    return EJSON.equals(oldValue, value);
+  },
+
+  _ensureKey: function (key) {
+    ReactiveDict.prototype._ensureKey.call(this, key);
+
+    var self = this;
+    if (!(key in self.keyValueDeps)) {
+      self.keyValueDeps[key] = {};
+    }
+  },
+
+  _getMigrationData: function () {
+    return this.keys;
+  }
+});


### PR DESCRIPTION
- Until now, ReactiveDict always serialized and deserialized everything when getting and setting. This means you can't store any values that are not serializable, for example functions and objects with prototypes
- With this PR, the new default is to not serialize
- If you pass a string to the constructor, ReactiveDict will give you back a SerializingReactiveDict to preserve backwards compatibility with migrating ReactiveDict (like Session)
- You can also call the SerializingReactiveDict constructor directly
- `ReactiveDict#equals` doesn't work on a non-serializing reactive dict, because it is impossible to implement it efficiently

### Breaking changes

- If you construct a ReactiveDict with no argument to the constructor, you will not be able to use `equals`

### Possible solution

- Keep ReactiveDict as it is, and introduce a new class called NonSerializingReactiveDict, but that seems a little silly