### PR TITLE
Accounts.sendVerificationEmail() - incorrect error text

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -739,6 +739,10 @@ Accounts.sendVerificationEmail = function (userId, address) {
     var email = _.find(user.emails || [],
                        function (e) { return !e.verified; });
     address = (email || {}).address;
+
+    if (!address) {
+      throw new Error("That user has no unverified email addresses.");
+    }
   }
   // make sure we have a valid address
   if (!address || !_.contains(_.pluck(user.emails || [], 'address'), address))


### PR DESCRIPTION
If a user has email verified and `Accounts.sendVerificationEmail()` is called with that userId - server logs error ` No such email address for user.`.
Whereas it should log `This email is already verified`.