### PR TITLE
Mention the _id is included in the `user` arg to onCreateUser

### DIFF
--- a/docs/client/full-api/api/accounts.md
+++ b/docs/client/full-api/api/accounts.md
@@ -296,7 +296,7 @@ password-based users or from an external service login flow. `options` may come
 from an untrusted client so make sure to validate any values you read from
 it. The `user` argument is created on the server and contains a
 proposed user object with all the automatically generated fields
-required for the user to log in.
+required for the user to log in, including the `_id`.
 
 The function should return the user document (either the one passed in or a
 newly-created object) with whatever modifications are desired. The returned


### PR DESCRIPTION
Reason is people have been assuming onCreateUser is a PRE-create hook, and no user id was available. See

* http://stackoverflow.com/questions/12984637/is-there-a-post-createuser-hook-in-meteor-when-using-accounts-ui-package
* https://forums.meteor.com/t/initializing-some-collections-when-a-user-creates-an-account/3949/6