### PR TITLE
Use MaxCDN as our new CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ Interested in contributing to Meteor?
 
 We are hiring!  Visit https://www.meteor.com/jobs to
 learn more about working full-time on the Meteor project.
+
+Bandwidth and content distribution graciously provided by [MaxCDN](https://www.maxcdn.com/).

--- a/meteor
+++ b/meteor
@@ -61,7 +61,7 @@ function install_dev_bundle {
     mkdir "$BUNDLE_TMPDIR"
 
     # duplicated in scripts/windows/download-dev-bundle.ps1:
-    DEV_BUNDLE_URL_ROOT="https://d3sqy0vbqsdhku.cloudfront.net/"
+    DEV_BUNDLE_URL_ROOT="https://static-meteor.netdna-ssl.com/"
     # If you set $USE_TEST_DEV_BUNDLE_SERVER then we will download
     # dev bundles copied by copy-dev-bundle-from-jenkins.sh without --prod.
     # It still only does this if the version number has changed

--- a/scripts/windows/download-dev-bundle.ps1
+++ b/scripts/windows/download-dev-bundle.ps1
@@ -17,7 +17,7 @@ echo "Going to download the dependency kit from the Internet"
 $ErrorActionPreference = "Stop"
 
 # duplicated in top-level meteor script:
-$DEV_BUNDLE_URL_ROOT="https://d3sqy0vbqsdhku.cloudfront.net/"
+$DEV_BUNDLE_URL_ROOT="https://static-meteor.netdna-ssl.com/"
 # If you set $USE_TEST_DEV_BUNDLE_SERVER then we will download
 # dev bundles copied by copy-dev-bundle-from-jenkins.sh without --prod.
 # It still only does this if the version number has changed


### PR DESCRIPTION
MaxCDN has graciously agreed to host our compiled packages and bootstrap tarballs. Thanks, MaxCDN!