### PR TITLE
[Work in progress] Upgrade to Node 5

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=0.6.2
+BUNDLE_VERSION=5.0.0
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -5,7 +5,7 @@ set -u
 
 UNAME=$(uname)
 ARCH=$(uname -m)
-NODE_VERSION=0.10.43
+NODE_VERSION=5.11.0
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -77,6 +77,21 @@ rm -Recurse -Force "${DIR}\bin\node_modules"
 copy "${CHECKOUT_DIR}\scripts\npm.cmd" "${DIR}\bin\npm.cmd"
 npm version
 
+mkdir "${DIR}\bin\npm3"
+cd "${DIR}\bin\npm3"
+echo "{}" | Out-File package.json -Encoding ascii # otherwise it doesn't install in local dir
+npm install npm@3.1.2
+
+# add bin\npm3 to the front of the path so we can use npm 3 for building
+$env:PATH = "${DIR}\bin\npm3;${env:PATH}"
+
+# npm depends on a hardcoded file path to node-gyp, so we need this to be
+# un-flattened
+cd node_modules\npm
+npm install node-gyp
+cd ..\..
+cp node_modules\npm\bin\npm.cmd
+
 # install dev-bundle-package.json
 # use short folder names
 # b for build
@@ -128,6 +143,9 @@ cp "$DIR\mongodb\$mongo_name\bin\mongo.exe" $DIR\mongodb\bin
 
 rm -Recurse -Force $mongo_zip
 rm -Recurse -Force "$DIR\mongodb\$mongo_name"
+
+# Remove npm 3 before we package the dev bundle
+rm -Recurse -Force "${DIR}\bin\npm3"
 
 rm -Recurse -Force "$py_msi"
 python --version

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -2,7 +2,7 @@
 # use 32bit by default
 $PLATFORM = "windows_x86"
 $MONGO_VERSION = "2.6.7"
-$NODE_VERSION = "0.10.43"
+$NODE_VERSION = "5.11.0"
 $NPM_VERSION = "2.14.22"
 $PYTHON_VERSION = "2.7.10" # For node-gyp
 

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -40,16 +40,6 @@ fi
 # export path so we use the downloaded node and npm
 export PATH="$DIR/bin:$PATH"
 
-# install npm 3 in a temporary directory
-mkdir "$DIR/bin/npm3"
-cd "$DIR/bin/npm3"
-npm install npm@3.1.2
-cp node_modules/npm/bin/npm .
-
-# export path again with our temporary npm3 directory first,
-# so we can use npm 3 during builds
-export PATH="$DIR/bin/npm3:$PATH"
-
 which node
 which npm
 
@@ -134,9 +124,6 @@ curl -O $BROWSER_STACK_LOCAL_URL
 gunzip BrowserStackLocal*
 mv BrowserStackLocal* BrowserStackLocal
 mv BrowserStackLocal "$DIR/bin/"
-
-# remove our temporary npm3 directory
-rm -rf "$DIR/bin/npm3"
 
 # Sanity check to see if we're not breaking anything by replacing npm
 INSTALLED_NPM_VERSION=$(cat "$DIR/lib/node_modules/npm/package.json" |


### PR DESCRIPTION
This pull request targets the [`wip-upgrade-node`](https://github.com/meteor/meteor/tree/wip-upgrade-node) branch, and will include any changes that help with upgrading Meteor's bundled version of Node to version ~5.11.0, which is the latest stable release.

This PR will remain open until Meteor is completely stable on Node 5, but changes that make sense for any version of Node (4, 5, or 6) will get merged into the target branch earlier.

Equivalent PR for Node ~4.4.3: https://github.com/meteor/meteor/pull/6921
Equivalent PR for Node ~6.0.0: https://github.com/meteor/meteor/pull/6923