### PR TITLE
Upgrades generate_dev_bundle scripts on both Unix and Windows to use npm 3

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -20,6 +20,7 @@ var packageJson = {
   // Version is not important but is needed to prevent warnings.
   version: "0.0.0",
   dependencies: {
+    npm: "1.4.28",
     fibers: fibersVersion,
     "meteor-babel": "0.4.4",
     "meteor-promise": "0.4.0",

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -20,10 +20,7 @@ $BUNDLE_VERSION = $BUNDLE_VERSION.Trim()
 $DIR = $script_path + "\gdbXXX"
 echo $DIR
 
-# removing folders isn't easy on Windows, try both commands
-rm -Recurse -Force "${DIR}"
-cmd /C "rmdir /S /Q ${DIR}"
-
+cmd /c rmdir "$DIR" /s /q
 mkdir "$DIR"
 cd "$DIR"
 
@@ -40,7 +37,7 @@ npm install
 npm shrinkwrap
 
 mkdir -Force "${DIR}\server-lib\node_modules"
-cp -R "${DIR}\b\t\node_modules\*" "${DIR}\server-lib\node_modules\"
+cmd /c robocopy "${DIR}\b\t\node_modules" "${DIR}\server-lib\node_modules" /e /nfl /ndl
 
 mkdir -Force "${DIR}\etc"
 Move-Item package.json "${DIR}\etc\"
@@ -54,12 +51,9 @@ npm dedupe
 # install the latest flatten-packages
 npm install -g flatten-packages
 flatten-packages .
-cp -R "${DIR}\b\p\node_modules\" "${DIR}\lib\node_modules\"
+cmd /c robocopy "${DIR}\b\p\node_modules" "${DIR}\lib\node_modules" /e /nfl /ndl
 cd "$DIR"
-
-# deleting folders is hard so we try twice
-rm -Recurse -Force "${DIR}\b"
-cmd /C "rmdir /s /q $DIR\b"
+cmd /c rmdir "${DIR}\b" /s /q
 
 cd "$DIR"
 mkdir "$DIR\mongodb"
@@ -122,14 +116,11 @@ echo "${BUNDLE_VERSION}" | Out-File .bundle_version.txt -Encoding ascii
 cd "$DIR\.."
 
 # rename and move the folder with the devbundle
-# XXX this can generate a path that is too long
-Move-Item "$DIR" "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}"
+cmd /c robocopy "$DIR" "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}" /e /move /nfl /ndl
 
 cmd /c 7z.exe a -ttar dev_bundle.tar "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}"
 cmd /c 7z.exe a -tgzip "${CHECKOUT_DIR}\dev_bundle_${PLATFORM}_${BUNDLE_VERSION}.tar.gz" dev_bundle.tar
 del dev_bundle.tar
-rm -Recurse -Force "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}"
-cmd /C "rmdir /s /q dev_bundle_${PLATFORM}_${BUNDLE_VERSION}"
+cmd /c rmdir "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}" /s /q
 
 echo "Done building Dev Bundle!"
-

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -101,9 +101,6 @@ flatten-packages .
 cd node_modules\npm
 npm install node-gyp
 
-# this path is too long
-rm -Recurse -Force "node_modules\node-gyp\node_modules\request\node_modules\combined-stream\node_modules\delayed-stream\test"
-
 cd ..\..
 
 cp node_modules\npm\bin\npm.cmd .

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -17,7 +17,8 @@ $BUNDLE_VERSION = Select-String -Path ($CHECKOUT_DIR + "\meteor") -Pattern 'BUND
 $BUNDLE_VERSION = $BUNDLE_VERSION.Trim()
 
 # generate-dev-bundle-xxxxxxxx shortly
-$DIR = $script_path + "\gdbXXX"
+# convert relative path to absolute path because not all commands know how to deal with this themselves
+$DIR = $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("${script_path}\..\gdbXXX")
 echo $DIR
 
 cmd /c rmdir "$DIR" /s /q

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -5,7 +5,7 @@ $MONGO_VERSION = "2.6.7"
 $NODE_VERSION = "0.10.40"
 
 # take it form the environment if exists
-if (Test-Path variable:global:PLATFORM) {
+if (Test-Path env:PLATFORM) {
   $PLATFORM = (Get-Item env:PLATFORM).Value
 }
 

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -149,6 +149,9 @@ delete sqlite3/deps
 delete wordwrap/test
 delete moment/min
 
+# Remove esprima tests to reduce the size of the dev bundle
+find . -path '*/esprima-fb/test' | xargs rm -rf
+
 cd "$DIR/lib/node_modules/fibers/bin"
 shrink_fibers
 

--- a/tools/files.js
+++ b/tools/files.js
@@ -23,7 +23,6 @@ var buildmessage = require('./buildmessage.js');
 var watch = require('./watch.js');
 var fiberHelpers = require('./fiber-helpers.js');
 var colonConverter = require("./colon-converter.js");
-var Console = require("./console.js").Console;
 
 var miniFiles = require("./server/mini-files.js");
 
@@ -643,7 +642,7 @@ files.freeTempDir = function (tempDir) {
       // Don't crash and print a stack trace because we failed to delete a temp
       // directory. This happens sometimes on Windows and seems to be
       // unavoidable.
-      Console.debug(err);
+      console.log(err);
     }
 
     tempDirs = _.without(tempDirs, tempDir);
@@ -659,7 +658,7 @@ if (! process.env.METEOR_SAVE_TMPDIRS) {
         // Don't crash and print a stack trace because we failed to delete a temp
         // directory. This happens sometimes on Windows and seems to be
         // unavoidable.
-        Console.debug(err);
+        console.log(err);
       }
     });
 


### PR DESCRIPTION
Only uses npm 3 for generating the bundles, we'll keep using npm 1.x for everything else for now.