### PR TITLE
Replace deprecated router function

### DIFF
--- a/examples/localmarket/lib/router.js
+++ b/examples/localmarket/lib/router.js
@@ -22,60 +22,73 @@ if (Meteor.isClient) {
 }
 
 HomeController = RouteController.extend({
-  onBeforeAction: function() {
-    Meteor.subscribe('latestActivity', function() {
+  onBeforeAction: function () {
+    Meteor.subscribe('latestActivity', function () {
       dataReadyHold.release();
     });
   }
 });
 
 FeedController = RouteController.extend({
-  onBeforeAction: function() {
+  onBeforeAction: function () {
     this.feedSubscription = feedSubscription;
   }
 });
 
 RecipesController = RouteController.extend({
-  data: function() {
+  data: function () {
     return _.values(RecipesData);
   }
 });
 
 BookmarksController = RouteController.extend({
-  onBeforeAction: function() {
+  onBeforeAction: function () {
     if (Meteor.user())
       Meteor.subscribe('bookmarks');
     else
       Overlay.open('authOverlay');
   },
-  data: function() {
+  data: function () {
     if (Meteor.user())
       return _.values(_.pick(RecipesData, Meteor.user().bookmarkedRecipeNames));
   }
 });
 
 RecipeController = RouteController.extend({
-  onBeforeAction: function() {
+  onBeforeAction: function () {
     Meteor.subscribe('recipe', this.params.name);
   },
-  data: function() {
+  data: function () {
     return RecipesData[this.params.name];
   }
 });
 
 AdminController = RouteController.extend({
-  onBeforeAction: function() {
+  onBeforeAction: function () {
     Meteor.subscribe('news');
   }
 });
 
+Router.route('home', {
+  path: '/'
+});
 
-Router.route('home', {path: '/'});
 Router.route('feed');
-Router.route('recipes');
-Router.route('bookmarks');
-Router.route('about');
-Router.route('recipe', {path: '/recipes/:name'});
-Router.route('admin', {layoutTemplate: null});
 
-Router.onBeforeAction('dataNotFound', {only: 'recipe'});
+Router.route('recipes');
+
+Router.route('bookmarks');
+
+Router.route('about');
+
+Router.route('recipe', {
+  path: '/recipes/:name'
+});
+
+Router.route('admin', {
+  layoutTemplate: null
+});
+
+Router.onBeforeAction('dataNotFound', {
+  only: 'recipe'
+});

--- a/examples/localmarket/lib/router.js
+++ b/examples/localmarket/lib/router.js
@@ -69,14 +69,13 @@ AdminController = RouteController.extend({
   }
 });
 
-Router.map(function() {
-  this.route('home', {path: '/'});
-  this.route('feed');
-  this.route('recipes');
-  this.route('bookmarks');
-  this.route('about');
-  this.route('recipe', {path: '/recipes/:name'});
-  this.route('admin', { layoutTemplate: null });
-});
+
+Router.route('home', {path: '/'});
+Router.route('feed');
+Router.route('recipes');
+Router.route('bookmarks');
+Router.route('about');
+Router.route('recipe', {path: '/recipes/:name'});
+Router.route('admin', {layoutTemplate: null});
 
 Router.onBeforeAction('dataNotFound', {only: 'recipe'});

--- a/examples/todos/lib/router.js
+++ b/examples/todos/lib/router.js
@@ -30,34 +30,32 @@ if (Meteor.isClient) {
   Router.onBeforeAction('dataNotFound', {except: ['join', 'signin']});
 }
 
-Router.map(function() {
-  this.route('join');
-  this.route('signin');
+Router.route('join');
+Router.route('signin');
 
-  this.route('listsShow', {
-    path: '/lists/:_id',
-    // subscribe to todos before the page is rendered but don't wait on the
-    // subscription, we'll just render the items as they arrive
-    onBeforeAction: function () {
-      this.todosHandle = Meteor.subscribe('todos', this.params._id);
+Router.route('listsShow', {
+  path: '/lists/:_id',
+  // subscribe to todos before the page is rendered but don't wait on the
+  // subscription, we'll just render the items as they arrive
+  onBeforeAction: function () {
+    this.todosHandle = Meteor.subscribe('todos', this.params._id);
 
-      if (this.ready()) {
-        // Handle for launch screen defined in app-body.js
-        dataReadyHold.release();
-      }
-    },
-    data: function () {
-      return Lists.findOne(this.params._id);
-    },
-    action: function () {
-      this.render();
+    if (this.ready()) {
+      // Handle for launch screen defined in app-body.js
+      dataReadyHold.release();
     }
-  });
+  },
+  data: function () {
+    return Lists.findOne(this.params._id);
+  },
+  action: function () {
+    this.render();
+  }
+});
 
-  this.route('home', {
-    path: '/',
-    action: function() {
-      Router.go('listsShow', Lists.findOne());
-    }
-  });
+Router.route('home', {
+  path: '/',
+  action: function() {
+    Router.go('listsShow', Lists.findOne());
+  }
 });


### PR DESCRIPTION
`Router.map` is deprecated and should be replaced with `Router.route`.
The author of iron-router confirmed this in the [following issue](https://github.com/iron-meteor/iron-router/issues/1026).