### PR TITLE
fix @index lexical scoping

### DIFF
--- a/packages/blaze/lookup.js
+++ b/packages/blaze/lookup.js
@@ -81,13 +81,6 @@ Blaze._lexicalBindingLookup = function (view, name) {
   var currentView = view;
   var blockHelpersStack = [];
 
-  var boundaryTemplateView = null;
-
-  Tracker.nonreactive(function () {
-    if (view.templateInstance)
-      boundaryTemplateView = view.templateInstance().view;
-  });
-
   // walk up the views up to the templateInstance view, inclusive
   do {
     // skip block helpers views
@@ -98,7 +91,7 @@ Blaze._lexicalBindingLookup = function (view, name) {
         return bindingReactiveVar.get();
       };
     }
-  } while (currentView !== boundaryTemplateView
+  } while (! currentView.templateInstance
            && (currentView = currentView.parentView));
 
   return null;


### PR DESCRIPTION
See discussion in slack #blaze channel: this change makes sure `@index` is only accessible within the `{{#each}}` block, but not from a template nested inside the `{{#each}}` block.