### PR TITLE
Using the google `email` scope for oAuth.

### DIFF
--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -23,9 +23,9 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
 
   var credentialToken = Random.secret();
 
-  // always need this to get user id from google.
-  var requiredScope = ['profile'];
-  var scope = ['email'];
+  // we need the email scope to get user id from google.
+  var requiredScope = ['email'];
+  var scope = [];
   if (options.requestPermissions)
     scope = options.requestPermissions;
   scope = _.union(scope, requiredScope);


### PR DESCRIPTION
This PR is related to https://github.com/meteor/meteor/issues/5650.

The `email` scope is enough for getting the required data, including the
user ID, so no need for the `profile` scope, which may deter users.
