### PR TITLE
Add notice about ROOT_URL to OAuth API docs

### DIFF
--- a/docs/client/full-api/api/accounts.md
+++ b/docs/client/full-api/api/accounts.md
@@ -221,6 +221,10 @@ is loaded. The function `Accounts.loginServicesConfigured()` is a reactive data
 source that will return true once the login service is configured; you should
 not make login buttons visible or active until it is true.
 
+Ensure that your `ROOT_URL` matches the authorized domain/callback URL that you
+configure with the external service (for instance, if you are running Meteor
+behind a proxy server on port 80 or 443).
+
 {{> autoApiBox "currentUser"}}
 
 {{> autoApiBox "loggingIn"}}


### PR DESCRIPTION
A possible pitfall when configuring OAuth is that after proxying the Meteor application behind (for instance) nginx, the ROOT_URL doesn't match the hostname/port combination expected.