### PR TITLE
Improving error code output in tool code.

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -323,9 +323,9 @@ var Connection = function (url, options) {
   };
 
   if (Meteor.isServer) {
-    self._stream.on('message', Meteor.bindEnvironment(onMessage, Meteor._debug));
-    self._stream.on('reset', Meteor.bindEnvironment(onReset, Meteor._debug));
-    self._stream.on('disconnect', Meteor.bindEnvironment(onDisconnect, Meteor._debug));
+    self._stream.on('message', Meteor.bindEnvironment(onMessage, "handling DDP message"));
+    self._stream.on('reset', Meteor.bindEnvironment(onReset, "handling DDP reset"));
+    self._stream.on('disconnect', Meteor.bindEnvironment(onDisconnect, "handling DDP disconnect"));
   } else {
     self._stream.on('message', onMessage);
     self._stream.on('reset', onReset);


### PR DESCRIPTION
Hey @glasser, can you give this a look? It seems like a brittle solution but I don't know of another way to pass the error object because e.stack is lost once we leave the exception. Then, in debug.js, we use `arguments` and so I did some hairy stuff to get it to still be of the form that it was before. I don't know if it's necessary to do console.log.apply instead of just doing a console.log (do we do this so that it applies all indices of the arguments object) and in that case I can change it to console.log in my check case.

I ran all of test-packages, and it passes fine (unlike the earlier solution that broke bindEnvironment tests).

I think this is important because it doesn't currently print the stack and I spent a lot of time identifying where I didn't have something defined since there was no stack trace. Thanks!
