### PR TITLE
Take a test runner as commandline argument

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1615,7 +1615,7 @@ function doTestCommand(options) {
     projectContext.projectConstraintsFile.writeIfModified();
   } else if (options["test-app"]) {
     // XXX look in package list for testOnly packages
-    global.testCommandMetadata.driverPackage = 'avital:mocha';
+    global.testCommandMetadata.driverPackage = options['driver-package'] || 'avital:mocha';
 
     // Default to `--integration`
     if (!options.unit && !options.integration) {


### PR DESCRIPTION
This isn't quite the complete solution we are planning, but it is enough to allow others to test alternate runners. 

I've tested this with https://github.com/tmeasday/meteor-mocha/tree/1.3-reporter, and it works against Todos (you need to `meteor remove avital:mocha; meteor add tmeasday:mocha`)