### PR TITLE
Adds truthiness check b4 accessing property in facebook package. Fixes #7255

### DIFF
--- a/packages/facebook/facebook_client.js
+++ b/packages/facebook/facebook_client.js
@@ -37,7 +37,7 @@ Facebook.requestCredential = function (options, credentialRequestCompleteCallbac
         '&state=' + OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl);
 
   // Handle authentication type (e.g. for force login you need authType: "reauthenticate")
-  if (options.authType) {
+  if (options && options.authType) {
     loginUrl += "&authType=" + encodeURIComponent(options.authType);
   }
 


### PR DESCRIPTION
Adds truthness check b4 accessing property in facebook package. Fixes #7255:


Trying to login using `facebook@1.2.7` (newest version) in Meteor 1.3.3.1 yields the following type check error:

```
facebook_client.js:40 Uncaught TypeError: Cannot read property 'authType' of null
```

Please do let me know if you need more info to reproduce.
I'm attaching a one-line PR that fixes this.
