### PR TITLE
Allow smtps:// in MAIL_URL to enable secureConnection

### DIFF
--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -17,9 +17,9 @@ var MailComposer = EmailInternals.NpmModules.mailcomposer.module.MailComposer;
 
 var makePool = function (mailUrlString) {
   var mailUrl = urlModule.parse(mailUrlString);
-  if (mailUrl.protocol !== 'smtp:')
+  if (mailUrl.protocol !== 'smtp:' && mailUrl.protocol !== 'smtps:')
     throw new Error("Email protocol in $MAIL_URL (" +
-                    mailUrlString + ") must be 'smtp'");
+                    mailUrlString + ") must be 'smtp' or 'smtps'");
 
   var port = +(mailUrl.port);
   var auth = false;

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -33,7 +33,7 @@ var makePool = function (mailUrlString) {
   var pool = simplesmtp.createClientPool(
     port,  // Defaults to 25
     mailUrl.hostname,  // Defaults to "localhost"
-    { secureConnection: (port === 465),
+    { secureConnection: (port === 465) || (mailUrl.protocol === 'smtps:'),
       // XXX allow maxConnections to be configured?
       auth: auth });
 


### PR DESCRIPTION
This backwards compatible patch allows smtps protocol, and secureConnection on port 587.  Port 465 is non-standard and assigned to something else.  See #7042 for details.