### PR TITLE
Fix incorrect History entry about Match.Maybe and Match.Optional

### DIFF
--- a/History.md
+++ b/History.md
@@ -68,6 +68,8 @@
 
 * Fixed bugs: https://github.com/meteor/meteor/milestones/Release%201.3.2
 
+* Fixed unintended change to `Match.Optional` which caused it to behave the same as the new `Match.Maybe` and incorrectly matching `null` where it previously would not have allowed it. #6735 
+
 ## v1.3.1
 
 * Long isopacket node_modules paths have been shortened, fixing upgrade
@@ -289,6 +291,12 @@
 
 * Improve automatic blocking of URLs in attribute values to also
   include `vbscript:` URLs.
+
+### Check
+
+* Introduced new matcher `Match.Maybe(type)` which will also match (permit) `null` in addition to `undefined`.  This is a suggested replacement (where appropriate) for `Match.Optional` which did not permit `null`.  This prevents the need to use `Match.OneOf(null, undefined, type)`. #6220 
+
+#### Change 1.3.2
 
 ### Testing
 

--- a/History.md
+++ b/History.md
@@ -296,8 +296,6 @@
 
 * Introduced new matcher `Match.Maybe(type)` which will also match (permit) `null` in addition to `undefined`.  This is a suggested replacement (where appropriate) for `Match.Optional` which did not permit `null`.  This prevents the need to use `Match.OneOf(null, undefined, type)`. #6220 
 
-#### Change 1.3.2
-
 ### Testing
 
 * Packages can now be marked as `testOnly` to only run as part of app


### PR DESCRIPTION
The log entry about `Match.*` bugs in 1.3.2 is actually opposite of what was changed.  This clarifies it and adds an entry for the original addition of `Match.Maybe` to the 1.3 log.

This was my mistake for not submitting a `History.md` entry with my fix in #6736 and leaving it (a confusing situation) to be interpreted by the person who wrote the History.  I didn't even notice it was wrong the second time I read it!

Fixes #7083