### PR TITLE
Update react example to React 0.14

### DIFF
--- a/examples/simple-todos-react/.meteor/versions
+++ b/examples/simple-todos-react/.meteor/versions
@@ -16,7 +16,7 @@ caching-html-compiler@1.0.2
 callback-hook@1.0.4
 check@1.1.0
 coffeescript@1.0.11
-cosmos:browserify@0.5.1
+cosmos:browserify@0.9.4
 ddp@1.2.2
 ddp-client@1.2.1
 ddp-common@1.2.2
@@ -36,7 +36,7 @@ htmljs@1.0.5
 http@1.1.1
 id-map@1.0.4
 jquery@1.11.4
-jsx@0.2.1
+jsx@0.2.3
 launch-screen@1.0.4
 less@2.5.1
 livedata@1.0.15
@@ -57,11 +57,11 @@ ordered-dict@1.0.4
 promise@0.5.1
 random@1.0.5
 rate-limit@1.0.0
-react@0.1.13
-react-meteor-data@0.1.9
-react-runtime@0.13.3_7
-react-runtime-dev@0.13.3_7
-react-runtime-prod@0.13.3_6
+react@0.14.3
+react-meteor-data@0.2.4
+react-runtime@0.14.4
+react-runtime-dev@0.14.4
+react-runtime-prod@0.14.4
 reactive-dict@1.1.3
 reactive-var@1.0.6
 reload@1.1.4

--- a/examples/simple-todos-react/AccountsUIWrapper.jsx
+++ b/examples/simple-todos-react/AccountsUIWrapper.jsx
@@ -2,7 +2,7 @@ AccountsUIWrapper = React.createClass({
   componentDidMount() {
     // Use Meteor Blaze to render login buttons
     this.view = Blaze.render(Template.loginButtons,
-      React.findDOMNode(this.refs.container));
+      ReactDOM.findDOMNode(this.refs.container));
   },
   componentWillUnmount() {
     // Clean up Blaze view

--- a/examples/simple-todos-react/App.jsx
+++ b/examples/simple-todos-react/App.jsx
@@ -43,12 +43,12 @@ App = React.createClass({
     event.preventDefault();
 
     // Find the text field via the React ref
-    var text = React.findDOMNode(this.refs.textInput).value.trim();
+    var text = this.refs.textInput.value.trim();
 
     Meteor.call("addTask", text);
 
     // Clear form
-    React.findDOMNode(this.refs.textInput).value = "";
+    this.refs.textInput.value = "";
   },
 
   toggleHideCompleted() {


### PR DESCRIPTION
The current example code for React does not work. There was a change in 5773b7e3b0a that moved to use ReactDOM but the `.meteor/versions` file was not updated.

Besides fixing this, also made changes to remove warnings and removed the use of `findDOMNode` to access the input. This is no longer needed in 0.14, reference: [Starting with this release, this.refs.giraffe is the actual DOM node](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#dom-node-refs).