### PR TITLE
Put cordova.js behind other js file

### DIFF
--- a/packages/boilerplate-generator/boilerplate_web.cordova.html
+++ b/packages/boilerplate-generator/boilerplate_web.cordova.html
@@ -24,7 +24,6 @@
     }
   </script>
 
-  <script type="text/javascript" src="/cordova.js"></script>
 {{#each js}}  <script type="text/javascript" src="{{url}}"></script>
 {{/each}}
 {{#each additionalStaticJs}}
@@ -37,6 +36,7 @@
             src='{{rootUrlPathPrefix}}{{pathname}}'></script>
   {{/if}}
 {{/each}}
+  <script type="text/javascript" src="/cordova.js"></script>
   {{{head}}}
 </head>
 


### PR DESCRIPTION
When i build cordova app with --production flag, open the app it throw jQuery is not defined, because cordova.js was load before jquery.