### PR TITLE
wrap Meteor call in bindEnvironment

### DIFF
--- a/packages/spiderable/spiderable_server.js
+++ b/packages/spiderable/spiderable_server.js
@@ -113,7 +113,7 @@ WebApp.connectHandlers.use(function (req, res, next) {
        ("exec phantomjs " + phantomJsArgs + " /dev/stdin <<'END'\n" +
         phantomScript + "END\n")],
       {timeout: Spiderable.requestTimeoutMs, maxBuffer: MAX_BUFFER},
-      function (error, stdout, stderr) {
+      Meteor.bindEnvironment( function (error, stdout, stderr) {
         if (!error && /<html/i.test(stdout)) {
           res.writeHead(200, {'Content-Type': 'text/html; charset=UTF-8'});
           res.end(stdout);
@@ -127,7 +127,7 @@ WebApp.connectHandlers.use(function (req, res, next) {
 
           next();
         }
-      });
+      }));
   } else {
     next();
   }


### PR DESCRIPTION
Call to `Meteor._debug` fails because this is not wrapped in `Meteor.bindEnvironment`

Full error:
```
W20151011-20:45:16.805(-7)? (STDERR) Error: Meteor code must always run within a Fiber. Try wrapping callbacks that you pass to non-Meteor libraries with Meteor.bindEnvironment.
W20151011-20:45:16.805(-7)? (STDERR)     at Object.Meteor._nodeCodeMustBeInFiber (packages/meteor/dynamics_nodejs.js:9:1)
W20151011-20:45:16.805(-7)? (STDERR)     at [object Object]._.extend.get (packages/meteor/dynamics_nodejs.js:21:1)
W20151011-20:45:16.805(-7)? (STDERR)     at [object Object].RouteController.lookupOption (packages/iron_router/lib/route_controller.js:66:1)
W20151011-20:45:16.805(-7)? (STDERR)     at new Controller.extend.constructor (packages/iron_router/lib/route_controller.js:26:1)
W20151011-20:45:16.805(-7)? (STDERR)     at [object Object].ctor (packages/iron_core/lib/iron_core.js:88:1)
W20151011-20:45:16.805(-7)? (STDERR)     at Function.Router.createController (packages/iron_router/lib/router.js:201:1)
W20151011-20:45:16.805(-7)? (STDERR)     at Function.Router.dispatch (packages/iron_router/lib/router_server.js:39:1)
W20151011-20:45:16.805(-7)? (STDERR)     at Object.router (packages/iron_router/lib/router.js:15:1)
W20151011-20:45:16.806(-7)? (STDERR)     at next (/Users/clarencel/.meteor/packages/webapp/.1.2.2.a66w3t++os+web.browser+web.cordova/npm/node_modules/connect/lib/proto.js:190:15)
W20151011-20:45:16.806(-7)? (STDERR)     at packages/spiderable/spiderable_server.js:128:1
```
