### PR TITLE
let package names start with digits

### DIFF
--- a/tools/linker.js
+++ b/tools/linker.js
@@ -4,7 +4,7 @@ var buildmessage = require('./buildmessage');
 var watch = require('./watch.js');
 
 var packageDot = function (name) {
-  if (/^[a-zA-Z0-9]*$/.exec(name))
+  if (/^[a-zA-Z][a-zA-Z0-9]*$/.exec(name))
     return "Package." + name;
   else
     return "Package['" + name + "']";


### PR DESCRIPTION
Issue meteor/meteor#3670.

The old reg ex used in `packageDot` function accepted names starting with digits which is wrong, because it results in the function spitting out invalid javascript, e.g. `Package.6to5` which should be `Package['6to5']`.

I changed the reg ex to require the first digit to be alphabetical which should fix the issue.

As a side effect the reg ex now no longer accepts an empty string which should not be a problem, because a package without a name should not exist in the first place.