### PR TITLE
add modifier $position to $push in minimongo

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2229,6 +2229,22 @@ Tinytest.add("minimongo - modify", function (test) {
     {a: [{x: 3}, {x: 4}]});
   modify({}, {$push: {a: {$each: [1, 2, 3], $slice: 0}}}, {a: []});
   modify({a: [1, 2]}, {$push: {a: {$each: [1, 2, 3], $slice: 0}}}, {a: []});
+  // $push with $position modifier
+  // No negative number for $position
+  exception({a: []}, {$push: {a: {$each: [0], $position: -1}}});
+  modify({a: [1, 2]}, {$push: {a: {$each: [0], $position: 0}}},
+    {a: [0, 1, 2]});
+  modify({a: [1, 2]}, {$push: {a: {$each: [-1, 0], $position: 0}}},
+    {a: [-1, 0, 1, 2]});
+  modify({a: [1, 3]}, {$push: {a: {$each: [2], $position: 1}}}, {a: [1, 2, 3]});
+  modify({a: [1, 4]}, {$push: {a: {$each: [2, 3], $position: 1}}},
+    {a: [1, 2, 3, 4]});
+  modify({a: [1, 2]}, {$push: {a: {$each: [3], $position: 3}}}, {a: [1, 2, 3]});
+  modify({a: [1, 2]}, {$push: {a: {$each: [3], $position: 99}}},
+    {a: [1, 2, 3]});
+  modify({a: [1, 2]}, {$push: {a: {$each: [3], $position: 99, $slice: -2}}},
+    {a: [2, 3]});
+
 
   // $pushAll
   modify({}, {$pushAll: {a: [1]}}, {a: [1]});

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2244,6 +2244,16 @@ Tinytest.add("minimongo - modify", function (test) {
     {a: [1, 2, 3]});
   modify({a: [1, 2]}, {$push: {a: {$each: [3], $position: 99, $slice: -2}}},
     {a: [2, 3]});
+  modify(
+    {a: [{x: 1}, {x: 2}]},
+    {$push: {a: {$each: [{x: 3}], $position: 0, $sort: {x: 1}, $slice: -3}}},
+    {a: [{x: 1}, {x: 2}, {x: 3}]}
+  );
+  modify(
+    {a: [{x: 1}, {x: 2}]},
+    {$push: {a: {$each: [{x: 3}], $position: 0, $sort: {x: 1}, $slice: 0}}},
+    {a: []}
+  );
 
 
   // $pushAll


### PR DESCRIPTION
Issue meteor/meteor#4158.

Adds the `$position` modifier to `$push` in minimongo. Also adds tests.

Behavior of `$push` with multiple modifiers is documented [here](http://docs.mongodb.org/manual/reference/operator/update/push/#modifiers) as
> 1. Update array to add elements in the correct position.
> 2. Apply sort, if specified.
> 3. Slice the array, if specified.
> 4. Store the array.


**Details:**
As described in the last paragraph [here](http://docs.mongodb.org/manual/reference/operator/update/position/#up._S_position), if value of `$position` exceeds the size of the array to be modified, then the operation is the same as not using the `$position` at all.
The minimongo code I added still runs through the [`$position` code path](https://github.com/meteor/meteor/blob/d383e479b3ea5354583e7c194f80a2e6c96a59de/packages/minimongo/modify.js#L279-L282) in that case. To short-circuit, you could add `if (position < target[index].length) position = arg.$position` [here](https://github.com/meteor/meteor/blob/d383e479b3ea5354583e7c194f80a2e6c96a59de/packages/minimongo/modify.js#L242), which would result in running through the [regular code path](https://github.com/meteor/meteor/blob/d383e479b3ea5354583e7c194f80a2e6c96a59de/packages/minimongo/modify.js#L276-L277). I am not sure which behavior is desired, but it should not matter anyways.