### PR TITLE
Append always a public property to Meteor.settings.public

### DIFF
--- a/packages/meteor/server_environment.js
+++ b/packages/meteor/server_environment.js
@@ -14,6 +14,12 @@ if (process.env.METEOR_SETTINGS) {
   }
 }
 
+// Make sure that there is always a public attribute
+// to enable Meteor.settings.public on client
+if (!Meteor.settings.public) {
+    Meteor.settings.public = {};
+}
+
 // Push a subset of settings to the client.
 if (Meteor.settings && Meteor.settings.public &&
     typeof __meteor_runtime_config__ === "object") {


### PR DESCRIPTION
If no settings are given via --settings or METEOR_SETTINGS the structure is only initialized as an empty object. This causes, that the `__meteor_runtime_config__.PUBLIC_SETTINGS` is left empty.

In that case you can't set client settings during Meteor.startup(). In case of the missing initialized `__meteor_runtime_config__.PUBLIC_SETTINGS` changes are not "seen" on the client side.

````
Meteor.startup(function() {
  Meteor.settings.public.my_opt = "Available";
});
````

It would be great if this could be appended, then a developer can add even public settings e.g. during initialization of packages.

Cheers,
Tom
