### PR TITLE
Allow PORT as a string if it matches named pipe pattern. Fixes #4413

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -439,7 +439,7 @@ var getUrlPrefixForArch = function (arch) {
     '' : '/' + '__' + arch.replace(/^web\./, '');
 };
 
-// parse port to see if its a named pipe. If so, return as-is (String), otherwise return as Int
+// parse port to see if its a Windows Server style named pipe. If so, return as-is (String), otherwise return as Int
 WebAppInternals.parsePort = function (port) {
   if( /\\\\?.+\\pipe\\?.+/.test(port) ) {
     return port;

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -439,6 +439,15 @@ var getUrlPrefixForArch = function (arch) {
     '' : '/' + '__' + arch.replace(/^web\./, '');
 };
 
+// parse port to see if its a named pipe. If so, return as-is (String), otherwise return as Int
+WebAppInternals.parsePort = function (port) {
+  if( /\\\\?.+\\pipe\\?.+/.test(port) ) {
+    return port;
+  }
+
+  return parseInt(port);
+};
+
 var runWebAppServer = function () {
   var shuttingDown = false;
   var syncQueue = new Meteor._SynchronousQueue();
@@ -755,7 +764,7 @@ var runWebAppServer = function () {
     WebAppInternals.generateBoilerplate();
 
     // only start listening after all the startup code has run.
-    var localPort = parseInt(process.env.PORT) || 0;
+    var localPort = WebAppInternals.parsePort(process.env.PORT) || 0;
     var host = process.env.BIND_IP;
     var localIp = host || '0.0.0.0';
     httpServer.listen(localPort, localIp, Meteor.bindEnvironment(function() {

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -158,6 +158,7 @@ Tinytest.add("webapp - generating boilerplate should not change runtime config",
 
 // Support 'named pipes' (strings) as ports for support of Windows Server / Azure deployments
 Tinytest.add("webapp - port should be parsed as int unless it is a named pipe", function(test){
+  // Named pipes on Windows Server follow the format: \\.\pipe\{randomstring} or \\{servername}\pipe\{randomstring}
   var namedPipe = "\\\\.\\pipe\\b27429e9-61e3-4c12-8bfe-950fa3295f74";
   var namedPipeServer = "\\\\SERVERNAME-1234\\pipe\\6e157e98-faef-49e4-a0cf-241037223308";
 
@@ -169,7 +170,7 @@ Tinytest.add("webapp - port should be parsed as int unless it is a named pipe", 
       8080);
   test.equal(WebAppInternals.parsePort("8080"),
       8080);
-  test.equal(WebAppInternals.parsePort("8080abc"),
+  test.equal(WebAppInternals.parsePort("8080abc"), // ensure strangely formatted ports still work for backwards compatibility
       8080);
 });
 

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -156,6 +156,23 @@ Tinytest.add("webapp - generating boilerplate should not change runtime config",
   test.isFalse(__meteor_runtime_config__.WEBAPP_TEST_KEY);
 });
 
+// Support 'named pipes' (strings) as ports for support of Windows Server / Azure deployments
+Tinytest.add("webapp - port should be parsed as int unless it is a named pipe", function(test){
+  var namedPipe = "\\\\.\\pipe\\b27429e9-61e3-4c12-8bfe-950fa3295f74";
+  var namedPipeServer = "\\\\SERVERNAME-1234\\pipe\\6e157e98-faef-49e4-a0cf-241037223308";
+
+  test.equal(WebAppInternals.parsePort(namedPipe),
+      "\\\\.\\pipe\\b27429e9-61e3-4c12-8bfe-950fa3295f74");
+  test.equal(WebAppInternals.parsePort(namedPipeServer),
+      "\\\\SERVERNAME-1234\\pipe\\6e157e98-faef-49e4-a0cf-241037223308");
+  test.equal(WebAppInternals.parsePort(8080),
+      8080);
+  test.equal(WebAppInternals.parsePort("8080"),
+      8080);
+  test.equal(WebAppInternals.parsePort("8080abc"),
+      8080);
+});
+
 __meteor_runtime_config__.WEBAPP_TEST_A = '<p>foo</p>';
 __meteor_runtime_config__.WEBAPP_TEST_B = '</script>';
 


### PR DESCRIPTION
Windows Server uses 'named pipes' instead of a port number. This allows named pipes to be used according to this pattern: [Pipe Names](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365783(v=vs.85).aspx).  
Fixes https://github.com/meteor/meteor/issues/4413