### PR TITLE
Added beforeSend hook  to http client

### DIFF
--- a/packages/http/httpcall_client.js
+++ b/packages/http/httpcall_client.js
@@ -173,6 +173,19 @@ HTTP.call = function(method, url, options, callback) {
       }
     };
 
+    // Allow custom control over XHR and abort early.
+    if(options.beforeSend) {
+      // Sanity
+      var beforeSend = _.once(options.beforeSend);
+
+      // Possibly change the call so the xhr is the context.
+      if(false === beforeSend.call(null, xhr, options)) {
+
+        // Abort the request
+        return xhr.abort();
+      }
+    }
+
     // send it on its way
     xhr.send(content);
 

--- a/packages/http/httpcall_client.js
+++ b/packages/http/httpcall_client.js
@@ -175,12 +175,12 @@ HTTP.call = function(method, url, options, callback) {
     };
 
     // Allow custom control over XHR and abort early.
-    if(options.beforeSend) {
+    if (options.beforeSend) {
       // Sanity
       var beforeSend = _.once(options.beforeSend);
 
       // Call the callback and check to see if the request was aborted
-      if(false === beforeSend.call(null, xhr, options)) {
+      if (false === beforeSend.call(null, xhr, options)) {
         return xhr.abort();
       }
     }

--- a/packages/http/httpcall_client.js
+++ b/packages/http/httpcall_client.js
@@ -179,10 +179,8 @@ HTTP.call = function(method, url, options, callback) {
       // Sanity
       var beforeSend = _.once(options.beforeSend);
 
-      // Possibly change the call so the xhr is the context.
+      // Call the callback and check to see if the request was aborted
       if(false === beforeSend.call(null, xhr, options)) {
-
-        // Abort the request
         return xhr.abort();
       }
     }

--- a/packages/http/httpcall_client.js
+++ b/packages/http/httpcall_client.js
@@ -13,6 +13,7 @@
  * @param {Number} options.timeout Maximum time in milliseconds to wait for the request before failing.  There is no timeout by default.
  * @param {Boolean} options.followRedirects If `true`, transparently follow HTTP redirects. Cannot be set to `false` on the client. Default `true`.
  * @param {Object} options.npmRequestOptions On the server, `HTTP.call` is implemented by using the [npm `request` module](https://www.npmjs.com/package/request). Any options in this object will be passed directly to the `request` invocation.
+ * @param {Function} options.beforeSend On the Client, this will be called before the request is sent to allow for more granular ajax manipulation, `xhr` object is passed as the first argument, returning false within this callback will cancel the request.
  * @param {Function} [asyncCallback] Optional callback.  If passed, the method runs asynchronously, instead of synchronously, and calls asyncCallback.  On the client, this callback is required.
  */
 HTTP.call = function(method, url, options, callback) {

--- a/packages/http/httpcall_server.js
+++ b/packages/http/httpcall_server.js
@@ -25,6 +25,10 @@ var _call = function(method, url, options, callback) {
 
   options = options || {};
 
+  if (_.has(options, 'beforeSend')) {
+    throw new Error("Option beforeSend not supported on server.");
+  }
+
   method = (method || "").toUpperCase();
 
   if (! /^https?:\/\//.test(url))

--- a/packages/http/httpcall_tests.js
+++ b/packages/http/httpcall_tests.js
@@ -454,6 +454,23 @@ testAsyncMulti("httpcall - npmRequestOptions", [
   }
 ]);
 
+testAsyncMulti("httpcall - beforeSend", [
+  function (test, expect) {
+    var fired = false;
+    var bSend = function(xhr){
+      test.isFalse(fired);
+      fired = true;
+      test.isTrue(temp1 instanceof XMLHttpRequest);
+    };
+
+    if (Meteor.isClient) {
+      HTTP.get(url_prefix() + "/", {beforeSend: bSend}, function () {
+        test.isTrue(fired)
+      });
+    }
+  }
+]);
+
 
 if (Meteor.isServer) {
   // This is testing the server's static file sending code, not the http


### PR DESCRIPTION
This small PR is to help solve the issue caused by the xhr object being locked in the `http.call` closure.

This PR add's a small callback that's fired just before the `xhr.send` is called, allowing for the xhr object to be manipulated to allow developers to take full control over request.

Including but not limited to

- Monitoring the state of the request.
- Monitoring the progress of the request.
- Changing the behaviour of the request (e.g. `async: false`).
- Performing XHR based async file uploads.
- Aborting the request (e.g. within a `'progress'` event..)

Reason for implementing the hook in this fasion, i.e. named `beforeSend` and the `xhr` + `options` being passed over is to replicate the implementation that `jQuery` provides:

> **beforeSend**
> Type: **Function**( **jqXHR** jqXHR, **PlainObject** settings )
> A pre-request callback function that can be used to modify the jqXHR (in jQuery 1.4.x, XMLHTTPRequest) object before it is sent. Use this to set custom headers, etc. The jqXHR and settings objects are passed as arguments. This is an Ajax Event. Returning false in the beforeSend function will cancel the request. As of jQuery 1.5, the beforeSend option will be called regardless of the type of request.

Source: http://api.jquery.com/jquery.ajax/

Thanks