### PR TITLE
Better error messages

### DIFF
--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -430,13 +430,15 @@ class ResourceSlot {
 
     if (! archinfo.matches(unibuild.arch, "web")) {
       throw new Error("Document sections can only be emitted to " +
-                      "web targets");
+                      "web targets: " + self.inputResource.path);
     }
     if (options.section !== "head" && options.section !== "body") {
-      throw new Error("'section' must be 'head' or 'body'");
+      throw new Error("'section' must be 'head' or 'body': " +
+                      self.inputResource.path);
     }
     if (typeof options.data !== "string") {
-      throw new Error("'data' option to appendDocument must be a string");
+      throw new Error("'data' option to appendDocument must be a string: " +
+                      self.inputResource.path);
     }
 
     self.outputResources.push({


### PR DESCRIPTION
Otherwise it is really hard to know where the errors are coming from. Now the error is like:

```
While processing files with peerlibrary:blaze-components (for target os.osx.x86_64):
/tools/isobuild/compiler-plugin.js:432:13: Document sections can only be emitted to web targets: test-templating.html
```
