### PR TITLE
For #6436 -- allow test drivers to `.start()` on the server

### DIFF
--- a/packages/meteor/test_environment.js
+++ b/packages/meteor/test_environment.js
@@ -10,8 +10,7 @@ var TEST_METADATA = JSON.parse(TEST_METADATA_STR || "{}");
 Meteor.isTest = !!TEST_METADATA.isTest;
 Meteor.isAppTest = !!TEST_METADATA.isAppTest;
 
-
-if (Meteor.isClient && (Meteor.isTest || Meteor.isAppTest)) {
+if (Meteor.isTest || Meteor.isAppTest) {
   Meteor.startup(function() {
     var testDriverPackageName = TEST_METADATA.driverPackage;
     if (typeof testDriverPackageName !== "string") {
@@ -23,11 +22,18 @@ if (Meteor.isClient && (Meteor.isTest || Meteor.isAppTest)) {
       throw new Error("Can't find test driver package: " + testDriverPackageName);
     }
 
-    if (typeof testDriverPackage.runTests !== "function") {
-      throw new Error("Test driver package " + testDriverPackageName
-        + " missing `runTests` export");
+    // On the client, the test driver *must* define `runTests`
+    if (Meteor.isClient) {
+      if (typeof testDriverPackage.runTests !== "function") {
+        throw new Error("Test driver package " + testDriverPackageName
+          + " missing `runTests` export");
+      }
+      testDriverPackage.runTests();  
+    } else {
+      // The server can optionally define `start`
+      if (typeof testDriverPackage.start === "function") {
+        testDriverPackage.start();
+      }
     }
-
-    testDriverPackage.runTests();
   });
 }


### PR DESCRIPTION
***1 Upvote*** @zol do you think this is satisfactory syntax?

A driver package can now define `.runTests()` on the client, which kicks off the test process, and `.start()` on the server which can be used for various purposes as discussed on #6436