### PR TITLE
Allow --port in "test" to support a bindaddr, same as non-test

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1671,7 +1671,12 @@ function doTestCommand(options) {
 
   return runTestAppForPackages(projectContext, _.extend(
     options,
-    { mobileServerUrl: utils.formatUrl(parsedMobileServerUrl) }));
+    {
+      mobileServerUrl: utils.formatUrl(parsedMobileServerUrl),
+      proxyPort: parsedServerUrl.port,
+      proxyHost: parsedServerUrl.host,
+    }
+  ));
 }
 
 // Returns the "local-test:*" package names for the given package names (or for
@@ -1755,7 +1760,8 @@ var runTestAppForPackages = function (projectContext, options) {
     var runAll = require('../runners/run-all.js');
     return runAll.run({
       projectContext: projectContext,
-      proxyPort: options.port,
+      proxyPort: options.proxyPort,
+      proxyHost: options.proxyHost,
       debugPort: options['debug-port'],
       disableOplog: options['disable-oplog'],
       settingsFile: options.settings,

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -391,11 +391,11 @@ selftest.define("run and SIGKILL parent process", ["yet-unsolved-windows-failure
   run.stop();
 });
 
-selftest.define("'meteor run --port' requires a port", function () {
+selftest.define("'meteor run --port' accepts/rejects proper values", function () {
   var s = new Sandbox();
   var run;
 
-  s.createApp("myapp", "app-prints-pid");
+  s.createApp("myapp", "standard-app");
   s.cd("myapp");
 
   run = s.run("run", "--port", "example.com");
@@ -407,6 +407,37 @@ selftest.define("'meteor run --port' requires a port", function () {
   run.waitSecs(30);
   run.matchErr("--port must include a port");
   run.expectExit(1);
+
+  run = s.run("run", "--port", "3500");
+  run.match('App running at: http://localhost:3500/');
+  run.stop();
+
+  run = s.run("run", "--port", "127.0.0.1:3500");
+  run.match('App running at: http://127.0.0.1:3500/');
+  run.stop();
+});
+
+selftest.define("'meteor test --port' accepts/rejects proper values", function () {
+  var s = new Sandbox();
+  var run;
+
+  s.createApp("myapp", "standard-app");
+  s.cd("myapp");
+
+  var runAddPackage = s.run("add", "practicalmeteor:mocha");
+  runAddPackage.waitSecs(30);
+  runAddPackage.match(/practicalmeteor:mocha\b.*?added/)
+  runAddPackage.expectExit(0);
+
+  run = s.run("test", "--port", "3700", "--driver-package", "practicalmeteor:mocha");
+  run.waitSecs(30);
+  run.match('App running at: http://localhost:3700/');
+  run.stop();
+
+  run = s.run("test", "--port", "127.0.0.1:3700", "--driver-package", "practicalmeteor:mocha");
+  run.waitSecs(30);
+  run.match('App running at: http://127.0.0.1:3700/');
+  run.stop();
 });
 
 // Regression test for #3582.  Previously, meteor run would ignore changes to


### PR DESCRIPTION
The `test` mode wasn't passing the proper proxyHost and proxyPort values to runAll.  This changes the behaviour to work the same as the regular `run` mode and also adds tests for both modes to test the bindaddr (localAddress) is taking effect properly.

Fixes #6961 