### PR TITLE
Add support for parentTemplate calls, similar to parentData.

### DIFF
--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -438,13 +438,13 @@ Blaze.TemplateInstance.prototype.subscriptionsReady = function () {
  * @function
  * @param {Integer} [numLevels] The number of levels beyond the template instance to look. Defaults to 1.
  */
-Blaze.TemplateInstance.prototype.parentTemplate = function (levels) {
+Blaze.TemplateInstance.prototype.parentTemplate = function (numLevels) {
     var view = Blaze.currentView;
-    if (typeof levels === "undefined") {
-        levels = 1;
+    if (typeof numLevels === "undefined") {
+        numLevels = 1;
     }
     while (view) {
-        if (view.name.substring(0, 9) === "Template." && !(levels--)) {
+        if (view.name.substring(0, 9) === "Template." && !(numLevels--)) {
             return view.templateInstance();
         }
         view = view.parentView;

--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -431,6 +431,26 @@ Blaze.TemplateInstance.prototype.subscriptionsReady = function () {
   return this._allSubsReady;
 };
 
+
+/**
+ * @summary Accesses other template instances that enclose the current template instance.
+ * @locus Client
+ * @function
+ * @param {Integer} [numLevels] The number of levels beyond the template instance to look. Defaults to 1.
+ */
+Blaze.TemplateInstance.prototype.parentTemplate = function (levels) {
+    var view = Blaze.currentView;
+    if (typeof levels === "undefined") {
+        levels = 1;
+    }
+    while (view) {
+        if (view.name.substring(0, 9) === "Template." && !(levels--)) {
+            return view.templateInstance();
+        }
+        view = view.parentView;
+    }
+};
+
 /**
  * @summary Specify template helpers available to this template.
  * @locus Client

--- a/packages/spacebars-tests/template_tests.html
+++ b/packages/spacebars-tests/template_tests.html
@@ -832,6 +832,16 @@ Hi there!
   {{/each}}
 </template>
 
+<template name="spacebars_test_template_parent_template_helper">
+  {{#with "parent"}}
+    {{> spacebars_test_template_parent_template_helper_child}}
+  {{/with}}
+</template>
+
+<template name="spacebars_test_template_parent_template_helper_child">
+  {{foo}}
+</template>
+
 <template name="spacebars_test_svg_anchor">
   <svg>
     <a xlink:href="http://www.example.com">Foo</a>

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -2390,6 +2390,34 @@ Tinytest.add(
 );
 
 Tinytest.add(
+  "spacebars-tests - template_tests - Template.parentTemplate from helpers",
+  function (test) {
+    var childTmpl = Template.spacebars_test_template_parent_template_helper_child;
+    var parentTmpl = Template.spacebars_test_template_parent_template_helper;
+    var bar = new ReactiveVar("bar");
+    parentTmpl.onCreated(function() {
+      this.bar = bar;
+      console.log(this.bar);
+    });
+
+    var height = new ReactiveVar(1);
+
+    childTmpl.helpers({
+      foo: function () {
+        return Template.instance().parentTemplate(height.get()).bar.get();
+      }
+    });
+
+    var div = renderToDiv(parentTmpl);
+    test.equal(canonicalizeHtml(div.innerHTML), "bar");
+
+    bar.set("baz");
+    Tracker.flush();
+    test.equal(canonicalizeHtml(div.innerHTML), "baz");
+  }
+);
+
+Tinytest.add(
   "spacebars - SVG <a> elements",
   function (test) {
     if (! document.createElementNS) {


### PR DESCRIPTION
I talked to @stubailo about this a little. I used this so I could create a search/filter type component using a reactive var instead of needing messy/global session vars. I can imagine there are many other use cases for this type of function call being available.

Tests are included, as well as some lightweight docs.

Do you guys have a CI server setup that shows the status? I have to comment out a good bit of tests to even get things running.
