### PR TITLE
Default to error if it's actually a string

### DIFF
--- a/packages/meteor/fiber_helpers.js
+++ b/packages/meteor/fiber_helpers.js
@@ -150,7 +150,7 @@ _.extend(Meteor._SynchronousQueue.prototype, {
         // We'll throw this exception through runTask.
         exception = err;
       } else {
-        Meteor._debug("Exception in queued task: " + err.stack);
+        Meteor._debug("Exception in queued task: " + (err.stack || err));
       }
     }
     self._currentTaskFiber = undefined;

--- a/packages/meteor/fiber_stubs_client.js
+++ b/packages/meteor/fiber_stubs_client.js
@@ -46,7 +46,7 @@ _.extend(Meteor._SynchronousQueue.prototype, {
             // for.
             throw e;
           } else {
-            Meteor._debug("Exception in queued task: " + e.stack);
+            Meteor._debug("Exception in queued task: " + (e.stack || e));
           }
         }
       }


### PR DESCRIPTION
It happens when transform function throws an exception, for example.