### PR TITLE
[docs-hexo] Clarify that "session" and "check" must be installed

### DIFF
--- a/docs/source/api/check.md
+++ b/docs/source/api/check.md
@@ -7,6 +7,12 @@ The `check` package includes pattern checking functions useful for checking the 
 of variables and an [extensible library of patterns](#matchpatterns) to specify which types you are
 expecting.
 
+To add `check` (or `Match`) to your application, run this command in your terminal:
+
+```bash
+meteor add check
+```
+
 {% apibox "check" %}
 
 Meteor methods and publish functions can take arbitrary [EJSON](#ejson) types as arguments, but most

--- a/docs/source/api/session.md
+++ b/docs/source/api/session.md
@@ -12,6 +12,12 @@ you call [`Session.get`](#session_get)`("currentList")`
 from inside a template, the template will automatically be rerendered
 whenever [`Session.set`](#session_set)`("currentList", x)` is called.
 
+To add `Session` to your application, run this command in your terminal:
+
+```bash
+meteor add session
+```
+
 {% apibox "Session.set" %}
 
 Example:


### PR DESCRIPTION
Same thing I did in fd2bc2a8b31bb35ca65cf946e8f1d9171cd8d2f2 except for the (previously unware-of) hexo docs.

Fixes #6932