### PR TITLE
Fixed manifest.json path on Windows

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -501,7 +501,7 @@ var runWebAppServer = function () {
 
         // Serve the program as a string at /foo/<arch>/manifest.json
         // XXX change manifest.json -> program.json
-        staticFiles[path.join(urlPrefix, getItemPathname('/manifest.json'))] = {
+        staticFiles[urlPrefix + getItemPathname('/manifest.json')] = {
           content: JSON.stringify(program),
           cacheable: true,
           hash: program.version,


### PR DESCRIPTION
This made URL paths with `\` which then did not correctly resolve. There is no need to be OS specific here, it breaks things.