### PR TITLE
Reusable Accounts constructors

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -16,6 +16,9 @@ AccountsClient = function AccountsClient(options) {
 
   this._pageLoadLoginCallbacks = [];
   this._pageLoadLoginAttemptInfo = null;
+
+  // Defined in url_client.js.
+  this._initUrlMatching();
 };
 
 var Ap = AccountsClient.prototype =

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -406,16 +406,3 @@ if (Package.blaze) {
     return Meteor.loggingIn();
   });
 }
-
-/**
- * @namespace Accounts
- * @summary The namespace for all client-side accounts-related methods.
- */
-Accounts = new AccountsClient();
-
-/**
- * @summary A [Mongo.Collection](#collections) containing user documents.
- * @locus Anywhere
- * @type {Mongo.Collection}
- */
-Meteor.users = Accounts._users;

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -1,26 +1,43 @@
+// @summary Constructor for AccountsClient instances. Available only on
+//          the client for now, though server code might also want to
+//          create a client connection to an accounts server.
+// @locus Client
+// @param options {Object} an object with fields:
+// - connection {Object} Optional DDP connection to reuse.
+// - ddpUrl {String} Optional URL for creating a new DDP connection.
+AccountsClient = function AccountsClient(options) {
+  AccountsCommon.call(this, options);
+
+  this._loggingIn = false;
+  this._loggingInDeps = new Tracker.Dependency;
+
+  this._loginServicesHandle =
+    this.connection.subscribe("meteor.loginServiceConfiguration");
+
+  this._pageLoadLoginCallbacks = [];
+  this._pageLoadLoginAttemptInfo = null;
+};
+
+var Ap = AccountsClient.prototype =
+  Object.create(AccountsCommon.prototype);
+Ap.constructor = AccountsClient;
+
 ///
 /// CURRENT USER
 ///
 
