### PR TITLE
Cordova: support for local plugins

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -52,7 +52,7 @@ var packageJson = {
     // 2.4.0 (more or less, the package.json change isn't committed) plus our PR
     // https://github.com/williamwicks/node-eachline/pull/4
     eachline: "https://github.com/meteor/node-eachline/tarball/ff89722ff94e6b6a08652bf5f44c8fffea8a21da",
-    cordova: "4.3.0",
+    cordova: "4.2.0",
     pathwatcher: "4.1.0"
   }
 };

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -52,7 +52,7 @@ var packageJson = {
     // 2.4.0 (more or less, the package.json change isn't committed) plus our PR
     // https://github.com/williamwicks/node-eachline/pull/4
     eachline: "https://github.com/meteor/node-eachline/tarball/ff89722ff94e6b6a08652bf5f44c8fffea8a21da",
-    cordova: "4.2.0",
+    cordova: "4.3.0",
     pathwatcher: "4.1.0"
   }
 };

--- a/tools/commands-cordova.js
+++ b/tools/commands-cordova.js
@@ -2904,17 +2904,17 @@ _.extend(Android.prototype, {
         }
       }
 
-      if (self.isPlatformInstalled('android-19')) {
-        log && Console.success("Found Android 19 API");
+      if (self.isPlatformInstalled('android-21')) {
+        log && Console.success("Found Android 21 API");
       } else {
         if (fixSilent) {
-          log && Console.info("Installing Android 19 API");
-          self.installTarget('android-19', function () {
-            return self.isPlatformInstalled('android-19');
+          log && Console.info("Installing Android 21 API");
+          self.installTarget('android-21', function () {
+            return self.isPlatformInstalled('android-21');
           });
-          log && Console.success("Installed Android 19 API");
+          log && Console.success("Installed Android 21 API");
         } else {
-          log && Console.failInfo("Android API 19 not found");
+          log && Console.failInfo("Android API 21 not found");
 
           result.missing.push("android-api");
           result.acceptable = false;
@@ -2922,8 +2922,8 @@ _.extend(Android.prototype, {
       }
 
       // (We could alternatively check for
-      // {SDK}/system-images/android-19/default/x86/build.prop)
-      if (self.hasTarget('19', 'default/x86')) {
+      // {SDK}/system-images/android-21/default/x86/build.prop)
+      if (self.hasTarget('21', 'default/x86')) {
         log && Console.success("Found suitable Android x86 image");
       } else {
         if (fixSilent) {
@@ -2937,8 +2937,8 @@ _.extend(Android.prototype, {
           });
 
           log && Console.info("Installing Android x86 image");
-          self.installTarget('sys-img-x86-android-19', function () {
-            return self.hasTarget('19', 'default/x86');
+          self.installTarget('sys-img-x86-android-21', function () {
+            return self.hasTarget('21', 'default/x86');
           });
           log && Console.success("Installed Android x86 image");
         } else {

--- a/tools/commands-cordova.js
+++ b/tools/commands-cordova.js
@@ -473,7 +473,7 @@ var installPlugin = function (cordovaPath, name, version, conf) {
 
   var pluginInstallCommand;
 
-  if (utils.isUrlWithFileUri(version)) {
+  if (utils.isUrlWithFileScheme(version)) {
     // Strip file://
     pluginInstallCommand = version.substr(7);
   } else {
@@ -634,19 +634,16 @@ var ensureCordovaPlugins = function (projectContext, options) {
   // are up to date since we do not track changes in their sources.
 
   var shouldReinstallPlugins = false,
-      shouldReinstallPluginsFromLocalPaths = false,
-      pluginsFromLocalPath = {};
+    pluginsFromLocalPath = {},
+    pluginFromLocalPath;
 
   // Iterate through all of the plugins and find if any of them have a new
   // version. Additionally check if we have plugins installed from local path.
-  var pluginFromLocalPath;
   _.each(plugins, function (version, name) {
     // Check if plugin is installed from local path
-    pluginFromLocalPath = utils.isUrlWithFileUri(version);
-    if (pluginFromLocalPath) {
-        shouldReinstallPluginsFromLocalPaths = true;
-        pluginsFromLocalPath[name] = version;
-    }
+    pluginFromLocalPath = utils.isUrlWithFileScheme(version);
+    if (pluginFromLocalPath)
+      pluginsFromLocalPath[name] = version;
 
     // XXX there is a hack here that never updates a package if you are
     // trying to install it from a URL, because we can't determine if
@@ -666,10 +663,10 @@ var ensureCordovaPlugins = function (projectContext, options) {
     }
   });
 
-  if (shouldReinstallPluginsFromLocalPaths)
+  if (pluginsFromLocalPath.length > 0)
     verboseLog('Reinstalling cordova plugins added from the local path');
 
-  if (shouldReinstallPlugins || shouldReinstallPluginsFromLocalPaths) {
+  if (shouldReinstallPlugins || pluginsFromLocalPath.length > 0) {
     // Loop through all of the current plugins and remove them one by one until
     // we have deleted proper amount of plugins. It's necessary to loop because
     // we might have dependencies between plugins.
@@ -702,9 +699,9 @@ var ensureCordovaPlugins = function (projectContext, options) {
     buildmessage.enterJob({ title: "installing Cordova plugins"}, function () {
       installedPlugins = getInstalledPlugins(cordovaPath);
       if (shouldReinstallPlugins)
-          uninstallPlugins(installedPlugins, true);
+        uninstallPlugins(installedPlugins, true);
       else
-          uninstallPlugins(pluginsFromLocalPath, false);
+        uninstallPlugins(pluginsFromLocalPath, false);
 
       // Now install necessary plugins.
       try {

--- a/tools/tests/apps/package-tests/packages/empty-cordova-plugin/package.js
+++ b/tools/tests/apps/package-tests/packages/empty-cordova-plugin/package.js
@@ -1,0 +1,10 @@
+Package.describe({
+  version: "1.0.0",
+  summary: "contains a empty cordova plugin"
+});
+
+Package.onUse(function(api) {
+  Cordova.depends({
+    'com.cordova.empty': 'file://../../../../cordova-local-plugin'
+  });
+});

--- a/tools/tests/apps/package-tests/packages/empty-cordova-plugin/package.js
+++ b/tools/tests/apps/package-tests/packages/empty-cordova-plugin/package.js
@@ -7,10 +7,9 @@ Package.onUse(function(api) {
   Cordova.depends({
     // In the test "meteor reinstalls only local cordova plugins on consecutive
     // builds/runs" (test in file cordova-plugin.js) the "plugin"
-    // directory from this package is copied one level up from the meteor app.
+    // directory from this package is copied one level up from the meteor project.
     // Cordova local plugins must have an absolute or relative path to
-    // meteor_app/.meteor/local/cordova-build, so in this case the plugin will
-    // be 4 levels up from cordova-build directory.
-    'com.cordova.empty': 'file://../../../../cordova-local-plugin'
+    // meteor project, so in this case the plugin will be one level up from it.
+    'com.cordova.empty': 'file://../cordova-local-plugin'
   });
 });

--- a/tools/tests/apps/package-tests/packages/empty-cordova-plugin/package.js
+++ b/tools/tests/apps/package-tests/packages/empty-cordova-plugin/package.js
@@ -1,10 +1,16 @@
 Package.describe({
   version: "1.0.0",
-  summary: "contains a empty cordova plugin"
+  summary: "contains an empty cordova plugin"
 });
 
 Package.onUse(function(api) {
   Cordova.depends({
+    // In the test "meteor reinstalls only local cordova plugins on consecutive
+    // builds/runs" (test in file cordova-plugin.js) the "plugin"
+    // directory from this package is copied one level up from the meteor app.
+    // Cordova local plugins must have an absolute or relative path to
+    // meteor_app/.meteor/local/cordova-build, so in this case the plugin will
+    // be 4 levels up from cordova-build directory.
     'com.cordova.empty': 'file://../../../../cordova-local-plugin'
   });
 });

--- a/tools/tests/apps/package-tests/packages/empty-cordova-plugin/plugin/plugin.xml
+++ b/tools/tests/apps/package-tests/packages/empty-cordova-plugin/plugin/plugin.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+        id="com.cordova.empty" version="0.2.3">
+    <name>Empty</name>
+    <description>Cordova Empty Plugin</description>
+    <keywords>cordova,empty</keywords>
+    <repo>https://github.com</repo>
+
+    <js-module src="www/Empty.js" name="Empty">
+        <clobbers target="cordova.plugins.Empty" />
+    </js-module>
+
+
+     <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="Empty" >
+                <param name="android-package" value="com.cordova.empty.Empty"/>
+            </feature>
+        </config-file>
+
+        <source-file src="src/android/Empty.java" target-dir="src/com/cordova/empty" />
+    </platform>
+
+</plugin>

--- a/tools/tests/apps/package-tests/packages/empty-cordova-plugin/plugin/src/android/Empty.java
+++ b/tools/tests/apps/package-tests/packages/empty-cordova-plugin/plugin/src/android/Empty.java
@@ -1,0 +1,17 @@
+package com.cordova.empty;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+public class Empty extends CordovaPlugin {
+    public Object onMessage(String id, Object data) {
+        return null;
+    }
+    @Override
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        return false;
+    }
+}

--- a/tools/tests/apps/package-tests/packages/empty-cordova-plugin/plugin/src/android/Empty_changed.java
+++ b/tools/tests/apps/package-tests/packages/empty-cordova-plugin/plugin/src/android/Empty_changed.java
@@ -1,0 +1,18 @@
+package com.cordova.empty;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+public class Empty extends CordovaPlugin {
+    public Object onMessage(String id, Object data) {
+        System.out.println("change");
+        return null;
+    }
+    @Override
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        return false;
+    }
+}

--- a/tools/tests/apps/package-tests/packages/empty-cordova-plugin/plugin/www/Empty.js
+++ b/tools/tests/apps/package-tests/packages/empty-cordova-plugin/plugin/www/Empty.js
@@ -1,0 +1,3 @@
+var Empty = {
+};
+module.exports = Empty;

--- a/tools/tests/cordova-plugins.js
+++ b/tools/tests/cordova-plugins.js
@@ -421,7 +421,7 @@ selftest.define("meteor reinstalls only local cordova plugins on consecutive bui
   );
 
   // Add the local cordova plugin
-  run = s.run("add", "cordova:com.cordova.empty@file://../../../../cordova-local-plugin");
+  run = s.run("add", "cordova:com.cordova.empty@file://../cordova-local-plugin");
   run.waitSecs(60);
   run.match("added cordova plugin com.cordova.empty");
   run.expectExit(0);

--- a/tools/tests/cordova-plugins.js
+++ b/tools/tests/cordova-plugins.js
@@ -277,7 +277,7 @@ selftest.define("add cordova plugins", ["slow", "cordova"], function () {
   // Add a package with Cordova.depends with local plugin (added from path)
   run = s.run("add", "empty-cordova-plugin");
   run.match("added,");
-  run.match("contains a empty cordova plugin");
+  run.match("contains an empty cordova plugin");
   run.expectExit(0);
 
 });

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -466,7 +466,7 @@ exports.generateSubsetsOfIncreasingSize = function (total, cb) {
   }
 };
 
-exports.isUrlWithFileUri = function (x) {
+exports.isUrlWithFileScheme = function (x) {
   return /^file:\/\/.+/.test(x);
 };
 
@@ -496,7 +496,7 @@ exports.ensureOnlyExactVersions = function (dependencies) {
 };
 exports.isExactVersion = function (version) {
   return semver.valid(version) || exports.isUrlWithSha(version)
-    || exports.isUrlWithFileUri(version);
+    || exports.isUrlWithFileScheme(version);
 };
 
 

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -466,6 +466,10 @@ exports.generateSubsetsOfIncreasingSize = function (total, cb) {
   }
 };
 
+exports.isUrlWithFileUri = function (x) {
+  return /^file:\/\/.+/.test(x);
+};
+
 exports.isUrlWithSha = function (x) {
   // For now, just support http/https, which is at least less restrictive than
   // the old "github only" rule.
@@ -491,7 +495,8 @@ exports.ensureOnlyExactVersions = function (dependencies) {
   });
 };
 exports.isExactVersion = function (version) {
-  return semver.valid(version) || exports.isUrlWithSha(version);
+  return semver.valid(version) || exports.isUrlWithSha(version)
+    || exports.isUrlWithFileUri(version);
 };
 
 

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -476,6 +476,10 @@ exports.isUrlWithSha = function (x) {
   return /^https?:\/\/.*[0-9a-f]{40}/.test(x);
 };
 
+exports.isPathRelative = function (x) {
+  return x.charAt(0) !== '/';
+};
+
 // If there is a version that isn't exact, throws an Error with a
 // human-readable message that is suitable for showing to the user.
 // dependencies may be falsey or empty.


### PR DESCRIPTION
I'm working on project which heavily depends on a cordova plugin which is also under development. Without support for plugins added from local path it was really hard to work on simultaneously on both meteor project and cordova plugin.

Supported syntax is:
meteor add cordova:com.my.plugin@file://../../my/relative/path
meteor add cordova:com.my.plugin@file:///home/user/my/absolute/path

Because I did not want to check whether the plugin has changed I am refreshing the plugin on each build/run. This done by issuing remove and adding the plugin again.
Because cordova 4.2.0 is not properly handling removing plugins added from local path I had to switch to 4.3.0 in which this issue is resolved.

I see that some discussion have been going on here https://github.com/meteor/meteor/issues/2925
Let me know if there is any chance this could be accepted and if yes I am looking forward for comments on this. 
