### PR TITLE
Don't merge CSS files during development

### DIFF
--- a/packages/standard-minifiers-css/plugin/minify-css.js
+++ b/packages/standard-minifiers-css/plugin/minify-css.js
@@ -14,17 +14,19 @@ CssToolsMinifier.prototype.processFilesForBundle = function (files, options) {
 
   if (! files.length) return;
 
-  var merged = mergeCss(files);
-
+  // Don't merge or minify anything for development
   if (mode === 'development') {
-    files[0].addStylesheet({
-      data: merged.code,
-      sourceMap: merged.sourceMap,
-      path: 'merged-stylesheets.css'
+    files.forEach(function (file) {
+      file.addStylesheet({
+        data: file.getContentsAsBuffer(),
+        sourceMap: file.getSourceMap(),
+        path: file.getPathInBundle()
+      });
     });
     return;
   }
 
+  var merged = mergeCss(files);
   var minifiedFiles = CssTools.minifyCss(merged.code);
 
   if (files.length) {


### PR DESCRIPTION
In our app, it takes 2.5s to merge CSS files whenever the server does a client refresh (if you run METEOR_PROFILE=1 I'm talking about `ClientTarget#minifyCss`). This pull request disables CSS merging while in development and now `ClientTarget#minifyCss` takes 2ms. I haven't noticed any bugs introduced by this change, and have been enjoying the speedup! 

I suspect that this change will most greatly effect users that are including a non-minified version of a CSS framework or users with a ton of CSS files. I think that it is also preferable in general to have the CSS files not be merged during development, for the sake of debugging.