### PR TITLE
Have cursor.count() respect applySkipLimit and make it consistent

### DIFF
--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -5716,7 +5716,17 @@ DocsData = {
     "memberof": "Mongo.Cursor",
     "name": "count",
     "options": [],
-    "params": [],
+    "params": [
+      {
+        "description": "<p>Optional. Specifies whether to consider the effects of the <code>skip</code> and <code>limit</code> options. By default, the <code>count()</code> method ignores the effects of the <code>skip</code> and <code>limit</code> options. Set <code>applySkipLimit</code> to true to consider the effect of these options.</p>",
+        "name": "applySkipLimit",
+        "type": {
+          "names": [
+            "Boolean"
+          ]
+        }
+      },
+    ],
     "returns": [
       {
         "type": {

--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -3540,7 +3540,7 @@ DocsData = {
   "HTTP.del": {
     "filepath": "http/httpcall_common.js",
     "kind": "function",
-    "lineno": 78,
+    "lineno": 82,
     "locus": "Anywhere",
     "longname": "HTTP.del",
     "memberof": "HTTP",
@@ -3583,7 +3583,7 @@ DocsData = {
   "HTTP.get": {
     "filepath": "http/httpcall_common.js",
     "kind": "function",
-    "lineno": 45,
+    "lineno": 49,
     "locus": "Anywhere",
     "longname": "HTTP.get",
     "memberof": "HTTP",
@@ -3626,7 +3626,7 @@ DocsData = {
   "HTTP.post": {
     "filepath": "http/httpcall_common.js",
     "kind": "function",
-    "lineno": 56,
+    "lineno": 60,
     "locus": "Anywhere",
     "longname": "HTTP.post",
     "memberof": "HTTP",
@@ -3669,7 +3669,7 @@ DocsData = {
   "HTTP.put": {
     "filepath": "http/httpcall_common.js",
     "kind": "function",
-    "lineno": 67,
+    "lineno": 71,
     "locus": "Anywhere",
     "longname": "HTTP.put",
     "memberof": "HTTP",
@@ -5718,14 +5718,15 @@ DocsData = {
     "options": [],
     "params": [
       {
-        "description": "<p>Optional. Specifies whether to consider the effects of the <code>skip</code> and <code>limit</code> options. By default, the <code>count()</code> method ignores the effects of the <code>skip</code> and <code>limit</code> options. Set <code>applySkipLimit</code> to true to consider the effect of these options.</p>",
+        "description": "<p>Optional. Specifies whether to consider the effects of the <code>skip</code> and <code>limit</code> options.\nBy default, the <code>count()</code> method ignores the effects of the <code>skip</code> and <code>limit</code> options.\nSet <code>applySkipLimit</code> to true to consider the effect of these options.</p>",
         "name": "applySkipLimit",
+        "optional": true,
         "type": {
           "names": [
             "Boolean"
           ]
         }
-      },
+      }
     ],
     "returns": [
       {
@@ -5830,7 +5831,7 @@ DocsData = {
   "Mongo.Cursor#observe": {
     "filepath": "minimongo/minimongo.js",
     "kind": "function",
-    "lineno": 303,
+    "lineno": 318,
     "locus": "Anywhere",
     "longname": "Mongo.Cursor#observe",
     "memberof": "Mongo.Cursor",
@@ -5853,7 +5854,7 @@ DocsData = {
   "Mongo.Cursor#observeChanges": {
     "filepath": "minimongo/minimongo.js",
     "kind": "function",
-    "lineno": 315,
+    "lineno": 330,
     "locus": "Anywhere",
     "longname": "Mongo.Cursor#observeChanges",
     "memberof": "Mongo.Cursor",

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -221,14 +221,21 @@ LocalCollection.Cursor.prototype.fetch = function () {
  * @locus Anywhere
  * @returns {Number}
  */
-LocalCollection.Cursor.prototype.count = function () {
+LocalCollection.Cursor.prototype.count = function (applySkipLimit) {
   var self = this;
+  // Have to respect `applySkipLimit`, so we remove limit if `applySkipLimit` is not true
+  // and then restore the limit once we've got the count
+  var originalLimit = self.limit;
+  if(!applySkipLimit) self.limit = undefined;
 
   if (self.reactive)
     self._depend({added: true, removed: true},
                  true /* allow the observe to be unordered */);
 
-  return self._getRawObjects({ordered: true}).length;
+  var count = self._getRawObjects({ordered: true}).length;
+  self.limit = originalLimit;
+
+  return count;
 };
 
 LocalCollection.Cursor.prototype._publishCursor = function (sub) {

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -223,10 +223,14 @@ LocalCollection.Cursor.prototype.fetch = function () {
  */
 LocalCollection.Cursor.prototype.count = function (applySkipLimit) {
   var self = this;
-  // Have to respect `applySkipLimit`, so we remove limit if `applySkipLimit` is not true
-  // and then restore the limit once we've got the count
+  // Have to respect `applySkipLimit`, so we remove limit & skip if `applySkipLimit`
+  // is not true and then restore limit & skip once we've got the count
   var originalLimit = self.limit;
-  if(!applySkipLimit) self.limit = undefined;
+  var originalSkip = self.skip;
+  if(!applySkipLimit){
+    self.limit = undefined;
+    self.skip = undefined;
+  }
 
   if (self.reactive)
     self._depend({added: true, removed: true},
@@ -234,6 +238,7 @@ LocalCollection.Cursor.prototype.count = function (applySkipLimit) {
 
   var count = self._getRawObjects({ordered: true}).length;
   self.limit = originalLimit;
+  self.skip = originalSkip;
 
   return count;
 };

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -219,6 +219,9 @@ LocalCollection.Cursor.prototype.fetch = function () {
  * @method  count
  * @instance
  * @locus Anywhere
+ * @param {Boolean} [applySkipLimit] Optional. Specifies whether to consider the effects of the `skip` and `limit` options.
+ * By default, the `count()` method ignores the effects of the `skip` and `limit` options.
+ * Set `applySkipLimit` to true to consider the effect of these options.
  * @returns {Number}
  */
 LocalCollection.Cursor.prototype.count = function (applySkipLimit) {
@@ -227,7 +230,7 @@ LocalCollection.Cursor.prototype.count = function (applySkipLimit) {
   // is not true and then restore limit & skip once we've got the count
   var originalLimit = self.limit;
   var originalSkip = self.skip;
-  if(!applySkipLimit){
+  if (! applySkipLimit) {
     self.limit = undefined;
     self.skip = undefined;
   }

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -135,26 +135,46 @@ Tinytest.add("minimongo - basics", function (test) {
   test.equal(c.find("abc").count(), 0);
   test.equal(c.find(undefined).count(), 0);
   test.equal(c.find().count(), 3);
-  test.equal(c.find(1, {skip: 1}).count(), 0);
-  test.equal(c.find({_id: 1}, {skip: 1}).count(), 0);
-  test.equal(c.find({}, {skip: 1}).count(), 2);
-  test.equal(c.find({}, {skip: 2}).count(), 1);
-  test.equal(c.find({}, {limit: 2}).count(), 2);
-  test.equal(c.find({}, {limit: 1}).count(), 1);
-  test.equal(c.find({}, {skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find({tags: "fruit"}, {skip: 1}).count(), 1);
-  test.equal(c.find({tags: "fruit"}, {limit: 1}).count(), 1);
-  test.equal(c.find({tags: "fruit"}, {skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find(1, {sort: ['_id','desc'], skip: 1}).count(), 0);
-  test.equal(c.find({_id: 1}, {sort: ['_id','desc'], skip: 1}).count(), 0);
-  test.equal(c.find({}, {sort: ['_id','desc'], skip: 1}).count(), 2);
-  test.equal(c.find({}, {sort: ['_id','desc'], skip: 2}).count(), 1);
-  test.equal(c.find({}, {sort: ['_id','desc'], limit: 2}).count(), 2);
-  test.equal(c.find({}, {sort: ['_id','desc'], limit: 1}).count(), 1);
-  test.equal(c.find({}, {sort: ['_id','desc'], skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], skip: 1}).count(), 1);
-  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], limit: 1}).count(), 1);
-  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], skip: 1, limit: 1}).count(), 1);
+  test.equal(c.find(1, {skip: 1}).count(), 1);
+  test.equal(c.find(1, {skip: 1}).count(true), 0);
+  test.equal(c.find({_id: 1}, {skip: 1}).count(), 1);
+  test.equal(c.find({_id: 1}, {skip: 1}).count(true), 0);
+  test.equal(c.find({}, {skip: 1}).count(), 3);
+  test.equal(c.find({}, {skip: 1}).count(true), 2);
+  test.equal(c.find({}, {skip: 2}).count(), 3);
+  test.equal(c.find({}, {skip: 2}).count(true), 1);
+  test.equal(c.find({}, {limit: 2}).count(), 3);
+  test.equal(c.find({}, {limit: 2}).count(true), 2);
+  test.equal(c.find({}, {limit: 1}).count(), 3);
+  test.equal(c.find({}, {limit: 1}).count(true), 1);
+  test.equal(c.find({}, {skip: 1, limit: 1}).count(), 3);
+  test.equal(c.find({}, {skip: 1, limit: 1}).count(true), 1);
+  test.equal(c.find({tags: "fruit"}, {skip: 1}).count(), 2);
+  test.equal(c.find({tags: "fruit"}, {skip: 1}).count(true), 1);
+  test.equal(c.find({tags: "fruit"}, {limit: 1}).count(), 2);
+  test.equal(c.find({tags: "fruit"}, {limit: 1}).count(true), 1);
+  test.equal(c.find({tags: "fruit"}, {skip: 1, limit: 1}).count(), 2);
+  test.equal(c.find({tags: "fruit"}, {skip: 1, limit: 1}).count(true), 1);
+  test.equal(c.find(1, {sort: ['_id','desc'], skip: 1}).count(), 1);
+  test.equal(c.find(1, {sort: ['_id','desc'], skip: 1}).count(true), 0);
+  test.equal(c.find({_id: 1}, {sort: ['_id','desc'], skip: 1}).count(), 1);
+  test.equal(c.find({_id: 1}, {sort: ['_id','desc'], skip: 1}).count(true), 0);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 1}).count(), 3);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 1}).count(true), 2);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 2}).count(), 3);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 2}).count(true), 1);
+  test.equal(c.find({}, {sort: ['_id','desc'], limit: 2}).count(), 3);
+  test.equal(c.find({}, {sort: ['_id','desc'], limit: 2}).count(true), 2);
+  test.equal(c.find({}, {sort: ['_id','desc'], limit: 1}).count(), 3);
+  test.equal(c.find({}, {sort: ['_id','desc'], limit: 1}).count(true), 1);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 1, limit: 1}).count(), 3);
+  test.equal(c.find({}, {sort: ['_id','desc'], skip: 1, limit: 1}).count(true), 1);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], skip: 1}).count(), 2);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], skip: 1}).count(true), 1);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], limit: 1}).count(), 2);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], limit: 1}).count(true), 1);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], skip: 1, limit: 1}).count(), 2);
+  test.equal(c.find({tags: "fruit"}, {sort: ['_id','desc'], skip: 1, limit: 1}).count(true), 1);
 
   // Regression test for #455.
   c.insert({foo: {bar: 'baz'}});
