### PR TITLE
Patch to allow users to override root cert list Fixes #4757

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -33,6 +33,7 @@ var Connection = function (url, options) {
     },
     heartbeatInterval: 17500,
     heartbeatTimeout: 15000,
+    fayeOptions: {},
     // These options are only for testing.
     reloadWithOutstanding: false,
     supportedDDPVersions: DDPCommon.SUPPORTED_DDP_VERSIONS,
@@ -59,7 +60,8 @@ var Connection = function (url, options) {
       // should have a real API for handling client-stream-level
       // errors.
       _dontPrintErrors: options._dontPrintErrors,
-      connectTimeoutMs: options.connectTimeoutMs
+      connectTimeoutMs: options.connectTimeoutMs,
+      fayeOptions: options.fayeOptions
     });
   }
 

--- a/packages/ddp-client/stream_client_nodejs.js
+++ b/packages/ddp-client/stream_client_nodejs.js
@@ -21,6 +21,7 @@ LivedataTest.ClientStream = function (endpoint, options) {
   self.endpoint = endpoint;
 
   self.headers = self.options.headers || {};
+  self.fayeOptions = self.options.fayeOptions || {};
 
   self._initCommon(self.options);
 
@@ -137,6 +138,7 @@ _.extend(LivedataTest.ClientStream.prototype, {
       headers: self.headers,
       extensions: [deflate]
     };
+    fayeOptions = _.extend(fayeOptions, self.fayeOptions);
     var proxyUrl = self._getProxyUrl(targetUrl);
     if (proxyUrl) {
       fayeOptions.proxy = { origin: proxyUrl };

--- a/tools/http-helpers.js
+++ b/tools/http-helpers.js
@@ -169,6 +169,9 @@ _.extend(exports, {
 
     // This should never, ever be false, or else why are you using SSL?
     options.forceSSL = true;
+    if (process.env.METEOR_ADDITIONAL_CERT) {
+      options.ca = require('fs').readFileSync(process.env.METEOR_ADDITIONAL_CERT);
+    }
 
     // followRedirect is very dangerous because request does not
     // appear to segregate cookies by origin, so any cookies (and

--- a/tools/service-connection.js
+++ b/tools/service-connection.js
@@ -50,6 +50,11 @@ var ServiceConnection = function (endpointUrl, options) {
       connectFuture.return();
     }
   });
+  if (process.env.METEOR_ADDITIONAL_CERT) {
+    options.fayeOptions= {
+      ca: require('fs').readFileSync(process.env.METEOR_ADDITIONAL_CERT)
+    }
+  }
 
   self.connection = Package['ddp-client'].DDP.connect(endpointUrl, options);
 


### PR DESCRIPTION
Uses environment variable `METEOR_ADDITIONAL_CERT` which must contain a fully qualified path to a pem format root certificate.

Fixes #4757