### PR TITLE
Added use call for accounts-base (fixes #4638)

### DIFF
--- a/packages/google/package.js
+++ b/packages/google/package.js
@@ -7,7 +7,7 @@ Package.onUse(function(api) {
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
   api.use('http', ['server']);
-  api.use(['underscore', 'service-configuration'], ['client', 'server']);
+  api.use(['underscore', 'service-configuration', 'accounts-base'], ['client', 'server']);
   api.use(['random', 'templating'], 'client');
 
   api.export('Google');


### PR DESCRIPTION
This PR fixes the issue caused in #4638, adding the use call allows the `Accounts` reference to be in scope for the google package.

Currently unless accounts-base is within `.meteor/packages` or is implied by a 2nd level package, login fails.

Thanks