### PR TITLE
Remove docs for @index

### DIFF
--- a/packages/spacebars/README.md
+++ b/packages/spacebars/README.md
@@ -365,9 +365,6 @@ for example), but it may also be a plain JavaScript array, `null`, or
 An "else" section may be provided, which is used (with no new data
 context) if there are zero items in the sequence at any time.
 
-You can use a special variable `@index` in the body of `#each` to get the
-0-based index of the currently rendered value in the sequence.
-
 ### Reactivity Model for Each
 
 When the argument to `#each` changes, the DOM is always updated to reflect the


### PR DESCRIPTION
The docs link to this file as the spacebars readme. But, using `@index` throws:

       client/templates/foo/foo.template.html:15: Expected IDENTIFIER

Should be removed from the docs until it is implemented. Seems to be tracked in #2587 if I understood correctly.