### PR TITLE
Update simple-todos.js

### DIFF
--- a/examples/simple-todos/simple-todos.js
+++ b/examples/simple-todos/simple-todos.js
@@ -49,7 +49,7 @@ if (Meteor.isClient) {
       // Clear form
       event.target.text.value = "";
     },
-    "change .hide-completed input": function (event) {
+    "change .hide-completed": function (event) {
       Session.set("hideCompleted", event.target.checked);
     }
   });


### PR DESCRIPTION
It works without *input*, also in the event maps documentation (http://docs.meteor.com/#/full/eventmaps) the various formats don't have the third part like in the example above. I have just started learning this, so sorry if I am missing something.