### PR TITLE
Handle authentication type in Facebook

### DIFF
--- a/packages/facebook/facebook_client.js
+++ b/packages/facebook/facebook_client.js
@@ -35,12 +35,12 @@ Facebook.requestCredential = function (options, credentialRequestCompleteCallbac
         '&redirect_uri=' + OAuth._redirectUri('facebook', config) +
         '&display=' + display + '&scope=' + scope +
         '&state=' + OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl);
-  
+
   // Handle authentication type (e.g. for force login you need authType: "reauthenticate")
   if (options.authType) {
-    loginUrl = loginUrl + "&authType=" + options.authType;
+    loginUrl += "&authType=" + encodeURIComponent(options.authType);
   }
-  
+
   OAuth.launchLogin({
     loginService: "facebook",
     loginStyle: loginStyle,

--- a/packages/facebook/facebook_client.js
+++ b/packages/facebook/facebook_client.js
@@ -35,7 +35,12 @@ Facebook.requestCredential = function (options, credentialRequestCompleteCallbac
         '&redirect_uri=' + OAuth._redirectUri('facebook', config) +
         '&display=' + display + '&scope=' + scope +
         '&state=' + OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl);
-
+  
+  // Handle authentication type (e.g. for force login you need authType: "reauthenticate")
+  if (options.authType) {
+    loginUrl = loginUrl + "&authType=" + options.authType;
+  }
+  
   OAuth.launchLogin({
     loginService: "facebook",
     loginStyle: loginStyle,


### PR DESCRIPTION
Allow using authType in Facebook login (https://developers.facebook.com/docs/facebook-login/reauthentication) :balloon:
