### PR TITLE
Add missing brackets around hexstring opt param

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -673,7 +673,7 @@ Mongo.Collection.prototype.rawDatabase = function () {
  * @summary Create a Mongo-style `ObjectID`.  If you don't specify a `hexString`, the `ObjectID` will generated randomly (not using MongoDB's ID construction rules).
  * @locus Anywhere
  * @class
- * @param {String} hexString Optional.  The 24-character hexadecimal contents of the ObjectID to create
+ * @param {String} [hexString] Optional.  The 24-character hexadecimal contents of the ObjectID to create
  */
 Mongo.ObjectID = MongoID.ObjectID;
 


### PR DESCRIPTION
In the JSDoc of the Mongo.objectId() method, the param name hexstring was missing brackets, causing the data.js generating script to forget the optional:true attribute for the param.
