### PR TITLE
Make clear those are Cordova platforms

### DIFF
--- a/tools/cli/commands-cordova.js
+++ b/tools/cli/commands-cordova.js
@@ -43,7 +43,7 @@ main.registerCommand({
     for (platform of platformsToAdd) {
       if (_.contains(installedPlatforms, platform)) {
         buildmessage.error(`${platform}: platform is already added`);
-      } else if (!_.contains(cordova.AVAILABLE_PLATFORMS, platform)) {
+      } else if (!_.contains(cordova.CORDOVA_PLATFORMS, platform)) {
         buildmessage.error(`${platform}: no such platform`);
       }
     }
@@ -67,7 +67,9 @@ main.registerCommand({
 
     for (platform of platformsToAdd) {
       Console.info(`${platform}: added platform`);
-      cordovaProject.checkPlatformRequirements(platform);
+      if (_.contains(cordovaPlatforms, platform)) {
+        cordovaProject.checkPlatformRequirements(platform);
+      }
     }
   });
 });
@@ -142,10 +144,10 @@ main.registerCommand({
 
   const platform = options.args[0];
 
-  if (!_.contains(cordova.AVAILABLE_PLATFORMS, platform)) {
+  if (!_.contains(cordova.CORDOVA_PLATFORMS, platform)) {
     Console.warn(`Unknown platform: ${platform}`);
     Console.info(`Valid platforms are: \
-${cordova.AVAILABLE_PLATFORMS.join(', ')}`);
+${cordova.CORDOVA_PLATFORMS.join(', ')}`);
     return 1;
   }
 

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -8,7 +8,7 @@ import { oldToNew as oldToNewPluginIds, newToOld as newToOldPluginIds }
 
 export const CORDOVA_ARCH = "web.cordova";
 
-export const AVAILABLE_PLATFORMS = ['ios', 'android'];
+export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
 const PLATFORM_TO_DISPLAY_NAME_MAP = {
   'ios': 'iOS',
@@ -28,7 +28,7 @@ export function displayNamesForPlatforms(platforms) {
 // Right now, the only other platforms are the default browser and server
 // platforms.
 export function filterPlatforms(platforms) {
-  return _.intersection(platforms, AVAILABLE_PLATFORMS);
+  return _.intersection(platforms, CORDOVA_PLATFORMS);
 }
 
 export function splitPluginsAndPackages(packages) {

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -21,7 +21,7 @@ import cordova_util from 'cordova-lib/src/cordova/util.js';
 import superspawn from 'cordova-lib/src/cordova/superspawn.js';
 import PluginInfoProvider from 'cordova-lib/src/PluginInfoProvider.js';
 
-import { AVAILABLE_PLATFORMS, displayNameForPlatform, displayNamesForPlatforms,
+import { CORDOVA_PLATFORMS, displayNameForPlatform, displayNamesForPlatforms,
   newPluginId, convertPluginVersions, convertToGitUrl,
   installationInstructionsUrlForPlatform } from './index.js';
 import { CordovaBuilder } from './builder.js';
@@ -363,7 +363,7 @@ from Cordova project`, async () => {
 
     for (platform of installedPlatforms) {
       if (!_.contains(platforms, platform) &&
-        _.contains(AVAILABLE_PLATFORMS, platform)) {
+        _.contains(CORDOVA_PLATFORMS, platform)) {
         this.removePlatform(platform);
       }
     }


### PR DESCRIPTION
When adding custom platforms it is a bit misleading to name available platforms. But the main issue is that `checkPlatformRequirements` is called for all platforms, despite calling `filterPlatforms` earlier. This fixes it so that only for Cordova platforms check is called.