### PR TITLE
Always use identity.email for the email field for github accounts

### DIFF
--- a/packages/github/github_server.js
+++ b/packages/github/github_server.js
@@ -5,13 +5,12 @@ OAuth.registerService('github', 2, null, function(query) {
   var accessToken = getAccessToken(query);
   var identity = getIdentity(accessToken);
   var emails = getEmails(accessToken);
-  var primaryEmail = _.findWhere(emails, {primary: true});
 
   return {
     serviceData: {
       id: identity.id,
       accessToken: OAuth.sealSecret(accessToken),
-      email: identity.email || primaryEmail.email,
+      email: identity.email,
       username: identity.login,
       emails: emails
     },


### PR DESCRIPTION
Code introduced in f32f07a can error out because identity.email might
be empty and primaryEmail might be undefined at the same time.

Let’s always use the publicly visible email for the `email` field and if
scope is enough to provide the GitHub account’s list of emails then we
only add that to the `emails` field and developers which use the `user` or
`user:email` scope should use the `emails` field instead of `email` field.

If the scope is revoked, the list of emails will become empty in the
`emails` field.

@martijnwalraven
I think this is the best approach, because with this solution we hand over control to the developers and don't force them to always use the `user:email` scope even if they were to set their own scope.