### PR TITLE
Fix whitespace and command-output handling of npm.cmd

### DIFF
--- a/scripts/npm.cmd
+++ b/scripts/npm.cmd
@@ -1,1 +1,1 @@
-%~dp0\node.exe %~dp0\..\lib\node_modules\npm\bin\npm-cli.js %*
+@"%~dp0\node.exe" "%~dp0\..\lib\node_modules\npm\bin\npm-cli.js" %*


### PR DESCRIPTION
The current implementation of the npm wrapper on Windows does not work properly if the username contains a whitespace, because your AppData-path will then contain a whitespace.

Steps to reproduce:

1. Create a user account with a whitespace in it's name, such that your user directory path will be something like `C:\Users\John Doe\`
2. If you run, e.g., `meteor npm version` you end up with Windows' command not found error.

The same issue exists for the script path/first parameter. I encountered this when using npm-shrinkwrap: You will not trigger Windows' command not found error but module-not-found errors:

```
   error: couldn't install npm packages from npm-shrinkwrap: Command failed:
   module.js:340
   throw err;
   ^
   Error: Cannot find module 'C:\Users\Daniel'
   at Function.Module._resolveFilename (module.js:338:15)
   at Function.Module._load (module.js:280:25)
   at Function.Module.runMain (module.js:497:10)
   at startup (node.js:119:16)
   at node.js:945:3
```

I've also added an @-sign. This allows for easier parsing of the output of `meteor npm version` and the likes via scripts by suppressing CMDs behavior to always write commands in cmd-scripts to the command line. This way it is also consistent with the behavior of those commands on *NIX systems (which is why I would consider the current behavior a bug).