### PR TITLE
Added `throwStubExceptions` option to Meteor.call

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -823,13 +823,18 @@ _.extend(Connection.prototype, {
 
     // If an exception occurred in a stub, and we're ignoring it
     // because we're doing an RPC and want to use what the server
-    // returns instead, log it so the developer knows.
+    // returns instead, log it so the developer knows
+    // (unless they explicitly ask to see the error).
     //
     // Tests can set the 'expected' flag on an exception so it won't
     // go to log.
-    if (exception && !exception.expected) {
-      Meteor._debug("Exception while simulating the effect of invoking '" +
-                    name + "'", exception, exception.stack);
+    if (exception) {
+      if (options.throwStubExceptions) {
+        throw exception;
+      } else if (!exception.expected) {
+        Meteor._debug("Exception while simulating the effect of invoking '" +
+          name + "'", exception, exception.stack);
+      }
     }
 
 

--- a/packages/ddp-client/livedata_tests.js
+++ b/packages/ddp-client/livedata_tests.js
@@ -193,6 +193,19 @@ testAsyncMulti("livedata - basic method invocation", [
       test.equal(Meteor.call("exception", "both"), undefined);
       test.equal(Meteor.call("exception", "server"), undefined);
       test.equal(Meteor.call("exception", "client"), undefined);
+      
+      // If we pass throwStubExceptions then we *should* see thrown exceptions
+      // on the client
+      test.throws(function () {
+        Meteor.apply("exception", ["both"], {throwStubExceptions: true});
+      });
+      test.equal(
+        Meteor.apply("exception", ["server"], {throwStubExceptions: true}), 
+        undefined);
+      test.throws(function () {
+        Meteor.apply("exception", ["client"], {throwStubExceptions: true});
+      });
+      
     }
 
     // With callback


### PR DESCRIPTION
Allows method simulations to be used as validators and enables freely throwing exceptions in method definitions without worrying about spurious logging on the client.

The motivation for this is to allow *a* solution to one of the problems outlined here: https://meteor.hackpad.com/Separating-call-into-call-and-callAsync-kNjhay2PLlM

I realise a better solution is probably warranted but this allows workarounds.

A related question: To actually make throwing `Meteor.Error`s practically useful for things like validation, we'd like to pass an object as the `details` field. As [documented](http://docs.meteor.com/#/full/meteor_error) `details` is a String, although it works to set it as an arbitrary stringify-able object. Would it make sense to make that official?