### PR TITLE
Use dependencies in check package

### DIFF
--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -1,3 +1,5 @@
+import {Meteor} from 'meteor/meteor'
+
 // XXX docs
 
 // Things we explicitly do NOT support:


### PR DESCRIPTION
It might be nice to show by example in the Meteor packages the recommended way of importing things.

It might be nice if there was an option to disable globals so that even if a package uses `api.export` those exports never get attached globally. The only way to use those would-be-meteor-package-exports would be to `require` or `import` them.