### PR TITLE
change docs to doc

### DIFF
--- a/docs/client/full-api/api/collections.md
+++ b/docs/client/full-api/api/collections.md
@@ -463,7 +463,7 @@ Posts.allow({
 });
 
 Posts.deny({
-  update: function (userId, docs, fields, modifier) {
+  update: function (userId, doc, fields, modifier) {
     // can't change owners
     return _.contains(fields, 'owner');
   },


### PR DESCRIPTION
This parameter name is misleading. A single document is passed to the Meteor.deny({update}) function, not an array of documents