### PR TITLE
Package-scoped variables, new instruction api.pckgscope(), consequent update of the coffeescript package

### DIFF
--- a/docs/client/full-api/api/packagejs.md
+++ b/docs/client/full-api/api/packagejs.md
@@ -35,6 +35,8 @@ rest of this section will explain the specific API commands in greater detail.
       api.use('iron:router@1.0.0');
       // Give users of this package access to the Templating package.
       api.imply('templating')
+      // Make the scope of EmailIntern internal to this package.
+      api.pckgscope('EmailIntern', 'server');
       // Export the object 'Email' to packages or apps that use this package.
       api.export('Email', 'server');
       // Specify the source code for the package.

--- a/packages/coffeescript/README.md
+++ b/packages/coffeescript/README.md
@@ -26,22 +26,5 @@ Here's how CoffeeScript works with Meteor's namespacing.
 * Package-scope variables declared in `.js` files are visible in any
   `.coffee` files in the same app or project.
 
-* There is no way to make a package-scope variable from a `.coffee`
-  file other than exporting it. We couldn't figure out a way to make
-  this fit naturally inside the CoffeeScript language. If you want to
-  use package-scope variables with CoffeeScript, one way is to make a
-  short `.js` file that declares all of your package-scope
-  variables. They can then be read, mutated, and extended in `.coffee`
-  files.
-
-* If you want to share variables between `.coffee` files in the same
-  package, and don't want to separately declare them in a `.js` file,
-  we have an experimental feature that you may like. An object called
-  `share` is visible in CoffeeScript code and is shared across all
-  `.coffee` files in the same package. So, you can write `share.foo`
-  for a value that is shared between all CoffeeScript code in a
-  package, but doesn't escape that package.
-
-Heavy CoffeeScript users, please let us know how this arrangement
-works for you, whether `share` is helpful for you, and anything else
-you'd like to see changed.
+* To make a package-scope variable use the instruction `api.pckgscope()` in
+  `package.js`.

--- a/tools/isobuild/README.md
+++ b/tools/isobuild/README.md
@@ -149,3 +149,8 @@ argument.
 
 In the end, the final WatchSet that contains merged information about every used
 file, is returned to the caller.
+
+
+## New Feature: Package Scope
+to be done
+

--- a/tools/isobuild/README.md
+++ b/tools/isobuild/README.md
@@ -149,8 +149,3 @@ argument.
 
 In the end, the final WatchSet that contains merged information about every used
 file, is returned to the caller.
