### PR TITLE
Generate dev bundle script : fix missing directory

### DIFF
--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -85,6 +85,7 @@ mkdir "${DIR}/build/npm-tool-install"
 cd "${DIR}/build/npm-tool-install"
 node "${CHECKOUT_DIR}/scripts/dev-bundle-tool-package.js" >package.json
 npm install
+mkdir -p "${DIR}/lib/node_modules/"
 cp -R node_modules/* "${DIR}/lib/node_modules/"
 # Also include node_modules/.bin, so that `meteor npm` can make use of
 # commands like node-gyp and node-pre-gyp.


### PR DESCRIPTION
The current `generate_dev_bundle.sh` script forgets to create the `lib/node_modules` directory in the build dir, which ends up in an undefined target when it attempts to add node modules to it. This PR aims at fixing it, so that the script works properly.

Thank you for this great project, and keep up the good work ! :+1: 