### PR TITLE
`buildMode === "test"` for both `test` and `test-packages`

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1731,14 +1731,8 @@ var runTestAppForPackages = function (projectContext, options) {
   var buildOptions = {
     minifyMode: options.production ? 'production' : 'development'
   };
-  if (options["test-packages"]) {
-    buildOptions.buildMode = buildOptions.minifyMode;
-  } else if (options["test"]) {
-    buildOptions.buildMode = "test";
-  } else {
-    throw new Error("Neither test-packages nor test in options");
-  }
-
+  buildOptions.buildMode = "test";
+  
   if (options.deploy) {
     // Run the constraint solver and build local packages.
     main.captureAndExit("=> Errors while initializing project:", function () {


### PR DESCRIPTION
@benjamn I just wanted to sanity check this with you, I'm pretty confident it should happen.

I think we hadn't done this for back-compat reasons, however it doesn't make sense as it means that test-drivers and test utilities can't be `testOnly` if they want to be usable for `meteor test-packages`. Which kind of makes it pointless to have `testOnly`.

I don't anticipate it will cause problems, but I'm not entirely sure.