### PR TITLE
Don't use _.has function to check the _id property existence

### DIFF
--- a/packages/minimongo/wrap_transform.js
+++ b/packages/minimongo/wrap_transform.js
@@ -32,7 +32,7 @@ LocalCollection.wrapTransform = function (transform) {
       throw new Error("transform must return object");
     }
 
-    if (_.has(transformed, '_id')) {
+    if (transformed._id)) {
       if (!EJSON.equals(transformed._id, id)) {
         throw new Error("transformed document can't have different _id");
       }


### PR DESCRIPTION
There are situations where a transformed document can have a getter function for the _id field:

```js
var transformed = new Class(attrs);

Object.defineProperty(Class.prototype, '_id', {
  get: function() {
    return this._values._id;
  }
});
```

In such situation the `_.has` method will not detect existence of the `_id` property. However checking it in the following way `if (transformed._id)` will work.
