### PR TITLE
Use Meteor.setTimeout to be able to use tests on the server

### DIFF
--- a/packages/tracker/tracker_tests.js
+++ b/packages/tracker/tracker_tests.js
@@ -452,7 +452,7 @@ Tinytest.addAsync('tracker - no infinite recomputation', function (test, onCompl
     c.invalidate();
   });
   test.isFalse(reran);
-  setTimeout(function () {
+  Meteor.setTimeout(function () {
     c.stop();
     Tracker.afterFlush(function () {
       test.isTrue(reran);


### PR DESCRIPTION
I am using the same tests file to run tests also for our implementation of server-side autorun. This is necessary for things to be correctly bound.