### PR TITLE
Zhenya/accounts

### DIFF
--- a/packages/meteor-developer/meteor_developer_client.js
+++ b/packages/meteor-developer/meteor_developer_client.js
@@ -40,7 +40,7 @@ var requestCredential = function (options, credentialRequestCompleteCallback) {
     loginUrl: loginUrl,
     credentialRequestCompleteCallback: credentialRequestCompleteCallback,
     credentialToken: credentialToken,
-    popupOptions: {width: 470, height: 420}
+    popupOptions: {width: 470, height: 490}
   });
 };
 

--- a/packages/oauth/oauth_browser.js
+++ b/packages/oauth/oauth_browser.js
@@ -56,7 +56,16 @@ var openCenteredPopup = function(url, width, height) {
                   ',left=' + left + ',top=' + top + ',scrollbars=yes');
 
   var newwindow = window.open(url, 'Login', features);
+
+  if (typeof newwindow === 'undefined') {
+    // blocked by a popup blocker maybe?
+    var err = new Error("The popup was blocked by the browser");
+    err.attemptedUrl = url;
+    throw err;
+  }
+
   if (newwindow.focus)
     newwindow.focus();
+  
   return newwindow;
 };

--- a/packages/oauth/oauth_browser.js
+++ b/packages/oauth/oauth_browser.js
@@ -59,7 +59,7 @@ var openCenteredPopup = function(url, width, height) {
 
   if (typeof newwindow === 'undefined') {
     // blocked by a popup blocker maybe?
-    var err = new Error("The popup was blocked by the browser");
+    var err = new Error("The login popup was blocked by the browser");
     err.attemptedUrl = url;
     throw err;
   }


### PR DESCRIPTION
This makes cases when popup blockers block auth dialogs a little neater w.r.t. what gets thrown. Also tweaked the height of a popup window when `Meteor.loginWithMeteorDeveloperAccount({loginStyle: 'popup'})` to help fit the UI without scrollbars.