### PR TITLE
Additional env.METEOR_WAREHOUSE_BASE to allow multi-user setup

### DIFF
--- a/tools/tropohouse.js
+++ b/tools/tropohouse.js
@@ -26,6 +26,10 @@ var defaultWarehouseDir = function () {
   if (process.env.METEOR_WAREHOUSE_DIR)
     return process.env.METEOR_WAREHOUSE_DIR;
 
+  // a hook to allow multi-user running meteor from single global meteor installation
+  if (process.env.METEOR_WAREHOUSE_BASE)
+    return process.env.METEOR_WAREHOUSE_BASE;
+
   var warehouseBase = files.inCheckout()
      ? files.getCurrentToolsDir() : files.getHomeDir();
   // XXX This will be `.meteor` soon, once we've written the code to make the


### PR DESCRIPTION
running meteor from single global meteor installation (checkout).

As figured out while working on issue https://github.com/4commerce-technologies-AG/meteor/issues/16 following feature request is sent as pull request:

---

After fresh check-out installation there is following error, when trying to start meteor like

```
meteor --version
```

<pre>
Retrying after error { [Error: SQLITE_CANTOPEN: unable to open database file] stack: [Getter] }
Retrying after error { [Error: SQLITE_CANTOPEN: unable to open database file] stack: [Getter] }

/usr/local/lib/meteor/dev_bundle/lib/node_modules/fibers/future.js:278
						throw(ex);
						      ^
Error: SQLITE_CANTOPEN: unable to open database file
    at Object.Future.wait (/usr/local/lib/meteor/dev_bundle/lib/node_modules/fibers/future.js:398:15)
    at [object Object]._.extend._execute (/usr/local/lib/meteor/tools/catalog-remote.js:366:22)
    at /usr/local/lib/meteor/tools/catalog-remote.js:143:10
    at [object Object]._.extend._retry (/usr/local/lib/meteor/tools/catalog-remote.js:155:16)
    at new Db (/usr/local/lib/meteor/tools/catalog-remote.js:142:8)
    at [object Object]._.extend.initialize (/usr/local/lib/meteor/tools/catalog-remote.js:701:15)
    at /usr/local/lib/meteor/tools/main.js:743:20
    - - - - -
</pre>

The failure depends on an ACCESS RIGHTS when meteor tries to update / read package informations for your installed meteor dev environment.

Procedure to reproduce when trying to setup a global meteor installation:

**Login as user root**
1. Get meteor from git checkout at /usr/local/lib
1. Run `scripts/generate-dev-bundle.sh`
1. Run `meteor --version` for first time to install generated dev_bundle

**Login as normal user**
1. Run `meteor --version`

The problem is located in case of the _meteor warehouse directory_  which will be created when meteor is launched for the first time. This is normally `.meteor` in the checkout path.

Sqlite3 database files are just allowed to read for others but should opened for read/write:
<pre>
root@localhost:/# ls -la .meteor/package-metadata/v2.0.1/packages.data.db*
-rw-r--r-- 1 root root  1024 Mai  5 22:00 .meteor/package-metadata/v2.0.1/packages.data.db
-rw-r--r-- 1 root root 32768 Mai  5 22:00 .meteor/package-metadata/v2.0.1/packages.data.db-shm
-rw-r--r-- 1 root root 25184 Mai  5 22:00 .meteor/package-metadata/v2.0.1/packages.data.db-wal
</pre>

See source at meteor tree [tools/catalog-remote.js](https://github.com/meteor/meteor/blob/devel/tools/catalog-remote.js#L275-276)

**Proposal:**

Instead of changing all directories to rwx or to have multiple installations of meteor for each user, it would nice, to just have a folder to decide where the build commands will store their information during development.

Just setting METEOR_WAREHOUSE_DIR does not work because it also affects other parts of launch process so that meteor will not run. Therefor I decided to add another env for that.

**Login as normal user**
1. Run `METEOR_WAREHOUSE_BASE=$HOME/.meteor meteor --version`


Looking forward to your feedback
Tom

