### PR TITLE
Improve Meteor Solver performance and add in environment flag to cache dependencies for only dev mode. 

### DIFF
--- a/packages/constraint-solver/catalog-cache.js
+++ b/packages/constraint-solver/catalog-cache.js
@@ -14,7 +14,7 @@ var pvkey = function (pkg, version) {
 CS.CatalogCache = function (deps) {
   // String(PackageAndVersion) -> String -> Dependency.
   // For example, "foo 1.0.0" -> "bar" -> Dependency.fromString("?bar@1.0.2").
-  if(typeof deps === 'undefined')
+  if(typeof deps === 'undefined' || process.env.METEOR_FAST_RESOLVER == 'dev')
   {
     _dependenicesCache = {};
     this._dependencies = {};
@@ -68,7 +68,8 @@ CS.CatalogCache.prototype.addPackageVersion = function (p, v, deps) {
 
     var depsByPackage = {};
     this._dependencies[key] = depsByPackage;
-    _dependenicesCache[key] = depsByPackage;
+    if(process.env.METEOR_FAST_RESOLVER == 'dev')
+      _dependenicesCache[key] = depsByPackage;
     _.each(deps, function (d) {
       var p2 = d.packageConstraint.package;
       if (_.has(depsByPackage, p2)) {
@@ -94,9 +95,13 @@ CS.CatalogCache.prototype.getDependencyMap = function (p, v) {
 // Returns an array of version strings, sorted, possibly empty.
 // (Don't mutate the result.)
 CS.CatalogCache.prototype.getPackageVersions = function (pkg) {
-  var resultCache = (_.has(_versionCache, pkg) ? _versionCache[pkg] : []);
-  if(resultCache.length)
-    return resultCache;
+  if(process.env.METEOR_FAST_RESOLVER == 'dev')
+  {
+    var resultCache = (_.has(_versionCache, pkg) ? _versionCache[pkg] : []);
+    if(resultCache.length)
+      return resultCache;
+  }
+
   var result = (_.has(this._versions, pkg) ?
                 this._versions[pkg] : []);
   if ((!result.length) || result.sorted) {
@@ -106,7 +111,8 @@ CS.CatalogCache.prototype.getPackageVersions = function (pkg) {
     // (we'll sort again if more versions are pushed onto the array)
     result.sort(PV.compare);
     result.sorted = true;
-    _versionCache[pkg] = result;
+    if(process.env.METEOR_FAST_RESOLVER == 'dev')
+      _versionCache[pkg] = result;
     return result;
   }
 };

--- a/packages/constraint-solver/catalog-cache.js
+++ b/packages/constraint-solver/catalog-cache.js
@@ -2,7 +2,7 @@ var CS = ConstraintSolver;
 var PV = PackageVersion;
 
 var _lockedVersionCache = {};
-var __lockDependenices = {};
+var _dependenicesCache = {};
 
 var pvkey = function (pkg, version) {
   return pkg + " " + version;
@@ -12,12 +12,15 @@ var pvkey = function (pkg, version) {
 CS.CatalogCache = function () {
   // String(PackageAndVersion) -> String -> Dependency.
   // For example, "foo 1.0.0" -> "bar" -> Dependency.fromString("?bar@1.0.2").
-  if(_.isUndefined(__lockDependenices))
+  var enabledFastSolver = process.env['METEOR_FAST_SOLVER'] == true;
+  if(enabledFastSolver)
+    console.log("METEOR FAST SOLVER IS ENABLED. THIS IS DESIGNED FOR ONLY DEVELOPMENT MODE. IF YOU CHANGE PACKAGES THEN YOU WILL NEED TO RESTART METEOR MANUALLY.");
+  if(_.isUndefined(_dependenicesCache) || enabledFastSolver) //fix this if change package
   {
-    __lockDependenices = {};
+    _dependenicesCache = {};
     this._dependencies = {};
   }else{
-    this._dependencies = __lockDependenices;
+    this._dependencies = _dependenicesCache;
   }
   // A map derived from the keys of _dependencies, for ease of iteration.
   // "foo" -> ["1.0.0", ...]
@@ -49,7 +52,7 @@ CS.CatalogCache.prototype.addPackageVersion = function (p, v, deps) {
 
   var depsByPackage = {};
   this._dependencies[key] = depsByPackage;
-  __lockDependenices[key] = depsByPackage;
+  _dependenicesCache[key] = depsByPackage;
   _.each(deps, function (d) {
     var p2 = d.packageConstraint.package;
     if (_.has(depsByPackage, p2)) {

--- a/packages/constraint-solver/catalog-cache.js
+++ b/packages/constraint-solver/catalog-cache.js
@@ -1,7 +1,7 @@
 var CS = ConstraintSolver;
 var PV = PackageVersion;
 
-var _lockedVersionCache = {};
+var _versionCache = {};
 var _dependenicesCache = {};
 
 var pvkey = function (pkg, version) {
@@ -77,7 +77,7 @@ CS.CatalogCache.prototype.getDependencyMap = function (p, v) {
 // Returns an array of version strings, sorted, possibly empty.
 // (Don't mutate the result.)
 CS.CatalogCache.prototype.getPackageVersions = function (pkg) {
-  var resultCache = (_.has(_lockedVersionCache, pkg) ? _lockedVersionCache[pkg] : []);
+  var resultCache = (_.has(_versionCache, pkg) ? _versionCache[pkg] : []);
   if(resultCache.length)
     return resultCache;
   var result = (_.has(this._versions, pkg) ?
@@ -89,7 +89,7 @@ CS.CatalogCache.prototype.getPackageVersions = function (pkg) {
     // (we'll sort again if more versions are pushed onto the array)
     result.sort(PV.compare);
     result.sorted = true;
-    _lockedVersionCache[pkg] = result;
+    _versionCache[pkg] = result;
     return result;
   }
 };

--- a/packages/constraint-solver/catalog-cache.js
+++ b/packages/constraint-solver/catalog-cache.js
@@ -1,6 +1,8 @@
 var CS = ConstraintSolver;
 var PV = PackageVersion;
 
+var _lockedVersionCache = {};
+
 var pvkey = function (pkg, version) {
   return pkg + " " + version;
 };
@@ -64,6 +66,9 @@ CS.CatalogCache.prototype.getDependencyMap = function (p, v) {
 // Returns an array of version strings, sorted, possibly empty.
 // (Don't mutate the result.)
 CS.CatalogCache.prototype.getPackageVersions = function (pkg) {
+  var resultCache = (_.has(_lockedVersionCache, pkg) ? _lockedVersionCache[pkg] : []);
+  if(resultCache.length)
+    return resultCache;
   var result = (_.has(this._versions, pkg) ?
                 this._versions[pkg] : []);
   if ((!result.length) || result.sorted) {
@@ -73,6 +78,7 @@ CS.CatalogCache.prototype.getPackageVersions = function (pkg) {
     // (we'll sort again if more versions are pushed onto the array)
     result.sort(PV.compare);
     result.sorted = true;
+    _lockedVersionCache[pkg] = result;
     return result;
   }
 };

--- a/packages/constraint-solver/catalog-cache.js
+++ b/packages/constraint-solver/catalog-cache.js
@@ -14,20 +14,27 @@ var pvkey = function (pkg, version) {
 CS.CatalogCache = function (deps) {
   // String(PackageAndVersion) -> String -> Dependency.
   // For example, "foo 1.0.0" -> "bar" -> Dependency.fromString("?bar@1.0.2").
-  if(_.isUndefined(_dependenicesCache) || _.difference(_previousDepsCache, deps).length > 0 || _.difference(deps, _previousDepsCache).length > 0 || _previousDepsCache.length === 0 || _depCacheCount < 1)
+  if(_.isUndefined(deps))
   {
-    if(_previousDepsCache.length === 0 || _.difference(_previousDepsCache, deps).length > 0 || _.difference(deps, _previousDepsCache).length > 0)
-    {
-      _depCacheCount = 0;
-    }else{
-      _depCacheCount++;
-    }
     _dependenicesCache = {};
-    _previousDepsCache = deps;
     this._dependencies = {};
   }else{
-    this._dependencies = _dependenicesCache;
+    if(_.isUndefined(_dependenicesCache) || _.difference(_previousDepsCache, deps).length > 0 || _.difference(deps, _previousDepsCache).length > 0 || _previousDepsCache.length === 0 || _depCacheCount < 1)
+    {
+      if(_previousDepsCache.length === 0 || _.difference(_previousDepsCache, deps).length > 0 || _.difference(deps, _previousDepsCache).length > 0)
+      {
+        _depCacheCount = 0;
+      }else{
+        _depCacheCount++;
+      }
+      _dependenicesCache = {};
+      _previousDepsCache = deps;
+      this._dependencies = {};
+    }else{
+      this._dependencies = _dependenicesCache;
+    }
   }
+
   // A map derived from the keys of _dependencies, for ease of iteration.
   // "foo" -> ["1.0.0", ...]
   // Versions in the array are unique but not sorted, unless the `.sorted`

--- a/packages/constraint-solver/catalog-cache.js
+++ b/packages/constraint-solver/catalog-cache.js
@@ -2,6 +2,7 @@ var CS = ConstraintSolver;
 var PV = PackageVersion;
 
 var _lockedVersionCache = {};
+var __lockDependenices = {};
 
 var pvkey = function (pkg, version) {
   return pkg + " " + version;
@@ -11,7 +12,13 @@ var pvkey = function (pkg, version) {
 CS.CatalogCache = function () {
   // String(PackageAndVersion) -> String -> Dependency.
   // For example, "foo 1.0.0" -> "bar" -> Dependency.fromString("?bar@1.0.2").
-  this._dependencies = {};
+  if(_.isUndefined(__lockDependenices))
+  {
+    __lockDependenices = {};
+    this._dependencies = {};
+  }else{
+    this._dependencies = __lockDependenices;
+  }
   // A map derived from the keys of _dependencies, for ease of iteration.
   // "foo" -> ["1.0.0", ...]
   // Versions in the array are unique but not sorted, unless the `.sorted`
@@ -42,6 +49,7 @@ CS.CatalogCache.prototype.addPackageVersion = function (p, v, deps) {
 
   var depsByPackage = {};
   this._dependencies[key] = depsByPackage;
+  __lockDependenices[key] = depsByPackage;
   _.each(deps, function (d) {
     var p2 = d.packageConstraint.package;
     if (_.has(depsByPackage, p2)) {

--- a/packages/constraint-solver/catalog-cache.js
+++ b/packages/constraint-solver/catalog-cache.js
@@ -4,7 +4,7 @@ var PV = PackageVersion;
 var _versionCache = {};
 var _dependenicesCache = {};
 var _previousDepsCache = [];
-var _depCacheCount = [];
+var _depCacheCount = 0;
 
 var pvkey = function (pkg, version) {
   return pkg + " " + version;

--- a/packages/constraint-solver/catalog-cache.js
+++ b/packages/constraint-solver/catalog-cache.js
@@ -14,7 +14,7 @@ var pvkey = function (pkg, version) {
 CS.CatalogCache = function (deps) {
   // String(PackageAndVersion) -> String -> Dependency.
   // For example, "foo 1.0.0" -> "bar" -> Dependency.fromString("?bar@1.0.2").
-  if(_.isUndefined(deps))
+  if(typeof deps === 'undefined')
   {
     _dependenicesCache = {};
     this._dependencies = {};

--- a/packages/constraint-solver/catalog-loader.js
+++ b/packages/constraint-solver/catalog-loader.js
@@ -21,8 +21,7 @@ CS.CatalogLoader = function (fromCatalog, toCatalogCache) {
 
   self.catalog = fromCatalog;
   self.catalogCache = toCatalogCache;
-
-  if(_.isUndefined(_preSortedVersionRecordsCache))
+  if(_.isUndefined(_preSortedVersionRecordsCache) || process.env.METEOR_FAST_RESOLVER != 'dev')
   {
     _preSortedVersionRecordsCache = {};
     self._sortedVersionRecordsCache = {};
@@ -62,7 +61,8 @@ CS.CatalogLoader.prototype._getSortedVersionRecords = function (pkg) {
   if (! _.has(this._sortedVersionRecordsCache, pkg)) {
     this._sortedVersionRecordsCache[pkg] =
       this.catalog.getSortedVersionRecords(pkg);
-    _preSortedVersionRecordsCache[pkg] = this._sortedVersionRecordsCache[pkg];
+    if(process.env.METEOR_FAST_RESOLVER != 'dev')
+      _preSortedVersionRecordsCache[pkg] = this._sortedVersionRecordsCache[pkg];
   }
 
   return this._sortedVersionRecordsCache[pkg];

--- a/packages/constraint-solver/catalog-loader.js
+++ b/packages/constraint-solver/catalog-loader.js
@@ -61,7 +61,7 @@ CS.CatalogLoader.prototype._getSortedVersionRecords = function (pkg) {
   if (! _.has(this._sortedVersionRecordsCache, pkg)) {
     this._sortedVersionRecordsCache[pkg] =
       this.catalog.getSortedVersionRecords(pkg);
-    if(process.env.METEOR_FAST_RESOLVER != 'dev')
+    if(process.env.METEOR_FAST_RESOLVER == 'dev')
       _preSortedVersionRecordsCache[pkg] = this._sortedVersionRecordsCache[pkg];
   }
 

--- a/packages/constraint-solver/catalog-loader.js
+++ b/packages/constraint-solver/catalog-loader.js
@@ -14,7 +14,7 @@ var CS = ConstraintSolver;
 // making the right catalog calls and doing the right caching.
 // Calling a catalog method generally means running a SQLite query,
 // which could be time-consuming.
-var _lockedSortedVersionRecordsCache = undefined;
+var _preSortedVersionRecordsCache = undefined;
 
 CS.CatalogLoader = function (fromCatalog, toCatalogCache) {
   var self = this;
@@ -22,13 +22,13 @@ CS.CatalogLoader = function (fromCatalog, toCatalogCache) {
   self.catalog = fromCatalog;
   self.catalogCache = toCatalogCache;
 
-  if(_.isUndefined(_lockedSortedVersionRecordsCache))
+  if(_.isUndefined(_preSortedVersionRecordsCache))
   {
-    _lockedSortedVersionRecordsCache = {};
+    _preSortedVersionRecordsCache = {};
     self._sortedVersionRecordsCache = {};
   }else{
     //keep the same sortedVersionRecordsCache data after CatalogLoader is reloaded that will improve solver performance.
-    self._sortedVersionRecordsCache = _lockedSortedVersionRecordsCache; 
+    self._sortedVersionRecordsCache = _preSortedVersionRecordsCache;
   }
 };
 
@@ -62,6 +62,7 @@ CS.CatalogLoader.prototype._getSortedVersionRecords = function (pkg) {
   if (! _.has(this._sortedVersionRecordsCache, pkg)) {
     this._sortedVersionRecordsCache[pkg] =
       this.catalog.getSortedVersionRecords(pkg);
+    _preSortedVersionRecordsCache[pkg] = this._sortedVersionRecordsCache[pkg];
   }
 
   return this._sortedVersionRecordsCache[pkg];

--- a/packages/constraint-solver/catalog-loader.js
+++ b/packages/constraint-solver/catalog-loader.js
@@ -14,6 +14,7 @@ var CS = ConstraintSolver;
 // making the right catalog calls and doing the right caching.
 // Calling a catalog method generally means running a SQLite query,
 // which could be time-consuming.
+var _lockedSortedVersionRecordsCache = undefined;
 
 CS.CatalogLoader = function (fromCatalog, toCatalogCache) {
   var self = this;
@@ -21,7 +22,14 @@ CS.CatalogLoader = function (fromCatalog, toCatalogCache) {
   self.catalog = fromCatalog;
   self.catalogCache = toCatalogCache;
 
-  self._sortedVersionRecordsCache = {};
+  if(_.isUndefined(_lockedSortedVersionRecordsCache))
+  {
+    _lockedSortedVersionRecordsCache = {};
+    self._sortedVersionRecordsCache = {};
+  }else{
+    //keep the same sortedVersionRecordsCache data after CatalogLoader is reloaded that will improve solver performance.
+    self._sortedVersionRecordsCache = _lockedSortedVersionRecordsCache; 
+  }
 };
 
 // We rely on the following `catalog` methods:

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -679,6 +679,7 @@ _.extend(ProjectContext.prototype, {
 
     var constraintSolverPackage =
           isopackets.load('constraint-solver')['constraint-solver'];
+    var depsAndConstraints = self._getRootDepsAndConstraints();
     var resolver =
           new constraintSolverPackage.ConstraintSolver.PackagesResolver(
             self.projectCatalog, {
@@ -686,7 +687,8 @@ _.extend(ProjectContext.prototype, {
                 Console.nudge(true);
               },
               Profile: Profile,
-              resultCache: self._resolverResultCache
+              resultCache: self._resolverResultCache,
+                depsResult: depsAndConstraints.deps
             });
     return resolver;
   },


### PR DESCRIPTION
I improved sortVersionRecordsCache, dependenices and version performance.

Without METEOR_FAST_SOLVER, meteor solver will be fast without dependencies cache.

With METEOR_FAST_SOLVER, meteor solver will be faster with dependencies cache for only dev mode.

Ex: METEOR_FAST_SOLVER=dev meteor

Related issues:
#4284
#2950