### PR TITLE
Convert to HTML error page

### DIFF
--- a/tools/runners/run-proxy.js
+++ b/tools/runners/run-proxy.js
@@ -172,40 +172,7 @@ _.extend(Proxy.prototype, {
 
       var c = self.httpQueue.shift();
       if (self.mode === "errorpage") {
-        // XXX serve an app that shows the logs nicely and that also
-        // knows how to reload when the server comes back up
-        c.res.writeHead(200, {'Content-Type': 'text/html'});
-        c.res.write(`
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>App crashing</title>
-    <style type='text/css'>
-      body { margin: 0; }
-      h3 {
-        margin: 0;
-        font-family: sans-serif;
-        padding: 20px 10px 10px 10px;
-        background: #eee;
-      }
-      pre { margin: 20px; }
-    </style>
-  </head>
-
-  <body>
-    <h3>Your app is crashing. Here's the latest log:</h3>
-
-    <pre>`);
-
-        _.each(runLog.getLog(), function (item) {
-          c.res.write(item.message + "\n");
-        });
-
-        c.res.write(`</pre>
-  </body>
-</html>`)
-
-        c.res.end();
+        showErrorPage(c.res);
       } else {
         self.proxy.web(c.req, c.res, {
           target: 'http://' + self.proxyToHost + ':' + self.proxyToPort
@@ -237,5 +204,60 @@ _.extend(Proxy.prototype, {
     self._tryHandleConnections();
   }
 });
+
+function showErrorPage(res) {
+  // XXX serve an app that shows the logs nicely and that also
+  // knows how to reload when the server comes back up
+  res.writeHead(200, {'Content-Type': 'text/html'});
+  res.write(`
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>App crashing</title>
+    <style type='text/css'>
+      body { margin: 0; }
+      h3 {
+        margin: 0;
+        font-family: sans-serif;
+        padding: 20px 10px 10px 10px;
+        background: #eee;
+      }
+      pre { margin: 20px; }
+    </style>
+  </head>
+
+  <body>
+    <h3>Your app is crashing. Here's the latest log:</h3>
+
+    <pre>`);
+
+      _.each(runLog.getLog(), function (item) {
+        res.write(escapeEntities(item.message) + "\n");
+      });
+
+      res.write(`</pre>
+  </body>
+</html>`)
+
+  res.end();
+}
+
+// Copied from packages/blaze/preamble.js
+function escapeEntities(str) {
+  const escapeMap = {
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#x27;",
+    "`": "&#x60;", /* IE allows backtick-delimited attributes?? */
+    "&": "&amp;"
+  };
+
+  const escapeChar = function(c) {
+    return escapeMap[c];
+  };
+
+  return str.replace(/[&<>"'`]/g, escapeChar);
+}
 
 exports.Proxy = Proxy;

--- a/tools/runners/run-proxy.js
+++ b/tools/runners/run-proxy.js
@@ -174,12 +174,36 @@ _.extend(Proxy.prototype, {
       if (self.mode === "errorpage") {
         // XXX serve an app that shows the logs nicely and that also
         // knows how to reload when the server comes back up
-        c.res.writeHead(200, {'Content-Type': 'text/plain'});
-        c.res.write("Your app is crashing. Here's the latest log.\n\n");
+        c.res.writeHead(200, {'Content-Type': 'text/html'});
+        c.res.write(`
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>App crashing</title>
+    <style type='text/css'>
+      body { margin: 0; }
+      h3 {
+        margin: 0;
+        font-family: sans-serif;
+        padding: 20px 10px 10px 10px;
+        background: #eee;
+      }
+      pre { margin: 20px; }
+    </style>
+  </head>
+
+  <body>
+    <h3>Your app is crashing. Here's the latest log:</h3>
+
+    <pre>`);
 
         _.each(runLog.getLog(), function (item) {
           c.res.write(item.message + "\n");
         });
+
+        c.res.write(`</pre>
+  </body>
+</html>`)
 
         c.res.end();
       } else {


### PR DESCRIPTION
One big reason we need this is that the text format doesn't work on Windows
because of line endings. We could just replace the line endings based on
platform, but this seemed better overall.