### PR TITLE
mongo url is good for an hour now

### DIFF
--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -369,7 +369,7 @@ running.
 
 Instead of opening a shell, specifying --url (-U) will return a URL
 suitable for an external program to connect to the database. For remote
-databases on deployed applications, the URL is valid for one minute.
+databases on deployed applications, the URL is valid for one hour.
 
 Options:
   --url, -U  return a Mongo database URL


### PR DESCRIPTION
This functionality was changed by @multilinear. Change the cli help to match this.