### PR TITLE
Make setDefault compatible with object type argument

### DIFF
--- a/packages/reactive-dict/reactive-dict-tests.js
+++ b/packages/reactive-dict/reactive-dict-tests.js
@@ -16,6 +16,18 @@ Tinytest.add('ReactiveDict - setDefault', function (test) {
   dict.setDefault('D', undefined);
   test.equal(dict.all(), {A: 'blah', B: undefined,
                           C: 'default', D: undefined});
+
+  dict = new ReactiveDict;
+  dict.set('A', 'blah');
+  dict.set('B', undefined);
+  dict.setDefault({
+    A: 'default',
+    B: 'defualt',
+    C: 'default',
+    D: undefined
+  });
+  test.equal(dict.all(), {A: 'blah', B: undefined,
+                          C: 'default', D: undefined});
 });
 
 Tinytest.add('ReactiveDict - all() works', function (test) {

--- a/packages/reactive-dict/reactive-dict.js
+++ b/packages/reactive-dict/reactive-dict.js
@@ -79,8 +79,18 @@ _.extend(ReactiveDict.prototype, {
     }
   },
 
-  setDefault: function (key, value) {
+  setDefault: function (keyOrObject, value) {
     var self = this;
+
+    if ((typeof keyOrObject === 'object') && (value === undefined)) {
+      // Called as `dict.setDefault({...})`
+      self._setDefaultObject(keyOrObject);
+      return;
+    }
+    // the input isn't an object, so it must be a key
+    // and we resume with the rest of the function
+    var key = keyOrObject;
+
     if (! _.has(self.keys, key)) {
       self.set(key, value);
     }
@@ -195,6 +205,14 @@ _.extend(ReactiveDict.prototype, {
 
     _.each(object, function (value, key){
       self.set(key, value);
+    });
+  },
+
+  _setDefaultObject: function (object) {
+    var self = this;
+
+    _.each(object, function (value, key){
+      self.setDefault(key, value);
     });
   },
 


### PR DESCRIPTION
Make the behavior of ReactiveDict.setDefault match that of ReactiveDict.set when it comes to the Object argument form.  Copied implementation strategy from set method.  Closes #6992.
