### PR TITLE
Add Assets.absoluteFilePath(assetPath)

### DIFF
--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -1639,6 +1639,27 @@ DocsData = {
     "scope": "static",
     "summary": "Retrieve the contents of the static server asset as a UTF8-encoded string."
   },
+  "Assets.absoluteFilePath": {
+    "kind": "function",
+    "locus": "Server",
+    "longname": "Assets.absoluteFilePath",
+    "memberof": "Assets",
+    "name": "absoluteFilePath",
+    "options": [],
+    "params": [
+      {
+        "description": "<p>The path of the asset, relative to the application's <code>private</code> subdirectory.</p>",
+        "name": "assetPath",
+        "type": {
+          "names": [
+            "String"
+          ]
+        }
+      }
+    ],
+    "scope": "static",
+    "summary": "Get the absolute path to the static server asset. Note that assets are read-only."
+  },
   "Blaze": {
     "filepath": "blaze/preamble.js",
     "kind": "namespace",

--- a/docs/client/full-api/api/assets.md
+++ b/docs/client/full-api/api/assets.md
@@ -9,6 +9,7 @@ into your application's bundle.
 
 {{> autoApiBox "Assets.getText"}}
 {{> autoApiBox "Assets.getBinary"}}
+{{> autoApiBox "Assets.absoluteFilePath"}}
 
 Static server assets are included by placing them in the application's `private`
 subdirectory. For example, if an application's `private` subdirectory includes a

--- a/tools/runners/run-all.js
+++ b/tools/runners/run-all.js
@@ -109,48 +109,41 @@ class Runner {
 
   // XXX leave a pidfile and check if we are already running
   start() {
-    const self = this;
-
-    self.proxy.start();
+    this.proxy.start();
 
     // print the banner only once we've successfully bound the port
-    if (! self.quiet && ! self.stopped) {
-      runLog.log("[[[[[ " + self.banner + " ]]]]]\n");
+    if (! this.quiet && ! this.stopped) {
+      runLog.log("[[[[[ " + this.banner + " ]]]]]\n");
       runLog.log("Started proxy.",  { arrow: true });
     }
 
-    var unblockAppRunner = self.appRunner.makeBeforeStartPromise();
-    self._startMongoAsync().then(unblockAppRunner);
+    const unblockAppRunner = this.appRunner.makeBeforeStartPromise();
+    this._startMongoAsync().then(unblockAppRunner);
 
-    if (! self.stopped) {
-      self.updater.start();
-    }
-
-    if (! self.stopped) {
-      buildmessage.enterJob({ title: "starting your app" }, function () {
-        self.appRunner.start();
+    if (! this.stopped) {
+      this.updater.start();
+      buildmessage.enterJob({ title: "starting your app" }, () => {
+        this.appRunner.start();
       });
-      if (! self.quiet && ! self.stopped) {
+
+      if (! this.quiet) {
         runLog.log("Started your app.",  { arrow: true });
-      }
-    }
-
-    if (! self.stopped && ! self.quiet) {
-      runLog.log("");
-      runLog.log("App running at: " + self.rootUrl,  { arrow: true });
-
-      if (process.platform === "win32") {
-        runLog.log("   Type Control-C twice to stop.");
         runLog.log("");
-      }
-    }
+        runLog.log("App running at: " + this.rootUrl,  { arrow: true });
 
-    if (self.selenium && ! self.stopped) {
-      buildmessage.enterJob({ title: "starting Selenium" }, function () {
-        self.selenium.start();
-      });
-      if (! self.quiet && ! self.stopped) {
-        runLog.log("Started Selenium.", { arrow: true });
+        if (process.platform === "win32") {
+          runLog.log("   Type Control-C twice to stop.");
+          runLog.log("");
+        }
+      }
+
+      if (this.selenium) {
+        buildmessage.enterJob({ title: "starting Selenium" }, () => {
+          this.selenium.start();
+        });
+        if (! this.quiet) {
+          runLog.log("Started Selenium.", { arrow: true });
+        }
       }
     }
 

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -236,7 +236,16 @@ Fiber(function () {
       },
       getBinary: function (assetPath, callback) {
         return getAsset(assetPath, undefined, callback);
-      }
+      },
+      absoluteFilePath: function (assetPath) {
+        if (!fileInfo.assets || !_.has(fileInfo.assets, assetPath)) {
+          throw new Error("Unknown asset: " + assetPath);
+        }
+
+        assetPath = files.convertToStandardPath(assetPath);
+        var filePath = path.join(serverDir, fileInfo.assets[assetPath]);
+        return files.convertToOSPath(filePath);
+      },
     };
 
     var isModulesRuntime =


### PR DESCRIPTION
Fixes #3705

Adds `Assets.absoluteFilePath(assetPath)`. I need this in Meteor 1.3 in order for this mocha test driver package I made to work: https://github.com/DispatchMe/meteor-mocha

@stubailo, you had some concerns about providing this in #3705, but I think it's useful and we shouldn't be concerned about what improper things people might do when provided with the file path.

(The run-all.js stuff is just unrelated code cleanup that just simplifies that logic a bit.)