### PR TITLE
Return existing 'users' collection, if it exists, otherwise a new one #BugFix

### DIFF
--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -18,12 +18,8 @@ AccountsCommon = class AccountsCommon {
     this.connection = undefined;
     this._initConnection(options || {});
 
-    // There is an allow call in accounts_server.js that restricts writes to
-    // this collection.
-    this.users = new Mongo.Collection("users", {
-      _preventAutopublish: true,
-      connection: this.connection
-    });
+    // If Collection exists get it, if not create a new one
+    this.users = this._getUsersCollection();
 
     // Callback exceptions are printed with Meteor._debug and ignored.
     this._onLoginHook = new Hook({
@@ -187,6 +183,23 @@ AccountsCommon = class AccountsCommon {
     } else {
       this.connection = Meteor.connection;
     }
+  }
+
+  _getUsersCollection() {
+    // Check if the "users" collection exists.
+    // We assume that it is under the Meteor.users ns
+    // 
+    // However, if the collection exists return it,
+    // otherwise create and return a new one.
+    if (Meteor.users instanceof Mongo.Collection &&
+        Meteor.users._name === "users") {
+      return Meteor.users;
+    }
+
+    return new Mongo.Collection("users", {
+      _preventAutopublish: true,
+      connection: this.connection
+    });
   }
 
   _getTokenLifetimeMs() {


### PR DESCRIPTION
Related to #6070 

Summary: If you try to create a new AccountsClient after the regular Accounts Object was created, you will get en Error because the underlying AccountsCommon constructor will go to create a new "users" collection, right? 

So there is a discussion going on, how to return an existing collection from the Mongo.Collection constructor itself in #5778, but this quick fix, will make at least the AccountsClient work as it should.