### PR TITLE
Adding new Facebook user-agent to spiderable

### DIFF
--- a/packages/spiderable/spiderable_server.js
+++ b/packages/spiderable/spiderable_server.js
@@ -14,6 +14,7 @@ var urlParser = Npm.require('url');
 // here. I shed a silent tear.
 Spiderable.userAgentRegExps = [
   /^facebookexternalhit/i,
+  /^Facebot/,
   /^linkedinbot/i,
   /^twitterbot/i,
   /^slackbot-linkexpanding/i


### PR DESCRIPTION
According to Facebook
(https://developers.facebook.com/docs/sharing/webmasters/crawler), they
have a new (May 2014) crawler named Facebot. Spiderable doesn't
currently work for Facebot. It ought to.  

PS. I shed a tear along with @stuabilo that this is even a thing.