### PR TITLE
Fix method calls during reconnect

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -199,7 +199,12 @@ Mongo.Collection = function (name, options) {
       },
       retrieveOriginals: function () {
         return self._collection.retrieveOriginals();
-      }
+      },
+
+      // Used to preserve current versions of documents across a store reset.
+      getDoc: function(id) {
+        return self.findOne(id);
+      },
     });
 
     if (!ok)


### PR DESCRIPTION
User could enter irrecoverable broken state after doing any action while
reconnecting (specifically between stream reset and quiescence).
In this state some or all documents in collections would be missing,
because the loop processing buffered messages is interrupted with an
exception in _process_added.

This commonly happened on slow/bad networks, such as mobile.