### PR TITLE
Remove windows illegal caracter in package server file

### DIFF
--- a/tools/config.js
+++ b/tools/config.js
@@ -201,7 +201,7 @@ _.extend(exports, {
     serverUrl = serverUrl.replace(/\.meteor\.com$/, '');
 
     // Replace other weird stuff with X.
-    serverUrl = serverUrl.replace(/[^a-zA-Z0-9.:-]/g, 'X');
+    serverUrl = serverUrl.replace(/[^a-zA-Z0-9.-]/g, 'X');
 
     return serverUrl;
   },


### PR DESCRIPTION
This function needs to filter out illegal file characters in windows that can appear in an url.

Context:
I'm trying to create a meteor package server (to be open sourced) for private packages.
When the url of this package server is for example: http.//127.0.0.1:3000
It will think my database file is 127.0.0.1:3000.data.db, but ':' is an illegal character in windows...