### PR TITLE
Use request host when calling phantom parser, rather than Meteor default host

### DIFF
--- a/packages/spiderable/spiderable_server.js
+++ b/packages/spiderable/spiderable_server.js
@@ -60,7 +60,10 @@ WebApp.connectHandlers.use(function (req, res, next) {
       _.any(Spiderable.userAgentRegExps, function (re) {
         return re.test(req.headers['user-agent']); })) {
 
-    var url = Spiderable._urlForPhantom(Meteor.absoluteUrl(), req.url);
+    // Gets the absolute URL for requested host - it takes the protocol (http or https) from Meteor absoluteUrl
+    // And replaces the Meteor configured host with the original one coming in main request
+    var absoluteUrlForRequestedHost = Meteor.absoluteUrl().replace(/:\/\/.*/, '://' + req.headers.host + '/');
+    var url = Spiderable._urlForPhantom(absoluteUrlForRequestedHost, req.url);
 
     // This string is going to be put into a bash script, so it's important
     // that 'url' (which comes from the network) can neither exploit phantomjs


### PR DESCRIPTION
Refs #4362

@stubailo the fix is actually simpler than what I thought. I'm not sure how to write the automated test, if you can give me a hint, welcomed.

This is the problem:
- Meteor.absoluteUrl() will always return a default hostname you have configured.
- If you have a site that servers multiple domains/hostnames or subdomains, and your app behaviour depends on it, you get into SEO spiderable issues. Because original hostname is always replaced by Meteor default hostname.

The solution:
- We take the protocol (http|https) from Meteor.absoluteUrl() method, however, we will always use the original hostname (of request) when we build the URL that the phantom parser will use to process the equal request.

About the test:
- The only idea I have is to separate that URL composition into another method. Similar to what you guys are doing for Spiderable._urlForPhantom. Then we can write a simple test for that method that shows that it behaves as expected and replaces the base URL properly.

Please let me know how to proceed. Hope it helps :) thanks.

Mauricio.
