### PR TITLE
Get proper packageName in bundler.js. Fixes #6555

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -339,6 +339,11 @@ export class NodeModulesDirectory {
             parts[2] === "meteor") {
           info.packageName = parts[3];
         }
+        else if (parts.length === 3 && 
+                 parts[0] === "npm" && 
+                 parts[2] === "node_modules") {
+          info.packageName = parts[1];
+        }
       }
 
       if (files.pathIsAbsolute(path)) {


### PR DESCRIPTION
It seems that `program.json` file in some packages has different `node_modules` format than bundler script expects. One example is `angular-templates`, where you can find:

```
    {
      "node_modules": "npm/babel-compiler/node_modules",
      "sourceMap": "packages/babel-compiler.js.map",
      "path": "packages/babel-compiler.js"
    },
```

It leads `NodeModulesDirectory.readDirsFromJSON` method to return `undefined` for `packageName`.

This pull requests adds parsing code for this path format so package name is extracted properly.