### PR TITLE
Create noRetry option on Connection.apply

### DIFF
--- a/docs/client/full-api/api/methods.md
+++ b/docs/client/full-api/api/methods.md
@@ -74,7 +74,7 @@ it will re-call the method when it reconnects. This means that a client may
 call a method multiple times when it only means to call it once. If this
 behavior is problematic for your method, consider attaching a unique ID
 to each method call on the client, and checking on the server whether a call
-with this ID has already been made.
+with this ID has already been made.  Alternatively, you can use [`Meteor.apply`](#meteor_apply) with the noRetry option set to true.
 
 {{> autoApiBox "DDPCommon.MethodInvocation#userId"}}
 
@@ -178,7 +178,10 @@ even if the method's writes are not available yet, you can specify an
 
 `Meteor.apply` is just like `Meteor.call`, except that the method arguments are
 passed as an array rather than directly as arguments, and you can specify
-options about how the client executes the method.
+options about how the client executes the method.  Options permitted are:
+- `wait` (Client only): If true, don't send this method until all previous method calls have completed, and don't send any subsequent method calls until this one is completed.
+- `onResultReceived` (Client only): This callback is invoked with the error or result of the method (just like `asyncCallback`) as soon as the error or result is available. The local cache may not yet reflect the writes performed by the method.
+- `noRetry` (Client only): if true, don't send this method again on reload, simply call the callback with an error (will be `Meteor.Error(409)`)
 
 <h2 id="ddpratelimiter"><span>DDPRateLimiter</span></h2>
 

--- a/packages/ddp-client/livedata_connection_tests.js
+++ b/packages/ddp-client/livedata_connection_tests.js
@@ -742,39 +742,43 @@ Tinytest.add("livedata stub - reconnect", function (test) {
   o.stop();
 });
 
-Tinytest.add("livedata stub - reconnect non-idempotent method", function(test) {
-  // This test is for https://github.com/meteor/meteor/issues/6108
-  var stream = new StubStream();
-  var conn = newConnection(stream);
+if (Meteor.isClient) {
+  Tinytest.add("livedata stub - reconnect non-idempotent method", function(test) {
+    // This test is for https://github.com/meteor/meteor/issues/6108
+    var stream = new StubStream();
+    var conn = newConnection(stream);
 
-  startAndConnect(test, stream);
+    startAndConnect(test, stream);
 
-  var methodCallbackFired = false;
-  var methodCallbackErrored = false;
-  // call with noRetry true so that the method should fail to retry on reconnect.
-  conn.apply('do_something', [], {noRetry: true}, function(error) {
-    methodCallbackFired = true;
-    // failure on reconnect should trigger an error.
-    if (error && error.error === 409) {
-      methodCallbackErrored = true;
-    }
+    var methodCallbackFired = false;
+    var methodCallbackErrored = false;
+    // call with noRetry true so that the method should fail to retry on reconnect.
+    conn.apply('do_something', [], {noRetry: true}, function(error) {
+      methodCallbackFired = true;
+      // failure on reconnect should trigger an error.
+      if (error && error.error === 409) {
+        methodCallbackErrored = true;
+      }
+    });
+
+    //The method has not succeeded yet
+    test.isFalse(methodCallbackFired);
+    // reconnect.
+    stream.sent.shift();
+    // "receive the message"
+    stream.reset();
+
+    //The method callback should fire even though the stream has not sent a response.
+    //the callback should have been fired with an error.
+    test.isTrue(methodCallbackFired);
+    test.isTrue(methodCallbackErrored);
+
+    // verify that a reconnect message was sent.
+    testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+    // verify that the method message was not sent.
+    test.isUndefined(stream.sent.shift());
   });
-
-  //The method has not succeeded yet
-  test.isFalse(methodCallbackFired);
-  // reconnect.
-  stream.reset();
-
-  //The method callback should fire even though the stream has not sent a response.
-  //the callback should have been fired with an error.
-  test.isTrue(methodCallbackFired);
-  test.isTrue(methodCallbackErrored);
-
-  // verify that a reconnect message was sent.
-  testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
-  // verify that the method message was not sent.
-  test.isUndefined(stream.sent.shift);
-});
+}
 
 if (Meteor.isClient) {
   Tinytest.add("livedata stub - reconnect method which only got result", function (test) {

--- a/packages/ddp-client/livedata_connection_tests.js
+++ b/packages/ddp-client/livedata_connection_tests.js
@@ -768,13 +768,17 @@ if (Meteor.isClient) {
     // "receive the message"
     stream.reset();
 
+    // verify that a reconnect message was sent.
+    testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+
+    // Make sure that the stream triggers connection.
+    stream.receive({msg: 'connected', session: SESSION_ID + 1});
+
     //The method callback should fire even though the stream has not sent a response.
     //the callback should have been fired with an error.
     test.isTrue(methodCallbackFired);
     test.isTrue(methodCallbackErrored);
 
-    // verify that a reconnect message was sent.
-    testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
     // verify that the method message was not sent.
     test.isUndefined(stream.sent.shift());
   });


### PR DESCRIPTION
Implements #6108.

Test is included, as is updated documentation.
All tests in ddp-client package (including new test for #6108) pass.

Implemented as simply a `noRetry` flag on apply which triggers it to fail with a Meteor.Error(409) instead of retrying on reconnect.