### PR TITLE
Allow `meteor mongo` to connect to any MONGO_URL

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1118,21 +1118,27 @@ main.registerCommand({
 
   if (options.args.length === 0) {
     // localhost mode
-    var findMongoPort =
-      require('../runners/run-mongo.js').findMongoPort;
-    var mongoPort = findMongoPort(files.pathJoin(options.appDir, ".meteor", "local", "db"));
-
-    // XXX detect the case where Meteor is running, but MONGO_URL was
-    // specified?
-
-    if (! mongoPort) {
-      Console.info("mongo: Meteor isn't running a local MongoDB server.");
+	if (process.env.MONGO_URL) {
+	  mongoUrl = process.env.MONGO_URL;
+	} else {
+      var findMongoPort =
+        require('../runners/run-mongo.js').findMongoPort;
+      var mongoPort = findMongoPort(files.pathJoin(options.appDir, ".meteor", "local", "db"));
+	  mongoUrl = "mongodb://127.0.0.1:" + mongoPort + "/meteor";
+    }
+	
+    if (! mongoUrl) {	  
+      Console.info("mongo: Meteor doesn't know the MongoDB server.");
       Console.info();
       Console.info(`\
-This command only works while Meteor is running your application locally. \
-Start your application first with 'meteor' and then run this command in a new \
-terminal. This error will also occur if you asked Meteor to use a different \
-MongoDB server with $MONGO_URL when you ran your application.`);
+This command works if \
+- Meteor is running your application locally. \
+- The environment variable $MONGO_URL is provided. \
+- You want connect to a deploy server.`);
+      Console.info();
+      Console.info(`\
+If you're trying to connect to a local mongo database, start your application \
+first with 'meteor' and then run this command in a new terminal.`);
       Console.info();
       Console.info(`\
 If you're trying to connect to the database of an app you deployed with \
@@ -1140,7 +1146,7 @@ ${Console.command("'meteor deploy'")}, specify your site's name as an argument \
 to this command.`);
       return 1;
     }
-    mongoUrl = "mongodb://127.0.0.1:" + mongoPort + "/meteor";
+    
 
   } else {
     // remote mode


### PR DESCRIPTION
Hello,

The command `meteor mongo` should wwork with variable MONGO_URL and now do.

Normally no change on actual process.

I don't see tests on this part. As the change is little and i have no time to redraw test for all this command, i pull request as it. (but if you will indicate tests that i can to complete quickly, I will do.).

Best Regards

Link to #7064 