### PR TITLE
Proof of Concept: Put Spiderable on a CSS Diet

### DIFF
--- a/packages/spiderable/phantom_script.js
+++ b/packages/spiderable/phantom_script.js
@@ -1,6 +1,14 @@
 // 'url' is assigned to in a statement before this.
 var page = require('webpage').create();
 
+// don't fetch css assets
+page.onResourceRequested = function(requestData, networkRequest) {
+  var match = requestData.url.match(/\.css/g);
+  if (match != null) {
+    networkRequest.cancel();
+  }
+};
+
 var isReady = function () {
   return page.evaluate(function () {
     if (typeof Meteor === 'undefined'


### PR DESCRIPTION
**Issue:** When using Spiderable: `phantom.js` will load all assets, however this includes that `phantom.js` loads `CSS` assets (as expected), this however is double-edged because `phantom.js` is slowed down as it fetches & parses the asset.

**Use Case:** In an application I'm building I was able to cut response time down from 11s seconds, to 6-7 seconds. With no negative side effects (I don't use `display: none` a lot, I hide via reactivity). Under 10 seconds is important for the application I'm working on because FaceBook does a timeout after 10 seconds.

**Potential Challenges:** This change is a proof of concept that we can skip css assets all together, this may have odd side-effects however (what happens during serialization for a `display: none`?, etc). 

**Forward Discussion:** We should consider adding this change optionally (this is a proof of concept), we should discuss the best way to configure this (on/off flag, environment variables, default on or off?).

Thanks :smile:
