### PR TITLE
Ability to override the default warehouse url base

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
   [PR #6760](https://github.com/meteor/meteor/pull/6760) [Issue #6532](https://github.com/meteor/meteor/issues/6532)
 * Allow using authType in Facebook login [PR #5694](https://github.com/meteor/meteor/pull/5694)
 * Adds flush() method to Tracker to force recomputation [PR #4710](https://github.com/meteor/meteor/pull/4710)
+* Allow overridding the default warehouse url by specifying `METEOR_WAREHOUSE_URLBASE` [PR #7054](https://github.com/meteor/meteor/pull/7054)
 
 ## v1.3.2.3
 

--- a/tools/packaging/warehouse.js
+++ b/tools/packaging/warehouse.js
@@ -43,7 +43,9 @@ var files = require('../fs/files.js');
 var httpHelpers = require('../utils/http-helpers.js');
 var fiberHelpers = require('../utils/fiber-helpers.js');
 
-var WAREHOUSE_URLBASE = 'https://warehouse.meteor.com';
+// Use `METEOR_WAREHOUSE_URLBASE` to override the default warehouse
+// url base. 
+var WAREHOUSE_URLBASE = process.env.METEOR_WAREHOUSE_URLBASE || 'https://warehouse.meteor.com';
 
 var warehouse = exports;
 _.extend(warehouse, {


### PR DESCRIPTION
Discussed about it at #6944. This PR gives you ability to override the default warehouse urlbase (`warehouse.meteor.com`) by setting `METEOR_WAREHOUSE_URLBASE`.