### PR TITLE
Change package creation skeleton to import properly

### DIFF
--- a/tools/static-assets/skel-pack/~fs-name~-tests.js
+++ b/tools/static-assets/skel-pack/~fs-name~-tests.js
@@ -2,7 +2,7 @@
 import { Tinytest } from "meteor/tinytest";
 
 // Import and rename a variable exported by ~fs-name~.js.
-import { name as packageName } from "meteor/~fs-name~";
+import { name as packageName } from "meteor/~name~";
 
 // Write your tests here!
 // Here is an example.


### PR DESCRIPTION
The package skeleton test example was importing the module as if it was outside the package.  This changes it to reference the local package source, relative to itself, so that this sequence of commands will work properly:

```
meteor create my-app1
cd my-app1
meteor create --package my-app1:my-package123
meteor add my-app1:my-package123
meteor test-packages my-app1:my-package123
```

Fixes #6653