### PR TITLE
If stdout is non-empty, assume that 'tasklist' and 'netstat' succeeded

### DIFF
--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -76,7 +76,7 @@ if (process.platform === 'win32') {
 
     child_process.exec('tasklist /fi "IMAGENAME eq mongod.exe"',
       function (error, stdout, stderr) {
-        if (error) {
+        if (error && stdout.length == 0) {
           var additionalInfo = JSON.stringify(error);
           if (error.code === 'ENOENT') {
             additionalInfo = "tasklist wasn't found on your system, it usually can be found at C:\\Windows\\System32\\.";
@@ -99,7 +99,7 @@ if (process.platform === 'win32') {
             'netstat -ano',
             {maxBuffer: 1024 * 1024 * 10},
             function (error, stdout, stderr) {
-            if (error) {
+            if (error && stdout.length == 0) {
               fut['throw'](new Error("Couldn't run netstat -ano: " +
                 JSON.stringify(error)));
               return;


### PR DESCRIPTION
My Meteor app failed after a Windows 10 upgrade. A bit of digging revealed

See my indepth analysis on that issue for more specifics. The TLDR is that
even when I run the child_process invocation by hand in a node REPL it
looks like the command both succeeded and failed (I.e. stdout contains the
successful invocation but `error` is non-null.) This happens for both
mongod and netstat invocations.

I'm sorry, I can't test this because I suspect it requires exposure to
multiple Windows environments and I just have my tablet. My hope is that
MDG has better test infrastructure than I do and can put this through its
paces so it can land in a release quickly.

I also don't know if this is the correct solution. I do know that it
turned my failing Meteor app into one that at least mostly launches,
barring a non-OS-specific package error, and that this fix is letting me
get back to work. :) Perhaps a Node/Windows integration expert can look at
why this command appears to both succeed and fail, but I'm not that
person.
