### PR TITLE
Patch to allow users to override root cert list

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -33,6 +33,7 @@ var Connection = function (url, options) {
     },
     heartbeatInterval: 17500,
     heartbeatTimeout: 15000,
+    npmFayeOptions: {},
     // These options are only for testing.
     reloadWithOutstanding: false,
     supportedDDPVersions: DDPCommon.SUPPORTED_DDP_VERSIONS,
@@ -59,7 +60,8 @@ var Connection = function (url, options) {
       // should have a real API for handling client-stream-level
       // errors.
       _dontPrintErrors: options._dontPrintErrors,
-      connectTimeoutMs: options.connectTimeoutMs
+      connectTimeoutMs: options.connectTimeoutMs,
+      npmFayeOptions: options.npmFayeOptions
     });
   }
 

--- a/packages/ddp-client/stream_client_nodejs.js
+++ b/packages/ddp-client/stream_client_nodejs.js
@@ -21,6 +21,7 @@ LivedataTest.ClientStream = function (endpoint, options) {
   self.endpoint = endpoint;
 
   self.headers = self.options.headers || {};
+  self.npmFayeOptions = self.options.npmFayeOptions || {};
 
   self._initCommon(self.options);
 
@@ -137,6 +138,7 @@ _.extend(LivedataTest.ClientStream.prototype, {
       headers: self.headers,
       extensions: [deflate]
     };
+    fayeOptions = _.extend(fayeOptions, self.npmFayeOptions);
     var proxyUrl = self._getProxyUrl(targetUrl);
     if (proxyUrl) {
       fayeOptions.proxy = { origin: proxyUrl };

--- a/tools/meteor-services/service-connection.js
+++ b/tools/meteor-services/service-connection.js
@@ -1,7 +1,7 @@
 var Future = require("fibers/future");
 var _ = require("underscore");
 var isopackets = require('../tool-env/isopackets.js');
-var fs = require('fs');
+var files = require('../fs/files.js');
 
 // Wrapper to manage a connection to a DDP service. The main difference between
 // it and a raw DDP connection is that the constructor blocks until a successful
@@ -53,7 +53,7 @@ var ServiceConnection = function (endpointUrl, options) {
   });
   if (process.env.CAFILE) {
     options.npmFayeOptions = {
-      ca: fs.readFileSync(process.env.CAFILE)
+      ca: files.readFile(process.env.CAFILE)
     }
   }
 

--- a/tools/meteor-services/service-connection.js
+++ b/tools/meteor-services/service-connection.js
@@ -1,6 +1,7 @@
 var Future = require("fibers/future");
 var _ = require("underscore");
 var isopackets = require('../tool-env/isopackets.js');
+var fs = require('fs');
 
 // Wrapper to manage a connection to a DDP service. The main difference between
 // it and a raw DDP connection is that the constructor blocks until a successful
@@ -50,6 +51,11 @@ var ServiceConnection = function (endpointUrl, options) {
       connectFuture.return();
     }
   });
+  if (process.env.CAFILE) {
+    options.npmFayeOptions = {
+      ca: fs.readFileSync(process.env.CAFILE)
+    }
+  }
 
   self.connection = Package['ddp-client'].DDP.connect(endpointUrl, options);
 

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -170,7 +170,7 @@ _.extend(exports, {
     // This should never, ever be false, or else why are you using SSL?
     options.forceSSL = true;
     if (process.env.CAFILE) {
-      options.ca = files.readFileSync(process.env.CAFILE);
+      options.ca = files.readFile(process.env.CAFILE);
     }
 
     // followRedirect is very dangerous because request does not

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -169,6 +169,9 @@ _.extend(exports, {
 
     // This should never, ever be false, or else why are you using SSL?
     options.forceSSL = true;
+    if (process.env.CAFILE) {
+      options.ca = files.readFileSync(process.env.CAFILE);
+    }
 
     // followRedirect is very dangerous because request does not
     // appear to segregate cookies by origin, so any cookies (and


### PR DESCRIPTION
Fixes #4757
Update to Pull Request #4827
Uses environment variable CAFILE (to match NPM) which must contain a fully qualified path to a pem format root certificate to include in the list of trusted root certs.

This additional root certificate will be needed for those behind an SSL inspection proxy which acts as an SSL termination point and resigns the traffic with its own root certificate.