### PR TITLE
Bump Circle CI parallelism to 8x

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,21 +10,39 @@ case $CIRCLE_NODE_INDEX in
 0)
   echo "Running test-packages"
   echo "Running self-test (1): A-Com"
-  ./packages/test-in-console/run.sh && ./meteor self-test --file "^[a-b]|^c[a-n]|^co[a-l]|^compiler-plugins" --exclude "$SELF_TEST_EXCLUDE"
+  ./packages/test-in-console/run.sh
+  ./meteor self-test --headless \
+      --file "^[a-b]|^c[a-n]|^co[a-l]|^compiler-plugins" \
+      --exclude "$SELF_TEST_EXCLUDE"
   ;;
 1)
   echo "Running self-test (2): Con-K"
   echo "Running self-test (3): L-O"
-  ./meteor self-test --file "^co[n-z]|^c[p-z]|^[d-k]" --exclude "$SELF_TEST_EXCLUDE" && ./meteor self-test --file "^[l-o]" --exclude "$SELF_TEST_EXCLUDE"
+  ./meteor self-test --headless \
+      --file "^co[n-z]|^c[p-z]|^[d-k]" \
+      --exclude "$SELF_TEST_EXCLUDE"
+  ./meteor self-test --headless \
+      --file "^[l-o]" \
+      --exclude "$SELF_TEST_EXCLUDE"
   ;;
 2)
   echo "Running self-test (4): P"
   echo "Running self-test (5): Run"
-  ./meteor self-test --file "^p" --exclude "$SELF_TEST_EXCLUDE"  && ./meteor self-test --file "^run" --exclude "$SELF_TEST_EXCLUDE"
+  ./meteor self-test --headless \
+      --file "^p" \
+      --exclude "$SELF_TEST_EXCLUDE"
+  ./meteor self-test --headless \
+      --file "^run" \
+      --exclude "$SELF_TEST_EXCLUDE"
   ;;
 3)
   echo "Running self-test (6): R-So"
   echo "Running self-test (7): Sp-Z"
-  ./meteor self-test --file "^r(?!un)|^s[a-o]" --exclude "$SELF_TEST_EXCLUDE" && ./meteor self-test --file "^s[p-z]|^[t-z]|^command-line" --exclude "$SELF_TEST_EXCLUDE"
+  ./meteor self-test --headless \
+      --file "^r(?!un)|^s[a-o]" \
+      --exclude "$SELF_TEST_EXCLUDE"
+  ./meteor self-test --headless \
+      --file "^s[p-z]|^[t-z]|^command-line" \
+      --exclude "$SELF_TEST_EXCLUDE"
   ;;
 esac

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -9,38 +9,46 @@ export EMACS=t
 case $CIRCLE_NODE_INDEX in
 0)
   echo "Running test-packages"
-  echo "Running self-test (1): A-Com"
   ./packages/test-in-console/run.sh
+  ;;
+1)
+  echo "Running self-test (1): A-Com"
   ./meteor self-test --headless \
       --file "^[a-b]|^c[a-n]|^co[a-l]|^compiler-plugins" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
-1)
+2)
   echo "Running self-test (2): Con-K"
-  echo "Running self-test (3): L-O"
   ./meteor self-test --headless \
       --file "^co[n-z]|^c[p-z]|^[d-k]" \
       --exclude "$SELF_TEST_EXCLUDE"
+  ;;
+3)
+  echo "Running self-test (3): L-O"
   ./meteor self-test --headless \
       --file "^[l-o]" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
-2)
+4)
   echo "Running self-test (4): P"
-  echo "Running self-test (5): Run"
   ./meteor self-test --headless \
       --file "^p" \
       --exclude "$SELF_TEST_EXCLUDE"
+  ;;
+5)
+  echo "Running self-test (5): Run"
   ./meteor self-test --headless \
       --file "^run" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
-3)
+6)
   echo "Running self-test (6): R-So"
-  echo "Running self-test (7): Sp-Z"
   ./meteor self-test --headless \
       --file "^r(?!un)|^s[a-o]" \
       --exclude "$SELF_TEST_EXCLUDE"
+  ;;
+7)
+  echo "Running self-test (7): Sp-Z"
   ./meteor self-test --headless \
       --file "^s[p-z]|^[t-z]|^command-line" \
       --exclude "$SELF_TEST_EXCLUDE"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,43 +13,43 @@ case $CIRCLE_NODE_INDEX in
   ;;
 1)
   echo "Running self-test (1): A-Com"
