### PR TITLE
Polling observer driver - Allow to customize polling Interval

### DIFF
--- a/packages/mongo/polling_observe_driver.js
+++ b/packages/mongo/polling_observe_driver.js
@@ -60,8 +60,9 @@ PollingObserveDriver = function (options) {
   if (options._testOnlyPollCallback) {
     self._testOnlyPollCallback = options._testOnlyPollCallback;
   } else {
+    var pollingInterval = self._cursorDescription.options._pollingInterval || 10 * 1000;
     var intervalHandle = Meteor.setInterval(
-      _.bind(self._ensurePollIsScheduled, self), 10 * 1000);
+      _.bind(self._ensurePollIsScheduled, self), pollingInterval);
     self._stopCallbacks.push(function () {
       Meteor.clearInterval(intervalHandle);
     });


### PR DESCRIPTION
Allow users to change polling default interval per cursor, Important when using polling instead of oplog.
For example: Collection.find({}, {_disableOplog:true, _pollingInterval:4000}) so the pooling will happen at least once in  4 sec.