### PR TITLE
Falsey in Collection#deny and Collection#allow

### DIFF
--- a/packages/mongo/allow_tests.js
+++ b/packages/mongo/allow_tests.js
@@ -828,6 +828,28 @@ if (Meteor.isServer) {
 
     _.each(['insert', 'update', 'remove'], function (key) {
       var options = {};
+      options[key] = false;
+      test.throws(function () {
+        collection.allow(options);
+      });
+      test.throws(function () {
+        collection.deny(options);
+      });
+    });
+
+    _.each(['insert', 'update', 'remove'], function (key) {
+      var options = {};
+      options[key] = undefined;
+      test.throws(function () {
+        collection.allow(options);
+      });
+      test.throws(function () {
+        collection.deny(options);
+      });
+    });
+
+    _.each(['insert', 'update', 'remove'], function (key) {
+      var options = {};
       options[key] = ['an array']; // this should be a function, not an array
       test.throws(function () {
         collection.allow(options);

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -750,7 +750,7 @@ Mongo.Collection.ObjectID = Mongo.ObjectID;
     self._restricted = true;
 
     _.each(['insert', 'update', 'remove'], function (name) {
-      if (options[name]) {
+      if (options.hasOwnProperty(name)) {
         if (!(options[name] instanceof Function)) {
           throw new Error(allowOrDeny + ": Value for `" + name + "` must be a function");
         }


### PR DESCRIPTION
This minor change will help prevent potential security issues.

Currently, the following snippet gets silently ignored:

```js
Articles.allow({
  insert: false
});
```

Instead, the above snippet should throw an error.

The code currently does check truthy values, but doesn't check falsey values. Instead, it should check all defined values. This pull request fixes the check for truthy values with defined values.

I decided to use `Object#hasOwnProperty` instead of e.g. `options[name] !== undefined` because in some situation `undefined` might also be passed to one of the keys.

This issue came to light after a team member wrote the following piece of code:

```js
var isAdmin = function() {
    return Roles.userIsInRole(Meteor.userId(), ['admin']);
};

Articles.deny({
    insert: !isAdmin
});
```

Luckily this was flagged during a code review. But to my surprise, Meteor didn't throw any errors. After investigating, I found the truthy check to be the issue.

I hope to get this request merged!