### PR TITLE
Update .eslintrc - Remove last comma

### DIFF
--- a/scripts/admin/eslint/.eslintrc
+++ b/scripts/admin/eslint/.eslintrc
@@ -167,6 +167,6 @@
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
     "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
-    "spaced-line-comment": 2,        // http://eslint.org/docs/rules/spaced-line-comment
+    "spaced-line-comment": 2         // http://eslint.org/docs/rules/spaced-line-comment
   }
 }


### PR DESCRIPTION
I followed this guide about [Meteor code style](http://guide.meteor.com/code-style.html), which has a link to [Set up Sublime Text for ES2015](http://info.meteor.com/blog/set-up-sublime-text-for-meteor-es6-es2015-and-jsx-syntax-and-linting).

In the step 4, we can copy ESLint configuration used by Meteor, but ESLint cannot read this file, it generates an error in the status bar : "cannot read config file" because of the last comma.

I use Sublime Text 3 build 3103.