### PR TITLE
Correct History for 1.2.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -41,7 +41,7 @@
   Meteor. [#5458](https://github.com/meteor/meteor/issues/5458)
 
 * Normally, you can't deploy to free meteor.com hosting or Galaxy from a
-  non-Linux machine if you have *local* non-published packages with binary
+  non-Unix machine if you have *local* non-published packages with binary
   dependencies, nor can you run `meteor build --architecture SomeOtherArch`. As
   a temporary workaround, if you set the `METEOR_DEP_BINARY_WORKAROUND`
   variable, you will be able to deploy to Galaxy (but not free meteor.com


### PR DESCRIPTION
Both Mac and Linux are based off Unix, but Mac is not based off Linux, therefore, you can run it on a `non-Unix` machine rather than a `non-Linux` machine.