### PR TITLE
WIP: Move allow/deny entirely into a separate package and refactor insert/update/remove

### DIFF
--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -5372,9 +5372,9 @@ DocsData = {
     "summary": "Constructor for a Collection"
   },
   "Mongo.Collection#allow": {
-    "filepath": "mongo/collection.js",
+    "filepath": "allow-deny/allow-deny.js",
     "kind": "function",
-    "lineno": 791,
+    "lineno": 43,
     "locus": "Server",
     "longname": "Mongo.Collection#allow",
     "memberof": "Mongo.Collection",
@@ -5422,9 +5422,9 @@ DocsData = {
     "summary": "Allow users to write directly to this collection from client code, subject to limitations you define."
   },
   "Mongo.Collection#deny": {
-    "filepath": "mongo/collection.js",
+    "filepath": "allow-deny/allow-deny.js",
     "kind": "function",
-    "lineno": 803,
+    "lineno": 58,
     "locus": "Server",
     "longname": "Mongo.Collection#deny",
     "memberof": "Mongo.Collection",
@@ -5474,7 +5474,7 @@ DocsData = {
   "Mongo.Collection#find": {
     "filepath": "mongo/collection.js",
     "kind": "function",
-    "lineno": 261,
+    "lineno": 264,
     "locus": "Anywhere",
     "longname": "Mongo.Collection#find",
     "memberof": "Mongo.Collection",
@@ -5571,7 +5571,7 @@ DocsData = {
   "Mongo.Collection#findOne": {
     "filepath": "mongo/collection.js",
     "kind": "function",
-    "lineno": 287,
+    "lineno": 290,
     "locus": "Anywhere",
     "longname": "Mongo.Collection#findOne",
     "memberof": "Mongo.Collection",
@@ -5659,7 +5659,7 @@ DocsData = {
   "Mongo.Collection#insert": {
     "filepath": "mongo/collection.js",
     "kind": "function",
-    "lineno": 431,
+    "lineno": 426,
     "locus": "Anywhere",
     "longname": "Mongo.Collection#insert",
     "memberof": "Mongo.Collection",
@@ -5692,7 +5692,7 @@ DocsData = {
   "Mongo.Collection#rawCollection": {
     "filepath": "mongo/collection.js",
     "kind": "function",
-    "lineno": 660,
+    "lineno": 681,
     "locus": "Server",
     "longname": "Mongo.Collection#rawCollection",
     "memberof": "Mongo.Collection",
@@ -5705,7 +5705,7 @@ DocsData = {
   "Mongo.Collection#rawDatabase": {
     "filepath": "mongo/collection.js",
     "kind": "function",
-    "lineno": 672,
+    "lineno": 693,
     "locus": "Server",
     "longname": "Mongo.Collection#rawDatabase",
     "memberof": "Mongo.Collection",
@@ -5718,7 +5718,7 @@ DocsData = {
   "Mongo.Collection#remove": {
     "filepath": "mongo/collection.js",
     "kind": "function",
-    "lineno": 455,
+    "lineno": 568,
     "locus": "Anywhere",
     "longname": "Mongo.Collection#remove",
     "memberof": "Mongo.Collection",
@@ -5751,7 +5751,7 @@ DocsData = {
   "Mongo.Collection#update": {
     "filepath": "mongo/collection.js",
     "kind": "function",
-    "lineno": 441,
+    "lineno": 507,
     "locus": "Anywhere",
     "longname": "Mongo.Collection#update",
     "memberof": "Mongo.Collection",
@@ -5821,7 +5821,7 @@ DocsData = {
   "Mongo.Collection#upsert": {
     "filepath": "mongo/collection.js",
     "kind": "function",
-    "lineno": 617,
+    "lineno": 635,
     "locus": "Anywhere",
     "longname": "Mongo.Collection#upsert",
     "memberof": "Mongo.Collection",
@@ -5883,7 +5883,7 @@ DocsData = {
     "filepath": "mongo/collection.js",
     "instancename": "cursor",
     "kind": "class",
-    "lineno": 694,
+    "lineno": 715,
     "longname": "Mongo.Cursor",
     "memberof": "Mongo",
     "name": "Cursor",
@@ -6051,7 +6051,7 @@ DocsData = {
   "Mongo.ObjectID": {
     "filepath": "mongo/collection.js",
     "kind": "class",
-    "lineno": 687,
+    "lineno": 708,
     "locus": "Anywhere",
     "longname": "Mongo.ObjectID",
     "memberof": "Mongo",

--- a/packages/allow-deny/allow-deny-tests.js
+++ b/packages/allow-deny/allow-deny-tests.js
@@ -1,0 +1,1 @@
+// Currently in 'mongo' package

--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -1,0 +1,493 @@
+///
+/// Remote methods and access control.
+///
+
+// Restrict default mutators on collection. allow() and deny() take the
+// same options:
+//
+// options.insert {Function(userId, doc)}
+//   return true to allow/deny adding this document
+//
+// options.update {Function(userId, docs, fields, modifier)}
+//   return true to allow/deny updating these documents.
+//   `fields` is passed as an array of fields that are to be modified
+//
+// options.remove {Function(userId, docs)}
+//   return true to allow/deny removing these documents
+//
+// options.fetch {Array}
+//   Fields to fetch for these validators. If any call to allow or deny
+//   does not have this option then all fields are loaded.
+//
+// allow and deny can be called multiple times. The validators are
+// evaluated as follows:
+// - If neither deny() nor allow() has been called on the collection,
+//   then the request is allowed if and only if the "insecure" smart
+//   package is in use.
+// - Otherwise, if any deny() function returns true, the request is denied.
+// - Otherwise, if any allow() function returns true, the request is allowed.
+// - Otherwise, the request is denied.
+//
+// Meteor may call your deny() and allow() functions in any order, and may not
+// call all of them if it is able to make a decision without calling them all
+// (so don't include side effects).
+
+AllowDeny = {
+  CollectionPrototype: {}
+};
+
+// In the `mongo` package, we will extend Mongo.Collection.prototype with these
+// methods
+const CollectionPrototype = AllowDeny.CollectionPrototype;
+
+/**
+ * @summary Allow users to write directly to this collection from client code, subject to limitations you define.
+ * @locus Server
+ * @method allow
+ * @memberOf Mongo.Collection
+ * @instance
+ * @param {Object} options
+ * @param {Function} options.insert,update,remove Functions that look at a proposed modification to the database and return true if it should be allowed.
+ * @param {String[]} options.fetch Optional performance enhancement. Limits the fields that will be fetched from the database for inspection by your `update` and `remove` functions.
+ * @param {Function} options.transform Overrides `transform` on the  [`Collection`](#collections).  Pass `null` to disable transformation.
+ */
+CollectionPrototype.allow = function(options) {
+  addValidator(this, 'allow', options);
+};
+
+/**
+ * @summary Override `allow` rules.
+ * @locus Server
+ * @method deny
+ * @memberOf Mongo.Collection
+ * @instance
+ * @param {Object} options
+ * @param {Function} options.insert,update,remove Functions that look at a proposed modification to the database and return true if it should be denied, even if an [allow](#allow) rule says otherwise.
+ * @param {String[]} options.fetch Optional performance enhancement. Limits the fields that will be fetched from the database for inspection by your `update` and `remove` functions.
+ * @param {Function} options.transform Overrides `transform` on the  [`Collection`](#collections).  Pass `null` to disable transformation.
+ */
+CollectionPrototype.deny = function(options) {
+  addValidator(this, 'deny', options);
+};
+
+CollectionPrototype._defineMutationMethods = function() {
+  const self = this;
+
+  // set to true once we call any allow or deny methods. If true, use
+  // allow/deny semantics. If false, use insecure mode semantics.
+  self._restricted = false;
+
+  // Insecure mode (default to allowing writes). Defaults to 'undefined' which
+  // means insecure iff the insecure package is loaded. This property can be
+  // overriden by tests or packages wishing to change insecure mode behavior of
+  // their collections.
+  self._insecure = undefined;
+
+  self._validators = {
+    insert: {allow: [], deny: []},
+    update: {allow: [], deny: []},
+    remove: {allow: [], deny: []},
+    upsert: {allow: [], deny: []}, // dummy arrays; can't set these!
+    fetch: [],
+    fetchAllFields: false
+  };
+
+  if (!self._name)
+    return; // anonymous collection
+
+  // XXX Think about method namespacing. Maybe methods should be
+  // "Meteor:Mongo:insert/NAME"?
+  self._prefix = '/' + self._name + '/';
+
+  // mutation methods
+  if (self._connection) {
+    const m = {};
+
+    _.each(['insert', 'update', 'remove'], function (method) {
+      m[self._prefix + method] = function (/* ... */) {
+        // All the methods do their own validation, instead of using check().
+        check(arguments, [Match.Any]);
+        const args = _.toArray(arguments);
+        try {
+          // For an insert, if the client didn't specify an _id, generate one
+          // now; because this uses DDP.randomStream, it will be consistent with
+          // what the client generated. We generate it now rather than later so
+          // that if (eg) an allow/deny rule does an insert to the same
+          // collection (not that it really should), the generated _id will
+          // still be the first use of the stream and will be consistent.
+          //
+          // However, we don't actually stick the _id onto the document yet,
+          // because we want allow/deny rules to be able to differentiate
+          // between arbitrary client-specified _id fields and merely
+          // client-controlled-via-randomSeed fields.
+          let generatedId = null;
+          if (method === "insert" && !_.has(args[0], '_id')) {
+            generatedId = self._makeNewID();
+          }
+
+          if (this.isSimulation) {
+            // In a client simulation, you can do any mutation (even with a
+            // complex selector).
+            if (generatedId !== null)
+              args[0]._id = generatedId;
+            return self._collection[method].apply(
+              self._collection, args);
+          }
+
+          // This is the server receiving a method call from the client.
+
+          // We don't allow arbitrary selectors in mutations from the client: only
+          // single-ID selectors.
+          if (method !== 'insert')
+            throwIfSelectorIsNotId(args[0], method);
+
+          if (self._restricted) {
+            // short circuit if there is no way it will pass.
+            if (self._validators[method].allow.length === 0) {
+              throw new Meteor.Error(
+                403, "Access denied. No allow validators set on restricted " +
+                  "collection for method '" + method + "'.");
+            }
+
+            const validatedMethodName =
+                  '_validated' + method.charAt(0).toUpperCase() + method.slice(1);
+            args.unshift(this.userId);
+            method === 'insert' && args.push(generatedId);
+            return self[validatedMethodName].apply(self, args);
+          } else if (self._isInsecure()) {
+            if (generatedId !== null)
+              args[0]._id = generatedId;
+            // In insecure mode, allow any mutation (with a simple selector).
+            // XXX This is kind of bogus.  Instead of blindly passing whatever
+            //     we get from the network to this function, we should actually
+            //     know the correct arguments for the function and pass just
+            //     them.  For example, if you have an extraneous extra null
+            //     argument and this is Mongo on the server, the .wrapAsync'd
+            //     functions like update will get confused and pass the
+            //     "fut.resolver()" in the wrong slot, where _update will never
+            //     invoke it. Bam, broken DDP connection.  Probably should just
+            //     take this whole method and write it three times, invoking
+            //     helpers for the common code.
+            return self._collection[method].apply(self._collection, args);
+          } else {
+            // In secure mode, if we haven't called allow or deny, then nothing
+            // is permitted.
+            throw new Meteor.Error(403, "Access denied");
+          }
+        } catch (e) {
+          if (e.name === 'MongoError' || e.name === 'MinimongoError') {
+            throw new Meteor.Error(409, e.toString());
+          } else {
+            throw e;
+          }
+        }
+      };
+    });
+    // Minimongo on the server gets no stubs; instead, by default
+    // it wait()s until its result is ready, yielding.
+    // This matches the behavior of macromongo on the server better.
+    // XXX see #MeteorServerNull
+    if (Meteor.isClient || self._connection === Meteor.server)
+      self._connection.methods(m);
+  }
+};
+
+CollectionPrototype._updateFetch = function (fields) {
+  const self = this;
+
+  if (!self._validators.fetchAllFields) {
+    if (fields) {
+      self._validators.fetch = _.union(self._validators.fetch, fields);
+    } else {
+      self._validators.fetchAllFields = true;
+      // clear fetch just to make sure we don't accidentally read it
+      self._validators.fetch = null;
+    }
+  }
+};
+
+CollectionPrototype._isInsecure = function () {
+  const self = this;
+  if (self._insecure === undefined)
+    return !!Package.insecure;
+  return self._insecure;
+};
+
+CollectionPrototype._validatedInsert = function (userId, doc,
+                                                         generatedId) {
+  const self = this;
+
+  // call user validators.
+  // Any deny returns true means denied.
+  if (_.any(self._validators.insert.deny, function(validator) {
+    return validator(userId, docToValidate(validator, doc, generatedId));
+  })) {
+    throw new Meteor.Error(403, "Access denied");
+  }
+  // Any allow returns true means proceed. Throw error if they all fail.
+  if (_.all(self._validators.insert.allow, function(validator) {
+    return !validator(userId, docToValidate(validator, doc, generatedId));
+  })) {
+    throw new Meteor.Error(403, "Access denied");
+  }
+
+  // If we generated an ID above, insert it now: after the validation, but
+  // before actually inserting.
+  if (generatedId !== null)
+    doc._id = generatedId;
+
+  self._collection.insert.call(self._collection, doc);
+};
+
+// Simulate a mongo `update` operation while validating that the access
+// control rules set by calls to `allow/deny` are satisfied. If all
+// pass, rewrite the mongo operation to use $in to set the list of
+// document ids to change ##ValidatedChange
+CollectionPrototype._validatedUpdate = function(
+    userId, selector, mutator, options) {
+  const self = this;
+
+  check(mutator, Object);
+
+  options = _.clone(options) || {};
+
+  if (!LocalCollection._selectorIsIdPerhapsAsObject(selector))
+    throw new Error("validated update should be of a single ID");
+
+  // We don't support upserts because they don't fit nicely into allow/deny
+  // rules.
+  if (options.upsert)
+    throw new Meteor.Error(403, "Access denied. Upserts not " +
+                           "allowed in a restricted collection.");
+
+  const noReplaceError = "Access denied. In a restricted collection you can only" +
+        " update documents, not replace them. Use a Mongo update operator, such " +
+        "as '$set'.";
+
+  // compute modified fields
+  const fields = [];
+  if (_.isEmpty(mutator)) {
+    throw new Meteor.Error(403, noReplaceError);
+  }
+  _.each(mutator, function (params, op) {
+    if (op.charAt(0) !== '$') {
+      throw new Meteor.Error(403, noReplaceError);
+    } else if (!_.has(ALLOWED_UPDATE_OPERATIONS, op)) {
+      throw new Meteor.Error(
+        403, "Access denied. Operator " + op + " not allowed in a restricted collection.");
+    } else {
+      _.each(_.keys(params), function (field) {
+        // treat dotted fields as if they are replacing their
+        // top-level part
+        if (field.indexOf('.') !== -1)
+          field = field.substring(0, field.indexOf('.'));
+
+        // record the field we are trying to change
+        if (!_.contains(fields, field))
+          fields.push(field);
+      });
+    }
+  });
+
+  const findOptions = {transform: null};
+  if (!self._validators.fetchAllFields) {
+    findOptions.fields = {};
+    _.each(self._validators.fetch, function(fieldName) {
+      findOptions.fields[fieldName] = 1;
+    });
+  }
+
+  const doc = self._collection.findOne(selector, findOptions);
+  if (!doc)  // none satisfied!
+    return 0;
+
+  // call user validators.
+  // Any deny returns true means denied.
+  if (_.any(self._validators.update.deny, function(validator) {
+    const factoriedDoc = transformDoc(validator, doc);
+    return validator(userId,
+                     factoriedDoc,
+                     fields,
+                     mutator);
+  })) {
+    throw new Meteor.Error(403, "Access denied");
+  }
+  // Any allow returns true means proceed. Throw error if they all fail.
+  if (_.all(self._validators.update.allow, function(validator) {
+    const factoriedDoc = transformDoc(validator, doc);
+    return !validator(userId,
+                      factoriedDoc,
+                      fields,
+                      mutator);
+  })) {
+    throw new Meteor.Error(403, "Access denied");
+  }
+
+  options._forbidReplace = true;
+
+  // Back when we supported arbitrary client-provided selectors, we actually
+  // rewrote the selector to include an _id clause before passing to Mongo to
+  // avoid races, but since selector is guaranteed to already just be an ID, we
+  // don't have to any more.
+
+  return self._collection.update.call(
+    self._collection, selector, mutator, options);
+};
+
+// Only allow these operations in validated updates. Specifically
+// whitelist operations, rather than blacklist, so new complex
+// operations that are added aren't automatically allowed. A complex
+// operation is one that does more than just modify its target
+// field. For now this contains all update operations except '$rename'.
+// http://docs.mongodb.org/manual/reference/operators/#update
+const ALLOWED_UPDATE_OPERATIONS = {
+  $inc:1, $set:1, $unset:1, $addToSet:1, $pop:1, $pullAll:1, $pull:1,
+  $pushAll:1, $push:1, $bit:1
+};
+
+// Simulate a mongo `remove` operation while validating access control
+// rules. See #ValidatedChange
+CollectionPrototype._validatedRemove = function(userId, selector) {
+  const self = this;
+
+  const findOptions = {transform: null};
+  if (!self._validators.fetchAllFields) {
+    findOptions.fields = {};
+    _.each(self._validators.fetch, function(fieldName) {
+      findOptions.fields[fieldName] = 1;
+    });
+  }
+
+  const doc = self._collection.findOne(selector, findOptions);
+  if (!doc)
+    return 0;
+
+  // call user validators.
+  // Any deny returns true means denied.
+  if (_.any(self._validators.remove.deny, function(validator) {
+    return validator(userId, transformDoc(validator, doc));
+  })) {
+    throw new Meteor.Error(403, "Access denied");
+  }
+  // Any allow returns true means proceed. Throw error if they all fail.
+  if (_.all(self._validators.remove.allow, function(validator) {
+    return !validator(userId, transformDoc(validator, doc));
+  })) {
+    throw new Meteor.Error(403, "Access denied");
+  }
+
+  // Back when we supported arbitrary client-provided selectors, we actually
+  // rewrote the selector to {_id: {$in: [ids that we found]}} before passing to
+  // Mongo to avoid races, but since selector is guaranteed to already just be
+  // an ID, we don't have to any more.
+
+  return self._collection.remove.call(self._collection, selector);
+};
+
+CollectionPrototype._callMutatorMethod = function _callMutatorMethod(name, args, callback) {
+  if (Meteor.isClient && !callback && !alreadyInSimulation()) {
+    // Client can't block, so it can't report errors by exception,
+    // only by callback. If they forget the callback, give them a
+    // default one that logs the error, so they aren't totally
+    // baffled if their writes don't work because their database is
+    // down.
+    // Don't give a default callback in simulation, because inside stubs we
+    // want to return the results from the local collection immediately and
+    // not force a callback.
+    callback = function (err) {
+      if (err)
+        Meteor._debug(name + " failed: " + (err.reason || err.stack));
+    };
+  }
+
+  // For two out of three mutator methods, the first argument is a selector
+  const firstArgIsSelector = name === "update" || name === "remove";
+  if (firstArgIsSelector && !alreadyInSimulation()) {
+    // If we're about to actually send an RPC, we should throw an error if
+    // this is a non-ID selector, because the mutation methods only allow
+    // single-ID selectors. (If we don't throw here, we'll see flicker.)
+    throwIfSelectorIsNotId(args[0], name);
+  }
+
+  const mutatorMethodName = this._prefix + name;
+  return this._connection.apply(
+    mutatorMethodName, args, { returnStubValue: true }, callback);
+}
+
+function transformDoc(validator, doc) {
+  if (validator.transform)
+    return validator.transform(doc);
+  return doc;
+}
+
+function docToValidate(validator, doc, generatedId) {
+  let ret = doc;
+  if (validator.transform) {
+    ret = EJSON.clone(doc);
+    // If you set a server-side transform on your collection, then you don't get
+    // to tell the difference between "client specified the ID" and "server
+    // generated the ID", because transforms expect to get _id.  If you want to
+    // do that check, you can do it with a specific
+    // `C.allow({insert: f, transform: null})` validator.
+    if (generatedId !== null) {
+      ret._id = generatedId;
+    }
+    ret = validator.transform(ret);
+  }
+  return ret;
+}
+
+function addValidator(collection, allowOrDeny, options) {
+  // validate keys
+  const VALID_KEYS = ['insert', 'update', 'remove', 'fetch', 'transform'];
+  _.each(_.keys(options), function (key) {
+    if (!_.contains(VALID_KEYS, key))
+      throw new Error(allowOrDeny + ": Invalid key: " + key);
+  });
+
+  collection._restricted = true;
+
+  _.each(['insert', 'update', 'remove'], function (name) {
+    if (options.hasOwnProperty(name)) {
+      if (!(options[name] instanceof Function)) {
+        throw new Error(allowOrDeny + ": Value for `" + name + "` must be a function");
+      }
+
+      // If the transform is specified at all (including as 'null') in this
+      // call, then take that; otherwise, take the transform from the
+      // collection.
+      if (options.transform === undefined) {
+        options[name].transform = collection._transform;  // already wrapped
+      } else {
+        options[name].transform = LocalCollection.wrapTransform(
+          options.transform);
+      }
+
+      collection._validators[name][allowOrDeny].push(options[name]);
+    }
+  });
+
+  // Only update the fetch fields if we're passed things that affect
+  // fetching. This way allow({}) and allow({insert: f}) don't result in
+  // setting fetchAllFields
+  if (options.update || options.remove || options.fetch) {
+    if (options.fetch && !(options.fetch instanceof Array)) {
+      throw new Error(allowOrDeny + ": Value for `fetch` must be an array");
+    }
+    collection._updateFetch(options.fetch);
+  }
+}
+
+function throwIfSelectorIsNotId(selector, methodName) {
+  if (!LocalCollection._selectorIsIdPerhapsAsObject(selector)) {
+    throw new Meteor.Error(
+      403, "Not permitted. Untrusted code may only " + methodName +
+        " documents by ID.");
+  }
+};
+
+// Determine if we are in a DDP method simulation
+function alreadyInSimulation() {
+  const enclosing = DDP._CurrentInvocation.get();
+  return enclosing && enclosing.isSimulation;
+}

--- a/packages/allow-deny/package.js
+++ b/packages/allow-deny/package.js
@@ -1,0 +1,32 @@
+Package.describe({
+  name: 'allow-deny',
+  version: '1.0.0',
+  // Brief, one-line summary of the package.
+  summary: 'Implements functionality for allow/deny and client-side db operations',
+  // URL to the Git repository containing the source code for this package.
+  git: 'https://github.com/meteor/meteor',
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
+  documentation: 'README.md'
+});
+
+Package.onUse(function(api) {
+  api.use([
+    'ecmascript',
+    'underscore',
+    'minimongo', // Just for LocalCollection.wrapTransform :[
+    'check',
+    'ejson',
+    'ddp',
+  ]);
+
+  api.addFiles('allow-deny.js');
+  api.export('AllowDeny');
+});
+
+Package.onTest(function(api) {
+  api.use('ecmascript');
+  api.use('tinytest');
+  api.use('allow-deny');
+  api.addFiles('allow-deny-tests.js');
+});

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -3271,7 +3271,7 @@ if (Meteor.isServer) {
         collection.update(selector, {$set: 5});
       });
     });
-    
+
     test.equal(collection.find().count(), 10);
   });
 }

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -22,11 +22,20 @@ Npm.strip({
 
 Package.onUse(function (api) {
   api.use('npm-mongo', 'server');
+  api.use('allow-deny');
 
-  api.use(['random', 'ejson', 'underscore', 'minimongo',
-           'ddp', 'tracker', 'diff-sequence', 'mongo-id'],
-          ['client', 'server']);
-  api.use('check', ['client', 'server']);
+  api.use([
+    'random',
+    'ejson',
+    'underscore',
+    'minimongo',
+    'ddp',
+    'tracker',
+    'diff-sequence',
+    'mongo-id',
+    'check',
+    'ecmascript'
+  ]);
 
   // Binary Heap data structure is used to optimize oplog observe driver
   // performance.


### PR DESCRIPTION
As a first start to making it possible to use collections without allow/deny, I'm working on splitting out the code. This is a first step to solving #5096, and in general will be good for reducing the size of the `mongo` package. Consider that all of the code I'm moving was in _one file_, called `collection.js`.

In order to enable this, I needed to refactor `insert`/`update`/`remove` so that I could actually understand the control flow of those functions, which I think is a benefit in itself.

This should result in zero user-facing changes; the next PR will have some of the changes related to making it possible to not use allow/deny at all, or enable it per-collection.

@avital to review.