### PR TITLE
Refactor reset password and enroll account

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -517,54 +517,7 @@ Meteor.methods({forgotPassword: function (options) {
  * @param {String} [email] Optional. Which address of the user's to send the email to. This address must be in the user's `emails` list. Defaults to the first email in the list.
  */
 Accounts.sendResetPasswordEmail = function (userId, email) {
-  // Make sure the user exists, and email is one of their addresses.
-  var user = Meteor.users.findOne(userId);
-  if (!user)
-    throw new Error("Can't find user");
-  // pick the first email if we weren't passed an email.
-  if (!email && user.emails && user.emails[0])
-    email = user.emails[0].address;
-  // make sure we have a valid email
-  if (!email || !_.contains(_.pluck(user.emails || [], 'address'), email))
-    throw new Error("No such email for user.");
-
-  var token = Random.secret();
-  var when = new Date();
-  var tokenRecord = {
-    token: token,
-    email: email,
-    when: when
-  };
-  Meteor.users.update(userId, {$set: {
-    "services.password.reset": tokenRecord
-  }});
-  // before passing to template, update user object with new token
-  Meteor._ensure(user, 'services', 'password').reset = tokenRecord;
-
-  var resetPasswordUrl = Accounts.urls.resetPassword(token);
-
-  var options = {
-    to: email,
-    from: Accounts.emailTemplates.resetPassword.from
-      ? Accounts.emailTemplates.resetPassword.from(user)
-      : Accounts.emailTemplates.from,
-    subject: Accounts.emailTemplates.resetPassword.subject(user)
-  };
-
-  if (typeof Accounts.emailTemplates.resetPassword.text === 'function') {
-    options.text =
-      Accounts.emailTemplates.resetPassword.text(user, resetPasswordUrl);
-  }
-
-  if (typeof Accounts.emailTemplates.resetPassword.html === 'function')
-    options.html =
-      Accounts.emailTemplates.resetPassword.html(user, resetPasswordUrl);
-
-  if (typeof Accounts.emailTemplates.headers === 'object') {
-    options.headers = Accounts.emailTemplates.headers;
-  }
-
-  Email.send(options);
+  Meteor.call('sendEmail', userId, email, 'resetPassword');
 };
 
 // send the user an email informing them that their account was created, with
@@ -582,58 +535,69 @@ Accounts.sendResetPasswordEmail = function (userId, email) {
  * @param {String} [email] Optional. Which address of the user's to send the email to. This address must be in the user's `emails` list. Defaults to the first email in the list.
  */
 Accounts.sendEnrollmentEmail = function (userId, email) {
-  // XXX refactor! This is basically identical to sendResetPasswordEmail.
-
-  // Make sure the user exists, and email is in their addresses.
-  var user = Meteor.users.findOne(userId);
-  if (!user)
-    throw new Error("Can't find user");
-  // pick the first email if we weren't passed an email.
-  if (!email && user.emails && user.emails[0])
-    email = user.emails[0].address;
-  // make sure we have a valid email
-  if (!email || !_.contains(_.pluck(user.emails || [], 'address'), email))
-    throw new Error("No such email for user.");
-
-  var token = Random.secret();
-  var when = new Date();
-  var tokenRecord = {
-    token: token,
-    email: email,
-    when: when
-  };
-  Meteor.users.update(userId, {$set: {
-    "services.password.reset": tokenRecord
-  }});
-
-  // before passing to template, update user object with new token
-  Meteor._ensure(user, 'services', 'password').reset = tokenRecord;
-
-  var enrollAccountUrl = Accounts.urls.enrollAccount(token);
-
-  var options = {
-    to: email,
-    from: Accounts.emailTemplates.enrollAccount.from
-      ? Accounts.emailTemplates.enrollAccount.from(user)
-      : Accounts.emailTemplates.from,
-    subject: Accounts.emailTemplates.enrollAccount.subject(user)
-  };
-
-  if (typeof Accounts.emailTemplates.enrollAccount.text === 'function') {
-    options.text =
-      Accounts.emailTemplates.enrollAccount.text(user, enrollAccountUrl);
-  }
-
-  if (typeof Accounts.emailTemplates.enrollAccount.html === 'function')
-    options.html =
-      Accounts.emailTemplates.enrollAccount.html(user, enrollAccountUrl);
-
-  if (typeof Accounts.emailTemplates.headers === 'object') {
-    options.headers = Accounts.emailTemplates.headers;
-  }
-
-  Email.send(options);
+  Meteor.call('sendEmail', userId, email, 'enrollAccount');
 };
+
+Meteor.methods({
+  sendEmail: function (userId, email, type) { // type options: resetPassword, enrollAccount
+    // Make sure the user exists, and email is one of their addresses.
+    var user = Meteor.users.findOne(userId);
+    if (!user)
+      throw new Error("Can't find user");
+    // pick the first email if we weren't passed an email.
+    if (!email && user.emails && user.emails[0])
+      email = user.emails[0].address;
+    // make sure we have a valid email
+    if (!email || !_.contains(_.pluck(user.emails || [], 'address'), email))
+      throw new Error("No such email for user.");
+
+    var token = Random.secret();
+    var when = new Date();
+    var tokenRecord = {
+      token: token,
+      email: email,
+      when: when
+    };
+    Meteor.users.update(userId, {
+      $set: {
+        "services.password.reset": tokenRecord
+      }
+    });
+    // before passing to template, update user object with new token
+    Meteor._ensure(user, 'services', 'password').reset = tokenRecord;
+
+    var url;
+
+    if (type === 'resetPassword') {
+      url = Accounts.urls.resetPassword(token);
+    }
+
+    if (type === 'enrollAccount') {
+      url = Accounts.urls.enrollAccount(token);
+    }
+
+    var options = {
+      to: email,
+      from: Accounts.emailTemplates[type].from ? Accounts.emailTemplates[type].from(user) : Accounts.emailTemplates.from,
+      subject: Accounts.emailTemplates[type].subject(user)
+    };
+
+    if (typeof Accounts.emailTemplates[type].text === 'function') {
+      options.text =
+        Accounts.emailTemplates[type].text(user, url);
+    }
+
+    if (typeof Accounts.emailTemplates[type].html === 'function')
+      options.html =
+      Accounts.emailTemplates[type].html(user, url);
+
+    if (typeof Accounts.emailTemplates.headers === 'object') {
+      options.headers = Accounts.emailTemplates.headers;
+    }
+
+    Email.send(options);
+  }
+});
 
 
 // Take token from sendResetPasswordEmail or sendEnrollmentEmail, change


### PR DESCRIPTION
Was working with `Accounts.sendResetPasswordEmail` and `Accounts.sendEnrollmentEmail` and noticed a comment that the two could be refactored.  I went ahead and abstracted the 99% of the identical code from both and wrapped it in a 'sendEmail' method.  The only real difference between the two (which were a good 50 lines of code each) was the key `resetPassword` and `enrollAccount`.