### PR TITLE
Expose holdCount within launch-screen package

### DIFF
--- a/packages/launch-screen/mobile-launch-screen.js
+++ b/packages/launch-screen/mobile-launch-screen.js
@@ -36,6 +36,7 @@ LaunchScreen = {
 
     // Returns a launch screen handle with a release method
     return {
+      holdCount: holdCount,
       release: release
     };
   }


### PR DESCRIPTION
It'd be a good idea to expose holdCount within this package, so we can tell if LaunchScreen is currently holding. This would be useful in situations where the `reload-on-resume` package is receiving a hot code push/update, and the screen is currently holding. Rather than showing a loading/spinner page, since the splash screen is still being shown, we can just immediately reload the page, preventing an additional loading/spinner page from being shown to expedite the waiting process.