### PR TITLE
Correct Spacebars readme link

### DIFF
--- a/packages/spacebars/README.md
+++ b/packages/spacebars/README.md
@@ -6,4 +6,4 @@ of Handlebars, but it has been tailored to produce reactive Meteor templates
 when compiled.
 
 
-Read more at http://docs.meteor.com/#/full/spacebars
+Read more at http://docs.meteor.com/packages/spacebars.html


### PR DESCRIPTION
One of several PRs to correct references to the new location of the Spacebars docs.