### PR TITLE
Throw a non-empty error when getUrl gets an empty response body

### DIFF
--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -330,7 +330,7 @@ _.extend(exports, {
     var body = result.body;
 
     if (response.statusCode >= 400 && response.statusCode < 600)
-      throw body;
+      throw body || ('Could not get '+ response.request.href + ', server returned ['+response.statusCode+']');
     else
       return body;
   }


### PR DESCRIPTION
Fixes https://github.com/meteor/meteor/issues/4921