### PR TITLE
Add missing parameter fro api.addFiles

### DIFF
--- a/tools/package-api.js
+++ b/tools/package-api.js
@@ -279,6 +279,7 @@ _.extend(PackageAPI.prototype, {
    * on the server (or the client), you can pass in the second argument
    * (e.g., 'server', 'client', 'web.browser', 'web.cordova') to specify
    * what architecture the file is used with.
+   * @param {Object} [fileOptions] Options passed via fileOptions are visible to build plugins.
    */
   addFiles: function (paths, arch, fileOptions) {
     var self = this;

--- a/tools/package-api.js
+++ b/tools/package-api.js
@@ -279,7 +279,7 @@ _.extend(PackageAPI.prototype, {
    * on the server (or the client), you can pass in the second argument
    * (e.g., 'server', 'client', 'web.browser', 'web.cordova') to specify
    * what architecture the file is used with.
-   * @param {Object} [fileOptions] Options passed via fileOptions are visible to build plugins.
+   * @param {Object} [fileOptions] Options that get passed to build plugins (f.e. the coffeescript plugin).
    */
   addFiles: function (paths, arch, fileOptions) {
     var self = this;


### PR DESCRIPTION
I'm not sure if that's the complete definition of the parameter, but it would be helpful to see in the docs. Is fileOptions used by anything other than build plugins?