### PR TITLE
Update rules `space-after-keywords` and `space-return-throw-case` to `keyword-spacing`

### DIFF
--- a/scripts/admin/eslint/.eslintrc
+++ b/scripts/admin/eslint/.eslintrc
@@ -162,11 +162,10 @@
       "before": false,
       "after": true
     }],
-    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "keyword-spacing": 2,       // http://eslint.org/docs/rules/keyword-spacing
     "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
-    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
     "spaced-line-comment": 2,        // http://eslint.org/docs/rules/spaced-line-comment
   }
 }


### PR DESCRIPTION
Replace old rules by new one.
- http://eslint.org/docs/rules/space-after-keywords
- http://eslint.org/docs/rules/space-return-throw-case

> Replacement notice: This rule was removed in ESLint v2.0 and replaced by **keyword-spacing** rule. Some style guides will require or disallow spaces following the certain keywords.