### PR TITLE
Implement "ecmascript" core package using compiler plugins

### DIFF
--- a/packages/babel-compiler/.npm/package/.gitignore
+++ b/packages/babel-compiler/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/babel-compiler/.npm/package/README
+++ b/packages/babel-compiler/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,442 @@
+{
+  "dependencies": {
+    "meteor-babel": {
+      "version": "0.4.3",
+      "dependencies": {
+        "babel-core": {
+          "version": "5.7.1",
+          "dependencies": {
+            "babel-plugin-constant-folding": {
+              "version": "1.0.1"
+            },
+            "babel-plugin-dead-code-elimination": {
+              "version": "1.0.2"
+            },
+            "babel-plugin-eval": {
+              "version": "1.0.1"
+            },
+            "babel-plugin-inline-environment-variables": {
+              "version": "1.0.1"
+            },
+            "babel-plugin-jscript": {
+              "version": "1.0.1"
+            },
+            "babel-plugin-member-expression-literals": {
+              "version": "1.0.1"
+            },
+            "babel-plugin-property-literals": {
+              "version": "1.0.1"
+            },
+            "babel-plugin-proto-to-assign": {
+              "version": "1.0.3"
+            },
+            "babel-plugin-react-constant-elements": {
+              "version": "1.0.3"
+            },
+            "babel-plugin-react-display-name": {
+              "version": "1.0.3"
+            },
+            "babel-plugin-remove-console": {
+              "version": "1.0.1"
+            },
+            "babel-plugin-remove-debugger": {
+              "version": "1.0.1"
+            },
+            "babel-plugin-runtime": {
+              "version": "1.0.7"
+            },
+            "babel-plugin-undeclared-variables-check": {
+              "version": "1.0.2",
+              "dependencies": {
+                "leven": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "babel-plugin-undefined-to-void": {
+              "version": "1.1.6"
+            },
+            "babylon": {
+              "version": "5.7.1"
+            },
+            "bluebird": {
+              "version": "2.9.34"
+            },
+            "chalk": {
+              "version": "1.1.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "core-js": {
+              "version": "0.9.18"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1"
+                }
+              }
+            },
+            "detect-indent": {
+              "version": "3.0.1",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1"
+                },
+                "minimist": {
+                  "version": "1.1.1"
+                }
+              }
+            },
+            "estraverse": {
+              "version": "4.1.0"
+            },
+            "esutils": {
+              "version": "2.0.2"
+            },
+            "fs-readdir-recursive": {
+              "version": "0.1.2"
+            },
+            "globals": {
+              "version": "6.4.1"
+            },
+            "home-or-tmp": {
+              "version": "1.0.0",
+              "dependencies": {
+                "os-tmpdir": {
+                  "version": "1.0.1"
+                },
+                "user-home": {
+                  "version": "1.1.1"
+                }
+              }
+            },
+            "is-integer": {
+              "version": "1.0.4",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "is-nan": {
+                  "version": "1.1.0",
+                  "dependencies": {
+                    "define-properties": {
+                      "version": "1.1.0",
+                      "dependencies": {
+                        "foreach": {
+                          "version": "2.0.5"
+                        },
+                        "object-keys": {
+                          "version": "1.0.6"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "js-tokens": {
+              "version": "1.0.1"
+            },
+            "line-numbers": {
+              "version": "0.2.0",
+              "dependencies": {
+                "left-pad": {
+                  "version": "0.0.3"
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.10.0"
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "output-file-sync": {
+              "version": "1.1.1",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0"
+                }
+              }
+            },
+            "path-exists": {
+              "version": "1.0.0"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0"
+            },
+            "private": {
+              "version": "0.1.6"
+            },
+            "regenerator": {
+              "version": "0.8.34",
+              "dependencies": {
+                "commoner": {
+                  "version": "0.10.3",
+                  "dependencies": {
+                    "q": {
+                      "version": "1.1.2"
+                    },
+                    "commander": {
+                      "version": "2.5.1"
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.8"
+                    },
+                    "glob": {
+                      "version": "4.2.2",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
+                        "minimatch": {
+                          "version": "1.0.0",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.6.5"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8"
+                        }
+                      }
+                    },
+                    "install": {
+                      "version": "0.1.8"
+                    },
+                    "iconv-lite": {
+                      "version": "0.4.11"
+                    }
+                  }
+                },
+                "defs": {
+                  "version": "1.1.0",
+                  "dependencies": {
+                    "alter": {
+                      "version": "0.2.0",
+                      "dependencies": {
+                        "stable": {
+                          "version": "0.1.5"
+                        }
+                      }
+                    },
+                    "ast-traverse": {
+                      "version": "0.1.1"
+                    },
+                    "breakable": {
+                      "version": "1.0.0"
+                    },
+                    "esprima-fb": {
+                      "version": "8001.1001.0-dev-harmony-fb"
+                    },
+                    "simple-fmt": {
+                      "version": "0.1.0"
+                    },
+                    "simple-is": {
+                      "version": "0.2.0"
+                    },
+                    "stringmap": {
+                      "version": "0.2.2"
+                    },
+                    "stringset": {
+                      "version": "0.2.1"
+                    },
+                    "tryor": {
+                      "version": "0.1.2"
+                    },
+                    "yargs": {
+                      "version": "1.3.3"
+                    }
+                  }
+                },
+                "esprima-fb": {
+                  "version": "13001.1.0-dev-harmony-fb"
+                },
+                "recast": {
+                  "version": "0.10.18",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "14001.1.0-dev-harmony-fb"
+                    },
+                    "ast-types": {
+                      "version": "0.8.2"
+                    }
+                  }
+                },
+                "through": {
+                  "version": "2.3.8"
+                }
+              }
+            },
+            "regexpu": {
+              "version": "1.2.0",
+              "dependencies": {
+                "recast": {
+                  "version": "0.10.21",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "15001.1.0-dev-harmony-fb"
+                    },
+                    "ast-types": {
+                      "version": "0.8.3"
+                    }
+                  }
+                },
+                "regenerate": {
+                  "version": "1.2.1"
+                },
+                "regjsgen": {
+                  "version": "0.2.0"
+                },
+                "regjsparser": {
+                  "version": "0.1.4",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0"
+                    }
+                  }
+                }
+              }
+            },
+            "repeating": {
+              "version": "1.1.3",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "resolve": {
+              "version": "1.1.6"
+            },
+            "shebang-regex": {
+              "version": "1.0.0"
+            },
+            "slash": {
+              "version": "1.0.0"
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "source-map-support": {
+              "version": "0.2.10",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.32",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "strip-json-comments": {
+              "version": "1.0.2"
+            },
+            "to-fast-properties": {
+              "version": "1.0.1"
+            },
+            "trim-right": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "1.1.1"
+        },
+        "meteor-async-await": {
+          "version": "0.1.1"
+        }
+      }
+    }
+  }
+}

--- a/packages/babel-compiler/README.md
+++ b/packages/babel-compiler/README.md
@@ -1,0 +1,50 @@
+[Babel](http://babeljs.io/) is a parser and transpiler for ECMAScript 2015
+syntax and beyond, which enables some upcoming JavaScript syntax features
+to be used in today's browsers and runtimes.
+
+Meteor's Babel support consists of the following core packages:
+
+* `babel-compiler` - Exposes the [Babel API](https://babeljs.io/docs/usage/api/)
+  on the symbol `Babel`.  For example, `Babel.compile(source, options)`.
+
+* `babel-runtime` - Meteor versions of the external helpers used by
+  Babel-generated code.  Meteor's core packages must run on IE 8 without
+  polyfills, so these helpers cannot assume the existence of
+  `Object.defineProperty`, `Object.freeze`, and so on.
+
+### Babel API
+
+The `babel-compiler` package exports the `Babel` symbol, which exposes
+functionality provided by the
+[`meteor-babel`](https://www.npmjs.com/package/meteor-babel) NPM package,
+which is in turn implmented using the
+[`babel-core`](https://www.npmjs.com/package/babel-core) NPM package.
+Note that you can only use the `babel-compiler` package on the server.
+
+Example:
+
+```js
+var babelOptions = Babel.getDefaultOptions();
+
+// Modify the default options, if necessary:
+babelOptions.whitelist = [
+  "es6.blockScoping", // For `let`
+  "es6.arrowFunctions" // For `=>`
+];
+
+var result = Babel.compile(
+  "let square = (x) => x*x;",
+  babelOptions
+);
+
+// result.code will be something like
+// "var square = function (x) {\n  return x * x;\n};"
+```
+
+Use `Babel.compile(source)` to transpile code using a set of default
+options that work well for Meteor code.
+
+Resources:
+
+* [API docs](https://babeljs.io/docs/usage/api/)
+* [List of transformers](https://babeljs.io/docs/usage/transformers/)

--- a/packages/babel-compiler/babel.js
+++ b/packages/babel-compiler/babel.js
@@ -1,0 +1,61 @@
+var meteorBabel = Npm.require('meteor-babel');
+
+/**
+ * Returns a new object containing default options appropriate for
+ */
+function getDefaultOptions(extraFeatures) {
+  if (extraFeatures) {
+    check(extraFeatures, {
+      // Modify options to enable ES2015 module syntax.
+      modules: Match.Optional(Boolean),
+      // Modify options to enable async/await syntax powered by Fibers.
+      meteorAsyncAwait: Match.Optional(Boolean)
+    });
+  }
+
+  // See https://github.com/meteor/babel/blob/master/options.js for more
+  // information about what the default options are.
+  var options = meteorBabel.getDefaultOptions(extraFeatures);
+
+  // The sourceMap option should probably be removed from the default
+  // options returned by meteorBabel.getDefaultOptions.
+  delete options.sourceMap;
+
+  return options;
+}
+
+Babel = {
+  getDefaultOptions: getDefaultOptions,
+
+  compile: function (source, options) {
+    options = options || getDefaultOptions();
+    return meteorBabel.compile(source, options);
+  },
+
+  // Provided for backwards compatibility; prefer Babel.compile.
+  transformMeteor: function (source, extraOptions) {
+    var options = getDefaultOptions();
+
+    if (extraOptions) {
+      if (extraOptions.extraWhitelist) {
+        options.whitelist.push.apply(
+          options.whitelist,
+          extraOptions.extraWhitelist
+        );
+      }
+
+      for (var key in extraOptions) {
+        if (key !== "extraWhitelist" &&
+            hasOwnProperty.call(extraOptions, key)) {
+          options[key] = extraOptions[key];
+        }
+      }
+    }
+
+    return meteorBabel.compile(code, options);
+  },
+
+  setCacheDir: function (cacheDir) {
+    meteorBabel.setCacheDir(cacheDir);
+  }
+};

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -1,0 +1,17 @@
+Package.describe({
+  name: "babel-compiler",
+  summary: "Parser/transpiler for ECMAScript 6+ syntax",
+  // Tracks the npm version below.  Use wrap numbers to increment
+  // without incrementing the npm version.
+  version: '5.7.1'
+});
+
+Npm.depends({
+  'meteor-babel': '0.4.3'
+});
+
+Package.onUse(function (api) {
+  api.addFiles('babel.js', 'server');
+  api.use('check');
+  api.export('Babel', 'server');
+});

--- a/packages/babel-runtime/README.md
+++ b/packages/babel-runtime/README.md
@@ -1,0 +1,61 @@
+# babel-runtime
+
+Meteor maintains a version of the runtime helpers needed by Babel-transpiled code.
+In most cases, the code is copied from Babel's helper implementations, though we
+have also made some changes.
+
+Benefits of maintaining our own package include:
+
+* IE 8 support.  Babel's helpers target IE 9 and do not work in IE 8, but generally
+  IE 8 support can be achieved with only minor changes.
+
+* Backwards-compatibility.  When the Babel compiler changes, the helpers sometimes
+  change.  Our Babel package can keep old helpers for back-compat.  (If we change
+  over to publishing original ES6 code in packages instead of transpiled code, this
+  becomes less important.)
+
+* Client-side code size.  We've made the helpers file as small as possible.
+
+## Helpers
+
+Helpers needed for each transform **as of [Babel v5.6.15](https://github.com/babel/babel/tree/a1a46882fddc596a47e0e29017c5440ab6d7d9c0/src/babel/transformation/transformers)**:
+
+* es3.propertyLiterals: None
+* es3.memberExpressionLiterals: None
+* es6.arrowFunctions: None
+* es6.templateLiterals
+  * `taggedTemplateLiteralLoose`
+* es6.classes
+  * `inherits`
+  * `classCallCheck`
+  * `createClass` (only for getter/setters)
+  * Excluded because only for decorator support(2): `createDecoratedClass`, `defineDecoratedPropertyDescriptor`
+* es6.constants: None
+* es6.blockScoping: None
+  * Excluded because only for spec mode(1): `temporalUndefined`, `temporalAssertDefined`
+* es6.properties.shorthand: None
+* es6.properties.computed: None
+  * Excluded because only for non-loose mode(1): `defineProperty`
+* es6.parameters: None
+* es6.spread
+  * `bind` (for `new A(...b)`)
+* es6.forOf: None
+* es7.objectRestSpread
+  * `_extends`
+  * Everything in es6.destructuring
+* es6.destructuring
+  * `objectWithoutProperties`
+  * `objectDestructuringEmpty`
+* es7.trailingFunctionCommas: None
+* flow: None
+
+Footnotes:
+
+1. A transform can be run in "loose," normal, or "spec" mode, with "loose" providing
+   the fastest, most lightweight, and usually most browser-compatible transpilation,
+   while "spec" mode tries extra hard to be spec-compliant at the expense of those
+   things.  We've found that "loose" mode is the best mode for production code for
+   every transform we've looked at.
+
+2. Decorators are still a Stage 1 proposal and are only implemented in Babel as
+   an experiment.

--- a/packages/babel-runtime/babel-runtime.js
+++ b/packages/babel-runtime/babel-runtime.js
@@ -1,0 +1,210 @@
+// The name `babelHelpers` is hard-coded in Babel.  Otherwise we would make it
+// something capitalized and more descriptive, like `BabelRuntime`.
+babelHelpers = {
+  // es6.templateLiterals
+  // Constructs the object passed to the tag function in a tagged
+  // template literal.
+  taggedTemplateLiteralLoose: function (strings, raw) {
+    // Babel's own version of this calls Object.freeze on `strings` and
+    // `strings.raw`, but it doesn't seem worth the compatibility and
+    // performance concerns.  If you're writing code against this helper,
+    // don't add properties to these objects.
+    strings.raw = raw;
+    return strings;
+  },
+
+  // es6.classes
+  // Checks that a class constructor is being called with `new`, and throws
+  // an error if it is not.
+  classCallCheck: function (instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  },
+
+  // es6.classes
+  inherits: function (subClass, superClass) {
+    if (typeof superClass !== "function" && superClass !== null) {
+      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+    }
+
+    if (superClass) {
+      if (Object.create) {
+        // All but IE 8
+        subClass.prototype = Object.create(superClass.prototype, {
+          constructor: {
+            value: subClass,
+            enumerable: false,
+            writable: true,
+            configurable: true
+          }
+        });
+      } else {
+        // IE 8 path.  Slightly worse for modern browsers, because `constructor`
+        // is enumerable and shows up in the inspector unnecessarily.
+        // It's not an "own" property of any instance though.
+        //
+        // For correctness when writing code,
+        // don't enumerate all the own-and-inherited properties of an instance
+        // of a class and expect not to find `constructor` (but who does that?).
+        var F = function () {
+          this.constructor = subClass;
+        };
+        F.prototype = superClass.prototype;
+        subClass.prototype = new F();
+      }
+
+      // For modern browsers, this would be `subClass.__proto__ = superClass`,
+      // but IE <=10 don't support `__proto__`, and in this case the difference
+      // would be detectable; code that works in modern browsers could easily
+      // fail on IE 8 if we ever used the `__proto__` trick.
+      //
+      // There's no perfect way to make static methods inherited if they are
+      // assigned after declaration of the classes.  The best we can do is
+      // to copy them.  In other words, when you write `class Foo
+      // extends Bar`, we copy the static methods from Bar onto Foo, but future
+      // ones are not copied.
+      //
+      // For correctness when writing code, don't add static methods to a class
+      // after you subclass it.
+      for (var k in superClass) {
+        if (_hasOwnProperty.call(superClass, k)) {
+          subClass[k] = superClass[k];
+        }
+      }
+    }
+  },
+
+  createClass: (function () {
+    var hasDefineProperty = false;
+    try {
+      // IE 8 has a broken Object.defineProperty, so feature-test by
+      // trying to call it.
+      Object.defineProperty({}, 'x', {});
+      hasDefineProperty = true;
+    } catch (e) {}
+
+    function defineProperties(target, props) {
+      for (var i = 0; i < props.length; i++) {
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if ("value" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+      }
+    }
+
+    return function (Constructor, protoProps, staticProps) {
+      if (! hasDefineProperty) {
+        // e.g. `class Foo { get bar() {} }`.  If you try to use getters and
+        // setters in IE 8, you will get a big nasty error, with or without
+        // Babel.  I don't know of any other syntax features besides getters
+        // and setters that will trigger this error.
+        throw new Error(
+          "Your browser does not support this type of class property.  " +
+            "For example, Internet Explorer 8 does not support getters and " +
+            "setters.");
+      }
+
+      if (protoProps) defineProperties(Constructor.prototype, protoProps);
+      if (staticProps) defineProperties(Constructor, staticProps);
+      return Constructor;
+    };
+  })(),
+
+  // es7.objectRestSpread and react (JSX)
+  _extends: Object.assign || (function (target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        if (_hasOwnProperty.call(source, key)) {
+          target[key] = source[key];
+        }
+      }
+    }
+    return target;
+  }),
+
+  // es6.destructuring
+  objectWithoutProperties: function (obj, keys) {
+    var target = {};
+    outer: for (var i in obj) {
+      if (! _hasOwnProperty.call(obj, i)) continue;
+      for (var j = 0; j < keys.length; j++) {
+        if (keys[j] === i) continue outer;
+      }
+      target[i] = obj[i];
+    }
+    return target;
+  },
+
+  // es6.destructuring
+  objectDestructuringEmpty: function (obj) {
+    if (obj == null) throw new TypeError("Cannot destructure undefined");
+  },
+
+  // es6.spread
+  bind: Function.prototype.bind || (function () {
+    var isCallable = function (value) { return typeof value === 'function'; };
+    var $Object = Object;
+    var to_string = Object.prototype.toString;
+    var array_slice = Array.prototype.slice;
+    var array_concat = Array.prototype.concat;
+    var array_push = Array.prototype.push;
+    var max = Math.max;
+    var Empty = function Empty() {};
+
+    // Copied from es5-shim.js (3ac7942).  See original for more comments.
+    return function bind(that) {
+      var target = this;
+      if (!isCallable(target)) {
+        throw new TypeError('Function.prototype.bind called on incompatible ' + target);
+      }
+
+      var args = array_slice.call(arguments, 1);
+
+      var bound;
+      var binder = function () {
+
+        if (this instanceof bound) {
+          var result = target.apply(
+            this,
+            array_concat.call(args, array_slice.call(arguments))
+          );
+          if ($Object(result) === result) {
+            return result;
+          }
+          return this;
+        } else {
+          return target.apply(
+            that,
+            array_concat.call(args, array_slice.call(arguments))
+          );
+        }
+      };
+
+      var boundLength = max(0, target.length - args.length);
+
+      var boundArgs = [];
+      for (var i = 0; i < boundLength; i++) {
+        array_push.call(boundArgs, '$' + i);
+      }
+
+      // Create a Function from source code so that it has the right `.length`.
+      // Probably not important for Babel.  This code violates CSPs that ban
+      // `eval`, but the browsers that need this polyfill don't have CSP!
+      bound = Function('binder', 'return function (' + boundArgs.join(',') + '){ return binder.apply(this, arguments); }')(binder);
+
+      if (target.prototype) {
+        Empty.prototype = target.prototype;
+        bound.prototype = new Empty();
+        Empty.prototype = null;
+      }
+
+      return bound;
+    };
+
+  })()
+};
+
+var _hasOwnProperty = Object.prototype.hasOwnProperty;

--- a/packages/babel-runtime/package.js
+++ b/packages/babel-runtime/package.js
@@ -1,0 +1,12 @@
+Package.describe({
+  name: "babel-runtime",
+  summary: "Runtime support for output of Babel transpiler",
+  version: '0.1.1',
+  documentation: 'README.md'
+});
+
+Package.onUse(function (api) {
+  // Code runs on client or server, wherever it is asked for!
+  api.export('babelHelpers'); // See note in babel-runtime.js
+  api.addFiles('babel-runtime.js');
+});

--- a/packages/ecmascript/README.md
+++ b/packages/ecmascript/README.md
@@ -1,0 +1,20 @@
+The `ecmascript` package registers a compiler plugin that transpiles
+ECMAScript 2015+ to ECMAScript 5 (standard JS) in all `.js` files. By
+default, this package is pre-installed for all new apps and packages.
+
+To add this package to an existing app, run the following command from
+your app directory:
+
+```bash
+meteor add ecmascript
+```
+
+To add the `ecmascript` package to an existing package, include the
+statement `api.use('ecmascript');` in the `Package.onUse` callback in your
+`package.js` file:
+
+```js
+Package.onUse(function (api) {
+  api.use('ecmascript');
+});
+```

--- a/packages/ecmascript/ecmascript-tests.js
+++ b/packages/ecmascript/ecmascript-tests.js
@@ -1,0 +1,5 @@
+// Write your tests here!
+// Here is an example.
+Tinytest.add('example', function (test) {
+  test.equal(true, true);
+});

--- a/packages/ecmascript/ecmascript-tests.js
+++ b/packages/ecmascript/ecmascript-tests.js
@@ -1,5 +1,41 @@
-// Write your tests here!
-// Here is an example.
-Tinytest.add('example', function (test) {
-  test.equal(true, true);
+Tinytest.addAsync("ecmascript", (test, done) => {
+  // Verify that the runtime was installed.
+  test.equal(typeof babelHelpers, "object");
+
+  class Base {
+    constructor(...args) {
+      this.sum = 0;
+      args.forEach(arg => this.sum += arg);
+    }
+
+    static inherited() {
+      return "inherited";
+    }
+  }
+
+  class Derived extends Base {
+    constructor() {
+      super(1, 2, 3);
+    }
+  }
+
+  // Check that static methods are inherited.
+  test.equal(Derived.inherited(), "inherited");
+
+  const d = new Derived();
+  test.equal(d.sum, 6);
+
+  const expectedError = new Error("expected");
+
+  Promise.resolve("working").then(result => {
+    test.equal(result, "working");
+    throw expectedError;
+  }).catch(error => {
+    test.equal(error, expectedError);
+    if (Meteor.isServer) {
+      var Fiber = Npm.require("fibers");
+      // Make sure the Promise polyfill runs callbacks in a Fiber.
+      test.instanceOf(Fiber.current, Fiber);
+    }
+  }).then(done, error => test.exception(error));
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -5,6 +5,10 @@ Package.describe({
   documentation: 'README.md'
 });
 
+Npm.depends({
+  "meteor-promise": "0.2.4"
+});
+
 Package.registerBuildPlugin({
   name: 'compile-ecmascript',
   use: ['babel-compiler@5.6.17'],
@@ -14,4 +18,14 @@ Package.registerBuildPlugin({
 Package.onUse(function (api) {
   api.use('isobuild:compiler-plugin@1.0.0');
   api.imply('babel-runtime@0.1.0');
+
+  api.addFiles("promise_server.js", "server");
+  api.addFiles(
+    // This may not be the most robust way of referring to an NPM asset,
+    // but at least api.addFiles will fail if the file does not exist.
+    '.npm/package/node_modules/meteor-promise/promise_client.js',
+    'client',
+    { bare: true }
+  );
+  api.export("Promise");
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,0 +1,17 @@
+Package.describe({
+  name: 'ecmascript',
+  version: '0.1.0',
+  summary: 'Compiler plugin that supports ES2015+ in all .js files',
+  documentation: 'README.md'
+});
+
+Package.registerBuildPlugin({
+  name: 'compile-ecmascript',
+  use: ['babel-compiler@5.6.17'],
+  sources: ['plugin.js']
+});
+
+Package.onUse(function (api) {
+  api.use('isobuild:compiler-plugin@1.0.0');
+  api.imply('babel-runtime@0.1.0');
+});

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -29,3 +29,8 @@ Package.onUse(function (api) {
   );
   api.export("Promise");
 });
+
+Package.onTest(function (api) {
+  api.use(["ecmascript", "tinytest"]);
+  api.addFiles("ecmascript-tests.js");
+});

--- a/packages/ecmascript/plugin.js
+++ b/packages/ecmascript/plugin.js
@@ -1,0 +1,46 @@
+function BabelCompiler() {}
+
+var BCp = BabelCompiler.prototype;
+
+BCp.processFilesForTarget = function (inputFiles) {
+  inputFiles.forEach(function (inputFile) {
+    var source = inputFile.getContentsAsString();
+    var inputFilePath = inputFile.getPathInPackage();
+    var outputFilePath = inputFile.getPathInPackage();
+    var fileOptions = inputFile.getFileOptions();
+    var toBeAdded = {
+      sourcePath: inputFilePath,
+      path: outputFilePath,
+      data: source,
+      hash: inputFile.getSourceHash(),
+      sourceMap: null,
+      bare: !! fileOptions.bare
+    };
+
+    if (fileOptions.transpile !== false) {
+      var babelOptions = Babel.getDefaultOptions();
+      babelOptions.sourceMap = true;
+      babelOptions.filename = inputFilePath;
+      babelOptions.sourceFileName = "/" + inputFilePath;
+      babelOptions.sourceMapName = "/" + outputFilePath + ".map";
+
+      var result = Babel.compile(source, babelOptions);
+
+      toBeAdded.data = result.code;
+      toBeAdded.hash = result.hash;
+      toBeAdded.sourceMap = result.map;
+    }
+
+    inputFile.addJavaScript(toBeAdded);
+  });
+};
+
+BCp.setDiskCacheDirectory = function (cacheDir) {
+  Babel.setCacheDir(cacheDir);
+};
+
+Plugin.registerCompiler({
+  extensions: ['js'],
+}, function () {
+  return new BabelCompiler();
+});

--- a/packages/ecmascript/promise_server.js
+++ b/packages/ecmascript/promise_server.js
@@ -1,0 +1,1 @@
+Promise = Npm.require("meteor-promise");

--- a/tools/build-plugin.js
+++ b/tools/build-plugin.js
@@ -222,7 +222,10 @@ export class SourceProcessorSet {
         // If there is no special sourceProcessor for handling a .js file,
         // we can still classify it as extension/js, only without any
         // source processors. #HardcodeJs
-        return new SourceClassification('extension', {extension});
+        return new SourceClassification('extension', {
+          extension,
+          usesDefaultSourceProcessor: true
+        });
       }
 
       if (this._legacyHandlers.hasOwnProperty(extension)) {
@@ -287,8 +290,14 @@ export class SourceProcessorSet {
 }
 
 class SourceClassification {
-  constructor(type, {legacyHandler, extension, sourceProcessors,
-                     legacyIsTemplate, arch} = {}) {
+  constructor(type, {
+    legacyHandler,
+    extension,
+    sourceProcessors,
+    usesDefaultSourceProcessor,
+    legacyIsTemplate,
+    arch,
+  } = {}) {
     const knownTypes = ['extension', 'filename', 'legacy-handler', 'wrong-arch',
                         'unmatched'];
     if (knownTypes.indexOf(type) === -1) {
@@ -346,6 +355,20 @@ class SourceClassification {
         throw Error('extension SourceClassification needs extension!');
       }
       this.extension = extension;
+    }
+
+    if (usesDefaultSourceProcessor) {
+      if (this.extension !== 'js' &&
+          this.extension !== 'css') {
+        // We only currently hard-code support for processing .js files
+        // when no source processor is registered (#HardcodeJs). Default
+        // support could conceivably be extended to .css files too, but
+        // anything else is almost certainly a mistake.
+        throw Error('non-JS/CSS file relying on default source processor?');
+      }
+      this.usesDefaultSourceProcessor = true;
+    } else {
+      this.usesDefaultSourceProcessor = false;
     }
   }
 

--- a/tools/compiler.js
+++ b/tools/compiler.js
@@ -533,6 +533,8 @@ var compileUnibuild = function (options) {
       resources.push({
         type: "source",
         extension: classification.extension || null,
+        usesDefaultSourceProcessor:
+          !! classification.usesDefaultSourceProcessor,
         data: contents,
         path: relPath,
         hash: hash,

--- a/tools/isopack.js
+++ b/tools/isopack.js
@@ -1149,7 +1149,8 @@ _.extend(Isopack.prototype, {
           // If we're going to write a legacy prelink file later, track the
           // original form of the resource object (with the source in a Buffer,
           // etc) instead of the later version.  #HardcodeJs
-          if (writeLegacyBuilds && resource.type === "source" &&
+          if (writeLegacyBuilds &&
+              resource.type === "source" &&
               resource.extension == "js") {
             jsResourcesForLegacyPrelink.push({
               data: resource.data,

--- a/tools/isopack.js
+++ b/tools/isopack.js
@@ -869,6 +869,8 @@ _.extend(Isopack.prototype, {
           resources.push({
             type: "source",
             extension: resource.extension,
+            usesDefaultSourceProcessor:
+              !! resource.usesDefaultSourceProcessor,
             data: data,
             path: resource.path,
             hash: resource.hash,
@@ -943,6 +945,49 @@ _.extend(Isopack.prototype, {
     });
   },
 
+  _canWriteLegacyBuilds(options) {
+    if (! options.includePreCompilerPluginIsopackVersions) {
+      return false;
+    }
+
+    function isResourceUnsafeForLegacyBuilds(resource) {
+      if (resource.type === "source") {
+        // This package cannot be represented as an isopack-1 Isopack if
+        // it uses a file implemented by registerCompiler other than the
+        // very basic JS and CSS types.
+        if (resource.extension === "js") {
+          if (resource.usesDefaultSourceProcessor) {
+            // If this JS resource uses hard-coded support for plain old
+            // ES5, then it is safe to write as part of a legacy Isopack.
+            return false;
+          }
+
+          if (resource.fileOptions &&
+              resource.fileOptions.transpile === false) {
+            // If this resource file is contained by a package that
+            // registers a custom source processor, its processing may
+            // still be disabled by passing the {transpile:false} option
+            // to api.addFiles.
+            return false;
+          }
+
+          // A custom source processor is registered, and there is no
+          // special exemption for this file, so it cannot be safely
+          // written as part of a legacy Isopack.
+          return true;
+        }
+
+        return resource.extension !== "css";
+      }
+
+      return false;
+    }
+
+    return ! this.unibuilds.some(
+      unibuild => unibuild.resources.some(isResourceUnsafeForLegacyBuilds)
+    );
+  },
+
   // options:
   //
   // - includeIsopackBuildInfo: If set, write an isopack-buildinfo.json file.
@@ -983,13 +1028,7 @@ _.extend(Isopack.prototype, {
         mainJson.cordovaDependencies = self.cordovaDependencies;
       }
 
-      var writeLegacyBuilds = false;
-      if (options.includePreCompilerPluginIsopackVersions) {
-        // We will reset this to false if at any point later we determine that
-        // this package cannot be saved in the legacy format (because it uses a
-        // compiler plugin other than JS or CSS).
-        writeLegacyBuilds = true;
-      }
+      const writeLegacyBuilds = self._canWriteLegacyBuilds(options);
 
       var isopackBuildInfoJson = null;
       if (options.includeIsopackBuildInfo) {
@@ -1058,17 +1097,6 @@ _.extend(Isopack.prototype, {
         });
 
         var jsResourcesForLegacyPrelink = [];
-        if (writeLegacyBuilds) {
-          if (_.any(unibuild.resources, function (resource) {
-            return resource.type === "source" && resource.extension !== "js"
-              && resource.extension !== "css";
-          })) {
-            // This package cannot be represented as an isopack-1 Isopack
-            // because it uses a file implemented by registerCompiler other than
-            // the very basic JS and CSS types.
-            writeLegacyBuilds = false;
-          }
-        }
 
         // Save unibuild dependencies. Keyed by the json path rather than thinking
         // too hard about how to encode pair (name, arch).
@@ -1174,6 +1202,8 @@ _.extend(Isopack.prototype, {
               { data: resource.data }),
             length: resource.data.length,
             offset: 0,
+            usesDefaultSourceProcessor:
+              resource.usesDefaultSourceProcessor || undefined,
             servePath: resource.servePath || undefined,
             path: resource.path || undefined,
             hash: resource.hash || undefined,

--- a/tools/skel-pack/package.js
+++ b/tools/skel-pack/package.js
@@ -12,6 +12,7 @@ Package.describe({
 
 Package.onUse(function(api) {
 ~cc~  api.versionsFrom('~release~');
+  api.use('ecmascript');
   api.addFiles('~fs-name~.js');
 });
 

--- a/tools/skel/.meteor/packages
+++ b/tools/skel/.meteor/packages
@@ -8,3 +8,4 @@ meteor-platform
 standard-minifiers # JS/CSS minifiers run for production mode
 autopublish # publishes all data to the clients for prototyping
 insecure # allows all DB writes from clients for prototyping
+ecmascript # allows ECMAScript2015+ syntax by default


### PR DESCRIPTION
This is a work in progress in the sense that I know there will be important feedback, but it's feature-complete in the sense that the design seems sound, and everything is working as far as I can tell.

I hope my comments and commit messages explain my approach in more detail, but the short explanation is that we can allow compiler plugins for the `.js` extension, as long as we simply fall back to hard-coded JS support when no plugin is registered for the `.js` extension. The `ecmascript` package obviously cannot depend on itself, and therefore it must be written in plain ES5, but all future apps and packages can use the `ecmascript` package by default, and all past packages/apps can opt into using it by running `meteor add ecmascript`.

To do:
- [x] allow packages that `api.use('ecmascript')` to specify that certain files should not be transpiled
- [x] update [babel-compiler/README.md](https://github.com/meteor/meteor/blob/ecmascript-compiler-plugin/packages/babel-compiler/README.md)
- [x] update metadata in [ecmascript/package.js](https://github.com/meteor/meteor/blob/ecmascript-compiler-plugin/packages/ecmascript/package.js)
- [x] verify that source maps work in all contexts
- [x] provide a polyfill for `Promise`
- [ ] ~~provide a polyfill for `Map`~~
- [ ] ~~provide a polyfill for `Set`~~
- [x] Add some tests of the `ecmascript` package.

I'm going to hold off on including `Map` and `Set` polyfills until we've had a chance to vet the https://github.com/zloirock/core-js implementations in [tool code](https://github.com/meteor/meteor/tree/devel/tools).

cc @dgreensp @glasser @Slava @stubailo