### PR TITLE
Add missing babel helpers required for es7.decorators and es6.modules

### DIFF
--- a/packages/babel-compiler/babel.js
+++ b/packages/babel-compiler/babel.js
@@ -1,7 +1,7 @@
 var meteorBabel = Npm.require('meteor-babel');
 
-// Read in user config from optional babel.json file, which must be located 
-// in the project root directory. babel.json must be formatted as in the 
+// Read in user config from optional .babelrc file, which must be located 
+// in the project root directory. .babelrc must be formatted as in the 
 // example below.
 //{
 //    "whitelist": [
@@ -18,7 +18,7 @@ var babelUserConfig = function () {
   var path = Npm.require('path');
 
   var appdir = process.env.PWD || process.cwd();
-  var babelOptionsFilePath = path.join(appdir, 'babel.json');
+  var babelOptionsFilePath = path.join(appdir, '.babelrc');
 
   if (fs.existsSync(babelOptionsFilePath)) {
     return JSON.parse(fs.readFileSync(babelOptionsFilePath, {encoding: 'utf8'}));
@@ -50,7 +50,7 @@ function getDefaultOptions(extraFeatures) {
   // information about what the default options are.
   var options = meteorBabel.getDefaultOptions(extraFeatures);
 
-  // Bring in user Babel config options from babel.json
+  // Bring in user Babel config options from .babelrc
   for (propName in babelUserConfig) {
     if (babelUserConfig.hasOwnProperty(propName)) {
       var prop = babelUserConfig[propName];

--- a/packages/babel-compiler/babel.js
+++ b/packages/babel-compiler/babel.js
@@ -1,30 +1,5 @@
 var meteorBabel = Npm.require('meteor-babel');
 
-// Read in user config from optional .babelrc file, which must be located 
-// in the project root directory. .babelrc must be formatted as in the 
-// example below.
-//{
-//    "whitelist": [
-//        "es7.decorators",
-//        "es7.classProperties",
-//        "es7.exportExtensions",
-//        "es7.comprehensions",
-//        "es6.modules"
-//    ],
-//    "stage": 0
-//}
-var babelUserConfig = function () {
-  var fs = Npm.require('fs');
-  var path = Npm.require('path');
-
-  var appdir = process.env.PWD || process.cwd();
-  var babelOptionsFilePath = path.join(appdir, '.babelrc');
-
-  if (fs.existsSync(babelOptionsFilePath)) {
-    return JSON.parse(fs.readFileSync(babelOptionsFilePath, {encoding: 'utf8'}));
-  }
-}();
-
 function validateExtraFeatures(extraFeatures) {
   if (extraFeatures) {
     check(extraFeatures, {
@@ -49,21 +24,6 @@ function getDefaultOptions(extraFeatures) {
   // See https://github.com/meteor/babel/blob/master/options.js for more
   // information about what the default options are.
   var options = meteorBabel.getDefaultOptions(extraFeatures);
-
-  // Bring in user Babel config options from .babelrc
-  for (propName in babelUserConfig) {
-    if (babelUserConfig.hasOwnProperty(propName)) {
-      var prop = babelUserConfig[propName];
-      if (prop instanceof Array) {
-        prop.forEach(function (opt) {
-          if (options[propName].indexOf(opt) === -1)
-            options[propName].push(opt);
-        })
-      } else {
-        options[propName] = prop;
-      }
-    }
-  }
 
   // The sourceMap option should probably be removed from the default
   // options returned by meteorBabel.getDefaultOptions.

--- a/packages/babel-runtime/babel-runtime.js
+++ b/packages/babel-runtime/babel-runtime.js
@@ -25,7 +25,19 @@ function canDefineNonEnumerableProperties() {
 // The name `babelHelpers` is hard-coded in Babel.  Otherwise we would make it
 // something capitalized and more descriptive, like `BabelRuntime`.
 babelHelpers = {
-  // Provides support for es7.decorators
+  // Provides support for es7.decorators 
+  defineDecoratedPropertyDescriptor: function (target, key, descriptors) {
+    var _descriptor = descriptors[key];
+    if (!_descriptor) return;
+    var descriptor = {};
+
+    for (var _key in _descriptor) descriptor[_key] = _descriptor[_key];
+
+    descriptor.value = descriptor.initializer ? descriptor.initializer.call(target) : undefined;
+    Object.defineProperty(target, key, descriptor);
+  },
+    
+  // Provides support for es7.decorators 
   createDecoratedClass: (function () {
         function defineProperties(target, descriptors, initializers) {
             for (var i = 0; i < descriptors.length; i++) {

--- a/packages/babel-runtime/babel-runtime.js
+++ b/packages/babel-runtime/babel-runtime.js
@@ -25,6 +25,20 @@ function canDefineNonEnumerableProperties() {
 // The name `babelHelpers` is hard-coded in Babel.  Otherwise we would make it
 // something capitalized and more descriptive, like `BabelRuntime`.
 babelHelpers = {
+  // Provides support for es7.decorators
+  createDecoratedClass: function (obj) {
+    return obj && obj.__esModule ? obj : {
+      "default": obj
+    };
+  },
+
+  // Provides support for es6.modules and "import ... from" keywords
+  interopRequireDefault: function (obj) {
+    return obj && obj.__esModule ? obj : {
+      "default": obj
+    };
+  },
+
   // Meteor-specific runtime helper for wrapping the object of for-in
   // loops, so that inherited Array methods defined by es5-shim can be
   // ignored in browsers where they cannot be defined as non-enumerable.

--- a/packages/babel-runtime/babel-runtime.js
+++ b/packages/babel-runtime/babel-runtime.js
@@ -26,11 +26,37 @@ function canDefineNonEnumerableProperties() {
 // something capitalized and more descriptive, like `BabelRuntime`.
 babelHelpers = {
   // Provides support for es7.decorators
-  createDecoratedClass: function (obj) {
-    return obj && obj.__esModule ? obj : {
-      "default": obj
-    };
-  },
+  createDecoratedClass: (function () {
+        function defineProperties(target, descriptors, initializers) {
+            for (var i = 0; i < descriptors.length; i++) {
+                var descriptor = descriptors[i];
+                var decorators = descriptor.decorators;
+                var key = descriptor.key;
+                delete descriptor.key;
+                delete descriptor.decorators;
+                descriptor.enumerable = descriptor.enumerable || false;
+                descriptor.configurable = true;
+                if ('value' in descriptor || descriptor.initializer) descriptor.writable = true;
+                if (decorators) {
+                    for (var f = 0; f < decorators.length; f++) {
+                        var decorator = decorators[f];
+                        if (typeof decorator === 'function') { descriptor = decorator(target, key, descriptor) || descriptor; } else { throw new TypeError('The decorator for method ' + descriptor.key + ' is of the invalid type ' + typeof decorator); }
+                    }
+                    if (descriptor.initializer !== undefined) {
+                        initializers[key] = descriptor;
+                        continue;
+                    }
+                }
+                Object.defineProperty(target, key, descriptor);
+            }
+        }
+
+        return function (Constructor, protoProps, staticProps, protoInitializers, staticInitializers) {
+            if (protoProps) defineProperties(Constructor.prototype, protoProps, protoInitializers);
+            if (staticProps) defineProperties(Constructor, staticProps, staticInitializers);
+            return Constructor;
+        };
+    })(),
 
   // Provides support for es6.modules and "import ... from" keywords
   interopRequireDefault: function (obj) {


### PR DESCRIPTION
Added missing babel helpers required for es7.decorators and es6.modules (see also issue https://github.com/meteor/meteor/issues/5246).

The `ecmascript` Meteor 1.2 package supports custom whitelisting of various Babel transformers through the use of the `.babelrc` file, placed in the project root directory. This is standard Babel functionality, please read https://babeljs.io/docs/usage/babelrc/.

However, some of the transformers require in-browser runtime support through extra functions called Babel helpers, which are defined on the `babelHelpers` object in the `babel-runtime.js` file of the `babel-runtime` package. 

**ES7 decorators** and **ES6 modules** require the following helper functions, which are not included as standard: `createDecoratedClass`, `defineDecoratedPropertyDescriptor` and `interopRequireDefault`. This PR adds these helper functions to the `babel-runtime` package.

`.babelrc` must be formatted as in the example below.
```json
{
    "whitelist": [
        "es7.decorators",
        "es7.classProperties",
        "es7.exportExtensions",
        "es7.comprehensions",
        "es6.modules"
    ]
}
````
