### PR TITLE
jiku/modules/pixi

### DIFF
--- a/tools/tests/apps/modules/README.md
+++ b/tools/tests/apps/modules/README.md
@@ -8,3 +8,18 @@ npm test # just does `meteor run`
 ```
 
 then visit [localhost:3000](//localhost:3000) in your browser.
+
+### jiku
+
+Maybe related issues with PIXI through Webpack
+
+[1](https://github.com/pixijs/pixi.js/issues/1854)
+[2](https://github.com/pixijs/pixi.js/issues/2078)
+
+Where they set
+
+```javascript
+node: {
+    fs: "empty"
+}
+```

--- a/tools/tests/apps/modules/package.json
+++ b/tools/tests/apps/modules/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "dependencies": {
     "moment": "2.11.1",
-    "regenerator": "^0.8.42"
+    "regenerator": "^0.8.42",
+    "pixi.js": "^3.0.9"
   },
   "scripts": {
     "test": "../../../../meteor run"

--- a/tools/tests/apps/modules/tests.js
+++ b/tools/tests/apps/modules/tests.js
@@ -194,3 +194,11 @@ describe("Meteor packages", () => {
     assert.strictEqual(mtp.where, Meteor.isServer ? "server" : "client");
   });
 });
+
+describe("PixiJS", () => {
+  Meteor.isClient &&
+  it("should be importable on the client", () => {
+    import PIXI from "pixi.js";
+    assert.strictEqual(require("PIXI"), PIXI);
+  });
+});


### PR DESCRIPTION
For issue #6052.

Maybe related issues with PIXI through Webpack

https://github.com/pixijs/pixi.js/issues/1854
https://github.com/pixijs/pixi.js/issues/2078

Where they set

node: {
    fs: "empty"
}