### PR TITLE
add random argument when cordova get manifest.json

### DIFF
--- a/packages/autoupdate/autoupdate_cordova.js
+++ b/packages/autoupdate/autoupdate_cordova.js
@@ -79,7 +79,7 @@ var localPathPrefix = null;
 var onNewVersion = function () {
   var ft = new FileTransfer();
   var urlPrefix = Meteor.absoluteUrl() + '__cordova';
-  HTTP.get(urlPrefix + '/manifest.json', function (err, res) {
+  HTTP.get(urlPrefix + '/manifest.json?' + Random.id(), function (err, res) {
     if (err || ! res.data) {
       log('Failed to download the manifest ' + (err && err.message) + ' ' + (res && res.content));
       return;
@@ -307,4 +307,3 @@ var ensureLocalPathPrefix = function (cb) {
     cb();
   }
 };
-


### PR DESCRIPTION
add random argument when cordova get manifest.json.

---------
I build and install the app, but when i update the server bundle, the app went white screen.

after reading the source,  i trace the autoupdate's http request,  but it didn't request for the manifest.json and used the preview version manifest.json to download the manifest(these requests are append the random argument), i just saw the manifest requests, and then the app become white screen.

then i hack the bundle js, everything works fine now.
