### PR TITLE
Default to error if it's actually a string #2

### DIFF
--- a/packages/blaze/exceptions.js
+++ b/packages/blaze/exceptions.js
@@ -39,7 +39,7 @@ Blaze._reportException = function (e, msg) {
   // In Chrome, `e.stack` is a multiline string that starts with the message
   // and contains a stack trace.  Furthermore, `console.log` makes it clickable.
   // `console.log` supplies the space between the two arguments.
-  debugFunc()(msg || 'Exception caught in template:', e.stack || e.message);
+  debugFunc()(msg || 'Exception caught in template:', e.stack || e.message || e);
 };
 
 Blaze._wrapCatchingExceptions = function (f, where) {


### PR DESCRIPTION
It happens if error is a simple string: ``throw "Bork!"``

Same as #4130 but in a different place.