### PR TITLE
DDP Buffering Tests for Meteor 1.3.3

### DIFF
--- a/packages/ddp-client/.npm/package/npm-shrinkwrap.json
+++ b/packages/ddp-client/.npm/package/npm-shrinkwrap.json
@@ -19,6 +19,11 @@
         }
       }
     },
+    "lolex": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.4.0.tgz",
+      "from": "lolex@1.4.0"
+    },
     "permessage-deflate": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.3.tgz",

--- a/packages/ddp-client/livedata_connection_tests.js
+++ b/packages/ddp-client/livedata_connection_tests.js
@@ -1,3 +1,5 @@
+import lolex from 'lolex';
+
 var newConnection = function (stream, options) {
   // Some of these tests leave outstanding methods with no result yet
   // returned. This should not block us from re-running tests when sources
@@ -96,7 +98,6 @@ Tinytest.add("livedata stub - receive data", function (test) {
 });
 
 Tinytest.add("livedata stub - buffering data", function (test) {
-  var lolex = Npm.require('lolex');
   var stream = new StubStream();
 
   // Install special setTimeout that lets us control it in tests, courtesy of sinon's lolex

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -6,6 +6,7 @@ Package.describe({
 
 Npm.depends({
   "faye-websocket": "0.9.4",
+  "lolex": "1.4.0",
   "permessage-deflate": "0.1.3"
 });
 

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -49,6 +49,7 @@ Package.onTest(function (api) {
   api.use('mongo', ['client', 'server']);
   api.use('test-helpers', ['client', 'server']);
   api.use([
+    'ecmascript',
     'underscore',
     'tinytest',
     'random',


### PR DESCRIPTION
This is an adaptation of @tmeasday's 74230beba8777cb9104c4180525e2a3fe09772c4 test that he created for meteor/meteor#5680.  Due to occasional failures, it now uses sinon's `lolex` npm library to allow us to control the setTimeout/setInterval within the test itself, providing for tick-accurate testing. Also nifty because it allows the test to finish in less time than it actually takes.