### PR TITLE
Escape script tag in History.md

### DIFF
--- a/History.md
+++ b/History.md
@@ -259,7 +259,7 @@
 
 * Add methods of the form BrowserPolicy.content.allow<ContentType>BlobUrl() to BrowserPolicy #5141
 
-* Move <script> tags to end of <body> to enable 'loading' UI to be inserted into the boilerplate #6375
+* Move `<script>` tags to end of <body> to enable 'loading' UI to be inserted into the boilerplate #6375
 
 Patches contributed by GitHub users vereed, mitar, nathan-muir,
 robfallows, skishore, okland, Primigenus, zimme, welelay, rgoomar,


### PR DESCRIPTION
An unescaped `<script>` tag prevented viewing the full History.md file. Added backticks to restore visibility.

Before the fix:
![screen shot 2016-03-14 at 9 49 50 pm](https://cloud.githubusercontent.com/assets/871917/13768054/c36bf7ec-ea2e-11e5-8a97-e4f1e72a82f8.png)

