### PR TITLE
Allow access to registered custom types

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -192,6 +192,10 @@ EJSON._getTypes = function () {
   return customTypes;
 };
 
+EJSON._getConverters = function () {
+  return builtinConverters;
+};
+
 // for both arrays and objects, in-place modification.
 var adjustTypesToJSONValue =
 EJSON._adjustTypesToJSONValue = function (obj) {

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -188,6 +188,9 @@ EJSON._isCustomType = function (obj) {
     _.has(customTypes, obj.typeName());
 };
 
+EJSON._getTypes = function () {
+  return customTypes;
+};
 
 // for both arrays and objects, in-place modification.
 var adjustTypesToJSONValue =


### PR DESCRIPTION
I am creating a JSON schema validator around EJSON format and it would be really great if I could access the information which custom types have been registered, so that I could extend the schema validator in an automatic way.