-
-
-## New Feature: Package Scope
-to be done
-

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -205,6 +205,18 @@ _.extend(InputFile.prototype, {
   },
 
   /**
+   * @summary Returns a list of symbols declared as pckg scope in this target.
+   * The result of `api.pckgscope('symbol')` calls in target's control file such
+   * as package.js.
+   * @memberof InputFile
+   * @returns {String[]}
+   */
+  getDeclaredPckgscopes: function () {
+    var self = this;
+    return self._resourceSlot.packageSourceBatch.unibuild.declaredPckgscopes;
+  },
+
+  /**
    * @summary Returns a relative path that can be used to form error messages or
    * other display properties. Can be used as an input to a source map.
    * @memberof InputFile
@@ -556,6 +568,7 @@ _.extend(PackageSourceBatch.prototype, {
             ".js"),
       name: self.unibuild.pkg.name || null,
       declaredExports: _.pluck(self.unibuild.declaredExports, 'name'),
+      declaredPckgscopes: _.pluck(self.unibuild.declaredPckgscopes, 'name'),
       imports: imports,
       // XXX report an error if there is a package called global-imports
       importStubServePath: isApp && '/packages/global-imports.js',

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -570,6 +570,11 @@ var compileUnibuild = function (options) {
     return _.pick(symbol, ['name', 'testOnly']);
   });
 
+  // *** Determine captured variables
+  var declaredPckgscopes = _.map(inputSourceArch.declaredPckgscopes, function (symbol) {
+    return _.pick(symbol, ['name']);
+  });
+
   // *** Consider npm dependencies and portability
   var arch = inputSourceArch.arch;
   if (arch === "os" && ! isPortable) {
@@ -590,6 +595,7 @@ var compileUnibuild = function (options) {
     watchSet: watchSet,
     nodeModulesPath: nodeModulesPath,
     declaredExports: declaredExports,
+    declaredPckgscopes: declaredPckgscopes,
     resources: resources
   });
 

--- a/tools/isobuild/isopack.js
+++ b/tools/isobuild/isopack.js
@@ -31,6 +31,7 @@ var rejectBadPath = function (p) {
 // - watchSet
 // - nodeModulesPath
 // - declaredExports
+// - declaredPckgscopes
 // - resources
 
 var nextBuildId = 1;
@@ -64,6 +65,10 @@ var Unibuild = function (isopack, options) {
   // A list of objects with keys 'name' (required) and 'testOnly' (boolean,
   // defaults to false).
   self.declaredExports = options.declaredExports;
+
+  // 'declaredPckgscopes' are the variables which are visible in this package.
+  // A list of objects with key 'name' (required).
+  self.declaredPckgscopes = options.declaredPckgscopes;
 
   // All of the data provided for eventual inclusion in the bundle,
   // other than JavaScript that still needs to be fed through the
@@ -1045,6 +1050,9 @@ _.extend(Isopack.prototype, {
         declaredExports = unibuildJson.declaredExports || [];
       }
 
+      var declaredPckgscopes;
+      declaredPckgscopes = unibuildJson.declaredPckgscopes || [];
+
       unibuildJson.uses && unibuildJson.uses.forEach((use) => {
         if (!use.weak && compiler.isIsobuildFeaturePackage(use.package) &&
             self.isobuildFeatures.indexOf(use.package) === -1) {
@@ -1062,6 +1070,7 @@ _.extend(Isopack.prototype, {
         watchSet: unibuildWatchSets[unibuildMeta.path],
         nodeModulesPath: nodeModulesPath,
         declaredExports: declaredExports,
+        declaredPckgscopes: declaredPckgscopes,
         resources: resources
       }));
     });
@@ -1257,6 +1266,7 @@ _.extend(Isopack.prototype, {
         var unibuildJson = {
           format: "isopack-2-unibuild",
           declaredExports: unibuild.declaredExports,
+          declaredPckgscopes: unibuild.declaredPckgscopes,
           uses: _.map(unibuild.uses, function (u) {
             return {
               'package': u.package,
@@ -1493,6 +1503,14 @@ _.extend(Isopack.prototype, {
                 });
                 packageVariableNames[symbol.name] = true;
               });
+              _.each(unibuild.declaredPckgscopes, function (symbol) {
+                if (_.has(packageVariableNames, symbol.name))
+                  return;
+                packageVariables.push({
+                  name: symbol.name
+                });
+                packageVariableNames[symbol.name] = true;
+              });
               _.each(results.assignedVariables, function (name) {
                 if (_.has(packageVariableNames, name))
                   return;
@@ -1525,6 +1543,7 @@ _.extend(Isopack.prototype, {
           }
           unibuildJson.resources = newResources;
           delete unibuildJson.declaredExports;
+          delete unibuildJson.declaredPckgscopes;
           builder.writeJson(legacyFilename, unibuildJson);
         });
 

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -695,6 +695,8 @@ var getFooter = function (options) {
 // declaredExports: an array of symbols that the module exports. Symbols are
 // {name,testOnly} pairs.
 //
+// declaredPckgscopes: an array of symbols that have the module as scope..
+//
 // imports: a map from imported symbol to the name of the package that it is
 // imported from
 //
@@ -707,7 +709,8 @@ var getFooter = function (options) {
 // Output is an array of output files: objects with keys source, servePath,
 // sourceMap.
 var fullLink = Profile("linker.fullLink", function (inputFiles, {
-    useGlobalNamespace, combinedServePath, name, declaredExports, imports,
+    useGlobalNamespace, combinedServePath, name, declaredExports,
+    declaredPckgscopes, imports,
     importStubServePath, includeSourceMapInstructions
   }) {
   buildmessage.assertInJob();
@@ -751,7 +754,8 @@ var fullLink = Profile("linker.fullLink", function (inputFiles, {
   // into a single scope.
   var header = getHeader({
     imports,
-    packageVariables: _.union(assignedVariables, declaredExports)
+    packageVariables: _.union(assignedVariables, declaredExports,
+      declaredPckgscopes)
   });
 
   var footer = getFooter({

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -695,7 +695,7 @@ var getFooter = function (options) {
 // declaredExports: an array of symbols that the module exports. Symbols are
 // {name,testOnly} pairs.
 //
-// declaredPckgscopes: an array of symbols that have the module as scope..
+// declaredPckgscopes: an array of symbols with package-scope.
 //
 // imports: a map from imported symbol to the name of the package that it is
 // imported from

--- a/tools/isobuild/package-api.js
+++ b/tools/isobuild/package-api.js
@@ -83,7 +83,7 @@ function PackageAPI (options) {
   // symbols exported
   self.exports = {};
 
-  // symbols with package scope
+  // symbols with package-scope
   self.pckgscopes = {};
 
   // packages used and implied (keys are 'package', 'unordered', and
@@ -95,7 +95,7 @@ function PackageAPI (options) {
   _.each(compiler.ALL_ARCHES, function (arch) {
     self.sources[arch] = {};
     self.exports[arch] = [];
-    self.pckgscope[arch] = [];
+    self.pckgscopes[arch] = [];
     self.uses[arch] = [];
     self.implies[arch] = [];
   });
@@ -482,7 +482,7 @@ _.extend(PackageAPI.prototype, {
     });
   },
 
-  // Package Scope symbols in this package.
+  // Symbols with package-scope in this package.
   //
   // @param symbols String (eg "Foo") or array of String
   // @param arch 'web', 'server', 'web.browser', 'web.cordova'
@@ -494,9 +494,9 @@ _.extend(PackageAPI.prototype, {
    *
    * @memberOf PackageAPI
    * @instance
-   * @summary Makes variables visible in your package. The specified
-   * variables (declared without `var` in the source code) will be available
-   * to all files in this package.
+   * @summary Makes variables visible in your package, but not outside. The
+   * specified variables (declared without `var` in the source code) will be
+   * available to all files in this package.
    * @locus package.js
    * @param {String|String[]} pckgscopeObjects Name of the object to be shared in this
    * package, or an array of object names.

--- a/tools/isobuild/package-api.js
+++ b/tools/isobuild/package-api.js
@@ -83,6 +83,9 @@ function PackageAPI (options) {
   // symbols exported
   self.exports = {};
 
+  // symbols with package scope
+  self.pckgscopes = {};
+
   // packages used and implied (keys are 'package', 'unordered', and
   // 'weak').  an "implied" package is a package that will be used by a unibuild
   // which uses us.
@@ -92,6 +95,7 @@ function PackageAPI (options) {
   _.each(compiler.ALL_ARCHES, function (arch) {
     self.sources[arch] = {};
     self.exports[arch] = [];
+    self.pckgscope[arch] = [];
     self.uses[arch] = [];
     self.implies[arch] = [];
   });
@@ -474,6 +478,51 @@ _.extend(PackageAPI.prototype, {
       }
       forAllMatchingArchs(arch, function (w) {
         self.exports[w].push({name: symbol, testOnly: !!options.testOnly});
+      });
+    });
+  },
+
+  // Package Scope symbols in this package.
+  //
+  // @param symbols String (eg "Foo") or array of String
+  // @param arch 'web', 'server', 'web.browser', 'web.cordova'
+  // or an array of those.
+  // The default is ['web', 'server'].
+  // @param options 'testOnly', boolean.
+
+  /**
+   *
+   * @memberOf PackageAPI
+   * @instance
+   * @summary Makes variables visible in your package. The specified
+   * variables (declared without `var` in the source code) will be available
+   * to all files in this package.
+   * @locus package.js
+   * @param {String|String[]} pckgscopeObjects Name of the object to be shared in this
+   * package, or an array of object names.
+   * @param {String|String[]} [architecture] If you only want to export the
+   * object on the server (or the client), you can pass in the second argument
+   * (e.g., 'server', 'client', 'web.browser', 'web.cordova') to specify what
+   * architecture the export is used with. You can specify multiple
+   * architectures by passing in an array, for example `['web.cordova',
+   * 'os.linux']`.
+   */
+  pckgscope: function (symbols, arch) {
+    var self = this;
+
+    symbols = toArray(symbols);
+    arch = toArchArray(arch);
+
+    _.each(symbols, function (symbol) {
+      // XXX be unicode-friendlier
+      if (!symbol.match(/^([_$a-zA-Z][_$a-zA-Z0-9]*)$/)) {
+        buildmessage.error("Bad pckg scoped symbol: " + symbol,
+                           { useMyCaller: true });
+        // recover by ignoring
+        return;
+      }
+      forAllMatchingArchs(arch, function (w) {
+        self.pckgscopes[w].push({name: symbol});
       });
     });
   }

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -258,7 +258,7 @@ var SourceArch = function (pkg, options) {
   // strings).
   self.declaredExports = options.declaredExports || null;
 
-  // Symbols that in this architecture should be package scoped. List of symbols
+  // Symbols that in this architecture should be package-scoped. List of symbols
   // (as strings).
   self.declaredPckgscopes = options.declaredPckgscopes || null;
 
@@ -1531,7 +1531,7 @@ _.extend(PackageSource.prototype, {
     });
    },
 
-  // Returns an array of objects, representing this package's scope
+  // Returns an array of objects, representing this package-scoped
   // objects. Each object has the following keys:
   //  - name: name (ex: "Accounts")
   //  - arch: an array of strings representing architectures for which this

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -186,6 +186,7 @@ var getExcerptFromReadme = function (text) {
 // - implies
 // - getSourcesFunc
 // - declaredExports
+// - declaredPckgscopes
 // - watchSet
 //
 // Do not include the source files in watchSet. They will be
@@ -256,6 +257,10 @@ var SourceArch = function (pkg, options) {
   // Symbols that this architecture should export. List of symbols (as
   // strings).
   self.declaredExports = options.declaredExports || null;
+
+  // Symbols that in this architecture should be package scoped. List of symbols
+  // (as strings).
+  self.declaredPckgscopes = options.declaredPckgscopes || null;
 
   // Files and directories that we want to monitor for changes in
   // development mode, as a watch.WatchSet. In the latest refactoring
@@ -1185,6 +1190,7 @@ _.extend(PackageSource.prototype, {
         implies: api.implies[arch],
         getSourcesFunc: function () { return _.values(api.sources[arch]); },
         declaredExports: api.exports[arch],
+        declaredPckgscopes: api.pckgscopes[arch],
         watchSet: watchSet
       }));
     });
