### PR TITLE
Give a hint when using a Chrome blocked port.

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -95,12 +95,85 @@ export function parseServerOptionsForRunCommand(options, runTargets) {
 
 function parsePortOption(portOption) {
   let parsedServerUrl = utils.parseUrl(portOption);
-
+  // Chrome blocked those ports for safety reasons. 
+  // See: https://src.chromium.org/viewvc/chrome/trunk/src/net/base/net_util.cc?view=markup
+  const blockedPorts = [
+    1,    // tcpmux
+	  7,    // echo
+	  9,    // discard
+	  11,   // systat
+	  13,   // daytime
+	  15,   // netstat
+	  17,   // qotd
+	  19,   // chargen
+	  20,   // ftp data
+	  21,   // ftp access
+	  22,   // ssh
+	  23,   // telnet
+	  25,   // smtp
+	  37,   // time
+	  42,   // name
+	  43,   // nicname
+	  53,   // domain
+	  77,   // priv-rjs
+	  79,   // finger
+	  87,   // ttylink
+	  95,   // supdup
+	  101,  // hostriame
+	  102,  // iso-tsap
+	  103,  // gppitnp
+	  104,  // acr-nema
+	  109,  // pop2
+	  110,  // pop3
+	  111,  // sunrpc
+	  113,  // auth
+	  115,  // sftp
+	  117,  // uucp-path
+	  119,  // nntp
+	  123,  // NTP
+	  135,  // loc-srv /epmap
+	  139,  // netbios
+	  143,  // imap2
+	  179,  // BGP
+	  389,  // ldap
+	  465,  // smtp+ssl
+	  512,  // print / exec
+	  513,  // login
+	  514,  // shell
+	  515,  // printer
+	  526,  // tempo
+	  530,  // courier
+	  531,  // chat
+	  532,  // netnews
+	  540,  // uucp
+	  556,  // remotefs
+	  563,  // nntp+ssl
+	  587,  // stmp?
+	  601,  // ??
+	  636,  // ldap+ssl
+	  993,  // ldap+ssl
+	  995,  // pop3+ssl
+	  2049, // nfs
+	  3659, // apple-sasl / PasswordServer
+	  4045, // lockd
+	  6000, // X11
+	  6665, // Alternate IRC [Apple addition]
+	  6666, // Alternate IRC [Apple addition]
+	  6667, // Standard IRC [Apple addition]
+	  6668, // Alternate IRC [Apple addition]
+	  6669 // Alternate IRC [Apple addition]
+	];
   if (!parsedServerUrl.port) {
     Console.error("--port must include a port.");
     throw new main.ExitWithCode(1);
   }
-
+  // Give a hint when user tries to use Chrome blocked ports.
+  if (_.contains(blockedPorts, parsedServerUrl.port)) {
+      Console.info("Port ${parsedServerUrl.port} is blocked by Chrome " +
+      "for some safety reasons. Meteor may still runs on this port but " +
+      "you may not be able to visit it.");
+      Console.info("See: https://src.chromium.org/viewvc/chrome/trunk/src/net/base/net_util.cc");
+  }
   return parsedServerUrl;
 }
 

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -169,7 +169,7 @@ function parsePortOption(portOption) {
   }
   // Give a hint when user tries to use Chrome blocked ports.
   if (_.contains(blockedPorts, parsedServerUrl.port)) {
-      Console.info("Port ${parsedServerUrl.port} is blocked by Chrome " +
+      Console.info(`Port ${parsedServerUrl.port} is blocked by Chrome ` +
       "for some safety reasons. Meteor may still runs on this port but " +
       "you may not be able to visit it.");
       Console.info("See: https://src.chromium.org/viewvc/chrome/trunk/src/net/base/net_util.cc");

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -99,70 +99,70 @@ function parsePortOption(portOption) {
   // See: https://src.chromium.org/viewvc/chrome/trunk/src/net/base/net_util.cc?view=markup
   const blockedPorts = [
     1,    // tcpmux
-	  7,    // echo
-	  9,    // discard
-	  11,   // systat
-	  13,   // daytime
-	  15,   // netstat
-	  17,   // qotd
-	  19,   // chargen
-	  20,   // ftp data
-	  21,   // ftp access
-	  22,   // ssh
-	  23,   // telnet
-	  25,   // smtp
-	  37,   // time
-	  42,   // name
-	  43,   // nicname
-	  53,   // domain
-	  77,   // priv-rjs
-	  79,   // finger
-	  87,   // ttylink
-	  95,   // supdup
-	  101,  // hostriame
-	  102,  // iso-tsap
-	  103,  // gppitnp
-	  104,  // acr-nema
-	  109,  // pop2
-	  110,  // pop3
-	  111,  // sunrpc
-	  113,  // auth
-	  115,  // sftp
-	  117,  // uucp-path
-	  119,  // nntp
-	  123,  // NTP
-	  135,  // loc-srv /epmap
-	  139,  // netbios
-	  143,  // imap2
-	  179,  // BGP
-	  389,  // ldap
-	  465,  // smtp+ssl
-	  512,  // print / exec
-	  513,  // login
-	  514,  // shell
-	  515,  // printer
-	  526,  // tempo
-	  530,  // courier
-	  531,  // chat
-	  532,  // netnews
-	  540,  // uucp
-	  556,  // remotefs
-	  563,  // nntp+ssl
-	  587,  // stmp?
-	  601,  // ??
-	  636,  // ldap+ssl
-	  993,  // ldap+ssl
-	  995,  // pop3+ssl
-	  2049, // nfs
-	  3659, // apple-sasl / PasswordServer
-	  4045, // lockd
-	  6000, // X11
-	  6665, // Alternate IRC [Apple addition]
-	  6666, // Alternate IRC [Apple addition]
-	  6667, // Standard IRC [Apple addition]
-	  6668, // Alternate IRC [Apple addition]
-	  6669 // Alternate IRC [Apple addition]
-	];
+    7,    // echo
+    9,    // discard
+    11,   // systat
+    13,   // daytime
+    15,   // netstat
+    17,   // qotd
+    19,   // chargen
+    20,   // ftp data
+    21,   // ftp access
+    22,   // ssh
+    23,   // telnet
+    25,   // smtp
+    37,   // time
+    42,   // name
+    43,   // nicname
+    53,   // domain
+    77,   // priv-rjs
+    79,   // finger
+    87,   // ttylink
+    95,   // supdup
+    101,  // hostriame
+    102,  // iso-tsap
+    103,  // gppitnp
+    104,  // acr-nema
+    109,  // pop2
+    110,  // pop3
+    111,  // sunrpc
+    113,  // auth
+    115,  // sftp
+    117,  // uucp-path
+    119,  // nntp
+    123,  // NTP
+    135,  // loc-srv /epmap
+    139,  // netbios
+    143,  // imap2
+    179,  // BGP
+    389,  // ldap
+    465,  // smtp+ssl
+    512,  // print / exec
+    513,  // login
+    514,  // shell
+    515,  // printer
+    526,  // tempo
+    530,  // courier
+    531,  // chat
+    532,  // netnews
+    540,  // uucp
+    556,  // remotefs
+    563,  // nntp+ssl
+    587,  // stmp?
+    601,  // ??
+    636,  // ldap+ssl
+    993,  // ldap+ssl
+    995,  // pop3+ssl
+    2049, // nfs
+    3659, // apple-sasl / PasswordServer
+    4045, // lockd
+    6000, // X11
+    6665, // Alternate IRC [Apple addition]
+    6666, // Alternate IRC [Apple addition]
+    6667, // Standard IRC [Apple addition]
+    6668, // Alternate IRC [Apple addition]
+    6669 // Alternate IRC [Apple addition]
+  ];
   if (!parsedServerUrl.port) {
     Console.error("--port must include a port.");
     throw new main.ExitWithCode(1);


### PR DESCRIPTION
When you try to visit your app in development with Chrome on a Chrome blocked port, for example, 6000, you would receive an `ERR_UNSAFE_PORT` on Chrome. This PR gives user a hint when they try to do so.
For the blocked port list, see the source: https://src.chromium.org/viewvc/chrome/trunk/src/net/base/net_util.cc?view=markup