### PR TITLE
duplicate class names fixes #5632

### DIFF
--- a/packages/blaze/attrs.js
+++ b/packages/blaze/attrs.js
@@ -102,9 +102,13 @@ var ClassHandler = DiffingAttributeHandler.extend({
   parseValue: function (attrString) {
     var tokens = {};
 
-    _.each(attrString.split(' '), function(token) {
-      if (token)
-        tokens[token] = token;
+    var similarTokens = 0;
+    _.each(attrString.split(' '), function(token, i) {
+      if (token) {
+        // Duplicate class names (e.g: Semantic UI)
+        if (tokens[token] && i > 0) tokens[Object.keys(tokens)[(i-similarTokens++)-1]] += ' ' + token;
+        else tokens[token] = token;
+      }
     });
     return tokens;
   }

--- a/packages/blaze/attrs.js
+++ b/packages/blaze/attrs.js
@@ -106,7 +106,7 @@ var ClassHandler = DiffingAttributeHandler.extend({
     _.each(attrString.split(' '), function(token, i) {
       if (token) {
         // Duplicate class names (e.g: Semantic UI)
-        if (tokens[token] && i > 0) tokens[Object.keys(tokens)[(i-similarTokens++)-1]] += ' ' + token;
+        if (tokens[token] && i > 0) tokens[Object.keys(tokens)[(i - similarTokens++) - 1]] += ' ' + token;
         else tokens[token] = token;
       }
     });


### PR DESCRIPTION
***2 Upvotes*** Fix for Semantic UI duplicate classes and other similar frameworks that make use of repeated classes where order of classes matter.

It would be appreciated if you could get this merged asap.