@@ -2772,7 +2792,9 @@ Tinytest.add("minimongo - immediate invalidate", function (test) {
 
 
 Tinytest.add("minimongo - count on cursor with limit", function(test){
-  var coll = new LocalCollection(), count;
+  var coll = new LocalCollection(), countApplied, countNotApplied;
+  // countApplied = count with applySkipLimit true
+  // countNotApplied = count with applySkipLimit false
 
   coll.insert({_id: 'A'});
   coll.insert({_id: 'B'});
@@ -2781,27 +2803,33 @@ Tinytest.add("minimongo - count on cursor with limit", function(test){
 
   var c = Tracker.autorun(function (c) {
     var cursor = coll.find({_id: {$exists: true}}, {sort: {_id: 1}, limit: 3});
-    count = cursor.count();
+    countApplied = cursor.count(true);
+    countNotApplied = cursor.count();
   });
 
-  test.equal(count, 3);
+  test.equal(countApplied, 3);
+  test.equal(countNotApplied, 4);
 
   coll.remove('A'); // still 3 in the collection
   Tracker.flush();
-  test.equal(count, 3);
+  test.equal(countApplied, 3);
+  test.equal(countNotApplied, 3);
 
-  coll.remove('B'); // expect count now 2
+  coll.remove('B'); // 2 in collection
   Tracker.flush();
-  test.equal(count, 2);
+  test.equal(countApplied, 2);
+  test.equal(countNotApplied, 2);
 
 
   coll.insert({_id: 'A'}); // now 3 again
   Tracker.flush();
-  test.equal(count, 3);
+  test.equal(countApplied, 3);
+  test.equal(countNotApplied, 3);
 
   coll.insert({_id: 'B'}); // now 4 entries, but count should be 3 still
   Tracker.flush();
-  test.equal(count, 3);
+  test.equal(countApplied, 3);
+  test.equal(countNotApplied, 4);
 
   c.stop();
 });

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1055,9 +1055,9 @@ _.extend(SynchronousCursor.prototype, {
     return self.map(_.identity);
   },
 
-  count: function () {
+  count: function (applySkipLimit) {
     var self = this;
-    return self._synchronousCount().wait();
+    return self._synchronousCount(applySkipLimit).wait();
   },
 
   // This method is NOT wrapped in Cursor.


### PR DESCRIPTION
Fixes #1201 and also adds the `applySkipLimit` flag to `count()` as per the [MongoDB documentation](http://docs.mongodb.org/master/reference/method/cursor.count/). `count()` now works the same in the client and in the server - both need the `applySkipLimit` flag to make it respect `limit` and `skip`.
