### PR TITLE
Fix #4804 and throw error when Mongo selector is array

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -328,6 +328,12 @@ Mongo.Collection._rewriteSelector = function (selector) {
   if (LocalCollection._selectorIsId(selector))
     selector = {_id: selector};
 
+  if (_.isArray(selector)) {
+    // This is consistent with the Mongo console itself; if we don't do this
+    // check passing an empty array ends up selecting all items
+    throw new Error("Mongo selector can't be an array.");
+  }
+
   if (!selector || (('_id' in selector) && !selector._id))
     // can't match anything
     return {_id: Random.id()};

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -3120,3 +3120,28 @@ Meteor.isServer && Tinytest.add("mongo-livedata - npm modules", function (test) 
   test.isTrue(rawDb);
   test.isTrue(rawDb.admin);
 });
+
+if (Meteor.isServer) {
+  Tinytest.add("mongo-livedata - update/remove don't accept an array as a selector #4804", function (test) {
+    var collection = new Mongo.Collection(Random.id());
+
+    _.times(10, function () {
+      collection.insert({ data: "Hello" });
+    });
+
+    test.equal(collection.find().count(), 10);
+
+    // Test several array-related selectors
+    _.each([[], [1, 2, 3], [{}]], function (selector) {
+      test.throws(function () {
+        collection.remove(selector);
+      });
+
+      test.throws(function () {
+        collection.update(selector, {$set: 5});
+      });
+    });
+    
+    test.equal(collection.find().count(), 10);
+  });
+}


### PR DESCRIPTION
An array is not a valid selector in Mongo, so we should fail fast in that case. Also, before this fix, if you passed an empty array as a selector, it would select everything just like `{}`.