### PR TITLE
adding check for NODE_ENV before overriding in 'meteor run'

### DIFF
--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -196,7 +196,9 @@ _.extend(AppProcess.prototype, {
     env.APP_ID = self.projectContext.appIdentifier;
 
     // Display errors from (eg) the NPM connect module over the network.
-    env.NODE_ENV = 'development';
+    if (!env.NODE_ENV) {
+      env.NODE_ENV = 'development';
+    }
     // We run the server behind our own proxy, so we need to increment
     // the HTTP forwarded count.
     env.HTTP_FORWARDED_COUNT =


### PR DESCRIPTION
Very simple improvement here.

When running `meteor` or `meteor run`, the NODE_ENV is set to 'development'.  In some cases when we are wanting to test production-like behaviour we try to override this variable locally, but are never able to.  Found this line and adding a check to wrap around it.
