### PR TITLE
Fix for stripping BOM in import scanner. Fixes #6489

### DIFF
--- a/tools/isobuild/import-scanner.js
+++ b/tools/isobuild/import-scanner.js
@@ -377,7 +377,7 @@ export default class ImportScanner {
     // because the buffer-to-string conversion in `fs.readFileSync()`
     // translates it to FEFF, the UTF-16 BOM.
     if (info.dataString.charCodeAt(0) === 0xfeff) {
-      info.dataString = info.data.slice(1);
+      info.dataString = info.dataString.slice(1);
     }
 
     const ext = pathExtname(absPath).toLowerCase();


### PR DESCRIPTION
As discussed in #6489 the build process crashes when a module js file contains BOM mark. This change fixes stripping the BOM in import-scanner.js.