### PR TITLE
Allow a function to be passed in the 'sort' clause

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -274,9 +274,15 @@ _.extend(Mongo.Collection.prototype, {
     if (args.length < 2) {
       return { transform: self._transform };
     } else {
+      let sortClauseSpec;
+      if (this._collection instanceof LocalCollection) {
+        sortClauseSpec = Match.OneOf(Object, Array, Function, undefined);
+      } else {
+        sortClauseSpec = Match.OneOf(Object, Array, undefined);
+      }
       check(args[1], Match.Optional(Match.ObjectIncluding({
         fields: Match.Optional(Match.OneOf(Object, undefined)),
-        sort: Match.Optional(Match.OneOf(Object, Array, Function, undefined)),
+        sort: Match.Optional(sortClauseSpec),
         limit: Match.Optional(Match.OneOf(Number, undefined)),
         skip: Match.Optional(Match.OneOf(Number, undefined))
      })));

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -276,7 +276,7 @@ _.extend(Mongo.Collection.prototype, {
     } else {
       check(args[1], Match.Optional(Match.ObjectIncluding({
         fields: Match.Optional(Match.OneOf(Object, undefined)),
-        sort: Match.Optional(Match.OneOf(Object, Array, undefined)),
+        sort: Match.Optional(Match.OneOf(Object, Array, Function, undefined)),
         limit: Match.Optional(Match.OneOf(Number, undefined)),
         skip: Match.Optional(Match.OneOf(Number, undefined))
      })));

--- a/packages/mongo/collection_tests.js
+++ b/packages/mongo/collection_tests.js
@@ -52,3 +52,48 @@ Tinytest.add('collection - call new Mongo.Collection with defineMutationMethods=
     test.equal(nomethods._connection[handlerPropName]['/' + noMethodCollectionName + '/insert'], undefined);
   }
 );
+
+Tinytest.add('collection - call find with sort function',
+  function (test) {
+    var handlerPropName = Meteor.isClient ? '_methodHandlers' : 'method_handlers';
+    var initialize = function (collection) {
+      collection.insert({a: 2});
+      collection.insert({a: 3});
+      collection.insert({a: 1});
+    };
+
+    var sorter = function (a, b) {
+      return a.a - b.a;
+    }
+
+    var getSorted = function (collection) {
+      return collection.find({}, {sort: sorter}).map(function (doc) { return doc.a; });
+    };
+
+    var collectionName = 'sort' + test.id;
+    var localCollection = new Mongo.Collection(null);
+    var namedCollection = new Mongo.Collection(collectionName, {connection: null});
+
+    initialize(localCollection);
+    test.equal(getSorted(localCollection), [1, 2, 3]);
+
+    initialize(namedCollection);
+    test.equal(getSorted(namedCollection), [1, 2, 3]);
+  }
+);
+
+Tinytest.add('collection - call native find with sort function',
+  function (test) {
+    var collectionName = 'sortNative' + test.id;
+    var nativeCollection = new Mongo.Collection(collectionName);
+
+    if (Meteor.isServer) {
+      test.throws(
+        function () {
+          nativeCollection.find({}, {sort: function(){}}).map(function (doc) { return doc.a; })
+        },
+        /Match error/
+      );
+    }
+  }
+);


### PR DESCRIPTION
Fixes #2730.

Do you think that it is sufficient or should I create separate checks for `MongoInternals` and `LocalCollection`?