### PR TITLE
Provides architectural dependencies between targets

### DIFF
--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -606,6 +606,7 @@ api.addAssets('${relPath}', 'client').`);
     arch: arch,
     uses: inputSourceArch.uses,
     implies: inputSourceArch.implies,
+    archDependencies: inputSourceArch.archDependencies,
     watchSet: watchSet,
     nodeModulesPath: nodeModulesPathOrUndefined,
     declaredExports: declaredExports,

--- a/tools/isobuild/isopack.js
+++ b/tools/isobuild/isopack.js
@@ -45,6 +45,7 @@ var Unibuild = function (isopack, options) {
 
   self.uses = options.uses;
   self.implies = options.implies || [];
+  self.archDependencies = options.archDependencies || [];
 
   // This WatchSet will end up having the watch items from the
   // SourceArch (such as package.js or .meteor/packages), plus all of
@@ -1084,6 +1085,7 @@ _.extend(Isopack.prototype, {
         arch: unibuildMeta.arch,
         uses: unibuildJson.uses,
         implies: unibuildJson.implies,
+        archDependencies: unibuildJson.archDependencies,
         watchSet: unibuildWatchSets[unibuildMeta.path],
         nodeModulesPath: nodeModulesPath,
         declaredExports: declaredExports,
@@ -1293,6 +1295,7 @@ _.extend(Isopack.prototype, {
             };
           }),
           implies: (_.isEmpty(unibuild.implies) ? undefined : unibuild.implies),
+          archDependencies: unibuild.archDependencies,
           node_modules: nodeModulesPath,
           resources: []
         };

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -196,6 +196,7 @@ var getExcerptFromReadme = function (text) {
 // - arch [required]
 // - uses
 // - implies
+// - archDependencies
 // - getFiles
 // - declaredExports
 // - watchSet
@@ -249,6 +250,9 @@ var SourceArch = function (pkg, options) {
   // of the same type as the elements of self.uses (although for now
   // unordered and weak are not allowed).
   self.implies = options.implies || [];
+
+  // Architecture dependencies.
+  self.archDependencies = options.archDependencies || [];
 
   // A function that returns the source files for this architecture. Object with
   // keys `sources` and `assets`, where each is an array of objects with keys
@@ -1231,6 +1235,7 @@ _.extend(PackageSource.prototype, {
         arch: arch,
         uses: api.uses[arch],
         implies: api.implies[arch],
+        archDependencies: api.archDependencies[arch],
         getFiles: function () {
           return api.files[arch];
         },


### PR DESCRIPTION
Fixes: #6099 

Now you can use `api.archDepends({client: 'web.worker'})` to get `web.worker` content automatically included when `client` dependency is made.