### PR TITLE
Fix typo in todos example

### DIFF
--- a/examples/todos/client/head.html
+++ b/examples/todos/client/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="utf-8">
   <title>Todos - All your todos synced wherever you happen to be</title>
-  <meta name="description" content="The simple todo list that keeps your todos in sync everywhere free forever. Todo is open source and powered by Meteor.">
+  <meta name="description" content="The simple todo list that keeps your todos in sync everywhere free forever. Todos is open source and powered by Meteor.">
   <meta name="viewport" content="user-scalable=no, initial-scale=1, minimal-ui, maximum-scale=1, minimum-scale=1" />
   <link rel="shortcut icon" type="image/png" href="favicon.png?v1" sizes="16x16 32x32 64x64">
   <link rel="apple-touch-icon" sizes="120x120" href="apple-touch-icon-precomposed.png">


### PR DESCRIPTION
Todos is spelled wrong in one of the meta tags. 

It doesn't make a meaningful difference but I thought I'd make the change just in case anyone hosts this.