### PR TITLE
Improve Tests for the `email` package

### DIFF
--- a/packages/email/email_tests.js
+++ b/packages/email/email_tests.js
@@ -1,12 +1,25 @@
 var streamBuffers = Npm.require('stream-buffers');
 
-Tinytest.add("email - dev mode smoke test", function (test) {
+var devWarningBanner = "(Mail not sent; to enable " +
+  "sending, set the MAIL_URL environment variable.)\n";
+
+function smokeEmailTest(testFunction) {
   // This only tests dev mode, so don't run the test if this is deployed.
   if (process.env.MAIL_URL) return;
 
   try {
     var stream = new streamBuffers.WritableStreamBuffer;
     EmailTest.overrideOutputStream(stream);
+
+    testFunction(stream);
+
+  } finally {
+    EmailTest.restoreOutputStream();
+  }
+}
+
+Tinytest.add("email - fully customizable", function (test) {
+  smokeEmailTest(function(stream) {
     Email.send({
       from: "foo@example.com",
       to: "bar@example.com",
@@ -21,8 +34,7 @@ Tinytest.add("email - dev mode smoke test", function (test) {
     // XXX brittle if mailcomposer changes header order, etc
     test.equal(stream.getContentsAsString("utf8"),
                "====== BEGIN MAIL #0 ======\n" +
-               "(Mail not sent; to enable sending, set the MAIL_URL " +
-                 "environment variable.)\n" +
+               devWarningBanner +
                "MIME-Version: 1.0\r\n" +
                "X-Meteor-Test: a custom header\r\n" +
                "Date: dummy\r\n" +
@@ -37,7 +49,57 @@ Tinytest.add("email - dev mode smoke test", function (test) {
                "of the message\r\n" +
                "From us.\r\n" +
                "====== END MAIL #0 ======\n");
+  });
+});
 
+Tinytest.add("email - undefined headers sends properly", function (test) {
+  smokeEmailTest(function (stream) {
+    Email.send({
+      from: "foo@example.com",
+      to: "bar@example.com",
+      subject: "This is the subject",
+      text: "This is the body\nof the message\nFrom us.",
+    });
+
+    test.matches(stream.getContentsAsString("utf8"),
+      /^====== BEGIN MAIL #0 ======$[\s\S]+^To: bar@example.com$/m);
+  });
+});
+
+Tinytest.add("email - multiple e-mails same stream", function (test) {
+  smokeEmailTest(function (stream) {
+    // Test if date header is automaticall generated, if not specified
+    Email.send({
+      from: "foo@example.com",
+      to: "bar@example.com",
+      subject: "This is the subject",
+      text: "This is the body\nof the message\nFrom us.",
+    });
+
+    var contents;
+
+    contents = stream.getContentsAsString("utf8");
+    test.matches(contents, /^====== BEGIN MAIL #0 ======$/m);
+    test.matches(contents, /^From: foo@example.com$/m);
+    test.matches(contents, /^To: bar@example.com$/m);
+
+    Email.send({
+      from: "qux@example.com",
+      to: "baz@example.com",
+      subject: "This is important",
+      text: "This is another message\nFrom Qux.",
+    });
+
+    contents = stream.getContentsAsString("utf8");
+    test.matches(contents, /^====== BEGIN MAIL #1 ======$/m);
+    test.matches(contents, /^From: qux@example.com$/m);
+    test.matches(contents, /^To: baz@example.com$/m);
+
+  });
+});
+
+Tinytest.add("email - using mail composer", function (test) {
+  smokeEmailTest(function (stream) {
     // Test direct MailComposer usage.
     var mc = new EmailInternals.NpmModules.mailcomposer.module.MailComposer;
     mc.setMessageOption({
@@ -46,17 +108,20 @@ Tinytest.add("email - dev mode smoke test", function (test) {
     });
     Email.send({mailComposer: mc});
     test.equal(stream.getContentsAsString("utf8"),
-               "====== BEGIN MAIL #1 ======\n" +
-               "(Mail not sent; to enable sending, set the MAIL_URL " +
-                 "environment variable.)\n" +
+               "====== BEGIN MAIL #0 ======\n" +
+               devWarningBanner +
                "MIME-Version: 1.0\r\n" +
                "From: a@b.com\r\n" +
                "Content-Type: text/plain; charset=utf-8\r\n" +
                "Content-Transfer-Encoding: quoted-printable\r\n" +
                "\r\n" +
                "body\r\n" +
-               "====== END MAIL #1 ======\n");
-    
+               "====== END MAIL #0 ======\n");
+  });
+});
+
+Tinytest.add("email - date auto generated", function (test) {
+  smokeEmailTest(function (stream) {
     // Test if date header is automaticall generated, if not specified
     Email.send({
       from: "foo@example.com",
@@ -70,7 +135,5 @@ Tinytest.add("email - dev mode smoke test", function (test) {
 
     test.matches(stream.getContentsAsString("utf8"),
                  /^Date: .+$/m);
-  } finally {
-    EmailTest.restoreOutputStream();
-  }
+  });
 });


### PR DESCRIPTION
* Added `smokeEmailTest` function which sets up test stream
* Splits the previously combined tests into multiple tests
* Created test that catches error in PR #6916, caught in #7123
* Confirmed regression without 6e071838af0c9594cdbf9b23ded7ef5806510a86

Per @tmeasday in https://github.com/meteor/meteor/pull/6916#issuecomment-221953805