### PR TITLE
Use the _id fast path for selectors that are an object with only an _id.

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -92,19 +92,22 @@ LocalCollection.Cursor = function (collection, selector, options) {
 
   self.collection = collection;
   self.sorter = null;
+  self.matcher = new Minimongo.Matcher(selector);
 
   if (LocalCollection._selectorIsId(selector)) {
     // stash for fast path
     self._selectorId = selector;
-    self.matcher = new Minimongo.Matcher(selector);
+  } else if (LocalCollection._selectorIsIdPerhapsAsObject(selector)) {
+    // also do the fast path for { _id: idString }
+    self._selectorId = selector._id;
   } else {
     self._selectorId = undefined;
-    self.matcher = new Minimongo.Matcher(selector);
     if (self.matcher.hasGeoQuery() || options.sort) {
       self.sorter = new Minimongo.Sorter(options.sort || [],
                                          { matcher: self.matcher });
     }
   }
+
   self.skip = options.skip;
   self.limit = options.limit;
   self.fields = options.fields;


### PR DESCRIPTION
@glasser take a peek?