### PR TITLE
Replace all uses of Future in tools/ code with equivalent Promise-based code

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -6,7 +6,6 @@ var buildmessage = require('../utils/buildmessage.js');
 var auth = require('../meteor-services/auth.js');
 var authClient = require('../meteor-services/auth-client.js');
 var config = require('../meteor-services/config.js');
-var Future = require('fibers/future');
 var runLog = require('../runners/run-log.js');
 var utils = require('../utils/utils.js');
 var httpHelpers = require('../utils/http-helpers.js');
@@ -2159,7 +2158,6 @@ main.registerCommand({
   maybeLog("Connecting: " + Console.command("ssh " + printOptions));
 
   var child_process = require('child_process');
-  var future = new Future;
 
   if (arch.match(/win/)) {
     // The ssh output from Windows machines is buggy, it can overlay your
@@ -2172,32 +2170,27 @@ main.registerCommand({
     "ssh", connOptions,
     { stdio: 'inherit' }); // Redirect spawn stdio to process
 
-  sshCommand.on('error', function (err) {
-    if (err.code === "ENOENT") {
-      if (process.platform === "win32") {
-        Console.error("Could not find the `ssh` command in your PATH.",
-          "Please read this page about using the get-machine command on Windows:",
-          Console.url("https://github.com/meteor/meteor/wiki/Accessing-Meteor-provided-build-machines-from-Windows"));
-      } else {
-        Console.error("Could not find the `ssh` command in your PATH.");
+  return new Promise(function (resolve) {
+    sshCommand.on('error', function (err) {
+      if (err.code === "ENOENT") {
+        if (process.platform === "win32") {
+          Console.error("Could not find the `ssh` command in your PATH.",
+                        "Please read this page about using the get-machine command on Windows:",
+                        Console.url("https://github.com/meteor/meteor/wiki/Accessing-Meteor-provided-build-machines-from-Windows"));
+        } else {
+          Console.error("Could not find the `ssh` command in your PATH.");
+        }
+
+        resolve(1);
       }
+    });
 
-      future.return(1);
-    }
-  });
-
-  sshCommand.on('exit', function (code, signal) {
-    if (signal) {
+    sshCommand.on('exit', function (code, signal) {
       // XXX: We should process the signal in some way, but I am not sure we
       // care right now.
-      future.return(1);
-    } else {
-      future.return(code);
-    }
-  });
-  var sshEnd = future.wait();
-
-  return sshEnd;
+      resolve(signal ? 1 : code);
+    });
+  }).await();
 });
 
 
@@ -2216,7 +2209,6 @@ main.registerCommand({
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
   buildmessage.enterJob({ title: "A test progressbar" }, function () {
-    var doneFuture = new Future;
     var progress = buildmessage.getCurrentProgressTracker();
     var totalProgress = { current: 0, end: options.secs, done: false };
     var i = 0;
@@ -2226,23 +2218,25 @@ main.registerCommand({
       totalProgress.end = undefined;
     }
 
-    var updateProgress = function () {
-      i++;
-      if (! options.spinner) {
-        totalProgress.current = i;
+    new Promise(function (resolve) {
+      function updateProgress() {
+        i++;
+        if (! options.spinner) {
+          totalProgress.current = i;
+        }
+
+        if (i === n) {
+          totalProgress.done = true;
+          progress.reportProgress(totalProgress);
+          resolve();
+        } else {
+          progress.reportProgress(totalProgress);
+          setTimeout(updateProgress, 1000);
+        }
       }
 
-      if (i === n) {
-        totalProgress.done = true;
-        progress.reportProgress(totalProgress);
-        doneFuture.return();
-      } else {
-        progress.reportProgress(totalProgress);
-        setTimeout(updateProgress, 1000);
-      }
-    };
-    setTimeout(updateProgress);
-    doneFuture.wait();
+      setTimeout(updateProgress);
+    }).await();
   });
 });
 

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -6,7 +6,6 @@ if (showRequireProfile) {
 var assert = require("assert");
 var _ = require('underscore');
 var Fiber = require('fibers');
-var Future = require('fibers/future');
 var Console = require('../console/console.js').Console;
 var files = require('../fs/files.js');
 var warehouse = require('../packaging/warehouse.js');
@@ -490,14 +489,13 @@ var springboard = function (rel, options) {
   }
 
   if (process.platform === 'win32') {
-    var ret = new Future();
-    var child = require("child_process").spawn(
-      files.convertToOSPath(executable + ".bat"), newArgv,
-      { env: process.env, stdio: 'inherit' });
-    child.on('exit', function (code) {
-      ret.return(code);
-    });
-    process.exit(ret.wait());
+    process.exit(new Promise(function (resolve) {
+      var batPath = files.convertToOSPath(executable + ".bat");
+      var child = require("child_process").spawn(batPath, newArgv, {
+        env: process.env,
+        stdio: 'inherit'
+      }).on('exit', resolve);
+    }).await());
   }
 
   // Now exec; we're not coming back.

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -56,7 +56,6 @@
 /// In addition to printing functions, the Console class provides progress bar
 /// support, that is mostly handled through buildmessage.js.
 var _ = require('underscore');
-var Fiber = require('fibers');
 var readline = require('readline');
 var util = require('util');
 var buildmessage = require('../utils/buildmessage.js');
@@ -432,18 +431,16 @@ _.extend(StatusPoller.prototype, {
   _startPoller: function () {
     var self = this;
 
-    if (self._pollFiber) {
+    if (self._pollPromise) {
       throw new Error("Already started");
     }
 
-    self._pollFiber = Fiber(function () {
+    self._pollPromise = (async() => {
       while (! self._stop) {
         utils.sleepMs(STATUS_INTERVAL_MS);
-
         self.statusPoll();
       }
-    });
-    self._pollFiber.run();
+    })();
   },
 
   stop: function () {

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -57,7 +57,6 @@
 /// support, that is mostly handled through buildmessage.js.
 var _ = require('underscore');
 var Fiber = require('fibers');
-var Future = require('fibers/future');
 var readline = require('readline');
 var util = require('util');
 var buildmessage = require('../utils/buildmessage.js');
@@ -1260,8 +1259,6 @@ _.extend(Console.prototype, {
 Console.prototype.readLine = function (options) {
   var self = this;
 
-  var fut = new Future();
-
   options = _.extend({
     echo: true,
     stream: self._stream
@@ -1298,16 +1295,16 @@ Console.prototype.readLine = function (options) {
     rl.prompt();
   }
 
-  rl.on('line', function (line) {
-    rl.close();
-    if (! options.echo) {
-      options.stream.write("\n");
-    }
-    self._setProgressDisplay(previousProgressDisplay);
-    fut['return'](line);
-  });
-
-  return fut.wait();
+  return new Promise(function (resolve) {
+    rl.on('line', function (line) {
+      rl.close();
+      if (! options.echo) {
+        options.stream.write("\n");
+      }
+      self._setProgressDisplay(previousProgressDisplay);
+      resolve(line);
+    });
+  }).await();
 };
 
 

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -13,7 +13,6 @@ var Fiber = require('fibers');
 var crypto = require('crypto');
 
 var rimraf = require('rimraf');
-var Future = require('fibers/future');
 var sourcemap = require('source-map');
 var sourceMapRetrieverStack = require('../tool-env/source-map-retriever-stack.js');
 
@@ -273,9 +272,7 @@ files.statOrNull = function (path) {
 // Like rm -r.
 files.rm_recursive = Profile("files.rm_recursive", function (p) {
   if (Fiber.current && Fiber.yield && ! Fiber.yield.disallowed) {
-    var fut = new Future();
-    rimraf(files.convertToOSPath(p), fut.resolver());
-    fut.wait();
+    Promise.denodeify(rimraf)(files.convertToOSPath(p)).await();
   } else {
     rimraf.sync(files.convertToOSPath(p));
   }
@@ -313,13 +310,13 @@ files.fileHash = function (filename) {
   var hash = crypto.createHash('sha256');
   hash.setEncoding('base64');
   var rs = files.createReadStream(filename);
-  var fut = new Future();
-  rs.on('end', function () {
-    rs.close();
-    fut.return(hash.digest('base64'));
-  });
-  rs.pipe(hash, { end: false });
-  return fut.wait();
+  return new Promise(function (resolve) {
+    rs.on('end', function () {
+      rs.close();
+      resolve(hash.digest('base64'));
+    });
+    rs.pipe(hash, { end: false });
+  }).await();
 };
 
 // This is the result of running fileHash on a blank file.
@@ -577,19 +574,14 @@ files.copyFile = function (from, to) {
 var copyFileHelper = function (from, to, mode) {
   var readStream = files.createReadStream(from);
   var writeStream = files.createWriteStream(to, { mode: mode });
-  var future = new Future;
-  var onError = function (e) {
-    future.isResolved() || future.throw(e);
-  };
-  readStream.on('error', onError);
-  writeStream.on('error', onError);
-  writeStream.on('open', function () {
-    readStream.pipe(writeStream);
-  });
-  writeStream.once('finish', function () {
-    future.isResolved() || future.return();
-  });
-  future.wait();
+  new Promise(function (resolve, reject) {
+    readStream.on('error', reject);
+    writeStream.on('error', reject);
+    writeStream.on('open', function () {
+      readStream.pipe(writeStream);
+    });
+    writeStream.once('finish', resolve);
+  }).await();
 };
 
 // Make a temporary directory. Returns the path to the newly created
@@ -694,37 +686,30 @@ files.extractTarGz = function (buffer, destPath, options) {
   var tempDir = files.pathJoin(parentDir, '.tmp' + utils.randomToken());
   files.mkdir_p(tempDir);
 
-  var future = new Future;
-
   var tar = require("tar");
   var zlib = require("zlib");
-  var gunzip = zlib.createGunzip()
-    .on('error', function (e) {
-      future.isResolved() || future.throw(e);
-    });
 
-  var extractor = new tar.Extract({ path: files.convertToOSPath(tempDir) })
-    .on('entry', function (e) {
+  new Promise(function (resolve, reject) {
+    var gunzip = zlib.createGunzip().on('error', reject);
+
+    var extractor = new tar.Extract({
+      path: files.convertToOSPath(tempDir)
+    }).on('entry', function (e) {
       if (process.platform === "win32" || options.forceConvert) {
         // On Windows, try to convert old packages that have colons in paths
         // by blindly replacing all of the paths. Otherwise, we can't even
         // extract the tarball
         e.path = colonConverter.convert(e.path);
       }
-    })
-    .on('error', function (e) {
-      future.isResolved() || future.throw(e);
-    })
-    .on('end', function () {
-      future.isResolved() || future.return();
-    });
+    }).on('error', reject)
+      .on('end', resolve);
 
-  // write the buffer to the (gunzip|untar) pipeline; these calls
-  // cause the tar to be extracted to disk.
-  gunzip.pipe(extractor);
-  gunzip.write(buffer);
-  gunzip.end();
-  future.wait();
+    // write the buffer to the (gunzip|untar) pipeline; these calls
+    // cause the tar to be extracted to disk.
+    gunzip.pipe(extractor);
+    gunzip.write(buffer);
+    gunzip.end();
+  }).await();
 
   // succeed!
   var topLevelOfArchive = files.readdir(tempDir);
@@ -801,17 +786,12 @@ files.createTarGzStream = function (dirPath, options) {
 // Tar-gzips a directory into a tarball on disk, synchronously.
 // The tar archive will contain a top-level directory named after dirPath.
 files.createTarball = function (dirPath, tarball, options) {
-  var future = new Future;
   var out = files.createWriteStream(tarball);
-  out.on('error', function (err) {
-    future.throw(err);
-  });
-  out.on('close', function () {
-    future.return();
-  });
-
-  files.createTarGzStream(dirPath, options).pipe(out);
-  future.wait();
+  new Promise(function (resolve, reject) {
+    out.on('error', reject);
+    out.on('close', resolve);
+    files.createTarGzStream(dirPath, options).pipe(out);
+  }).await();
 };
 
 // Use this if you'd like to replace a directory with another
@@ -1343,43 +1323,52 @@ function wrapFsFunc(fsFuncName, pathArgIndices, options) {
       const shouldBeSync = alwaysSync || sync;
 
       if (canYield && shouldBeSync) {
-        const fut = new Future;
+        const promise = new Promise((resolve, reject) => {
+          args.push((err, value) => {
+            if (options.noErr) {
+              resolve(err);
+            } else if (err) {
+              reject(err);
+            } else {
+              resolve(value);
+            }
+          });
 
-        args.push(function callback(err, value) {
-          if (options.noErr) {
-            fut.return(err);
-          } else if (err) {
-            fut.throw(err);
-          } else {
-            fut.return(value);
-          }
+          fsFunc.apply(fs, args);
         });
 
-        fsFunc.apply(fs, args);
+        const result = promise.await();
 
-        const result = fut.wait();
         return options.modifyReturnValue
           ? options.modifyReturnValue(result)
           : result;
+
       } else if (shouldBeSync) {
         // Should be sync but can't yield: we are not in a Fiber.
         // Run the sync version of the fs.* method.
         const result = fsFuncSync.apply(fs, args);
         return options.modifyReturnValue ?
                options.modifyReturnValue(result) : result;
+
       } else if (! sync) {
         // wrapping a plain async version
-        const cb = args[fsFunc.length - 1];
-        if (typeof cb === 'function') {
-          args[fsFunc.length - 1] = function (err, res) {
+        let cb = args[args.length - 1];
+        if (typeof cb === "function") {
+          args.pop();
+        } else {
+          cb = null;
+        }
+
+        Promise.denodeify(fsFunc)
+          .apply(fs, args)
+          .then(function (res) {
             if (options.modifyReturnValue) {
               res = options.modifyReturnValue(res);
             }
-            Fiber(cb.bind(null, err, res)).run();
-          };
-        }
-        fsFunc.apply(fs, args);
-        return null;
+            cb && cb(null, res);
+          }, cb);
+
+        return;
       }
 
       throw new Error('unexpected');

--- a/tools/meteor-services/auth.js
+++ b/tools/meteor-services/auth.js
@@ -6,7 +6,6 @@ var httpHelpers = require('../utils/http-helpers.js');
 var fiberHelpers = require('../utils/fiber-helpers.js');
 var querystring = require('querystring');
 var url = require('url');
-var Future = require('fibers/future');
 var isopackets = require('../tool-env/isopackets.js');
 var Console = require('../console/console.js').Console;
 
@@ -52,21 +51,20 @@ var loggedInAccountsConnection = function (token) {
     config.getAuthDDPUrl()
   );
 
-  var fut = new Future;
-  connection.apply(
-    'login',
-    [{ resume: token }],
-    { wait: true },
-    function (err, result) {
-      fut['return']({ err: err, result: result });
-    }
-  );
-  var outcome = fut.wait();
+  return new Promise(function (resolve, reject) {
+    connection.apply(
+      'login',
+      [{ resume: token }],
+      { wait: true },
+      function (err) {
+        err ? reject(err) : resolve(connection);
+      }
+    );
 
-  if (outcome.err) {
+  }).catch(function (err) {
     connection.close();
 
-    if (outcome.err.error === 403) {
+    if (err.error === 403) {
       // This is not an ideal value for the error code, but it means
       // "server rejected our access token". For example, it expired
       // or we revoked it from the web.
@@ -74,10 +72,9 @@ var loggedInAccountsConnection = function (token) {
     }
 
     // Something else went wrong
-    throw outcome.err;
-  }
+    throw err;
 
-  return connection;
+  }).await();
 };
 
 // The accounts server has some wrapped methods that take and return
@@ -98,30 +95,45 @@ var sessionMethodCaller = function (methodName, options) {
     args.push({
       session: auth.getSessionId(config.getAccountsDomain()) || null
     });
-    var fut = new Future();
+
+    var timer;
     var conn = options.connection || openAccountsConnection();
-    conn.apply(methodName, args, fiberHelpers.firstTimeResolver(fut));
-    if (options.timeout !== undefined) {
-      var timer = setTimeout(fiberHelpers.bindEnvironment(function () {
-        if (!fut.isResolved()) {
-          fut.throw(new Error('Method call timed out'));
+
+    function cleanUp() {
+      timer && clearTimeout(timer);
+      options.connection || conn.close();
+    }
+
+    return new Promise(function (resolve, reject) {
+      conn.apply(methodName, args, function (err, res) {
+        err ? reject(err) : resolve(res);
+      });
+
+      if (options.timeout !== undefined) {
+        timer = setTimeout(function () {
+          reject(new Error('Method call timed out'));
+        }, options.timeout);
+      }
+
+    }).then(function (result) {
+      cleanUp();
+
+      if (result) {
+        if (result.session) {
+          // The bindEnvironment call above ensures the file IO operations
+          // that happen in auth.setSessionId take place in a Fiber.
+          auth.setSessionId(config.getAccountsDomain(), result.session);
         }
-      }), options.timeout);
-    }
-    try {
-      var result = fut.wait();
-    } finally {
-      if (timer) {
-        clearTimeout(timer);
+        result = result.result;
       }
-      if (! options.connection) {
-        conn.close();
-      }
-    }
-    if (result && result.session) {
-      auth.setSessionId(config.getAccountsDomain(), result.session);
-    }
-    return result && result.result;
+
+      return result;
+
+    }, function (err) {
+      cleanUp();
+      throw err;
+
+    }).await();
   };
 };
 
@@ -626,8 +638,8 @@ exports.pollForRegistrationCompletion = function (options) {
   // We are logged in but we don't yet have a username. Ask the server
   // if a username was chosen since we last checked.
   var username = null;
-  var fut = new Future();
   var connection = loggedInAccountsConnection(session.token);
+  var timer;
 
   if (! connection) {
     // Server says our credential isn't any good anymore! Get rid of
@@ -641,32 +653,30 @@ exports.pollForRegistrationCompletion = function (options) {
     return;
   }
 
-  connection.call('getUsername', function (err, result) {
-    if (fut.isResolved()) {
-      return;
+  new Promise(function (resolve) {
+    connection.call('getUsername', function (err, username) {
+      // If anything went wrong, return null just as we would have if we
+      // hadn't bothered to ask the server.
+      resove(err ? null : username);
+    });
+
+    timer = setTimeout(function () {
+      resolve(null);
+    }, 5000);
+
+  // Intentionally calling bindEnvironment on the .then callback rather
+  // than the function that calls resolve.
+  }).then(fiberHelpers.bindEnvironment(function (username) {
+    connection.close();
+    clearTimeout(timer);
+
+    if (username) {
+      writeMeteorAccountsUsername(username);
     }
 
-    if (err) {
-      // If anything went wrong, return null just as we would have if
-      // we hadn't bothered to ask the server.
-      fut['return'](null);
-      return;
-    }
-    fut['return'](result);
-  });
-
-  var timer = setTimeout(fiberHelpers.bindEnvironment(function () {
-    if (! fut.isResolved()) {
-      fut['return'](null);
-    }
-  }), 5000);
-
-  username = fut.wait();
-  connection.close();
-  clearTimeout(timer);
-  if (username) {
-    writeMeteorAccountsUsername(username);
-  }
+  // We don't actually care about the result, just that the side-effects
+  // of writeMeteorAccountsUsername happen.
+  })).await();
 };
 
 exports.registrationUrl = function () {

--- a/tools/packaging/package-client.js
+++ b/tools/packaging/package-client.js
@@ -1,4 +1,3 @@
-var Future = require('fibers/future');
 var _ = require('underscore');
 
 var config = require('../meteor-services/config.js');
@@ -189,9 +188,8 @@ var _updateServerPackageData = function (dataStore, options) {
       var zlib = require('zlib');
       var colsGzippedBuffer = new Buffer(
         remoteData.collectionsCompressed, 'base64');
-      var fut = new Future;
-      zlib.gunzip(colsGzippedBuffer, fut.resolver());
-      var colsJSON = fut.wait();
+      var gunzip = Promise.denodeify(zlib.gunzip);
+      var colsJSON = gunzip(colsGzippedBuffer).await();
       remoteData.collections = JSON.parse(colsJSON);
       delete remoteData.collectionsCompressed;
     }

--- a/tools/packaging/warehouse.js
+++ b/tools/packaging/warehouse.js
@@ -37,7 +37,6 @@
 /// environment variable). The setup of that is handled by release.js.
 
 var os = require("os");
-var Future = require("fibers/future");
 var _ = require("underscore");
 
 var files = require('../fs/files.js');
@@ -190,7 +189,6 @@ _.extend(warehouse, {
   // all of the missing versioned packages referenced from the release manifest
   // @param releaseVersion {String} eg "0.1"
   _populateWarehouseForRelease: function (releaseVersion, showInstalling) {
-    var future = new Future;
     var releasesDir = files.pathJoin(warehouse.getWarehouseDir(), 'releases');
     files.mkdir_p(releasesDir, 0o755);
     var releaseManifestPath = files.pathJoin(releasesDir,

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -7,7 +7,6 @@ var child_process = require('child_process');
 
 var _ = require('underscore');
 var isopackets = require('../tool-env/isopackets.js');
-var Future = require('fibers/future');
 
 // Given a Mongo URL, open an interative Mongo shell on this terminal
 // on that database.
@@ -78,7 +77,7 @@ if (process.platform === 'win32') {
   // Windows doesn't have a ps equivalent that (reliably) includes the command
   // line, so approximate using the combined output of tasklist and netstat.
   findMongoPids = function (app_dir, port) {
-    var fut = new Future;
+    var promise = fiberHelpers.makeFulfillablePromise();
 
     child_process.exec('tasklist /fi "IMAGENAME eq mongod.exe"',
       function (error, stdout, stderr) {
@@ -87,8 +86,9 @@ if (process.platform === 'win32') {
           if (error.code === 'ENOENT') {
             additionalInfo = "tasklist wasn't found on your system, it usually can be found at C:\\Windows\\System32\\.";
           }
-          fut['throw'](new Error("Couldn't run tasklist.exe: " +
-            additionalInfo));
+          promise.reject(
+            new Error("Couldn't run tasklist.exe: " + additionalInfo)
+          );
           return;
         } else {
           // Find the pids of all mongod processes
@@ -106,8 +106,10 @@ if (process.platform === 'win32') {
             {maxBuffer: 1024 * 1024 * 10},
             function (error, stdout, stderr) {
             if (error) {
-              fut['throw'](new Error("Couldn't run netstat -ano: " +
-                JSON.stringify(error)));
+              promise.reject(
+                new Error("Couldn't run netstat -ano: " +
+                          JSON.stringify(error))
+              );
               return;
             } else {
               var pids = [];
@@ -131,17 +133,17 @@ if (process.platform === 'win32') {
                 }
               });
 
-              fut['return'](pids);
+              promise.resolve(pids);
             }
           });
         }
       });
 
-    return fut.wait();
+    return promise.await();
   };
 } else {
   findMongoPids = function (appDir, port) {
-    var fut = new Future;
+    var promise = fiberHelpers.makeFulfillablePromise();
 
     // 'ps ax' should be standard across all MacOS and Linux.
     // However, ps on OS X corrupts some non-ASCII characters in arguments,
@@ -181,8 +183,11 @@ if (process.platform === 'win32') {
       {maxBuffer: 1024 * 1024 * 10},
       function (error, stdout, stderr) {
         if (error) {
-          fut['throw'](new Error("Couldn't run ps ax: " +
-            JSON.stringify(error) + "; " + error.message));
+          promise.reject(
+            new Error("Couldn't run ps ax: " +
+                      JSON.stringify(error) + "; " +
+                      error.message)
+          );
           return;
         }
 
@@ -208,10 +213,10 @@ if (process.platform === 'win32') {
           }
         });
 
-        fut['return'](ret);
+        promise.resolve(ret);
       });
 
-    return fut.wait();
+    return promise.await();
   };
 }
 
@@ -259,19 +264,17 @@ if (process.platform === 'win32') {
     // (The METEOR-PORT file may point to an old Mongo server that's now
     // stopped)
     var net = require('net');
-    var mongoTestConnectFuture = new Future;
-    var client = net.connect({port: mongoPort}, function() {
-      // The server is running.
-      client.end();
-      mongoTestConnectFuture.isResolved() || mongoTestConnectFuture.return();
-    });
-    client.on('error', function () {
-      mongoPort = null;
-      mongoTestConnectFuture.isResolved() || mongoTestConnectFuture.return();
-    });
-    mongoTestConnectFuture.wait();
 
-    return mongoPort;
+    return new Promise(resolve => {
+      var client = net.connect({
+        port: mongoPort
+      }, () => {
+        // The server is running.
+        client.end();
+        resolve(mongoPort);
+      });
+      client.on('error', () => resolve(null));
+    }).await();
   }
 }
 
@@ -374,18 +377,9 @@ var launchMongo = function (options) {
 
   var subHandles = [];
   var stopped = false;
-  var stopFuture = new Future;
-
-  // Like Future.wrap and _.bind in one.
-  var yieldingMethod = function (object, methodName, ...args) {
-    var f = new Future;
-    args.push(f.resolver());
-    object[methodName](...args);
-    return fiberHelpers.waitForOne(stopFuture, f);
-  };
-
-  var handle = {
-    stop: function () {
+  var handle = {};
+  var stopPromise = new Promise((resolve, reject) => {
+    handle.stop = function () {
       if (stopped) {
         return;
       }
@@ -394,8 +388,19 @@ var launchMongo = function (options) {
         handle.stop();
       });
 
-      stopFuture.throw(new StoppedDuringLaunch);
-    }
+      if (options.onStopped) {
+        options.onStopped();
+      }
+
+      reject(new StoppedDuringLaunch);
+    };
+  });
+
+  var yieldingMethod = function (object, methodName, ...args) {
+    return Promise.race([
+      stopPromise,
+      Promise.denodeify(object[methodName]).apply(object, args)
+    ]).await();
   };
 
   var launchOneMongoAndWaitForReadyForInitiate = function (dbPath, port,
@@ -403,7 +408,6 @@ var launchMongo = function (options) {
     files.mkdir_p(dbPath, 0o755);
 
     var proc = null;
-    var procExitHandler;
 
     if (options.allowKilling) {
       findMongoAndKillItDead(port, dbPath);
@@ -476,7 +480,7 @@ var launchMongo = function (options) {
       }
     });
 
-    procExitHandler = fiberHelpers.bindEnvironment(function (code, signal) {
+    var procExitHandler = fiberHelpers.bindEnvironment(function (code, signal) {
       // Defang subHandle.stop().
       proc = null;
 
@@ -494,17 +498,23 @@ var launchMongo = function (options) {
     var replSetReadyToBeInitiated = false;
     var replSetReady = false;
 
-    var readyToTalkFuture = new Future;
+    var maybeReadyToTalk;
+    var readyToTalkPromise = new Promise(function (resolve) {
+      maybeReadyToTalk = function () {
+        if (resolve &&
+            listening &&
+            (noOplog || replSetReadyToBeInitiated || replSetReady)) {
+          proc.stdout.removeListener('data', stdoutOnData);
+          resolve();
+          resolve = null;
+        }
+      };
+    });
 
-    var maybeReadyToTalk = function () {
-      if (readyToTalkFuture.isResolved()) {
-        return;
-      }
-      if (listening && (noOplog || replSetReadyToBeInitiated || replSetReady)) {
-        proc.stdout.removeListener('data', stdoutOnData);
-        readyToTalkFuture.return();
-      }
-    };
+    var stopOrReadyPromise = Promise.race([
+      stopPromise,
+      readyToTalkPromise,
+    ]);
 
     var detectedErrors = {};
     var stdoutOnData = fiberHelpers.bindEnvironment(function (data) {
@@ -542,7 +552,7 @@ var launchMongo = function (options) {
       stderrOutput += data;
     });
 
-    fiberHelpers.waitForOne(stopFuture, readyToTalkFuture);
+    stopOrReadyPromise.await();
   };
 
 
@@ -708,7 +718,7 @@ var MongoRunner = function (options) {
 
   self.handle = null;
   self.shuttingDown = false;
-  self.startupFuture = null;
+  self.resolveStartupPromise = null;
 
   self.errorCount = 0;
   self.errorTimer = null;
@@ -746,9 +756,10 @@ _.extend(MRp, {
     }
 
     // Otherwise, wait for a successful _startOrRestart, or a failure.
-    if (!self.startupFuture) {
-      self.startupFuture = new Future;
-      self.startupFuture.wait();
+    if (! self.resolveStartupPromise) {
+      new Promise(function (resolve) {
+        self.resolveStartupPromise = resolve;
+      }).await();
     }
   },
 
@@ -783,7 +794,10 @@ _.extend(MRp, {
       port: self.port,
       multiple: self.multiple,
       allowKilling: allowKilling,
-      onExit: _.bind(self._exited, self)
+      onExit: _.bind(self._exited, self),
+      onStopped() {
+        self.suppressExitMessage = false;
+      },
     });
 
     // It has successfully started up, so if it exits after this point, that
@@ -905,10 +919,10 @@ _.extend(MRp, {
 
   _allowStartupToReturn: function () {
     var self = this;
-    if (self.startupFuture) {
-      var startupFuture = self.startupFuture;
-      self.startupFuture = null;
-      startupFuture.return();
+    if (self.resolveStartupPromise) {
+      var resolve = self.resolveStartupPromise;
+      self.resolveStartupPromise = null;
+      resolve();
     }
   },
 

--- a/tools/runners/run-proxy.js
+++ b/tools/runners/run-proxy.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var Future = require('fibers/future');
 var runLog = require('./run-log.js');
 
 // options: listenPort, proxyToPort, proxyToHost, onFailure
@@ -57,7 +56,11 @@ _.extend(Proxy.prototype, {
       self._tryHandleConnections();
     });
 
-    var fut = new Future;
+    var allowStart;
+    var promise = new Promise(function (resolve) {
+      allowStart = resolve;
+    });
+
     self.server.on('error', function (err) {
       if (err.code === 'EADDRINUSE') {
         var port = self.listenPort;
@@ -80,8 +83,7 @@ _.extend(Proxy.prototype, {
         runLog.log('' + err);
       }
       self.onFailure();
-      // Allow start() to return.
-      fut.isResolved() || fut['return']();
+      allowStart();
     });
 
     // Don't crash if the app doesn't respond. instead return an error
@@ -118,10 +120,10 @@ _.extend(Proxy.prototype, {
         // necessary.
         server.close();
       }
-      fut.isResolved() || fut['return']();
+      allowStart();
     });
 
-    fut.wait();
+    promise.await();
   },
 
   // Idempotent.

--- a/tools/runners/run-updater.js
+++ b/tools/runners/run-updater.js
@@ -21,15 +21,15 @@ _.extend(Updater.prototype, {
 
     // Check every 3 hours. (Should not share buildmessage state with
     // the main fiber.)
-    self.timer = setInterval(fiberHelpers.inBareFiber(function () {
+    async function check() {
       self._check();
-    }), 3 * 60 * 60 * 1000);
+    }
+
+    self.timer = setInterval(check, 3 * 60 * 60 * 1000);
 
     // Also start a check now, but don't block on it. (This should
     // not share buildmessage state with the main fiber.)
-    new Fiber(function () {
-      self._check();
-    }).run();
+    check();
   },
 
   _check: function () {

--- a/tools/utils/fiber-helpers.js
+++ b/tools/utils/fiber-helpers.js
@@ -2,19 +2,15 @@ var _ = require("underscore");
 var Fiber = require("fibers");
 
 exports.parallelEach = function (collection, callback, context) {
-  var errors = [];
+  const errors = [];
   context = context || null;
 
-  var results = Promise.all(_.map(collection, function (...args) {
-    return new Promise(function (resolve, reject) {
-      Fiber(function () {
-        try {
-          resolve(callback.apply(context, args));
-        } catch (err) {
-          reject(err);
-        }
-      }).run();
-    }).catch(function (error) {
+  const results = Promise.all(_.map(collection, (...args) => {
+    async function run() {
+      return callback.apply(context, args);
+    }
+
+    return run().catch(error => {
       // Collect the errors but do not propagate them so that we can
       // re-throw the first error after all iterations have completed.
       errors.push(error);

--- a/tools/utils/fiber-helpers.js
+++ b/tools/utils/fiber-helpers.js
@@ -126,20 +126,6 @@ exports.bindEnvironment = function (func) {
   };
 };
 
-// An alternative to bindEnvironment for the rare case where you
-// want the callback you're passing to some Node function to start
-// a new fiber but *NOT* to inherit the current environment.
-// Eg, if you are trying to do the equivalent of start a background
-// thread.
-exports.inBareFiber = function (func) {
-  return function (...args) {
-    var self = this;
-    new Fiber(function () {
-      func.apply(self, args);
-    }).run();
-  };
-};
-
 // Returns a Promise that supports .resolve(result) and .reject(error).
 exports.makeFulfillablePromise = function () {
   var resolve, reject;

--- a/tools/utils/fiber-helpers.js
+++ b/tools/utils/fiber-helpers.js
@@ -166,3 +166,15 @@ exports.inBareFiber = function (func) {
     }).run();
   };
 };
+
+// Returns a Promise that supports .resolve(result) and .reject(error).
+exports.makeFulfillablePromise = function () {
+  var resolve, reject;
+  var promise = new Promise(function (res, rej) {
+    resolve = res;
+    reject = rej;
+  });
+  promise.resolve = resolve;
+  promise.reject = reject;
+  return promise;
+};

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -1,4 +1,3 @@
-var Future = require('fibers/future');
 var _ = require('underscore');
 var semver = require('semver');
 var os = require('os');
@@ -207,9 +206,9 @@ exports.sleepMs = function (ms) {
     return;
   }
 
-  var fut = new Future;
-  setTimeout(function () { fut['return']() }, ms);
-  fut.wait();
+  new Promise(function (resolve) {
+    setTimeout(resolve, ms);
+  }).await();
 };
 
 // Return a short, high entropy string without too many funny
@@ -518,8 +517,6 @@ exports.isValidVersion = function (version, {forCordova}) {
 
 
 exports.execFileSync = function (file, args, opts) {
-  var future = new Future;
-
   var child_process = require('child_process');
   var eachline = require('eachline');
 
@@ -539,26 +536,24 @@ exports.execFileSync = function (file, args, opts) {
       process.stderr.write(line + '\n');
     }));
 
-    p.on('exit', function (code) {
-      future.return(code);
-    });
-
     return {
-      success: !future.wait(),
+      success: ! new Promise(function (resolve) {
+        p.on('exit', resolve);
+      }).await(),
       stdout: "",
       stderr: ""
     };
   }
 
-  child_process.execFile(file, args, opts, function (err, stdout, stderr) {
-    future.return({
-      success: ! err,
-      stdout: stdout,
-      stderr: stderr
+  return new Promise(function (resolve) {
+    child_process.execFile(file, args, opts, function (err, stdout, stderr) {
+      resolve({
+        success: ! err,
+        stdout: stdout,
+        stderr: stderr
+      });
     });
-  });
-
-  return future.wait();
+  }).await();
 };
 
 exports.execFileAsync = function (file, args, opts) {
@@ -634,17 +629,13 @@ _.extend(exports.ThrottledYield.prototype, {
   yield: function () {
     var self = this;
     if (self._throttle.isAllowed()) {
-      var f = new Future;
       // setImmediate allows signals and IO to be processed but doesn't
       // otherwise add time-based delays. It is better for yielding than
       // process.nextTick (which doesn't allow signals or IO to be processed) or
       // setTimeout 1 (which adds a minimum of 1 ms and often more in delays).
       // XXX Actually, setImmediate is so fast that we might not even need
       // to use the throttler at all?
-      setImmediate(function () {
-        f.return();
-      });
-      f.wait();
+      new Promise(setImmediate).await();
     }
   }
 });


### PR DESCRIPTION
This branch has been sitting around since May 2015. After rebasing it against https://github.com/meteor/meteor/pull/4619, I decided I'd rather not rebase it again if I can help it.

Note that many of these commits use `Promise.prototype.await` to yield the current `Fiber` until the `Promise` is resolved, which (like `Future.prototype.wait`) allows the code creating the `Promise` to avoid returning the `Promise` to the caller. This works great in an environment with `Fiber`s, but it might be better, if this code was being written from scratch, to stick to `Promise.prototype.then` or `async` functions and `await` expressions, so that the calling code can decide how to orchestrate the asynchronous operations.