@@ -1513,6 +1519,30 @@ _.extend(PackageSource.prototype, {
           return;
         }
         // Add the export to the export map.
+        if (! _.has(ret, exp.name)) {
+          ret[exp.name] = [arch.arch];
+        } else {
+          ret[exp.name].push(arch.arch);
+        }
+     });
+    });
+    return _.map(ret, function (arches, name) {
+      return { name: name, architectures: arches };
+    });
+   },
+
+  // Returns an array of objects, representing this package's scope
+  // objects. Each object has the following keys:
+  //  - name: name (ex: "Accounts")
+  //  - arch: an array of strings representing architectures for which this
+  //    object is declared.
+  getPckgscopes: function () {
+    var self = this;
+    var ret = {};
+    // Go over all of the architectures, and aggregate the exports together.
+    _.each(self.architectures, function (arch) {
+      _.each(arch.declaredPckgscopes, function (exp) {
+        // Add the package scope object to the map.
         if (! _.has(ret, exp.name)) {
           ret[exp.name] = [arch.arch];
         } else {


### PR DESCRIPTION
At this moment it is not possible to write a meteor package in coffeescript and strict mode. See [this stackoverflow question](http://stackoverflow.com/questions/31759640).

This pull request contains the following changes:
* new instruction **api.pckgscope()**  to be used in *package.js* to declare variables with package
 scope. This instruction is similar to **api.export()**  with the difference that in this context there is no
 export.
* the consequent updates to the **isobuild**
* the consequent updates to the **coffeescript package**. The entire problem with share is now
 obsolete
* update to the documentation of the *coffeescript package*. 
* small update of the packaging documentation