### PR TITLE
Implement App.appendToConfig

### DIFF
--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -104,6 +104,9 @@ export class CordovaBuilder {
       }
     };
 
+    // Custom elements that will be appended into config.xml's widgets
+    this.custom = [];
+
     const packageMap = this.projectContext.packageMap;
 
     if (packageMap && packageMap.getInfo('launch-screen')) {
@@ -247,6 +250,17 @@ export class CordovaBuilder {
       config.element('preference', {
         name: key,
         value: value.toString()
+      });
+    });
+
+    // Set custom tags into widget element
+    _.each(this.custom, elementSet => {
+      let tag = config
+        .element(elementSet.name, elementSet.contents.attrs);
+
+      _.each(elementSet.contents.children, child => {
+        tag.element(child.name, child.attrs);
+        if(child.txt) tag.txt(child.txt);
       });
     });
 
@@ -628,6 +642,22 @@ configuration. The key may be deprecated.`);
       }
 
       builder.accessRules[pattern] = options;
+    },
+
+    /**
+     * @summary Append custom tags into config's widget element.
+     *
+     * `App.appendToConfig('custom-tag', {attrs: '', children: {}});`
+     *
+     * @param  {String} elementName The tag name
+     * @param  {Object} contents    The contents
+     * @memberOf App
+     */
+    appendToConfig: function (name, contents) {
+      builder.custom.push({
+        name,
+        contents
+      });
     }
   };
 }


### PR DESCRIPTION
As I also needed a solution for https://github.com/meteor/meteor/issues/5756, I attempted to implement it.
Still need to write some tests, but that's the idea. So now you're able to append custom tags to `config.xml`. Eg:

```
App.appendToConfig('universal-links', {
  children: [
    {
      name: 'host',
      attrs: {
        name: 'myhost.com'
      },
    }
  ]
});
```

and `config.xml` will get:

```
<?xml version="1.0"?>
<widget id="com.example.ul" version="1.5.5" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
  <name>UniversalLinks</name>
  <description>Another app</description>
  <author href="twitter.com/_gabrielrubens" email="grsabreu@gmail.com">Gabriel Rubens</author>

  <universal-links>
    <host name="myhost.com"/>
  </universal-links>
</widget>
```
Let me know how I can improve something!
Cheers