### PR TITLE
Ability to expose additional path over http://meteor.local/<prefix> on Cordova

### DIFF
--- a/packages/meteor/cordova_environment.js
+++ b/packages/meteor/cordova_environment.js
@@ -6,3 +6,94 @@
  */
 Meteor.isCordova = true;
 
+Meteor.Cordova = Meteor.Cordova || {};
+
+Meteor.Cordova._additionalDataPath = null;
+Meteor.Cordova._additionalDataUrlPrefix = 'data';
+
+Meteor.Cordova._trimFileProtocol = function(path) {
+    var fileProtocol = 'file://';
+
+    if (path.substr(0, fileProtocol.length) === fileProtocol)
+        path = path.substr(fileProtocol.length);
+
+    return path;
+};
+
+/**
+ * @memberOf Meteor
+ * @summary Sets an additional path on the mobile device that will be available in the Cordova environment using the url http://meteor.local/data
+ * @locus Client
+ * @param {String} [path] An absolute, valid path to a directory on the mobile device
+ */
+Meteor.Cordova.setAdditionalDataPath = function(path) {
+
+    var cordovaUpdate = cordova && cordova.plugins && cordova.plugins.CordovaUpdate;
+    if (! cordovaUpdate) {
+        throw new Error('No CordovaUpdate plugin found. Is this running in Cordova?');
+    }
+
+    if (! path || path.length === 0) {
+        throw new Error('Path not specified.');
+    }
+
+    path = Meteor.Cordova._trimFileProtocol(path);
+
+    if (path.substr(0,1) !== '/') {
+        throw new Error('Relative paths are not supported.');
+    }
+
+    cordovaUpdate.setAdditionalDataPath(
+        path,
+        function() { Meteor.Cordova._additionalDataPath = path; },
+        function(error) { throw new Error(error); }
+    );
+};
+
+/**
+ * @memberOf Meteor
+ * @summary Sets the url prefix that the additional data path is available on so that the url looks like http://meteor.local/<prefix>. The default prefix is `data`.
+ * @locus Client
+ * @param {String} [prefix] Must be alphaumeric and different from `plugins`
+ */
+Meteor.Cordova.setAdditionalDataUrlPrefix = function(prefix) {
+
+    var cordovaUpdate = cordova && cordova.plugins && cordova.plugins.CordovaUpdate;
+    if (! cordovaUpdate) {
+        throw new Error('No CordovaUpdate plugin found. Is this running in Cordova?');
+    }
+
+    if (! prefix || prefix.length === 0) {
+        throw new Error('Prefix not specified.');
+    }
+
+    cordovaUpdate.setAdditionalDataUrlPrefix(
+        prefix,
+        function() { Meteor.Cordova._additionalDataUrlPrefix = prefix; },
+        function(error) { throw new Error(error); }
+    );
+};
+
+/**
+ * @memberOf Meteor
+ * @summary Super simple method that returns the proper url for accessing a file that is in the directory that was previously set as an additional data path.
+ * @locus Client
+ * @param {String} [path] An absolute, valid path to a file on the mobile device
+ */
+Meteor.getUrlForPath = function(path) {
+    if (! path) {
+        throw new Error('Path not provided.');
+    }
+
+    if (! Meteor.Cordova._additionalDataPath) {
+        throw new Error('Additional data path not set. Use Meteor.setAdditionalDataPath first.');
+    }
+
+    path = Meteor.Cordova._trimFileProtocol(path);
+
+    if (path.substr(0, Meteor.Cordova._additionalDataPath.length) !== Meteor.Cordova._additionalDataPath) {
+        throw new Error('Path must be an absolute path and start with the path previously set with Meteor.setAdditionalDataPath.');
+    }
+
+    return "http://meteor.local/" + Meteor.Cordova._additionalDataUrlPrefix + '/' + path.substr(Meteor.Cordova._additionalDataPath.length);
+};

--- a/packages/meteor/cordova_environment.js
+++ b/packages/meteor/cordova_environment.js
@@ -80,7 +80,7 @@ Meteor.Cordova.setAdditionalDataUrlPrefix = function(prefix) {
  * @locus Client
  * @param {String} [path] An absolute, valid path to a file on the mobile device
  */
-Meteor.getUrlForPath = function(path) {
+Meteor.Cordova.getUrlForPath = function(path) {
     if (! path) {
         throw new Error('Path not provided.');
     }

--- a/packages/meteor/cordova_environment_test.js
+++ b/packages/meteor/cordova_environment_test.js
@@ -3,4 +3,3 @@ Tinytest.add("environment - cordova basics", function (test) {
   test.isTrue(Meteor.isClient);
   test.isTrue(Meteor.isCordova);
 });
-

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -17,6 +17,8 @@ Cordova.depends({
   'cordova-plugin-legacy-whitelist': '1.1.0',
   // the cordova plugin built by Meteor Core team that "emulates a server" on
   // the mobile device. Serving the files and checking for the HCP updates.
+
+  // Update will be needed!
   'com.meteor.cordova-update': 'https://github.com/meteor/com.meteor.cordova-update/tarball/92fe99b7248075318f6446b288995d4381d24cd2'
 });
 


### PR DESCRIPTION
This is a solution for problems mentioned here https://github.com/meteor/meteor/issues/3799
@martijnwalraven: I know you are planning on rewriting the whole thing but take a look and let me know if this could maybe be accepted at least as a solution for now. If you have a different approach to this problem also let me know. This is just something I made for my team and we are already using this in some apps for like a half a year now. If this does not fit your plans that is ok, maybe at least you will be able to use some of this code :smile: 
The crucial part is here: https://github.com/meteor/com.meteor.cordova-update/pull/6

Code lacks tests but I am having a problem with `meteor test-packages --ios-device` - whenever I change anything in the test meteor goes into endless loop saying that the client was modified x1560 
times and goes up every second. No idea currently, maybe I should report it as bug.

Api is described in methods comments.

Demo:
1. checkout https://github.com/wojtkowiak/test
2. checkout https://github.com/wojtkowiak/com.meteor.cordova-update/tree/additional-data-path
3. checkout https://github.com/wojtkowiak/meteor/tree/additional-path
4. on line https://github.com/wojtkowiak/meteor/blob/additional-path/packages/webapp/package.js#L22 change the tarball url to file:///path/to/checkouted/com.meteor.cordova-update
5. run the app from checkout
