### PR TITLE
missing space

### DIFF
--- a/docs/client/basic/introduction.html
+++ b/docs/client/basic/introduction.html
@@ -53,7 +53,7 @@ catches your interest, we hope you'll get involved with the project!
 
 <dt><span>Forums</span></dt>
 <dd>Visit the <a href="https://forums.meteor.com">Meteor discussion
-    forums</a> to announce projects, get help, talk about the community,
+    forums</a>  to announce projects, get help, talk about the community,
   or discuss changes to core.
 </dd>
 


### PR DESCRIPTION
very minor edit. this line renders as "Visit the Meteor discussion forumsto announce projects" with no space between forrums & to.