### PR TITLE
Added default deployment-target for ios to 7.0.

### DIFF
--- a/tools/commands-cordova.js
+++ b/tools/commands-cordova.js
@@ -1443,7 +1443,8 @@ var consumeControlFile = function (
   // set some defaults different from the Phonegap/Cordova defaults
   var additionalConfiguration = {
     'webviewbounce': false,
-    'DisallowOverscroll': true
+    'DisallowOverscroll': true,
+    'deployment-target': "7.0"
   };
 
   if (projectContext.packageMap.getInfo('launch-screen')) {


### PR DESCRIPTION
This PR defines a default Deployment Target for iOS devices in config.xml (See #3153 for more information).

*Testing*

1. Create a meteor App
1. Add iOS plattform
1. Build mobile packages
1. open XCode. The Deployment is 7.0 (or the one specified with `App.setPreference`)

With this Deployment Target and the following mobile-config.js it's possible to submit Apps to the Apple App store without errors and warnings.

```
App.icons({
  // iOS
  'iphone': 'resources/icons/icon-60x60.png',
  'iphone_2x': 'resources/icons/icon-60x60@2x.png',
  'iphone_3x': 'resources/icons/icon-180x180.png',
  'ipad': 'resources/icons/icon-76x76.png',
  'ipad_2x': 'resources/icons/icon-76x76@2x.png',
});
```


