### PR TITLE
Fix issue #4862. Don't wrap login callbacks with bindEnvironment.

### DIFF
--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -22,10 +22,12 @@ AccountsCommon = function _AccountsCommon(options) {
 
   // Callback exceptions are printed with Meteor._debug and ignored.
   this._onLoginHook = new Hook({
+    bindEnvironment: false,
     debugPrintExceptions: "onLogin callback"
   });
 
   this._onLoginFailureHook = new Hook({
+    bindEnvironment: false,
     debugPrintExceptions: "onLoginFailure callback"
   });
 };

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -45,7 +45,7 @@ AccountsServer = function AccountsServer(server) {
   setupDefaultLoginHandlers(this);
   setExpireTokensInterval(this);
 
-  this._validateLoginHook = new Hook;
+  this._validateLoginHook = new Hook({ bindEnvironment: false });
   this._validateNewUserHooks = [
     defaultValidateNewUserHook.bind(this)
   ];

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -373,3 +373,44 @@ Tinytest.addAsync(
     );
   }
 );
+
+Tinytest.add(
+  'accounts - hook callbacks can access Meteor.userId()',
+  function (test) {
+    var userId = Accounts.insertUserDoc({}, { username: Random.id() });
+    var stampedToken = Accounts._generateStampedLoginToken();
+    Accounts._insertLoginToken(userId, stampedToken);
+
+    var validateStopper = Accounts.validateLoginAttempt(function(attempt) {
+      test.equal(Meteor.userId(), validateAttemptExpectedUserId, "validateLoginAttempt");
+      return true;
+    });
+    var onLoginStopper = Accounts.onLogin(function(attempt) {
+      test.equal(Meteor.userId(), onLoginExpectedUserId, "onLogin");
+    });
+    var onLoginFailureStopper = Accounts.onLoginFailure(function(attempt) {
+      test.equal(Meteor.userId(), onLoginFailureExpectedUserId, "onLoginFailure");
+    });
+
+    var conn = DDP.connect(Meteor.absoluteUrl());
+
+    // On a new connection, Meteor.userId() should be null until logged in.
+    var validateAttemptExpectedUserId = null;
+    var onLoginExpectedUserId = userId;
+    conn.call('login', { resume: stampedToken.token });
+
+    // Now that the user is logged in on the connection, Meteor.userId() should
+    // return that user.
+    validateAttemptExpectedUserId = userId;
+    conn.call('login', { resume: stampedToken.token });
+
+    // Trigger onLoginFailure callbacks
+    var onLoginFailureExpectedUserId = userId;
+    test.throws(function() { conn.call('login', { resume: "bogus" }) }, '403');
+
+    conn.disconnect();
+    validateStopper.stop();
+    onLoginStopper.stop();
+    onLoginFailureStopper.stop();
+  }
+);

--- a/packages/callback-hook/hook_tests.js
+++ b/packages/callback-hook/hook_tests.js
@@ -1,0 +1,55 @@
+Tinytest.add("callback-hook - binds to registrar's env by default", function (test) {
+  var hook = new Hook();
+  var envVar = new Meteor.EnvironmentVariable;
+  envVar.withValue("registrar's value", function() {
+    hook.register(function() {
+      test.equal(envVar.get(), "registrar's value");
+    });
+  });
+  envVar.withValue("invoker's value", function() {
+    hook.each(function(callback) {
+      callback();
+    });
+  });
+});
+
+Tinytest.add("callback-hook - uses invoker's env with {bindEnvironment: false}", function (test) {
+  var hook = new Hook({ bindEnvironment: false });
+  var envVar = new Meteor.EnvironmentVariable;
+  envVar.withValue("registrar's value", function() {
+    hook.register(function() {
+      test.equal(envVar.get(), "invoker's value");
+    });
+  });
+  envVar.withValue("invoker's value", function() {
+    hook.each(function(callback) {
+      callback();
+    });
+  });
+});
+
+Tinytest.add("callback-hook - exceptions unhandled with {bindEnvironment: false}", function (test) {
+  var hook = new Hook({ bindEnvironment: false });
+  hook.register(function() {
+    throw new Error("Test error");
+  });
+  hook.each(function(callback) {
+    test.throws(callback, "Test error");
+  });
+});
+
+Tinytest.add("callback-hook - exceptionHandler used with {bindEnvironment: false}", function (test) {
+  var exToThrow = new Error("Test error");
+  var thrownEx = null;
+  var hook = new Hook({
+    bindEnvironment: false,
+    exceptionHandler: function (ex) { thrownEx = ex; }
+  });
+  hook.register(function() {
+    throw exToThrow;
+  });
+  hook.each(function(callback) {
+    callback();
+  });
+  test.equal(exToThrow, thrownEx);
+});

--- a/packages/callback-hook/package.js
+++ b/packages/callback-hook/package.js
@@ -10,3 +10,9 @@ Package.onUse(function (api) {
 
   api.addFiles('hook.js', ['client', 'server']);
 });
+
+Package.onTest(function (api) {
+  api.use('callback-hook');
+  api.use('tinytest');
+  api.addFiles('hook_tests.js', 'server');
+});


### PR DESCRIPTION
Changes to packages/callback-hook:
- Add bindEnvironment option to Hook constructor (defaults to true).
- Add internal helper function dontBindEnvironment() which does all the
  error handling stuff like Meteor.bindEnvironment() but doesn't change
  the environment.
- Use dontBindEnvironment() instead of Meteor.bindEnvironment() when
  bindEnvironment option is false.
- Add tests.

Changes to packages/accounts-base:
- Create hooks with { bindEnvironment: false }
- Add test for whether Meteor.userId() is available in login callbacks.