### PR TITLE
Remove handle.stop() after update

### DIFF
--- a/packages/autoupdate/autoupdate_cordova.js
+++ b/packages/autoupdate/autoupdate_cordova.js
@@ -48,7 +48,6 @@ Autoupdate._retrySubscription = function() {
         var checkNewVersionDocument = function(doc) {
           var self = this;
           if (doc.version !== autoupdateVersionCordova) {
-            handle && handle.stop();
             newVersionAvailable();
           }
         };


### PR DESCRIPTION
Removed handle.stop() so that live query continues to run after the first code push, and newer versions continue to download.

Important when delaying reload until after a resume, otherwise it takes multiple resumes to get to the latest bundle.