### PR TITLE
Override should come after Platform Synchronize

### DIFF
--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -157,11 +157,11 @@ outdated platforms`);
 
     builder.writeConfigXmlAndCopyResources();
     builder.copyWWW(bundlePath);
-    builder.copyBuildOverride();
 
     this.ensurePlatformsAreSynchronized();
     this.ensurePluginsAreSynchronized(pluginVersions,
       builder.pluginsConfiguration);
+    builder.copyBuildOverride();
   }
 
   prepareForPlatform(platform) {


### PR DESCRIPTION
While processing a clean build (ie: meteor reset) this error occurs, because the platform directory exists but it empty.  The order should be reversed, per documentation: https://github.com/meteor/meteor/wiki/Meteor-Cordova-integration#advanced-build-customization 

Others have issues too: https://github.com/meteor/meteor/issues/5373

Create a cordova-build-override/platforms/android/build-extras.gradle
Then run:
$ meteor reset
$ meteor build <dir> --server <server> --verbose
....
Processing mobile-config.js
Writing new config.xml
Creating Cordova project
% Creating a new cordova project.
Preparing Cordova project from app bundle
Processing mobile-config.js
Copying resources for mobile apps
Writing new config.xml
Copying over the cordova-build-override directory
Adding platform iOS to Cordova project
% Adding ios project...
Adding plugin cordova-plugin-camera@1.2.0 to Cordova project
% Fetching plugin "cordova-plugin-camera@1.2.0" via npm
% Installing "cordova-plugin-camera" for android
% Failed to install 'cordova-plugin-camera':CordovaError: The provided path "/Users/horner/prj/wodrival/.meteor/local/cordova-build/platforms/android" is not an Android project.
    at new android_parser (/Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/cordova-lib/src/cordova/metadata/android_parser.js:35:15)
    at new PlatformProjectAdapter (/Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/cordova-lib/src/platforms/platforms.js:61:19)
    at Object.getPlatformProject (/Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/cordova-lib/src/platforms/platforms.js:97:23)
    at handleInstall (/Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/cordova-lib/src/plugman/install.js:563:36)
    at /Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/cordova-lib/src/plugman/install.js:363:28
    at _fulfilled (/Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/q/q.js:787:54)
    at self.promiseDispatch.done (/Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/q/q.js:816:30)
    at Promise.promise.promiseDispatch (/Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/q/q.js:749:13)
    at /Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/q/q.js:509:49
    at flush (/Users/horner/.meteor/packages/meteor-tool/.1.1.10.1g3vmog++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/q/q.js:108:17)
    at process._tickCallback (node.js:448:13)
=> Errors executing Cordova commands: