### PR TITLE
Add methods of the form BrowserPolicy.content.allow<ContentType>BlobUrl() to BrowserPolicy

### DIFF
--- a/packages/browser-policy-content/browser-policy-content.js
+++ b/packages/browser-policy-content/browser-policy-content.js
@@ -255,6 +255,7 @@ _.each(["script", "object", "img", "media",
          var allowMethodName = "allow" + methodResource + "Origin";
          var disallowMethodName = "disallow" + methodResource;
          var allowDataMethodName = "allow" + methodResource + "DataUrl";
+         var allowBlobMethodName = "allow" + methodResource + "BlobUrl";
          var allowSelfMethodName = "allow" + methodResource + "SameOrigin";
 
          var disallow = function () {
@@ -277,6 +278,10 @@ _.each(["script", "object", "img", "media",
          BrowserPolicy.content[allowDataMethodName] = function () {
            prepareForCspDirective(directive);
            cspSrcs[directive].push("data:");
+         };
+         BrowserPolicy.content[allowBlobMethodName] = function () {
+           prepareForCspDirective(directive);
+           cspSrcs[directive].push("blob:");
          };
          BrowserPolicy.content[allowSelfMethodName] = function () {
            prepareForCspDirective(directive);


### PR DESCRIPTION
This PR is for adding methods of the form BrowserPolicy.content.allow<ContentType>BlobUrl() to BrowserPolicy, to support the "blob:" CSP directive.
