### PR TITLE
Remove duplicate call to `DDPCommon.stringifyDDP`

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -294,7 +294,7 @@ var Session = function (server, version, socket, options) {
     httpHeaders: self.socket.headers
   };
 
-  self.send({msg: 'connected', session: self.id});
+  self.send({ msg: 'connected', session: self.id });
 
   // On initial connect, spin up all the universal publishers.
   Fiber(function () {

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -294,8 +294,8 @@ var Session = function (server, version, socket, options) {
     httpHeaders: self.socket.headers
   };
 
-  socket.send(DDPCommon.stringifyDDP({msg: 'connected',
-                            session: self.id}));
+  self.send({msg: 'connected', session: self.id});
+
   // On initial connect, spin up all the universal publishers.
   Fiber(function () {
     self.startUniversalSubs();


### PR DESCRIPTION
This code simplification in ddp-server removes the duplicate call to
`DDPCommon.stringifyDDP` when sending the `connected` message.

The change makes the code easier to understand: it clarifies that
there's nothing magical about the `connnected` message: it is sent in
the same way as the other DDP messages.

It is almost a pure refactoring: if the undocumented `_printSentDDP`
option is false (the default), there's no change in the behavior of
the code.

Previously, if `Meteor._printSentDDP` was set, the server would
display other sent messages but not the `connected` message.  With
this change, when the option is set then all sent DDP messages will be
displayed.