### PR TITLE
Fixed typo: remove erroneous comma from skeleton

### DIFF
--- a/tools/static-assets/skel/client/main.js
+++ b/tools/static-assets/skel/client/main.js
@@ -11,12 +11,12 @@ Template.hello.onCreated(function helloOnCreated() {
 Template.hello.helpers({
   counter() {
     return Template.instance().counter.get();
-  },
+  }
 });
 
 Template.hello.events({
   'click button'(event, instance) {
     // increment the counter when button is clicked
     instance.counter.set(instance.counter.get() + 1);
-  },
+  }
 });


### PR DESCRIPTION
The skeleton app created by `meteor --create` creates a skeleton app, whose `client/main.js` file has erroneous commas after their first and only helper and event map objects.

This does not break anything, but since this is the first thing a new Meteor developer will see, we would not want to leave an unprofessional impression with typos.

CC: @platform