### PR TITLE
Fixes #5776: Test app debugger listens TOOL_NODE_FLAGS debug port + 1

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -125,11 +125,11 @@ In the case that your `self-test` spawns a test app, it is as well possible
 to debug the new `meteor` call. A debugger will be listening to the port after
 the one given in the `TOOL_NODE_FLAGS` environment variable.
 
-For example
+For example,
 ```bash
-TOOL_NODE_FLAGS="--debug-brk=6060" ./meteor self-test 'custom minifier - devel vs prod'
+TOOL_NODE_FLAGS="--debug-brk=5858" ./meteor self-test 'custom minifier - devel vs prod'
 ```
-will break on the first line in the test runner and expose a debugger on the
+will break on the first line of the test runner and expose a debugger on the
 port 5858. After the execution is continued, it will spawn a test application
 that will break in the first line, exposing the debugger in port 5859. The
 way to access the debuggers using `node-inspector` usually is opening the urls

--- a/tools/README.md
+++ b/tools/README.md
@@ -110,14 +110,35 @@ call. Otherwise, it won't start measuring anything.
 Currently, to debug the tool with `node-inspector`, you can set the `
 TOOL_NODE_FLAGS` environment variable to be `--debug` or `--debug-brk`. This
 will modify the `meteor` bash script and run the tool with debugging enabled.
- Note that `node-inspector` should be compatible with the `node`
-version in the `dev_bundle`.
+The debugger will be listening to port 5858 by default, but it could be
+changed using the notation `--debug=6060` or `--debug-brk=6060`. Note that
+`node-inspector` should be compatible with the `node` version in the
+`dev_bundle`.
 
 Next, start `node-inspector` from your checkout by going to
 `path/to/your/meteor/dev_bundle/lib/node_modules/node-inspector/bin` and
 run `inspector.js`.
 This will tell you the URL of the node inspector. If used with `--
 debug-brk`, the script will pause on the first line.
+
+In the case that your `self-test` spawns a test app, it is as well possible
+to debug the new `meteor` call. A debugger will be listening to the port after
+the one given in the `TOOL_NODE_FLAGS` environment variable.
+
+For example
+```bash
+TOOL_NODE_FLAGS="--debug-brk=6060" ./meteor self-test 'custom minifier - devel vs prod'
+```
+will break on the first line in the test runner and expose a debugger on the
+port 5858. After the execution is continued, it will spawn a test application
+that will break in the first line, exposing the debugger in port 5859. The
+way to access the debuggers using `node-inspector` usually is opening the urls
+http://127.0.0.1:8080/debug?port=5858 and http://127.0.0.1:8080/debug?port=5858.
+
+Finally, if you want to set some break points, you could use the statement
+`debugger` in the place where you want to break the execution. Also, the
+`node-inspector` interface allows the set up of some breakpoints.
+
 
 ## Development
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -121,23 +121,14 @@ run `inspector.js`.
 This will tell you the URL of the node inspector. If used with `--
 debug-brk`, the script will pause on the first line.
 
-In the case that your `self-test` spawns a test app, it is as well possible
-to debug the new `meteor` call. A debugger will be listening to the port after
-the one given in the `TOOL_NODE_FLAGS` environment variable.
-
-For example,
-```bash
-TOOL_NODE_FLAGS="--debug-brk=5858" ./meteor self-test 'custom minifier - devel vs prod'
-```
-will break on the first line of the test runner and expose a debugger on the
-port 5858. After the execution is continued, it will spawn a test application
-that will break in the first line, exposing the debugger in port 5859. The
-way to access the debuggers using `node-inspector` usually is opening the urls
-http://127.0.0.1:8080/debug?port=5858 and http://127.0.0.1:8080/debug?port=5858.
-
-Finally, if you want to set some break points, you could use the statement
-`debugger` in the place where you want to break the execution. Also, the
-`node-inspector` interface allows the set up of some breakpoints.
+In order to debug the test apps that `self-test` will spawn, the env
+variable `SELF_TEST_TOOL_NODE_FLAGS` could be used the same way
+`TOOL_NODE_FLAGS` is used. If you are setting the env variable
+`SELF_TEST_TOOL_NODE_FLAGS` with `TOOL_NODE_FLAGS`, consider specifying a
+custom port, as they could collide trying to listen to the same port.
+To set a custom port, you could set the variable in the followind manner
+`SELF_TEST_TOOL_NODE_FLAGS="--debug-brk=5859"` and the debugger will
+listen to the port 5859 and not the default 5858.
 
 
 ## Development

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -826,6 +826,26 @@ _.extend(Sandbox.prototype, {
     if (!self.warehouse && release.current.isProperRelease()) {
       env.METEOR_TEST_LATEST_RELEASE = release.current.name;
     }
+
+    // When --debug or --debug-brk are set in env variable TOOL_NODE_FLAGS, the
+    // new spawn process will have the port set to port + 1, in order to avoid
+    // collisions trying to bind multiple times the same port.
+    var TOOL_NODE_FLAGS = process.env.TOOL_NODE_FLAGS;
+    if (typeof TOOL_NODE_FLAGS !== 'undefined') {
+      let args = TOOL_NODE_FLAGS.match(/"[^"]+"|'[^']+'|\S+/g).map(arg => {
+        let isIncludedInArg = v => arg.indexOf(v) > -1;
+
+        if (_.any(['--debug', '--debug-brk'], isIncludedInArg)) {
+          let opt = arg.split('=')[0],
+              port = Number(arg.split('=')[1]) || 5858;
+          return opt + '=' + (port + 1);
+        } else { 
+          return arg;
+        }
+      });
+      env.TOOL_NODE_FLAGS = args.join(' ');
+    }
+
     return env;
   },
 

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -827,24 +827,11 @@ _.extend(Sandbox.prototype, {
       env.METEOR_TEST_LATEST_RELEASE = release.current.name;
     }
 
-    // When --debug or --debug-brk are set in env variable TOOL_NODE_FLAGS, the
-    // new spawn process will have the port set to port + 1, in order to avoid
-    // collisions trying to bind multiple times the same port.
-    var TOOL_NODE_FLAGS = process.env.TOOL_NODE_FLAGS;
-    if (typeof TOOL_NODE_FLAGS !== 'undefined') {
-      let args = TOOL_NODE_FLAGS.match(/"[^"]+"|'[^']+'|\S+/g).map(arg => {
-        let isIncludedInArg = v => arg.indexOf(v) > -1;
-
-        if (_.any(['--debug', '--debug-brk'], isIncludedInArg)) {
-          let opt = arg.split('=')[0],
-              port = Number(arg.split('=')[1]) || 5858;
-          return opt + '=' + (port + 1);
-        } else { 
-          return arg;
-        }
-      });
-      env.TOOL_NODE_FLAGS = args.join(' ');
-    }
+    // Allow user to set TOOL_NODE_FLAGS for self-test app.
+    if (process.env.TOOL_NODE_FLAGS && ! process.env.SELF_TEST_TOOL_NODE_FLAGS)
+      console.log('Consider setting SELF_TEST_TOOL_NODE_FLAGS to configure ' +
+                  'self-test test applicaion spawns');
+    env.TOOL_NODE_FLAGS = process.env.SELF_TEST_TOOL_NODE_FLAGS || '';
 
     return env;
   },


### PR DESCRIPTION
This pull request fixes the issue #5776.

I did not write tests for the pull request but if the MDG considers they are needed for this modifications, I will work on them.