### PR TITLE
Fixed: Missing space between words in docs. #4149

### DIFF
--- a/docs/client/basic/introduction.html
+++ b/docs/client/basic/introduction.html
@@ -53,7 +53,7 @@ catches your interest, we hope you'll get involved with the project!
 
 <dt><span>Forums</span></dt>
 <dd>Visit the <a href="https://forums.meteor.com">Meteor discussion
-    forums</a>to announce projects, get help, talk about the community,
+    forums</a> to announce projects, get help, talk about the community,
   or discuss changes to core.
 </dd>
 


### PR DESCRIPTION
Added a space between the "forumsto" under the "Forums" subheading under "Developer Resources" on the Documentation page.