### PR TITLE
wrapAsync: Allow use of null value to signal no callback was passed

### DIFF
--- a/packages/meteor/helpers.js
+++ b/packages/meteor/helpers.js
@@ -82,7 +82,7 @@ _.extend(Meteor, {
 
   /**
    * @memberOf Meteor
-   * @summary Wrap a function that takes a callback function as its final parameter. The signature of the callback of the wrapped function should be `function(error, result){}`. On the server, the wrapped function can be used either synchronously (without passing a callback) or asynchronously (when a callback is passed). On the client, a callback is always required; errors will be logged if there is no callback. If a callback is provided, the environment captured when the original function was called will be restored in the callback.
+   * @summary Wrap a function that takes a callback function as its final parameter. The signature of the callback of the wrapped function should be `function(error, result){}`. On the server, the wrapped function can be used either synchronously (by omitting the callback or passing the value `null` for the callback) or asynchronously (when a callback is passed). If the last argument passed to the wrapped function is a function, it will be used as the callback. On the client, a callback is always required; errors will be logged if there is no callback. If a callback is provided, the environment captured when the original function was called will be restored in the callback.
    * @locus Anywhere
    * @param {Function} func A function that takes a callback as its final parameter
    * @param {Object} [context] Optional `this` object against which the original function will be invoked
@@ -99,6 +99,8 @@ _.extend(Meteor, {
         if (type !== "undefined") {
           if (type === "function") {
             callback = arg;
+          } else if (arg === null) {
+            --i; // replace the null value with callback in the function call
           }
           break;
         }


### PR DESCRIPTION
Closes #7010

There is a convention in the Javascript community to use the value `null` for a function argument that is intentionally not provided. 

When a function returned by `wrapAsync` (the "wrapped function") is called, the arguments are inspected in reverse order to determine if a callback was provided. If the last argument (that is not undefined) is a function, it is used as the callback.  If the last argument is not a function, then the call is "fiberized" by **appending** a `future.resolver()` to the arguments to be used as a callback in the inner function call.

This behavior is not ideal because there is no way to correctly call a wrapped function when the last non-callback argument is also a function. There are **many** examples of this in the `async` npm library: https://github.com/caolan/async. With the current implementation, replacing the callback argument with `null` in the wrapped function call results in the inner function being called with `null` for the callback and the `future.resolver` is never touched.

I think that if the last (not undefined) parameter in the wrapped function call is `null`, that the inner function should be called with the `future.resolver` **replacing** the `null` value. This provides a way to correctly call any wrapped function "sync" style on the server; just pass `null` for the callback argument. This makes no difference on the client, because if the last argument is not a function, an error is thrown; and, these "sync" style calls are only supposed to be made on the server anyway.

The only break of existing code I can see is when the last non-callback argument is the value `null` and the callback parameter is simply omitted (because that is how you have to do it in the current version).  This shouldn't be very common, and it can be fixed by adding an extra `null` value for the callback parameter.

I think the case where the last non-callback argument is a function is probably much more common and currently there is no call signature to fix that.

Providing the `null` option for the callback makes it so the wrapped function can have any signature and still be called in "sync" style of "async" style on the server.