### PR TITLE
Implement Promise-returning Meteor.{call,apply}Async methods.

### DIFF
--- a/packages/ddp-client/client_convenience.js
+++ b/packages/ddp-client/client_convenience.js
@@ -42,18 +42,24 @@ if (Meteor.isClient) {
     }
   };
 
-  Meteor.connection =
+  const conn = Meteor.connection =
     DDP.connect(ddpUrl, {
       onDDPVersionNegotiationFailure: onDDPVersionNegotiationFailure
     });
 
   // Proxy the public methods of Meteor.connection so they can
   // be called directly on Meteor.
-  _.each(['subscribe', 'methods', 'call', 'apply', 'status', 'reconnect',
-          'disconnect'],
-         function (name) {
-           Meteor[name] = _.bind(Meteor.connection[name], Meteor.connection);
-         });
+  _.each([
+    'subscribe',
+    'methods',
+    'call', 'callAsync',
+    'apply', 'applyAsync',
+    'status',
+    'reconnect',
+    'disconnect'
+  ], name => {
+    Meteor[name] = conn[name].bind(conn);
+  });
 } else {
   // Never set up a default connection on the server. Don't even map
   // subscribe/call/etc onto Meteor.

--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -719,12 +719,12 @@ _.extend(Connection.prototype, {
    * @param {EJSONable} [arg1,arg2...] Optional method arguments
    * @param {Function} [asyncCallback] Optional callback, which is called asynchronously with the error or result after the method is complete. If not provided, the method runs synchronously if possible (see below).
    */
-  call: function (name /* .. [arguments] .. callback */) {
-    // if it's a function, the last argument is the result callback,
-    // not a parameter to the remote method.
-    var args = Array.prototype.slice.call(arguments, 1);
-    if (args.length && typeof args[args.length - 1] === "function")
+  call(name, ...args) {
+    if (args.length && typeof args[args.length - 1] === "function") {
+      // If it's a function, the last argument is the result callback,
+      // not a parameter to the remote method.
       var callback = args.pop();
+    }
     return this.apply(name, args, callback);
   },
 
@@ -762,7 +762,7 @@ _.extend(Connection.prototype, {
    * @param {Boolean} options.noRetry (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
    * @param {Function} [asyncCallback] Optional callback; same semantics as in [`Meteor.call`](#meteor_call).
    */
-  apply: function (name, args, options, callback) {
+  apply(name, args, options, callback) {
     var self = this;
 
     // We were passed 3 arguments. They may be either (name, args, options)

--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -787,15 +787,7 @@ _.extend(Connection.prototype, {
     // while because of a wait method).
     args = EJSON.clone(args);
 
-    // Lazily allocate method ID once we know that it'll be needed.
-    var methodId = (function () {
-      var id;
-      return function () {
-        if (id === undefined)
-          id = '' + (self._nextMethodId++);
-        return id;
-      };
-    })();
+    const methodId = self._makeLazyMethodIdGetter();
 
     var enclosing = DDP._CurrentInvocation.get();
     var alreadyInSimulation = enclosing && enclosing.isSimulation;
@@ -956,6 +948,16 @@ _.extend(Connection.prototype, {
     }
 
     return options.returnStubValue ? stubReturnValue : undefined;
+  },
+
+  _makeLazyMethodIdGetter() {
+    let id;
+    return () => {
+      if (id === undefined) {
+        id = String(this._nextMethodId++);
+      }
+      return id;
+    };
   },
 
   _enqueueMethodInvoker(methodInvoker, wait) {

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -52,6 +52,7 @@ Package.onTest(function (api) {
     'ecmascript',
     'underscore',
     'tinytest',
+    'ecmascript',
     'random',
     'tracker',
     'reactive-var',

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -12,7 +12,7 @@ Npm.depends({
 
 Package.onUse(function (api) {
   api.use(['check', 'random', 'ejson', 'underscore', 'tracker',
-           'retry', 'id-map'],
+           'retry', 'id-map', 'ecmascript'],
           ['client', 'server']);
 
   // common functionality

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1550,79 +1550,26 @@ _.extend(Server.prototype, {
     });
   },
 
-  call: function (name /*, arguments */) {
-    // if it's a function, the last argument is the result callback,
-    // not a parameter to the remote method.
-    var args = Array.prototype.slice.call(arguments, 1);
-    if (args.length && typeof args[args.length - 1] === "function")
+  call(name, ...args) {
+    if (args.length && typeof args[args.length - 1] === "function") {
+      // If it's a function, the last argument is the result callback, not
+      // a parameter to the remote method.
       var callback = args.pop();
+    }
+
     return this.apply(name, args, callback);
   },
 
-  // @param options {Optional Object}
-  // @param callback {Optional Function}
-  apply: function (name, args, options, callback) {
-    var self = this;
-
+  apply(name, args, options, callback) {
     // We were passed 3 arguments. They may be either (name, args, options)
     // or (name, args, callback)
-    if (!callback && typeof options === 'function') {
+    if (! callback && typeof options === 'function') {
       callback = options;
       options = {};
     }
     options = options || {};
 
-    if (callback)
-      // It's not really necessary to do this, since we immediately
-      // run the callback in this fiber before returning, but we do it
-      // anyway for regularity.
-      // XXX improve error message (and how we report it)
-      callback = Meteor.bindEnvironment(
-        callback,
-        "delivering result of invoking '" + name + "'"
-      );
-
-    // Run the handler
-    var handler = self.method_handlers[name];
-    var exception;
-    if (!handler) {
-      exception = new Meteor.Error(404, `Method '${name}' not found`);
-    } else {
-      // If this is a method call from within another method, get the
-      // user state from the outer method, otherwise don't allow
-      // setUserId to be called
-      var userId = null;
-      var setUserId = function() {
-        throw new Error("Can't call setUserId on a server initiated method call");
-      };
-      var connection = null;
-      var currentInvocation = DDP._CurrentInvocation.get();
-      if (currentInvocation) {
-        userId = currentInvocation.userId;
-        setUserId = function(userId) {
-          currentInvocation.setUserId(userId);
-        };
-        connection = currentInvocation.connection;
-      }
-
-      var invocation = new DDPCommon.MethodInvocation({
-        isSimulation: false,
-        userId: userId,
-        setUserId: setUserId,
-        connection: connection,
-        randomSeed: DDPCommon.makeRpcSeed(currentInvocation, name)
-      });
-      try {
-        var result = DDP._CurrentInvocation.withValue(invocation, function () {
-          return maybeAuditArgumentChecks(
-            handler, invocation, EJSON.clone(args), "internal call to '" +
-              name + "'");
-        });
-        result = EJSON.clone(result);
-      } catch (e) {
-        exception = e;
-      }
-    }
+    const promise = this.applyAsync(name, args, options);
 
     // Return the result in whichever way the caller asked for it. Note that we
     // do NOT block on the write fence in an analogous way to how the client
@@ -1630,12 +1577,62 @@ _.extend(Server.prototype, {
     // cursor observe callbacks have fired when your callback is invoked. (We
     // can change this if there's a real use case.)
     if (callback) {
-      callback(exception, result);
-      return undefined;
+      promise.then(
+        result => callback(undefined, result),
+        exception => callback(exception)
+      );
+    } else {
+      return promise.await();
     }
-    if (exception)
-      throw exception;
-    return result;
+  },
+
+  // A version of the call method that always returns a Promise.
+  callAsync(name, ...args) {
+    return this.applyAsync(name, args);
+  },
+
+  // @param options {Optional Object}
+  applyAsync(name, args, options) {
+    // Run the handler
+    var handler = this.method_handlers[name];
+    if (! handler) {
+      return Promise.reject(new Meteor.Error(404, `Method '${name}' not found`));
+    }
+
+    // If this is a method call from within another method, get the
+    // user state from the outer method, otherwise don't allow
+    // setUserId to be called
+    var userId = null;
+    var setUserId = function() {
+      throw new Error("Can't call setUserId on a server initiated method call");
+    };
+    var connection = null;
+    var currentInvocation = DDP._CurrentInvocation.get();
+    if (currentInvocation) {
+      userId = currentInvocation.userId;
+      setUserId = function(userId) {
+        currentInvocation.setUserId(userId);
+      };
+      connection = currentInvocation.connection;
+    }
+
+    var invocation = new DDPCommon.MethodInvocation({
+      isSimulation: false,
+      userId,
+      setUserId,
+      connection,
+      randomSeed: DDPCommon.makeRpcSeed(currentInvocation, name)
+    });
+
+    return new Promise(resolve => resolve(
+      DDP._CurrentInvocation.withValue(
+        invocation,
+        () => maybeAuditArgumentChecks(
+          handler, invocation, EJSON.clone(args),
+          "internal call to '" + name + "'"
+        )
+      )
+    )).then(EJSON.clone);
   },
 
   _urlForSession: function (sessionId) {

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -194,6 +194,16 @@ Tinytest.addAsync(
       )
     );
 
+    const serverCallAsyncPromise = Meteor.server.callAsync(
+      "testResolvedPromise",
+      "Meteor.server.callAsync"
+    );
+
+    const serverApplyAsyncPromise = Meteor.server.applyAsync(
+      "testResolvedPromise",
+      ["Meteor.server.applyAsync"]
+    );
+
     const clientCallRejectedPromise = new Promise(resolve => {
       clientConn.call(
         "testRejectedPromise",
@@ -205,9 +215,13 @@ Tinytest.addAsync(
     Promise.all([
       clientCallPromise,
       clientCallRejectedPromise,
+      serverCallAsyncPromise,
+      serverApplyAsyncPromise
     ]).then(results => test.equal(results, [
       "clientConn.call with callback after waiting",
       "[with callback raised Meteor.Error]",
+      "Meteor.server.callAsync after waiting",
+      "Meteor.server.applyAsync after waiting"
     ]), error => test.fail(error))
       .then(onComplete);
   })

--- a/packages/ddp-server/server_convenience.js
+++ b/packages/ddp-server/server_convenience.js
@@ -11,10 +11,16 @@ Meteor.refresh = function (notification) {
 
 // Proxy the public methods of Meteor.server so they can
 // be called directly on Meteor.
-_.each(['publish', 'methods', 'call', 'apply', 'onConnection'],
-       function (name) {
-         Meteor[name] = _.bind(Meteor.server[name], Meteor.server);
-       });
+_.each([
+  'publish',
+  'methods',
+  'call', 'callAsync',
+  'apply', 'applyAsync',
+  'onConnection'
+], name => {
+  const server = Meteor.server;
+  Meteor[name] = _.bind(server[name], server);
+});
 
 // Meteor.server used to be called Meteor.default_server. Provide
 // backcompat as a courtesy even though it was never documented.


### PR DESCRIPTION
Like #4939, but this PR implements the same functionality on both client and server.

In short, `Meteor.{call,apply}Async` are just like their synchronous counterparts, except that they do not take a callback, and they always return a `Promise`. The eventual value of this `Promise` is the value returned from the server, unless you call `Meteor.applyAsync(method, args, { returnStubValue: true })`, in which case the `Promise` will evaluate to the stub result (though of course the full RPC call will still go through to the server).

The trickiest part was allowing method stubs to return `Promise` objects, while still calling `connection._saveOriginals()` and `connection._retrieveAndStoreOriginals(methodId())` at the right times, in a way that worked for both synchronous `Meteor.{call,apply}` and asychronous `Meteor.{call,apply}Async`. If everything was asynchronous, this would all be a lot easier!

The preliminary "Decompose …" commits demonstrate that there was some opportunity to reuse code between the synchronous and asynchronous versions of these methods.

cc @stubailo @dgreensp @glasser
