### PR TITLE
Update Google Client ID instructions

### DIFF
--- a/packages/google/google_configure.html
+++ b/packages/google/google_configure.html
@@ -10,10 +10,10 @@
       "Create Project", if needed. Wait for Google to finish provisioning.
     </li>
     <li>
-      On the left sidebar, go to "APIs &amp; auth" and, underneath, "Consent Screen". Make sure to enter an email address and a product name, and save.
+      On the left sidebar, go to "Credentials" and, on the right, "OAuth Consent Screen". Make sure to enter an email address and a product name, and save.
     </li>
     <li>
-      On the left sidebar, go to "APIs &amp; auth" and then, "Credentials". "Create New Client ID", then select "Web application" as the type.
+      On the left sidebar, go to "Credentials". Press the "Create credentials" button, then select "Web application" as the type.
     </li>
     <li>
      Set Authorized Javascript Origins to: <span class="url">{{siteUrl}}</span>
@@ -22,7 +22,7 @@
       Set Authorized Redirect URI to: <span class="url">{{siteUrl}}_oauth/google</span>
     </li>
     <li>
-      Finish by clicking "Create Client ID".
+      Finish by clicking "Create".
     </li>
   </ol>
 </template>


### PR DESCRIPTION
The Google API Manager has changed it's interface since this was last updated. I've corrected the instructions with as little change as possible to accurately describe the current workflow.

This issue was reported for another project, here, and I figured this was a simple fix to provide: https://github.com/sandstorm-io/sandstorm/issues/1756