### PR TITLE
Added missing parameter documentation for api.addFiles.

### DIFF
--- a/tools/package-api.js
+++ b/tools/package-api.js
@@ -282,6 +282,8 @@ _.extend(PackageAPI.prototype, {
    * on the server (or the client), you can pass in the second argument
    * (e.g., 'server', 'client', 'web.browser', 'web.cordova') to specify
    * what architecture the file is used with.
+   * @param {Object} [fileOptions] Options that get will be passed to build
+   * plugins (f.e. the coffeescript plugin).
    */
   addFiles: function (paths, arch, fileOptions) {
     var self = this;


### PR DESCRIPTION
I'm not sure if this is the complete description of the `fileOptions` parameter, but it would be helpful to see in the docs. Is `fileOptions` used by anything other than build plugins, so that I may update this PR?