### PR TITLE
Allow all pending observe callbacks to be run before stop

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -394,7 +394,19 @@ _.extend(LocalCollection.Cursor.prototype, {
     var handle = new LocalCollection.ObserveHandle;
     _.extend(handle, {
       collection: self.collection,
-      stop: function () {
+      stop: function (flush) {
+        if (flush && Meteor.isServer && self.collection._observeQueue._draining) {
+          var Future = Npm.require('fibers/future');
+          var future = new Future();
+          self.collection._observeQueue.queueTask(function () {
+            future.return()
+          });
+          // Just to make sure that this will be drained. Probably this is a noop because we are
+          // already draining when we enter this code path.
+          self.collection._observeQueue.drain();
+          future.wait();
+        }
+
         if (self.reactive)
           delete self.collection.queries[qid];
       }

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -394,21 +394,27 @@ _.extend(LocalCollection.Cursor.prototype, {
     var handle = new LocalCollection.ObserveHandle;
     _.extend(handle, {
       collection: self.collection,
-      stop: function (flush) {
-        if (flush && Meteor.isServer && self.collection._observeQueue._draining) {
+      stop: function () {
+        if (self.reactive)
+          delete self.collection.queries[qid];
+      },
+      flush: function () {
+        // If it is already draining, then draining is hapenning in some other
+        // fiber, so we want to block this fiber as well.
+        if (Meteor.isServer && self.collection._observeQueue._draining) {
           var Future = Npm.require('fibers/future');
           var future = new Future();
           self.collection._observeQueue.queueTask(function () {
             future.return()
           });
-          // Just to make sure that this will be drained. Probably this is a noop because we are
-          // already draining when we enter this code path.
+          // Just to make sure that this will be drained. Probably this is a
+          // noop because we are already draining when we enter this code path.
           self.collection._observeQueue.drain();
           future.wait();
         }
-
-        if (self.reactive)
-          delete self.collection.queries[qid];
+        else {
+          self.collection._observeQueue.drain();
+        }
       }
     });
 


### PR DESCRIPTION
This allows fixing a really nasty race-condition between when observe callbacks are scheduled and when they are run. Currently, you can get observe callbacks scheduled, you can call stop, and then callbacks are run. Which can be quite surprising (that callbacks are run after observe was stopped). Especially if code around stop also cleaned some things observe callbacks expect to still have.

Alternatively, we might want to expose a `flush` method on the handle, which flushes pending callbacks when called?

Also, should handle stop in fact remove all pending callbacks? So I think there should be maybe three options:
* leave callbacks to run after stop
* run all callbacks before stop
* drop all pending callbacks
