### PR TITLE
Use fast PRNG to generate `_id` for documents created outside methods

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,13 @@ message for more details.
 
 ## v.NEXT
 
+* `coll.insert()` now uses a faster (but cryptographically insecure)
+  algorithm to generate document IDs when called outside of a method
+  and an `_id` field is not explicitly passed. With this change, there
+  are no longer two algorithms used to generate document
+  IDs. `Random.id()` can still be used to generate crpytographically
+  secure document IDs. #5161
+
 * No longer include the `json` package by default, which contains code for
   `JSON.parse` and `JSON.stringify`.  (The last browser to not support JSON
   natively was Internet Explorer 7.)

--- a/packages/ddp-common/random_stream.js
+++ b/packages/ddp-common/random_stream.js
@@ -49,9 +49,11 @@ DDPCommon.RandomStream.get = function (scope, name) {
     name = "default";
   }
   if (!scope) {
-    // There was no scope passed in;
-    // the sequence won't actually be reproducible.
-    return Random;
+    // There was no scope passed in; the sequence won't actually be
+    // reproducible. but make it fast (and not cryptographically
+    // secure) anyways, so that the behavior is similar to what you'd
+    // get by passing in a scope.
+    return Random.fast;
   }
   var randomStream = scope.randomStream;
   if (!randomStream) {

--- a/packages/ddp-common/random_stream.js
+++ b/packages/ddp-common/random_stream.js
@@ -37,13 +37,14 @@ function randomToken() {
   return Random.hexString(20);
 };
 
-// Returns the random stream with the specified name, in the specified scope.
-// If scope is null (or otherwise falsey) then we will use Random, which will
-// give us as random numbers as possible, but won't produce the same
-// values across client and server.
-// However, scope will normally be the current DDP method invocation, so
-// we'll use the stream with the specified name, and we should get consistent
-// values on the client and server sides of a method call.
+// Returns the random stream with the specified name, in the specified
+// scope. If a scope is passed, then we use that to seed a (not
+// cryptographically secure) PRNG using the fast Alea algorithm.  If
+// scope is null (or otherwise falsey) then we use a generated seed.
+//
+// However, scope will normally be the current DDP method invocation,
+// so we'll use the stream with the specified name, and we should get
+// consistent values on the client and server sides of a method call.
 DDPCommon.RandomStream.get = function (scope, name) {
   if (!name) {
     name = "default";
@@ -53,7 +54,7 @@ DDPCommon.RandomStream.get = function (scope, name) {
     // reproducible. but make it fast (and not cryptographically
     // secure) anyways, so that the behavior is similar to what you'd
     // get by passing in a scope.
-    return Random.fast;
+    return Random.insecure;
   }
   var randomStream = scope.randomStream;
   if (!randomStream) {

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -62,14 +62,18 @@ Mongo.Collection = function (name, options) {
   switch (options.idGeneration) {
   case 'MONGO':
     self._makeNewID = function () {
-      var src = name ? DDP.randomStream('/collection/' + name) : Random;
+      var src = name
+            ? DDP.randomStream('/collection/' + name)
+            : Random.fast;
       return new Mongo.ObjectID(src.hexString(24));
     };
     break;
   case 'STRING':
   default:
     self._makeNewID = function () {
-      var src = name ? DDP.randomStream('/collection/' + name) : Random;
+      var src = name
+            ? DDP.randomStream('/collection/' + name)
+            : Random.fast;
       return src.id();
     };
     break;

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -64,7 +64,7 @@ Mongo.Collection = function (name, options) {
     self._makeNewID = function () {
       var src = name
             ? DDP.randomStream('/collection/' + name)
-            : Random.fast;
+            : Random.insecure;
       return new Mongo.ObjectID(src.hexString(24));
     };
     break;
@@ -73,7 +73,7 @@ Mongo.Collection = function (name, options) {
     self._makeNewID = function () {
       var src = name
             ? DDP.randomStream('/collection/' + name)
-            : Random.fast;
+            : Random.insecure;
       return src.id();
     };
     break;

--- a/packages/random/package.js
+++ b/packages/random/package.js
@@ -5,6 +5,7 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use('underscore');
+  api.use('ecmascript');
   api.export('Random');
   api.addFiles('random.js');
   api.addFiles('deprecated.js');
@@ -12,6 +13,7 @@ Package.onUse(function (api) {
 
 Package.onTest(function(api) {
   api.use('random');
+  api.use('ecmascript');
   api.use('tinytest');
   api.addFiles('random_tests.js', ['client', 'server']);
 });

--- a/packages/random/random.js
+++ b/packages/random/random.js
@@ -261,4 +261,4 @@ Random.createWithSeeds = function (...seeds) {
 
 // Used like `Random`, but much faster and not cryptographically
 // secure
-Random.fast = createAleaGeneratorWithGeneratedSeed();
+Random.insecure = createAleaGeneratorWithGeneratedSeed();

--- a/packages/random/random.js
+++ b/packages/random/random.js
@@ -89,36 +89,65 @@ var UNMISTAKABLE_CHARS = "23456789ABCDEFGHJKLMNPQRSTWXYZabcdefghijkmnopqrstuvwxy
 var BASE64_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" +
   "0123456789-_";
 
-// If seeds are provided, then the alea PRNG will be used, since cryptographic
-// PRNGs (Node crypto and window.crypto.getRandomValues) don't allow us to
-// specify seeds. The caller is responsible for making sure to provide a seed
-// for alea if a csprng is not available.
-var RandomGenerator = function (seedArray) {
+// `type` is one of `RandomGenerator.Type` as defined below.
+//
+// options:
+// - seeds: (required, only for RandomGenerator.Type.ALEA) an array
+//   whose items will be `toString`ed and used as the seed to the Alea
+//   algorithm
+var RandomGenerator = function (type, options) {
   var self = this;
-  if (seedArray !== undefined)
-    self.alea = Alea.apply(null, seedArray);
+  self.type = type;
+
+  if (!RandomGenerator.Type[type]) {
+    throw new Error("Unknown random generator type: " + type);
+  }
+
+  if (type === RandomGenerator.Type.ALEA) {
+    if (!options.seeds) {
+      throw new Error("No seeds were provided for Alea PRNG");
+    }
+    self.alea = Alea.apply(null, options.seeds);
+  }
+};
+
+// Types of PRNGs supported by the `RandomGenerator` class
+RandomGenerator.Type = {
+  // Use Node's built-in `crypto.getRandomBytes` (cryptographically
+  // secure but not seedable, runs only on the server). Reverts to
+  // `crypto.getPseudoRandomBytes` in the extremely uncommon case that
+  // there isn't enough entropy yet
+  NODE_CRYPTO: "NODE_CRYPTO",
+
+  // Use non-IE browser's built-in `window.crypto.getRandomValues`
+  // (cryptographically secure but not seedable, runs only in the
+  // browser).
+  BROWSER_CRYPTO: "BROWSER_CRYPTO",
+
+  // Use the *fast*, seedaable and not cryptographically secure
+  // Alea algorithm
+  ALEA: "ALEA",
 };
 
 RandomGenerator.prototype.fraction = function () {
   var self = this;
-  if (self.alea) {
+  if (self.type === RandomGenerator.Type.ALEA) {
     return self.alea();
-  } else if (nodeCrypto) {
+  } else if (self.type === RandomGenerator.Type.NODE_CRYPTO) {
     var numerator = parseInt(self.hexString(8), 16);
     return numerator * 2.3283064365386963e-10; // 2^-32
-  } else if (typeof window !== "undefined" && window.crypto &&
-             window.crypto.getRandomValues) {
+  } else if (self.type === RandomGenerator.Type.BROWSER_CRYPTO) {
     var array = new Uint32Array(1);
     window.crypto.getRandomValues(array);
     return array[0] * 2.3283064365386963e-10; // 2^-32
   } else {
-    throw new Error('No random generator available');
+    throw new Error('Unknown random generator type: ' + self.type);
   }
 };
 
 RandomGenerator.prototype.hexString = function (digits) {
   var self = this;
-  if (nodeCrypto && ! self.alea) {
+  if (self.type === RandomGenerator.Type.NODE_CRYPTO) {
     var numBytes = Math.ceil(digits / 2);
     var bytes;
     // Try to get cryptographically strong randomness. Fall back to
@@ -134,11 +163,7 @@ RandomGenerator.prototype.hexString = function (digits) {
     // of randomness, so we need to trim the last digit.
     return result.substring(0, digits);
   } else {
-    var hexDigits = [];
-    for (var i = 0; i < digits; ++i) {
-      hexDigits.push(self.choice("0123456789abcdef"));
-    }
-    return hexDigits.join('');
+    return this._randomString(digits, "0123456789abcdef");
   }
 };
 
@@ -203,16 +228,37 @@ var width = (typeof window !== 'undefined' && window.innerWidth) ||
 
 var agent = (typeof navigator !== 'undefined' && navigator.userAgent) || "";
 
-if (nodeCrypto ||
-    (typeof window !== "undefined" &&
-     window.crypto && window.crypto.getRandomValues))
-  Random = new RandomGenerator();
-else
-  Random = new RandomGenerator([new Date(), height, width, agent, Math.random()]);
-
-Random.createWithSeeds = function () {
-  if (arguments.length === 0) {
-    throw new Error('No seeds were provided');
-  }
-  return new RandomGenerator(arguments);
+function createAleaGeneratorWithGeneratedSeed() {
+  return new RandomGenerator(
+    RandomGenerator.Type.ALEA,
+    {seeds: [new Date, height, width, agent, Math.random()]});
 };
+
+if (Meteor.isServer) {
+  Random = new RandomGenerator(RandomGenerator.Type.NODE_CRYPTO);
+} else {
+  if (typeof window !== "undefined" && window.crypto &&
+      window.crypto.getRandomValues) {
+    Random = new RandomGenerator(RandomGenerator.Type.BROWSER_CRYPTO);
+  } else {
+    // On IE 10 and below, there's no browser crypto API
+    // available. Fall back to Alea
+    //
+    // XXX looks like at the moment, we use Alea in IE 11 as well,
+    // which has `window.msCrypto` instead of `window.crypto`.
+    Random = createAleaGeneratorWithGeneratedSeed();
+  }
+}
+
+// Create a non-cryptographically secure PRNG with a given seed (using
+// the Alea algorithm)
+Random.createWithSeeds = function (...seeds) {
+  if (seeds.length === 0) {
+    throw new Error("No seeds were provided");
+  }
+  return new RandomGenerator(RandomGenerator.Type.ALEA, {seeds: seeds});
+};
+
+// Used like `Random`, but much faster and not cryptographically
+// secure
+Random.fast = createAleaGeneratorWithGeneratedSeed();


### PR DESCRIPTION
This change harmonizes server document ID generation regardless of whether
it happens inside of a method or not, by using Alea in both cases.

This cuts time of inserting small documents outside of methods
on the server by over 30%, and more importantly makes it easier to be
confident in benchmarking numbers.

---

BACKGROUND

When calling `coll.insert()` on the server within methods, we use the Alea PRNG
(which is fast, can be seeded, and not cryptographically secure) to generate
the `_id` field for the newly created document (unless an `_id` field was
explicitly passed).

The reason we use Alea is so that we can seed the PRNG from the client, as to
ensure consistently chosen IDs for methods that create multiple documents and
run on both client and server.

Prior to this change, when calling `coll.insert()` on the server *not* inside
methods, we'd use Node's cryptographically secure `crypto.getRandomBytes()`
which is slower (due to allocating buffers that need to cross from JS
into native code).

With this change, we always use Alea when generating a document ID.

---

CRYPTOGRAPHICALLY SECURE IDS STILL AVAILABLE

If an app wants to guarantee using a cryptographically secure PRNG
when generating IDs, just generate IDs yourself:
`coll.insert({_id: Random.id(), ...})`.

`Random.id()` still uses a CSPRNG (unless you're on IE, or
on the server and not enough entropy has been collected, which is
basically never the case).

f you *want* the faster Alea algorithm, use `Random.fast.id()`
(The `Random.fast` object has all the same methods as on `Random`)

---

BENCHMARK RESULTS

Here are the measured times for inserting 5000 documents, before
and after this change (on my machine):

Benchmark                         | Before | After
--------------------------------- | ------ | ------
direct insert from `meteor shell` | 2179ms | 1520ms
a method called from a browser    | 1617ms | 1570ms
a method called from the server   | 1491ms | 1487ms
direct insert from the server     | 2272ms | 1445ms

(The benchmark can be found here:
https://github.com/avital/mongo-timing/blob/f32ea073b7bd242ef9294bd916327238c5f03ba2/benchmark2.sh)
