### PR TITLE
Mongo 3.2 update/upsert returns nMatched as numberAffected

### DIFF
--- a/packages/ddp-server/.npm/package/npm-shrinkwrap.json
+++ b/packages/ddp-server/.npm/package/npm-shrinkwrap.json
@@ -3,36 +3,36 @@
     "permessage-deflate": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.5.tgz",
-      "from": "permessage-deflate@0.1.5"
+      "from": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.5.tgz"
     },
     "sockjs": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.14.tgz",
-      "from": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.14.tgz",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.17.tgz",
+      "from": "sockjs@0.3.17",
       "dependencies": {
         "faye-websocket": {
-          "version": "0.9.4",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
-          "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+          "from": "faye-websocket@>=0.10.0 <0.11.0",
           "dependencies": {
             "websocket-driver": {
-              "version": "0.5.4",
-              "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.4.tgz",
-              "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.4.tgz",
+              "version": "0.6.5",
+              "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+              "from": "websocket-driver@>=0.5.1",
               "dependencies": {
                 "websocket-extensions": {
                   "version": "0.1.1",
                   "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-                  "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                  "from": "websocket-extensions@>=0.1.1"
                 }
               }
             }
           }
         },
-        "node-uuid": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+        "uuid": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+          "from": "uuid@>=2.0.2 <3.0.0"
         }
       }
     }

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -725,7 +725,7 @@ var simulateUpsertWithInsertedId = function (collection, selector, mod,
                         bindEnvironmentForWrite(function (err, result) {
                           if (err)
                             callback(err);
-                          else if (result && result.result.nModified != 0){
+                          else if (result && result.result.n != 0){
                             callback(null, {
                               numberAffected: result.result.n
                             });

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -615,13 +615,7 @@ var transformResult = function (driverResult) {
         meteorResult.insertedId = mongoResult.upserted[0]._id;
       }
     } else {
-      //The remove call, resturns only {ok: 1, n: [number of removed documents]}
-      //update apis return the nModified with the number of changed documents
-      if (mongoResult.nModified != null) {
-        meteorResult.numberAffected = mongoResult.nModified;
-      } else if (mongoResult.n) {
-        meteorResult.numberAffected = mongoResult.n;
-      }
+      meteorResult.numberAffected = mongoResult.n;
     }
   }
 
@@ -733,7 +727,7 @@ var simulateUpsertWithInsertedId = function (collection, selector, mod,
                             callback(err);
                           else if (result && result.result.nModified != 0){
                             callback(null, {
-                              numberAffected: result.result.nModified
+                              numberAffected: result.result.n
                             });
                           }
                           else

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -3345,3 +3345,87 @@ if (Meteor.isClient) {
     }
   });
 }
+
+if (Meteor.isServer) {
+  Tinytest.add('mongo update/upsert - returns nMatched as numberAffected', function (test, onComplete) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('update_nmatched'+collName);
+
+    coll.insert({animal: 'cat', legs: 4});
+    coll.insert({animal: 'dog', legs: 4});
+    coll.insert({animal: 'echidna', legs: 4});
+    coll.insert({animal: 'platypus', legs: 4});
+    coll.insert({animal: 'starfish', legs: 5});
+
+    var affected = coll.update({legs: 4}, {$set: {category: 'quadruped'}})
+    test.equal(affected, 1);
+
+    //Changes only 3 but matched 4 documents
+    var affected = coll.update({legs: 4}, {$set: {category: 'quadruped'}}, {multi: true})
+    test.equal(affected, 4);
+
+    //Again, changes nothing but returns nModified
+    var affected = coll.update({legs: 4}, {$set: {category: 'quadruped'}}, {multi: true})
+    test.equal(affected, 4);
+
+    //upsert:true changes nothing, 4 modified
+    var affected = coll.update({legs: 4}, {$set: {category: 'quadruped'}}, {multi: true, upsert:true})
+    test.equal(affected, 4);
+
+    //upsert method works as upsert:true
+    var result = coll.upsert({legs: 4}, {$set: {category: 'quadruped'}}, {multi: true})
+    test.equal(result.numberAffected, 4);
+  });
+
+  Tinytest.addAsync('mongo livedata - update/upsert callback returns nMatched as numberAffected', function (test, onComplete) {
+    var collName = Random.id();
+    var coll = new Mongo.Collection('update_nmatched'+collName);
+
+    coll.insert({animal: 'cat', legs: 4});
+    coll.insert({animal: 'dog', legs: 4});
+    coll.insert({animal: 'echidna', legs: 4});
+    coll.insert({animal: 'platypus', legs: 4});
+    coll.insert({animal: 'starfish', legs: 5});
+
+    var test1 = function () {
+      coll.update({legs: 4}, {$set: {category: 'quadruped'}}, function (err, result) {
+        test.equal(result, 1);
+        test2();
+      })
+    }
+
+    var test2 = function () {
+      //Changes only 3 but matched 4 documents
+      coll.update({legs: 4}, {$set: {category: 'quadruped'}}, {multi: true}, function (err, result) {
+        test.equal(result, 4);
+        test3();
+      });
+    }
+
+    var test3 = function () {
+      //Again, changes nothing but returns nModified
+      coll.update({legs: 4}, {$set: {category: 'quadruped'}}, {multi: true}, function (err, result) {
+        test.equal(result, 4);
+        test4();
+      });
+    }
+
+    var test4 = function () {
+      //upsert:true changes nothing, 4 modified
+      coll.update({legs: 4}, {$set: {category: 'quadruped'}}, {multi: true, upsert:true}, function (err, result) {
+        test.equal(result, 4);
+        test5();
+      });
+    }
+
+    var test5 = function () {
+      //upsert method works as upsert:true
+      coll.upsert({legs: 4}, {$set: {category: 'quadruped'}}, {multi: true}, function (err, result) {
+        test.equal(result.numberAffected, 4);
+        onComplete();
+      });
+    }
+
+    test1();
+  });
+}


### PR DESCRIPTION
- Add tests for the previous behaviour (returning nMatched)
   - I verified they pass on devel too before adding to this branch.
- Fix a bug with upserting when it did not cause any change.