### PR TITLE
Added options to extend ddp for custom messages

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -76,6 +76,9 @@ var Connection = function (url, options) {
   self._heartbeatInterval = options.heartbeatInterval;
   self._heartbeatTimeout = options.heartbeatTimeout;
 
+  // Option to extend ddp messages with custom messages 
+  self._customMessages = options.customMessages || {};
+  
   // Tracks methods which the user has tried to call but which have not yet
   // called their user callback (ie, they are waiting on their result or for all
   // of their writes to be written to the local cache). Map from method ID to
@@ -258,6 +261,8 @@ var Connection = function (url, options) {
       self._livedata_result(msg);
     else if (msg.msg === 'error')
       self._livedata_error(msg);
+    else if (_.include(_.keys(self._customMessages), msg.msg))
+      self._customMessages[msg.msg].call(self, msg);
     else
       Meteor._debug("discarding unknown livedata message type", msg);
   };


### PR DESCRIPTION
By either giving option in connection creation `options._customMessages`.
Or dynamically by extending Meteor.connection
```
_.extend(Meteor.connection._customMessages, {
    updateBatch: function() {},
    subscriptionRedirect: function(){}
});
```

I needed this for couple of use cases :
1. Handling sending batch updates from server to client.
2. Do subscription redirect - send the client to get subscription from another server.