### PR TITLE
Bump the sockjs package

### DIFF
--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -6,7 +6,7 @@ Package.describe({
 
 Npm.depends({
   "permessage-deflate": "0.1.5",
-  sockjs: "0.3.14"
+  sockjs: "0.3.17"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
This exposes additional headers: https://github.com/sockjs/sockjs-node/blob/master/Changelog

This is useful when working with [Sandstorm](http://sandstorm.io/) which uses some of those headers to convey current host, which can then be used for dynamic `Meteor.absoluteUrl`.