### PR TITLE
Update the account username docs

### DIFF
--- a/docs/client/basic/sections/accounts.md
+++ b/docs/client/basic/sections/accounts.md
@@ -46,7 +46,7 @@ user document:
 ```
 {
   _id: "bbca5d6a-2156-41c4-89da-0329e8c99a4f",  // Meteor.userId()
-  username: "cool_kid_13", // unique name
+  username: "cool_kid_13", // optional non unique name only provided by certain services
   emails: [
     // each email address can only belong to one user.
     { address: "cool@example.com", verified: true },
@@ -75,7 +75,7 @@ user document:
 A user document can contain any data you want to store about a user. Meteor
 treats the following fields specially:
 
-- `username`: a unique String identifying the user.
+- `username`: a optional non-unique String identifying the user.
 - `emails`: an Array of Objects with keys `address` and `verified`;
   an email address may belong to at most one user. `verified` is
   a Boolean which is true if the user has [verified the

--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -103,7 +103,7 @@ DocsData = {
     "name": "createUser",
     "options": [
       {
-        "description": "<p>A unique name for this user.</p>",
+        "description": "<p>A name for this user.</p>",
         "name": "username",
         "type": {
           "names": [

--- a/docs/client/full-api/api/accounts.md
+++ b/docs/client/full-api/api/accounts.md
@@ -36,7 +36,7 @@ user document:
 
     {
       _id: "bbca5d6a-2156-41c4-89da-0329e8c99a4f",  // Meteor.userId()
-      username: "cool_kid_13", // unique name
+      username: "cool_kid_13", // non-unique name
       emails: [
         // each email address can only belong to one user.
         { address: "cool@example.com", verified: true },
@@ -64,7 +64,7 @@ user document:
 A user document can contain any data you want to store about a user. Meteor
 treats the following fields specially:
 
-- `username`: a unique String identifying the user.
+- `username`: a non-unique String identifying the user.
 - `emails`: an Array of Objects with keys `address` and `verified`;
   an email address may belong to at most one user. `verified` is
   a Boolean which is true if the user has [verified the


### PR DESCRIPTION
Note: I'm a complete meteor noob but as far as I can tell this field no longer exists or certainly not as documented

For one the none of the `accounts-xxx` packages ask for a username. [`accounts-password`](https://atmospherejs.com/meteor/accounts-password) only asks for email and password, no username is set. [`accounts-facebook`](https://atmospherejs.com/meteor/accounts-facebook) sets username but does no check for uniqueness.

Even if this is a bad PR I hope you'll consider the docs seem to be out of date. Maybe someone that knows it better can submit a better PR.