### PR TITLE
Prevent email from becoming unverified when adding the same email

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -891,8 +891,7 @@ Accounts.addEmail = function (userId, newEmail, verified) {
         _id: user._id,
         'emails.address': email.address
       }, {$set: {
-        'emails.$.address': newEmail,
-        'emails.$.verified': verified
+        'emails.$.address': newEmail
       }});
       return true;
     }


### PR DESCRIPTION
If the email being added is (technically) the same, the expected behaviour should not be to send a new verification email.

Many applications have the email as part of a 'profile' of some sort, and are updated together with the profile. Case in point - https://forums.meteor.com/t/how-to-update-user-account-password-email-and-profile-together/834. Not saying it's best practice but enough people do it.

So when they update the 'email' field in the code, many run `Accounts.addEmail()`. But if the email is the same, by default the `verified` property becomes `false` and the user will have to verify their email again.

At the moment, we are:

1. Using `Accounts.findUserByEmail()` to find if there is a user with the same email address
2. Checks whether that user is the user we want to update
3. If it is the same user we check if that email is verified, and store the `Boolean` in a variable
4. Call `Accounts.addEmail()` passing in that variable

**tl;dr** If the email being add/updated is the same, the expected behaviour should not be to send a new verification email.