### PR TITLE
Document Meteor.defer function

### DIFF
--- a/docs/client/full-api/api/core.md
+++ b/docs/client/full-api/api/core.md
@@ -40,7 +40,7 @@ followed by your application code.
 
 {{> autoApiBox "Meteor.wrapAsync"}}
 
-{{> auotApiBox "Meteor.defer"}}
+{{> autoApiBox "Meteor.defer"}}
 
 {{> autoApiBox "Meteor.absoluteUrl"}}
 

--- a/docs/client/full-api/api/core.md
+++ b/docs/client/full-api/api/core.md
@@ -40,6 +40,8 @@ followed by your application code.
 
 {{> autoApiBox "Meteor.wrapAsync"}}
 
+{{> auotApiBox "Meteor.defer"}}
+
 {{> autoApiBox "Meteor.absoluteUrl"}}
 
 {{> autoApiBox "Meteor.settings"}}

--- a/docs/client/full-api/tableOfContents.js
+++ b/docs/client/full-api/tableOfContents.js
@@ -10,6 +10,7 @@ var toc = [
       "Meteor.isCordova",
       "Meteor.startup",
       "Meteor.wrapAsync",
+      "Meteor.defer",
       "Meteor.absoluteUrl",
       "Meteor.settings",
       "Meteor.release"

--- a/packages/meteor/timers.js
+++ b/packages/meteor/timers.js
@@ -67,7 +67,7 @@ _.extend(Meteor, {
   
   /**
    * @memberOf Meteor
-   * @summary Defer execution of a function to run asynchronously in the background.
+   * @summary Defer execution of a function to run asynchronously in the background (similar to `Meteor.setTimeout(func, 0)`.
    * @locus Anywhere
    * @param {Function} func The function to run
    */

--- a/packages/meteor/timers.js
+++ b/packages/meteor/timers.js
@@ -64,6 +64,13 @@ _.extend(Meteor, {
   // Tracker.afterFlush or Node's nextTick (in practice). Then tests can do:
   //    callSomethingThatDefersSomeWork();
   //    Meteor.defer(expect(somethingThatValidatesThatTheWorkHappened));
+  
+  /**
+   * @memberOf Meteor
+   * @summary Defer execution of a function to run asynchronously in the background.
+   * @locus Anywhere
+   * @param {Function} func The function to run
+   */
   defer: function (f) {
     Meteor._setImmediate(bindAndCatch("defer callback", f));
   }


### PR DESCRIPTION
This commit resolves issues #2176 and #4442. Many Meteor tutorials and developers use the Meteor.defer function call on both the client and the server, but it is not documented. In addition, this function is even used in the latest [Meteor 1.3 todos example](https://github.com/meteor/todos/blob/9f515946f30331451af07960df845f43448aff3b/imports/ui/components/lists-show.js#L61) and was recently discussed on [Meteor Forums](https://forums.meteor.com/t/todos-app-madness/20239/6). 

I added this to the Meteor Core section right after Meteor.wrapAsync as it flowed best for me in this section. I did not put it in the Timers section as Meteor.defer is not really a timer call per se and in fact can have very slightly different behavior from `Meteor.setTimeout(func, 0)`.

This could be flushed out even further with examples of how/why to use this call on the server and the client, but that is probably best left for the Meteor Guide.