### PR TITLE
Document how to use local dependencies for build plugins.

### DIFF
--- a/docs/client/full-api/api/packagejs.md
+++ b/docs/client/full-api/api/packagejs.md
@@ -62,6 +62,15 @@ coffeescript package for an example. Build plugins are fully-fledged Meteor
 programs in their own right and have their own namespace, package dependencies,
 source files and npm requirements.
 
+{{#note}}
+You can use [local packages](#writingpackages) to define custom build plugins
+for your app, with one caveat. In published packages, build plugins are already
+bundled with their transitive dependencies. So if you want a dependency of a
+build plugin to be satisfied by a local package, you must use a local copy of
+the package that defines the plugin (even if you make no changes to that
+package) so that Meteor will pick up the local dependency.
+{{/note}}
+
 <h3 id="packagedescription"><span>Package Description</span></h3>
 
 Provide basic package information with `Package.describe(options)`. To publish a


### PR DESCRIPTION
I wasted ~30 minutes discovering this behavior while trying to test a modification to the TypeScript build plugin, which is registered by the meteortypescript:compiler package but depends on the barbatus:ts-compilers package for the bulk of the implementation (including the code I needed to modify).

Here's a reproduction based on what I was originally trying to do.  It includes a local version of barbatus:ts-compilers that compiles all TypeScript files in "bare" mode, but this local version is only used when meteortypescript:compiler is also local.  I'm using Linux (Fedora 23), but I doubt it matters.
```
$ git clone https://github.com/mattmccutchen/meteor-build-plugin-deps-repro
$ cd meteor-build-plugin-deps-repro
$ meteor
# Wait for Meteor to finish building and then press ^C
$ grep bare .meteor/local/build/programs/server/app/repro.js
# No output.
# The build plugin is still using the bundled version of barbatus:ts-compilers:
$ ls -l ~/.meteor/packages/meteortypescript_compiler/3.1.0/plugin.compileTypescript.os/packages/barbatus_ts-compilers.js
$ ln -s ../tests/meteortypescript_compiler packages
$ meteor
# Wait for Meteor to finish building and then press ^C
$ grep bare .meteor/local/build/programs/server/app/repro.js
// This file is in bare mode and is not in its own closure.            //
```