### PR TITLE
Don't revalidate cache on HCR

### DIFF
--- a/packages/reload/reload.js
+++ b/packages/reload/reload.js
@@ -219,7 +219,7 @@ Reload._reload = function (options) {
   var tryReload = function () { _.defer(function () {
     if (Reload._migrate(tryReload, options)) {
       // Tell the browser to shut down this VM and make a new one
-      window.location.reload();
+      window.location = window.location.href;
     }
   }); };
 


### PR DESCRIPTION
If you look at the network traffic on a hot code reload, the browser doesn't automatically load any of the files from the cache. It revalidates each file with the server and waits for a 304 before proceeding. This is because the reload package performs a refresh rather than a redirect. As discussed in this post http://stackoverflow.com/questions/26166433/browser-caching-prevent-request-that-returns-304, refreshes require cache revalidation whereas redirects don't. So this code changes the refresh to a reload, which allows the browser to load everything from the cache. This significantly speeds things up, on the order of multiple seconds.

@tmeasday and I came up with this change on a Skype call we had earlier today