### PR TITLE
Prevent creation of non-function methods

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -645,6 +645,8 @@ _.extend(Connection.prototype, {
   methods: function (methods) {
     var self = this;
     _.each(methods, function (func, name) {
+      if (typeof func !== 'function')
+        throw new Error("Method '" + name + "' must be a function");
       if (self._methodHandlers[name])
         throw new Error("A method named '" + name + "' is already defined");
       self._methodHandlers[name] = func;

--- a/packages/ddp-client/livedata_tests.js
+++ b/packages/ddp-client/livedata_tests.js
@@ -64,6 +64,16 @@ Tinytest.add("livedata - methods with colliding names", function (test) {
   });
 });
 
+Tinytest.add("livedata - non-function method", function (test) {
+  var x = Random.id();
+  var m = {};
+  m[x] = 'kitten';
+
+  test.throws(function () {
+    Meteor.methods(m);
+  });
+});
+
 var echoTest = function (item) {
   return function (test, expect) {
     if (Meteor.isServer) {

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1457,6 +1457,8 @@ _.extend(Server.prototype, {
   methods: function (methods) {
     var self = this;
     _.each(methods, function (func, name) {
+      if (typeof func !== 'function')
+        throw new Error("Method '" + name + "' must be a function");
       if (self.method_handlers[name])
         throw new Error("A method named '" + name + "' is already defined");
       self.method_handlers[name] = func;


### PR DESCRIPTION
Resolves #4447 

This addition is meant to prevent the appearance of misleading error messages (see issue above) a little too late.

Feel free to point out any breaking cases which would make this contribution harmful to some current usages of Meteor methods. I already tried to feed something other than a function to current version of `Meteor.methods`, it always ended up shouting at me when I tried to call said methods.