### PR TITLE
Moves <script> tags to end of <body>

### DIFF
--- a/packages/boilerplate-generator/boilerplate_web.browser.html
+++ b/packages/boilerplate-generator/boilerplate_web.browser.html
@@ -1,7 +1,12 @@
 <html {{htmlAttributes}}>
 <head>
 {{#each css}}  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="{{../bundledJsCssUrlRewriteHook url}}">{{/each}}
-
+{{{head}}}
+{{{dynamicHead}}}
+</head>
+<body>
+{{{body}}}
+{{{dynamicBody}}}
 {{#if inlineScriptsAllowed}}
 <script type='text/javascript'>__meteor_runtime_config__ = JSON.parse(decodeURIComponent({{meteorRuntimeConfig}}));</script>
 {{else}}
@@ -19,12 +24,5 @@
             src='{{rootUrlPathPrefix}}{{pathname}}'></script>
   {{/if}}
 {{/each}}
-
-{{{head}}}
-{{{dynamicHead}}}
-</head>
-<body>
-{{{body}}}
-{{{dynamicBody}}}
 </body>
 </html>


### PR DESCRIPTION
Rather than include our bundle from <head>, include it at the end of <body> . This way, code can make use of the new `dynamicHead` feature to add loading html into the boilerplate. (as requested by #3860)


