### PR TITLE
Feature: Add new option { imply: true } to packages api.use method.

### DIFF
--- a/tools/package-api.js
+++ b/tools/package-api.js
@@ -193,6 +193,28 @@ _.extend(PackageAPI.prototype, {
       return;
     }
 
+    // We don't allow weak or unordered implies, since the main
+    // purpose of imply is to provide imports and plugins.
+    if (options.imply && (options.unordered || options.weak)) {
+      buildmessage.error(
+        "We don't allow weak or unordered implies.",
+        { useMyCaller: true });
+      // recover by ignoring
+      return;
+    }
+
+    // We currently disallow build plugins in debugOnly packages; but if
+    // you could use imply in a debugOnly package, you could pull in the
+    // build plugin from an implied package, which would have the same
+    // problem as allowing build plugins directly in the package. So no
+    // imply either!
+    if (options.imply && self.debugOnly) {
+      buildmessage.error("can't use imply in debugOnly packages",
+      { useMyCaller: true });
+      // recover by ignoring
+      return;
+    }
+
     // using for loop rather than underscore to help with useMyCaller
     for (var i = 0; i < names.length; ++i) {
       var name = names[i];
@@ -213,6 +235,14 @@ _.extend(PackageAPI.prototype, {
           unordered: options.unordered || false,
           weak: options.weak || false
         });
+        // If option imply is set then we directly imply that element.
+        // All validation checks if this imply is valid are done already
+        if (options.imply) {
+          self.implies[a].push({
+            package: parsed.package,
+            constraint: parsed.constraintString
+          });
+        }
       });
     }
   },


### PR DESCRIPTION
Hi, in case often have to write annoying lines of api.use and api.imply lines, I make the suggestion for a new option during api.use.

````
api.use('package', 'arch', options: { imply: true });
````

I also added necessarily checks, to make sure that the same race conditions are tested as if someone had used

````
api.use()
api.imply()
````

Looking forward to your feedback
Tom
 