### PR TITLE
Enter nested job scope per package architecture when downloading

### DIFF
--- a/tools/tropohouse.js
+++ b/tools/tropohouse.js
@@ -458,16 +458,20 @@ _.extend(exports.Tropohouse.prototype, {
         // try to rename over the other thing?  but that's the same as in
         // warehouse?
         _.each(buildsToDownload, function (build) {
-          try {
-            var buildTempDir = self._downloadBuildToTempDir(
-              { packageName: packageName, version: version }, build);
-          } catch (e) {
-            if (!(e instanceof files.OfflineError))
-              throw e;
-            buildmessage.error(e.error.message);
-          }
-          buildInputDirs.push(buildTempDir);
-          buildTempDirs.push(buildTempDir);
+          buildmessage.enterJob({
+            title: "downloading " + packageName + "@" + version + " for " + build.buildArchitectures + "..."
+          }, function() {
+            try {
+              var buildTempDir = self._downloadBuildToTempDir(
+                { packageName: packageName, version: version }, build);
+            } catch (e) {
+              if (!(e instanceof files.OfflineError))
+                throw e;
+              buildmessage.error(e.error.message);
+            }
+            buildInputDirs.push(buildTempDir);
+            buildTempDirs.push(buildTempDir);
+          });
         });
         if (buildmessage.jobHasMessages())
           return;


### PR DESCRIPTION
This fixes a crash when two architectures need to be downloaded
for the same package. It happens when building for non-host architecture
if packages have not been cached yet.

Crash happened because progress object got reused for another download request,
and progress objects are not supposed to be reused.

How to reproduce:
Build any meteor project for os.linux.x86_64 when ~/.meteor is empty

CLA has been signed by the company (Hansoft) and sent via e-mail