-// This is reactive.
-
-/**
- * @summary Get the current user id, or `null` if no user is logged in. A reactive data source.
- * @locus Anywhere but publish functions
- */
-Meteor.userId = function () {
-  return Accounts.connection.userId();
+// @override
+Ap.userId = function () {
+  return this.connection.userId();
 };
 
-var loggingIn = false;
-var loggingInDeps = new Tracker.Dependency;
 // This is mostly just called within this file, but Meteor.loginWithPassword
 // also uses it to make loggingIn() be true during the beginPasswordExchange
 // method call too.
-Accounts._setLoggingIn = function (x) {
-  if (loggingIn !== x) {
-    loggingIn = x;
-    loggingInDeps.changed();
+Ap._setLoggingIn = function (x) {
+  if (this._loggingIn !== x) {
+    this._loggingIn = x;
+    this._loggingInDeps.changed();
   }
 };
 
@@ -29,21 +46,12 @@ Accounts._setLoggingIn = function (x) {
  * @locus Client
  */
 Meteor.loggingIn = function () {
-  loggingInDeps.depend();
-  return loggingIn;
+  return Accounts.loggingIn();
 };
 
-// This calls userId, which is reactive.
-
-/**
- * @summary Get the current user record, or `null` if no user is logged in. A reactive data source.
- * @locus Anywhere but publish functions
- */
-Meteor.user = function () {
-  var userId = Meteor.userId();
-  if (!userId)
-    return null;
-  return Meteor.users.findOne(userId);
+Ap.loggingIn = function () {
+  this._loggingInDeps.depend();
+  return this._loggingIn;
 };
 
 ///
@@ -74,26 +82,30 @@ Meteor.user = function () {
 // - userCallback: Will be called with no arguments once the user is fully
 //                 logged in, or with the error on error.
 //
-Accounts.callLoginMethod = function (options) {
+Ap.callLoginMethod = function (options) {
+  var self = this;
+
   options = _.extend({
     methodName: 'login',
     methodArguments: [{}],
     _suppressLoggingIn: false
   }, options);
+
   // Set defaults for callback arguments to no-op functions; make sure we
   // override falsey values too.
   _.each(['validateResult', 'userCallback'], function (f) {
     if (!options[f])
       options[f] = function () {};
   });
+
   // Prepare callbacks: user provided and onLogin/onLoginFailure hooks.
   var loginCallbacks = _.once(function (error) {
     if (!error) {
-      onLoginHook.each(function (callback) {
+      self._onLoginHook.each(function (callback) {
         callback();
       });
     } else {
-      onLoginFailureHook.each(function (callback) {
+      self._onLoginFailureHook.each(function (callback) {
         callback();
       });
     }
@@ -118,9 +130,9 @@ Accounts.callLoginMethod = function (options) {
   // will occur before the callback from the resume login call.)
   var onResultReceived = function (err, result) {
     if (err || !result || !result.token) {
-      Accounts.connection.onReconnect = null;
+      self.connection.onReconnect = null;
     } else {
-      Accounts.connection.onReconnect = function () {
+      self.connection.onReconnect = function () {
         reconnected = true;
         // If our token was updated in storage, use the latest one.
         var storedToken = storedLoginToken();
@@ -131,11 +143,11 @@ Accounts.callLoginMethod = function (options) {
           };
         }
         if (! result.tokenExpires)
-          result.tokenExpires = Accounts._tokenExpiration(new Date());
-        if (Accounts._tokenExpiresSoon(result.tokenExpires)) {
-          makeClientLoggedOut();
+          result.tokenExpires = self._tokenExpiration(new Date());
+        if (self._tokenExpiresSoon(result.tokenExpires)) {
+          self.makeClientLoggedOut();
         } else {
-          Accounts.callLoginMethod({
+          self.callLoginMethod({
             methodArguments: [{resume: result.token}],
             // Reconnect quiescence ensures that the user doesn't see an
             // intermediate state before the login method finishes. So we don't
@@ -162,7 +174,7 @@ Accounts.callLoginMethod = function (options) {
                 // periodic localStorage poll will call `makeClientLoggedOut`
                 // eventually if another tab wiped the token from storage.
                 if (storedTokenNow && storedTokenNow === result.token) {
-                  makeClientLoggedOut();
+                  self.makeClientLoggedOut();
                 }
               }
               // Possibly a weird callback to call, but better than nothing if
@@ -190,7 +202,7 @@ Accounts.callLoginMethod = function (options) {
     // Note that we need to call this even if _suppressLoggingIn is true,
     // because it could be matching a _setLoggingIn(true) from a
     // half-completed pre-reconnect login method.
-    Accounts._setLoggingIn(false);
+    self._setLoggingIn(false);
     if (error || !result) {
       error = error || new Error(
         "No result from call to " + options.methodName);
@@ -205,28 +217,28 @@ Accounts.callLoginMethod = function (options) {
     }
 
     // Make the client logged in. (The user data should already be loaded!)
-    makeClientLoggedIn(result.id, result.token, result.tokenExpires);
+    self.makeClientLoggedIn(result.id, result.token, result.tokenExpires);
     loginCallbacks();
   };
 
   if (!options._suppressLoggingIn)
-    Accounts._setLoggingIn(true);
-  Accounts.connection.apply(
+    self._setLoggingIn(true);
+  self.connection.apply(
     options.methodName,
     options.methodArguments,
     {wait: true, onResultReceived: onResultReceived},
     loggedInAndDataReadyCallback);
 };
 
-makeClientLoggedOut = function() {
-  unstoreLoginToken();
-  Accounts.connection.setUserId(null);
-  Accounts.connection.onReconnect = null;
+Ap.makeClientLoggedOut = function () {
+  this.unstoreLoginToken();
+  this.connection.setUserId(null);
+  this.connection.onReconnect = null;
 };
 
-makeClientLoggedIn = function(userId, token, tokenExpires) {
-  storeLoginToken(userId, token, tokenExpires);
-  Accounts.connection.setUserId(userId);
+Ap.makeClientLoggedIn = function (userId, token, tokenExpires) {
+  this.storeLoginToken(userId, token, tokenExpires);
+  this.connection.setUserId(userId);
 };
 
 /**
@@ -235,11 +247,18 @@ makeClientLoggedIn = function(userId, token, tokenExpires) {
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  */
 Meteor.logout = function (callback) {
-  Accounts.connection.apply('logout', [], {wait: true}, function(error, result) {
+  return Accounts.logout(callback);
+};
+
+Ap.logout = function (callback) {
+  var self = this;
+  self.connection.apply('logout', [], {
+    wait: true
+  }, function (error, result) {
     if (error) {
       callback && callback(error);
     } else {
-      makeClientLoggedOut();
+      self.makeClientLoggedOut();
       callback && callback();
     }
   });
@@ -251,6 +270,12 @@ Meteor.logout = function (callback) {
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  */
 Meteor.logoutOtherClients = function (callback) {
+  return Accounts.logoutOtherClients(callback);
+};
+
+Ap.logoutOtherClients = function (callback) {
+  var self = this;
+
   // We need to make two method calls: one to replace our current token,
   // and another to remove all tokens except the current one. We want to
   // call these two methods one after the other, without any other
@@ -267,17 +292,18 @@ Meteor.logoutOtherClients = function (callback) {
   // `getNewToken`, we won't actually send the `removeOtherTokens` call
   // until the `getNewToken` callback has finished running, because they
   // are both wait methods.
-  Accounts.connection.apply(
+  self.connection.apply(
     'getNewToken',
     [],
     { wait: true },
     function (err, result) {
       if (! err) {
-        storeLoginToken(Meteor.userId(), result.token, result.tokenExpires);
+        self.storeLoginToken(self.userId(), result.token, result.tokenExpires);
       }
     }
   );
-  Accounts.connection.apply(
+
+  self.connection.apply(
     'removeOtherTokens',
     [],
     { wait: true },
@@ -292,16 +318,14 @@ Meteor.logoutOtherClients = function (callback) {
 /// LOGIN SERVICES
 ///
 
-var loginServicesHandle =
-  Accounts.connection.subscribe("meteor.loginServiceConfiguration");
-
 // A reactive function returning whether the loginServiceConfiguration
 // subscription is ready. Used by accounts-ui to hide the login button
 // until we have all the configuration loaded
 //
-Accounts.loginServicesConfigured = function () {
-  return loginServicesHandle.ready();
+Ap.loginServicesConfigured = function () {
+  return this._loginServicesHandle.ready();
 };
+
 
 // Some login services such as the redirect login flow or the resume
 // login handler can log the user in at page load time.  The
@@ -312,19 +336,17 @@ Accounts.loginServicesConfigured = function () {
 // initiated in a previous VM, and we now have the result of the login
 // attempt in a new VM.
 
-var pageLoadLoginCallbacks = [];
-var pageLoadLoginAttemptInfo = null;
-
 // Register a callback to be called if we have information about a
 // login attempt at page load time.  Call the callback immediately if
 // we already have the page load login attempt info, otherwise stash
 // the callback to be called if and when we do get the attempt info.
 //
-Accounts.onPageLoadLogin = function (f) {
-  if (pageLoadLoginAttemptInfo)
-    f(pageLoadLoginAttemptInfo);
-  else
-    pageLoadLoginCallbacks.push(f);
+Ap.onPageLoadLogin = function (f) {
+  if (this._pageLoadLoginAttemptInfo) {
+    f(this._pageLoadLoginAttemptInfo);
+  } else {
+    this._pageLoadLoginCallbacks.push(f);
+  }
 };
 
 
@@ -332,14 +354,18 @@ Accounts.onPageLoadLogin = function (f) {
 // Call registered callbacks, and also record the info in case
 // someone's callback hasn't been registered yet.
 //
-Accounts._pageLoadLogin = function (attemptInfo) {
-  if (pageLoadLoginAttemptInfo) {
+Ap._pageLoadLogin = function (attemptInfo) {
+  if (this._pageLoadLoginAttemptInfo) {
     Meteor._debug("Ignoring unexpected duplicate page load login attempt info");
     return;
   }
-  _.each(pageLoadLoginCallbacks, function (callback) { callback(attemptInfo); });
-  pageLoadLoginCallbacks = [];
-  pageLoadLoginAttemptInfo = attemptInfo;
+
+  _.each(this._pageLoadLoginCallbacks, function (callback) {
+    callback(attemptInfo);
+  });
+
+  this._pageLoadLoginCallbacks = [];
+  this._pageLoadLoginAttemptInfo = attemptInfo;
 };
 
 
@@ -370,3 +396,16 @@ if (Package.blaze) {
     return Meteor.loggingIn();
   });
 }
+
+/**
+ * @namespace Accounts
+ * @summary The namespace for all client-side accounts-related methods.
+ */
+Accounts = new AccountsClient();
+
+/**
+ * @summary A [Mongo.Collection](#collections) containing user documents.
+ * @locus Anywhere
+ * @type {Mongo.Collection}
+ */
+Meteor.users = Accounts._users;

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -19,6 +19,9 @@ AccountsClient = function AccountsClient(options) {
 
   // Defined in url_client.js.
   this._initUrlMatching();
+
+  // Defined in localstorage_token.js.
+  this._initLocalStorage();
 };
 
 var Ap = AccountsClient.prototype =
@@ -138,11 +141,11 @@ Ap.callLoginMethod = function (options) {
       self.connection.onReconnect = function () {
         reconnected = true;
         // If our token was updated in storage, use the latest one.
-        var storedToken = storedLoginToken();
+        var storedToken = self._storedLoginToken();
         if (storedToken) {
           result = {
             token: storedToken,
-            tokenExpires: storedLoginTokenExpires()
+            tokenExpires: self._storedLoginTokenExpires()
           };
         }
         if (! result.tokenExpires)
@@ -157,7 +160,7 @@ Ap.callLoginMethod = function (options) {
             // need to show a logging-in animation.
             _suppressLoggingIn: true,
             userCallback: function (error) {
-              var storedTokenNow = storedLoginToken();
+              var storedTokenNow = self._storedLoginToken();
               if (error) {
                 // If we had a login error AND the current stored token is the
                 // one that we tried to log in with, then declare ourselves
@@ -234,13 +237,13 @@ Ap.callLoginMethod = function (options) {
 };
 
 Ap.makeClientLoggedOut = function () {
-  this.unstoreLoginToken();
+  this._unstoreLoginToken();
   this.connection.setUserId(null);
   this.connection.onReconnect = null;
 };
 
 Ap.makeClientLoggedIn = function (userId, token, tokenExpires) {
-  this.storeLoginToken(userId, token, tokenExpires);
+  this._storeLoginToken(userId, token, tokenExpires);
   this.connection.setUserId(userId);
 };
 
@@ -301,7 +304,11 @@ Ap.logoutOtherClients = function (callback) {
     { wait: true },
     function (err, result) {
       if (! err) {
-        self.storeLoginToken(self.userId(), result.token, result.tokenExpires);
+        self._storeLoginToken(
+          self.userId(),
+          result.token,
+          result.tokenExpires
+        );
       }
     }
   );

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -1,12 +1,64 @@
-/**
- * @namespace Accounts
- * @summary The namespace for all accounts-related methods.
- */
-Accounts = {};
+// @summary Super-constructor for AccountsClient an AccountsServer.
+// @locus Anywhere
+// @param options {Object} an object with fields:
+// - connection {Object} Optional DDP connection to reuse.
+// - ddpUrl {String} Optional URL for creating a new DDP connection.
+AccountsCommon = function AccountsCommon(options) {
+  // Currently this is read directly by packages like accounts-password
+  // and accounts-ui-unstyled.
+  this._options = {};
 
-// Currently this is read directly by packages like accounts-password
-// and accounts-ui-unstyled.
-Accounts._options = {};
+  // Note that setting this.connection = null causes this.users to be a
+  // LocalCollection, which is not what we want.
+  this.connection = undefined;
+  this._initConnection(options || {});
+
+  // There is an allow call in accounts_server.js that restricts writes to
+  // this collection.
+  this.users = new Mongo.Collection("users", {
+    _preventAutopublish: true,
+    connection: this.connection
+  });
+
+  // Callback exceptions are printed with Meteor._debug and ignored.
+  this._onLoginHook = new Hook({
+    debugPrintExceptions: "onLogin callback"
+  });
+
+  this._onLoginFailureHook = new Hook({
+    debugPrintExceptions: "onLoginFailure callback"
+  });
+};
+
+var Ap = AccountsCommon.prototype;
+
+/**
+ * @summary Get the current user id, or `null` if no user is logged in. A reactive data source.
+ * @locus Anywhere but publish functions
+ */
+Ap.userId = function () {
+  throw new Error("userId method not implemented");
+};
+
+Ap.user = function () {
+  var userId = this.userId();
+  return userId ? this.users.findOne(userId) : null;
+};
+
+// Note that Accounts is defined separately in accounts_client.js and
+// accounts_server.js.
+
+Meteor.userId = function () {
+  return Accounts.userId();
+};
+
+/**
+ * @summary Get the current user record, or `null` if no user is logged in. A reactive data source.
+ * @locus Anywhere but publish functions
+ */
+Meteor.user = function () {
+  return Accounts.user();
+};
 
 // how long (in days) until a login token expires
 var DEFAULT_LOGIN_EXPIRATION_DAYS = 90;
@@ -22,6 +74,9 @@ CONNECTION_CLOSE_DELAY_MS = 10 * 1000;
 
 // Set up config for the accounts system. Call this on both the client
 // and the server.
+//
+// Note that this method gets overridden on AccountsServer.prototype, but
+// the overriding method calls the overridden method.
 //
 // XXX we should add some enforcement that this is called on both the
 // client and the server. Otherwise, a user can
@@ -52,7 +107,9 @@ CONNECTION_CLOSE_DELAY_MS = 10 * 1000;
  * @param {Number} options.loginExpirationInDays The number of days from when a user logs in until their token expires and they are logged out. Defaults to 90. Set to `null` to disable login expiration.
  * @param {String} options.oauthSecretKey When using the `oauth-encryption` package, the 16 byte key using to encrypt sensitive account credentials in the database, encoded in base64.  This option may only be specifed on the server.  See packages/oauth-encryption/README.md for details.
  */
-Accounts.config = function(options) {
+Ap.config = function (options) {
+  var self = this;
+
   // We don't want users to accidentally only call Accounts.config on the
   // client, where some of the options will have partial effects (eg removing
   // the "create account" button from accounts-ui if forbidClientAccountCreation
@@ -91,21 +148,19 @@ Accounts.config = function(options) {
   // set values in Accounts._options
   _.each(VALID_KEYS, function (key) {
     if (key in options) {
-      if (key in Accounts._options) {
+      if (key in self._options) {
         throw new Error("Can't set `" + key + "` more than once");
-      } else {
-        Accounts._options[key] = options[key];
       }
+      self._options[key] = options[key];
     }
   });
-
-  // If the user set loginExpirationInDays to null, then we need to clear the
-  // timer that periodically expires tokens.
-  if (Meteor.isServer)
-    maybeStopExpireTokensInterval();
 };
 
-if (Meteor.isClient) {
+Ap._initConnection = function (options) {
+  if (! Meteor.isClient) {
+    return;
+  }
+
   // The connection used by the Accounts system. This is the connection
   // that will get logged in by Meteor.login(), and this is the
   // connection whose login state will be reflected by Meteor.userId().
@@ -113,10 +168,13 @@ if (Meteor.isClient) {
   // It would be much preferable for this to be in accounts_client.js,
   // but it has to be here because it's needed to create the
   // Meteor.users collection.
-  Accounts.connection = Meteor.connection;
 
-  if (typeof __meteor_runtime_config__ !== "undefined" &&
-      __meteor_runtime_config__.ACCOUNTS_CONNECTION_URL) {
+  if (options.connection) {
+    this.connection = options.connection;
+  } else if (options.ddpUrl) {
+    this.connection = DDP.connect(options.ddpUrl);
+  } else if (typeof __meteor_runtime_config__ !== "undefined" &&
+             __meteor_runtime_config__.ACCOUNTS_CONNECTION_URL) {
     // Temporary, internal hook to allow the server to point the client
     // to a different authentication server. This is for a very
     // particular use case that comes up when implementing a oauth
@@ -124,83 +182,62 @@ if (Meteor.isClient) {
     //
     // We will eventually provide a general way to use account-base
     // against any DDP connection, not just one special one.
-    Accounts.connection = DDP.connect(
-      __meteor_runtime_config__.ACCOUNTS_CONNECTION_URL)
+    this.connection =
+      DDP.connect(__meteor_runtime_config__.ACCOUNTS_CONNECTION_URL);
+  } else {
+    this.connection = Meteor.connection;
   }
-}
-
-// Users table. Don't use the normal autopublish, since we want to hide
-// some fields. Code to autopublish this is in accounts_server.js.
-// XXX Allow users to configure this collection name.
-
-/**
- * @summary A [Mongo.Collection](#collections) containing user documents.
- * @locus Anywhere
- * @type {Mongo.Collection}
- */
-Meteor.users = new Mongo.Collection("users", {
-  _preventAutopublish: true,
-  connection: Meteor.isClient ? Accounts.connection : Meteor.connection
-});
-// There is an allow call in accounts_server that restricts this
-// collection.
+};
 
 // loginServiceConfiguration and ConfigError are maintained for backwards compatibility
 Meteor.startup(function () {
   var ServiceConfiguration =
     Package['service-configuration'].ServiceConfiguration;
-  Accounts.loginServiceConfiguration = ServiceConfiguration.configurations;
-  Accounts.ConfigError = ServiceConfiguration.ConfigError;
+  Ap.loginServiceConfiguration = ServiceConfiguration.configurations;
+  Ap.ConfigError = ServiceConfiguration.ConfigError;
 });
 
 // Thrown when the user cancels the login process (eg, closes an oauth
 // popup, declines retina scan, etc)
-Accounts.LoginCancelledError = function(description) {
+Ap.LoginCancelledError = function (description) {
+  Error.apply(this, arguments);
   this.message = description;
 };
 
 // This is used to transmit specific subclass errors over the wire. We should
 // come up with a more generic way to do this (eg, with some sort of symbolic
 // error code rather than a number).
-Accounts.LoginCancelledError.numericError = 0x8acdc2f;
-Accounts.LoginCancelledError.prototype = new Error();
-Accounts.LoginCancelledError.prototype.name = 'Accounts.LoginCancelledError';
+Ap.LoginCancelledError.numericError = 0x8acdc2f;
+var LCEp = Ap.LoginCancelledError.prototype = Object.create(Error.prototype);
+LCEp.constructor = Ap.LoginCancelledError;
+LCEp.name = 'Accounts.LoginCancelledError';
 
-getTokenLifetimeMs = function () {
-  return (Accounts._options.loginExpirationInDays ||
+Ap._getTokenLifetimeMs = function () {
+  return (this._options.loginExpirationInDays ||
           DEFAULT_LOGIN_EXPIRATION_DAYS) * 24 * 60 * 60 * 1000;
 };
 
-Accounts._tokenExpiration = function (when) {
+Ap._tokenExpiration = function (when) {
   // We pass when through the Date constructor for backwards compatibility;
   // `when` used to be a number.
-  return new Date((new Date(when)).getTime() + getTokenLifetimeMs());
+  return new Date((new Date(when)).getTime() + this._getTokenLifetimeMs());
 };
 
-Accounts._tokenExpiresSoon = function (when) {
-  var minLifetimeMs = .1 * getTokenLifetimeMs();
+Ap._tokenExpiresSoon = function (when) {
+  var minLifetimeMs = .1 * this._getTokenLifetimeMs();
   var minLifetimeCapMs = MIN_TOKEN_LIFETIME_CAP_SECS * 1000;
   if (minLifetimeMs > minLifetimeCapMs)
     minLifetimeMs = minLifetimeCapMs;
   return new Date() > (new Date(when) - minLifetimeMs);
 };
 
-// Callback exceptions are printed with Meteor._debug and ignored.
-onLoginHook = new Hook({
-  debugPrintExceptions: "onLogin callback"
-});
-onLoginFailureHook = new Hook({
-  debugPrintExceptions: "onLoginFailure callback"
-});
-
-
 /**
  * @summary Register a callback to be called after a login attempt succeeds.
  * @locus Anywhere
  * @param {Function} func The callback to be called when login is successful.
  */
-Accounts.onLogin = function (func) {
-  return onLoginHook.register(func);
+Ap.onLogin = function (func) {
+  return this._onLoginHook.register(func);
 };
 
 /**
@@ -208,6 +245,6 @@ Accounts.onLogin = function (func) {
  * @locus Anywhere
  * @param {Function} func The callback to be called after the login has failed.
  */
-Accounts.onLoginFailure = function (func) {
-  return onLoginFailureHook.register(func);
+Ap.onLoginFailure = function (func) {
+  return this._onLoginFailureHook.register(func);
 };

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1464,20 +1464,3 @@ Ap._deleteSavedTokensForAllUsersOnStartup = function () {
     });
   });
 };
-
-/**
- * @namespace Accounts
- * @summary The namespace for all server-side accounts-related methods.
- */
-Accounts = new AccountsServer();
-
-// Users table. Don't use the normal autopublish, since we want to hide
-// some fields. Code to autopublish this is in accounts_server.js.
-// XXX Allow users to configure this collection name.
-
-/**
- * @summary A [Mongo.Collection](#collections) containing user documents.
- * @locus Anywhere
- * @type {Mongo.Collection}
- */
-Meteor.users = Accounts._users;

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1,10 +1,69 @@
 var crypto = Npm.require('crypto');
 
+// @summary Constructor for the Accounts namespace on the server. Note
+//          that this constructor is less likely to be instantiated
+//          multiple times than the AccountsClient constructor, because a
+//          single server can provide only one set of methods.
+// @locus Server
+// @param server {Object} Often === Meteor.server; needs to support
+//                        server.methods (like Meteor.methods).
+AccountsServer = function AccountsServer(server) {
+  var self = this;
+
+  AccountsCommon.call(self);
+
+  self._server = server || Meteor.server;
+  // Set up the server's methods, as if by calling Meteor.methods.
+  self._initServerMethods();
+
+  self._initAccountDataHooks();
+
+  // If autopublish is on, publish these user fields. Login service
+  // packages (eg accounts-google) add to these by calling
+  // addAutopublishFields.  Notably, this isn't implemented with multiple
+  // publishes since DDP only merges only across top-level fields, not
+  // subfields (such as 'services.facebook.accessToken')
+  self._autopublishFields = {
+    loggedInUser: ['profile', 'username', 'emails'],
+    otherUsers: ['profile', 'username']
+  };
+  self._initServerPublications();
+
+  // connectionId -> {connection, loginToken}
+  self._accountData = {};
+
+  // connection id -> observe handle for the login token that this
+  // connection is currently associated with, or null. Null indicates that
+  // we are in the process of setting up the observe.
+  self._userObservesForConnections = {};
+
+  // list of all registered handlers.
+  self._loginHandlers = [];
+
+  setupUsersCollection(self.users);
+  setupDefaultLoginHandlers(self);
+  setExpireTokensInterval(self);
+
+  self._validateLoginHook = new Hook;
+  self._validateNewUserHooks = [function () {
+    // It would be simpler to use .bind(self), but I'm not sure if
+    // PhantomJS supports Function.prototype.bind yet (ugh).
+    return defaultValidateNewUserHook.apply(self, arguments);
+  }];
+
+  self._deleteSavedTokensForAllUsersOnStartup();
+};
+
+var Ap = AccountsServer.prototype =
+  Object.create(AccountsCommon.prototype);
+Ap.constructor = AccountsServer;
+
 ///
 /// CURRENT USER
 ///
 
-Meteor.userId = function () {
+// @override of "abstract" non-implementation in accounts_common.js
+Ap.userId = function () {
   // This function only works if called inside a method. In theory, it
   // could also be called from publish statements, since they also
   // have a userId associated with them. However, given that publish
@@ -20,43 +79,31 @@ Meteor.userId = function () {
   return currentInvocation.userId;
 };
 
-Meteor.user = function () {
-  var userId = Meteor.userId();
-  if (!userId)
-    return null;
-  return Meteor.users.findOne(userId);
-};
-
-
 ///
 /// LOGIN HOOKS
 ///
-
-// Exceptions inside the hook callback are passed up to us.
-var validateLoginHook = new Hook();
 
 /**
  * @summary Validate login attempts.
  * @locus Server
  * @param {Function} func Called whenever a login is attempted (either successful or unsuccessful).  A login can be aborted by returning a falsy value or throwing an exception.
  */
-Accounts.validateLoginAttempt = function (func) {
-  return validateLoginHook.register(func);
+Ap.validateLoginAttempt = function (func) {
+  // Exceptions inside the hook callback are passed up to us.
+  return this._validateLoginHook.register(func);
 };
-
-
 
 // Give each login hook callback a fresh cloned copy of the attempt
 // object, but don't clone the connection.
 //
-var cloneAttemptWithConnection = function (connection, attempt) {
+function cloneAttemptWithConnection(connection, attempt) {
   var clonedAttempt = EJSON.clone(attempt);
   clonedAttempt.connection = connection;
   return clonedAttempt;
-};
+}
 
-var validateLogin = function (connection, attempt) {
-  validateLoginHook.each(function (callback) {
+Ap._validateLogin = function (connection, attempt) {
+  this._validateLoginHook.each(function (callback) {
     var ret;
     try {
       ret = callback(cloneAttemptWithConnection(connection, attempt));
@@ -82,15 +129,15 @@ var validateLogin = function (connection, attempt) {
 };
 
 
-var successfulLogin = function (connection, attempt) {
-  onLoginHook.each(function (callback) {
+Ap._successfulLogin = function (connection, attempt) {
+  this._onLoginHook.each(function (callback) {
     callback(cloneAttemptWithConnection(connection, attempt));
     return true;
   });
 };
 
-var failedLogin = function (connection, attempt) {
-  onLoginFailureHook.each(function (callback) {
+Ap._failedLogin = function (connection, attempt) {
+  this._onLoginFailureHook.each(function (callback) {
     callback(cloneAttemptWithConnection(connection, attempt));
     return true;
   });
@@ -183,10 +230,12 @@ var tryLoginMethod = function (type, fn) {
 // indicates that the login token has already been inserted into the
 // database and doesn't need to be inserted again.  (It's used by the
 // "resume" login handler).
-var loginUser = function (methodInvocation, userId, stampedLoginToken) {
+Ap._loginUser = function (methodInvocation, userId, stampedLoginToken) {
+  var self = this;
+
   if (! stampedLoginToken) {
-    stampedLoginToken = Accounts._generateStampedLoginToken();
-    Accounts._insertLoginToken(userId, stampedLoginToken);
+    stampedLoginToken = self._generateStampedLoginToken();
+    self._insertLoginToken(userId, stampedLoginToken);
   }
 
   // This order (and the avoidance of yields) is important to make
@@ -196,10 +245,10 @@ var loginUser = function (methodInvocation, userId, stampedLoginToken) {
   // currently a public API for reading the login token on a
   // connection).
   Meteor._noYieldsAllowed(function () {
-    Accounts._setLoginToken(
+    self._setLoginToken(
       userId,
       methodInvocation.connection,
-      Accounts._hashLoginToken(stampedLoginToken.token)
+      self._hashLoginToken(stampedLoginToken.token)
     );
   });
 
@@ -208,7 +257,7 @@ var loginUser = function (methodInvocation, userId, stampedLoginToken) {
   return {
     id: userId,
     token: stampedLoginToken.token,
-    tokenExpires: Accounts._tokenExpiration(stampedLoginToken.when)
+    tokenExpires: self._tokenExpiration(stampedLoginToken.when)
   };
 };
 
@@ -220,7 +269,12 @@ var loginUser = function (methodInvocation, userId, stampedLoginToken) {
 // If the login is allowed and isn't aborted by a validate login hook
 // callback, log in the user.
 //
-var attemptLogin = function (methodInvocation, methodName, methodArgs, result) {
+Ap._attemptLogin = function (
+  methodInvocation,
+  methodName,
+  methodArgs,
+  result
+) {
   if (!result)
     throw new Error("result is required");
 
@@ -232,7 +286,7 @@ var attemptLogin = function (methodInvocation, methodName, methodArgs, result) {
 
   var user;
   if (result.userId)
-    user = Meteor.users.findOne(result.userId);
+    user = this.users.findOne(result.userId);
 
   var attempt = {
     type: result.type || "unknown",
@@ -245,21 +299,25 @@ var attemptLogin = function (methodInvocation, methodName, methodArgs, result) {
   if (user)
     attempt.user = user;
 
-  // validateLogin may mutate `attempt` by adding an error and changing allowed
+  // _validateLogin may mutate `attempt` by adding an error and changing allowed
   // to false, but that's the only change it can make (and the user's callbacks
   // only get a clone of `attempt`).
-  validateLogin(methodInvocation.connection, attempt);
+  this._validateLogin(methodInvocation.connection, attempt);
 
   if (attempt.allowed) {
     var ret = _.extend(
-      loginUser(methodInvocation, result.userId, result.stampedLoginToken),
+      this._loginUser(
+        methodInvocation,
+        result.userId,
+        result.stampedLoginToken
+      ),
       result.options || {}
     );
-    successfulLogin(methodInvocation.connection, attempt);
+    this._successfulLogin(methodInvocation.connection, attempt);
     return ret;
   }
   else {
-    failedLogin(methodInvocation.connection, attempt);
+    this._failedLogin(methodInvocation.connection, attempt);
     throw attempt.error;
   }
 };
@@ -269,8 +327,14 @@ var attemptLogin = function (methodInvocation, methodName, methodArgs, result) {
 // Ensure that thrown exceptions are caught and that login hook
 // callbacks are still called.
 //
-Accounts._loginMethod = function (methodInvocation, methodName, methodArgs, type, fn) {
-  return attemptLogin(
+Ap._loginMethod = function (
+  methodInvocation,
+  methodName,
+  methodArgs,
+  type,
+  fn
+) {
+  return this._attemptLogin(
     methodInvocation,
     methodName,
     methodArgs,
@@ -286,7 +350,12 @@ Accounts._loginMethod = function (methodInvocation, methodName, methodArgs, type
 // is no corresponding method for a successful login; methods that can
 // succeed at logging a user in should always be actual login methods
 // (using either Accounts._loginMethod or Accounts.registerLoginHandler).
-Accounts._reportLoginFailure = function (methodInvocation, methodName, methodArgs, result) {
+Ap._reportLoginFailure = function (
+  methodInvocation,
+  methodName,
+  methodArgs,
+  result
+) {
   var attempt = {
     type: result.type || "unknown",
     allowed: false,
@@ -294,12 +363,15 @@ Accounts._reportLoginFailure = function (methodInvocation, methodName, methodArg
     methodName: methodName,
     methodArguments: _.toArray(methodArgs)
   };
-  if (result.userId)
-    attempt.user = Meteor.users.findOne(result.userId);
 
-  validateLogin(methodInvocation.connection, attempt);
-  failedLogin(methodInvocation.connection, attempt);
-  // validateLogin may mutate attempt to set a new error message. Return
+  if (result.userId) {
+    attempt.user = this.users.findOne(result.userId);
+  }
+
+  this._validateLogin(methodInvocation.connection, attempt);
+  this._failedLogin(methodInvocation.connection, attempt);
+
+  // _validateLogin may mutate attempt to set a new error message. Return
   // the modified version.
   return attempt;
 };
@@ -308,9 +380,6 @@ Accounts._reportLoginFailure = function (methodInvocation, methodName, methodArg
 ///
 /// LOGIN HANDLERS
 ///
-
-// list of all registered handlers.
-var loginHandlers = [];
 
 // The main entry point for auth packages to hook in to login.
 //
@@ -325,12 +394,16 @@ var loginHandlers = [];
 // - `undefined`, meaning don't handle;
 // - a login method result object
 
-Accounts.registerLoginHandler = function(name, handler) {
+Ap.registerLoginHandler = function (name, handler) {
   if (! handler) {
     handler = name;
     name = null;
   }
-  loginHandlers.push({name: name, handler: handler});
+
+  this._loginHandlers.push({
+    name: name,
+    handler: handler
+  });
 };
 
 
@@ -348,9 +421,9 @@ Accounts.registerLoginHandler = function(name, handler) {
 // Try all of the registered login handlers until one of them doesn't
 // return `undefined`, meaning it handled this call to `login`. Return
 // that return value.
-var runLoginHandlers = function (methodInvocation, options) {
-  for (var i = 0; i < loginHandlers.length; ++i) {
-    var handler = loginHandlers[i];
+Ap._runLoginHandlers = function (methodInvocation, options) {
+  for (var i = 0; i < this._loginHandlers.length; ++i) {
+    var handler = this._loginHandlers[i];
 
     var result = tryLoginMethod(
       handler.name,
@@ -359,10 +432,13 @@ var runLoginHandlers = function (methodInvocation, options) {
       }
     );
 
-    if (result)
+    if (result) {
       return result;
-    else if (result !== undefined)
+    }
+
+    if (result !== undefined) {
       throw new Meteor.Error(400, "A login handler should return a result or undefined");
+    }
   }
 
   return {
@@ -379,8 +455,8 @@ var runLoginHandlers = function (methodInvocation, options) {
 // Any connections associated with old-style unhashed tokens will be
 // in the process of becoming associated with hashed tokens and then
 // they'll get closed.
-Accounts.destroyToken = function (userId, loginToken) {
-  Meteor.users.update(userId, {
+Ap.destroyToken = function (userId, loginToken) {
+  this.users.update(userId, {
     $pull: {
       "services.resume.loginTokens": {
         $or: [
@@ -392,32 +468,38 @@ Accounts.destroyToken = function (userId, loginToken) {
   });
 };
 
-// Actual methods for login and logout. This is the entry point for
-// clients to actually log in.
-Meteor.methods({
+Ap._initServerMethods = function () {
+  // The methods created in this function need to be created here so that
+  // this variable is available in their scope.
+  var accounts = this;
+
+  // This object will be populated with methods and then passed to
+  // accounts._server.methods further below.
+  var methods = {};
+
   // @returns {Object|null}
   //   If successful, returns {token: reconnectToken, id: userId}
   //   If unsuccessful (for example, if the user closed the oauth login popup),
   //     throws an error describing the reason
-  login: function(options) {
+  methods.login = function (options) {
     var self = this;
 
     // Login handlers should really also check whatever field they look at in
     // options, but we don't enforce it.
     check(options, Object);
 
-    var result = runLoginHandlers(self, options);
+    var result = accounts._runLoginHandlers(self, options);
 
-    return attemptLogin(self, "login", arguments, result);
-  },
+    return accounts._attemptLogin(self, "login", arguments, result);
+  };
 
-  logout: function() {
-    var token = Accounts._getLoginToken(this.connection.id);
-    Accounts._setLoginToken(this.userId, this.connection, null);
+  methods.logout = function () {
+    var token = accounts._getLoginToken(this.connection.id);
+    accounts._setLoginToken(this.userId, this.connection, null);
     if (token && this.userId)
-      Accounts.destroyToken(this.userId, token);
+      accounts.destroyToken(this.userId, token);
     this.setUserId(null);
-  },
+  };
 
   // Delete all the current user's tokens and close all open connections logged
   // in as this user. Returns a fresh new login token that this client can
@@ -436,9 +518,9 @@ Meteor.methods({
   // this method directly.
   //
   // @returns {Object} Object with token and tokenExpires keys.
-  logoutOtherClients: function () {
+  methods.logoutOtherClients = function () {
     var self = this;
-    var user = Meteor.users.findOne(self.userId, {
+    var user = accounts.users.findOne(self.userId, {
       fields: {
         "services.resume.loginTokens": true
       }
@@ -450,32 +532,32 @@ Meteor.methods({
       // the tokens in the database in case we crash before actually deleting
       // them.
       var tokens = user.services.resume.loginTokens;
-      var newToken = Accounts._generateStampedLoginToken();
+      var newToken = accounts._generateStampedLoginToken();
       var userId = self.userId;
-      Meteor.users.update(userId, {
+      accounts.users.update(userId, {
         $set: {
           "services.resume.loginTokensToDelete": tokens,
           "services.resume.haveLoginTokensToDelete": true
         },
-        $push: { "services.resume.loginTokens": Accounts._hashStampedToken(newToken) }
+        $push: { "services.resume.loginTokens": accounts._hashStampedToken(newToken) }
       });
       Meteor.setTimeout(function () {
         // The observe on Meteor.users will take care of closing the connections
         // associated with `tokens`.
-        deleteSavedTokens(userId, tokens);
-      }, Accounts._noConnectionCloseDelayForTest ? 0 :
+        accounts._deleteSavedTokensForUser(userId, tokens);
+      }, accounts._noConnectionCloseDelayForTest ? 0 :
                         CONNECTION_CLOSE_DELAY_MS);
       // We do not set the login token on this connection, but instead the
       // observe closes the connection and the client will reconnect with the
       // new token.
       return {
         token: newToken.token,
-        tokenExpires: Accounts._tokenExpiration(newToken.when)
+        tokenExpires: accounts._tokenExpiration(newToken.when)
       };
     } else {
       throw new Meteor.Error("You are not logged in.");
     }
-  },
+  };
 
   // Generates a new login token with the same expiration as the
   // connection's current token and saves it to the database. Associates
@@ -485,9 +567,9 @@ Meteor.methods({
   // @returns Object
   //   If successful, returns { token: <new token>, id: <user id>,
   //   tokenExpires: <expiration date> }.
-  getNewToken: function () {
+  methods.getNewToken = function () {
     var self = this;
-    var user = Meteor.users.findOne(self.userId, {
+    var user = accounts.users.findOne(self.userId, {
       fields: { "services.resume.loginTokens": 1 }
     });
     if (! self.userId || ! user) {
@@ -497,7 +579,7 @@ Meteor.methods({
     // expiration than the curren token. Otherwise, a bad guy with a
     // stolen token could use this method to stop his stolen token from
     // ever expiring.
-    var currentHashedToken = Accounts._getLoginToken(self.connection.id);
+    var currentHashedToken = accounts._getLoginToken(self.connection.id);
     var currentStampedToken = _.find(
       user.services.resume.loginTokens,
       function (stampedToken) {
@@ -507,45 +589,165 @@ Meteor.methods({
     if (! currentStampedToken) { // safety belt: this should never happen
       throw new Meteor.Error("Invalid login token");
     }
-    var newStampedToken = Accounts._generateStampedLoginToken();
+    var newStampedToken = accounts._generateStampedLoginToken();
     newStampedToken.when = currentStampedToken.when;
-    Accounts._insertLoginToken(self.userId, newStampedToken);
-    return loginUser(self, self.userId, newStampedToken);
-  },
+    accounts._insertLoginToken(self.userId, newStampedToken);
+    return accounts._loginUser(self, self.userId, newStampedToken);
+  };
 
   // Removes all tokens except the token associated with the current
   // connection. Throws an error if the connection is not logged
   // in. Returns nothing on success.
-  removeOtherTokens: function () {
+  methods.removeOtherTokens = function () {
     var self = this;
     if (! self.userId) {
       throw new Meteor.Error("You are not logged in.");
     }
-    var currentToken = Accounts._getLoginToken(self.connection.id);
-    Meteor.users.update(self.userId, {
+    var currentToken = accounts._getLoginToken(self.connection.id);
+    accounts.users.update(self.userId, {
       $pull: {
         "services.resume.loginTokens": { hashedToken: { $ne: currentToken } }
       }
     });
-  }
-});
+  };
+
+  // Allow a one-time configuration for a login service. Modifications
+  // to this collection are also allowed in insecure mode.
+  methods.configureLoginService = function (options) {
+    check(options, Match.ObjectIncluding({service: String}));
+    // Don't let random users configure a service we haven't added yet (so
+    // that when we do later add it, it's set up with their configuration
+    // instead of ours).
+    // XXX if service configuration is oauth-specific then this code should
+    //     be in accounts-oauth; if it's not then the registry should be
+    //     in this package
+    if (!(accounts.oauth
+          && _.contains(accounts.oauth.serviceNames(), options.service))) {
+      throw new Meteor.Error(403, "Service unknown");
+    }
+
+    var ServiceConfiguration =
+      Package['service-configuration'].ServiceConfiguration;
+    if (ServiceConfiguration.configurations.findOne({service: options.service}))
+      throw new Meteor.Error(403, "Service " + options.service + " already configured");
+
+    if (_.has(options, "secret") && usingOAuthEncryption())
+      options.secret = OAuthEncryption.seal(options.secret);
+
+    ServiceConfiguration.configurations.insert(options);
+  };
+
+  accounts._server.methods(methods);
+};
+
+Ap._initAccountDataHooks = function () {
+  var accounts = this;
+
+  accounts._server.onConnection(function (connection) {
+    accounts._accountData[connection.id] = {
+      connection: connection
+    };
+
+    connection.onClose(function () {
+      accounts._removeTokenFromConnection(connection.id);
+      delete accounts._accountData[connection.id];
+    });
+  });
+};
+
+Ap._initServerPublications = function () {
+  var accounts = this;
+
+  // Publish all login service configuration fields other than secret.
+  accounts._server.publish("meteor.loginServiceConfiguration", function () {
+    var ServiceConfiguration =
+      Package['service-configuration'].ServiceConfiguration;
+    return ServiceConfiguration.configurations.find({}, {fields: {secret: 0}});
+  }, {is_auto: true}); // not techincally autopublish, but stops the warning.
+
+  // Publish the current user's record to the client.
+  accounts._server.publish(null, function () {
+    if (this.userId) {
+      return accounts.users.find({
+        _id: this.userId
+      }, {
+        fields: {
+          profile: 1,
+          username: 1,
+          emails: 1
+        }
+      });
+    } else {
+      return null;
+    }
+  }, /*suppress autopublish warning*/{is_auto: true});
+
+  // Use Meteor.startup to give other packages a chance to call
+  // addAutopublishFields.
+  Package.autopublish && Meteor.startup(function () {
+    // ['profile', 'username'] -> {profile: 1, username: 1}
+    var toFieldSelector = function (fields) {
+      return _.object(_.map(fields, function (field) {
+        return [field, 1];
+      }));
+    };
+
+    accounts._server.publish(null, function () {
+      if (this.userId) {
+        return accounts.users.find({
+          _id: this.userId
+        }, {
+          fields: toFieldSelector(accounts._autopublishFields.loggedInUser)
+        });
+      } else {
+        return null;
+      }
+    }, /*suppress autopublish warning*/{is_auto: true});
+
+    // XXX this publish is neither dedup-able nor is it optimized by our special
+    // treatment of queries on a specific _id. Therefore this will have O(n^2)
+    // run-time performance every time a user document is changed (eg someone
+    // logging in). If this is a problem, we can instead write a manual publish
+    // function which filters out fields based on 'this.userId'.
+    accounts._server.publish(null, function () {
+      var selector = this.userId ? {
+        _id: { $ne: this.userId }
+      } : {};
+
+      return accounts.users.find(selector, {
+        fields: toFieldSelector(accounts._autopublishFields.otherUsers)
+      });
+    }, /*suppress autopublish warning*/{is_auto: true});
+  });
+};
+
+// Add to the list of fields or subfields to be automatically
+// published if autopublish is on. Must be called from top-level
+// code (ie, before Meteor.startup hooks run).
+//
+// @param opts {Object} with:
+//   - forLoggedInUser {Array} Array of fields published to the logged-in user
+//   - forOtherUsers {Array} Array of fields published to users that aren't logged in
+Ap.addAutopublishFields = function (opts) {
+  this._autopublishFields.loggedInUser.push.apply(
+    this._autopublishFields.loggedInUser, opts.forLoggedInUser);
+  this._autopublishFields.otherUsers.push.apply(
+    this._autopublishFields.otherUsers, opts.forOtherUsers);
+};
 
 ///
 /// ACCOUNT DATA
 ///
 
-// connectionId -> {connection, loginToken}
-var accountData = {};
-
 // HACK: This is used by 'meteor-accounts' to get the loginToken for a
 // connection. Maybe there should be a public way to do that.
-Accounts._getAccountData = function (connectionId, field) {
-  var data = accountData[connectionId];
+Ap._getAccountData = function (connectionId, field) {
+  var data = this._accountData[connectionId];
   return data && data[field];
 };
 
-Accounts._setAccountData = function (connectionId, field, value) {
-  var data = accountData[connectionId];
+Ap._setAccountData = function (connectionId, field, value) {
+  var data = this._accountData[connectionId];
 
   // safety belt. shouldn't happen. accountData is set in onConnection,
   // we don't have a connectionId until it is set.
@@ -558,21 +760,13 @@ Accounts._setAccountData = function (connectionId, field, value) {
     data[field] = value;
 };
 
-Meteor.server.onConnection(function (connection) {
-  accountData[connection.id] = {connection: connection};
-  connection.onClose(function () {
-    removeTokenFromConnection(connection.id);
-    delete accountData[connection.id];
-  });
-});
-
 
 ///
 /// RECONNECT TOKENS
 ///
 /// support reconnecting using a meteor login token
 
-Accounts._hashLoginToken = function (loginToken) {
+Ap._hashLoginToken = function (loginToken) {
   var hash = crypto.createHash('sha256');
   hash.update(loginToken);
   return hash.digest('base64');
@@ -580,83 +774,79 @@ Accounts._hashLoginToken = function (loginToken) {
 
 
 // {token, when} => {hashedToken, when}
-Accounts._hashStampedToken = function (stampedToken) {
-  return _.extend(
-    _.omit(stampedToken, 'token'),
-    {hashedToken: Accounts._hashLoginToken(stampedToken.token)}
-  );
+Ap._hashStampedToken = function (stampedToken) {
+  return _.extend(_.omit(stampedToken, 'token'), {
+    hashedToken: this._hashLoginToken(stampedToken.token)
+  });
 };
 
 
 // Using $addToSet avoids getting an index error if another client
 // logging in simultaneously has already inserted the new hashed
 // token.
-Accounts._insertHashedLoginToken = function (userId, hashedToken, query) {
+Ap._insertHashedLoginToken = function (userId, hashedToken, query) {
   query = query ? _.clone(query) : {};
   query._id = userId;
-  Meteor.users.update(
-    query,
-    { $addToSet: {
-        "services.resume.loginTokens": hashedToken
-    } }
-  );
+  this.users.update(query, {
+    $addToSet: {
+      "services.resume.loginTokens": hashedToken
+    }
+  });
 };
 
 
 // Exported for tests.
-Accounts._insertLoginToken = function (userId, stampedToken, query) {
-  Accounts._insertHashedLoginToken(
+Ap._insertLoginToken = function (userId, stampedToken, query) {
+  this._insertHashedLoginToken(
     userId,
-    Accounts._hashStampedToken(stampedToken),
+    this._hashStampedToken(stampedToken),
     query
   );
 };
 
 
-Accounts._clearAllLoginTokens = function (userId) {
-  Meteor.users.update(
-    userId,
-    {$set: {'services.resume.loginTokens': []}}
-  );
+Ap._clearAllLoginTokens = function (userId) {
+  this.users.update(userId, {
+    $set: {
+      'services.resume.loginTokens': []
+    }
+  });
 };
 
-// connection id -> observe handle for the login token that this
-// connection is currently associated with, or null. Null indicates that
-// we are in the process of setting up the observe.
-var userObservesForConnections = {};
-
 // test hook
-Accounts._getUserObserve = function (connectionId) {
-  return userObservesForConnections[connectionId];
+Ap._getUserObserve = function (connectionId) {
+  return this._userObservesForConnections[connectionId];
 };
 
 // Clean up this connection's association with the token: that is, stop
 // the observe that we started when we associated the connection with
 // this token.
-var removeTokenFromConnection = function (connectionId) {
-  if (_.has(userObservesForConnections, connectionId)) {
-    var observe = userObservesForConnections[connectionId];
+Ap._removeTokenFromConnection = function (connectionId) {
+  if (_.has(this._userObservesForConnections, connectionId)) {
+    var observe = this._userObservesForConnections[connectionId];
     if (observe === null) {
       // We're in the process of setting up an observe for this
       // connection. We can't clean up that observe yet, but if we
       // delete the null placeholder for this connection, then the
       // observe will get cleaned up as soon as it has been set up.
-      delete userObservesForConnections[connectionId];
+      delete this._userObservesForConnections[connectionId];
     } else {
-      delete userObservesForConnections[connectionId];
+      delete this._userObservesForConnections[connectionId];
       observe.stop();
     }
   }
 };
 
-Accounts._getLoginToken = function (connectionId) {
-  return Accounts._getAccountData(connectionId, 'loginToken');
+Ap._getLoginToken = function (connectionId) {
+  return this._getAccountData(connectionId, 'loginToken');
 };
 
 // newToken is a hashed token.
-Accounts._setLoginToken = function (userId, connection, newToken) {
-  removeTokenFromConnection(connection.id);
-  Accounts._setAccountData(connection.id, 'loginToken', newToken);
+Ap._setLoginToken = function (userId, connection, newToken) {
+  var self = this;
+
+  self._removeTokenFromConnection(connection.id);
+  self._setAccountData(connection.id, 'loginToken', newToken);
 
   if (newToken) {
     // Set up an observe for this token. If the token goes away, we need
@@ -672,13 +862,13 @@ Accounts._setLoginToken = function (userId, connection, newToken) {
     // the real observe handle (unless the placeholder has been deleted,
     // signifying that the connection was closed already -- in this case
     // we just clean up the observe that we started).
-    userObservesForConnections[connection.id] = null;
+    self._userObservesForConnections[connection.id] = null;
     Meteor.defer(function () {
       var foundMatchingUser;
       // Because we upgrade unhashed login tokens to hashed tokens at
       // login time, sessions will only be logged in with a hashed
       // token. Thus we only need to observe hashed tokens here.
-      var observe = Meteor.users.find({
+      var observe = self.users.find({
         _id: userId,
         'services.resume.loginTokens.hashedToken': newToken
       }, { fields: { _id: 1 } }).observeChanges({
@@ -698,20 +888,20 @@ Accounts._setLoginToken = function (userId, connection, newToken) {
       // observe, etc) and just stop our observe now.
       //
       // Similarly, if the connection was already closed, then the onClose
-      // callback would have called removeTokenFromConnection and there won't be
-      // an entry in userObservesForConnections. We can stop the observe.
-      if (Accounts._getAccountData(connection.id, 'loginToken') !== newToken ||
-          !_.has(userObservesForConnections, connection.id)) {
+      // callback would have called _removeTokenFromConnection and there won't be
+      // an entry in _userObservesForConnections. We can stop the observe.
+      if (self._getAccountData(connection.id, 'loginToken') !== newToken ||
+          !_.has(self._userObservesForConnections, connection.id)) {
         observe.stop();
         return;
       }
 
-      if (userObservesForConnections[connection.id] !== null) {
+      if (self._userObservesForConnections[connection.id] !== null) {
         throw new Error("Non-null user observe for connection " +
                         connection.id + " while observe was being set up?");
       }
 
-      userObservesForConnections[connection.id] = observe;
+      self._userObservesForConnections[connection.id] = observe;
 
       if (! foundMatchingUser) {
         // We've set up an observe on the user associated with `newToken`,
@@ -725,19 +915,25 @@ Accounts._setLoginToken = function (userId, connection, newToken) {
   }
 };
 
+function setupDefaultLoginHandlers(accounts) {
+  accounts.registerLoginHandler("resume", function (options) {
+    return defaultResumeLoginHandler.call(this, accounts, options);
+  });
+}
+
 // Login handler for resume tokens.
-Accounts.registerLoginHandler("resume", function(options) {
+function defaultResumeLoginHandler(accounts, options) {
   if (!options.resume)
     return undefined;
 
   check(options.resume, String);
 
-  var hashedToken = Accounts._hashLoginToken(options.resume);
+  var hashedToken = accounts._hashLoginToken(options.resume);
 
   // First look for just the new-style hashed login token, to avoid
   // sending the unhashed token to the database in a query if we don't
   // need to.
-  var user = Meteor.users.findOne(
+  var user = accounts.users.findOne(
     {"services.resume.loginTokens.hashedToken": hashedToken});
 
   if (! user) {
@@ -746,7 +942,7 @@ Accounts.registerLoginHandler("resume", function(options) {
     // the old-style token OR the new-style token, because another
     // client connection logging in simultaneously might have already
     // converted the token.
-    user = Meteor.users.findOne({
+    user = accounts.users.findOne({
       $or: [
         {"services.resume.loginTokens.hashedToken": hashedToken},
         {"services.resume.loginTokens.token": options.resume}
@@ -775,7 +971,7 @@ Accounts.registerLoginHandler("resume", function(options) {
     oldUnhashedStyleToken = true;
   }
 
-  var tokenExpires = Accounts._tokenExpiration(token.when);
+  var tokenExpires = accounts._tokenExpiration(token.when);
   if (new Date() >= tokenExpires)
     return {
       userId: user._id,
@@ -789,7 +985,7 @@ Accounts.registerLoginHandler("resume", function(options) {
     // after we read it).  Using $addToSet avoids getting an index
     // error if another client logging in simultaneously has already
     // inserted the new hashed token.
-    Meteor.users.update(
+    accounts.users.update(
       {
         _id: user._id,
         "services.resume.loginTokens.token": options.resume
@@ -805,7 +1001,7 @@ Accounts.registerLoginHandler("resume", function(options) {
     // Remove the old token *after* adding the new, since otherwise
     // another client trying to login between our removing the old and
     // adding the new wouldn't find a token to login with.
-    Meteor.users.update(user._id, {
+    accounts.users.update(user._id, {
       $pull: {
         "services.resume.loginTokens": { "token": options.resume }
       }
@@ -819,19 +1015,20 @@ Accounts.registerLoginHandler("resume", function(options) {
       when: token.when
     }
   };
-});
+}
 
 // (Also used by Meteor Accounts server and tests).
 //
-Accounts._generateStampedLoginToken = function () {
-  return {token: Random.secret(), when: (new Date)};
+Ap._generateStampedLoginToken = function () {
+  return {
+    token: Random.secret(),
+    when: new Date
+  };
 };
 
 ///
 /// TOKEN EXPIRATION
 ///
-
-var expireTokenInterval;
 
 // Deletes expired tokens from the database and closes all open connections
 // associated with these tokens.
@@ -840,8 +1037,8 @@ var expireTokenInterval;
 // tests. oldestValidDate is simulate expiring tokens without waiting
 // for them to actually expire. userId is used by tests to only expire
 // tokens for the test user.
-var expireTokens = Accounts._expireTokens = function (oldestValidDate, userId) {
-  var tokenLifetimeMs = getTokenLifetimeMs();
+Ap._expireTokens = function (oldestValidDate, userId) {
+  var tokenLifetimeMs = this._getTokenLifetimeMs();
 
   // when calling from a test with extra arguments, you must specify both!
   if ((oldestValidDate && !userId) || (!oldestValidDate && userId)) {
@@ -855,7 +1052,7 @@ var expireTokens = Accounts._expireTokens = function (oldestValidDate, userId) {
 
   // Backwards compatible with older versions of meteor that stored login token
   // timestamps as numbers.
-  Meteor.users.update(_.extend(userFilter, {
+  this.users.update(_.extend(userFilter, {
     $or: [
       { "services.resume.loginTokens.when": { $lt: oldestValidDate } },
       { "services.resume.loginTokens.when": { $lt: +oldestValidDate } }
@@ -874,29 +1071,41 @@ var expireTokens = Accounts._expireTokens = function (oldestValidDate, userId) {
   // expired tokens.
 };
 
-maybeStopExpireTokensInterval = function () {
-  if (_.has(Accounts._options, "loginExpirationInDays") &&
-      Accounts._options.loginExpirationInDays === null &&
-      expireTokenInterval) {
-    Meteor.clearInterval(expireTokenInterval);
-    expireTokenInterval = null;
+// @override from accounts_common.js
+Ap.config = function (options) {
+  // Call the overridden implementation of the method.
+  var superResult = AccountsCommon.prototype.config.apply(this, arguments);
+
+  // If the user set loginExpirationInDays to null, then we need to clear the
+  // timer that periodically expires tokens.
+  if (_.has(this._options, "loginExpirationInDays") &&
+      this._options.loginExpirationInDays === null &&
+      this.expireTokenInterval) {
+    Meteor.clearInterval(this.expireTokenInterval);
+    this.expireTokenInterval = null;
   }
+
+  return superResult;
 };
 
-expireTokenInterval = Meteor.setInterval(expireTokens,
-                                         EXPIRE_TOKENS_INTERVAL_MS);
+function setExpireTokensInterval(accounts) {
+  accounts.expireTokenInterval = Meteor.setInterval(function () {
+    accounts._expireTokens();
+  }, EXPIRE_TOKENS_INTERVAL_MS);
+}
 
 
 ///
 /// OAuth Encryption Support
 ///
 
-var OAuthEncryption = Package["oauth-encryption"] && Package["oauth-encryption"].OAuthEncryption;
+var OAuthEncryption =
+  Package["oauth-encryption"] &&
+  Package["oauth-encryption"].OAuthEncryption;
 
-
-var usingOAuthEncryption = function () {
+function usingOAuthEncryption() {
   return OAuthEncryption && OAuthEncryption.keyIsLoaded();
-};
+}
 
 
 // OAuth service data is temporarily stored in the pending credentials
@@ -906,14 +1115,14 @@ var usingOAuthEncryption = function () {
 // user id included when storing the service data permanently in
 // the users collection.
 //
-var pinEncryptedFieldsToUser = function (serviceData, userId) {
+function pinEncryptedFieldsToUser(serviceData, userId) {
   _.each(_.keys(serviceData), function (key) {
     var value = serviceData[key];
     if (OAuthEncryption && OAuthEncryption.isSealed(value))
       value = OAuthEncryption.seal(OAuthEncryption.open(value), userId);
     serviceData[key] = value;
   });
-};
+}
 
 
 // Encrypt unencrypted login service secrets when oauth-encryption is
@@ -926,24 +1135,26 @@ var pinEncryptedFieldsToUser = function (serviceData, userId) {
 // block.  Perhaps we need a post-startup callback?
 
 Meteor.startup(function () {
-  if (!usingOAuthEncryption())
+  if (! usingOAuthEncryption()) {
     return;
+  }
 
   var ServiceConfiguration =
     Package['service-configuration'].ServiceConfiguration;
 
-  ServiceConfiguration.configurations.find( {$and: [
-      { secret: {$exists: true} },
-      { "secret.algorithm": {$exists: false} }
-    ] } ).
-    forEach(function (config) {
-      ServiceConfiguration.configurations.update(
-        config._id,
-        { $set: {
-          secret: OAuthEncryption.seal(config.secret)
-        } }
-      );
+  ServiceConfiguration.configurations.find({
+    $and: [{
+      secret: { $exists: true }
+    }, {
+      "secret.algorithm": { $exists: false }
+    }]
+  }).forEach(function (config) {
+    ServiceConfiguration.configurations.update(config._id, {
+      $set: {
+        secret: OAuthEncryption.seal(config.secret)
+      }
     });
+  });
 });
 
 
@@ -951,30 +1162,29 @@ Meteor.startup(function () {
 /// CREATE USER HOOKS
 ///
 
-var onCreateUserHook = null;
-
 /**
  * @summary Customize new user creation.
  * @locus Server
  * @param {Function} func Called whenever a new user is created. Return the new user object, or throw an `Error` to abort the creation.
  */
-Accounts.onCreateUser = function (func) {
-  if (onCreateUserHook)
+Ap.onCreateUser = function (func) {
+  if (this._onCreateUserHook) {
     throw new Error("Can only call onCreateUser once");
-  else
-    onCreateUserHook = func;
+  } else {
+    this._onCreateUserHook = func;
+  }
 };
 
 // XXX see comment on Accounts.createUser in passwords_server about adding a
 // second "server options" argument.
-var defaultCreateUserHook = function (options, user) {
+function defaultCreateUserHook(options, user) {
   if (options.profile)
     user.profile = options.profile;
   return user;
-};
+}
 
 // Called by accounts-password
-Accounts.insertUserDoc = function (options, user) {
+Ap.insertUserDoc = function (options, user) {
   // - clone user document, to protect from modification
   // - add createdAt timestamp
   // - prepare an _id, so that you can modify other collections (eg
@@ -987,16 +1197,20 @@ Accounts.insertUserDoc = function (options, user) {
   // the user document (in which you can modify its contents), and
   // one that gets called after (in which you should change other
   // collections)
-  user = _.extend({createdAt: new Date(), _id: Random.id()}, user);
+  user = _.extend({
+    createdAt: new Date(),
+    _id: Random.id()
+  }, user);
 
-  if (user.services)
+  if (user.services) {
     _.each(user.services, function (serviceData) {
       pinEncryptedFieldsToUser(serviceData, user._id);
     });
+  }
 
   var fullUser;
-  if (onCreateUserHook) {
-    fullUser = onCreateUserHook(options, user);
+  if (this._onCreateUserHook) {
+    fullUser = this._onCreateUserHook(options, user);
 
     // This is *not* part of the API. We need this because we can't isolate
     // the global server environment between tests, meaning we can't test
@@ -1007,14 +1221,14 @@ Accounts.insertUserDoc = function (options, user) {
     fullUser = defaultCreateUserHook(options, user);
   }
 
-  _.each(validateNewUserHooks, function (hook) {
-    if (!hook(fullUser))
+  _.each(this._validateNewUserHooks, function (hook) {
+    if (! hook(fullUser))
       throw new Meteor.Error(403, "User validation failed");
   });
 
   var userId;
   try {
-    userId = Meteor.users.insert(fullUser);
+    userId = this.users.insert(fullUser);
   } catch (e) {
     // XXX string parsing sucks, maybe
     // https://jira.mongodb.org/browse/SERVER-3069 will get fixed one day
@@ -1031,15 +1245,13 @@ Accounts.insertUserDoc = function (options, user) {
   return userId;
 };
 
-var validateNewUserHooks = [];
-
 /**
  * @summary Set restrictions on new user creation.
  * @locus Server
  * @param {Function} func Called whenever a new user is created. Takes the new user object, and returns true to allow the creation or false to abort.
  */
-Accounts.validateNewUser = function (func) {
-  validateNewUserHooks.push(func);
+Ap.validateNewUser = function (func) {
+  this._validateNewUserHooks.push(func);
 };
 
 // XXX Find a better place for this utility function
@@ -1051,8 +1263,8 @@ var quotemeta = function (str) {
 
 // Helper function: returns false if email does not match company domain from
 // the configuration.
-var testEmailDomain = function (email) {
-  var domain = Accounts._options.restrictCreationByEmailDomain;
+Ap._testEmailDomain = function (email) {
+  var domain = this._options.restrictCreationByEmailDomain;
   return !domain ||
     (_.isFunction(domain) && domain(email)) ||
     (_.isString(domain) &&
@@ -1060,20 +1272,21 @@ var testEmailDomain = function (email) {
 };
 
 // Validate new user's email or Google/Facebook/GitHub account's email
-Accounts.validateNewUser(function (user) {
-  var domain = Accounts._options.restrictCreationByEmailDomain;
+function defaultValidateNewUserHook(user) {
+  var self = this;
+  var domain = self._options.restrictCreationByEmailDomain;
   if (!domain)
     return true;
 
   var emailIsGood = false;
   if (!_.isEmpty(user.emails)) {
     emailIsGood = _.any(user.emails, function (email) {
-      return testEmailDomain(email.address);
+      return self._testEmailDomain(email.address);
     });
   } else if (!_.isEmpty(user.services)) {
     // Find any email of any service and check it
     emailIsGood = _.any(user.services, function (service) {
-      return service.email && testEmailDomain(service.email);
+      return service.email && self._testEmailDomain(service.email);
     });
   }
 
@@ -1084,7 +1297,7 @@ Accounts.validateNewUser(function (user) {
     throw new Meteor.Error(403, "@" + domain + " email required");
   else
     throw new Meteor.Error(403, "Email doesn't match the criteria.");
-});
+}
 
 ///
 /// MANAGING USER OBJECTS
@@ -1101,8 +1314,11 @@ Accounts.validateNewUser(function (user) {
 // @returns {Object} Object with token and id keys, like the result
 //        of the "login" method.
 //
-Accounts.updateOrCreateUserFromExternalService = function(
-  serviceName, serviceData, options) {
+Ap.updateOrCreateUserFromExternalService = function (
+  serviceName,
+  serviceData,
+  options
+) {
   options = _.clone(options || {});
 
   if (serviceName === "password" || serviceName === "resume")
@@ -1132,7 +1348,7 @@ Accounts.updateOrCreateUserFromExternalService = function(
     selector[serviceIdKey] = serviceData.id;
   }
 
-  var user = Meteor.users.findOne(selector);
+  var user = this.users.findOne(selector);
 
   if (user) {
     pinEncryptedFieldsToUser(serviceData, user._id);
@@ -1143,17 +1359,21 @@ Accounts.updateOrCreateUserFromExternalService = function(
     // XXX provide an onUpdateUser hook which would let apps update
     //     the profile too
     var setAttrs = {};
-    _.each(serviceData, function(value, key) {
+    _.each(serviceData, function (value, key) {
       setAttrs["services." + serviceName + "." + key] = value;
     });
 
     // XXX Maybe we should re-use the selector above and notice if the update
     //     touches nothing?
-    Meteor.users.update(user._id, {$set: setAttrs});
+    this.users.update(user._id, {
+      $set: setAttrs
+    });
+
     return {
       type: serviceName,
       userId: user._id
     };
+
   } else {
     // Create a new user with the service data. Pass other options through to
     // insertUserDoc.
@@ -1161,171 +1381,56 @@ Accounts.updateOrCreateUserFromExternalService = function(
     user.services[serviceName] = serviceData;
     return {
       type: serviceName,
-      userId: Accounts.insertUserDoc(options, user)
+      userId: this.insertUserDoc(options, user)
     };
   }
 };
 
+function setupUsersCollection(users) {
+  ///
+  /// RESTRICTING WRITES TO USER OBJECTS
+  ///
+  users.allow({
+    // clients can modify the profile field of their own document, and
+    // nothing else.
+    update: function (userId, user, fields, modifier) {
+      // make sure it is our record
+      if (user._id !== userId)
+        return false;
 
-///
-/// PUBLISHING DATA
-///
+      // user can only modify the 'profile' field. sets to multiple
+      // sub-keys (eg profile.foo and profile.bar) are merged into entry
+      // in the fields list.
+      if (fields.length !== 1 || fields[0] !== 'profile')
+        return false;
 
-// Publish the current user's record to the client.
-Meteor.publish(null, function() {
-  if (this.userId) {
-    return Meteor.users.find(
-      {_id: this.userId},
-      {fields: {profile: 1, username: 1, emails: 1}});
-  } else {
-    return null;
-  }
-}, /*suppress autopublish warning*/{is_auto: true});
-
-// If autopublish is on, publish these user fields. Login service
-// packages (eg accounts-google) add to these by calling
-// Accounts.addAutopublishFields Notably, this isn't implemented with
-// multiple publishes since DDP only merges only across top-level
-// fields, not subfields (such as 'services.facebook.accessToken')
-var autopublishFields = {
-  loggedInUser: ['profile', 'username', 'emails'],
-  otherUsers: ['profile', 'username']
-};
-
-// Add to the list of fields or subfields to be automatically
-// published if autopublish is on. Must be called from top-level
-// code (ie, before Meteor.startup hooks run).
-//
-// @param opts {Object} with:
-//   - forLoggedInUser {Array} Array of fields published to the logged-in user
-//   - forOtherUsers {Array} Array of fields published to users that aren't logged in
-Accounts.addAutopublishFields = function(opts) {
-  autopublishFields.loggedInUser.push.apply(
-    autopublishFields.loggedInUser, opts.forLoggedInUser);
-  autopublishFields.otherUsers.push.apply(
-    autopublishFields.otherUsers, opts.forOtherUsers);
-};
-
-if (Package.autopublish) {
-  // Use Meteor.startup to give other packages a chance to call
-  // addAutopublishFields.
-  Meteor.startup(function () {
-    // ['profile', 'username'] -> {profile: 1, username: 1}
-    var toFieldSelector = function(fields) {
-      return _.object(_.map(fields, function(field) {
-        return [field, 1];
-      }));
-    };
-
-    Meteor.server.publish(null, function () {
-      if (this.userId) {
-        return Meteor.users.find(
-          {_id: this.userId},
-          {fields: toFieldSelector(autopublishFields.loggedInUser)});
-      } else {
-        return null;
-      }
-    }, /*suppress autopublish warning*/{is_auto: true});
-
-    // XXX this publish is neither dedup-able nor is it optimized by our special
-    // treatment of queries on a specific _id. Therefore this will have O(n^2)
-    // run-time performance every time a user document is changed (eg someone
-    // logging in). If this is a problem, we can instead write a manual publish
-    // function which filters out fields based on 'this.userId'.
-    Meteor.server.publish(null, function () {
-      var selector;
-      if (this.userId)
-        selector = {_id: {$ne: this.userId}};
-      else
-        selector = {};
-
-      return Meteor.users.find(
-        selector,
-        {fields: toFieldSelector(autopublishFields.otherUsers)});
-    }, /*suppress autopublish warning*/{is_auto: true});
+      return true;
+    },
+    fetch: ['_id'] // we only look at _id.
   });
+
+  /// DEFAULT INDEXES ON USERS
+  users._ensureIndex('username', {unique: 1, sparse: 1});
+  users._ensureIndex('emails.address', {unique: 1, sparse: 1});
+  users._ensureIndex('services.resume.loginTokens.hashedToken',
+                     {unique: 1, sparse: 1});
+  users._ensureIndex('services.resume.loginTokens.token',
+                     {unique: 1, sparse: 1});
+  // For taking care of logoutOtherClients calls that crashed before the
+  // tokens were deleted.
+  users._ensureIndex('services.resume.haveLoginTokensToDelete',
+                     { sparse: 1 });
+  // For expiring login tokens
+  users._ensureIndex("services.resume.loginTokens.when", { sparse: 1 });
 }
-
-// Publish all login service configuration fields other than secret.
-Meteor.publish("meteor.loginServiceConfiguration", function () {
-  var ServiceConfiguration =
-    Package['service-configuration'].ServiceConfiguration;
-  return ServiceConfiguration.configurations.find({}, {fields: {secret: 0}});
-}, {is_auto: true}); // not techincally autopublish, but stops the warning.
-
-// Allow a one-time configuration for a login service. Modifications
-// to this collection are also allowed in insecure mode.
-Meteor.methods({
-  "configureLoginService": function (options) {
-    check(options, Match.ObjectIncluding({service: String}));
-    // Don't let random users configure a service we haven't added yet (so
-    // that when we do later add it, it's set up with their configuration
-    // instead of ours).
-    // XXX if service configuration is oauth-specific then this code should
-    //     be in accounts-oauth; if it's not then the registry should be
-    //     in this package
-    if (!(Accounts.oauth
-          && _.contains(Accounts.oauth.serviceNames(), options.service))) {
-      throw new Meteor.Error(403, "Service unknown");
-    }
-
-    var ServiceConfiguration =
-      Package['service-configuration'].ServiceConfiguration;
-    if (ServiceConfiguration.configurations.findOne({service: options.service}))
-      throw new Meteor.Error(403, "Service " + options.service + " already configured");
-
-    if (_.has(options, "secret") && usingOAuthEncryption())
-      options.secret = OAuthEncryption.seal(options.secret);
-
-    ServiceConfiguration.configurations.insert(options);
-  }
-});
-
-
-///
-/// RESTRICTING WRITES TO USER OBJECTS
-///
-
-Meteor.users.allow({
-  // clients can modify the profile field of their own document, and
-  // nothing else.
-  update: function (userId, user, fields, modifier) {
-    // make sure it is our record
-    if (user._id !== userId)
-      return false;
-
-    // user can only modify the 'profile' field. sets to multiple
-    // sub-keys (eg profile.foo and profile.bar) are merged into entry
-    // in the fields list.
-    if (fields.length !== 1 || fields[0] !== 'profile')
-      return false;
-
-    return true;
-  },
-  fetch: ['_id'] // we only look at _id.
-});
-
-/// DEFAULT INDEXES ON USERS
-Meteor.users._ensureIndex('username', {unique: 1, sparse: 1});
-Meteor.users._ensureIndex('emails.address', {unique: 1, sparse: 1});
-Meteor.users._ensureIndex('services.resume.loginTokens.hashedToken',
-                          {unique: 1, sparse: 1});
-Meteor.users._ensureIndex('services.resume.loginTokens.token',
-                          {unique: 1, sparse: 1});
-// For taking care of logoutOtherClients calls that crashed before the tokens
-// were deleted.
-Meteor.users._ensureIndex('services.resume.haveLoginTokensToDelete',
-                          { sparse: 1 });
-// For expiring login tokens
-Meteor.users._ensureIndex("services.resume.loginTokens.when", { sparse: 1 });
 
 ///
 /// CLEAN UP FOR `logoutOtherClients`
 ///
 
-var deleteSavedTokens = function (userId, tokensToDelete) {
+Ap._deleteSavedTokensForUser = function (userId, tokensToDelete) {
   if (tokensToDelete) {
-    Meteor.users.update(userId, {
+    this.users.update(userId, {
       $unset: {
         "services.resume.haveLoginTokensToDelete": 1,
         "services.resume.loginTokensToDelete": 1
@@ -1337,19 +1442,42 @@ var deleteSavedTokens = function (userId, tokensToDelete) {
   }
 };
 
-Meteor.startup(function () {
-  // If we find users who have saved tokens to delete on startup, delete them
-  // now. It's possible that the server could have crashed and come back up
-  // before new tokens are found in localStorage, but this shouldn't happen very
-  // often. We shouldn't put a delay here because that would give a lot of power
-  // to an attacker with a stolen login token and the ability to crash the
-  // server.
-  var users = Meteor.users.find({
-    "services.resume.haveLoginTokensToDelete": true
-  }, {
-    "services.resume.loginTokensToDelete": 1
+Ap._deleteSavedTokensForAllUsersOnStartup = function () {
+  var self = this;
+
+  // If we find users who have saved tokens to delete on startup, delete
+  // them now. It's possible that the server could have crashed and come
+  // back up before new tokens are found in localStorage, but this
+  // shouldn't happen very often. We shouldn't put a delay here because
+  // that would give a lot of power to an attacker with a stolen login
+  // token and the ability to crash the server.
+  Meteor.startup(function () {
+    self.users.find({
+      "services.resume.haveLoginTokensToDelete": true
+    }, {
+      "services.resume.loginTokensToDelete": 1
+    }).forEach(function (user) {
+      self._deleteSavedTokensForUser(
+        user._id,
+        user.services.resume.loginTokensToDelete
+      );
+    });
   });
-  users.forEach(function (user) {
-    deleteSavedTokens(user._id, user.services.resume.loginTokensToDelete);
-  });
-});
+};
+
+/**
+ * @namespace Accounts
+ * @summary The namespace for all server-side accounts-related methods.
+ */
+Accounts = new AccountsServer();
+
+// Users table. Don't use the normal autopublish, since we want to hide
+// some fields. Code to autopublish this is in accounts_server.js.
+// XXX Allow users to configure this collection name.
+
+/**
+ * @summary A [Mongo.Collection](#collections) containing user documents.
+ * @locus Anywhere
+ * @type {Mongo.Collection}
+ */
+Meteor.users = Accounts._users;

--- a/packages/accounts-base/globals_client.js
+++ b/packages/accounts-base/globals_client.js
@@ -1,0 +1,12 @@
+/**
+ * @namespace Accounts
+ * @summary The namespace for all client-side accounts-related methods.
+ */
+Accounts = new AccountsClient();
+
+/**
+ * @summary A [Mongo.Collection](#collections) containing user documents.
+ * @locus Anywhere
+ * @type {Mongo.Collection}
+ */
+Meteor.users = Accounts.users;

--- a/packages/accounts-base/globals_server.js
+++ b/packages/accounts-base/globals_server.js
@@ -1,0 +1,16 @@
+/**
+ * @namespace Accounts
+ * @summary The namespace for all server-side accounts-related methods.
+ */
+Accounts = new AccountsServer(Meteor.server);
+
+// Users table. Don't use the normal autopublish, since we want to hide
+// some fields. Code to autopublish this is in accounts_server.js.
+// XXX Allow users to configure this collection name.
+
+/**
+ * @summary A [Mongo.Collection](#collections) containing user documents.
+ * @locus Anywhere
+ * @type {Mongo.Collection}
+ */
+Meteor.users = Accounts.users;

--- a/packages/accounts-base/localstorage_token.js
+++ b/packages/accounts-base/localstorage_token.js
@@ -1,23 +1,30 @@
+var Ap = AccountsClient.prototype;
+
 // This file deals with storing a login token and user id in the
 // browser's localStorage facility. It polls local storage every few
 // seconds to synchronize login state between multiple tabs in the same
 // browser.
 
-var lastLoginTokenWhenPolled;
-
 // Login with a Meteor access token. This is the only public function
 // here.
 Meteor.loginWithToken = function (token, callback) {
-  Accounts.callLoginMethod({
-    methodArguments: [{resume: token}],
-    userCallback: callback});
+  return Accounts.loginWithToken(token, callback);
+};
+
+Ap.loginWithToken = function (token, callback) {
+  this.callLoginMethod({
+    methodArguments: [{
+      resume: token
+    }],
+    userCallback: callback
+  });
 };
 
 // Semi-internal API. Call this function to re-enable auto login after
 // if it was disabled at startup.
-Accounts._enableAutoLogin = function () {
-  autoLoginEnabled = true;
-  pollStoredLoginToken();
+Ap._enableAutoLogin = function () {
+  this._autoLoginEnabled = true;
+  this._pollStoredLoginToken();
 };
 
 
@@ -25,116 +32,153 @@ Accounts._enableAutoLogin = function () {
 /// STORING
 ///
 
-// Key names to use in localStorage
-var loginTokenKey = "Meteor.loginToken";
-var loginTokenExpiresKey = "Meteor.loginTokenExpires";
-var userIdKey = "Meteor.userId";
-
 // Call this from the top level of the test file for any test that does
 // logging in and out, to protect multiple tabs running the same tests
 // simultaneously from interfering with each others' localStorage.
-Accounts._isolateLoginTokenForTest = function () {
-  loginTokenKey = loginTokenKey + Random.id();
-  userIdKey = userIdKey + Random.id();
+Ap._isolateLoginTokenForTest = function () {
+  this.LOGIN_TOKEN_KEY = this.LOGIN_TOKEN_KEY + Random.id();
+  this.USER_ID_KEY = this.USER_ID_KEY + Random.id();
 };
 
-storeLoginToken = function(userId, token, tokenExpires) {
-  Meteor._localStorage.setItem(userIdKey, userId);
-  Meteor._localStorage.setItem(loginTokenKey, token);
+Ap._storeLoginToken = function (userId, token, tokenExpires) {
+  Meteor._localStorage.setItem(this.USER_ID_KEY, userId);
+  Meteor._localStorage.setItem(this.LOGIN_TOKEN_KEY, token);
   if (! tokenExpires)
-    tokenExpires = Accounts._tokenExpiration(new Date());
-  Meteor._localStorage.setItem(loginTokenExpiresKey, tokenExpires);
+    tokenExpires = this._tokenExpiration(new Date());
+  Meteor._localStorage.setItem(this.LOGIN_TOKEN_EXPIRES_KEY, tokenExpires);
 
   // to ensure that the localstorage poller doesn't end up trying to
   // connect a second time
-  lastLoginTokenWhenPolled = token;
+  this._lastLoginTokenWhenPolled = token;
 };
 
-unstoreLoginToken = function() {
-  Meteor._localStorage.removeItem(userIdKey);
-  Meteor._localStorage.removeItem(loginTokenKey);
-  Meteor._localStorage.removeItem(loginTokenExpiresKey);
+Ap._unstoreLoginToken = function () {
+  Meteor._localStorage.removeItem(this.USER_ID_KEY);
+  Meteor._localStorage.removeItem(this.LOGIN_TOKEN_KEY);
+  Meteor._localStorage.removeItem(this.LOGIN_TOKEN_EXPIRES_KEY);
 
   // to ensure that the localstorage poller doesn't end up trying to
   // connect a second time
-  lastLoginTokenWhenPolled = null;
+  this._lastLoginTokenWhenPolled = null;
 };
 
 // This is private, but it is exported for now because it is used by a
 // test in accounts-password.
 //
-storedLoginToken = Accounts._storedLoginToken = function() {
-  return Meteor._localStorage.getItem(loginTokenKey);
+Ap._storedLoginToken = function () {
+  return Meteor._localStorage.getItem(this.LOGIN_TOKEN_KEY);
 };
 
-storedLoginTokenExpires = function () {
-  return Meteor._localStorage.getItem(loginTokenExpiresKey);
+Ap._storedLoginTokenExpires = function () {
+  return Meteor._localStorage.getItem(this.LOGIN_TOKEN_EXPIRES_KEY);
 };
 
-var storedUserId = function() {
-  return Meteor._localStorage.getItem(userIdKey);
+Ap._storedUserId = function () {
+  return Meteor._localStorage.getItem(this.USER_ID_KEY);
 };
 
-var unstoreLoginTokenIfExpiresSoon = function () {
-  var tokenExpires = Meteor._localStorage.getItem(loginTokenExpiresKey);
-  if (tokenExpires && Accounts._tokenExpiresSoon(new Date(tokenExpires)))
-    unstoreLoginToken();
+Ap._unstoreLoginTokenIfExpiresSoon = function () {
+  var tokenExpires = this._storedLoginTokenExpires();
+  if (tokenExpires && this._tokenExpiresSoon(new Date(tokenExpires))) {
+    self._unstoreLoginToken();
+  }
 };
 
 ///
 /// AUTO-LOGIN
 ///
 
-if (autoLoginEnabled) {
-  // Immediately try to log in via local storage, so that any DDP
-  // messages are sent after we have established our user account
-  unstoreLoginTokenIfExpiresSoon();
-  var token = storedLoginToken();
-  if (token) {
-    // On startup, optimistically present us as logged in while the
-    // request is in flight. This reduces page flicker on startup.
-    var userId = storedUserId();
-    userId && Accounts.connection.setUserId(userId);
-    Meteor.loginWithToken(token, function (err) {
-      if (err) {
-        Meteor._debug("Error logging in with token: " + err);
-        makeClientLoggedOut();
-      }
-      Accounts._pageLoadLogin({
-        type: "resume",
-        allowed: !err,
-        error: err,
-        methodName: "login",
-        // XXX This is duplicate code with loginWithToken, but
-        // loginWithToken can also be called at other times besides
-        // page load.
-        methodArguments: [{resume: token}]
-      });
-    });
+Ap._initLocalStorage = function () {
+  var self = this;
+
+  // Key names to use in localStorage
+  self.LOGIN_TOKEN_KEY = "Meteor.loginToken";
+  self.LOGIN_TOKEN_EXPIRES_KEY = "Meteor.loginTokenExpires";
+  self.USER_ID_KEY = "Meteor.userId";
+
+  var rootUrlPathPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
+  if (rootUrlPathPrefix || this.connection !== Meteor.connection) {
+    // We want to keep using the same keys for existing apps that do not
+    // set a custom ROOT_URL_PATH_PREFIX, so that most users will not have
+    // to log in again after an app updates to a version of Meteor that
+    // contains this code, but it's generally preferable to namespace the
+    // keys so that connections from distinct apps to distinct DDP URLs
+    // will be distinct in Meteor._localStorage.
+    var namespace = ":" + this.connection._stream.rawUrl;
+    if (rootUrlPathPrefix) {
+      namespace += ":" + rootUrlPathPrefix;
+    }
+    self.LOGIN_TOKEN_KEY += namespace;
+    self.LOGIN_TOKEN_EXPIRES_KEY += namespace;
+    self.USER_ID_KEY += namespace;
   }
-}
 
-// Poll local storage every 3 seconds to login if someone logged in in
-// another tab
-lastLoginTokenWhenPolled = token;
-var pollStoredLoginToken = function() {
-  if (! autoLoginEnabled)
-    return;
+  if (self._autoLoginEnabled) {
+    // Immediately try to log in via local storage, so that any DDP
+    // messages are sent after we have established our user account
+    self._unstoreLoginTokenIfExpiresSoon();
+    var token = self._storedLoginToken();
+    if (token) {
+      // On startup, optimistically present us as logged in while the
+      // request is in flight. This reduces page flicker on startup.
+      var userId = self._storedUserId();
+      userId && self.connection.setUserId(userId);
+      self.loginWithToken(token, function (err) {
+        if (err) {
+          Meteor._debug("Error logging in with token: " + err);
+          self.makeClientLoggedOut();
+        }
 
-  var currentLoginToken = storedLoginToken();
-
-  // != instead of !== just to make sure undefined and null are treated the same
-  if (lastLoginTokenWhenPolled != currentLoginToken) {
-    if (currentLoginToken) {
-      Meteor.loginWithToken(currentLoginToken, function (err) {
-        if (err)
-          makeClientLoggedOut();
+        self._pageLoadLogin({
+          type: "resume",
+          allowed: !err,
+          error: err,
+          methodName: "login",
+          // XXX This is duplicate code with loginWithToken, but
+          // loginWithToken can also be called at other times besides
+          // page load.
+          methodArguments: [{resume: token}]
+        });
       });
-    } else {
-      Meteor.logout();
     }
   }
-  lastLoginTokenWhenPolled = currentLoginToken;
+
+  // Poll local storage every 3 seconds to login if someone logged in in
+  // another tab
+  self._lastLoginTokenWhenPolled = token;
+
+  if (self._pollIntervalTimer) {
+    // Unlikely that _initLocalStorage will be called more than once for
+    // the same AccountsClient instance, but just in case...
+    clearInterval(self._pollIntervalTimer);
+  }
+
+  self._pollIntervalTimer = setInterval(function () {
+    self._pollStoredLoginToken();
+  }, 3000);
 };
 
-setInterval(pollStoredLoginToken, 3000);
+Ap._pollStoredLoginToken = function () {
+  var self = this;
+
+  if (! self._autoLoginEnabled) {
+    return;
+  }
+
+  var currentLoginToken = self._storedLoginToken();
+
+  // != instead of !== just to make sure undefined and null are treated the same
+  if (self._lastLoginTokenWhenPolled != currentLoginToken) {
+    if (currentLoginToken) {
+      self.loginWithToken(currentLoginToken, function (err) {
+        if (err) {
+          self.makeClientLoggedOut();
+        }
+      });
+    } else {
+      self.logout();
+    }
+  }
+
+  self._lastLoginTokenWhenPolled = currentLoginToken;
+};

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -34,6 +34,8 @@ Package.onUse(function (api) {
   api.use('oauth-encryption', 'server', {weak: true});
 
   api.export('Accounts');
+  api.export('AccountsClient', 'client');
+  api.export('AccountsServer', 'server');
   api.export('AccountsTest', {testOnly: true});
 
   api.addFiles('accounts_common.js', ['client', 'server']);

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -38,7 +38,6 @@ Package.onUse(function (api) {
 
   api.addFiles('accounts_common.js', ['client', 'server']);
   api.addFiles('accounts_server.js', 'server');
-  api.addFiles('url_client.js', 'client');
   api.addFiles('url_server.js', 'server');
 
   // accounts_client must be before localstorage_token, because
@@ -46,6 +45,7 @@ Package.onUse(function (api) {
   // Accounts.callLoginMethod) on startup. And localstorage_token must be after
   // url_client, which sets autoLoginEnabled.
   api.addFiles('accounts_client.js', 'client');
+  api.addFiles('url_client.js', 'client');
   api.addFiles('localstorage_token.js', 'client');
 });
 

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -47,6 +47,12 @@ Package.onUse(function (api) {
   api.addFiles('accounts_client.js', 'client');
   api.addFiles('url_client.js', 'client');
   api.addFiles('localstorage_token.js', 'client');
+
+  // These files instantiate the default Accounts instance on the server
+  // and the client, so they must be evaluated last to ensure that the
+  // prototypes have been fully populated.
+  api.addFiles('globals_server.js', 'server');
+  api.addFiles('globals_client.js', 'client');
 });
 
 Package.onTest(function (api) {

--- a/packages/accounts-base/url_server.js
+++ b/packages/accounts-base/url_server.js
@@ -1,15 +1,15 @@
 // XXX These should probably not actually be public?
 
-Accounts.urls = {};
+AccountsServer.prototype.urls = {
+  resetPassword: function (token) {
+    return Meteor.absoluteUrl('#/reset-password/' + token);
+  },
 
-Accounts.urls.resetPassword = function (token) {
-  return Meteor.absoluteUrl('#/reset-password/' + token);
-};
+  verifyEmail: function (token) {
+    return Meteor.absoluteUrl('#/verify-email/' + token);
+  },
 
-Accounts.urls.verifyEmail = function (token) {
-  return Meteor.absoluteUrl('#/verify-email/' + token);
-};
-
-Accounts.urls.enrollAccount = function (token) {
-  return Meteor.absoluteUrl('#/enroll-account/' + token);
+  enrollAccount: function (token) {
+    return Meteor.absoluteUrl('#/enroll-account/' + token);
+  }
 };


### PR DESCRIPTION
This pull requests reduces the assumption of a singleton `Accounts` namespace in the `accounts-base` core package, making it much easier to manage multiple accounts connections without duplicating code.

At a high level, this refactoring was all about replacing the ad-hoc `Accounts` object with instances of the new `AccountsClient` and `AccountsServer` classes, which inherit from `AccountsCommon` so that methods can be shared (yay isomorphism!).

As an example of a luxury that had to be given up in order to support multiple accounts instances, initialization code that used to run at the top level (like the auto-login code) is now called from the constructor functions.

I think it's now much clearer which methods and properties are available on the client, on the server, or in both places, since each environment has a distinct `.prototype` where available methods are defined.