### PR TITLE
Conform to how mongo handles inclusive _id in projections (issue #3778)

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -1265,6 +1265,12 @@ Tinytest.add("minimongo - projection_compiler", function (test) {
   });
 
   test.throws(function () {
+    testProjection({ _id: 1, a: 0 }, [
+      [ { _id: "uid", a: 42 }, { _id: "uid" }, "Can only combine incl/excl rules with _id when excluding id" ]
+    ]);
+  });
+
+  test.throws(function () {
     testProjection({ 'a': 1, 'a.b': 1 }, [
       [ { a: { b: 42 } }, { a: { b: 42 } }, "Can't have ambiguous rules (one is prefix of another)" ]
     ]);

--- a/packages/minimongo/projection.js
+++ b/packages/minimongo/projection.js
@@ -58,10 +58,15 @@ projectionDetails = function (fields) {
   // like 'foo' and 'foo.bar' can assume that 'foo' comes first.
   var fieldsKeys = _.keys(fields).sort();
 
-  // If there are other rules other than '_id', treat '_id' differently in a
-  // separate case. If '_id' is the only rule, use it to understand if it is
-  // including/excluding projection.
-  if (fieldsKeys.length > 0 && !(fieldsKeys.length === 1 && fieldsKeys[0] === '_id'))
+  // If _id is the only field in the projection, do not remove it, since it is
+  // required to determine if this is an exclusion or exclusion. Also keep an
+  // inclusive _id, since inclusive _id follows the normal rules about mixing
+  // inclusive and exclusive fields. If _id is not the only field in the
+  // projection and is exclusive, remove it so it can be handled later by a
+  // special case, since exclusive _id is always allowed.
+  if (fieldsKeys.length > 0 &&
+      !(fieldsKeys.length === 1 && fieldsKeys[0] === '_id') &&
+      !(_.contains(fieldsKeys, '_id') && fields['_id']))
     fieldsKeys = _.reject(fieldsKeys, function (key) { return key === '_id'; });
 
   var including = null; // Unknown
@@ -71,7 +76,7 @@ projectionDetails = function (fields) {
     if (including === null)
       including = rule;
     if (including !== rule)
-      // This error message is copies from MongoDB shell
+      // This error message is copied from MongoDB shell
       throw MinimongoError("You cannot currently mix including and excluding fields.");
   });
 
@@ -167,4 +172,3 @@ LocalCollection._checkSupportedProjection = function (fields) {
       throw MinimongoError("Projection values should be one of 1, 0, true, or false");
   });
 };
-


### PR DESCRIPTION
Fix for [#3778](https://github.com/meteor/meteor/issues/3778)