### PR TITLE
Meteor no longer provides jquery history or layout

### DIFF
--- a/packages/jquery/README.md
+++ b/packages/jquery/README.md
@@ -12,6 +12,4 @@ This package is automatically included in every new Meteor app by `meteor create
 In addition to the `jquery` package, Meteor provides several jQuery
 plugins as separate packages. These include:
 
-* [`jquery-history`](https://github.com/balupton/history.js)
-* [`jquery-layout`](http://layout.jquery-dev.net/)
 * [`jquery-waypoints`](http://imakewebthings.com/jquery-waypoints/)


### PR DESCRIPTION
Documentation fix to remove references to jquery-history and jquery-layout packages, which Meteor no longer provides.