### PR TITLE
Adds changelog for PR #6964

### DIFF
--- a/History.md
+++ b/History.md
@@ -11,6 +11,7 @@
 * Allow `_id` in `$setOnInsert` in Minimongo: https://github.com/meteor/meteor/pull/7066
 * Added support for `$eq` to Minimongo: https://github.com/meteor/meteor/pull/4235
 * Insert a `Date` header into emails by default: https://github.com/meteor/meteor/pull/6916/files
+* `meteor test` now supports setting the bind address using `--port IP:PORT` the same as `meteor run` [PR #6964](https://github.com/meteor/meteor/pull/6964) [Issue #6961](https://github.com/meteor/meteor/issues/6961)
 
 ## v1.3.2.3
 


### PR DESCRIPTION
Adds changelog for PR #6964, (`--port IP:ADDR` support on `meteor test`), which is included in 1.3.3.