### PR TITLE
Include a new "devtools" package in the Meteor skeleton

### DIFF
--- a/packages/devtools/README.md
+++ b/packages/devtools/README.md
@@ -2,4 +2,5 @@
 
 A set of tools that improve the developer experience. These tools won’t be included in production builds of your app.
 
-1. [simple:dev-error-overlay](https://atmospherejs.com/simple/dev-error-overlay) - Display a nice overlay in your browser when your Meteor app has a server-side build error. You can also optionally display a desktop notification or play a sound!
+1. [`hot-code-push`](https://atmospherejs.com/meteor/hot-code-push) - Refresh the client automatically when the server has new code.
+2. [simple:dev-error-overlay](https://atmospherejs.com/simple/dev-error-overlay) - Display a nice overlay in your browser when your Meteor app has a server-side build error. You can also optionally display a desktop notification or play a sound!

--- a/packages/devtools/README.md
+++ b/packages/devtools/README.md
@@ -1,0 +1,5 @@
+# Devtools
+
+A set of tools that improve the developer experience. These tools won’t be included in production builds of your app.
+
+1. [simple:dev-error-overlay](https://atmospherejs.com/simple/dev-error-overlay) - Display a nice overlay in your browser when your Meteor app has a server-side build error. You can also optionally display a desktop notification or play a sound!

--- a/packages/devtools/package.js
+++ b/packages/devtools/package.js
@@ -1,9 +1,9 @@
 Package.describe({
   summary: "A set of tools that improve the developer experience",
-  version: '1.0.0',
-  debugOnly: true
+  version: '1.0.0'
 });
 
 Package.onUse(function (api) {
+  api.imply('hot-code-push');
   api.imply('simple:dev-error-overlay@1.4.0');
 });

--- a/packages/devtools/package.js
+++ b/packages/devtools/package.js
@@ -1,0 +1,9 @@
+Package.describe({
+  summary: "A set of tools that improve the developer experience",
+  version: '1.0.0',
+  debugOnly: true
+});
+
+Package.onUse(function (api) {
+  api.imply('simple:dev-error-overlay@1.4.0');
+});

--- a/packages/meteor-base/README.md
+++ b/packages/meteor-base/README.md
@@ -7,5 +7,4 @@ It comes with the following packages:
 1. [`meteor`](https://atmospherejs.com/meteor/meteor) - Super basic stuff about the programming environment, and a handler for the `css` file type.
 2. [`webapp`](https://atmospherejs.com/meteor/webapp) - The actual web server that handles connections, serves files, etc.
 3. [`underscore`](https://atmospherejs.com/meteor/underscore) - A library with lots of useful utilities that most of Meteor is built on.
-4. [`hot-code-push`](https://atmospherejs.com/meteor/hot-code-push) - Refresh the client automatically when the server has new code.
-5. [`ddp`](https://atmospherejs.com/meteor/ddp) - A protocol for communicating between the client and server. This is what enables `Meteor.methods`, `Meteor.publish`, `Meteor.subscribe`, etc.
+4. [`ddp`](https://atmospherejs.com/meteor/ddp) - A protocol for communicating between the client and server. This is what enables `Meteor.methods`, `Meteor.publish`, `Meteor.subscribe`, etc.

--- a/packages/meteor-base/package.js
+++ b/packages/meteor-base/package.js
@@ -24,8 +24,5 @@ Package.onUse(function(api) {
     // The protocol and client/server libraries that Meteor uses to send data
     'ddp',
     'livedata', // XXX COMPAT WITH PACKAGES BUILT FOR 0.9.0.
-
-    // Push code changes to the client and automatically reload the page
-    'hot-code-push'
   ]);
 });

--- a/tools/static-assets/skel/.meteor/packages
+++ b/tools/static-assets/skel/.meteor/packages
@@ -11,6 +11,7 @@ blaze-html-templates    # Compile .html files into Meteor Blaze views
 session                 # Client-side reactive dictionary for your app
 jquery                  # Helpful client-side library
 tracker                 # Meteor's client-side reactive programming library
+devtools                # Tools that improve the developer experience
 
 standard-minifier-css   # CSS minifier run for production mode
 standard-minifier-js    # JS minifier run for production mode

--- a/tools/upgraders.js
+++ b/tools/upgraders.js
@@ -217,10 +217,19 @@ the guide about breaking changes here:`,
       packagesFile.removePackages(['standard-minifiers']);
 
       packagesFile.addPackages([
-        // These packages replace meteor-platform in newly created apps
         'standard-minifier-css',
         'standard-minifier-js',
       ]);
+    }
+    projectContext.projectConstraintsFile.writeIfModified();
+  },
+
+  "1.3.1-devtools-package": function(projectContext) {
+    // The "hot-code-push" package previously implied by "meteor-base" is now
+    // included as part of "devtools"
+
+    if (packagesFile.getConstraint('meteor-base')) {
+      packagesFile.addPackages(['devtools']);
     }
     projectContext.projectConstraintsFile.writeIfModified();
   },


### PR DESCRIPTION
There has been a lot of discussions in the JavaScript community about how hard it is to set up a project correctly in our constantly evolving environment. In this ecosystem Meteor has always stood as a developer friendly platform to build JavaScript applications, and I believe there is an opportunity to work more in this direction.

I propose to add a package called `"debugger"` (we could find a better name) that consists of a set of tools activated in development mode only. It currently only contains the [simple:dev-error-overlay](https://atmospherejs.com/simple/dev-error-overlay) package developed by @stubailo, but in the future it could include other tools for things like type checking, hot reloading, state inspectors, etc. as these tools emerge and mature as community packages.