### PR TITLE
Allow the other types of URLs that npm supports.

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1892,7 +1892,7 @@ main.registerCommand({
 
       const newId = cordova.newPluginId(id);
 
-      if (!(version && utils.isValidVersion(version, {forNpm: false}))) {
+      if (!(version && utils.isValidVersion(version, {forCordova: true}))) {
         Console.error(`${id}: Meteor requires either an exact version \
 (e.g. ${id}@1.0.0), a Git URL with a SHA reference, or a local path.`);
         exitCode = 1;

--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1892,7 +1892,7 @@ main.registerCommand({
 
       const newId = cordova.newPluginId(id);
 
-      if (!(version && utils.isExactVersion(version, {forNpm: false}))) {
+      if (!(version && utils.isValidVersion(version, {forNpm: false}))) {
         Console.error(`${id}: Meteor requires either an exact version \
 (e.g. ${id}@1.0.0), a Git URL with a SHA reference, or a local path.`);
         exitCode = 1;

--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1892,7 +1892,7 @@ main.registerCommand({
 
       const newId = cordova.newPluginId(id);
 
-      if (!(version && utils.isExactVersion(version))) {
+      if (!(version && utils.isExactVersion(version, {forNpm: false}))) {
         Console.error(`${id}: Meteor requires either an exact version \
 (e.g. ${id}@1.0.0), a Git URL with a SHA reference, or a local path.`);
         exitCode = 1;

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -470,7 +470,7 @@ var getShrinkwrappedDependenciesTree = function (dir) {
 //
 // If more logic is added here, it should probably go in minimizeModule too.
 var canonicalVersion = function (depObj) {
-  if (utils.isUrlWithSha(depObj.from)) {
+  if (utils.isNpmUrl(depObj.from)) {
     return depObj.from;
   } else {
     return depObj.version;
@@ -500,7 +500,7 @@ var getShrinkwrappedDependencies = function (dir) {
 var installNpmModule = function (name, version, dir) {
   ensureConnected();
 
-  var installArg = utils.isUrlWithSha(version)
+  var installArg = utils.isNpmUrl(version)
     ? version : (name + "@" + version);
 
   // We don't use npm.commands.install since we couldn't figure out
@@ -640,7 +640,7 @@ var minimizeDependencyTree = function (tree) {
     if (module.resolved &&
         !module.resolved.match(/^https:\/\/registry.npmjs.org\//)) {
       version = module.resolved;
-    } else if (utils.isUrlWithSha(module.from)) {
+    } else if (utils.isNpmUrl(module.from)) {
       version = module.from;
     } else {
       version = module.version;

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -429,11 +429,11 @@ _.extend(PackageSource.prototype, {
     // serveRoot is actually a part of a url path, root here is a forward slash
     self.serveRoot = options.serveRoot || '/';
 
-    utils.ensureOnlyValidVersions(options.npmDependencies, {forNpm: true});
+    utils.ensureOnlyValidVersions(options.npmDependencies, {forCordova: false});
     self.npmDependencies = options.npmDependencies;
     self.npmCacheDirectory = options.npmDir;
 
-    utils.ensureOnlyValidVersions(options.cordovaDependencies, {forNpm: false});
+    utils.ensureOnlyValidVersions(options.cordovaDependencies, {forCordova: true});
     self.cordovaDependencies = options.cordovaDependencies;
 
     const sources = options.sources.map((source) => {
@@ -864,7 +864,7 @@ _.extend(PackageSource.prototype, {
         // XXX use something like seal or lockdown to have *complete*
         // confidence we're running the same code?
         try {
-          utils.ensureOnlyValidVersions(_npmDependencies, {forNpm: true});
+          utils.ensureOnlyValidVersions(_npmDependencies, {forCordova: false});
         } catch (e) {
           buildmessage.error(e.message, { useMyCaller: true, downcase: true });
           // recover by ignoring the Npm.depends line
@@ -976,7 +976,7 @@ _.extend(PackageSource.prototype, {
         // XXX use something like seal or lockdown to have *complete*
         // confidence we're running the same code?
         try {
-          utils.ensureOnlyValidVersions(_cordovaDependencies, {forNpm: false});
+          utils.ensureOnlyValidVersions(_cordovaDependencies, {forCordova: true});
         } catch (e) {
           buildmessage.error(e.message, { useMyCaller: true, downcase: true });
           // recover by ignoring the Npm.depends line

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -429,11 +429,11 @@ _.extend(PackageSource.prototype, {
     // serveRoot is actually a part of a url path, root here is a forward slash
     self.serveRoot = options.serveRoot || '/';
 
-    utils.ensureOnlyExactVersions(options.npmDependencies);
+    utils.ensureOnlyExactVersions(options.npmDependencies, {forNpm: true});
     self.npmDependencies = options.npmDependencies;
     self.npmCacheDirectory = options.npmDir;
 
-    utils.ensureOnlyExactVersions(options.cordovaDependencies);
+    utils.ensureOnlyExactVersions(options.cordovaDependencies, {forNpm: false});
     self.cordovaDependencies = options.cordovaDependencies;
 
     const sources = options.sources.map((source) => {
@@ -864,7 +864,7 @@ _.extend(PackageSource.prototype, {
         // XXX use something like seal or lockdown to have *complete*
         // confidence we're running the same code?
         try {
-          utils.ensureOnlyExactVersions(_npmDependencies);
+          utils.ensureOnlyExactVersions(_npmDependencies, {forNpm: true});
         } catch (e) {
           buildmessage.error(e.message, { useMyCaller: true, downcase: true });
           // recover by ignoring the Npm.depends line
@@ -976,7 +976,7 @@ _.extend(PackageSource.prototype, {
         // XXX use something like seal or lockdown to have *complete*
         // confidence we're running the same code?
         try {
-          utils.ensureOnlyExactVersions(_cordovaDependencies);
+          utils.ensureOnlyExactVersions(_cordovaDependencies, {forNpm: false});
         } catch (e) {
           buildmessage.error(e.message, { useMyCaller: true, downcase: true });
           // recover by ignoring the Npm.depends line

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -429,11 +429,11 @@ _.extend(PackageSource.prototype, {
     // serveRoot is actually a part of a url path, root here is a forward slash
     self.serveRoot = options.serveRoot || '/';
 
-    utils.ensureOnlyExactVersions(options.npmDependencies, {forNpm: true});
+    utils.ensureOnlyValidVersions(options.npmDependencies, {forNpm: true});
     self.npmDependencies = options.npmDependencies;
     self.npmCacheDirectory = options.npmDir;
 
-    utils.ensureOnlyExactVersions(options.cordovaDependencies, {forNpm: false});
+    utils.ensureOnlyValidVersions(options.cordovaDependencies, {forNpm: false});
     self.cordovaDependencies = options.cordovaDependencies;
 
     const sources = options.sources.map((source) => {
@@ -864,7 +864,7 @@ _.extend(PackageSource.prototype, {
         // XXX use something like seal or lockdown to have *complete*
         // confidence we're running the same code?
         try {
-          utils.ensureOnlyExactVersions(_npmDependencies, {forNpm: true});
+          utils.ensureOnlyValidVersions(_npmDependencies, {forNpm: true});
         } catch (e) {
           buildmessage.error(e.message, { useMyCaller: true, downcase: true });
           // recover by ignoring the Npm.depends line
@@ -976,7 +976,7 @@ _.extend(PackageSource.prototype, {
         // XXX use something like seal or lockdown to have *complete*
         // confidence we're running the same code?
         try {
-          utils.ensureOnlyExactVersions(_cordovaDependencies, {forNpm: false});
+          utils.ensureOnlyValidVersions(_cordovaDependencies, {forNpm: false});
         } catch (e) {
           buildmessage.error(e.message, { useMyCaller: true, downcase: true });
           // recover by ignoring the Npm.depends line

--- a/tools/tests/cordova-plugins.js
+++ b/tools/tests/cordova-plugins.js
@@ -159,7 +159,7 @@ selftest.define("change cordova plugins", ["cordova"], function () {
 
   // Introduce an error.
   s.cp('packages/contains-cordova-plugin/package3.js', 'packages/contains-cordova-plugin/package.js');
-  run.match("exact version");
+  run.match("valid version");
 
   // Fix the error.
   s.cp('packages/contains-cordova-plugin/package2.js', 'packages/contains-cordova-plugin/package.js');
@@ -191,7 +191,7 @@ selftest.define("add cordova plugins", ["slow", "cordova"], function () {
   run.expectExit(0);
 
   run = s.run("add", "cordova:cordova-plugin-file");
-  run.matchErr("exact version");
+  run.matchErr("valid version");
   run.expectExit(1);
 
   // The current behavior doesn't fail if a plugin is not in the registry until
@@ -258,7 +258,7 @@ selftest.define("add cordova plugins", ["slow", "cordova"], function () {
   run.expectExit(0);
 
   run = s.run("add", "cordova:com.example.plugin@file://");
-  run.matchErr("exact version");
+  run.matchErr("valid version");
   run.expectExit(1);
 
   run = s.run("add", "cordova:com.example.plugin@file://../../plugin_directory");

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -486,7 +486,7 @@ exports.isUrlWithSha = function (x) {
 exports.isNpmUrl = function (x) {
   // These are the various protocols that NPM supports, which we use to download NPM dependencies
   // See https://docs.npmjs.com/files/package.json#git-urls-as-dependencies
-  return exports.isUrlWithSha(x) || /^(git|git\+ssh|git\+http|git\+https)?:\/\/.*#/.test(x);
+  return exports.isUrlWithSha(x) || /^(git|git\+ssh|git\+http|git\+https)?:\/\//.test(x);
 };
 
 exports.isPathRelative = function (x) {

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -499,21 +499,21 @@ exports.isPathRelative = function (x) {
 //
 // This is talking about NPM/Cordova versions specifically, not Meteor versions.
 // It does not support the wrap number syntax.
-exports.ensureOnlyValidVersions = function (dependencies, {forNpm}) {
+exports.ensureOnlyValidVersions = function (dependencies, {forCordova}) {
   _.each(dependencies, function (version, name) {
     // We want a given version of a smart package (package.js +
     // .npm/npm-shrinkwrap.json) to pin down its dependencies precisely, so we
     // don't want anything too vague. For now, we support semvers and urls that
     // name a specific commit by SHA.
-    if (! exports.isValidVersion(version, {forNpm})) {
+    if (! exports.isValidVersion(version, {forCordova})) {
       throw new Error(
         "Must declare valid version of dependency: " + name + '@' + version);
     }
   });
 };
-exports.isValidVersion = function (version, {forNpm}) {
+exports.isValidVersion = function (version, {forCordova}) {
   return semver.valid(version) || exports.isUrlWithFileScheme(version)
-    || (forNpm ? exports.isNpmUrl(version) : exports.isUrlWithSha(version));
+    || (forCordova ? exports.isUrlWithSha(version): exports.isNpmUrl(version));
 };
 
 

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -493,25 +493,25 @@ exports.isPathRelative = function (x) {
   return x.charAt(0) !== '/';
 };
 
-// If there is a version that isn't exact, throws an Error with a
+// If there is a version that isn't valid, throws an Error with a
 // human-readable message that is suitable for showing to the user.
 // dependencies may be falsey or empty.
 //
 // This is talking about NPM/Cordova versions specifically, not Meteor versions.
 // It does not support the wrap number syntax.
-exports.ensureOnlyExactVersions = function (dependencies, {forNpm}) {
+exports.ensureOnlyValidVersions = function (dependencies, {forNpm}) {
   _.each(dependencies, function (version, name) {
     // We want a given version of a smart package (package.js +
     // .npm/npm-shrinkwrap.json) to pin down its dependencies precisely, so we
     // don't want anything too vague. For now, we support semvers and urls that
     // name a specific commit by SHA.
-    if (! exports.isExactVersion(version, {forNpm})) {
+    if (! exports.isValidVersion(version, {forNpm})) {
       throw new Error(
-        "Must declare exact version of dependency: " + name + '@' + version);
+        "Must declare valid version of dependency: " + name + '@' + version);
     }
   });
 };
-exports.isExactVersion = function (version, {forNpm}) {
+exports.isValidVersion = function (version, {forNpm}) {
   return semver.valid(version) || exports.isUrlWithFileScheme(version)
     || (forNpm ? exports.isNpmUrl(version) : exports.isUrlWithSha(version));
 };

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -477,9 +477,10 @@ exports.isUrlWithFileScheme = function (x) {
 };
 
 exports.isUrlWithSha = function (x) {
-  // For now, just support http/https, which is at least less restrictive than
-  // the old "github only" rule.
-  return /^https?:\/\/.*[0-9a-f]{40}/.test(x);
+  // These are the various protocols that NPM supports, which we use to download
+  // both NPM and Cordova dependencies
+  // See https://docs.npmjs.com/files/package.json#git-urls-as-dependencies
+  return /^(https|git|git\+ssh|git\+http|git\+https)?:\/\/.*[0-9a-f]{40}/.test(x);
 };
 
 exports.isPathRelative = function (x) {


### PR DESCRIPTION
See for instance #844 for people running into the
fact that our lack of support for git protocols means
dealing with private npm packages is a pain.