### PR TITLE
For path to match the one in the manifest

### DIFF
--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -431,7 +431,7 @@ _.extend(File.prototype, {
     }
 
     var chunks = [];
-    var pathNoSlash = self.servePath.replace(/^\//, "");
+    var pathNoSlash = self.servePath.replace(/^\//, "").replace(/:/g, '_');
 
     if (! self.bare) {
       var closureHeader = "(function(){";


### PR DESCRIPTION
This code tries to match [`setUrlFromRelPath`](https://github.com/meteor/meteor/blob/devel/tools/isobuild/bundler.js#L364) but it seems it was not updated when escaping was added.

Probably this should be extracted somewhere out. But for now, it can be at least synced.

Only cosmetic change.