### PR TITLE
Throw error for invalid exception handler

### DIFF
--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -94,6 +94,8 @@ Meteor.bindEnvironment = function (func, onException, _this) {
         error && error.stack || error
       );
     };
+  } else if (typeof(onException) !== 'function') {
+    throw new Error('onException argument must be a function, string or undefined for Meteor.bindEnvironment().');
   }
 
   return function (/* arguments */) {


### PR DESCRIPTION
Meteor.bindEnvironment() can have an invalid error handler accidentally passed as the second argument, especially in CoffeeScript where the issue is not easy to find. This can cause a cryptic error message about an exception being thrown when onException() itself is being called.