### PR TITLE
Increase circleci timeout and disable spinner for CI tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,3 +10,4 @@ test:
   override:
     - ./scripts/ci.sh :
         parallel: true
+        timeout: 1800

--- a/circle.yml
+++ b/circle.yml
@@ -10,4 +10,4 @@ test:
   override:
     - ./scripts/ci.sh :
         parallel: true
-        timeout: 1800
+        timeout: 1200

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,43 +13,43 @@ case $CIRCLE_NODE_INDEX in
   ;;
 1)
   echo "Running self-test (1): A-Com"
-  ./meteor self-test \
+  ./meteor self-test --headless \
       --file "^[a-b]|^c[a-n]|^co[a-l]|^compiler-plugins" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 2)
   echo "Running self-test (2): Con-K"
-  ./meteor self-test \
+  ./meteor self-test --headless \
       --file "^co[n-z]|^c[p-z]|^[d-k]" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 3)
   echo "Running self-test (3): L-O"
-  ./meteor self-test \
+  ./meteor self-test --headless \
       --file "^[l-o]" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 4)
   echo "Running self-test (4): P"
-  ./meteor self-test \
+  ./meteor self-test --headless \
       --file "^p" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 5)
   echo "Running self-test (5): Run"
-  ./meteor self-test \
+  ./meteor self-test --headless \
       --file "^run" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 6)
   echo "Running self-test (6): R-So"
-  ./meteor self-test \
+  ./meteor self-test --headless \
       --file "^r(?!un)|^s[a-o]" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;
 7)
   echo "Running self-test (7): Sp-Z"
-  ./meteor self-test \
+  ./meteor self-test --headless \
       --file "^s[p-z]|^[t-z]|^command-line" \
       --exclude "$SELF_TEST_EXCLUDE"
   ;;


### PR DESCRIPTION
Trying to see if re-enabling the `--headless` spinner that Ben put in place will work if combined with a longer timeout for CircleCI.

...about to find out.