### PR TITLE
OAuth - remove inline javascript from popup/redirect logins

### DIFF
--- a/packages/oauth/end_of_popup_response.html
+++ b/packages/oauth/end_of_popup_response.html
@@ -1,51 +1,11 @@
 <html>
-<head>
-<script type="text/javascript">
-
-function storeAndClose() {
-
-  var config = JSON.parse(document.getElementById("config").innerHTML);
-
-  if (config.setCredentialToken) {
-    var credentialToken = config.credentialToken;
-    var credentialSecret = config.credentialSecret;
-
-    if (config.isCordova) {
-      var credentialString = JSON.stringify({
-        credentialToken: credentialToken,
-        credentialSecret: credentialSecret
-      });
-
-      window.location.hash = credentialString;
-    }
-
-    if (window.opener && window.opener.Package &&
-          window.opener.Package.oauth) {
-      window.opener.Package.oauth.OAuth._handleCredentialSecret(
-        credentialToken, credentialSecret);
-    } else {
-      try {
-        localStorage[config.storagePrefix + credentialToken] = credentialSecret;
-      } catch (err) {
-        // We can't do much else, but at least close the popup instead
-        // of having it hang around on a blank page.
-      }
-    }
-  }
-
-  if (! config.isCordova) {
-    document.getElementById("completedText").style.display = "block";
-    window.close();
-  }
-}
-</script>
-</head>
-<body onload="storeAndClose()">
+<body>
   <p id="completedText" style="display:none;">
-    Login completed. <a href="#" onclick="window.close()">
+    Login completed. <a href="#" id="loginCompleted">
       Click here</a> to close this window.
   </p>
 
   <div id="config" style="display:none;">##CONFIG##</div>
+  <script type="text/javascript" src="/packages/oauth/end_of_popup_response.js"></script>
 </body>
 </html>

--- a/packages/oauth/end_of_popup_response.js
+++ b/packages/oauth/end_of_popup_response.js
@@ -1,0 +1,37 @@
+(function () {
+
+  var config = JSON.parse(document.getElementById("config").innerHTML);
+
+  if (config.setCredentialToken) {
+    var credentialToken = config.credentialToken;
+    var credentialSecret = config.credentialSecret;
+
+    if (config.isCordova) {
+      var credentialString = JSON.stringify({
+        credentialToken: credentialToken,
+        credentialSecret: credentialSecret
+      });
+
+      window.location.hash = credentialString;
+    }
+
+    if (window.opener && window.opener.Package &&
+          window.opener.Package.oauth) {
+      window.opener.Package.oauth.OAuth._handleCredentialSecret(
+        credentialToken, credentialSecret);
+    } else {
+      try {
+        localStorage[config.storagePrefix + credentialToken] = credentialSecret;
+      } catch (err) {
+        // We can't do much else, but at least close the popup instead
+        // of having it hang around on a blank page.
+      }
+    }
+  }
+
+  if (! config.isCordova) {
+    document.getElementById("completedText").style.display = "block";
+    document.getElementById("loginCompleted").onclick = function(){ window.close(); };
+    window.close();
+  }
+})();

--- a/packages/oauth/end_of_redirect_response.html
+++ b/packages/oauth/end_of_redirect_response.html
@@ -1,23 +1,6 @@
 <html>
-<head>
-<script type="text/javascript">
-
-  function storeAndRedirect () {
-
-    var config = JSON.parse(document.getElementById("config").innerHTML);
-
-    if (config.setCredentialToken) {
-      sessionStorage[config.storagePrefix + config.credentialToken] =
-      config.credentialSecret;
-    }
-
-    window.location = config.redirectUrl;
-
-  };
-
-</script>
-</head>
-<body onload="storeAndRedirect()">
+<body>
   <div id="config" style="display:none;">##CONFIG##</div>
+  <script type="text/javascript" src="/packages/oauth/end_of_redirect_response.js"></script>
 </body>
 </html>

--- a/packages/oauth/end_of_redirect_response.js
+++ b/packages/oauth/end_of_redirect_response.js
@@ -1,0 +1,12 @@
+(function () {
+
+  var config = JSON.parse(document.getElementById("config").innerHTML);
+
+  if (config.setCredentialToken) {
+    sessionStorage[config.storagePrefix + config.credentialToken] =
+    config.credentialSecret;
+  }
+
+  window.location = config.redirectUrl;
+
+})();

--- a/packages/oauth/package.js
+++ b/packages/oauth/package.js
@@ -35,6 +35,11 @@ Package.onUse(function (api) {
     'end_of_redirect_response.html'
   ], 'server');
 
+  api.addAssets([
+    'end_of_popup_response.js',
+    'end_of_redirect_response.js'
+  ], 'client');
+
   api.addFiles('oauth_common.js');
 
   // XXX COMPAT WITH 0.8.0


### PR DESCRIPTION
When `browser-policy` [1] is loaded _before_ the `oauth` package, the popup & redirect pages would fail due to policy violations. ([1] - With inline scripts disabled.)

However, when `browser-policy` loads after `oauth`, the header isn't injected when requesting the `/_oauth/xx` route, and they work fine.

It might be worth updating `browser-policy` to inject the header before all other handlers.

---

As for this PR - I wasn't sure whether to conditionally put the script into separate files, akin to `meteor_runtime_config.js`.

