### PR TITLE
Simple .babelrc support implementation

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -48,6 +48,8 @@ BCp.processFilesForTarget = function (inputFiles) {
       }
 
       var babelOptions = Babel.getDefaultOptions(self.extraFeatures);
+      var deps = mergeBabelrcOptions(babelOptions, inputFile);
+      deps.sourceHash = toBeAdded.hash;
 
       babelOptions.sourceMap = true;
       babelOptions.filename =
@@ -59,7 +61,7 @@ BCp.processFilesForTarget = function (inputFiles) {
 
       try {
         var result = profile('Babel.compile', function () {
-          return Babel.compile(source, babelOptions);
+          return Babel.compile(source, babelOptions, deps);
         });
       } catch (e) {
         if (e.loc) {

--- a/packages/babel-compiler/babel.js
+++ b/packages/babel-compiler/babel.js
@@ -21,9 +21,9 @@ Babel = {
   // Deprecated, now a no-op.
   validateExtraFeatures: Function.prototype,
 
-  compile: function (source, options) {
+  compile: function (source, options, deps) {
     options = options || getDefaultOptions();
-    return meteorBabel.compile(source, options);
+    return meteorBabel.compile(source, options, deps);
   },
 
   setCacheDir: function (cacheDir) {

--- a/packages/babel-compiler/babelrc-skel
+++ b/packages/babel-compiler/babelrc-skel
@@ -1,0 +1,10 @@
+{
+
+  "presets": [
+    "meteor"
+  ],
+
+  "plugins": [
+  ]
+
+}

--- a/packages/babel-compiler/babelrc.js
+++ b/packages/babel-compiler/babelrc.js
@@ -187,3 +187,17 @@ mergeBabelrcOptions = function(options, inputFile) {
     BABEL_ENV: process.env.BABEL_ENV || process.env.NODE_ENV || 'development'
   };
 }
+
+/*
+ * Use production babelrc env for testing, since some dev plugins (e.g. the old
+ * version of the react hotloading transforms) could break tests. 
+ *
+ * Meteor.isTest isn't available in a build plugin.  Does Meteor allow
+ * --options in between 'meteor test' ?
+ *
+ * Previously this was configurable via package.json's "ecmascript-hot"
+ * section, with options to 1) not change anything, 2) explicitly set to the
+ * desired setting, e.g. "testing" instead of "production".
+ */
+if (process.argv[2] === 'test' || process.argv[2] === 'test-packages')
+  process.env.BABEL_ENV = 'production';

--- a/packages/babel-compiler/babelrc.js
+++ b/packages/babel-compiler/babelrc.js
@@ -1,0 +1,189 @@
+/*
+ * See also:
+ *
+ *   * https://forums.meteor.com/t/meteor-1-3-and-babel-options/15275
+ *   * https://github.com/meteor/meteor/issues/6351
+ */
+
+/*
+ * Needed in core:
+ *
+ *   * Add .babelrc to watchlist, handle more gracefully.
+ *
+ *   * meteor-babel needs ability for custom cache hash deps (meteor/babel#9)
+ *
+ *   * We should drop the auto-insertion of `babel-plugin-react` and instead
+ *     put it in the babelrc-skel.  This is both more obvious to the user but
+ *     also ensures a consistent babel (via babelrc) experience tools (e.g.
+ *     external tests).
+ *
+ * TODO here
+ *
+ *   * {babelrc:false} also disables .babelignore, but that should be fine
+ *     since we hand pick the files to compile anyway.
+ *
+ */
+
+/*
+ * True if we're in a server package (vs build-plugin inside of meteor-tool)
+ */
+if (process.env.APP_ID) {
+  if (Meteor.isTest)
+    return;
+
+  // Our new way to ensure that the meteor preset is at required version.
+  // Ideally we should still read in babelrc's and only warn if they use the
+  // preset.
+  if (process.env.NODE_ENV === 'development') {
+    // Only necessary to warn in development; these packages are only used in
+    // the build process, and aren't packed for deployment.
+    var checkNpmVersions = Package['tmeasday:check-npm-versions'].checkNpmVersions;
+    checkNpmVersions({
+      'babel-preset-meteor': '^6.6.7'
+    }, 'gadicc:ecmascript-hot');
+  }
+
+  // Nothing else in this file needs to be run on the server (vs build plugin)
+  return;
+}
+
+/*
+ * Code below here is run in the build plugin only
+ */
+
+var fs = Npm.require('fs');
+var path = Npm.require('path');
+var crypto = Npm.require('crypto');
+var mkdirp = Npm.require('mkdirp');
+var JSON5 = Npm.require('json5');
+
+// XXX better way to do this?
+var tmp = null;
+projRoot = process.cwd();
+
+while (projRoot !== tmp && !fs.existsSync(path.join(projRoot, '.meteor'))) {
+  tmp = projRoot;  // used to detect drive root on windows too ("./.." == ".")
+  projRoot = path.normalize(path.join(projRoot, '..'));
+}
+
+if (projRoot === tmp) {
+  // We stop processing this file here in a non-devel environment
+  // because a production build won't have a .meteor directory.
+  // We need it during the build process (which is also "production"),
+  // but for now we assume that this kind of error would be detected
+  // during development.  Would love to hear of alternative ways to do
+  // this.  Could maybe check for "local/star.json" to identify devel build.
+  if (process.env.NODE_ENV !== 'development')
+    return;
+  else
+    throw new Error("Are you running inside a Meteor project dir?");
+}
+
+var babelrc = { root: {}, client: {}, server: {} };
+for (var key in babelrc) {
+  var obj = babelrc[key];
+  obj.path = path.join(projRoot, key == 'root' ? '' : key, '.babelrc');
+  obj.exists = fs.existsSync(obj.path);
+
+  if (key === 'root' && !obj.exists) {
+    console.log('Creating ' + obj.path);
+    obj.raw = Assets.getText('babelrc-skel');
+    var dir = path.dirname(obj.path);
+    mkdirp.sync(dir);
+    fs.writeFileSync(obj.path, obj.raw);
+    obj.exists = true;
+  }
+
+  if (obj.exists) {
+
+    // Will already exist if created from skeleton
+    if (!obj.raw)
+      obj.raw = fs.readFileSync(obj.path, 'utf8');
+
+    obj.hash = crypto.createHash('sha1').update(obj.raw).digest('hex');
+
+    try {
+      obj.contents = JSON5.parse(obj.raw);
+    } catch (err) {
+      console.log("Error parsing your " + key + "/.babelrc: " + err.message);
+      process.exit(); // could throw err if .babelrc was in meteor's file watcher
+    }
+
+    // Maybe we should allow anything and hash appropriately?  But then we'd
+    // also have to recursively follow any possible 'extends' chain.
+    if (obj.contents.extends) {
+      if (key === 'root') {
+        console.log("Warning, we don't support 'extends' in your root .babelrc. "
+          + "For now, you should modify your .babelrc too every time you change '"
+          + obj.contents.extends + "' to clear the cache");
+      } else {
+        if (obj.contents.extends !== '../.babelrc')
+          console.log("Warning, we only support extending '../.babelrc' in "
+            + "your client/server .babelrc.  For now, you should modify this "
+            + "file too anytime your 'extends' file changes, to clear the "
+            + "cache");
+
+        // Since we extend ../.babelrc, we need to include that too.
+        obj.combinedHash = crypto.createHash('sha1')
+          .update(obj.hash + babelrc.root.hash).digest('hex');
+      }
+    }
+
+    /*
+     * Quit on .babelrc change (need to rebuild all files through babel).
+     * Should be unnecessary if Meteor watches the file for restart.
+     */
+    fs.watch(obj.path, function(event) {
+      console.log("Your " + key + "/.babelrc was changed, please restart Meteor.");
+      process.exit();
+    });
+
+  }
+}
+
+/*
+ * XXX Don't force { "presets": [ "meteor" ] }
+ * If they have a `presets` field set, they probably know what they're doing.
+ * If they don't, we can warn with the appropriate suggestion.
+ * Before enabling this, need to see what else the meteor preset includes;
+ * perhaps require a certain plugin if the preset isn't used, etc.
+ */
+if (!babelrc.root.contents.presets /* || babelrc.presets.indexOf('meteor') === -1 */) {
+  console.log('Your .babelrc must include at least { "presets": [ "meteor" ] }');
+  process.exit(); // could throw err if .babelrc was in meteor's file watcher
+}
+
+function archType(arch) {
+  if (arch.substr(0, 4) === 'web.')
+    return 'client';
+  if (arch.substr(0, 3) === 'os.');
+    return 'server';
+  throw new Error("Unkown architecture: " + arch);
+}
+
+/*
+ * Merge the user's .babelrc into the given "options" object.
+ * First look for a target-specific (client/server) .babelrc otherwise
+ * default back to the project root's .babelrc.
+ *
+ * Returns a list of "deps" that must be used to cache the file, i.e.
+ * the hash of the relevant .babelrc and environment variables, which
+ * if changed, would result in a different result from babel.
+ */
+mergeBabelrcOptions = function(options, inputFile) {
+  var arch = archType(inputFile.getArch());
+
+  var obj = babelrc[arch];
+  if (!obj.exists)
+    obj = babelrc.root;
+
+  options.extends = obj.path;
+
+  return {
+    babelrcHash: obj.combinedHash || obj.hash,
+
+    // Because .babelrc may contain env-specific configs
+    // Default is 'development' as per http://babeljs.io/docs/usage/options/
+    BABEL_ENV: process.env.BABEL_ENV || process.env.NODE_ENV || 'development'
+  };
+}

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -10,14 +10,20 @@ Package.describe({
 });
 
 Npm.depends({
-  'meteor-babel': '0.9.2'
+  'meteor-babel': '0.9.2',
+  'json5': '0.5.0',
+  'mkdirp': '0.5.1'
 });
 
 Package.onUse(function (api) {
+  api.use('tmeasday:check-npm-versions@0.3.1', 'server');
+
   api.addFiles([
     'babel.js',
     'babel-compiler.js'
   ], 'server');
+
+  api.addAssets('babelrc-skel', 'server');
 
   api.export('Babel', 'server');
   api.export('BabelCompiler', 'server');

--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -38,7 +38,11 @@ var Connection = function (url, options) {
     reloadWithOutstanding: false,
     supportedDDPVersions: DDPCommon.SUPPORTED_DDP_VERSIONS,
     retry: true,
-    respondToPings: true
+    respondToPings: true,
+    // When updates are coming within this ms interval, batch them together.
+    bufferedWritesInterval: 5,
+    // Flush buffers immediately if writes are happening continuously for more than this many ms.
+    bufferedWritesMaxAge: 500
   }, options);
 
   // If set, called when we reconnect, queuing method calls _before_ the
@@ -173,6 +177,18 @@ var Connection = function (url, options) {
   self._updatesForUnknownStores = {};
   // if we're blocking a migration, the retry func
   self._retryMigrate = null;
+
+  self.__flushBufferedWrites = Meteor.bindEnvironment(
+    self._flushBufferedWrites, "flushing DDP buffered writes", self);
+  // Collection name -> array of messages.
+  self._bufferedWrites = {};
+  // When current buffer of updates must be flushed at, in ms timestamp.
+  self._bufferedWritesFlushAt = null;
+  // Timeout handle for the next processing of all pending writes
+  self._bufferedWritesFlushHandle = null;
+
+  self._bufferedWritesInterval = options.bufferedWritesInterval;
+  self._bufferedWritesMaxAge = options.bufferedWritesMaxAge;
 
   // metadata for subscriptions.  Map from sub ID to object with keys:
   //   - id
@@ -1229,9 +1245,6 @@ _.extend(Connection.prototype, {
   _livedata_data: function (msg) {
     var self = this;
 
-    // collection name -> array of messages
-    var updates = {};
-
     if (self._waitingForQuiescence()) {
       self._messagesBufferedUntilQuiescence.push(msg);
 
@@ -1252,12 +1265,55 @@ _.extend(Connection.prototype, {
       // We'll now process and all of our buffered messages, reset all stores,
       // and apply them all at once.
       _.each(self._messagesBufferedUntilQuiescence, function (bufferedMsg) {
-        self._processOneDataMessage(bufferedMsg, updates);
+        self._processOneDataMessage(bufferedMsg, self._bufferedWrites);
       });
       self._messagesBufferedUntilQuiescence = [];
     } else {
-      self._processOneDataMessage(msg, updates);
+      self._processOneDataMessage(msg, self._bufferedWrites);
     }
+
+    // Immediately flush writes when:
+    //  1. Buffering is disabled. Or;
+    //  2. any non-(added/changed/removed) message arrives.
+    var standardWrite = _.include(['added', 'changed', 'removed'], msg.msg);
+    if (self._bufferedWritesInterval === 0 || !standardWrite) {
+      self._flushBufferedWrites();
+      return;
+    }
+
+    if (self._bufferedWritesFlushAt === null) {
+      self._bufferedWritesFlushAt = new Date().valueOf() + self._bufferedWritesMaxAge;
+    }
+    else if (self._bufferedWritesFlushAt < new Date().valueOf()) {
+      self._flushBufferedWrites();
+      return;
+    }
+
+    if (self._bufferedWritesFlushHandle) {
+      clearTimeout(self._bufferedWritesFlushHandle);
+    }
+    self._bufferedWritesFlushHandle = setTimeout(self.__flushBufferedWrites,
+                                                      self._bufferedWritesInterval);
+  },
+
+  _flushBufferedWrites: function () {
+    var self = this;
+    if (self._bufferedWritesFlushHandle) {
+      clearTimeout(self._bufferedWritesFlushHandle);
+      self._bufferedWritesFlushHandle = null;
+    }
+
+    self._bufferedWritesFlushAt = null;
+    // We need to clear the buffer before passing it to
+    //  performWrites. As there's no guarantee that it
+    //  will exit cleanly.
+    var writes = self._bufferedWrites;
+    self._bufferedWrites = {};
+    self._performWrites(writes);
+  },
+
+  _performWrites: function(updates){
+    var self = this;
 
     if (self._resetStores || !_.isEmpty(updates)) {
       // Begin a transactional update of each store.
@@ -1535,6 +1591,11 @@ _.extend(Connection.prototype, {
     // id, result or error. error has error (code), reason, details
 
     var self = this;
+
+    // Lets make sure there are no buffered writes before returning result.
+    if (!_.isEmpty(self._bufferedWrites)) {
+      self._flushBufferedWrites();
+    }
 
     // find the outstanding request
     // should be O(1) in nearly all realistic use cases

--- a/packages/ddp-client/livedata_connection_tests.js
+++ b/packages/ddp-client/livedata_connection_tests.js
@@ -2,7 +2,10 @@ var newConnection = function (stream) {
   // Some of these tests leave outstanding methods with no result yet
   // returned. This should not block us from re-running tests when sources
   // change.
-  return new LivedataTest.Connection(stream, {reloadWithOutstanding: true});
+  return new LivedataTest.Connection(stream, {
+    reloadWithOutstanding: true,
+    bufferedWritesInterval: 0
+  });
 };
 
 var makeConnectMessage = function (session) {

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -333,7 +333,13 @@ export class NodeModulesDirectory {
   // objects returned by the toJSON method above. Note that this works
   // even if the node_modules parameter is a string, though that will only
   // be the case for bundles built before Meteor 1.3.
-  static readDirsFromJSON(node_modules, callerInfo) {
+  static readDirsFromJSON(node_modules, {
+    rebuildBinaries = false,
+    // Options consumed by readDirsFromJSON are listed above. Any other
+    // options will be passed on to NodeModulesDirectory constructor via
+    // this callerInfo object:
+    ...callerInfo,
+  }) {
     assert.strictEqual(typeof callerInfo.sourceRoot, "string");
 
     const nodeModulesDirectories = Object.create(null);
@@ -395,6 +401,12 @@ export class NodeModulesDirectory {
       add({ local: false }, node_modules);
     } else if (node_modules) {
       _.each(node_modules, add);
+    }
+
+    if (rebuildBinaries) {
+      _.each(nodeModulesDirectories, (info, path) => {
+        meteorNpm.rebuildIfNonPortable(path);
+      });
     }
 
     return nodeModulesDirectories;

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -402,7 +402,7 @@ var compileUnibuild = Profile(function (options) {
     nodeModulesDirectories[nmd.sourcePath] = nmd;
   }
 
-  Object.keys(inputSourceArch.localNodeModulesDirs).forEach(dir => {
+  _.each(inputSourceArch.localNodeModulesDirs, (info, dir) => {
     addNodeModulesDirectory({
       packageName: inputSourceArch.pkg.name,
       sourceRoot: inputSourceArch.sourceRoot,
@@ -411,6 +411,10 @@ var compileUnibuild = Profile(function (options) {
       // packages, as well as .npm/package/node_modules directories.
       npmDiscards: isopk.npmDiscards,
       local: true,
+      // The values of inputSourceArch.localNodeModulesDirs are usually
+      // just `true`, but if `info` is an object, then we let its
+      // properties override the properties defined above.
+      ...(_.isObject(info) ? info : Object.prototype),
     });
   });
 

--- a/tools/isobuild/isopack.js
+++ b/tools/isobuild/isopack.js
@@ -1085,11 +1085,15 @@ _.extend(Isopack.prototype, {
         }
       });
 
-      const nodeModulesDirectories =
-        bundler.NodeModulesDirectory.readDirsFromJSON(
-          unibuildJson.node_modules,
-          { packageName: self.name,
-            sourceRoot: unibuildBasePath });
+      const nodeModulesDirectories = bundler.NodeModulesDirectory
+        .readDirsFromJSON(unibuildJson.node_modules, {
+          packageName: self.name,
+          sourceRoot: unibuildBasePath,
+          // Rebuild binaries only when the isopack is first downloaded,
+          // and only when the unibuild arch matches the host arch.
+          rebuildBinaries: options.justDownloaded &&
+            archinfo.matches(archinfo.host(), unibuildMeta.arch)
+        });
 
       self.unibuilds.push(new Unibuild(self, {
         // At some point we stopped writing 'kind's to the metadata file, so

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -114,6 +114,22 @@ meteorNpm.updateDependencies = function (packageName,
   return true;
 };
 
+meteorNpm.rebuildIfNonPortable = function (nodeModulesDir) {
+  if (meteorNpm.dependenciesArePortable(nodeModulesDir)) {
+    return false;
+  }
+
+  const parentDir = files.pathDirname(nodeModulesDir);
+  const result = runNpmCommand(["rebuild"], parentDir);
+
+  if (! result.success) {
+    buildmessage.error(result.error);
+    return false;
+  }
+
+  return true;
+};
+
 // Return true if all of a package's npm dependencies are portable
 // (that is, if the node_modules can be copied anywhere and we'd
 // expect it to work, rather than containing native extensions that

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1310,6 +1310,25 @@ _.extend(PackageSource.prototype, {
         }
       });
 
+      const origAppDir = projectContext.getOriginalAppDirForTestPackages();
+
+      const origNodeModulesDir = origAppDir &&
+        files.pathJoin(origAppDir, "node_modules");
+
+      const origNodeModulesStat = origNodeModulesDir &&
+        files.statOrNull(origNodeModulesDir);
+
+      if (origNodeModulesStat &&
+          origNodeModulesStat.isDirectory()) {
+        sourceArch.localNodeModulesDirs["node_modules"] = {
+          // Override these properties when calling
+          // addNodeModulesDirectory in compileUnibuild.
+          sourceRoot: origAppDir,
+          sourcePath: origNodeModulesDir,
+          local: false,
+        };
+      }
+
       self.architectures.push(sourceArch);
 
       // sourceArch's WatchSet should include all the project metadata files

--- a/tools/packaging/tropohouse.js
+++ b/tools/packaging/tropohouse.js
@@ -511,10 +511,10 @@ _.extend(exports.Tropohouse.prototype, {
         // We need to turn our builds into a single isopack.
         var isopack = new Isopack();
         _.each(buildInputDirs, function (buildTempDir, i) {
-          isopack._loadUnibuildsFromPath(
-            packageName,
-            buildTempDir,
-            {firstIsopack: i === 0});
+          isopack._loadUnibuildsFromPath(packageName, buildTempDir, {
+            firstIsopack: i === 0,
+            justDownloaded: true,
+          });
         });
 
         self._saveIsopack(isopack, packageName, version);

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -555,6 +555,16 @@ _.extend(ProjectContext.prototype, {
     });
   }),
 
+  // When running test-packages for an app with local packages, this
+  // method will return the original app dir, as opposed to the temporary
+  // testRunnerAppDir created for the tests.
+  getOriginalAppDirForTestPackages() {
+    const appDir = this._projectDirForLocalPackages;
+    if (_.isString(appDir) && appDir !== this.projectDir) {
+      return appDir;
+    }
+  },
+
   _localPackageSearchDirs: function () {
     var self = this;
     var searchDirs = [files.pathJoin(self._projectDirForLocalPackages, 'packages')];


### PR DESCRIPTION
@benjamn, for when you get started on this (#6351).

I removed all the hotloading-related code, so this is hopefully a lot clearer.  It assumes the changes to `meteor-babel` from my PRs there.

Obviously not looking to have this merged as is.  I think it covers the main points so I hope will help.  You can use just as inspiration or merge and adapt as desired.  Let me know if you'd like anything else from me on this.

I think the main improvement that could be made when having control over all of Meteor vs a package, is to have Meteor watch and restart on a change to the various .babelrc's.  That and a better way to get the project directory :)  See also my notes (in comments) about having removed `babel-preset-meteor` and suggestion to do the same for `react`.