### PR TITLE
Missed filter to pass _getCollection through

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -442,7 +442,8 @@ _.extend(Connection.prototype, {
     // implemented by 'store' into a no-op.
     var store = {};
     _.each(['update', 'beginUpdate', 'endUpdate', 'saveOriginals',
-            'retrieveOriginals', 'getDoc'], function (method) {
+            'retrieveOriginals', 'getDoc',
+			'_getCollection'], function (method) {
               store[method] = function () {
                 return (wrappedStore[method]
                         ? wrappedStore[method].apply(wrappedStore, arguments)


### PR DESCRIPTION
When making change into a pull request (#5845) I missed this file change.

This now provides a way to access collections from stores on the client.