### PR TITLE
[meteor run --no-db] will not start the local mongo server

### DIFF
--- a/tools/commands.js
+++ b/tools/commands.js
@@ -194,6 +194,7 @@ var runCommandOptions = {
   requiresApp: true,
   maxArgs: Infinity,
   options: {
+    'no-db': { type: Boolean },
     port: { type: String, short: "p", default: DEFAULT_PORT },
     'mobile-server': { type: String },
     // XXX COMPAT WITH 0.9.2.2
@@ -230,6 +231,13 @@ main.registerCommand(_.extend(
 function doRunCommand (options) {
   cordova.setVerboseness(options.verbose);
   Console.setVerbose(options.verbose);
+
+  var mongoUrl = process.env.MONGO_URL;
+  var oplogUrl = process.env.MONGO_OPLOG_URL;
+  if (options['no-db']) {
+    mongoUrl = "THIS_IS_A_FAKE_MONGO_URL";
+    oplogUrl = "THIS_IS_A_FAKE_MONGO_OPLOG_URL";
+  }
 
   cordova.verboseLog('Parsing the --port option');
   try {
@@ -403,8 +411,8 @@ function doRunCommand (options) {
       includeDebug: ! options.production
     },
     rootUrl: process.env.ROOT_URL,
-    mongoUrl: process.env.MONGO_URL,
-    oplogUrl: process.env.MONGO_OPLOG_URL,
+    mongoUrl: mongoUrl,
+    oplogUrl: oplogUrl,
     mobileServerUrl: mobileServer,
     once: options.once,
     extraRunners: runners

--- a/tools/help.txt
+++ b/tools/help.txt
@@ -52,6 +52,7 @@ Options:
                    Defaults to your local IP and the port that the Meteor
                    server binds to. Can include a URL scheme (for
                    example, --mobile-server=https://example.com:443).
+  --no-db          Run without local mongo server.
   --production     Simulate production mode. Minify and bundle CSS and JS files.
   --raw-logs       Run without parsing logs from stdout and stderr.
   --settings       Set optional data for Meteor.settings on the server.


### PR DESCRIPTION
Hello,
This is not the use case for an app that uses `meteor-platform`.
This useful if we don't need the local mongo server.
Regards.
Jamal