### PR TITLE
Added in missing Meteor.isDevelopment.

### DIFF
--- a/docs/client/full-api/api/core.md
+++ b/docs/client/full-api/api/core.md
@@ -14,6 +14,7 @@ authentication mechanisms, should be kept in the `server` directory.
 
 {{> autoApiBox "Meteor.isCordova"}}
 {{> autoApiBox "Meteor.isDevelopment"}}
+{{> autoApiBox "Meteor.isProduction"}}
 
 {{> autoApiBox "Meteor.startup"}}
 

--- a/docs/client/full-api/api/core.md
+++ b/docs/client/full-api/api/core.md
@@ -13,6 +13,7 @@ authentication mechanisms, should be kept in the `server` directory.
 {{/note}}
 
 {{> autoApiBox "Meteor.isCordova"}}
+{{> autoApiBox "Meteor.isDevelopment"}}
 
 {{> autoApiBox "Meteor.startup"}}
 


### PR DESCRIPTION
Hi guys - just a small change; `Meteor.isDevelopment` was missing in the docs. I've added it in below `Meteor.isCordova`. Thanks!