### PR TITLE
blaze: don't snapshot data context in each..in

### DIFF
--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -171,16 +171,15 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
     }, {
       addedAt: function (id, item, index) {
         Tracker.nonreactive(function () {
-          var newDataContext;
+          var newItemView;
           if (eachView.variableName) {
             // new-style #each (as in {{#each item in items}})
-            // the new data context is the same
-            newDataContext = Blaze.getData(eachView);
+            // doesn't create a new data context
+            newItemView = Blaze.View('item', eachView.contentFunc);
           } else {
-            newDataContext = item;
+            newItemView = Blaze.With(item, eachView.contentFunc);
           }
 
-          var newItemView = Blaze.With(newDataContext, eachView.contentFunc);
           eachView.numItems++;
 
           var bindings = {};


### PR DESCRIPTION
#5181

When using the new-style `each..in` tag, the data context in items is now reactive. Instead of creating a `Blaze.With` with a snapshot of the surrounding context, it now creates a plain old `Blaze.View`. Accessing the data context inside the item view now traverses out to reactively access whatever data context is outside.