### PR TITLE
meteor shell: warn when using "import" in a way likely to fail

### DIFF
--- a/packages/ecmascript/ecmascript.js
+++ b/packages/ecmascript/ecmascript.js
@@ -3,6 +3,21 @@ ECMAScript = {
     const babelOptions = Babel.getDefaultOptions();
     babelOptions.sourceMap = false;
     babelOptions.ast = false;
+
+    /*
+     * Since import *will* work as expected if everything is on one line,
+     * we'll allow a case of the import statement being followed by a
+     * semicolon, some optional whitespace and a word character.
+     */
+    if (command.match(/(?!.*?;\s*\S+)^\s*import/)) {
+      throw new Error(
+        'Using "import" in the Meteor shell is unlikely to work how you ' +
+        'expect.  Try "var something = require(\'moduleId\').default;" ' +
+        'instead, or see ' +
+        'https://github.com/meteor/meteor/issues/6764 for more information.'
+      );
+    }
+
     return Babel.compile(command, babelOptions).code;
   }
 };

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -34,4 +34,5 @@ Package.onTest(function (api) {
   api.addFiles("bare-test-file.js", ["client", "server"], {
     bare: true
   });
+  api.addFiles("shell-tests.js", 'server');
 });

--- a/packages/ecmascript/shell-tests.js
+++ b/packages/ecmascript/shell-tests.js
@@ -1,0 +1,11 @@
+import { ECMAScript } from 'meteor/ecmascript';
+
+Tinytest.add("ecmascript - server - compileForShell - warn on imports", (test) => {
+  const compileForShell = ECMAScript.compileForShell;
+
+  test.throws(() => { compileForShell('import x from "x"'); });
+  test.throws(() => { compileForShell('import x from "x"; '); });
+
+  // no doesNotThrow in tinytest, but an uncaught exception will fail the test
+  compileForShell('import x from "x"; x;');
+});


### PR DESCRIPTION
PR for #6764 (cc: @benjamn)

I originally wanted to warn rather than fail, but with the way the result is sent back via a callback, it's one or the other.  Nevertheless, we can avoid failing on cases where we're confident the user actually knows what they're doing (i.e. using the imported var on the same line, see notes in `ecmascript.js` and test cases).

Not sure where the best place is to redirect for more info; happy to amend the (currently linked) original issue to explain what's going on here in more depth, and then I guess it will (helpfully) be an obvious place to report unexpected errors relating to importing from the shell.  Otherwise will amend however you suggest.