### PR TITLE
Fix issue with template subscribe

### DIFF
--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -364,7 +364,7 @@ Blaze.TemplateInstance.prototype.subscribe = function (/* arguments */) {
 
     if (_.isFunction(lastParam)) {
       options.onReady = args.pop();
-    } else if (lastParam && Match.test(lastParam, lastParamOptionsPattern)) {
+    } else if (lastParam && ! _.isEmpty(lastParam) && Match.test(lastParam, lastParamOptionsPattern)) {
       options = args.pop();
     }
   }


### PR DESCRIPTION
Reproduction: https://github.com/dburles/undefined-object-bug

This patch fixes an issue related to the `lastParamOptionsPattern` which is used to check for an options object, however it also matches on empty objects. See https://github.com/meteor/meteor/blob/devel/packages/blaze/template.js#L367

```js
if (Meteor.isClient) {
  // Server logs 'undefined'
  Template.body.onCreated(function() {
    this.subscribe('test', {});
  });

  // Works as expected, server logs an empty object {}
  // Meteor.subscribe('test', {});
}

if (Meteor.isServer) {
  Meteor.publish('test', function(options) {
    console.log(options);
  });
}
```
