### PR TITLE
Explain how to change logged-in user on client

### DIFF
--- a/docs/client/full-api/api/methods.md
+++ b/docs/client/full-api/api/methods.md
@@ -84,7 +84,7 @@ the [Meteor accounts system](#accounts_api) then this is handled for you.
 
 {{> autoApiBox "DDPCommon.MethodInvocation#setUserId"}}
 
-Call this function to change the currently logged in user on the
+Call this function to change the currently logged-in user on the
 connection that made this method call. This simply sets the value of
 `userId` for future method calls received on this connection. Pass
 `null` to log out the connection.
@@ -98,7 +98,7 @@ any future method calls on the connection. Any previous method calls on
 this connection will still see the value of `userId` that was in effect
 when they started.
 
-If you also want to change the logged in user on the client, then after calling
+If you also want to change the logged-in user on the client, then after calling
 `setUserId` on the server, call `Meteor.connection.setUserId(userId)` on the
 client.
 

--- a/docs/client/full-api/api/methods.md
+++ b/docs/client/full-api/api/methods.md
@@ -98,6 +98,18 @@ any future method calls on the connection. Any previous method calls on
 this connection will still see the value of `userId` that was in effect
 when they started.
 
+If you also want to change the logged in user on the client, then after calling
+`setUserId` on the server, call `Meteor.connection.setUserId(userId)` on the
+client. If you have user-specific subscriptions, they need to be updated, either
+by calling `Meteor.subscribe` again or by placing your subscriptions inside an
+autorun:
+
+```js
+Tracker.autorun(function() {
+  Meteor.subscribe('dataFor', Meteor.userId());
+});
+```
+
 {{> autoApiBox "DDPCommon.MethodInvocation#isSimulation"}}
 
 {{> autoApiBox "DDPCommon.MethodInvocation#unblock"}}

--- a/docs/client/full-api/api/methods.md
+++ b/docs/client/full-api/api/methods.md
@@ -100,15 +100,7 @@ when they started.
 
 If you also want to change the logged in user on the client, then after calling
 `setUserId` on the server, call `Meteor.connection.setUserId(userId)` on the
-client. If you have user-specific subscriptions, they need to be updated, either
-by calling `Meteor.subscribe` again or by placing your subscriptions inside an
-autorun:
-
-```js
-Tracker.autorun(function() {
-  Meteor.subscribe('dataFor', Meteor.userId());
-});
-```
+client.
 
 {{> autoApiBox "DDPCommon.MethodInvocation#isSimulation"}}
 


### PR DESCRIPTION
Those looking at the server-side `this.setUserId` docs will often want `Meteor.userId()` to update on the client as well, so I think it would be good to explain how to do that. 

On a separate note, the docs use the phrase `logged in user`. I believe it should have a hyphen: `logged-in user`. Should I submit a PR for that as well?

https://en.wikipedia.org/wiki/Compound_modifier
