### PR TITLE
Minimongo: Allow `_id` in `$setOnInsert`.

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2085,6 +2085,23 @@ Tinytest.add("minimongo - modify", function (test) {
     exceptionWithQuery(doc, {}, mod);
   };
 
+  var upsert = function (query, mod, expected) {
+    var coll = new LocalCollection;
+    
+    var result = coll.upsert(query, mod);
+    
+    var actual = coll.findOne();
+    
+    if (expected._id) {
+      test.equal(result.insertedId, expected._id);
+    }
+    else {
+      delete actual._id;
+    }
+    
+    test.equal(actual, expected);
+  };
+  
   // document replacement
   modify({}, {}, {});
   modify({a: 12}, {}, {}); // tested against mongodb
@@ -2406,6 +2423,13 @@ Tinytest.add("minimongo - modify", function (test) {
   exception({}, {$rename: {'a.b': 'a.b'}});
   modify({a: 12, b: 13}, {$rename: {a: 'b'}}, {b: 12});
 
+  // $setOnInsert
+  modify({a: 0}, {$setOnInsert: {a: 12}}, {a: 0});
+  upsert({a: 12}, {$setOnInsert: {b: 12}}, {a: 12, b: 12});
+  upsert({a: 12}, {$setOnInsert: {_id: 'test'}}, {_id: 'test', a: 12});
+  
+  exception({}, {$set: {_id: 'bad'}});
+  
   // $bit
   // unimplemented
 

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -49,7 +49,7 @@ LocalCollection._modify = function (doc, mod, options) {
           throw MinimongoError("An empty update path is not valid.");
         }
 
-        if (keypath === '_id') {
+        if (keypath === '_id' && op !== '$setOnInsert') {
           throw MinimongoError("Mod on _id not allowed");
         }
 


### PR DESCRIPTION
Mongo now allows specifying an `_id` in upserts using the `$setOnInsert` operator, but MiniMongo throws an error. This makes simulations for latency compensation very cumbersome.

However MiniMongo does support setting _id s with `$setOnInsert` as it stands now. Only the exception was thrown incorrectly.

So I have added the tests to the relevant test case and fixed the condition on throwing the exception.

Steps to reproduce: 

```JavaScript
let collection = new LocalCollection;
collection.upsert({foo: 'bar'}, {$setOnInsert: {_id: 'test'}});
```

Expected result:
```JavaScript
isEqual(collection.findOne(), {
  _id: 'test',
  foo: 'bar'
});
```

Actual result:

> Error: MinimongoError: Mod on _id not allowed [409]


