### PR TITLE
Don't decode username and password from auth

### DIFF
--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -25,8 +25,8 @@ var makePool = function (mailUrlString) {
   var auth = false;
   if (mailUrl.auth) {
     var parts = mailUrl.auth.split(':', 2);
-    auth = {user: parts[0] && decodeURIComponent(parts[0]),
-            pass: parts[1] && decodeURIComponent(parts[1])};
+    auth = {user: parts[0],
+            pass: parts[1]};
   }
 
   var simplesmtp = Npm.require('simplesmtp');


### PR DESCRIPTION
When using a password that contains a percent sign, meteor fails to send e-mail, throwing a `URIError: URI malformed`.

Parsing a SMTP URL with encoded auth credentials will get **unencoded** auth.

In the example below, the password is `pass%123`.
If MAIL_URL is set to `smtp://username%40hostname.tld:pass%25123@hostname.tld:25`, the parsed `mailUrl` will be
```
{ protocol: 'smtp:',
  slashes: true,
  auth: 'username@hostname.tld:pass%123',
  host: 'hostname.tld:25',
  port: '25',
  hostname: 'hostname.tld',
  hash: null,
  search: null,
  query: null,
  pathname: null,
  path: null,
  href: 'smtp://username%40hostname.tld:pass%25123@hostname.tld:25' }
```
which means that `mailUrl.auth` has already been decoded by the parser and must **not** be re-decoded.