### PR TITLE
Fix email verification MongoDB index

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -779,7 +779,7 @@ Accounts.createUser = function (options, callback) {
 ///
 /// PASSWORD-SPECIFIC INDEXES ON USERS
 ///
-Meteor.users._ensureIndex('emails.validationTokens.token',
+Meteor.users._ensureIndex('services.email.verificationTokens.token',
                           {unique: 1, sparse: 1});
 Meteor.users._ensureIndex('services.password.reset.token',
                           {unique: 1, sparse: 1});


### PR DESCRIPTION
The original index, "emails.validationTokens.token" is incorrect; it is never used in meteor.  A search of "validationTokens" across all the packages in `meteor/packages` returns nothing.

The correct index should be, "services.email.verificationTokens.token".  This is set in the `Accounts.sendVerificationEmail` function and queried in the `verifyEmail` method to locate the appropriate user record.

Without a matching index, a full table scan is run each time the `verifyEmail` method is called.