### PR TITLE
Remove unused RunCommand and add promise-based execFileSync/Async

### DIFF
--- a/tools/utils/processes.js
+++ b/tools/utils/processes.js
@@ -23,6 +23,8 @@ import child_process from 'child_process';
  * @param {Array|String} [options.stdio] Child's stdio configuration.
  * (Default: 'pipe') Specifying anything else than 'pipe' will disallow
  * capture.
+ * @param {Writable} [options.destination] If specified, instead of capturing
+ * the output, the child process stdout will be piped to the destination stream.
  * @param {String} [options.waitForClose] Whether to wait for the child process
  * streams to close or to resolve the promise when the child process exits.
  * @returns {String} The stdout from the command
@@ -44,6 +46,8 @@ export function execFileSync(command, args, options) {
  * @param {Array|String} [options.stdio] Child's stdio configuration.
  * (Default: 'pipe') Specifying anything else than 'pipe' will disallow
  * capture.
+ * @param {Writable} [options.destination] If specified, instead of capturing
+ * the output, the child process stdout will be piped to the destination stream.
  * @param {String} [options.waitForClose] Whether to wait for the child process
  * streams to close or to resolve the promise when the child process exits.
  * @returns {Promise<String>}
@@ -71,10 +75,14 @@ export function execFileAsync(command, args,
 
     let capturedStdout = '';
     if (child.stdout) {
-      child.stdout.setEncoding('utf8');
-      child.stdout.on('data', (data) => {
-        capturedStdout += data;
-      });
+      if (options.destination) {
+        child.stdout.pipe(options.destination);
+      } else {
+        child.stdout.setEncoding('utf8');
+        child.stdout.on('data', (data) => {
+          capturedStdout += data;
+        });
+      }
     }
 
     let capturedStderr = '';


### PR DESCRIPTION
The execFileSync function is meant to resemble the similarly-named Node
0.12 synchronous process creation API, but instead of being fully
blocking it uses a promise-based implementation. You can also use
execFileAsync directly, which returns a promise.

Some functionality is currently missing but could be added when the
need arises (e.g. support for timeout, maxBuffer, and encoding options).

Eventually, these versions should replace the ones in
tools/utils/utils.js and tools/tool-testing/selftest.js.