### PR TITLE
Collection.exists: New method in Mongo.Collection API

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -231,6 +231,24 @@ LocalCollection.Cursor.prototype.count = function () {
   return self._getRawObjects({ordered: true}).length;
 };
 
+/**
+ * @summary Checks if document(s) corresponding to the cursor exist.
+ * @memberOf Mongo.Cursor
+ * @method  exists
+ * @instance
+ * @locus Anywhere
+ * @returns {Boolean}
+ */
+LocalCollection.Cursor.prototype.exists = function () {
+  var self = this;
+
+  if (self.reactive)
+    self._depend({added: true, removed: true},
+                 true /* allow the observe to be unordered */);
+
+  return self._getRawObjects({ordered: true}).length > 0;
+};
+
 LocalCollection.Cursor.prototype._publishCursor = function (sub) {
   var self = this;
   if (! self.collection.name)

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -295,6 +295,32 @@ _.extend(Mongo.Collection.prototype, {
     var argArray = _.toArray(arguments);
     return self._collection.findOne(self._getFindSelector(argArray),
                                     self._getFindOptions(argArray));
+  },
+  
+  /**
+   * @summary Check if the documents in a collection that match the selector exists.
+   * @locus Anywhere
+   * @method exists
+   * @memberOf Mongo.Collection
+   * @instance
+   * @param {MongoSelector} [selector] A query describing the documents to find
+   * @param {Object} [options]
+   * @param {MongoSortSpecifier} options.sort Sort order (default: natural order)
+   * @param {Number} options.skip Number of results to skip at the beginning
+   * @param {Number} options.limit Maximum number of results to return
+   * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
+   * @param {Boolean} options.reactive (Client only) Default `true`; pass `false` to disable reactivity
+   * @param {Function} options.transform Overrides `transform` on the  [`Collection`](#collections) for this cursor.  Pass `null` to disable transformation.
+   * @returns {Boolean}
+   */
+  exists: function (/* selector, options */) {
+    // Collection.exists() (always return true if Collection isn't empty) behaves differently
+    // from Collection.exists(undefined) (always return false).  so be
+    // careful about the length of arguments.
+    var self = this;
+    var argArray = _.toArray(arguments);
+    return self._collection.find(self._getFindSelector(argArray),
+                                 self._getFindOptions(argArray)).count() ? true : false;
   }
 
 });

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -298,19 +298,14 @@ _.extend(Mongo.Collection.prototype, {
   },
   
   /**
-   * @summary Check if the documents in a collection that match the selector exists.
+   * @summary Check if the documents in a collection that match the selector exist.
    * @locus Anywhere
    * @method exists
    * @memberOf Mongo.Collection
    * @instance
    * @param {MongoSelector} [selector] A query describing the documents to find
    * @param {Object} [options]
-   * @param {MongoSortSpecifier} options.sort Sort order (default: natural order)
-   * @param {Number} options.skip Number of results to skip at the beginning
-   * @param {Number} options.limit Maximum number of results to return
-   * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
    * @param {Boolean} options.reactive (Client only) Default `true`; pass `false` to disable reactivity
-   * @param {Function} options.transform Overrides `transform` on the  [`Collection`](#collections) for this cursor.  Pass `null` to disable transformation.
    * @returns {Boolean}
    */
   exists: function (/* selector, options */) {
@@ -319,8 +314,9 @@ _.extend(Mongo.Collection.prototype, {
     // careful about the length of arguments.
     var self = this;
     var argArray = _.toArray(arguments);
-    return self._collection.find(self._getFindSelector(argArray),
-                                 self._getFindOptions(argArray)).count() ? true : false;
+    var isReactive = self._getFindOptions(argArray).reactive;
+    var options = {limit: 1, fields: { _id: 1 }, transform: null, reactive: isReactive};
+    return self._collection.find(self._getFindSelector(argArray), options).count() ? true : false;
   }
 
 });


### PR DESCRIPTION
I decided to add this new method because a lot of people use ``` !Collection.findOne() ``` instead of ``` !Collection.find().count() ``` to check if a document exists.

The latter one is way more performant but less elegant to write. That's why I think it is appropriate to have a method like this one.
Adding it to the Meteor Mongo.Collection API and in the official documentation will increase by a lot the performance of a lot of Meteor applications.

More information about that here (includes benchmark):
https://blog.serverdensity.com/checking-if-a-document-exists-mongodb-slow-findone-vs-find/
