### PR TITLE
[tests] Change destination IP for http error test to something more invalid

### DIFF
--- a/packages/http/httpcall_tests.js
+++ b/packages/http/httpcall_tests.js
@@ -90,15 +90,16 @@ testAsyncMulti("httpcall - errors", [
       test.isFalse(error.response);
     };
 
-    // 0.0.0.0 is an illegal IP address, and thus should always give an error.
+    const invalidIp = "0.0.0.199";
+    // This is an invalid destination IP address, and thus should always give an error.
     // If your ISP is intercepting DNS misses and serving ads, an obviously
     // invalid URL (http://asdf.asdf) might produce an HTTP response.
-    HTTP.call("GET", "http://0.0.0.0/", expect(unknownServerCallback));
+    HTTP.call("GET", `http://${invalidIp}/`, expect(unknownServerCallback));
 
     if (Meteor.isServer) {
       // test sync version
       try {
-        var unknownServerResult = HTTP.call("GET", "http://0.0.0.0/");
+        var unknownServerResult = HTTP.call("GET", `http://${invalidIp}/`);
         unknownServerCallback(undefined, unknownServerResult);
       } catch (e) {
         unknownServerCallback(e, e.response);

--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -21,6 +21,7 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
+  api.use('ecmascript');
   api.use('webapp', 'server');
   api.use('underscore');
   api.use('random');


### PR DESCRIPTION
Previously 0.0.0.0 was used, but that _can_ refer to the local machine and was causing problems when the test was run on a machine that had something (e.g. Apache, etc.) listening on 0.0.0.0:80.

Fixes #7038