### PR TITLE
Opt-in user email address request for twitter sign up

### DIFF
--- a/packages/twitter/twitter_server.js
+++ b/packages/twitter/twitter_server.js
@@ -9,10 +9,10 @@ var urls = {
 
 
 // https://dev.twitter.com/docs/api/1.1/get/account/verify_credentials
-Twitter.whitelistedFields = ['profile_image_url', 'profile_image_url_https', 'lang'];
+Twitter.whitelistedFields = ['profile_image_url', 'profile_image_url_https', 'lang', 'email'];
 
 OAuth.registerService('twitter', 1, urls, function(oauthBinding) {
-  var identity = oauthBinding.get('https://api.twitter.com/1.1/account/verify_credentials.json').data;
+  var identity = oauthBinding.get('https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true').data;
 
   var serviceData = {
     id: identity.id_str,


### PR DESCRIPTION
Overview
---
Meteor can get user email from twitter api, If your app is whitelisted on twitter. So I add `include_email=true` parameter by default for convenience. This change will make twitter api response to return email address if your site is whitelisted otherwise return null.

reference: https://dev.twitter.com/rest/reference/get/account/verify_credentials