### PR TITLE
Issue #5664 Client Accounts.forgotPassword and .verifyEmail pass error in callback

### DIFF
--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -116,7 +116,7 @@ Accounts.createUser = function (options, callback) {
   if (typeof options.password !== 'string')
     throw new Error("options.password must be a string");
   if (!options.password) {
-    callback(new Meteor.Error(400, "Password may not be empty"));
+    callback && callback(new Meteor.Error(400, "Password may not be empty"));
     return;
   }
 
@@ -153,7 +153,7 @@ Accounts.changePassword = function (oldPassword, newPassword, callback) {
 
   check(newPassword, String);
   if (!newPassword) {
-    callback(new Meteor.Error(400, "Password may not be empty"));
+    callback && callback(new Meteor.Error(400, "Password may not be empty"));
     return;
   }
 
@@ -209,7 +209,7 @@ Accounts.changePassword = function (oldPassword, newPassword, callback) {
  */
 Accounts.forgotPassword = function(options, callback) {
   if (!options.email) {
-    callback(new Meteor.Error(400, "Must pass options.email"));
+    callback && callback(new Meteor.Error(400, "Must pass options.email"));
     return;
   }
   Accounts.connection.call("forgotPassword", options, callback);
@@ -234,7 +234,7 @@ Accounts.resetPassword = function(token, newPassword, callback) {
   check(newPassword, String);
 
   if (!newPassword) {
-    callback(new Meteor.Error(400, "Password may not be empty"));
+    callback && callback(new Meteor.Error(400, "Password may not be empty"));
     return;
   }
 
@@ -258,7 +258,7 @@ Accounts.resetPassword = function(token, newPassword, callback) {
  */
 Accounts.verifyEmail = function(token, callback) {
   if (!token) {
-    callback(new Meteor.Error(400, "Need to pass token"));
+    callback && callback(new Meteor.Error(400, "Need to pass token"));
     return;
   }
 

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -208,8 +208,10 @@ Accounts.changePassword = function (oldPassword, newPassword, callback) {
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  */
 Accounts.forgotPassword = function(options, callback) {
-  if (!options.email)
-    throw new Error("Must pass options.email");
+  if (!options.email) {
+    callback(new Meteor.Error(400, "Must pass options.email"));
+    return;
+  }
   Accounts.connection.call("forgotPassword", options, callback);
 };
 
@@ -255,8 +257,10 @@ Accounts.resetPassword = function(token, newPassword, callback) {
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  */
 Accounts.verifyEmail = function(token, callback) {
-  if (!token)
-    throw new Error("Need to pass token");
+  if (!token) {
+    callback(new Meteor.Error(400, "Need to pass token"));
+    return;
+  }
 
   Accounts.callLoginMethod({
     methodName: 'verifyEmail',

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1163,6 +1163,34 @@ if (Meteor.isClient) (function () {
     },
     logoutStep
   ]);
+
+  testAsyncMulti("passwords - forgotPassword client return error when empty email", [
+    function (test, expect) {
+      // setup
+      this.email = '';
+    },
+    // forgotPassword called on client with blank email
+    function (test, expect) {
+      Accounts.forgotPassword(
+        { email: this.email }, expect(function (error) {
+          test.isTrue(error);
+      }));
+    },
+  ]);
+
+  testAsyncMulti("passwords - verifyEmail client return error when empty token", [
+    function (test, expect) {
+      // setup
+      this.token = '';
+    },
+    // verifyEmail called on client with blank token
+    function (test, expect) {
+      Accounts.verifyEmail(
+        this.token, expect(function (error) {
+          test.isTrue(error);
+      }));
+    },
+  ]);
 }) ();
 
 

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -308,6 +308,13 @@ if (Meteor.isClient) (function () {
       "username", [
     createUserStep,
     logoutStep,
+    // Create user error without callback should not throw error
+    function (test, expect) {
+      this.newUsername = 'adalovelace' + this.randomSuffix;
+      Accounts.createUser(
+        { username: this.newUsername, password: '' }
+        );
+    },
     // Attempting to create another user with a username that only differs in
     // case should fail
     function (test, expect) {
@@ -465,6 +472,14 @@ if (Meteor.isClient) (function () {
         test.isTrue(error);
         test.equal(Meteor.user().username, self.username);
       }));
+    },
+    // change password with bad old password, but no callback so no error
+    function (test, expect) {
+      Accounts.changePassword('wrong', 'doesntmatter');
+    },
+    // change password with blank new password, but no callback so no error
+    function (test, expect) {
+      Accounts.changePassword(this.password, '');
     },
     // change password with good old password.
     function (test, expect) {
@@ -1176,6 +1191,10 @@ if (Meteor.isClient) (function () {
           test.isTrue(error);
       }));
     },
+    // forgotPassword called on client with blank email, no callback so no error
+    function (test, expect) {
+      Accounts.forgotPassword({ email: this.email });
+    },
   ]);
 
   testAsyncMulti("passwords - verifyEmail client return error when empty token", [
@@ -1189,6 +1208,41 @@ if (Meteor.isClient) (function () {
         this.token, expect(function (error) {
           test.isTrue(error);
       }));
+    },
+    // verifyEmail called on client with blank token, no callback so no error
+    function (test, expect) {
+      Accounts.verifyEmail(this.token);
+    },
+  ]);
+
+  testAsyncMulti("passwords - resetPassword errors", [
+    function (test, expect) {
+      // setup
+      this.token = '';
+      this.newPassword = 'nonblankpassword';
+    },
+    // resetPassword called on client with blank token
+    function (test, expect) {
+      Accounts.resetPassword(
+        this.token, this.newPassword, expect(function (error) {
+          test.isTrue(error);
+      }));
+    },
+    function (test, expect) {
+      // setup
+      this.token = 'nonblank-token';
+      this.newPassword = '';
+    },
+    // resetPassword called on client with blank password
+    function (test, expect) {
+      Accounts.resetPassword(
+        this.token, this.newPassword, expect(function (error) {
+          test.isTrue(error);
+      }));
+    },
+    // resetPassword called on client with blank password, no callback so no error
+    function (test, expect) {
+      Accounts.resetPassword(this.token, this.newPassword);
     },
   ]);
 }) ();


### PR DESCRIPTION
To resolve issue #5664.
Accounts.forgotPassword and Accounts.verifyEmail to return error in callback instead of exception.
bugfix in packages/accounts-password/password_client.js
Two additional tests in packages/accounts-password/password_tests.js
