### PR TITLE
Allow new Mongo.Collection to be called multiple times for the same collection name

### DIFF
--- a/packages/mongo/collection_tests.js
+++ b/packages/mongo/collection_tests.js
@@ -9,3 +9,42 @@ Tinytest.add(
     );
   }
 );
+
+Tinytest.add('collection - call new Mongo.Collection multiple times',
+  function (test) {
+    new Mongo.Collection('multiple_times_1');
+
+    test.throws(
+      function () {
+        new Mongo.Collection('multiple_times_1');
+      },
+      /There is already a collection named "multiple_times_1"/
+    );
+  }
+);
+
+Tinytest.add('collection - call new Mongo.Collection multiple times with _suppressSameNameError=true',
+  function (test) {
+    new Mongo.Collection('multiple_times_2');
+
+    try {
+      new Mongo.Collection('multiple_times_2', {_suppressSameNameError: true});
+      test.ok();
+    } catch (error) {
+      console.log(error);
+      test.fail('Expected new Mongo.Collection not to throw an error when called twice with the same name');
+    }
+  }
+);
+
+Tinytest.add('collection - call new Mongo.Collection with defineMutationMethods=false',
+  function (test) {
+    var handlerPropName = Meteor.isClient ? '_methodHandlers' : 'method_handlers';
+
+    var hasmethods = new Mongo.Collection('hasmethods');
+    test.equal(typeof hasmethods._connection[handlerPropName]['/hasmethods/insert'], 'function');
+
+    var nomethods = new Mongo.Collection('nomethods', {defineMutationMethods: false});
+    test.equal(nomethods._connection[handlerPropName]['/nomethods/insert'], undefined);
+  }
+);


### PR DESCRIPTION
- No error is thrown when constructing a `Mongo.Collection` twice for the same name
- If mutation methods were already created for a named collection, we skip them and do not throw an error
- `Mongo.Collection` constructor takes a new option, `defineMutationMethods`, which can be set to false to skip creating the default mutation methods
- `_defineMutationMethods` function performance is slightly improved by returning earlier if there is no need to loop through method types

This could obviously have some edge cases effects I'm sure, but I can't think of any and all tests still pass. Maybe something weird would happen if defining it twice with different types of _id?

There is of course the chance that two packages, or a package and app, unknowingly use the same collection name and don't get an error. That possibility is not reason enough to keep throwing the error, though, IMO. (In fact this error often bites me when I _want_ to declare the same mongo collection as a package because the package does not export their reference.) Perhaps just a console.warn?

The reason for `defineMutationMethods: false` is so that packages can subclass `Mongo.Collection` and provide their own validated mutation methods, turning off the default ones.