### PR TITLE
Update source-map to last patch version (0.1.43)

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -38,7 +38,7 @@ var packageJson = {
     fstream: "https://github.com/meteor/fstream/tarball/d11b9ec4a13918447c8af7559c243c190744dd1c",
     tar: "1.0.2",
     kexec: "0.2.0",
-    "source-map": "0.1.40",
+    "source-map": "0.1.43",
     "browserstack-webdriver": "2.41.1",
     "node-inspector": "0.7.4",
     chalk: "0.5.1",


### PR DESCRIPTION
Major bugs have been fixed in source-map 0.1.41. I can't use source maps generated by Webpack with 0.1.40, but 0.1.41 is working fine. Meteor should update source-map to the last patched revision.

This is a major blocker to the Webpack compiler because until then, we have no source map.