### PR TITLE
Add Accounts.onLogout(func) Hook

### DIFF
--- a/docs/client/data.js
+++ b/docs/client/data.js
@@ -980,6 +980,32 @@ DocsData = {
     "scope": "instance",
     "summary": "Register a callback to be called after a login attempt fails."
   },
+  "AccountsClient#onLogout": {
+    "filepath": "accounts-base/accounts_common.js",
+    "inherited": true,
+    "inherits": "AccountsCommon#onLogout",
+    "kind": "function",
+    "lineno": 164,
+    "locus": "Anywhere",
+    "longname": "AccountsClient#onLogout",
+    "memberof": "AccountsClient",
+    "module": "accounts-base",
+    "name": "onLogout",
+    "options": [],
+    "params": [
+      {
+        "description": "<p>The callback to be called after the logout has finished.</p>",
+        "name": "func",
+        "type": {
+          "names": [
+            "function"
+          ]
+        }
+      }
+    ],
+    "scope": "instance",
+    "summary": "Register a callback to be called after a logout attempt succeeds."
+  },
   "AccountsClient#user": {
     "filepath": "accounts-base/accounts_common.js",
     "inherited": true,
@@ -1154,6 +1180,32 @@ DocsData = {
     ],
     "scope": "instance",
     "summary": "Register a callback to be called after a login attempt fails."
+  },
+  "AccountsCommon#onLogout": {
+    "filepath": "accounts-base/accounts_common.js",
+    "inherited": true,
+    "inherits": "AccountsCommon#onLogout",
+    "kind": "function",
+    "lineno": 164,
+    "locus": "Anywhere",
+    "longname": "AccountsCommon#onLogout",
+    "memberof": "AccountsCommon",
+    "module": "accounts-base",
+    "name": "onLogout",
+    "options": [],
+    "params": [
+      {
+        "description": "<p>The callback to be called after the logout has finished.</p>",
+        "name": "func",
+        "type": {
+          "names": [
+            "function"
+          ]
+        }
+      }
+    ],
+    "scope": "instance",
+    "summary": "Register a callback to be called after a logout attempt succeeds."
   },
   "AccountsCommon#user": {
     "filepath": "accounts-base/accounts_common.js",
@@ -1357,6 +1409,32 @@ DocsData = {
     ],
     "scope": "instance",
     "summary": "Register a callback to be called after a login attempt fails."
+  },
+  "AccountsServer#onLogout": {
+    "filepath": "accounts-base/accounts_common.js",
+    "inherited": true,
+    "inherits": "AccountsCommon#onLogout",
+    "kind": "function",
+    "lineno": 164,
+    "locus": "Anywhere",
+    "longname": "AccountsServer#onLogout",
+    "memberof": "AccountsServer",
+    "module": "accounts-base",
+    "name": "onLogout",
+    "options": [],
+    "params": [
+      {
+        "description": "<p>The callback to be called after the logout has finished.</p>",
+        "name": "func",
+        "type": {
+          "names": [
+            "function"
+          ]
+        }
+      }
+    ],
+    "scope": "instance",
+    "summary": "Register a callback to be called after a logout attempt succeeds."
   },
   "AccountsServer#user": {
     "filepath": "accounts-base/accounts_common.js",

--- a/docs/client/full-api/api/accounts.md
+++ b/docs/client/full-api/api/accounts.md
@@ -462,6 +462,8 @@ On the server, the callbacks get a single argument, the same attempt info
 object as [`validateLoginAttempt`](#accounts_validateloginattempt). On the
 client, no arguments are passed.
 
+{{> autoApiBox "AccountsCommon#onLogout"}}
+
 <h3 id="accounts_rate_limit"><span>Rate Limiting</span></h3>
 
 By default, there are rules added to the [`DDPRateLimiter`](#ddpratelimiter)

--- a/docs/client/full-api/nameToId.js
+++ b/docs/client/full-api/nameToId.js
@@ -50,6 +50,7 @@ nameToId = {
   "AccountsCommon#config": "accounts_config",
   "AccountsCommon#onLogin": "accounts_onlogin",
   "AccountsCommon#onLoginFailure": "accounts_onloginfailure",
+  "AccountsCommon#onLogout": "accounts_onlogout",
   "AccountsClient#loggingIn": "accounts_loggingin",
   "AccountsServer#validateLoginAttempt": "accounts_validateloginattempt",
   "AccountsServer#validateNewUser": "accounts_validatenewuser",

--- a/docs/client/full-api/tableOfContents.js
+++ b/docs/client/full-api/tableOfContents.js
@@ -130,6 +130,7 @@ var toc = [
       { name: "AccountsCommon#config", id: "accounts_config" },
       { name: "AccountsCommon#onLogin", id: "accounts_onlogin" },
       { name: "AccountsCommon#onLoginFailure", id: "accounts_onloginfailure" },
+      { name: "AccountsCommon#onLogout", id: "accounts_onlogout" },
       {type: "spacer"},
 
       { name: "AccountsClient#loggingIn", id: "accounts_loggingin" },

--- a/docs/client/names.json
+++ b/docs/client/names.json
@@ -34,6 +34,7 @@
   "AccountsCommon#config",
   "AccountsCommon#onLogin",
   "AccountsCommon#onLoginFailure",
+  "AccountsCommon#onLogout",
   "AccountsCommon#user",
   "AccountsCommon#userId",
   "AccountsServer",

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -198,16 +198,6 @@ Ap.callLoginMethod = function (options) {
     options.userCallback.apply(this, arguments);
   });
 
-  // Prepare callbacks: user provided and onLogout hook.
-  var logoutCallbacks = _.once(function (error) {
-    if (!error) {
-      self._onLogoutHook.each(function (callback) {
-        callback();
-        return true;
-      });
-    }
-  });
-
   var reconnected = false;
 
   // We want to set up onReconnect as soon as we get a result token back from
@@ -243,7 +233,7 @@ Ap.callLoginMethod = function (options) {
         if (! result.tokenExpires)
           result.tokenExpires = self._tokenExpiration(new Date());
         if (self._tokenExpiresSoon(result.tokenExpires)) {
-          self.makeClientLoggedOut(logoutCallbacks);
+          self.makeClientLoggedOut();
         } else {
           self.callLoginMethod({
             methodArguments: [{resume: result.token}],
@@ -272,7 +262,7 @@ Ap.callLoginMethod = function (options) {
                 // periodic localStorage poll will call `makeClientLoggedOut`
                 // eventually if another tab wiped the token from storage.
                 if (storedTokenNow && storedTokenNow === result.token) {
-                  self.makeClientLoggedOut(logoutCallbacks);
+                  self.makeClientLoggedOut();
                 }
               }
               // Possibly a weird callback to call, but better than nothing if

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -318,11 +318,17 @@ Ap.callLoginMethod = function (options) {
     loggedInAndDataReadyCallback);
 };
 
-Ap.makeClientLoggedOut = function (logoutCallbacks) {
+Ap.makeClientLoggedOut = function () {
+  // Ensure client was successfully logged in before running logout hooks.
+  if (this.connection._userId) {
+    this._onLogoutHook.each(function (callback) {
+      callback();
+      return true;
+    });
+  }
   this._unstoreLoginToken();
   this.connection.setUserId(null);
   this.connection.onReconnect = null;
-  logoutCallbacks();
 };
 
 Ap.makeClientLoggedIn = function (userId, token, tokenExpires) {

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -35,6 +35,11 @@ export class AccountsCommon {
       bindEnvironment: false,
       debugPrintExceptions: "onLoginFailure callback"
     });
+
+    this._onLogoutHook = new Hook({
+      bindEnvironment: false,
+      debugPrintExceptions: "onLogout callback"
+    });
   }
 
   /**
@@ -154,6 +159,15 @@ export class AccountsCommon {
    */
   onLoginFailure(func) {
     return this._onLoginFailureHook.register(func);
+  }
+
+  /**
+   * @summary Register a callback to be called after a logout attempt succeeds.
+   * @locus Anywhere
+   * @param {Function} func The callback to be called when logout is successful.
+   */
+  onLogout(func) {
+    return this._onLogoutHook.register(func);
   }
 
   _initConnection(options) {

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -176,6 +176,12 @@ Ap._failedLogin = function (connection, attempt) {
   });
 };
 
+Ap._successfulLogout = function () {
+  this._onLogoutHook.each(function (callback) {
+    callback();
+    return true;
+  });
+};
 
 ///
 /// LOGIN METHODS
@@ -532,6 +538,7 @@ Ap._initServerMethods = function () {
     if (token && this.userId)
       accounts.destroyToken(this.userId, token);
     this.setUserId(null);
+    accounts._successfulLogout();
   };
 
   // Delete all the current user's tokens and close all open connections logged

--- a/packages/accounts-password/password_tests_setup.js
+++ b/packages/accounts-password/password_tests_setup.js
@@ -54,6 +54,10 @@ Meteor.methods({
     capturedLogins[this.connection.id] = [];
   },
 
+  testCaptureLogouts: function() {
+    capturedLogouts = [];
+  },
+
   testFetchCapturedLogins: function () {
     if (capturedLogins[this.connection.id]) {
       var logins = capturedLogins[this.connection.id];
@@ -62,6 +66,10 @@ Meteor.methods({
     }
     else
       return [];
+  },
+  
+  testFetchCapturedLogouts: function() {
+    return capturedLogouts;
   }
 });
 
@@ -86,6 +94,14 @@ Accounts.onLoginFailure(function (attempt) {
       attempt: _.omit(attempt, 'connection')
     });
   }
+});
+
+var capturedLogouts = {};
+
+Accounts.onLogout(function() {
+  capturedLogouts.push({
+    successful: true
+  });
 });
 
 // Because this is global state that affects every client, we can't turn


### PR DESCRIPTION
`Accounts.onLogout(func)` is practically identical to the implementation of `Accounts.onLogin(func)`.  This PR is an effort to maintain symmetry between the available Login / Logout hooks.

Use cases include destroying active session variables, reverting UI elements, and any other cleanup that needs to occur immediately after the user is logged out.  

This PR is related to the following discussions:
[#5984](https://github.com/meteor/meteor/pull/5894)
#3867 
[#1074](https://github.com/meteor/meteor/issues/1074) 
[#426](https://github.com/meteor/meteor/issues/426)

Corresponding user-facing documentation has also been provided in this PR, as well as appropriate tests.