### PR TITLE
[1.2 RC] Add JSX extension on ecmascript

### DIFF
--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'ecmascript',
   version: '0.1.3-plugins.5',
-  summary: 'Compiler plugin that supports ES2015+ in all .js files',
+  summary: 'Compiler plugin that supports ES2015+ in all .js and .jsx files',
   documentation: 'README.md'
 });
 

--- a/packages/ecmascript/plugin.js
+++ b/packages/ecmascript/plugin.js
@@ -64,7 +64,7 @@ BCp.setDiskCacheDirectory = function (cacheDir) {
 };
 
 Plugin.registerCompiler({
-  extensions: ['js'],
+  extensions: ['js', 'jsx'],
 }, function () {
   return new BabelCompiler();
 });


### PR DESCRIPTION
Since we are already using Babel for compiling JS, the ecmascript extension should also support JSX files. Even Facebook is using Babel to compile JSX now. I don't see any reason why it should be on a different package for Meteor 1.2. Any reason why this is not supported?