### PR TITLE
Allow middleware to set http status code (fixes #5820)

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -708,7 +708,8 @@ var runWebAppServer = function () {
       return undefined;
     }
 
-    res.writeHead(200, headers);
+    var statusCode = res.statusCode ? res.statusCode : 200;
+    res.writeHead(statusCode, headers);
     res.write(boilerplate);
     res.end();
     return undefined;


### PR DESCRIPTION
This change will allow routers and other middleware to set the HTTP status code to something other than 200, for example returning a 404 if the route does not exist on the client or server. It retains the default 200 response if `res.statusCode` has not been set.

My first PR here, couldn't see an obvious way to add tests for this functionality as it's inside an anonymous function but happy to be enlightened.

In the case of Iron Router, there is already some commented-out code that this will allow to work as long as routes are defined on client & server (https://github.com/iron-meteor/iron-router/blob/devel/lib/router_server.js#L80-L89). There may be other SEO considerations (for the JS-rendering search engines) - if I click a client-side route from a 404 (where Iron Router NotFound template is rendered), perhaps the page should be refreshed to give Googlebot etc. the correct status code? Maybe Google already thought of that... I don't know.

Fixes #5820 