### PR TITLE
fix Match.Where function called twice bug

### DIFF
--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -235,7 +235,7 @@ var testSubtree = function (value, pattern) {
         path: err.path
       };
     }
-    if (pattern.condition(value))
+    if (result)
       return false;
     // XXX this error is terrible
     return {


### PR DESCRIPTION
Hi @stubailo I found the problem on `check` package related to issue:  https://github.com/meteor/meteor/issues/5630
Please review this PR it
