### PR TITLE
Remove template tags

### DIFF
--- a/docs/client/common/quick-start.md
+++ b/docs/client/common/quick-start.md
@@ -1,4 +1,3 @@
-{{#template name="quickStart"}}
 ## Quick start!
 
 Meteor supports [OS X, Windows, and Linux](https://github.com/meteor/meteor/wiki/Supported-Platforms).
@@ -34,4 +33,3 @@ Then, open a new terminal tab and unleash it on the world (on a free server we p
 ```bash
 meteor deploy myapp.meteor.com
 ```
-{{/template}}


### PR DESCRIPTION
At the beginning and end of the **quick-start.md**, there were **template tags** that didn't seem to belong with the content.  I removed them to help make the document less confusing.