### PR TITLE
Fix bug #5665: add DDP.onReconnect(), deprecate conn.onReconnect

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,13 @@
 ## v.NEXT
 
+* Deprecate use of `connection.onReconnect = func`. Instead, a new
+  `DDP.onReconnect(callback)` method should be used to register callbacks to
+  call when a connection reconnects. The connection that is reconnecting is
+  passed as the only argument to `callback`. This is used by the accounts system
+  to relogin on reconnects without interfering with other code which uses
+  `connection.onReconnect`.
+  [#5665](https://github.com/meteor/meteor/issues/5665)
+
 * Split up `standard-minifiers` in separate CSS (`standard-minifiers-css`) and JS
   minifiers(`standard-minifiers-js`). `standard-minifiers` now acts as an umbrella package for these
   2 minifiers.

--- a/docs/client/full-api/api/connections.md
+++ b/docs/client/full-api/api/connections.md
@@ -154,10 +154,6 @@ sets, call `DDP.connect` with the URL of the application.
   See [Meteor.reconnect](#meteor_reconnect).
 * `disconnect` -
   See [Meteor.disconnect](#meteor_disconnect).
-* `onReconnect` - Set this to a function to be called as the first step of
-  reconnecting. This function can call methods which will be executed before
-  any other outstanding methods. For example, this can be used to re-establish
-  the appropriate authentication context on the new connection.
 
 By default, clients open a connection to the server from which they're loaded.
 When you call `Meteor.subscribe`, `Meteor.status`, `Meteor.call`, and

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -217,7 +217,10 @@ Ap.callLoginMethod = function (options) {
       // already logged in they will still get logged in on reconnect.
       // See issue #4970.
     } else {
-      self.connection.onReconnect = function () {
+      self._reconnectStopper = DDP.onReconnect(function (conn) {
+        if (conn != self.connection) {
+          return;
+        }
         reconnected = true;
         // If our token was updated in storage, use the latest one.
         var storedToken = self._storedLoginToken();
@@ -268,7 +271,7 @@ Ap.callLoginMethod = function (options) {
               loginCallbacks(error);
             }});
         }
-      };
+      });
     }
   };
 
@@ -318,7 +321,7 @@ Ap.callLoginMethod = function (options) {
 Ap.makeClientLoggedOut = function () {
   this._unstoreLoginToken();
   this.connection.setUserId(null);
-  this.connection.onReconnect = null;
+  this._reconnectStopper && this._reconnectStopper.stop();
 };
 
 Ap.makeClientLoggedIn = function (userId, token, tokenExpires) {

--- a/packages/accounts-base/accounts_reconnect_tests.js
+++ b/packages/accounts-base/accounts_reconnect_tests.js
@@ -8,6 +8,12 @@ if (Meteor.isServer) {
 
 if (Meteor.isClient) {
   Tinytest.addAsync('accounts - reconnect auto-login', function(test, done) {
+    var onReconnectCalls = 0;
+    var reconnectHandler = function () {
+      onReconnectCalls++;
+    };
+    Meteor.connection.onReconnect = reconnectHandler;
+    
     var username1 = 'testuser1-' + Random.id();
     var username2 = 'testuser2-' + Random.id();
     var password1 = 'password1-' + Random.id();
@@ -69,6 +75,9 @@ if (Meteor.isClient) {
       test.isUndefined(err, 'Unexpected error calling getConnectionUserId');
       test.equal(connectionUserId, Meteor.userId(),
         'userId is different on client and server');
+      test.equal(Meteor.connection.onReconnect, reconnectHandler,
+        'Meteor.connection.onReconnect changed');
+      test.equal(onReconnectCalls, 2, 'wrong # of reconnect handler calls');
       done();
     }
   });

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "A user account system",
-  version: "1.2.2"
+  version: "1.2.3"
 });
 
 Package.onUse(function (api) {
@@ -18,9 +18,9 @@ Package.onUse(function (api) {
   // (service-configuration needs Accounts.connection)
   api.use('service-configuration', ['client', 'server'], { unordered: true });
 
-  // needed for getting the currently logged-in user
-  api.use('ddp', ['client', 'server']);
-
+  // needed for getting the currently logged-in user and handling reconnects
+  api.use('ddp@1.3.0', ['client', 'server']);
+  
   // need this because of the Meteor.users collection but in the future
   // we'd probably want to abstract this away
   api.use('mongo', ['client', 'server']);

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data client",
-  version: '1.2.1',
+  version: '1.3.0',
   documentation: null
 });
 
@@ -13,6 +13,9 @@ Package.onUse(function (api) {
   api.use(['check', 'random', 'ejson', 'underscore', 'tracker',
            'retry', 'id-map'],
           ['client', 'server']);
+
+  // for DDP.onReconnect
+  api.use('callback-hook', ['client', 'server']);
 
   // common functionality
   api.use('ddp-common', ['client', 'server']);

--- a/packages/ddp/package.js
+++ b/packages/ddp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data framework",
-  version: '1.2.2'
+  version: '1.3.0'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Deprecate use of `connection.onReconnect = func`. Instead, a new
`DDP.onReconnect(callback)` method should be used to register callbacks to call
when a connection reconnects. The connection that is reconnecting is passed as
the only argument to `callback`. This is used by the accounts system to relogin
on reconnects without interfering with other code which uses
`connection.onReconnect`.