However, this is the simpilest solution considering the scripts are not dynamic.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/meteor/pull/5628%23issuecomment-157544127%22%2C%20%22https%3A//github.com/meteor/meteor/pull/5628%23issuecomment-157548152%22%2C%20%22https%3A//github.com/meteor/meteor/pull/5628%23discussion_r45139758%22%2C%20%22https%3A//github.com/meteor/meteor/pull/5628%23discussion_r45143108%22%2C%20%22https%3A//github.com/meteor/meteor/pull/5628%23discussion_r45143546%22%2C%20%22https%3A//github.com/meteor/meteor/pull/5628%23discussion_r45144589%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/meteor/pull/5628%23issuecomment-157544127%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20looks%20like%20a%20good%20idea%20to%20me%2C%20but%20I%20don%27t%20have%20time%20to%20review%20it%20in%20detail%20at%20the%20moment.%22%2C%20%22created_at%22%3A%20%222015-11-17T23%3A28%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20Good%20point.%20I%27ll%20push%20a%20fix%20for%20that%20now.%22%2C%20%22created_at%22%3A%20%222015-11-17T23%3A52%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3112329%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nathan-muir%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ea17496ba31bb35ab2c12e5c2ddb8a55a6c662c3%20packages/oauth/end_of_popup_response.js%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/meteor/pull/5628%23discussion_r45143108%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20wonder%20why%20we%20would%20need%20both%20this%20line%20and%20the%20one%20below...%22%2C%20%22created_at%22%3A%20%222015-11-18T00%3A19%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20added%20the%20onclick%20handler%20to%20match%20the%20existing%20functionality%20of%20%60%3Ca%20href%3D%5C%22%23%5C%22%20onclick%3D%5C%22window.close%28%29%5C%22%3E%20..%20%3C/a%3E%60%20without%20inline%20scripts.%5Cr%5Cn%5Cr%5CnI%20suppose%20the%20original%20author%28%3F%29%20didn%27t%20want%20to%20leave%20the%20user%20without%20appropriate%20feedback%20if%20%60window.close%28%29%60%20failed%20on%20page%20load%20for%20some%20reason.%22%2C%20%22created_at%22%3A%20%222015-11-18T00%3A25%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3112329%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nathan-muir%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20I%20wonder%20if%20we%20are%20somehow%20losing%20that%20functionality%20by%20moving%20it%20to%20an%20external%20script%3F%20Perhaps%20that%20code%20was%20entirely%20redundant%20before%3F%20But%20in%20the%20way%20it%20is%20now%2C%20I%20think%20these%20two%20lines%20are%20definitely%20redundant%20unless%20%60window.close%28%29%60%20somehow%20works%20differently%20from%20an%20event%20handler%2C%20or%20can%20fail%20when%20called%20from%20a%20script%20tag%20directly.%22%2C%20%22created_at%22%3A%20%222015-11-18T00%3A37%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20packages/oauth/end_of_popup_response.js%3AL1-38%22%7D%2C%20%22Pull%20ad1ab4aa60c859ceab97ab8abbc067848f2f2ee8%20packages/oauth/end_of_popup_response.js%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/meteor/pull/5628%23discussion_r45139758%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Instead%20of%20using%20this%20onload%20cross-browser%20compat%20hack%2C%20could%20we%20just%20put%20the%20script%20tag%20at%20the%20bottom%20of%20the%20HTML%20page%3F%20That%20seems%20to%20work%20in%20every%20browser%3F%22%2C%20%22created_at%22%3A%20%222015-11-17T23%3A38%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20packages/oauth/end_of_popup_response.js%3AL1-43%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/meteor/pull/5628#issuecomment-157544127'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This looks like a good idea to me, but I don't have time to review it in detail at the moment.
- <a href='https://github.com/nathan-muir'><img border=0 src='https://avatars.githubusercontent.com/u/3112329?v=3' height=16 width=16'></a> @stubailo Good point. I'll push a fix for that now.
- [ ] <a href='#crh-comment-Pull ad1ab4aa60c859ceab97ab8abbc067848f2f2ee8 packages/oauth/end_of_popup_response.js 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/meteor/pull/5628#discussion_r45139758'>File: packages/oauth/end_of_popup_response.js:L1-43</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Instead of using this onload cross-browser compat hack, could we just put the script tag at the bottom of the HTML page? That seems to work in every browser?
- [ ] <a href='#crh-comment-Pull ea17496ba31bb35ab2c12e5c2ddb8a55a6c662c3 packages/oauth/end_of_popup_response.js 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/meteor/pull/5628#discussion_r45143108'>File: packages/oauth/end_of_popup_response.js:L1-38</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I wonder why we would need both this line and the one below...
- <a href='https://github.com/nathan-muir'><img border=0 src='https://avatars.githubusercontent.com/u/3112329?v=3' height=16 width=16'></a> I added the onclick handler to match the existing functionality of `<a href="#" onclick="window.close()"> .. </a>` without inline scripts.
I suppose the original author(?) didn't want to leave the user without appropriate feedback if `window.close()` failed on page load for some reason.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah I wonder if we are somehow losing that functionality by moving it to an external script? Perhaps that code was entirely redundant before? But in the way it is now, I think these two lines are definitely redundant unless `window.close()` somehow works differently from an event handler, or can fail when called from a script tag directly.


<a href='https://www.codereviewhub.com/meteor/meteor/pull/5628?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/meteor/pull/5628?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/meteor/pull/5628'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>