### PR TITLE
Fix EJSON to work with circular references

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -329,7 +329,7 @@ EJSON._adjustTypesFromJSONValue = function (obj) {
       return obj;
 
     _.each(obj, function (value, key) {
-       if (typeof value === 'object') {
+      if (typeof value === 'object') {
         var changed = fromJSONValueHelper(value, _base);
         if (value !== changed) {
           obj[key] = changed;

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -90,6 +90,11 @@ Tinytest.add("ejson - clone", function (test) {
   cloneTest([1, 2, 3]);
   cloneTest([1, "fasdf", {foo: 42}]);
   cloneTest({x: 42, y: "asdf"});
+  
+  // Test circular references
+  var circ = {};
+  circ.circ = circ;
+  cloneTest(circ);
 
   var testCloneArgs = function (/*arguments*/) {
     var clonedArgs = EJSON.clone(arguments);

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -41,6 +41,15 @@ Tinytest.add("ejson - some equality tests", function (test) {
   test.isFalse(EJSON.equals({a: 1, b: 2, c: 3}, {a: 1, c: 3, b: 4}));
   test.isFalse(EJSON.equals({a: {}}, {a: {b:2}}));
   test.isFalse(EJSON.equals({a: {b:2}}, {a: {}}));
+  
+  // Test circular references
+  var circ = {};
+  circ.circ = circ;
+  var circ2 = {};
+  circ2.circ = circ2;
+  test.isTrue(EJSON.equals(circ, circ));
+  test.isTrue(EJSON.equals(circ, circ2));
+  test.isFalse(EJSON.equals(circ, {}));
 });
 
 Tinytest.add("ejson - equality and falsiness", function (test) {


### PR DESCRIPTION
Fixes #4587 & #1446.

Modifications:
* EJSON.clone() does not recurse infinitely if met with a circular reference. Instead, circular references are cloned correctly.
* EJSON.equals() - same as above, circular references are compared correctly.
* EJSON._adjustTypesToJSONValue() & EJSON._adjustTypesFromJSONValue() - circular references are replaced with a string '#ref.base.\<key\>...\<key\>'. This can be translated back from a JSON string, so circular references are restored. A (possibly unwanted) side-effect is that not only circular references are replaced, but all objects that are found more than once. If this is a problem, I'll fix it later.
