### PR TITLE
Spiderable: Replace regex with DOM manipulation + keep JSON-LD

### DIFF
--- a/packages/spiderable/phantom_script.js
+++ b/packages/spiderable/phantom_script.js
@@ -13,15 +13,19 @@ var isReady = function () {
         || Package.spiderable.Spiderable === undefined) {
       return false;
     }
+    
+    // Remove all script tags except JSON-LD
+    var scriptTags = document.querySelectorAll('script:not([type="application/ld+json"])');
+    for (var i = 0; i < scriptTags.length; i++) {
+      scriptTags[i].parentNode.removeChild(scriptTags[i]);
+    }
+
+    // Remove meta fragment content
+    var fragment = document.querySelector('meta[name="fragment"][content="!"]');
+    fragment.parentNode.removeChild(fragment);
+    
     return Package.spiderable.Spiderable.isReady();
   });
-};
-
-var dumpPageContent = function () {
-  var out = page.content;
-  out = out.replace(/<script[^>]+>(.|\n|\r)*?<\/script\s*>/ig, '');
-  out = out.replace('<meta name="fragment" content="!">', '');
-  console.log(out);
 };
 
 page.open(url, function(status) {
@@ -31,7 +35,7 @@ page.open(url, function(status) {
 
 setInterval(function() {
   if (isReady()) {
-    dumpPageContent();
+    console.log(page.content);
     phantom.exit();
   }
 }, 100);

--- a/packages/spiderable/phantom_script.js
+++ b/packages/spiderable/phantom_script.js
@@ -14,17 +14,21 @@ var isReady = function () {
       return false;
     }
     
-    // Remove all script tags except JSON-LD
-    var scriptTags = document.querySelectorAll('script:not([type="application/ld+json"])');
-    for (var i = 0; i < scriptTags.length; i++) {
-      scriptTags[i].parentNode.removeChild(scriptTags[i]);
-    }
-
-    // Remove meta fragment content
-    var fragment = document.querySelector('meta[name="fragment"][content="!"]');
-    fragment.parentNode.removeChild(fragment);
+    var spiderableIsReady = Package.spiderable.Spiderable.isReady();
     
-    return Package.spiderable.Spiderable.isReady();
+    if (spiderableIsReady) {
+      // Remove all script tags except JSON-LD
+      var scriptTags = document.querySelectorAll('script:not([type="application/ld+json"])');
+      for (var i = 0; i < scriptTags.length; i++) {
+        scriptTags[i].parentNode.removeChild(scriptTags[i]);
+      }
+
+      // Remove meta fragment content
+      var fragment = document.querySelector('meta[name="fragment"][content="!"]');
+      fragment.parentNode.removeChild(fragment);
+    }
+    
+    return spiderableIsReady;
   });
 };
 


### PR DESCRIPTION
I think/hope @glasser suggested something along these lines in this issue: https://github.com/meteor/meteor/issues/2294

It gets rid of the regex for removing script tags and the fragment meta tag and uses DOM manipulation instead. It also keeps JSON-LD tags which are useful for semantic SEO - https://developers.google.com/schemas/formats/json-ld?hl=en
