### PR TITLE
Allow `--headless` option for `test` and `test-packages`

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1413,6 +1413,10 @@ testCommandOptions = {
     deploy: { type: String },
     production: { type: Boolean },
     settings: { type: String },
+    // Indicates whether these self-tests are running headless, e.g. in a
+    // continuous integration testing environment, where visual niceties
+    // like progress bars and spinners are unimportant.
+    headless: { type: Boolean },
     verbose: { type: Boolean, short: "v" },
 
     // Undocumented. See #Once
@@ -1489,6 +1493,9 @@ function doTestCommand(options) {
   global.testCommandMetadata = {};
 
   Console.setVerbose(!!options.verbose);
+  if (options.headless) {
+    Console.setHeadless(true);
+  }
 
   const runTargets = parseRunTargets(_.intersection(
     Object.keys(options), ['ios', 'ios-device', 'android', 'android-device']));


### PR DESCRIPTION
In a nutshell, I think the `--headless` option should be available to both the `test` and `test-packages` command.  I couldn't think of a good reason why it's not available, and it would be much nicer to see CI logs that don't have many lines of rotating progress bars.


![screen shot 2016-06-17 at 1 11 21 pm](https://cloud.githubusercontent.com/assets/3937510/16158978/156c417e-348e-11e6-92db-c9501a5d7050.png)


