### PR TITLE
Add buildMode option in compiler plugins

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -692,6 +692,7 @@ class Target {
   _runCompilerPlugins() {
     buildmessage.assertInJob();
     const processor = new compilerPluginModule.CompilerPluginProcessor({
+      buildMode: this.buildMode,
       unibuilds: this.unibuilds,
       arch: this.arch,
       isopackCache: this.isopackCache,

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -67,6 +67,7 @@ const LINKER_CACHE = new LRU({
 
 exports.CompilerPluginProcessor = function (options) {
   var self = this;
+  self.buildMode = options.buildMode;
   self.unibuilds = options.unibuilds;
   self.arch = options.arch;
   self.isopackCache = options.isopackCache;
@@ -137,7 +138,9 @@ _.extend(exports.CompilerPluginProcessor.prototype, {
             sourceProcessor.userPlugin.processFilesForTarget.bind(
               sourceProcessor.userPlugin));
           try {
-            markedMethod(inputFiles);
+            markedMethod(inputFiles, {
+              buildMode: self.buildMode
+            });
           } catch (e) {
             buildmessage.exception(e);
           }


### PR DESCRIPTION
For some compiler plugins (let's say Webpack :)), it is VERY important to know if we are building in production or development mode. It adds stuff on development for hot module replacement and start a dev server as an example.

By passing the buildMode option to the plugins, it will solve this problem. I badly need this. This is how people are doing it right now: `NODE_ENV=production meteor --production` to run in production. I would rather have only `meteor --production` and know we are running in production.

Let me know if I need to fix/add anything!
