### PR TITLE
Explain that connection is provided when call recurse into other methods

### DIFF
--- a/packages/ddp-common/method_invocation.js
+++ b/packages/ddp-common/method_invocation.js
@@ -51,7 +51,7 @@ DDPCommon.MethodInvocation = function (options) {
   // On the server, the connection this method call came in on.
 
   /**
-   * @summary Access inside a method invocation. The [connection](#meteor_onconnection) that this method was received on. `null` if the method is not associated with a connection, eg. a server initiated method call.
+   * @summary Access inside a method invocation. The [connection](#meteor_onconnection) that this method was received on. `null` if the method is not associated with a connection, eg. a server initiated method call. Calls to methods made from a server method which was in turn initiated from the client share the same `connection`. 
    * @locus Server
    * @name  connection
    * @memberOf DDPCommon.MethodInvocation


### PR DESCRIPTION
Not sure if this is the best language. But I have been bitten too many times with this. Not all server-side called methods have connection null. Only when it is started by the server-side. But if you recurse in one client-side started call into other methods connection stays the same.