### PR TITLE
Add case insensitive email lookup to forgotPassword function

### DIFF
--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -43,7 +43,7 @@ Package.onUse(function (api) {
   api.addFiles('accounts_common.js', ['client', 'server']);
   api.addFiles('accounts_server.js', 'server');
 
-  api.addFiles('accounts_rate_limit.js');
+  api.addFiles('accounts_rate_limit.js', 'server');
   api.addFiles('url_server.js', 'server');
 
   // accounts_client must be before localstorage_token, because

--- a/packages/accounts-password/email_tests.js
+++ b/packages/accounts-password/email_tests.js
@@ -3,7 +3,10 @@ var verifyEmailToken;
 var enrollAccountToken;
 
 Accounts._isolateLoginTokenForTest();
-Accounts.removeDefaultRateLimit();
+
+if (Meteor.isServer) {
+  Accounts.removeDefaultRateLimit();
+}
 
 testAsyncMulti("accounts emails - reset password flow", [
   function (test, expect) {

--- a/packages/accounts-password/email_tests.js
+++ b/packages/accounts-password/email_tests.js
@@ -1,33 +1,30 @@
-// intentionally initialize later so that we can debug tests after
-// they fail without trying to recreate a user with the same email
-// address
-var email1;
-var email2;
-var email3;
-var email4;
-
 var resetPasswordToken;
 var verifyEmailToken;
 var enrollAccountToken;
 
 Accounts._isolateLoginTokenForTest();
 Accounts.removeDefaultRateLimit();
+
 testAsyncMulti("accounts emails - reset password flow", [
   function (test, expect) {
-    email1 = Random.id() + "-intercept@example.com";
-    Accounts.createUser({email: email1, password: 'foobar'},
-                        expect(function (error) {
-                          test.equal(error, undefined);
-                        }));
+    this.randomSuffix = Random.id();
+    this.email = "Ada-intercept@example.com" + this.randomSuffix;
+    // Create the user with another email and add the tested for email later,
+    // so we can test whether forgotPassword respects the passed in email
+    Accounts.createUser({email: "another@example.com" + this.randomSuffix, password: 'foobar'},
+      expect((error) => {
+        test.equal(error, undefined);
+        Meteor.call("addEmailForTestAndVerify", this.email);
+      }));
   },
   function (test, expect) {
-    Accounts.forgotPassword({email: email1}, expect(function (error) {
+    Accounts.forgotPassword({email: this.email}, expect((error) => {
       test.equal(error, undefined);
     }));
   },
   function (test, expect) {
     Accounts.connection.call(
-      "getInterceptedEmails", email1, expect(function (error, result) {
+      "getInterceptedEmails", this.email, expect((error, result) => {
         test.equal(error, undefined);
         test.notEqual(result, undefined);
         test.equal(result.length, 2); // the first is the email verification
@@ -44,25 +41,87 @@ testAsyncMulti("accounts emails - reset password flow", [
       }));
   },
   function (test, expect) {
-    Accounts.resetPassword(resetPasswordToken, "newPassword", expect(function(error) {
+    Accounts.resetPassword(resetPasswordToken, "newPassword", expect((error) => {
       test.isFalse(error);
     }));
   },
   function (test, expect) {
-    Meteor.logout(expect(function (error) {
+    Meteor.logout(expect((error) => {
       test.equal(error, undefined);
       test.equal(Meteor.user(), null);
     }));
   },
   function (test, expect) {
     Meteor.loginWithPassword(
-      {email: email1}, "newPassword",
-      expect(function (error) {
+      {email: this.email}, "newPassword",
+      expect((error) => {
         test.isFalse(error);
       }));
   },
   function (test, expect) {
-    Meteor.logout(expect(function (error) {
+    Meteor.logout(expect((error) => {
+      test.equal(error, undefined);
+      test.equal(Meteor.user(), null);
+    }));
+  }
+]);
+
+testAsyncMulti(`accounts emails - \
+reset password flow with case insensitive email`, [
+  function (test, expect) {
+    this.randomSuffix = Random.id();
+    this.email = "Ada-intercept@example.com" + this.randomSuffix;
+    // Create the user with another email and add the tested for email later,
+    // so we can test whether forgotPassword respects the passed in email
+    Accounts.createUser({email: "another@example.com" + this.randomSuffix, password: 'foobar'},
+      expect((error) => {
+        test.equal(error, undefined);
+        Meteor.call("addEmailForTestAndVerify", this.email);
+      }));
+  },
+  function (test, expect) {
+    Accounts.forgotPassword({email: "ada-intercept@example.com" + this.randomSuffix}, expect((error) => {
+      test.equal(error, undefined);
+    }));
+  },
+  function (test, expect) {
+    Accounts.connection.call(
+      "getInterceptedEmails", this.email, expect((error, result) => {
+        test.equal(error, undefined);
+        test.notEqual(result, undefined);
+        test.equal(result.length, 2); // the first is the email verification
+        var options = result[1];
+
+        var re = new RegExp(Meteor.absoluteUrl() + "#/reset-password/(\\S*)");
+        var match = options.text.match(re);
+        test.isTrue(match);
+        resetPasswordToken = match[1];
+        test.isTrue(options.html.match(re));
+
+        test.equal(options.from, 'test@meteor.com');
+        test.equal(options.headers['My-Custom-Header'], 'Cool');
+      }));
+  },
+  function (test, expect) {
+    Accounts.resetPassword(resetPasswordToken, "newPassword", expect((error) => {
+      test.isFalse(error);
+    }));
+  },
+  function (test, expect) {
+    Meteor.logout(expect((error) => {
+      test.equal(error, undefined);
+      test.equal(Meteor.user(), null);
+    }));
+  },
+  function (test, expect) {
+    Meteor.loginWithPassword(
+      {email: this.email}, "newPassword",
+      expect((error) => {
+        test.isFalse(error);
+      }));
+  },
+  function (test, expect) {
+    Meteor.logout(expect((error) => {
       test.equal(error, undefined);
       test.equal(Meteor.user(), null);
     }));
@@ -71,7 +130,7 @@ testAsyncMulti("accounts emails - reset password flow", [
 
 var getVerifyEmailToken = function (email, test, expect) {
   Accounts.connection.call(
-    "getInterceptedEmails", email, expect(function (error, result) {
+    "getInterceptedEmails", email, expect((error, result) => {
       test.equal(error, undefined);
       test.notEqual(result, undefined);
       test.equal(result.length, 1);
@@ -89,7 +148,7 @@ var getVerifyEmailToken = function (email, test, expect) {
 };
 
 var loggedIn = function (test, expect) {
-  return expect(function (error) {
+  return expect((error) => {
     test.equal(error, undefined);
     test.isTrue(Meteor.user());
   });
@@ -97,25 +156,25 @@ var loggedIn = function (test, expect) {
 
 testAsyncMulti("accounts emails - verify email flow", [
   function (test, expect) {
-    email2 = Random.id() + "-intercept@example.com";
-    email3 = Random.id() + "-intercept@example.com";
+    this.email = Random.id() + "-intercept@example.com";
+    this.anotherEmail = Random.id() + "-intercept@example.com";
     Accounts.createUser(
-      {email: email2, password: 'foobar'},
+      {email: this.email, password: 'foobar'},
       loggedIn(test, expect));
   },
   function (test, expect) {
     test.equal(Meteor.user().emails.length, 1);
-    test.equal(Meteor.user().emails[0].address, email2);
+    test.equal(Meteor.user().emails[0].address, this.email);
     test.isFalse(Meteor.user().emails[0].verified);
     // We should NOT be publishing things like verification tokens!
     test.isFalse(_.has(Meteor.user(), 'services'));
   },
   function (test, expect) {
-    getVerifyEmailToken(email2, test, expect);
+    getVerifyEmailToken(this.email, test, expect);
   },
   function (test, expect) {
     // Log out, to test that verifyEmail logs us back in.
-    Meteor.logout(expect(function (error) {
+    Meteor.logout(expect((error) => {
       test.equal(error, undefined);
       test.equal(Meteor.user(), null);
     }));
@@ -126,26 +185,26 @@ testAsyncMulti("accounts emails - verify email flow", [
   },
   function (test, expect) {
     test.equal(Meteor.user().emails.length, 1);
-    test.equal(Meteor.user().emails[0].address, email2);
+    test.equal(Meteor.user().emails[0].address, this.email);
     test.isTrue(Meteor.user().emails[0].verified);
   },
   function (test, expect) {
     Accounts.connection.call(
-      "addEmailForTestAndVerify", email3,
-      expect(function (error, result) {
+      "addEmailForTestAndVerify", this.anotherEmail,
+      expect((error, result) => {
         test.isFalse(error);
         test.equal(Meteor.user().emails.length, 2);
-        test.equal(Meteor.user().emails[1].address, email3);
+        test.equal(Meteor.user().emails[1].address, this.anotherEmail);
         test.isFalse(Meteor.user().emails[1].verified);
       }));
   },
   function (test, expect) {
-    getVerifyEmailToken(email3, test, expect);
+    getVerifyEmailToken(this.anotherEmail, test, expect);
   },
   function (test, expect) {
     // Log out, to test that verifyEmail logs us back in. (And if we don't
     // do that, waitUntilLoggedIn won't be able to prevent race conditions.)
-    Meteor.logout(expect(function (error) {
+    Meteor.logout(expect((error) => {
       test.equal(error, undefined);
       test.equal(Meteor.user(), null);
     }));
@@ -155,11 +214,11 @@ testAsyncMulti("accounts emails - verify email flow", [
                          loggedIn(test, expect));
   },
   function (test, expect) {
-    test.equal(Meteor.user().emails[1].address, email3);
+    test.equal(Meteor.user().emails[1].address, this.anotherEmail);
     test.isTrue(Meteor.user().emails[1].verified);
   },
   function (test, expect) {
-    Meteor.logout(expect(function (error) {
+    Meteor.logout(expect((error) => {
       test.equal(error, undefined);
       test.equal(Meteor.user(), null);
     }));
@@ -168,7 +227,7 @@ testAsyncMulti("accounts emails - verify email flow", [
 
 var getEnrollAccountToken = function (email, test, expect) {
   Accounts.connection.call(
-    "getInterceptedEmails", email, expect(function (error, result) {
+    "getInterceptedEmails", email, expect((error, result) => {
       test.equal(error, undefined);
       test.notEqual(result, undefined);
       test.equal(result.length, 1);
@@ -187,18 +246,18 @@ var getEnrollAccountToken = function (email, test, expect) {
 
 testAsyncMulti("accounts emails - enroll account flow", [
   function (test, expect) {
-    email4 = Random.id() + "-intercept@example.com";
-    Accounts.connection.call("createUserOnServer", email4,
-      expect(function (error, result) {
+    this.email = Random.id() + "-intercept@example.com";
+    Accounts.connection.call("createUserOnServer", this.email,
+      expect((error, result) => {
         test.isFalse(error);
         var user = result;
         test.equal(user.emails.length, 1);
-        test.equal(user.emails[0].address, email4);
+        test.equal(user.emails[0].address, this.email);
         test.isFalse(user.emails[0].verified);
       }));
   },
   function (test, expect) {
-    getEnrollAccountToken(email4, test, expect);
+    getEnrollAccountToken(this.email, test, expect);
   },
   function (test, expect) {
     Accounts.resetPassword(enrollAccountToken, 'password',
@@ -206,26 +265,26 @@ testAsyncMulti("accounts emails - enroll account flow", [
   },
   function (test, expect) {
     test.equal(Meteor.user().emails.length, 1);
-    test.equal(Meteor.user().emails[0].address, email4);
+    test.equal(Meteor.user().emails[0].address, this.email);
     test.isTrue(Meteor.user().emails[0].verified);
   },
   function (test, expect) {
-    Meteor.logout(expect(function (error) {
+    Meteor.logout(expect((error) => {
       test.equal(error, undefined);
       test.equal(Meteor.user(), null);
     }));
   },
   function (test, expect) {
-    Meteor.loginWithPassword({email: email4}, 'password',
+    Meteor.loginWithPassword({email: this.email}, 'password',
                              loggedIn(test ,expect));
   },
   function (test, expect) {
     test.equal(Meteor.user().emails.length, 1);
-    test.equal(Meteor.user().emails[0].address, email4);
+    test.equal(Meteor.user().emails[0].address, this.email);
     test.isTrue(Meteor.user().emails[0].verified);
   },
   function (test, expect) {
-    Meteor.logout(expect(function (error) {
+    Meteor.logout(expect((error) => {
       test.equal(error, undefined);
       test.equal(Meteor.user(), null);
     }));

--- a/packages/accounts-password/email_tests_setup.js
+++ b/packages/accounts-password/email_tests_setup.js
@@ -6,7 +6,7 @@
 var interceptedEmails = {}; // (email address) -> (array of options)
 
 // add html email templates that just contain the url
-Accounts.emailTemplates.resetPassword.html = 
+Accounts.emailTemplates.resetPassword.html =
   Accounts.emailTemplates.enrollAccount.html =
   Accounts.emailTemplates.verifyEmail.html = function (user, url) {
     return url;

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -31,7 +31,7 @@ Package.onUse(function(api) {
 Package.onTest(function(api) {
   api.use(['accounts-password', 'tinytest', 'test-helpers', 'tracker',
            'accounts-base', 'random', 'email', 'underscore', 'check',
-           'ddp']);
+           'ddp', 'ecmascript']);
   api.addFiles('password_tests_setup.js', 'server');
   api.addFiles('password_tests.js', ['client', 'server']);
   api.addFiles('email_tests_setup.js', 'server');

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -500,11 +500,16 @@ Accounts.setPassword = function (userId, newPlaintextPassword, options) {
 Meteor.methods({forgotPassword: function (options) {
   check(options, {email: String});
 
-  var user = Meteor.users.findOne({"emails.address": options.email});
+  var user = Accounts._findUserByQuery({email: options.email});
   if (!user)
     throw new Meteor.Error(403, "User not found");
 
-  Accounts.sendResetPasswordEmail(user._id, options.email);
+  const emails = _.pluck(user.emails || [], 'address');
+  const caseSensitiveEmail = _.find(emails, email => {
+    return email.toLowerCase() === options.email.toLowerCase();
+  });
+
+  Accounts.sendResetPasswordEmail(user._id, caseSensitiveEmail);
 }});
 
 // send the user an email with a link that when opened allows the user

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -500,7 +500,7 @@ Accounts.setPassword = function (userId, newPlaintextPassword, options) {
 Meteor.methods({forgotPassword: function (options) {
   check(options, {email: String});
 
-  var user = Accounts._findUserByQuery({email: options.email});
+  var user = Accounts.findUserByEmail(options.email);
   if (!user)
     throw new Meteor.Error(403, "User not found");
 

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -26,11 +26,11 @@ if (Meteor.isClient) (function () {
   Accounts._isolateLoginTokenForTest();
 
   var addSkipCaseInsensitiveChecksForTest = function (value, test, expect) {
-    Meteor.call('addSkipCaseInsensitiveChecksForTest', value, expect);
+    Meteor.call('addSkipCaseInsensitiveChecksForTest', value);
   };
 
   var removeSkipCaseInsensitiveChecksForTest = function (value, test, expect) {
-    Meteor.call('removeSkipCaseInsensitiveChecksForTest', value, expect);
+    Meteor.call('removeSkipCaseInsensitiveChecksForTest', value);
   };
 
   var createUserStep = function (test, expect) {

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1,6 +1,8 @@
 Accounts._noConnectionCloseDelayForTest = true;
-Accounts.removeDefaultRateLimit();
+
 if (Meteor.isServer) {
+  Accounts.removeDefaultRateLimit();
+  
   Meteor.methods({
     getResetToken: function () {
       var token = Meteor.users.findOne(this.userId).services.password.reset;


### PR DESCRIPTION
This is a continuation of https://github.com/meteor/meteor/pull/5622, but I couldn't find a way to modify the pull request directly, so I had to create a separate branch.

I've cleaned up some of the test code to get rid of email variables shared between tests, and have made sure `forgotPassword` respects the passed in email and doesn't just use the first address in the user's `emails` list. Also, `Accounts.sendResetPasswordEmail` continues to expect a case sensitive email address (as do similar server functions).