### PR TITLE
Fixed incorrect property name in documentation

### DIFF
--- a/docs/client/full-api/api/methods.md
+++ b/docs/client/full-api/api/methods.md
@@ -208,7 +208,7 @@ var loginRule = {
     return Meteor.users.findOne(userId).type !== 'Admin';
   },
   type: 'method',
-  method: 'login'
+  name: 'login'
 }
 // Add the rule, allowing up to 5 messages every 1000 milliseconds.
 DDPRateLimiter.addRule(loginRule, 5, 1000);


### PR DESCRIPTION
As per the method summary, and independent verification, `name` should be used rather than `method` to identify the method or subscription targeted for rate limiting.

```- `name`: The name of the method or subscription being called```