### PR TITLE
Reload: detect href ending with `#`.

### DIFF
--- a/packages/reload/package.js
+++ b/packages/reload/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(['underscore'], 'client');
+  api.use(['underscore', 'ecmascript-runtime'], 'client');
   api.export('Reload', 'client');
   api.addFiles('reload.js', 'client');
   api.addFiles('deprecated.js', 'client');

--- a/packages/reload/reload.js
+++ b/packages/reload/reload.js
@@ -223,7 +223,7 @@ Reload._reload = function (options) {
       // with the server if we still have a valid cached copy. This doesn't work
       // when the location contains a hash however, because that wouldn't reload
       // the page and just scroll to the hash location instead.
-      if (window.location.hash) {
+      if (window.location.hash || _.last(window.location.href) === '#') {
         window.location.reload();
       } else {
         window.location.replace(window.location.href);

--- a/packages/reload/reload.js
+++ b/packages/reload/reload.js
@@ -223,7 +223,7 @@ Reload._reload = function (options) {
       // with the server if we still have a valid cached copy. This doesn't work
       // when the location contains a hash however, because that wouldn't reload
       // the page and just scroll to the hash location instead.
-      if (window.location.hash || _.last(window.location.href) === '#') {
+      if (window.location.hash || window.location.href.endsWith("#")) {
         window.location.reload();
       } else {
         window.location.replace(window.location.href);


### PR DESCRIPTION
Make sure URLs ending with `#` get properly picked up by `Reload` package and the app refreshes.

Fixes #7239 .