### PR TITLE
Remove the google `profile` scope.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,13 @@
 ## v.NEXT
 
+* The `google` package now uses the `email` scope as a mandatory field instead
+  of the `profile` scope. The `profile` scope is still added by default if the
+  `requestPermissions` option is not specified to maintain backward
+  compatibility, but it is now possible to pass an empty array to
+  `requestPermissions` in order to only request the `email` scope, which
+  reduces the amount of permissions requested from the user in the Google
+  popup. [PR #6975](https://github.com/meteor/meteor/pull/6975)
+
 ## v1.4
 
 * Node has been upgraded to 4.4.7.

--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -23,9 +23,9 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
 
   var credentialToken = Random.secret();
 
-  // always need this to get user id from google.
-  var requiredScope = ['profile'];
-  var scope = ['email'];
+  // we need the email scope to get user id from google.
+  var requiredScope = ['email'];
+  var scope = [];
   if (options.requestPermissions)
     scope = options.requestPermissions;
   scope = _.union(scope, requiredScope);

--- a/packages/google/google_client.js
+++ b/packages/google/google_client.js
@@ -25,7 +25,7 @@ Google.requestCredential = function (options, credentialRequestCompleteCallback)
 
   // we need the email scope to get user id from google.
   var requiredScope = ['email'];
-  var scope = [];
+  var scope = ['profile'];
   if (options.requestPermissions)
     scope = options.requestPermissions;
   scope = _.union(scope, requiredScope);


### PR DESCRIPTION
This is a re-submission of https://github.com/meteor/meteor/pull/5699.

The `email` scope is enough for getting the required data, including the user ID, so no need for the `profile` scope, which may deter users.

The discussion started at https://github.com/meteor/meteor/issues/5650

Our team anticipates Google to be a major choice for users during signup, so we would like to alleviate some of the concerns that requesting the `profile` scope may bring.

We would also like developers to have more control over more aspects, such as the way the popup window behaves (e.g, forcing it upon login for situations where there is more than one logged-in Google account).

I would really like to hear your opinions in the discussion thread.