### PR TITLE
Add meteor login / logout info to docs

### DIFF
--- a/docs/client/full-api/commandline.html
+++ b/docs/client/full-api/commandline.html
@@ -70,6 +70,16 @@ You can use the `--package` option, to create a new package. If used in an
 existing app, this command will create a package in the packages
 directory.
 
+<h3 id="meteorloginlogout">meteor login / logout</h3>
+
+Log in and out of your account using Meteor's authentication system.
+
+You can pass `METEOR_SESSION_FILE=token.json` before `meteor login` to generate
+a login session token so you don't have to share your login credentials with
+third-party service providers. You can revoke the token at any time from your
+[accounts settings page](https://www.meteor.com/account-settings/login-locations).
+
+
 <h3 id="meteordeploy">meteor deploy <i>site</i></h3>
 
 Deploy the project in your current directory to Meteor's servers.

--- a/docs/client/full-api/tableOfContents.js
+++ b/docs/client/full-api/tableOfContents.js
@@ -362,6 +362,7 @@ var toc = [
     "meteor run",
     "meteor debug",
     "meteor create",
+    "meteor login / logout",
     "meteor deploy",
     "meteor logs",
     "meteor update",


### PR DESCRIPTION
I recently came across the issue of how to handle Galaxy deployments with third-party continiuous integration providers. Unfortunately I couldn't find any infos in the documentation on how to handle `meteor login` without sharing my main credentials. Luckily I came across [this post](https://medium.com/@natestrauser/migrating-meteor-apps-from-modulus-to-galaxy-with-continuous-deployment-from-codeship-aed2044cabd9#.j4a68a16v) and the usage of `METEOR_SESSION_FILE` to generate a session token. To promote good security practices we should add this to the docs.