### PR TITLE
Better duplicate error checks for insertUserDoc

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1250,11 +1250,10 @@ Ap.insertUserDoc = function (options, user) {
     // XXX string parsing sucks, maybe
     // https://jira.mongodb.org/browse/SERVER-3069 will get fixed one day
     if (e.name !== 'MongoError') throw e;
-    var match = e.err.match(/E11000 duplicate key error index: ([^ ]+)/);
-    if (!match) throw e;
-    if (match[1].indexOf('$emails.address') !== -1)
+    if (e.code !== 11000) throw e;
+    if (e.err.indexOf('emails.address') !== -1)
       throw new Meteor.Error(403, "Email already exists.");
-    if (match[1].indexOf('username') !== -1)
+    if (e.err.indexOf('username') !== -1)
       throw new Meteor.Error(403, "Username already exists.");
     // XXX better error reporting for services.facebook.id duplicate, etc
     throw e;

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -123,7 +123,7 @@ Tinytest.add('accounts - insertUserDoc username', function (test) {
       {profile: {name: 'Foo Bar'}},
       userIn
     );
-  });
+  }, 'Username already exists.');
 
   // cleanup
   Meteor.users.remove(userId);
@@ -156,20 +156,20 @@ Tinytest.add('accounts - insertUserDoc email', function (test) {
       {profile: {name: 'Foo Bar'}},
       userIn
     );
-  });
+  }, 'Email already exists.');
 
   // now with only one of them.
   test.throws(function () {
     Accounts.insertUserDoc(
       {}, {emails: [{address: email1}]}
     );
-  });
+  }, 'Email already exists.');
 
   test.throws(function () {
     Accounts.insertUserDoc(
       {}, {emails: [{address: email2}]}
     );
-  });
+  }, 'Email already exists.');
 
 
   // a third email works.


### PR DESCRIPTION
Check the error code and just search for "email.address" or "username" in error message.

Tested with wiredTiger on mongo 3.0.3 and mmapv1 on mongo 2.6.7, which is Meteor 1.1.0.2 default db.

#4368