### PR TITLE
Added check of params for template's methods events and helpers

### DIFF
--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -438,7 +438,7 @@ Blaze.TemplateInstance.prototype.subscriptionsReady = function () {
  */
 Template.prototype.helpers = function (dict) {
   if (Object.prototype.toString.call(dict) !== "[object Object]") {
-    throw new Error('Dictionary of helper must be an object');
+    throw new Error('Template: Dictionary of helper must be an object');
   }
 
   for (var k in dict)
@@ -471,7 +471,7 @@ Template._withTemplateInstanceFunc = function (templateInstanceFunc, func) {
  */
 Template.prototype.events = function (eventMap) {
   if (Object.prototype.toString.call(eventMap) !== "[object Object]") {
-    throw new Error('Event Map must be an object');
+    throw new Error('Template: Event Map must be an object');
   }
 
   var template = this;

--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -437,6 +437,10 @@ Blaze.TemplateInstance.prototype.subscriptionsReady = function () {
  * @param {Object} helpers Dictionary of helper functions by name.
  */
 Template.prototype.helpers = function (dict) {
+  if (Object.prototype.toString.call(dict) !== "[object Object]") {
+    throw new Error('Dictionary of helper must be an object');
+  }
+
   for (var k in dict)
     this.__helpers.set(k, dict[k]);
 };
@@ -466,6 +470,10 @@ Template._withTemplateInstanceFunc = function (templateInstanceFunc, func) {
  * @param {EventMap} eventMap Event handlers to associate with this template.
  */
 Template.prototype.events = function (eventMap) {
+  if (Object.prototype.toString.call(eventMap) !== "[object Object]") {
+    throw new Error('Event Map must be an object');
+  }
+
   var template = this;
   var eventMap2 = {};
   for (var k in eventMap) {


### PR DESCRIPTION
Hello guys!

I use Сoffeescript and faced unpleasant trouble recently, when a small bug made me feel nerveous since I couldn't figure out its reason and Meteor didn't suggest anything. 

I wrote a code, where passed function instead of object  Event Map:

```js
Template.myJobsInfo.events ->
'click [data-action="check_status"]': -> console.log 'OK'
 ```

I did not receive mssage about error, but my code still did not work. As appeared Meteor does not check parameters, which are passed to methods events and helpers.

My minipatch allows to discard this undefined behavior.
