### PR TITLE
Docs <--> Hostory.md inconsistancy about Match.Optional

### DIFF
--- a/docs/client/full-api/api/check.md
+++ b/docs/client/full-api/api/check.md
@@ -122,7 +122,7 @@ check(undefined, Match.Maybe(String)); // OK
 
 {{#dtdd "<code>Match.Optional(<em>pattern</em>)</code>"}}
 
-Behaves like `Match.Maybe` except it doesn't accept `null`. If used in an object, the behavior is
+Behaves like `Match.Maybe` except it doesn't accept `undefined`. If used in an object, the behavior is
 identical to `Match.Maybe`.
 
 {{/dtdd}}


### PR DESCRIPTION
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/meteor/meteor/blob/devel/Contributing.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

I am not sure which of them is wrong, but something seems to be a bit odd here. See [History.md](https://github.com/meteor/meteor/blob/devel/History.md#v132) third-last bullet point.
The second sentence regarding the usage in an object seems to make no sense as well, or I am not able to get my head around it.