### PR TITLE
Better skeleton app

### DIFF
--- a/tools/static-assets/skel/.meteor/packages
+++ b/tools/static-assets/skel/.meteor/packages
@@ -12,9 +12,8 @@ reactive-var            # Client-side reactive dictionary for your app
 jquery                  # Helpful client-side library
 tracker                 # Meteor's client-side reactive programming library
 
-standard-minifiers
-#standard-minifier-css   # CSS minifier run for production mode
-#standard-minifier-js    # JS minifier run for production mode
+standard-minifier-css   # CSS minifier run for production mode
+standard-minifier-js    # JS minifier run for production mode
 es5-shim                # ECMAScript 5 compatibility for older browsers.
 ecmascript              # Enable ECMAScript2015+ syntax in app code
 

--- a/tools/static-assets/skel/.meteor/packages
+++ b/tools/static-assets/skel/.meteor/packages
@@ -19,4 +19,4 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 
 autopublish             # Publish all data to the clients (for prototyping)
 insecure                # Allow all DB writes from clients (for prototyping)
-skeleton:skeleton       # A 3rd-party package contains the Skeleton framework. (for prototyping)
+skeleton:skeleton       # A 3rd-party package contains the Skeleton framework (for prototyping)

--- a/tools/static-assets/skel/.meteor/packages
+++ b/tools/static-assets/skel/.meteor/packages
@@ -8,15 +8,16 @@ meteor-base             # Packages every Meteor app needs to have
 mobile-experience       # Packages for a great mobile UX
 mongo                   # The database Meteor supports right now
 blaze-html-templates    # Compile .html files into Meteor Blaze views
-session                 # Client-side reactive dictionary for your app
+reactive-var            # Client-side reactive dictionary for your app
 jquery                  # Helpful client-side library
 tracker                 # Meteor's client-side reactive programming library
 
-standard-minifier-css   # CSS minifier run for production mode
-standard-minifier-js    # JS minifier run for production mode
+standard-minifiers
+#standard-minifier-css   # CSS minifier run for production mode
+#standard-minifier-js    # JS minifier run for production mode
 es5-shim                # ECMAScript 5 compatibility for older browsers.
 ecmascript              # Enable ECMAScript2015+ syntax in app code
 
 autopublish             # Publish all data to the clients (for prototyping)
 insecure                # Allow all DB writes from clients (for prototyping)
-skeleton:skeleton       # A 3rd-party package contains the Skeleton framework (for prototyping)
+skeleton:skeleton       # A 3rd-party package contains the Skeleton framework. (for prototyping)

--- a/tools/static-assets/skel/.meteor/packages
+++ b/tools/static-assets/skel/.meteor/packages
@@ -19,3 +19,4 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 
 autopublish             # Publish all data to the clients (for prototyping)
 insecure                # Allow all DB writes from clients (for prototyping)
+skeleton:skeleton       # A 3rd-party package contains the Skeleton framework. (for prototyping)

--- a/tools/static-assets/skel/~name~.html
+++ b/tools/static-assets/skel/~name~.html
@@ -19,7 +19,7 @@
         <button class="button-primary">Click me!</button>
         <p>You've clicked the button {{counter}} times.</p>
       </div>
-      <div class="one-half column" style="margin-top: 25%">
+      <div class="one-half column" style="margin-top: 5%">
         <h5>Getting started</h5>
         <ul>
           <li><a href="https://www.meteor.com/try">The Tutorial</a></li>

--- a/tools/static-assets/skel/~name~.html
+++ b/tools/static-assets/skel/~name~.html
@@ -8,30 +8,28 @@
 </head>
 
 <body>
-  {{> hello}}
-</body>
-
-<template name="hello">
   <div class="container">
     <div class="row">
       <div class="one-half column" style="margin-top: 25%">
         <h4>Welcome to Meteor!</h4>
-        <button class="button-primary">Click me!</button>
-        <p>You've clicked the button {{counter}} times.</p>
+        {{> hello}}
       </div>
-      <div class="one-half column" style="margin-top: 5%">
+      <div class="one-half column" style="margin-top: 15%">
         <h5>Getting started</h5>
         <ul>
           <li><a href="https://www.meteor.com/try">The Tutorial</a></li>
           <li><a href="https://docs.meteor.com">Docs</a></li>
           <li><a href="https://forums.meteor.com">Discussions</a></li>
         </ul>
