### PR TITLE
[perf] Remove oplog notification cloning

### DIFF
--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -96,8 +96,7 @@ _.extend(OplogHandle.prototype, {
 
     var originalCallback = callback;
     callback = Meteor.bindEnvironment(function (notification) {
-      // XXX can we avoid this clone by making oplog.js careful?
-      originalCallback(EJSON.clone(notification));
+      originalCallback(notification);
     }, function (err) {
       Meteor._debug("Error in oplog callback", err.stack);
     });

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -96,6 +96,8 @@ _.extend(OplogHandle.prototype, {
 
     var originalCallback = callback;
     callback = Meteor.bindEnvironment(function (notification) {
+      // Prvent accidently modifying the notification
+      Object.freeze(notification);
       originalCallback(notification);
     }, function (err) {
       Meteor._debug("Error in oplog callback", err.stack);


### PR DESCRIPTION
We do `EJSON.clone` for every oplog entry we receive. Depending the oplog usage it'll use upto 10% - 40% CPU usage for that.
See below:

<img width="736" alt="screen shot 2015-07-26 at 12 18 24 am" src="https://cloud.githubusercontent.com/assets/50838/8890813/ef8fece4-332b-11e5-9dfb-72146368806b.png">
See it live: https://ui.kadira.io/cpf/TJNrApwTkPKMc49uq?metric=costlyPaths&pathId=0

I think this `EJSON.clone` add ~1.5 years back when start writing oplog implementation. It also marked for deleting later on.
I checked the codebase for OplogObserverDriver and it's safe and we don't modify the notification. I think we don't plan to add anymore features/refactors to the OplogObserverDriver soon.
So it's safe to remove this EJSON.clone.

That'll simply improve the oplog performance a lot.

### Test Case

* Here's the repo you can use for the test: https://github.com/arunoda/oplog-perf-test
