### PR TITLE
Adding {{foo.0.bar}} support in Spacebars (v2)

### DIFF
--- a/packages/spacebars-compiler/compile_tests.js
+++ b/packages/spacebars-compiler/compile_tests.js
@@ -78,7 +78,7 @@ Tinytest.add("spacebars-compiler - compiler errors", function (test) {
   isError("{{#each}}{{/each}}", "#each requires an argument");
   isError("{{#unless}}{{/unless}}", "#unless requires an argument");
 
-  isError("{{0 0}}", "Expected IDENTIFIER");
+  isError("{{0x6}}", "Expected IDENTIFIER");
 
   isError("{{> foo 0 0}}",
           "First argument must be a function");

--- a/packages/spacebars-compiler/compiler_output_tests.coffee
+++ b/packages/spacebars-compiler/compiler_output_tests.coffee
@@ -72,6 +72,26 @@ coffee.runCompilerOutputTests = (run) ->
   }
   """
 
+  run "{{foo.[0].[1]}}",
+  """
+  function() {
+    var view = this;
+    return Blaze.View("lookup:foo.0.1", function() {
+      return Spacebars.mustache(Spacebars.dot(view.lookup("foo"), "0", "1"));
+    });
+  }
+  """
+
+  run "{{foo.0.1}}",
+  """
+  function() {
+    var view = this;
+    return Blaze.View("lookup:foo.0.1", function() {
+      return Spacebars.mustache(Spacebars.dot(view.lookup("foo"), "0", "1"));
+    });
+  }
+  """
+
   run "{{foo.bar baz}}",
   """
   function() {

--- a/packages/spacebars-compiler/compiler_output_tests.coffee
+++ b/packages/spacebars-compiler/compiler_output_tests.coffee
@@ -40,6 +40,38 @@ coffee.runCompilerOutputTests = (run) ->
   }
   """
 
+  run "{{foo.0.bar}}",
+  """
+  function() {
+    var view = this;
+    return Blaze.View("lookup:foo.0.bar", function() {
+      return Spacebars.mustache(Spacebars.dot(view.lookup("foo"), "0", "bar"));
+    });
+  }
+  """
+
+  run "{{0.foo.1}}",
+  """
+  function() {
+    var view = this;
+    return Blaze.View("lookup:0.foo.1", function() {
+      return Spacebars.mustache(Spacebars.dot(
+               view.lookup("0"), "foo", "1"));
+    });
+  }
+  """
+
+  run "{{[0].foo.[1]}}",
+  """
+  function() {
+    var view = this;
+    return Blaze.View("lookup:0.foo.1", function() {
+      return Spacebars.mustache(Spacebars.dot(
+               view.lookup("0"), "foo", "1"));
+    });
+  }
+  """
+
   run "{{foo.bar baz}}",
   """
   function() {

--- a/packages/spacebars-compiler/templatetag.js
+++ b/packages/spacebars-compiler/templatetag.js
@@ -109,7 +109,8 @@ TemplateTag.parse = function (scannerOrString) {
   };
 
   var scanIdentifier = function (isFirstInPath) {
-    var id = BlazeTools.parseExtendedIdentifierName(scanner);
+    var id = BlazeTools.parseExtendedIdentifierName(scanner) ||
+              run(/^\d+(?![^.}) ])/);
     if (! id) {
       expected('IDENTIFIER');
     }


### PR DESCRIPTION
> Adding handling to allow {{foo.0.bar}} syntax in Spacebars, similar to {{foo[0].bar}}.

Also, does not remove {{[0].bar}} or {{0.bar}} (and even adds {{0 0}} as consequence) support

v1 one can find here #2663 

Resolving #2195
