### PR TITLE
Adds documentation for ignored folders

### DIFF
--- a/docs/client/full-api/concepts.html
+++ b/docs/client/full-api/concepts.html
@@ -156,7 +156,7 @@ The following folders are not loaded anywhere:
 
 - packages (covered later)
 - programs (for legacy reasons)
-- cordova-build-override
+- [`cordova-build-override`](https://github.com/meteor/meteor/wiki/Meteor-Cordova-Phonegap-integration#advanced-build-customization)
 
 ### Files outside special directories
 

--- a/docs/client/full-api/concepts.html
+++ b/docs/client/full-api/concepts.html
@@ -148,6 +148,16 @@ treated specially by Meteor:
     `node_modules` directories will not be available to your Meteor code. Use
     `Npm.depends` in your package `package.js` file for that.
 
+- **.***
+
+    Files starting witha  dot (`.`) are not loaded anywhere, including the `.meteor` folder.
+
+The following folders are not loaded anywhere:
+
+- packages (covered later)
+- programs (for legacy reasons)
+- cordova-build-override
+
 ### Files outside special directories
 
 All JavaScript files outside special directories are loaded on both the client


### PR DESCRIPTION
Based on https://github.com/meteor/meteor/blob/devel/tools/isobuild/package-source.js#L1303 these addintoal folders are ignored but not documented. Some of them may be intentionally left out of the documentation but I'm just suggesting adding documentation for all that seem appropriate.

I tried to reuse the phrase "not loaded anywhere" even if it's a bit awkward phrasing, I think. I wasn't sure if the Meteor file gobbler (as I like to call it) should be called an "autoloader" or something else...