-  ./meteor self-test --headless \
+  ./meteor self-test \
       --file "^[a-b]|^c[a-n]|^co[a-l]|^compiler-plugins" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 2)
   echo "Running self-test (2): Con-K"
-  ./meteor self-test --headless \
+  ./meteor self-test \
       --file "^co[n-z]|^c[p-z]|^[d-k]" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 3)
   echo "Running self-test (3): L-O"
-  ./meteor self-test --headless \
+  ./meteor self-test \
       --file "^[l-o]" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 4)
   echo "Running self-test (4): P"
-  ./meteor self-test --headless \
+  ./meteor self-test \
       --file "^p" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 5)
   echo "Running self-test (5): Run"
-  ./meteor self-test --headless \
+  ./meteor self-test \
       --file "^run" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 6)
   echo "Running self-test (6): R-So"
-  ./meteor self-test --headless \
+  ./meteor self-test \
       --file "^r(?!un)|^s[a-o]" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 7)
   echo "Running self-test (7): Sp-Z"
-  ./meteor self-test --headless \
+  ./meteor self-test \
       --file "^s[p-z]|^[t-z]|^command-line" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -2013,6 +2013,10 @@ main.registerCommand({
     slow: { type: Boolean },
     galaxy: { type: Boolean },
     browserstack: { type: Boolean },
+    // Indicates whether these self-tests are running headless, e.g. in a
+    // continuous integration testing environment, where visual niceties
+    // like progress bars and spinners are unimportant.
+    headless: { type: Boolean },
     history: { type: Number },
     list: { type: Boolean },
     file: { type: String },
@@ -2092,6 +2096,12 @@ main.registerCommand({
   var clients = {
     browserstack: options.browserstack
   };
+
+  if (options.headless) {
+    // There's no point in spinning the spinner when we're running
+    // continuous integration tests.
+    Console.disableSpinner();
+  }
 
   return selftest.runTests({
     // filtering options

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -214,6 +214,7 @@ var SpinnerRenderer = function () {
   self.frames = ['-', '\\', '|', '/'];
   self.start = +(new Date);
   self.interval = 250;
+  self.enabled = true;
   //// I looked at some Unicode indeterminate progress indicators, such as:
   ////
   //// spinner = "▁▃▄▅▆▇▆▅▄▃".split('');
@@ -352,6 +353,14 @@ _.extend(ProgressDisplayFull.prototype, {
     self._render();
   },
 
+  enableSpinner() {
+    this._spinnerRenderer.enabled = true;
+  },
+
+  disableSpinner() {
+    this._spinnerRenderer.enabled = false;
+  },
+
   _render: function () {
     var self = this;
 
@@ -379,7 +388,9 @@ _.extend(ProgressDisplayFull.prototype, {
     if (self._fraction !== undefined && progressColumns > 16) {
       // 16 is a heuristic number that allows enough space for a meaningful progress bar
       progressGraphic = "  " + self._progressBarRenderer.asString(progressColumns - 2);
-    } else if (progressColumns > 3) {
+    } else if (self._spinnerRenderer &&
+               self._spinnerRenderer.enabled &&
+               progressColumns > 3) {
       // 3 = 2 spaces + 1 spinner character
       progressGraphic = "  " + self._spinnerRenderer.asString();
     } else {
@@ -1243,6 +1254,20 @@ _.extend(Console.prototype, {
     }
 
     self._setProgressDisplay(newProgressDisplay);
+  },
+
+  enableSpinner() {
+    if (this._progressDisplay &&
+        this._progressDisplay.enableSpinner) {
+      this._progressDisplay.enableSpinner();
+    }
+  },
+
+  disableSpinner() {
+    if (this._progressDisplay &&
+        this._progressDisplay.disableSpinner) {
+      this._progressDisplay.disableSpinner();
+    }
   },
 
   _setProgressDisplay: function (newProgressDisplay) {


### PR DESCRIPTION
I've already increased the number of containers from 4 back to 8, but the `scripts/ci.sh` script needs to be updated to take advantage of the new resources.

Submitting this as a pull request not only because we just turned on branch protection for `devel` but also because it seems like a good idea to re-run the test suite after making significant changes to the test infrastructure.

cc @tmeasday @zol @stubailo