### PR TITLE
Upgrade Fibers to npm:latest for all platforms [1.0.8]=>[1.0.10], whi…

### DIFF
--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -4,23 +4,12 @@
 // We put this in a JS file so that it can contain comments. It is processed
 // into a package.json file by generate-dev-bundle.sh.
 
-var fibersVersion;
-if (process.platform === "win32") {
-  // We have a fork of fibers off of version 1.0.5 that searches farther for
-  // the isolate thread. This problem is a result of antivirus programs messing
-  // with the thread counts on Windows.
-  // Duplicated in dev-bundle-tool-package.js
-  fibersVersion = "https://github.com/meteor/node-fibers/tarball/d519f0c5971c33d99c902dad346b817e84bab001";
-} else {
-  fibersVersion = "1.0.8";
-}
-
 var packageJson = {
   name: "meteor-dev-bundle",
   // Version is not important but is needed to prevent warnings.
   version: "0.0.0",
   dependencies: {
-    fibers: fibersVersion,
+    "fibers": "1.0.10",
     "meteor-promise": "0.5.1",
     // Not yet upgrading Underscore from 1.5.2 to 1.7.0 (which should be done
     // in the package too) because we should consider using lodash instead

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -4,17 +4,6 @@
 // We put this in a JS file so that it can contain comments. It is processed
 // into a package.json file by generate-dev-bundle.sh.
 
-var fibersVersion;
-if (process.platform === "win32") {
-  // We have a fork of fibers off of version 1.0.5 that searches farther for
-  // the isolate thread. This problem is a result of antivirus programs messing
-  // with the thread counts on Windows.
-  // Duplicated in dev-bundle-server-package.js
-  fibersVersion = "https://github.com/meteor/node-fibers/tarball/d519f0c5971c33d99c902dad346b817e84bab001";
-} else {
-  fibersVersion = "1.0.8";
-}
-
 var packageJson = {
   name: "meteor-dev-bundle-tool",
   // Version is not important but is needed to prevent warnings.
@@ -23,7 +12,7 @@ var packageJson = {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version
     npm: "2.14.22",
-    fibers: fibersVersion,
+    "fibers": "1.0.10",
     "meteor-babel": "0.9.2",
     "meteor-promise": "0.5.1",
     // So that Babel 6 can emit require("babel-runtime/helpers/...") calls.


### PR DESCRIPTION
Meteor currently uses a fork of Node-Fibers for Windows, and a (minorly) out of date version for everything else. The Windows fork was created to fix thread searching [https://github.com/meteor/node-fibers/commit/d519f0c5971c33d99c902dad346b817e84bab001]. The author has integrated the fix into master [https://github.com/laverdet/node-fibers/commit/91c4b4020303379c4c50346882f39a201279f592], so the commit applied to meteor core [https://github.com/meteor/meteor/commit/466559a8c41ff8b623f56d1a04037a0c5ad485a7] is no longer needed.

TLDR: This commit will allow for simpler adoption of [future node versions](https://github.com/meteor/meteor/issues/5124#issuecomment-210968751) by upgrading one of the core Meteor deps, and using the same version for all platforms.