### PR TITLE
Error wasn't being instantiated property in livedata connection onReset

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -302,7 +302,7 @@ var Connection = function (url, options) {
           currentMethodBlock.splice(i, 1);
 
           // Make sure that the method is told that it failed.
-          methodInvoker.receiveResult(Meteor.Error('invocation-failed',
+          methodInvoker.receiveResult(new Meteor.Error('invocation-failed',
             'Method invocation might have failed due to dropped connection. ' +
             'Failing because `noRetry` option was passed to Meteor.apply.'));
         }


### PR DESCRIPTION
This was causing the "livedata stub - reconnect non-idempotent method" test to fail because it couldn't properly detect the (very much desired) error.

Fixes #6906