### PR TITLE
don't add {safe:true} to MongoDB indexes

### DIFF
--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -742,7 +742,6 @@ MongoConnection.prototype.findOne = function (collection_name, selector,
 MongoConnection.prototype._ensureIndex = function (collectionName, index,
                                                    options) {
   var self = this;
-  options = _.extend({safe: true}, options);
 
   // We expect this function to be called at startup, not from within a method,
   // so we don't interact with the write fence.


### PR DESCRIPTION
Based on the log message in e38cefbc0466167e4bf5a19010f8ba1a1e4aca62 the original intent of passing `{safe:true}` in the `_ensureIndex()` options was to emulate MongoDB's [`createIndex()`](http://docs.mongodb.org/manual/reference/method/db.collection.createIndex/) (neé [`ensureIndex()`](http://docs.mongodb.org/manual/reference/method/db.collection.ensureIndex/)) setting `{unique:true}`. Unfortunately, `{safe:true}` does not throw an error if duplicate data is found. That's what `{unique:true}` is for. `{safe:true}` simply adds the key `safe` with the value `true` to the index document.

Here's an illustration. Create a new collection:

    mongo> db.people.drop()
    mongo> db.people.insert({name:'Samus'})
    mongo> db.people.insert({name:'Samus'})
    mongo> db.people.find()
    {"_id": ObjectId("554b85018152d2b363cbc1d8"), "name": "Adam" }
    {"_id": ObjectId("554b85088152d2b363cbc1d9"), "name": "Adam" }

In a Meteor app, add:

    if (Meteor.isServer) {
      Meteor.startup(function() {
        People = new Mongo.Collection('people');
        People._ensureIndex({name:1});
      }
    }

Configure the app to connect to the above MongoDB server/database and start the app. No error is thrown, and a nonunique index is created with a `safe` key that (as far as I can tell) has no effect:

    mongo> db.people.getIndexes()[1]
    {
      "v": 1,
      "key": {
        "name": 1
      },
      "name": "name_1",
      "ns": "test.people",
      "safe": true
    }

MongoDB appears to store arbitrary keys on indexes. Anything in `options` is just shoved right in. Demonstration:

    mongo> db.people.dropIndex('name_1')
    mongo> db.people.createIndex({name:1},{Castlevania:false,Metroid:true})
    mongo> db.people.getIndexes()[1]
    {
      "v": 1,
      "key": {
        "name": 1
      },
      "name": "name_1",
      "ns": "test.people",
      "Castlevania": false,
      "Metroid": true
    }

Other notes:

* I have signed the [contributor agreement](https://contribute.meteor.com/).
* Discussion here: https://forums.meteor.com/t/why-does-collection--ensureindex-add-safe-true/3968