### PR TITLE
Use Babel 6 to implement ECMAScript 2015+ in tool code.

### DIFF
--- a/meteor
+++ b/meteor
@@ -3,7 +3,7 @@
 # Note: 0.5.17 used on branch origin/npm3
 # Note: 0.5.20 used on branch origin/cordova-improvements
 # Note: 0.5.21 used on branch release-1.2.2
-BUNDLE_VERSION=0.5.22
+BUNDLE_VERSION=0.5.23
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/logic-solver/logic_tests.js
+++ b/packages/logic-solver/logic_tests.js
@@ -1508,14 +1508,14 @@ Tinytest.add("logic-solver - toy packages", function (test) {
 
     var solver = new Logic.Solver();
 
-    _.each(allPackageVersions, function (versions, package) {
+    _.each(allPackageVersions, function (versions, pkg) {
       versions = _.map(versions, function (v) {
-        return package + "@" + v;
+        return pkg + "@" + v;
       });
       // e.g. atMostOne(["foo@1.0.0", "foo@1.0.1", "foo@2.0.0"])
       solver.require(Logic.atMostOne(versions));
       // e.g. equiv("foo", or(["foo@1.0.0", ...]))
-      solver.require(Logic.equiv(package, Logic.or(versions)));
+      solver.require(Logic.equiv(pkg, Logic.or(versions)));
     });
 
     _.each(dependencies, function (depMap, packageVersion) {


### PR DESCRIPTION
Note that `export default` no longer modifies `module.exports`, but simply defines `exports.default`, so these two import styles will work:
```js
import DefaultExport from "./export-default-module.js"; // preferred
var DefaultExport = require("./export-default-module.js").default;
```
but this style will no longer work:
```js
var DefaultExport = require("./export-default-module.js");
```
At least some of the test failures will be fixed with this Babel PR is resolved: https://github.com/babel/babel/pull/3310