### PR TITLE
Fixes #5200

### DIFF
--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -1546,6 +1546,16 @@ DocsData = {
             "String"
           ]
         }
+      },
+      {
+        "description": "<p>Optional. A platform name if that preference is platform-specific (either &quot;<code>ios<code>&quot; or &quot;<code>android<code>&quot;).</p>",
+        "name": "platform",
+        "optional": true,
+        "type": {
+          "names": [
+            "String"
+          ]
+        }
       }
     ],
     "scope": "static",

--- a/docs/client/full-api/api/mobile-config.md
+++ b/docs/client/full-api/api/mobile-config.md
@@ -40,6 +40,8 @@ App.launchScreens({
 // Set PhoneGap/Cordova preferences
 App.setPreference('BackgroundColor', '0xff0000ff');
 App.setPreference('HideKeyboardFormAccessoryBar', true);
+App.setPreference('Orientation', 'default');
+App.setPreference('Orientation', 'all', 'ios');
 
 // Pass preferences for a particular PhoneGap/Cordova plugin
 App.configurePlugin('com.phonegap.plugins.facebookconnect', {

--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -79,22 +79,28 @@ export class CordovaBuilder {
 
     // Set some defaults different from the Cordova defaults
     this.additionalConfiguration = {
-      'webviewbounce': false,
-      'DisallowOverscroll': true,
-      'deployment-target': '7.0'
+      global: {
+        'webviewbounce': false,
+        'DisallowOverscroll': true,
+        'deployment-target': '7.0'
+      },
+      platform: {
+          ios: {},
+          android: {}
+      }
     };
 
     const packageMap = this.projectContext.packageMap;
 
     if (packageMap && packageMap.getInfo('launch-screen')) {
-      this.additionalConfiguration.AutoHideSplashScreen = false;
-      this.additionalConfiguration.SplashScreen = 'screen';
-      this.additionalConfiguration.SplashScreenDelay = 10000;
+      this.additionalConfiguration.global.AutoHideSplashScreen = false;
+      this.additionalConfiguration.global.SplashScreen = 'screen';
+      this.additionalConfiguration.global.SplashScreenDelay = 10000;
     }
 
     if (packageMap && packageMap.getInfo('mobile-status-bar')) {
-      this.additionalConfiguration.StatusBarOverlaysWebView = false;
-      this.additionalConfiguration.StatusBarStyle = 'default';
+      this.additionalConfiguration.global.StatusBarOverlaysWebView = false;
+      this.additionalConfiguration.global.StatusBarStyle = 'default';
     }
 
     // Default access rules for plain Meteor-Cordova apps.
@@ -214,8 +220,8 @@ export class CordovaBuilder {
       email: this.metadata.email
     }).txt(this.metadata.author);
 
-    // Set the additional configuration preferences
-    _.each(this.additionalConfiguration, (value, key) => {
+    // Set the additional global configuration preferences
+    _.each(this.additionalConfiguration.global, (value, key) => {
       config.element('preference', {
         name: key,
         value: value.toString()
@@ -234,8 +240,20 @@ export class CordovaBuilder {
       config.element('access', opts);
     });
 
-    const iosPlatformElement = config.element('platform', { name: 'ios' });
-    const androidPlatformElement = config.element('platform', { name: 'android' });
+    const platformElement = {
+        ios: config.element('platform', {name: 'ios'}),
+        android: config.element('platform', {name: 'android'})
+    }
+
+    // Set the additional global configuration preferences
+    _.each(this.additionalConfiguration.platform, (prefs, platform) => {
+      _.each(prefs, (value, key) => {
+        platformElement[platform].element('preference', {
+          name: key,
+          value: value.toString()
+        });
+      });
+    });
 
     if (shouldCopyResources) {
       // Prepare the resources folder
@@ -244,10 +262,10 @@ export class CordovaBuilder {
 
       Console.debug('Copying resources for mobile apps');
 
-      this.configureAndCopyImages(iconsIosSizes, iosPlatformElement, 'icon');
-      this.configureAndCopyImages(iconsAndroidSizes, androidPlatformElement, 'icon');
-      this.configureAndCopyImages(launchIosSizes, iosPlatformElement, 'splash');
-      this.configureAndCopyImages(launchAndroidSizes, androidPlatformElement, 'splash');
+      this.configureAndCopyImages(iconsIosSizes, platformElement.ios, 'icon');
+      this.configureAndCopyImages(iconsAndroidSizes, platformElement.android, 'icon');
+      this.configureAndCopyImages(launchIosSizes, platformElement.ios, 'splash');
+      this.configureAndCopyImages(launchAndroidSizes, platformElement.android, 'splash');
     }
 
     Console.debug('Writing new config.xml');
@@ -449,10 +467,19 @@ function createAppConfiguration(builder) {
      * @param {String} name A preference name supported by Cordova's
      * `config.xml`.
      * @param {String} value The value for that preference.
+     * @param {String} [platform] Optional. A platform name if that preference is platform-specific (either "<code>ios<code>" or "<code>android<code>").
      * @memberOf App
      */
-    setPreference: function (key, value) {
-      builder.additionalConfiguration[key] = value;
+    setPreference: function (key, value, platform) {
+      if (platform) {
+        if (!_.contains(['ios', 'android'], platform)) {
+          throw new Error('Unkown platform type in App.setPreference (must be: null, "ios" or "android"): ' + platform);
+        }
+
+        builder.additionalConfiguration.platform[platform][key] = value;
+      } else {
+        builder.additionalConfiguration.global[key] = value;
+      }
     },
 
     /**


### PR DESCRIPTION
I have added support for platform-specific preferences in ```mobile-config.js```. It fixes issue #5200.

Setting global preferences doesn't change. Add a third parameter to ```setParameter``` to specify the platform you want. So you can fix issue #5200 with these lines:
```javascript
App.setPreference('Orientation', 'default'); // optional
App.setPreference('Orientation', 'all', 'ios');
```

This works with any preferences you want.

I have changed the ```additionalConfiguration``` attribute in the ```tools/cordova/builder.js``` file :
- Before:
```javascript
this.additionalConfiguration = {
  'Orientation': 'default',
  ...
};
```
- Now:
```javascript
this.additionalConfiguration = {
  global: {
    'Orientation': 'default',
    ...
  },
  platform: {
    ios: {
      'Orientation': 'all',
    },
    android: {}
  }
};
```