### PR TITLE
(minimongo) Fix pull modifier not excepting null values

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2326,6 +2326,7 @@ Tinytest.add("minimongo - modify", function (test) {
   modify({a: [2, 1, 2]}, {$pull: {a: 1}}, {a: [2, 2]});
   modify({a: [2, 1, 2]}, {$pull: {a: 2}}, {a: [1]});
   modify({a: [2, 1, 2]}, {$pull: {a: 3}}, {a: [2, 1, 2]});
+  modify({a: [1, null, 2, null]}, {$pull: {a: null}}, {a: [1, 2]});
   modify({a: []}, {$pull: {a: 3}}, {a: []});
   modify({a: [[2], [2, 1], [3]]}, {$pull: {a: [2, 1]}},
          {a: [[2], [3]]}); // tested

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -361,7 +361,7 @@ var MODIFIERS = {
       throw MinimongoError("Cannot apply $pull/pullAll modifier to non-array");
     else {
       var out = [];
-      if (typeof arg === "object" && !(arg instanceof Array)) {
+      if (arg != null && typeof arg === "object" && !(arg instanceof Array)) {
         // XXX would be much nicer to compile this once, rather than
         // for each document we modify.. but usually we're not
         // modifying that many documents, so we'll let it slide for


### PR DESCRIPTION
Originally created because of [angular-meteor issue #689](https://github.com/Urigo/angular-meteor/issues/689). From now on the $pull modifier would except null values.