### PR TITLE
Meteor.bindEnvironment - Ensure that a return value is always provided

### DIFF
--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -119,6 +119,6 @@ Meteor.bindEnvironment = function (func, onException, _this) {
 
     if (Fiber.current)
       return runWithEnvironment();
-    Fiber(runWithEnvironment).run();
+    return Fiber(runWithEnvironment).run();
   };
 };


### PR DESCRIPTION
Current issue:

When a bound function is invoked outside a fiber - the return value is dropped.

Minimal Reproduction:
```js
var myBoundFn = Meteor.bindEnviroment(function(){ return 1; });
setTimeout(function(){
 console.log('test ', myBoundFn());
});
// logs "test undefined"
```

Other use case: (Callbacks passed to `Promise.prototype.then` are run under Process.nextTick/ setImmediate).
```js
Promise.resolve(1).then(Meteor.bindEnviroment(function(v){
  console.log('got ', v, ' returning ', v + 1);
  return v + 1; // this value wont be returned to the promise chain!!
})).then(function(v){
  console.log('got ', v, ' returning ', v + 1);
  return v + 1;
});
//logs 
// got 1 return 2
// got undefined returning NaN
```

This wont work if the containing function calls `Fiber.yield`... but what other choices are there?