### PR TITLE
[Docs Only] Clarify that "session" and "check" must be installed

### DIFF
--- a/docs/client/full-api/api/check.md
+++ b/docs/client/full-api/api/check.md
@@ -2,6 +2,13 @@
 
 <h2 id="check_package"><span>Check</span></h2>
 
+To use `check` or `Match`, add the `check` package to your project by running
+in your terminal:
+
+```bash
+meteor add check
+```
+
 The `check` package includes pattern checking functions useful for checking the types and structure
 of variables and an [extensible library of patterns](#matchpatterns) to specify which types you are
 expecting.

--- a/docs/client/full-api/api/session.md
+++ b/docs/client/full-api/api/session.md
@@ -1,7 +1,13 @@
 {{#template name="apiSession"}}
 
-
 <h2 id="session"><span>Session</span></h2>
+
+To use `Session`, add the `session` package to your project by running
+in your terminal:
+
+```bash
+meteor add session
+```
 
 `Session` provides a global object on the client that you can use to
 store an arbitrary set of key-value pairs. Use it to store things like


### PR DESCRIPTION
In the docs, other packages made a clear distinction that they needed to be installed.  This distinction was left off for `session` and `check`, which were no longer included by default as of Meteor 1.2 (or earlier? Not sure, exactly.)

Fixes #6932