-        <h5>Or start building your app now</h5>
-        <pre><code>
-          meteor remove skeleton:skeleton
-          rm ~name~.*
-        </code></pre>
+        <h5>Serious app?</h5>
+        <pre><code>meteor remove skeleton:skeleton
+rm ~name~.*</code></pre>
       </div>
-    </div>
   </div>
+</div>
+</body>
+
+<template name="hello">
+  <button class="button-primary">Click me!</button>
+  <p>You've clicked the button {{counter}} times.</p>
 </template>

--- a/tools/static-assets/skel/~name~.html
+++ b/tools/static-assets/skel/~name~.html
@@ -1,14 +1,37 @@
 <head>
+  <meta charset="utf-8">
   <title>~name~</title>
+  <meta name="description" content="">
+  <meta name="author" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
 </head>
 
 <body>
-  <h1>Welcome to Meteor!</h1>
-
   {{> hello}}
 </body>
 
 <template name="hello">
-  <button>Click Me</button>
-  <p>You've pressed the button {{counter}} times.</p>
+  <div class="container">
+    <div class="row">
+      <div class="one-half column" style="margin-top: 25%">
+        <h4>Welcome to Meteor!</h4>
+        <button class="button-primary">Click me!</button>
+        <p>You've clicked the button {{counter}} times.</p>
+      </div>
+      <div class="one-half column" style="margin-top: 25%">
+        <h5>Getting started</h5>
+        <ul>
+          <li><a href="https://www.meteor.com/try">The Tutorial</a></li>
+          <li><a href="https://docs.meteor.com">Docs</a></li>
+          <li><a href="https://forums.meteor.com">Discussions</a></li>
+        </ul>
+        <h5>Or start building your app now</h5>
+        <pre><code>
+          meteor remove skeleton:skeleton
+          rm ~name~.*
+        </code></pre>
+      </div>
+    </div>
+  </div>
 </template>

--- a/tools/static-assets/skel/~name~.js
+++ b/tools/static-assets/skel/~name~.js
@@ -3,21 +3,17 @@ if (Meteor.isClient) {
   let Counter = new ReactiveVar(0);
 
   Template.hello.helpers({
-    counter: function () {
-      return Counter.get();
-    }
+    counter: () => Counter.get()
   });
 
   Template.hello.events({
-    'click button': function () {
-      // increment the counter when button is clicked
-      Counter.set(Counter.get() + 1);
-    }
+    // increment the counter when button is clicked
+    'click button': () => Counter.set(Counter.get() + 1)
   });
 }
 
 if (Meteor.isServer) {
-  Meteor.startup(function () {
+  Meteor.startup(() => {
     // code to run on server at startup
     // remember, in a both-side file, these code will still be sent to client.
   });

--- a/tools/static-assets/skel/~name~.js
+++ b/tools/static-assets/skel/~name~.js
@@ -1,17 +1,17 @@
 if (Meteor.isClient) {
   // counter starts at 0
-  Session.setDefault('counter', 0);
+  let Counter = new ReactiveVar(0);
 
   Template.hello.helpers({
     counter: function () {
-      return Session.get('counter');
+      return Counter.get();
     }
   });
 
   Template.hello.events({
     'click button': function () {
       // increment the counter when button is clicked
-      Session.set('counter', Session.get('counter') + 1);
+      Counter.set(Counter.get() + 1);
     }
   });
 }
@@ -19,5 +19,6 @@ if (Meteor.isClient) {
 if (Meteor.isServer) {
   Meteor.startup(function () {
     // code to run on server at startup
+    // remember, in a both-side file, these code will still be sent to client.
   });
 }


### PR DESCRIPTION
A picture shows how it looks:
![snip20160227_85](https://cloud.githubusercontent.com/assets/2545261/13373460/a2c6e3ae-dda3-11e5-9ebe-7e1aa45c8ab8.png)
I added some links for beginners to getting started, and instructions to begin with an empty project. Also comes with a better design powered by [Skeleton](http://getskeleton.com/).

But there are some thing we should notice: The basic styles come with `skeleton:skeleton`, which is a 3rd-party package (but official Skeleton wrapper). I don't know if we should imply it with the package system, or add its CSS rules to the CSS file. Also if you want to start building your own, you have to remove the package.

I think with Skeleton beginners can build their first app quickly. But some tutorials may need to add `meteor remove skeleton:skeleton` as a step.

I'm not a guy from Skeleton team to promote Skeleton :-)