### PR TITLE
Hook to alter service prov, query update or create

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1348,6 +1348,15 @@ Ap.updateOrCreateUserFromExternalService = function (
     selector[serviceIdKey] = serviceData.id;
   }
 
+  // HOOK: Check if an update is needed to the user account from user supplied hook,
+  // caller should provide array of filter functions for modifying selector
+  var _checkUpdateHooks = Accounts.onUpdateUserFindExistingUserHooks || [];
+  if(_checkUpdateHooks && Array.isArray(_checkUpdateHooks) && _checkUpdateHooks.length > 0){
+	  _checkUpdateHooks.map(function (func) { //Each update hook can check the selector and apply a callback
+			selector = func(selector, serviceName, serviceData, options); //Each hook should return a modified selector
+		});
+	}
+
   var user = this.users.findOne(selector);
 
   if (user) {


### PR DESCRIPTION
This pull request removes the need for hacky workarounds (several packages do this) to merge social accounts. This PR allows the user to modify the query logic used to determine if a newly connected service should be merged with an existing service. An example follows below. I have currently monkey patched the Meteor source to add this hook:

```
Accounts.onUpdateUserFindExistingUserHooks = [
 	function(selector, serviceName, serviceData, options){
		_.each(selector, function(value, key){
			var obj = {};
			obj[key] = value;
			or.push(obj);
		});

		var email = null;

		var pushEmail = function(val){
			or.push({emails: {$elemMatch: {address: val}}});
		}

		if(serviceData.emails){
			serviceData.emails.map(function(email){
				var val = email.email || email.address;
				if(val && email.verified) pushEmail(val);
			});
		}

		var newSelector = {$or: or};
		return newSelector;
	} 
]
```

This checks if an email verified by a third party provider already appears in the user database. If so, it modifies the selector used to find an existing user:

```
var user = this.users.findOne(selector);
```

Meteor then updates the existing user record and finishes the login process. This is a significant improvement over the existing practice in many packages of using the `Accounts.onCreateUser` hook to query for similar information, then delete the old account and merge its properties on the new account. The intention (I think) of such solutions is to merge accounts while preserving the new login session. However, this results in potential data loss / data integrity issues.

**My solution is not opinionated on how this should happen, and leaves it up to the developer to define.**
