### PR TITLE
change webapp interface to allow a function hook instead of a prefix

### DIFF
--- a/packages/boilerplate-generator/boilerplate_web.browser.html
+++ b/packages/boilerplate-generator/boilerplate_web.browser.html
@@ -1,13 +1,13 @@
 <html {{htmlAttributes}}>
 <head>
-{{#each css}}  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="{{../bundledJsCssPrefix}}{{url}}">{{/each}}
+{{#each css}}  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="{{../bundledJsCssUrlRewriteHook url}}">{{/each}}
 
 {{#if inlineScriptsAllowed}}
 <script type='text/javascript'>__meteor_runtime_config__ = JSON.parse(decodeURIComponent({{meteorRuntimeConfig}}));</script>
 {{else}}
 <script type='text/javascript' src='{{rootUrlPathPrefix}}/meteor_runtime_config.js'></script>
 {{/if}}
-{{#each js}}  <script type="text/javascript" src="{{../bundledJsCssPrefix}}{{url}}"></script>
+{{#each js}}  <script type="text/javascript" src="{{../bundledJsCssUrlRewriteHook url}}"></script>
 {{/each}}
 {{#each additionalStaticJs}}
   {{#if ../inlineScriptsAllowed}}

--- a/packages/boilerplate-generator/boilerplate_web.cordova.html
+++ b/packages/boilerplate-generator/boilerplate_web.cordova.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height">
   <meta name="msapplication-tap-highlight" content="no">
 
+{{! We are explicitly not using bundledJsCssUrlRewriteHook: in cordova we serve assets up directly from disk, so rewriting the URL does not make sense }}
+
 {{#each css}}  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="{{url}}">{{/each}}
 
   <script type='text/javascript'>

--- a/packages/boilerplate-generator/boilerplate_web.cordova.html
+++ b/packages/boilerplate-generator/boilerplate_web.cordova.html
@@ -24,7 +24,7 @@
   </script>
 
   <script type="text/javascript" src="/cordova.js"></script>
-{{#each js}}  <script type="text/javascript" src="{{url}"></script>
+{{#each js}}  <script type="text/javascript" src="{{url}}"></script>
 {{/each}}
 {{#each additionalStaticJs}}
   {{#if ../inlineScriptsAllowed}}

--- a/packages/boilerplate-generator/boilerplate_web.cordova.html
+++ b/packages/boilerplate-generator/boilerplate_web.cordova.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height">
   <meta name="msapplication-tap-highlight" content="no">
 
-{{#each css}}  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="{{../bundledJsCssPrefix}}{{url}}">{{/each}}
+{{#each css}}  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="{{url}}">{{/each}}
 
   <script type='text/javascript'>
     __meteor_runtime_config__ = JSON.parse(decodeURIComponent({{meteorRuntimeConfig}}));
@@ -22,7 +22,7 @@
   </script>
 
   <script type="text/javascript" src="/cordova.js"></script>
-{{#each js}}  <script type="text/javascript" src="{{../bundledJsCssPrefix}}{{url}}"></script>
+{{#each js}}  <script type="text/javascript" src="{{url}"></script>
 {{/each}}
 {{#each additionalStaticJs}}
   {{#if ../inlineScriptsAllowed}}

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -37,8 +37,6 @@ var archPath = {};
 
 var bundledJsCssUrlRewriteHook;
 
-var JsCssHook;
-
 var sha1 = function (contents) {
   var hash = crypto.createHash('sha1');
   hash.update(contents);
@@ -797,7 +795,7 @@ WebAppInternals.setInlineScriptsAllowed = function (value) {
 };
 
 
-WebAppInternals.bundledJsCssUrlRewriteHook = function (hookFn) {
+WebAppInternals.setBundledJsCssUrlRewriteHook = function (hookFn) {
   bundledJsCssUrlRewriteHook = hookFn;
   WebAppInternals.generateBoilerplate();
 };

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -35,7 +35,9 @@ WebApp.clientPrograms = {};
 // XXX maps archs to program path on filesystem
 var archPath = {};
 
-var bundledJsCssPrefix;
+var bundledJsCssUrlRewriteHook;
+
+var JsCssHook;
 
 var sha1 = function (contents) {
   var hash = crypto.createHash('sha1');
@@ -271,16 +273,11 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
     additionalOptions.runtimeConfigOverrides || {}
   );
 
-  var jsCssPrefix;
-  if (arch === 'web.cordova') {
-    // in cordova we serve assets up directly from disk so it doesn't make
-    // sense to use the prefix (ordinarily something like a CDN) and go out
-    // to the internet for those files.
-    jsCssPrefix = '';
-  } else {
-    jsCssPrefix = bundledJsCssPrefix ||
-      __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
-  }
+  var jsCssUrlRewriteHook = bundledJsCssUrlRewriteHook || function (url) {
+    var bundledPrefix =
+       __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
+    return bundledPrefix + url;
+  };
 
   return new Boilerplate(arch, manifest,
     _.extend({
@@ -305,7 +302,7 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
         meteorRuntimeConfig: JSON.stringify(
           encodeURIComponent(JSON.stringify(runtimeConfig))),
         rootUrlPathPrefix: __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '',
-        bundledJsCssPrefix: jsCssPrefix,
+        bundledJsCssUrlRewriteHook: jsCssUrlRewriteHook,
         inlineScriptsAllowed: WebAppInternals.inlineScriptsAllowed(),
         inline: additionalOptions.inline
       }
@@ -799,9 +796,18 @@ WebAppInternals.setInlineScriptsAllowed = function (value) {
   WebAppInternals.generateBoilerplate();
 };
 
-WebAppInternals.setBundledJsCssPrefix = function (prefix) {
-  bundledJsCssPrefix = prefix;
+
+WebAppInternals.bundledJsCssUrlRewriteHook = function (hookFn) {
+  bundledJsCssUrlRewriteHook = hookFn;
   WebAppInternals.generateBoilerplate();
+};
+
+WebAppInternals.setBundledJsCssPrefix = function (prefix) {
+  var self = this;
+  self.bundledJsCssUrlRewriteHook(
+    function (url) {
+      return prefix + url;
+  });
 };
 
 // Packages can call `WebAppInternals.addStaticJs` to specify static

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -802,7 +802,7 @@ WebAppInternals.setBundledJsCssUrlRewriteHook = function (hookFn) {
 
 WebAppInternals.setBundledJsCssPrefix = function (prefix) {
   var self = this;
-  self.bundledJsCssUrlRewriteHook(
+  self.setBundledJsCssUrlRewriteHook(
     function (url) {
       return prefix + url;
   });

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -346,7 +346,7 @@ class File {
       return; // eg, already got setUrlToHash
     if (/\?/.test(this.url))
       throw new Error("URL already has a query string");
-    this.url += "?" + this.hash();
+    this.url += "?hash=" + this.hash();
     this.cacheable = true;
   }
 


### PR DESCRIPTION
Add a bundledJsCssUrlRewriteHook function, which takes in a function and applies it
to the URL. Do not allow this on Cordova (handle that by just not calling it on Cordova).
Reimplement the bundledJsCssPrefix as a call to this function.