### PR TITLE
Allow HTTP OPTIONS method to correctly support CORS preflight

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -323,7 +323,7 @@ var staticFiles;
 // Serve static files from the manifest or added with
 // `addStaticJs`. Exported for tests.
 WebAppInternals.staticFilesMiddleware = function (staticFiles, req, res, next) {
-  if ('GET' != req.method && 'HEAD' != req.method) {
+  if ('GET' != req.method && 'HEAD' != req.method && 'OPTIONS' != req.method) {
     next();
     return;
   }


### PR DESCRIPTION
Otherwise CORS preflight does not work for `manifest.json` file. CORS preflight can happen if you are having some extra headers in your request for `manifest.json` (so if the request is classified as [non-simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests)).