### PR TITLE
Allow piping commands to `meteor shell` via STDIN

### DIFF
--- a/tools/static-assets/server/shell-server.js
+++ b/tools/static-assets/server/shell-server.js
@@ -87,9 +87,58 @@ Sp.listen = function listen() {
   });
 };
 
+function readJSONFromStream(inputStream, callback) {
+  var outputStream = new stream.PassThrough;
+  var dataSoFar = "";
+
+  function onData(buffer) {
+    var lines = buffer.toString("utf8").split("\n");
+
+    while (lines.length > 0) {
+      dataSoFar += lines.shift();
+
+      try {
+        var json = JSON.parse(dataSoFar);
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          continue;
+        }
+
+        return finish(error);
+      }
+
+      if (lines.length > 0) {
+        outputStream.write(lines.join("\n"));
+      }
+
+      inputStream.pipe(outputStream);
+
+      return finish(null, json);
+    }
+  }
+
+  function onClose() {
+    finish(new Error("stream unexpectedly closed"));
+  }
+
+  var finished = false;
+  function finish(error, json) {
+    if (! finished) {
+      finished = true;
+      inputStream.removeListener("data", onData);
+      inputStream.removeListener("error", finish);
+      inputStream.removeListener("close", onClose);
+      callback(error, json, outputStream);
+    }
+  }
+
+  inputStream.on("data", onData);
+  inputStream.on("error", finish);
+  inputStream.on("close", onClose);
+}
+
 Sp.onConnection = function onConnection(socket) {
   var self = this;
-  var dataSoFar = "";
 
   // Make sure this function doesn't try to write anything to the socket
   // after it has been closed.
@@ -110,21 +159,8 @@ Sp.onConnection = function onConnection(socket) {
   // JSON object over the socket. For example, only the client knows
   // whether it's running a TTY or an Emacs subshell or some other kind of
   // terminal, so the client must decide the value of options.terminal.
-  socket.on("data", function onData(buffer) {
-    // Just in case the options JSON comes in fragments.
-    dataSoFar += buffer.toString("utf8");
-
-    try {
-      var options = JSON.parse(dataSoFar);
-    } finally {
-      if (! _.isObject(options)) {
-        return; // Silence any parsing exceptions.
-      }
-    }
-
-    if (socket) {
-      socket.removeListener("data", onData);
-    }
+  readJSONFromStream(socket, function (error, options, replInputSocket) {
+    clearTimeout(timeout);
 
     if (options.key !== self.key) {
       if (socket) {
@@ -134,11 +170,33 @@ Sp.onConnection = function onConnection(socket) {
     }
     delete options.key;
 
-    clearTimeout(timeout);
+    if (options.evaluateAndExit) {
+      evalCommand(
+        "(" + options.evaluateAndExit.command + ")",
+        null, // evalCommand ignores the context parameter, anyway
+        options.evaluateAndExit.filename || "<meteor shell>",
+        function (error, result) {
+          if (socket) {
+            var message = error ? {
+              error: error + "",
+              code: 1
+            } : {
+              result: result
+            };
+
+            // Sending back a JSON payload allows the client to
+            // distinguish between errors and successful results.
+            socket.end(JSON.stringify(message) + "\n");
+          }
+        }
+      );
+      return;
+    }
+    delete options.evaluateAndExit;
 
     // Immutable options.
     _.extend(options, {
-      input: socket,
+      input: replInputSocket,
       output: socket,
       eval: evalCommand
     });


### PR DESCRIPTION
These changes make it possible to use `meteor shell` for single-command evaluation, with only the command output echoing to `stdout`. Errors are printed to `stderr`, and the `meteor shell` process returns a non-zero error code.

Example:
```js
> meteor create asdf
> cd asdf
> meteor &
> echo Meteor.isServer | meteor shell
true
```

cc @avital @glasser