### PR TITLE
Remove all verificationTokens for a specific email once verified

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -739,7 +739,7 @@ Meteor.methods({verifyEmail: function (token) {
         {_id: user._id,
          'emails.address': tokenRecord.address},
         {$set: {'emails.$.verified': true},
-         $pull: {'services.email.verificationTokens': {token: token}}});
+         $pull: {'services.email.verificationTokens': {address: tokenRecord.address}}});
 
       return {userId: user._id};
     }


### PR DESCRIPTION
This will break the other verification email links but it will keep the
user document cleaner. The email will be verified anyways so who cares
that the other verification links isn’t working any more.

#4626, @stubailo, Here you go.