### PR TITLE
Update google template

### DIFF
--- a/packages/google/google_configure.html
+++ b/packages/google/google_configure.html
@@ -10,7 +10,7 @@
       "Create Project", if needed. Wait for Google to finish provisioning.
     </li>
     <li>
-      On the left sidebar, go to "APIs &amp; auth" and, underneath, "Consent Screen". Make sure to enter a product name, and save.
+      On the left sidebar, go to "APIs &amp; auth" and, underneath, "Consent Screen". Make sure to enter an email address and a product name, and save.
     </li>
     <li>
       On the left sidebar, go to "APIs &amp; auth" and then, "Credentials". "Create New Client ID", then select "Web application" as the type.

--- a/packages/google/google_configure.html
+++ b/packages/google/google_configure.html
@@ -4,7 +4,7 @@
   </p>
   <ol>
     <li>
-      Visit <a href="https://code.google.com/apis/console/" target="blank">https://code.google.com/apis/console/</a>
+      Visit <a href="https://console.developers.google.com/" target="blank">https://console.developers.google.com/</a>
     </li>
     <li>
       "Create Project", if needed. Wait for Google to finish provisioning.


### PR DESCRIPTION
Simple text fixes to the Google account configure screen. Updated link to Google Developers Console, add note to enter email address since otherwise the sign-in will not work. 