### PR TITLE
Add more headers for JSON parsing

### DIFF
--- a/packages/http/httpcall_common.js
+++ b/packages/http/httpcall_common.js
@@ -21,7 +21,8 @@ populateData = function(response) {
   var contentType = (response.headers['content-type'] || ';').split(';')[0];
 
   // Only try to parse data as JSON if server sets correct content type.
-  if (_.include(['application/json', 'text/javascript'], contentType)) {
+  if (_.include(['application/json', 'text/javascript',
+      'application/javascript', 'application/x-javascript'], contentType)) {
     try {
       response.data = JSON.parse(response.content);
     } catch (err) {


### PR DESCRIPTION
Some APIs use other headers. For example, Flickr [uses `application/x-javascript`](https://api.flickr.com/services/feeds/photos_public.gne?lang=en-us&format=json&nojsoncallback=1).