### PR TITLE
Update the names of the packages checking for autopublish

### DIFF
--- a/packages/autopublish/package.js
+++ b/packages/autopublish/package.js
@@ -3,5 +3,5 @@ Package.describe({
   version: '1.0.3'
 });
 
-// This package is empty; its presence is detected by livedata and
+// This package is empty; its presence is detected by ddp-server and
 // accounts-base.


### PR DESCRIPTION
Since livedata isn't really a package anymore, I thought It'd be a good idea to update the comment inside the autopublish package.js.