### PR TITLE
Fix issue 5800: send object instead of Geolocation to createActivity

### DIFF
--- a/examples/localmarket/client/templates/share-overlay.js
+++ b/examples/localmarket/client/templates/share-overlay.js
@@ -46,11 +46,23 @@ Template.shareOverlay.events({
     var text = $(event.target).find('[name=text]').val();
     var tweet = Session.get(TWEETING_KEY);
     
+    var geoloc = Geolocation.currentLocation();
+    
+    if(geoloc) {
+      var loc = {
+        coords: {
+          accuracy: geoloc.coords.accuracy,
+          latitude: geoloc.coords.latitude,
+          longitude: geoloc.coords.longitude,
+        }
+      };
+    }
+    
     Meteor.call('createActivity', {
       recipeName: self.name,
       text: text,
       image: Session.get(IMAGE_KEY)
-    }, tweet, Geolocation.currentLocation(), function(error, result) {
+    }, tweet, loc, function(error, result) {
       if (error) {
         alert(error.reason);
       } else {


### PR DESCRIPTION
The localmarket example app does not seem to be working correctly in browser when creating a new activity. This pr should fix the issue described in #5800 