### PR TITLE
CS: Skips loading of the dependency cache if nothing has changed.

### DIFF
--- a/packages/constraint-solver/constraint-solver-input.js
+++ b/packages/constraint-solver/constraint-solver-input.js
@@ -148,7 +148,10 @@ CS.Input.prototype.isEqual = function (otherInput) {
   // This equality test is also overly sensitive to order,
   // missing opportunities to declare two inputs equal when only
   // the order has changed.
-  return _.isEqual(a.toJSONable(), b.toJSONable());
+  return _.isEqual(
+      _.omit(a.toJSONable(), "catalogCache"),
+      _.omit(b.toJSONable(), "catalogCache")
+  );
 };
 
 CS.Input.prototype.toJSONable = function () {

--- a/packages/constraint-solver/constraint-solver.js
+++ b/packages/constraint-solver/constraint-solver.js
@@ -56,17 +56,18 @@ CS.PackagesResolver.prototype.resolve = function (dependencies, constraints,
                                 'upgradeIndirectDepPatchVersions'));
   });
 
-  Profile.time(
-    "Input#loadFromCatalog (sqlite)",
-    function () {
-      input.loadFromCatalog(self.catalogLoader);
-    });
 
   var resultCache = self._options.resultCache;
   if (resultCache && resultCache.lastInput &&
       input.isEqual(resultCache.lastInput)) {
     return resultCache.lastOutput;
   }
+
+  Profile.time(
+      "Input#loadFromCatalog (sqlite)",
+      function () {
+        input.loadFromCatalog(self.catalogLoader);
+      });
 
   if (options.previousSolution && options.missingPreviousVersionIsError) {
     Profile.time("check for previous versions in catalog", function () {

--- a/packages/constraint-solver/package.js
+++ b/packages/constraint-solver/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Given the set of the constraints, picks a satisfying configuration",
-  version: "1.0.20"
+  version: "1.0.21-dev"
 });
 
 Package.onUse(function (api) {

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,8 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.1.11-dev'
+  version: '1.1.11-dev',
+  name: 'devgrok:meteor-tool',
+  git: "https://github.com/devgrok/meteor.git",
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.1.10'
+  version: '1.1.11-dev'
 });
 
 Package.includeTool();


### PR DESCRIPTION
This is an alternate solution to https://github.com/meteor/meteor/issues/2950

A fix for issue https://github.com/meteor/meteor/issues/5764

An optimisation of the "preparing packages" stage from 2600ms (in release 1.2.1) to 800ms (in local-dev).

Skips loading of the dependency cache if nothing has changed.
Excludes the cache from equality check as it shouldn't have changed.
