### PR TITLE
Fix documentation for Cordova.depends

### DIFF
--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -911,7 +911,7 @@ _.extend(PackageSource.prototype, {
        * [plugins.cordova.io](http://plugins.cordova.io/), so the plugins and
        * versions specified must exist there. Alternatively, the version
        * can be replaced with a GitHub tarball URL as described in the
-       * [Cordova / PhoneGap](https://github.com/meteor/meteor/wiki/Meteor-Cordova-Phonegap-integration#meteor-packages-with-cordovaphonegap-dependencies)
+       * [Cordova](https://github.com/meteor/meteor/wiki/Meteor-Cordova-integration#meteor-packages-with-cordova-dependencies)
        * page of the Meteor wiki on GitHub.
        * @param  {Object} dependencies An object where the keys are plugin
        * names and the values are version numbers or GitHub tarball URLs
@@ -929,7 +929,7 @@ _.extend(PackageSource.prototype, {
        * ```js
        * Cordova.depends({
        *   "org.apache.cordova.camera":
-       *     "https://github.com/apache/cordova-plugin-camera/tarball/d84b875c"
+       *     "https://github.com/apache/cordova-plugin-camera/tarball/d84b875c449d68937520a1b352e09f6d39044fbf"
        * });
        * ```
        *


### PR DESCRIPTION
The link to the github documentation on Meteor's cordova integration pointed to an outdated page that redirects to the new page, which means the anchor link was totally broken.

In addition, the example using a github tarball URL used the short form of the sha, which Meteor doesn't accept -- trying to use that example would throw `must declare exact version of dependency: org.apache.cordova.camera@https://github.com/apache/cordova-plugin-camera/tarball/d84b875c`