### PR TITLE
Allow packages to reference private npm by folder and install

### DIFF
--- a/tools/meteor-npm.js
+++ b/tools/meteor-npm.js
@@ -474,8 +474,13 @@ var getShrinkwrappedDependencies = function (dir) {
 var installNpmModule = function (name, version, dir) {
   ensureConnected();
 
-  var installArg = utils.isUrlWithSha(version)
-    ? version : (name + "@" + version);
+  var installArg = name + "@" + version;
+
+  if (utils.isUrlWithFileScheme(version)) {
+    installArg = version.replace(/^file:\/\//, '');
+  } else if (utils.isUrlWithSha(version)) {
+    installArg = version;
+  }
 
   // We don't use npm.commands.install since we couldn't figure out
   // how to silence all output (specifically the installed tree which


### PR DESCRIPTION
@SachaG I'm using this now, but I don't think it has to be merged—this is just a note to the work it seems you're in the middle of doing.

This also raises the question of whether or not to use "file://" as an indicator for a file reference because it's nonstandard by NPM. It's not obvious if file:// should be a TGZ or a directory. I'm using it as a directory.

This is supporting the use case of shipping a binary with a regular meteor server app. I believe that's consistent with its intention to support Cordova plugin binaries. Maybe we just need a better wrapper around the package API's `addFile` ?
