### PR TITLE
Catch up to oplog at most once per write fence

### DIFF
--- a/History.md
+++ b/History.md
@@ -21,6 +21,12 @@
 * `sub.ready()` should return true inside that subscription's `onReady`
   callback.  #4614
 
+### Livequery
+
+* Improved server performance by reducing overhead of processing oplog after
+  database writes. Improvements are most noticeable in case when a method is
+  doing a lot of writes on collections with plenty of active observers.
+
 
 ## in progress: v.1.1.1
 

--- a/packages/mongo/oplog_observe_driver.js
+++ b/packages/mongo/oplog_observe_driver.js
@@ -21,6 +21,8 @@ var finishIfNeedToPollQuery = function (f) {
   };
 };
 
+var currentId = 0;
+
 // OplogObserveDriver is an alternative to PollingObserveDriver which follows
 // the Mongo operation log instead of just re-polling the query. It obeys the
 // same simple interface: constructing it starts sending observeChanges
@@ -29,6 +31,9 @@ var finishIfNeedToPollQuery = function (f) {
 OplogObserveDriver = function (options) {
   var self = this;
   self._usesOplog = true;  // tests look at this
+
+  self._id = currentId;
+  currentId++;
 
   self._cursorDescription = options.cursorDescription;
   self._mongoHandle = options.mongoHandle;
@@ -137,24 +142,39 @@ OplogObserveDriver = function (options) {
       var fence = DDPServer._CurrentWriteFence.get();
       if (!fence)
         return;
-      var write = fence.beginWrite();
-      // This write cannot complete until we've caught up to "this point" in the
-      // oplog, and then made it back to the steady state.
-      Meteor.defer(function () {
+
+      if (fence._oplogObserveDrivers) {
+        fence._oplogObserveDrivers[self._id] = self;
+        return;
+      }
+
+      fence._oplogObserveDrivers = {};
+      fence._oplogObserveDrivers[self._id] = self;
+
+      fence.onBeforeFire(function () {
+        var drivers = fence._oplogObserveDrivers;
+        delete fence._oplogObserveDrivers;
+
+        // This fence cannot fire until we've caught up to "this point" in the
+        // oplog, and all observers made it back to the steady state.
         self._mongoHandle._oplogHandle.waitUntilCaughtUp();
-        if (self._stopped) {
-          // We're stopped, so just immediately commit.
-          write.committed();
-        } else if (self._phase === PHASE.STEADY) {
-          // Make sure that all of the callbacks have made it through the
-          // multiplexer and been delivered to ObserveHandles before committing
-          // writes.
-          self._multiplexer.onFlush(function () {
-            write.committed();
-          });
-        } else {
-          self._writesToCommitWhenWeReachSteady.push(write);
-        }
+
+        _.each(drivers, function (driver) {
+          if (driver._stopped)
+            return;
+
+          var write = fence.beginWrite();
+          if (driver._phase === PHASE.STEADY) {
+            // Make sure that all of the callbacks have made it through the
+            // multiplexer and been delivered to ObserveHandles before committing
+            // writes.
+            driver._multiplexer.onFlush(function () {
+              write.committed();
+            });
+          } else {
+            driver._writesToCommitWhenWeReachSteady.push(write);
+          }
+        });
       });
     }
   ));


### PR DESCRIPTION
Before this change, number of catch-up attempts was N*M, where N is number of writes inside of the fence, and M is number of active observers on affected collections. Every catch up issues yet another query to find the latest oplog entry.

It was extremely inefficient, in terms of both CPU usage and added latency. After executing write-heavy methods, application process was occupied for many seconds doing the same thing over and over again.

This change provides a performance improvement for all kinds of workloads.

---

CPU profile of write-intensive method before the change:
<img width="1141" alt="before" src="https://cloud.githubusercontent.com/assets/11211653/8548897/f40275b6-24c7-11e5-96b1-bab3fa3ceb7d.png">

After the change:
<img width="1141" alt="after" src="https://cloud.githubusercontent.com/assets/11211653/8548899/f8da82fe-24c7-11e5-9302-8711c2943831.png">

Before the change there was noticeable several seconds lag after the method invocation (which was caused by `waitUntilCaughtUp` function), before anything else could be processed. After the change that lag is gone, and application is responsive perceptively immediately after the operation is done.

The most visible effect is achieved when a method does a lot of writes, but this change improves efficiency all over the board.