### PR TITLE
Simple typo fix in Google OAuth configuration

### DIFF
--- a/packages/google/google_configure.html
+++ b/packages/google/google_configure.html
@@ -16,7 +16,7 @@
       On the left sidebar, go to "APIs &amp; auth" and then, "Credentials". "Create New Client ID", then select "Web application" as the type.
     </li>
     <li>
-     Set Authorized Javascript Origins to: <span class="url">{{siteUrl}}</span>
+     Set Authorized Javascript Origins to: <span class="url">{{siteUrlNoTrail}}</span>
     </li>
     <li>
       Set Authorized Redirect URI to: <span class="url">{{siteUrl}}_oauth/google</span>

--- a/packages/google/google_configure.js
+++ b/packages/google/google_configure.js
@@ -3,7 +3,7 @@ Template.configureLoginServiceDialogForGoogle.helpers({
     return Meteor.absoluteUrl();
   },
   siteUrlNoTrail: function () {
-    if (Meteor.absoluteUrl.slice(-1) === '/') {
+    if (Meteor.absoluteUrl().slice(-1) === '/') {
       return Meteor.absoluteUrl().slice(0, 1);
     } else {
       return Meteor.absoluteUrl();

--- a/packages/google/google_configure.js
+++ b/packages/google/google_configure.js
@@ -4,7 +4,7 @@ Template.configureLoginServiceDialogForGoogle.helpers({
   },
   siteUrlNoTrail: function () {
     if (Meteor.absoluteUrl.slice(-1) === '/') {
-      return Meteor.absoluteUrl().slice(0, 1_;
+      return Meteor.absoluteUrl().slice(0, 1);
     } else {
       return Meteor.absoluteUrl();
     }

--- a/packages/google/google_configure.js
+++ b/packages/google/google_configure.js
@@ -1,6 +1,13 @@
 Template.configureLoginServiceDialogForGoogle.helpers({
   siteUrl: function () {
     return Meteor.absoluteUrl();
+  },
+  siteUrlNoTrail: function () {
+    if (Meteor.absoluteUrl.slice(-1) === '/') {
+      return Meteor.absoluteUrl().slice(0, 1_;
+    } else {
+      return Meteor.absoluteUrl();
+    }
   }
 });
 


### PR DESCRIPTION
Google's OAuth credentials page does not permit trailing slashes. This patch resolves this.