### PR TITLE
Remove _.once and add cache to getPool

### DIFF
--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -41,14 +41,17 @@ var makePool = function (mailUrlString) {
   return pool;
 };
 
-var getPool = _.once(function () {
+var getPool = function() {
   // We delay this check until the first call to Email.send, in case someone
-  // set process.env.MAIL_URL in startup code.
+  // set process.env.MAIL_URL in startup code. Then we store in a cache until
+  // process.env.MAIL_URL changes.
   var url = process.env.MAIL_URL;
-  if (! url)
-    return null;
-  return makePool(url);
-});
+  if (this.cacheKey === undefined || this.cacheKey !== url) {
+    this.cacheKey = url;
+    this.cache = url ? makePool(url) : null;
+  }
+  return this.cache;
+}
 
 var next_devmode_mail_id = 0;
 var output_stream = process.stdout;


### PR DESCRIPTION
***1 Upvote*** Fix #4323
Using _.once gives you no option for "clearing the cache" of the ran function.
Using _.memoize, we can pass in the value of process.env.MAIL_URL, so once 
it changes, the function is allowed to be run again, caching the return value
for the current value of process.env.MAIL_URL.