### PR TITLE
Add remove function to Reactive-Dict

### DIFF
--- a/packages/reactive-dict/reactive-dict.js
+++ b/packages/reactive-dict/reactive-dict.js
@@ -165,6 +165,14 @@ _.extend(ReactiveDict.prototype, {
     });
 
   },
+  
+  remove: function (key) {
+    var self = this;
+
+    delete self.keys[key];
+
+    self.allDeps.changed();
+  },
 
   _setObject: function (object) {
     var self = this;


### PR DESCRIPTION
I'm looking forward to Dict.all() for debugging tools and building utilities. We also need a way to permanently remove keys from the dictionaries, because setting them to null will still cause them to be returned by Dict.all().
