### PR TITLE
METEOR_LOCAL_DIR. (Fixing #6532)

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,6 @@
+## v.NEXT
+* Now can use your own `.meteor/local` by specifying `METEOR_LOCAL_PATH`.
+  #6760 #6532
 ## v1.3.1
 
 * Long isopacket node_modules paths have been shortened, fixing upgrade

--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 ## v.NEXT
+
 * Now can use your own `.meteor/local` by specifying `METEOR_LOCAL_PATH`.
   #6760 #6532
+
 ## v1.3.1
 
 * Long isopacket node_modules paths have been shortened, fixing upgrade

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -88,8 +88,11 @@ _.extend(ProjectContext.prototype, {
     // Used to override the directory that Meteor's build process
     // writes to; used by `meteor test` so that you can test your
     // app in parallel to writing it, with an isolated database.
-    self.projectLocalDir = options.projectLocalDir ||
-      files.pathJoin(self.projectDir, '.meteor', 'local');
+    // You can override the default .meteor/local by specifying
+    // METEOR_LOCAL_DIR.
+    self.projectLocalDir = process.env.METEOR_LOCAL_DIR ?
+      process.env.METEOR_LOCAL_DIR : (options.projectLocalDir ||
+      files.pathJoin(self.projectDir, '.meteor', 'local'));
 
     // Used by 'meteor rebuild'; true to rebuild all packages, or a list of
     // package names.  Deletes the isopacks and their plugin caches.


### PR DESCRIPTION
#6532 
I'm not sure if providing this env should also override the `options.projectLocalDir`, which I think is provided when use `meteor test` and fire an instance as a mirror. If I do override it in just like what I did, `meteor test` may not work as expected when `METEOR_LOCAL_DIR` is provided.