### PR TITLE
Remove meteor free deploy instrcution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@ cd try-meteor
 meteor
 ```
 
-Deploy it to the world, for free:
-
-```bash
-meteor deploy try-meteor.meteor.com
-```
-
 ## Slow Start (for developers)
 
 If you want to run on the bleeding edge, or help develop Meteor, you


### PR DESCRIPTION
Removing The Meteor.com free tier deploy line from docs.

--
Error deploying application: The Meteor.com free tier is being decommissionned;
see
https://forums.meteor.com/t/meteor-com-free-hosting-ends-march-25-2016/19308
for details.