### PR TITLE
Faster DDPCommon.stringifyDDP

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -82,7 +82,7 @@ var isInfOrNan = function (obj) {
 var builtinConverters = [
   { // Date
     matchJSONValue: function (obj) {
-      return _.has(obj, '$date') && _.size(obj) === 1;
+      return _.has(obj, '$date') && hasSize(obj, 1);
     },
     matchObject: function (obj) {
       return obj instanceof Date;
@@ -97,7 +97,7 @@ var builtinConverters = [
   { // NaN, Inf, -Inf. (These are the only objects with typeof !== 'object'
     // which we match.)
     matchJSONValue: function (obj) {
-      return _.has(obj, '$InfNaN') && _.size(obj) === 1;
+      return _.has(obj, '$InfNaN') && hasSize(obj, 1);
     },
     matchObject: isInfOrNan,
     toJSONValue: function (obj) {
@@ -116,7 +116,7 @@ var builtinConverters = [
   },
   { // Binary
     matchJSONValue: function (obj) {
-      return _.has(obj, '$binary') && _.size(obj) === 1;
+      return _.has(obj, '$binary') && hasSize(obj, 1);
     },
     matchObject: function (obj) {
       return typeof Uint8Array !== 'undefined' && obj instanceof Uint8Array
@@ -131,10 +131,10 @@ var builtinConverters = [
   },
   { // Escaping one level
     matchJSONValue: function (obj) {
-      return _.has(obj, '$escape') && _.size(obj) === 1;
+      return _.has(obj, '$escape') && hasSize(obj, 1);
     },
     matchObject: function (obj) {
-      if (_.isEmpty(obj) || _.size(obj) > 2) {
+      if (!hasSize(obj, 1)) {
         return false;
       }
       return _.any(builtinConverters, function (converter) {
@@ -158,7 +158,7 @@ var builtinConverters = [
   },
   { // Custom
     matchJSONValue: function (obj) {
-      return _.has(obj, '$type') && _.has(obj, '$value') && _.size(obj) === 2;
+      return _.has(obj, '$type') && _.has(obj, '$value') && hasSize(obj, 2);
     },
     matchObject: function (obj) {
       return EJSON._isCustomType(obj);
@@ -450,7 +450,7 @@ EJSON.equals = function (a, b, options) {
       i++;
       return true;
     });
-    return ret && _.size(b) === i;
+    return ret && hasSize(b, i);
   }
 };
 

--- a/packages/ejson/has_size.js
+++ b/packages/ejson/has_size.js
@@ -1,0 +1,29 @@
+// Like `_.size(obj) === n` but faster by looking at at most `n+1`
+// items
+hasSize = function _hasSize(obj, n) {
+  var seen = 0;
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      seen++;
+      if (seen > n) {
+        return false;
+      }
+    }
+  }
+  return seen === n;
+};
+
+// Like `_.size(obj) <= n` but faster by looking at at most `n+1`
+// items
+hasSizeAtMost = function _hasSizeAtMost(obj, n) {
+  var seen = 0;
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      seen++;
+      if (seen > n) {
+        return false;
+      }
+    }
+  }
+  return true;
+};

--- a/packages/ejson/has_size_test.js
+++ b/packages/ejson/has_size_test.js
@@ -1,0 +1,34 @@
+Tinytest.add("ejson - hasSize", function (test) {
+  test.isTrue(hasSize({}, 0));
+  test.isFalse(hasSize({}, 1));
+  test.isFalse(hasSize({}, 2));
+  test.isFalse(hasSize({}, 3));
+
+  test.isFalse(hasSize({a: 1}, 0));
+  test.isTrue(hasSize({a: 1}, 1));
+  test.isFalse(hasSize({a: 1}, 2));
+  test.isFalse(hasSize({a: 1}, 3));
+
+  test.isFalse(hasSize({a: 1, b: 2}, 0));
+  test.isFalse(hasSize({a: 1, b: 2}, 1));
+  test.isTrue(hasSize({a: 1, b: 2}, 2));
+  test.isFalse(hasSize({a: 1, b: 2}, 3));
+});
+
+Tinytest.add("ejson - hasSizeAtMost", function (test) {
+  test.isTrue(hasSizeAtMost({}, 0));
+  test.isTrue(hasSizeAtMost({}, 1));
+  test.isTrue(hasSizeAtMost({}, 2));
+  test.isTrue(hasSizeAtMost({}, 3));
+
+  test.isFalse(hasSizeAtMost({a: 1}, 0));
+  test.isTrue(hasSizeAtMost({a: 1}, 1));
+  test.isTrue(hasSizeAtMost({a: 1}, 2));
+  test.isTrue(hasSizeAtMost({a: 1}, 3));
+
+  test.isFalse(hasSizeAtMost({a: 1, b: 2}, 0));
+  test.isFalse(hasSizeAtMost({a: 1, b: 2}, 1));
+  test.isTrue(hasSizeAtMost({a: 1, b: 2}, 2));
+  test.isTrue(hasSizeAtMost({a: 1, b: 2}, 3));
+});
+

--- a/packages/ejson/package.js
+++ b/packages/ejson/package.js
@@ -7,6 +7,8 @@ Package.onUse(function (api) {
   api.use(['underscore', 'base64']);
   api.export('EJSON');
   api.export('EJSONTest', {testOnly: true});
+  api.export(['hasSize', 'hasSizeAtMost'], {testOnly: true});
+  api.addFiles('has_size.js', ['client', 'server']);
   api.addFiles('ejson.js', ['client', 'server']);
   api.addFiles('stringify.js', ['client', 'server']);
 });
@@ -16,5 +18,6 @@ Package.onTest(function (api) {
   api.use(['tinytest', 'underscore']);
 
   api.addFiles('custom_models_for_tests.js', ['client', 'server']);
+  api.addFiles('has_size_test.js', ['client', 'server']);
   api.addFiles('ejson_test.js', ['client', 'server']);
 });


### PR DESCRIPTION
A few EJSON utility functions called from DDPCommon.stringifyDDP called
`_.size` for bounded size checks on objects. Instead, we now use faster
`hasSize` and `hasSizeAtMost` utility functions.

Improves performance of a local benchmark for stringifying 100000 small
messages from ~4600ms to ~4000ms (a 14% improvement)

This change was motivated by a production application being found to spend a
majority of server CPU time stringifying DDP messages.  (The app in question
has in the meanwhile been optimized by sending down far fewer DDP messages)
