### PR TITLE
Make Script More Portable With #!/usr/bin/env

### DIFF
--- a/docs/canonically_diff_docs.sh
+++ b/docs/canonically_diff_docs.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 echo "Please run this script from the docs app folder."
 echo "Make sure you have phantomjs installed!"
 

--- a/examples/unfinished/benchmark/run-local.sh
+++ b/examples/unfinished/benchmark/run-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PORT=9000
 if [ -z "$NUM_CLIENTS" ]; then

--- a/examples/unfinished/chat-benchmark/run-local.sh
+++ b/examples/unfinished/chat-benchmark/run-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PORT=9000
 NUM_CLIENTS=10

--- a/meteor
+++ b/meteor
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Note: 0.5.17 used on branch origin/npm3
 BUNDLE_VERSION=0.5.16

--- a/packages/spiderable/spiderable_server.js
+++ b/packages/spiderable/spiderable_server.js
@@ -109,8 +109,8 @@ WebApp.connectHandlers.use(function (req, res, next) {
     // instead, but that meant we couldn't use exec and had to manage several
     // processes.)
     child_process.execFile(
-      '/bin/bash',
-      ['-c',
+      '/usr/bin/env',
+      ['bash', '-c',
        ("exec phantomjs " + phantomJsArgs + " /dev/stdin <<'END'\n" +
         phantomScript + "END\n")],
       {timeout: Spiderable.requestTimeoutMs, maxBuffer: MAX_BUFFER},

--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "`dirname "$0"`"
 cd ../..

--- a/scripts/admin/copy-bootstrap-tarballs-from-jenkins.sh
+++ b/scripts/admin/copy-bootstrap-tarballs-from-jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires awscli to be installed and an appropriate ~/.aws/config.
 # Usage:

--- a/scripts/admin/copy-dev-bundle-from-jenkins.sh
+++ b/scripts/admin/copy-dev-bundle-from-jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires awscli to be installed and an appropriate ~/.aws/config.
 # Usage:

--- a/scripts/admin/copy-windows-installer-from-jenkins.sh
+++ b/scripts/admin/copy-windows-installer-from-jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run this script on Mac/Linux, not on Windows
 # Requires awscli to be installed and an appropriate ~/.aws/config.

--- a/scripts/admin/eslint/eslint.sh
+++ b/scripts/admin/eslint/eslint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ORIGDIR=$(pwd)
 cd $(dirname $0)

--- a/scripts/admin/find-author-github.sh
+++ b/scripts/admin/find-author-github.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export ARG="$1"
 curl -s "https://github.com/meteor/meteor/commit/$(git log --format=%H -1 --author "$1")" | perl -nle 'm!<span class="author-name"><a href="/([^"]+)"! and do { my $name = $1; $ENV{ARG} =~ /(<.+>)/; print "GITHUB: $name $1"; exit 0 }'

--- a/scripts/admin/find-new-npm-versions.sh
+++ b/scripts/admin/find-new-npm-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 BASEDIR=`dirname $0`
 cat $BASEDIR/generate-dev-bundle.sh | grep "npm install" | sed "s/npm install //" | sed "s/@.*//" | while read PACKAGE
 do

--- a/scripts/admin/install-from-bootstrap.sh
+++ b/scripts/admin/install-from-bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/scripts/admin/jsdoc/jsdoc.sh
+++ b/scripts/admin/jsdoc/jsdoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ORIGDIR=$(pwd)
 cd $(dirname $0)

--- a/scripts/admin/launch-meteor
+++ b/scripts/admin/launch-meteor
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is the script that we install somewhere in your $PATH (as "meteor")
 # when you run

--- a/scripts/admin/publish-meteor-tool-on-all-platforms.sh
+++ b/scripts/admin/publish-meteor-tool-on-all-platforms.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This scripts automates the release process of Meteor Tool.
 

--- a/scripts/admin/publish-meteor-tool-on-arch.sh
+++ b/scripts/admin/publish-meteor-tool-on-arch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This scripts automates the release process of Meteor Tool.
 

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ORIGDIR=$(pwd)
 cd $(dirname $0)

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1561,7 +1561,7 @@ class JsImage {
     });
 
     if (setupScriptPieces.length) {
-      setupScriptPieces.unshift('#!/bin/bash\n', 'set -e\n\n');
+      setupScriptPieces.unshift('#!/usr/bin/env bash\n', 'set -e\n\n');
       builder.write('setup.sh', {
         data: new Buffer(setupScriptPieces.join(''), 'utf8'),
         executable: true

--- a/tools/runners/run-velocity.js
+++ b/tools/runners/run-velocity.js
@@ -117,8 +117,8 @@ var runVelocity = function (url) {
       function visitWithPhantom (url) {
         var phantomScript = "require('webpage').create().open('" + url + "');";
         var browserProcess = child_process.execFile(
-          '/bin/bash',
-          ['-c',
+          '/usr/bin/env',
+          ['bash', '-c',
            ("exec " + phantomjs.path + " /dev/stdin <<'END'\n" +
             phantomScript + "END\n")]);
         browserProcesses.push(browserProcess);

--- a/tools/tests/fake-mongod/fake-mongod
+++ b/tools/tests/fake-mongod/fake-mongod
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the path to this script in SCRIPT_DIR, preserving cwd
 ORIG_DIR=$(pwd)

--- a/tools/tests/old/cli-test.sh
+++ b/tools/tests/old/cli-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This used to be run standalone, but now it's intended to always be
 # invoked by 'meteor self-test' (and eventually we should port the

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -1061,8 +1061,8 @@ _.extend(BrowserStackClient.prototype, {
       '-skipCheck'
     ];
     self.tunnelProcess = child_process.execFile(
-      '/bin/bash',
-      ['-c', args.join(' ')]
+      '/usr/bin/env',
+      ['bash', '-c', args.join(' ')]
     );
 
     // Called when the SSH tunnel is established.


### PR DESCRIPTION
To make the scripts more compatible on different linux environments, shebang should be changed in general to `#!/usr/bin/env bash` instead `#!/bin/bash`