### PR TITLE
Release 1.3.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,8 +1,43 @@
 ## v.NEXT
 
+## v1.3.4
+
+* The version of `npm` used by `meteor npm` and when installing
+  `Npm.depends` dependencies of Meteor packages has been upgraded from
+  2.15.1 to **3.9.6**, which should lead to much flatter node_modules
+  dependency trees.
+
+* The `meteor-babel` npm package has been upgraded to 0.11.6, and is now
+  installed using `npm@3.9.6`, fixing bugs arising from Windows path
+  limits, such as [#7247](https://github.com/meteor/meteor/issues/7247).
+
+* The `reify` npm package has been upgraded to 0.3.4, fixing
+  [#7250](https://github.com/meteor/meteor/issues/7250).
+
+* Thanks to caching improvements for the
+  `files.{stat,lstat,readdir,realpath}` methods and
+  `PackageSource#_findSources`, development server restart times are no
+  longer proportional to the number of files in `node_modules`
+  directories. [#7253](https://github.com/meteor/meteor/issues/7253)
+  [#7008](https://github.com/meteor/meteor/issues/7008)
+
+* When installed via `InstallMeteor.exe` on Windows, Meteor can now be
+  easily uninstalled through the "Programs and Features" control panel.
+
+* HTTP requests made by the `meteor` command-line tool now have a timeout
+  of 30 seconds, which can be adjusted by the `$TIMEOUT_SCALE_FACTOR`
+  environment variable. [#7143](https://github.com/meteor/meteor/pull/7143)
+
+* The `request` npm dependency of the `http` package has been upgraded
+  from 2.53.0 to 2.72.0.
+
 * The `--headless` option is now supported by `meteor test` and
   `meteor test-packages`, in addition to `meteor self-test`.
   [#7245](https://github.com/meteor/meteor/pull/7245)
+
+* Miscellaneous fixed bugs:
+  [#7255](https://github.com/meteor/meteor/pull/7255)
+  [#7239](https://github.com/meteor/meteor/pull/7239)
 
 ## v1.3.3.1
 

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=0.6.13
+BUNDLE_VERSION=0.6.14
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=0.6.14
+BUNDLE_VERSION=0.6.15
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -1,834 +1,573 @@
 {
   "dependencies": {
+    "acorn": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz",
+      "from": "acorn@>=3.2.0 <3.3.0"
+    },
+    "amdefine": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+      "from": "amdefine@>=0.0.4"
+    },
+    "ansi-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+      "from": "ansi-regex@>=2.0.0 <3.0.0"
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "from": "ansi-styles@>=2.2.1 <3.0.0"
+    },
+    "ast-types": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
+      "from": "ast-types@>=0.8.16 <0.9.0"
+    },
+    "babel-code-frame": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.8.0.tgz",
+      "from": "babel-code-frame@>=6.8.0 <7.0.0"
+    },
+    "babel-core": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz",
+      "from": "babel-core@>=6.9.1 <6.10.0"
+    },
+    "babel-generator": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.10.2.tgz",
+      "from": "babel-generator@>=6.9.0 <7.0.0"
+    },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.9.0.tgz",
+      "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0"
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
+      "from": "babel-helper-call-delegate@>=6.8.0 <7.0.0"
+    },
+    "babel-helper-define-map": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
+      "from": "babel-helper-define-map@>=6.9.0 <7.0.0"
+    },
+    "babel-helper-function-name": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
+      "from": "babel-helper-function-name@>=6.8.0 <7.0.0"
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
+      "from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0"
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
+      "from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0"
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
+      "from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0"
+    },
+    "babel-helper-regex": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
+      "from": "babel-helper-regex@>=6.8.0 <7.0.0"
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz",
+      "from": "babel-helper-replace-supers@>=6.8.0 <7.0.0"
+    },
+    "babel-helpers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz",
+      "from": "babel-helpers@>=6.8.0 <7.0.0"
+    },
+    "babel-messages": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+      "from": "babel-messages@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
+      "from": "babel-plugin-check-es2015-constants@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz",
+      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.8.0.tgz",
+      "from": "babel-plugin-syntax-async-generators@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz",
+      "from": "babel-plugin-syntax-flow@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz",
+      "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0"
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.8.0.tgz",
+      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.8.0.tgz",
+      "from": "babel-plugin-syntax-trailing-function-commas@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.10.1.tgz",
+      "from": "babel-plugin-transform-es2015-block-scoping@>=6.10.1 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.9.0.tgz",
+      "from": "babel-plugin-transform-es2015-classes@>=6.9.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-computed-properties@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz",
+      "from": "babel-plugin-transform-es2015-destructuring@>=6.9.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-for-of@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-literals@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <6.9.0"
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-object-super@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.9.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-spread@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-template-literals@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.8.0.tgz",
+      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es3-member-expression-literals": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.8.0.tgz",
+      "from": "babel-plugin-transform-es3-member-expression-literals@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-es3-property-literals": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.8.0.tgz",
+      "from": "babel-plugin-transform-es3-property-literals@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz",
+      "from": "babel-plugin-transform-flow-strip-types@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz",
+      "from": "babel-plugin-transform-object-rest-spread@>=6.8.0 <7.0.0"
+    },
+    "babel-plugin-transform-react-display-name": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
+      "from": "babel-plugin-transform-react-display-name@>=6.3.13 <7.0.0"
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
+      "from": "babel-plugin-transform-react-jsx@>=6.3.13 <7.0.0"
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
+      "from": "babel-plugin-transform-react-jsx-source@>=6.3.13 <7.0.0"
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz",
+      "from": "babel-plugin-transform-regenerator@>=6.9.0 <7.0.0"
+    },
+    "babel-plugin-transform-runtime": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.9.0.tgz",
+      "from": "babel-plugin-transform-runtime@>=6.9.0 <6.10.0"
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz",
+      "from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0"
+    },
+    "babel-preset-meteor": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-meteor/-/babel-preset-meteor-6.11.0.tgz",
+      "from": "babel-preset-meteor@>=6.11.0 <6.12.0"
+    },
+    "babel-preset-react": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.5.0.tgz",
+      "from": "babel-preset-react@>=6.5.0 <6.6.0"
+    },
+    "babel-register": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz",
+      "from": "babel-register@>=6.9.0 <7.0.0"
+    },
+    "babel-runtime": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
+      "from": "babel-runtime@>=6.9.2 <6.10.0"
+    },
+    "babel-template": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz",
+      "from": "babel-template@>=6.9.0 <6.10.0"
+    },
+    "babel-traverse": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.9.0.tgz",
+      "from": "babel-traverse@>=6.9.0 <6.10.0"
+    },
+    "babel-types": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.10.2.tgz",
+      "from": "babel-types@>=6.10.0 <6.11.0"
+    },
+    "babylon": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.1.tgz",
+      "from": "babylon@>=6.8.1 <6.9.0"
+    },
+    "balanced-match": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+      "from": "balanced-match@>=0.4.1 <0.5.0"
+    },
+    "brace-expansion": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+      "from": "brace-expansion@>=1.0.0 <2.0.0"
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "from": "chalk@>=1.1.0 <2.0.0"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "from": "concat-map@0.0.1"
+    },
+    "convert-source-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
+      "from": "convert-source-map@>=1.2.0 <1.3.0"
+    },
+    "core-js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
+      "from": "core-js@>=2.4.0 <3.0.0"
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "from": "debug@>=2.1.1 <3.0.0"
+    },
+    "detect-indent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+      "from": "detect-indent@>=3.0.1 <4.0.0"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "from": "esutils@>=2.0.2 <3.0.0"
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "from": "get-stdin@>=4.0.1 <5.0.0"
+    },
+    "globals": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+      "from": "globals@>=8.3.0 <9.0.0"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "from": "has-ansi@>=2.0.0 <3.0.0"
+    },
+    "home-or-tmp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+      "from": "home-or-tmp@>=1.0.0 <2.0.0"
+    },
+    "invariant": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
+      "from": "invariant@>=2.2.0 <3.0.0"
+    },
+    "is-finite": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+      "from": "is-finite@>=1.0.0 <2.0.0"
+    },
+    "js-tokens": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
+      "from": "js-tokens@>=1.0.2 <2.0.0"
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "from": "jsesc@>=0.5.0 <0.6.0"
+    },
+    "json5": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+      "from": "json5@>=0.4.0 <0.5.0"
+    },
+    "lodash": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+      "from": "lodash@>=4.13.1 <4.14.0"
+    },
+    "loose-envify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
+      "from": "loose-envify@>=1.0.0 <2.0.0"
+    },
+    "magic-string": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.1.tgz",
+      "from": "magic-string@>=0.15.0 <0.16.0"
+    },
     "meteor-babel": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.11.4.tgz",
-      "from": "meteor-babel@0.11.4",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.11.6.tgz",
+      "from": "meteor-babel@0.11.6"
+    },
+    "meteor-babel-helpers": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/meteor-babel-helpers/-/meteor-babel-helpers-0.0.3.tgz",
+      "from": "meteor-babel-helpers@0.0.3"
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "from": "minimatch@>=2.0.3 <3.0.0"
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "from": "minimist@>=1.1.0 <2.0.0"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "from": "mkdirp@>=0.5.1 <0.6.0",
       "dependencies": {
-        "babel-core": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz",
-          "from": "babel-core@>=6.9.1 <6.10.0",
-          "dependencies": {
-            "babel-code-frame": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.8.0.tgz",
-              "from": "babel-code-frame@>=6.8.0 <7.0.0",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "from": "chalk@>=1.1.0 <2.0.0",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "from": "supports-color@>=2.0.0 <3.0.0"
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "from": "esutils@>=2.0.2 <3.0.0"
-                },
-                "js-tokens": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-                  "from": "js-tokens@>=1.0.2 <2.0.0"
-                }
-              }
-            },
-            "babel-generator": {
-              "version": "6.10.0",
-              "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.10.0.tgz",
-              "from": "babel-generator@>=6.9.0 <7.0.0",
-              "dependencies": {
-                "detect-indent": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-                  "from": "detect-indent@>=3.0.1 <4.0.0",
-                  "dependencies": {
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                      "from": "get-stdin@>=4.0.1 <5.0.0"
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                      "from": "minimist@>=1.1.0 <2.0.0"
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-helpers": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz",
-              "from": "babel-helpers@>=6.8.0 <7.0.0"
-            },
-            "babel-messages": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-              "from": "babel-messages@>=6.8.0 <7.0.0"
-            },
-            "babel-register": {
-              "version": "6.9.0",
-              "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz",
-              "from": "babel-register@>=6.9.0 <7.0.0",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
-                  "from": "core-js@>=2.4.0 <3.0.0"
-                },
-                "home-or-tmp": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-                  "from": "home-or-tmp@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "os-tmpdir": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                      "from": "os-tmpdir@>=1.0.1 <2.0.0"
-                    },
-                    "user-home": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-                      "from": "user-home@>=1.1.1 <2.0.0"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "from": "minimist@0.0.8"
-                    }
-                  }
-                },
-                "source-map-support": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-                  "from": "source-map-support@>=0.2.10 <0.3.0",
-                  "dependencies": {
-                    "source-map": {
-                      "version": "0.1.32",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                      "from": "source-map@0.1.32",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                          "from": "amdefine@>=0.0.4"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "from": "debug@>=2.1.1 <3.0.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "from": "ms@0.7.1"
-                }
-              }
-            },
-            "json5": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "from": "json5@>=0.4.0 <0.5.0"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "from": "minimatch@>=2.0.3 <3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.5",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.1",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                      "from": "balanced-match@>=0.4.1 <0.5.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "from": "concat-map@0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "path-exists": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-              "from": "path-exists@>=1.0.0 <2.0.0"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0"
-            },
-            "private": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-              "from": "private@>=0.1.6 <0.2.0"
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "from": "shebang-regex@>=1.0.0 <2.0.0"
-            },
-            "slash": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-              "from": "slash@>=1.0.0 <2.0.0"
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "from": "source-map@>=0.5.0 <0.6.0"
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.8.0.tgz",
-          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <6.9.0",
-          "dependencies": {
-            "babel-plugin-transform-strict-mode": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz",
-              "from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0"
-            }
-          }
-        },
-        "babel-plugin-transform-runtime": {
-          "version": "6.9.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.9.0.tgz",
-          "from": "babel-plugin-transform-runtime@>=6.9.0 <6.10.0"
-        },
-        "babel-preset-meteor": {
-          "version": "6.10.0",
-          "from": "babel-preset-meteor@>=6.10.0 <6.11.0",
-          "dependencies": {
-            "babel-plugin-check-es2015-constants": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
-            },
-            "babel-plugin-syntax-async-functions": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz"
-            },
-            "babel-plugin-syntax-async-generators": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.8.0.tgz"
-            },
-            "babel-plugin-syntax-flow": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz"
-            },
-            "babel-plugin-syntax-object-rest-spread": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.8.0.tgz"
-            },
-            "babel-plugin-syntax-trailing-function-commas": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-arrow-functions": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-block-scoped-functions": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-block-scoping": {
-              "version": "6.10.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.10.1.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.10.1.tgz"
-            },
-            "babel-plugin-transform-es2015-classes": {
-              "version": "6.9.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.9.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.9.0.tgz",
-              "dependencies": {
-                "babel-helper-define-map": {
-                  "version": "6.9.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz"
-                },
-                "babel-helper-function-name": {
-                  "version": "6.8.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-                  "dependencies": {
-                    "babel-helper-get-function-arity": {
-                      "version": "6.8.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-                      "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
-                    }
-                  }
-                },
-                "babel-helper-optimise-call-expression": {
-                  "version": "6.8.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz"
-                },
-                "babel-helper-replace-supers": {
-                  "version": "6.8.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz"
-                },
-                "babel-messages": {
-                  "version": "6.8.0",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                }
-              }
-            },
-            "babel-plugin-transform-es2015-computed-properties": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-              "dependencies": {
-                "babel-helper-define-map": {
-                  "version": "6.9.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-                  "dependencies": {
-                    "babel-helper-function-name": {
-                      "version": "6.8.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-                      "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-                      "dependencies": {
-                        "babel-helper-get-function-arity": {
-                          "version": "6.8.0",
-                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-                          "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-transform-es2015-destructuring": {
-              "version": "6.9.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz"
-            },
-            "babel-plugin-transform-es2015-for-of": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-function-name": {
-              "version": "6.9.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-              "dependencies": {
-                "babel-helper-function-name": {
-                  "version": "6.8.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-                  "dependencies": {
-                    "babel-helper-get-function-arity": {
-                      "version": "6.8.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-                      "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-transform-es2015-literals": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-object-super": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-              "dependencies": {
-                "babel-helper-replace-supers": {
-                  "version": "6.8.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz",
-                  "dependencies": {
-                    "babel-helper-optimise-call-expression": {
-                      "version": "6.8.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-                      "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz"
-                    },
-                    "babel-messages": {
-                      "version": "6.8.0",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-transform-es2015-parameters": {
-              "version": "6.9.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz",
-              "dependencies": {
-                "babel-helper-call-delegate": {
-                  "version": "6.8.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-                  "dependencies": {
-                    "babel-helper-hoist-variables": {
-                      "version": "6.8.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-                      "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz"
-                    }
-                  }
-                },
-                "babel-helper-get-function-arity": {
-                  "version": "6.8.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
-                }
-              }
-            },
-            "babel-plugin-transform-es2015-shorthand-properties": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-spread": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-sticky-regex": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-              "dependencies": {
-                "babel-helper-regex": {
-                  "version": "6.9.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz"
-                }
-              }
-            },
-            "babel-plugin-transform-es2015-template-literals": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-typeof-symbol": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es2015-unicode-regex": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.8.0.tgz",
-              "dependencies": {
-                "babel-helper-regex": {
-                  "version": "6.9.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-                  "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz"
-                },
-                "regexpu-core": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-                  "from": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-                  "dependencies": {
-                    "regenerate": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-                      "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
-                    },
-                    "regjsgen": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-                      "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                    },
-                    "regjsparser": {
-                      "version": "0.1.5",
-                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                      "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                      "dependencies": {
-                        "jsesc": {
-                          "version": "0.5.0",
-                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                          "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-transform-es3-member-expression-literals": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.8.0.tgz"
-            },
-            "babel-plugin-transform-es3-property-literals": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.8.0.tgz"
-            },
-            "babel-plugin-transform-flow-strip-types": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz"
-            },
-            "babel-plugin-transform-object-rest-spread": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz"
-            },
-            "babel-plugin-transform-regenerator": {
-              "version": "6.9.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz",
-              "dependencies": {
-                "private": {
-                  "version": "0.1.6",
-                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-preset-react": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.5.0.tgz",
-          "from": "babel-preset-react@>=6.5.0 <6.6.0",
-          "dependencies": {
-            "babel-plugin-syntax-flow": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz",
-              "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0"
-            },
-            "babel-plugin-syntax-jsx": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz",
-              "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0"
-            },
-            "babel-plugin-transform-flow-strip-types": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz",
-              "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0"
-            },
-            "babel-plugin-transform-react-display-name": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
-              "from": "babel-plugin-transform-react-display-name@>=6.3.13 <7.0.0"
-            },
-            "babel-plugin-transform-react-jsx": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
-              "from": "babel-plugin-transform-react-jsx@>=6.3.13 <7.0.0",
-              "dependencies": {
-                "babel-helper-builder-react-jsx": {
-                  "version": "6.9.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.9.0.tgz",
-                  "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "from": "esutils@>=2.0.2 <3.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-transform-react-jsx-source": {
-              "version": "6.9.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
-              "from": "babel-plugin-transform-react-jsx-source@>=6.3.13 <7.0.0"
-            }
-          }
-        },
-        "babel-runtime": {
-          "version": "6.9.2",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
-          "from": "babel-runtime@>=6.9.2 <6.10.0",
-          "dependencies": {
-            "core-js": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
-              "from": "core-js@>=2.4.0 <3.0.0"
-            },
-            "regenerator-runtime": {
-              "version": "0.9.5",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-              "from": "regenerator-runtime@>=0.9.5 <0.10.0"
-            }
-          }
-        },
-        "babel-template": {
-          "version": "6.9.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz",
-          "from": "babel-template@>=6.9.0 <6.10.0"
-        },
-        "babel-traverse": {
-          "version": "6.9.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.9.0.tgz",
-          "from": "babel-traverse@>=6.9.0 <6.10.0",
-          "dependencies": {
-            "babel-code-frame": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.8.0.tgz",
-              "from": "babel-code-frame@>=6.8.0 <7.0.0",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "from": "chalk@>=1.1.0 <2.0.0",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "from": "supports-color@>=2.0.0 <3.0.0"
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "from": "esutils@>=2.0.2 <3.0.0"
-                },
-                "js-tokens": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-                  "from": "js-tokens@>=1.0.2 <2.0.0"
-                }
-              }
-            },
-            "babel-messages": {
-              "version": "6.8.0",
-              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-              "from": "babel-messages@>=6.8.0 <7.0.0"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "from": "debug@>=2.2.0 <3.0.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "from": "ms@0.7.1"
-                }
-              }
-            },
-            "globals": {
-              "version": "8.18.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-              "from": "globals@>=8.3.0 <9.0.0"
-            },
-            "invariant": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-              "from": "invariant@>=2.2.0 <3.0.0",
-              "dependencies": {
-                "loose-envify": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                  "dependencies": {
-                    "js-tokens": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-                      "from": "js-tokens@>=1.0.1 <2.0.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "babel-types": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.10.0.tgz",
-          "from": "babel-types@>=6.10.0 <6.11.0",
-          "dependencies": {
-            "esutils": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "from": "esutils@>=2.0.2 <3.0.0"
-            },
-            "to-fast-properties": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-              "from": "to-fast-properties@>=1.0.1 <2.0.0"
-            }
-          }
-        },
-        "babylon": {
-          "version": "6.8.1",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.1.tgz",
-          "from": "babylon@>=6.8.1 <6.9.0"
-        },
-        "convert-source-map": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
-          "from": "convert-source-map@>=1.2.0 <1.3.0"
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-          "from": "lodash@>=4.13.1 <4.14.0"
-        },
-        "meteor-babel-helpers": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/meteor-babel-helpers/-/meteor-babel-helpers-0.0.3.tgz",
-          "from": "meteor-babel-helpers@0.0.3"
-        },
-        "reify": {
-          "version": "0.3.3",
-          "from": "reify@>=0.3.3 <0.4.0",
-          "dependencies": {
-            "acorn": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz",
-              "from": "acorn@>=3.2.0 <3.3.0"
-            },
-            "ast-types": {
-              "version": "0.8.16",
-              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
-              "from": "ast-types@>=0.8.16 <0.9.0"
-            },
-            "magic-string": {
-              "version": "0.15.1",
-              "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.1.tgz",
-              "from": "magic-string@>=0.15.0 <0.16.0",
-              "dependencies": {
-                "vlq": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz",
-                  "from": "vlq@>=0.2.1 <0.3.0"
-                }
-              }
-            }
-          }
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "from": "minimist@0.0.8"
         }
       }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "from": "ms@0.7.1"
+    },
+    "number-is-nan": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+      "from": "number-is-nan@>=1.0.0 <2.0.0"
+    },
+    "os-tmpdir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+      "from": "os-tmpdir@>=1.0.1 <2.0.0"
+    },
+    "path-exists": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+      "from": "path-exists@>=1.0.0 <2.0.0"
+    },
+    "path-is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+    },
+    "private": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+      "from": "private@>=0.1.6 <0.2.0"
+    },
+    "regenerate": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
+      "from": "regenerate@>=1.2.1 <2.0.0"
+    },
+    "regenerator-runtime": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+      "from": "regenerator-runtime@>=0.9.5 <0.10.0"
+    },
+    "regexpu-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "from": "regexpu-core@>=1.0.0 <2.0.0"
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "from": "regjsgen@>=0.2.0 <0.3.0"
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "from": "regjsparser@>=0.1.4 <0.2.0"
+    },
+    "reify": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.3.4.tgz",
+      "from": "reify@>=0.3.4 <0.4.0"
+    },
+    "repeating": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+      "from": "repeating@>=1.1.0 <2.0.0"
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "from": "shebang-regex@>=1.0.0 <2.0.0"
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "from": "slash@>=1.0.0 <2.0.0"
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "from": "source-map@>=0.5.0 <0.6.0"
+    },
+    "source-map-support": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+      "from": "source-map-support@>=0.2.10 <0.3.0",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "from": "source-map@0.1.32"
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "from": "strip-ansi@>=3.0.0 <4.0.0"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "from": "supports-color@>=2.0.0 <3.0.0"
+    },
+    "to-fast-properties": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+      "from": "to-fast-properties@>=1.0.1 <2.0.0"
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "from": "user-home@>=1.1.1 <2.0.0"
+    },
+    "vlq": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz",
+      "from": "vlq@>=0.2.1 <0.3.0"
     }
   }
 }

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.3-rc.2'
+  version: '6.8.3'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.3'
+  version: '6.8.3-rc.0'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.3-rc.0'
+  version: '6.8.3-rc.1'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.3-rc.1'
+  version: '6.8.3-rc.2'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,11 +6,11 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.2'
+  version: '6.8.3'
 });
 
 Npm.depends({
-  'meteor-babel': '0.11.4',
+  'meteor-babel': '0.11.6',
 });
 
 Package.onUse(function (api) {

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.1"
+  version: "1.1.2-rc.0"
 });
 
 Package.registerBuildPlugin({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.2-rc.1"
+  version: "1.1.2-rc.2"
 });
 
 Package.registerBuildPlugin({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.2-rc.2"
+  version: "1.1.2"
 });
 
 Package.registerBuildPlugin({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.2-rc.0"
+  version: "1.1.2-rc.1"
 });
 
 Package.registerBuildPlugin({

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.6-rc.1',
+  version: '0.4.6-rc.2',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.6-rc.0',
+  version: '0.4.6-rc.1',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.5',
+  version: '0.4.6-rc.0',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.6-rc.2',
+  version: '0.4.6',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/facebook/package.js
+++ b/packages/facebook/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Facebook OAuth flow",
-  version: "1.2.7"
+  version: "1.2.8-rc.2"
 });
 
 Package.onUse(function(api) {

--- a/packages/facebook/package.js
+++ b/packages/facebook/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Facebook OAuth flow",
-  version: "1.2.8-rc.2"
+  version: "1.2.8"
 });
 
 Package.onUse(function(api) {

--- a/packages/http/.npm/package/npm-shrinkwrap.json
+++ b/packages/http/.npm/package/npm-shrinkwrap.json
@@ -1,192 +1,355 @@
 {
   "dependencies": {
-    "request": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
-      "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+    "ansi-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+      "from": "ansi-regex@>=2.0.0 <3.0.0"
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "from": "ansi-styles@>=2.2.1 <3.0.0"
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "from": "asn1@>=0.2.3 <0.3.0"
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "from": "assert-plus@>=0.2.0 <0.3.0"
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "from": "async@>=1.5.2 <2.0.0"
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "from": "aws-sign2@>=0.6.0 <0.7.0"
+    },
+    "aws4": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+      "from": "aws4@>=1.2.1 <2.0.0"
+    },
+    "bl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "from": "bl@>=1.1.2 <1.2.0"
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "from": "boom@>=2.0.0 <3.0.0"
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "from": "caseless@>=0.11.0 <0.12.0"
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "from": "chalk@>=1.1.1 <2.0.0"
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "from": "combined-stream@>=1.0.5 <1.1.0"
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "from": "commander@>=2.9.0 <3.0.0"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "from": "core-util-is@>=1.0.0 <1.1.0"
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "from": "cryptiles@>=2.0.0 <3.0.0"
+    },
+    "dashdash": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+      "from": "dashdash@>=1.12.0 <2.0.0",
       "dependencies": {
-        "aws-sign2": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-        },
-        "bl": {
-          "version": "0.9.4",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-          "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            }
-          }
-        },
-        "caseless": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "dependencies": {
-            "delayed-stream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-            }
-          }
-        },
-        "forever-agent": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-        },
-        "form-data": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.9.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-            }
-          }
-        },
-        "hawk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "dependencies": {
-            "boom": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
-              "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
-            },
-            "cryptiles": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
-            },
-            "hoek": {
-              "version": "2.11.1",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            }
-          }
-        },
-        "http-signature": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "dependencies": {
-            "asn1": {
-              "version": "0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-            },
-            "assert-plus": {
-              "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "ctype": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-            }
-          }
-        },
-        "isstream": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz",
-          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
-        },
-        "json-stringify-safe": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
-          "dependencies": {
-            "mime-db": {
-              "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
-            }
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
-        },
-        "qs": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
-          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-        },
-        "tough-cookie": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "from": "assert-plus@>=1.0.0 <2.0.0"
         }
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "from": "delayed-stream@>=1.0.0 <1.1.0"
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+    },
+    "extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "from": "extend@>=3.0.0 <3.1.0"
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "from": "extsprintf@1.0.2"
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "from": "forever-agent@>=0.6.1 <0.7.0"
+    },
+    "form-data": {
+      "version": "1.0.0-rc4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+      "from": "form-data@>=1.0.0-rc3 <1.1.0"
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "from": "generate-function@>=2.0.0 <3.0.0"
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "from": "generate-object-property@>=1.1.0 <2.0.0"
+    },
+    "getpass": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "from": "assert-plus@>=1.0.0 <2.0.0"
+        }
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "from": "graceful-readlink@>=1.0.0"
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "from": "har-validator@>=2.0.6 <2.1.0"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "from": "has-ansi@>=2.0.0 <3.0.0"
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "from": "hawk@>=3.1.3 <3.2.0"
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "from": "hoek@>=2.0.0 <3.0.0"
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "from": "http-signature@>=1.1.0 <1.2.0"
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "from": "inherits@>=2.0.1 <2.1.0"
+    },
+    "is-my-json-valid": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+      "from": "is-my-json-valid@>=2.12.4 <3.0.0"
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "from": "is-property@>=1.0.0 <2.0.0"
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "from": "is-typedarray@>=1.0.0 <1.1.0"
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "from": "isarray@>=1.0.0 <1.1.0"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "from": "isstream@>=0.1.2 <0.2.0"
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "from": "jodid25519@>=1.0.0 <2.0.0"
+    },
+    "jsbn": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+      "from": "jsbn@>=0.1.0 <0.2.0"
+    },
+    "json-schema": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+      "from": "json-schema@0.2.2"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0"
+    },
+    "jsonpointer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+      "from": "jsonpointer@2.0.0"
+    },
+    "jsprim": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+      "from": "jsprim@>=1.2.2 <2.0.0"
+    },
+    "mime-db": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+      "from": "mime-db@>=1.23.0 <1.24.0"
+    },
+    "mime-types": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+      "from": "mime-types@>=2.1.7 <2.2.0"
+    },
+    "node-uuid": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+      "from": "node-uuid@>=1.4.7 <1.5.0"
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "from": "oauth-sign@>=0.8.1 <0.9.0"
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "from": "pinkie@>=2.0.0 <3.0.0"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0"
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0"
+    },
+    "qs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
+      "from": "qs@>=6.1.0 <6.2.0"
+    },
+    "readable-stream": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "from": "readable-stream@>=2.0.5 <2.1.0"
+    },
+    "request": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
+      "from": "request@2.72.0"
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "from": "sntp@>=1.0.0 <2.0.0"
+    },
+    "sshpk": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+      "from": "sshpk@>=1.7.0 <2.0.0",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "from": "assert-plus@>=1.0.0 <2.0.0"
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "from": "string_decoder@>=0.10.0 <0.11.0"
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "from": "stringstream@>=0.0.4 <0.1.0"
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "from": "strip-ansi@>=3.0.0 <4.0.0"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "from": "supports-color@>=2.0.0 <3.0.0"
+    },
+    "tough-cookie": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+      "from": "tough-cookie@>=2.2.0 <2.3.0"
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0"
+    },
+    "tweetnacl": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+      "from": "tweetnacl@>=0.13.0 <0.14.0"
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "from": "util-deprecate@>=1.0.1 <1.1.0"
+    },
+    "verror": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "from": "verror@1.3.6"
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "from": "xtend@>=4.0.0 <5.0.0"
     }
   }
 }

--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Make HTTP calls to remote servers",
-  version: '1.1.7-rc.2'
+  version: '1.1.7'
 });
 
 Npm.depends({

--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Make HTTP calls to remote servers",
-  version: '1.1.7-rc.1'
+  version: '1.1.7-rc.2'
 });
 
 Npm.depends({

--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -1,9 +1,11 @@
 Package.describe({
   summary: "Make HTTP calls to remote servers",
-  version: '1.1.6'
+  version: '1.1.7'
 });
 
-Npm.depends({request: "2.53.0"});
+Npm.depends({
+  request: "2.72.0"
+});
 
 Package.onUse(function (api) {
   api.use([

--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Make HTTP calls to remote servers",
-  version: '1.1.7-rc.0'
+  version: '1.1.7-rc.1'
 });
 
 Npm.depends({

--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Make HTTP calls to remote servers",
-  version: '1.1.7'
+  version: '1.1.7-rc.0'
 });
 
 Npm.depends({

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.3-rc.1',
+  version: '2.6.3-rc.2',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.2',
+  version: '2.6.3-rc.0',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.3-rc.0',
+  version: '2.6.3-rc.1',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.3-rc.2',
+  version: '2.6.3',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.4-rc.1'
+  version: '1.3.4-rc.2'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.4-rc.0'
+  version: '1.3.4-rc.1'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.3_1'
+  version: '1.3.4-rc.0'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.4-rc.2'
+  version: '1.3.4'
 });
 
 Package.includeTool();

--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -1,32 +1,29 @@
 {
   "dependencies": {
+    "acorn": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz",
+      "from": "acorn@>=3.2.0 <3.3.0"
+    },
+    "ast-types": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
+      "from": "ast-types@>=0.8.16 <0.9.0"
+    },
+    "magic-string": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.1.tgz",
+      "from": "magic-string@>=0.15.0 <0.16.0"
+    },
     "reify": {
-      "version": "0.3.3",
-      "from": "reify@0.3.3",
-      "dependencies": {
-        "acorn": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz",
-          "from": "acorn@>=3.2.0 <3.3.0"
-        },
-        "ast-types": {
-          "version": "0.8.16",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
-          "from": "ast-types@>=0.8.16 <0.9.0"
-        },
-        "magic-string": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.1.tgz",
-          "from": "magic-string@>=0.15.0 <0.16.0",
-          "dependencies": {
-            "vlq": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz",
-              "from": "vlq@>=0.2.1 <0.3.0"
-            }
-          }
-        }
-      }
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.3.4.tgz",
+      "from": "reify@0.3.4"
+    },
+    "vlq": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz",
+      "from": "vlq@>=0.2.1 <0.3.0"
     }
   }
 }

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: "0.6.4-rc.1",
+  version: "0.6.4-rc.2",
   summary: "CommonJS module system",
   documentation: "README.md"
 });

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   name: "modules",
-  version: "0.6.3",
+  version: "0.6.4",
   summary: "CommonJS module system",
   documentation: "README.md"
 });
 
 Npm.depends({
-  reify: "0.3.3"
+  reify: "0.3.4"
 });
 
 Package.onUse(function(api) {

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: "0.6.4",
+  version: "0.6.4-rc.0",
   summary: "CommonJS module system",
   documentation: "README.md"
 });

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: "0.6.4-rc.2",
+  version: "0.6.4",
   summary: "CommonJS module system",
   documentation: "README.md"
 });

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: "0.6.4-rc.0",
+  version: "0.6.4-rc.1",
   summary: "CommonJS module system",
   documentation: "README.md"
 });

--- a/packages/reload/package.js
+++ b/packages/reload/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Reload the page while preserving application state.",
-  version: '1.1.10-rc.1'
+  version: '1.1.10-rc.2'
 });
 
 Package.onUse(function (api) {

--- a/packages/reload/package.js
+++ b/packages/reload/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Reload the page while preserving application state.",
-  version: '1.1.10-rc.2'
+  version: '1.1.10'
 });
 
 Package.onUse(function (api) {

--- a/packages/reload/package.js
+++ b/packages/reload/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(['underscore'], 'client');
+  api.use(['underscore', 'ecmascript-runtime'], 'client');
   api.export('Reload', 'client');
   api.addFiles('reload.js', 'client');
   api.addFiles('deprecated.js', 'client');

--- a/packages/reload/package.js
+++ b/packages/reload/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Reload the page while preserving application state.",
-  version: '1.1.9'
+  version: '1.1.10-rc.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/reload/reload.js
+++ b/packages/reload/reload.js
@@ -223,7 +223,7 @@ Reload._reload = function (options) {
       // with the server if we still have a valid cached copy. This doesn't work
       // when the location contains a hash however, because that wouldn't reload
       // the page and just scroll to the hash location instead.
-      if (window.location.hash) {
+      if (window.location.hash || window.location.href.endsWith("#")) {
         window.location.reload();
       } else {
         window.location.replace(window.location.href);

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.9',
+  version: '1.0.10-rc.0',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.10-rc.2',
+  version: '1.0.10',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.10-rc.1',
+  version: '1.0.10-rc.2',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.10-rc.0',
+  version: '1.0.10-rc.1',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.3-rc.2"
+  version: "2.512.3"
 });
 
 Package.registerBuildPlugin({

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.3-rc.1"
+  version: "2.512.3-rc.2"
 });
 
 Package.registerBuildPlugin({

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.2"
+  version: "2.512.3-rc.0"
 });
 
 Package.registerBuildPlugin({

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.3-rc.0"
+  version: "2.512.3-rc.1"
 });
 
 Package.registerBuildPlugin({

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.11'
+  version: '1.1.12-rc.0'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.12-rc.1'
+  version: '1.1.12-rc.2'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.12-rc.2'
+  version: '1.1.12'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.12-rc.0'
+  version: '1.1.12-rc.1'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.4-rc.0",
+ "version": "1.3.4-rc.1",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.3.1-rc.2",
+ "version": "1.3.4-rc.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.4-rc.1",
+ "version": "1.3.4-rc.2",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.3.3.1",
+  "version": "1.3.4",
   "recommended": false,
   "official": true,
   "description": "The Official Meteor Distribution"

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -6,6 +6,7 @@ set -u
 UNAME=$(uname)
 ARCH=$(uname -m)
 NODE_VERSION=0.10.45
+NPM_VERSION=3.9.6
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,7 +14,7 @@ var packageJson = {
     npm: "3.9.6",
     "node-gyp": "3.3.1",
     "node-pre-gyp": "0.6.26",
-    "meteor-babel": "0.11.4",
+    "meteor-babel": "0.11.6",
     "meteor-promise": "0.7.2",
     fibers: "1.0.13",
     promise: "7.1.1",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -11,7 +11,7 @@ var packageJson = {
   dependencies: {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version
-    npm: "2.15.1",
+    npm: "3.9.6",
     "node-gyp": "3.3.1",
     "node-pre-gyp": "0.6.26",
     "meteor-babel": "0.11.4",

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -3,7 +3,7 @@
 $PLATFORM = "windows_x86"
 $MONGO_VERSION = "2.6.7"
 $NODE_VERSION = "0.10.45"
-$NPM_VERSION = "2.15.1"
+$NPM_VERSION = "3.9.6"
 $PYTHON_VERSION = "2.7.10" # For node-gyp
 
 # take it form the environment if exists
@@ -68,29 +68,17 @@ rm -Recurse -Force $npm_zip
 $env:PATH = "${DIR}\bin;${env:PATH}"
 
 # Install the version of npm that we're actually going to expose from the
-# dev bundle. Note that we use npm@1.4.12 to install npm@${NPM_VERSION},
-# but we use npm@3.1.2 to install dev_bundle\lib\node_modules, so that the
-# dev bundle packages have a flatter structure. Three different versions!
+# dev bundle. Note that we use npm@1.4.12 to install npm@${NPM_VERSION}.
 cd "${DIR}\lib"
 npm install npm@${NPM_VERSION}
 rm -Recurse -Force "${DIR}\bin\node_modules"
 copy "${CHECKOUT_DIR}\scripts\npm.cmd" "${DIR}\bin\npm.cmd"
 npm version
 
-mkdir "${DIR}\bin\npm3"
-cd "${DIR}\bin\npm3"
-echo "{}" | Out-File package.json -Encoding ascii # otherwise it doesn't install in local dir
-npm install npm@3.1.2
-
-# add bin\npm3 to the front of the path so we can use npm 3 for building
-$env:PATH = "${DIR}\bin\npm3;${env:PATH}"
-
 # npm depends on a hardcoded file path to node-gyp, so we need this to be
 # un-flattened
 cd node_modules\npm
 npm install node-gyp
-cd ..\..
-cp node_modules\npm\bin\npm.cmd
 
 # install dev-bundle-package.json
 # use short folder names
@@ -143,9 +131,6 @@ cp "$DIR\mongodb\$mongo_name\bin\mongo.exe" $DIR\mongodb\bin
 
 rm -Recurse -Force $mongo_zip
 rm -Recurse -Force "$DIR\mongodb\$mongo_name"
-
-# Remove npm 3 before we package the dev bundle
-rm -Recurse -Force "${DIR}\bin\npm3"
 
 rm -Recurse -Force "$py_msi"
 python --version

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -40,8 +40,13 @@ fi
 # export path so we use the downloaded node and npm
 export PATH="$DIR/bin:$PATH"
 
+cd "$DIR/lib"
+# Overwrite the bundled version with the latest version of npm.
+npm install "npm@$NPM_VERSION"
+
 which node
 which npm
+npm version
 
 # When adding new node modules (or any software) to the dev bundle,
 # remember to update LICENSE.txt! Also note that we include all the
@@ -131,7 +136,7 @@ mv BrowserStackLocal "$DIR/bin/"
 # Sanity check to see if we're not breaking anything by replacing npm
 INSTALLED_NPM_VERSION=$(cat "$DIR/lib/node_modules/npm/package.json" |
 xargs -0 node -e "console.log(JSON.parse(process.argv[1]).version)")
-if [ "$INSTALLED_NPM_VERSION" != "2.15.1" ]; then
+if [ "$INSTALLED_NPM_VERSION" != "3.9.6" ]; then
   echo "Unexpected NPM version in lib/node_modules: $INSTALLED_NPM_VERSION"
   echo "We will be replacing it with our own version because the bundled node"
   echo "is built using PORTABLE=1, which makes npm look for node relative to"

--- a/scripts/windows/installer/WiXInstaller/Configuration.wxi
+++ b/scripts/windows/installer/WiXInstaller/Configuration.wxi
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
     <?define METEOR_ProductName  = "Meteor" ?>
+    <?define METEOR_ProductId    = "{1B1B4C6E-371D-4027-80AB-27922ABD7EE4}" ?>
     <?define METEOR_UpgradeCode  = "{D6831580-7DD8-4088-9792-64E4D37FEDDC}" ?>
     <?define BUNDLE_UpgradeCode  = "{D6F8653E-2F27-4FDD-9C92-66D7B4B21D79}" ?>
 

--- a/scripts/windows/installer/WiXInstaller/Meteor_Product.wxs
+++ b/scripts/windows/installer/WiXInstaller/Meteor_Product.wxs
@@ -7,7 +7,7 @@
 
     <?include Configuration.wxi?>
 
-    <Product Id="*" Name="$(var.METEOR_ProductName)" Language="1033" Version="1.0" Manufacturer="$(var.METEOR_Manufacturer)" UpgradeCode="$(var.METEOR_UpgradeCode)">
+    <Product Id="$(var.METEOR_ProductId)" Name="$(var.METEOR_ProductName)" Language="1033" Version="1.0" Manufacturer="$(var.METEOR_Manufacturer)" UpgradeCode="$(var.METEOR_UpgradeCode)">
         <Package Description="This package will install Meteor on your computer." InstallerVersion="300" Compressed="yes" InstallScope="perUser" InstallPrivileges="limited"/>
 
         <!-- This will allow a new msi package to upgrade an existing older version (in case patch is not used) -->

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -262,7 +262,9 @@ files.statOrNull = function (path) {
   try {
     return files.stat(path);
   } catch (e) {
-    if (e.code == "ENOENT") {
+    if (e.code === "ENOENT" ||
+        (process.platform === "win32" &&
+         e.code === "UNKNOWN")) {
       return null;
     }
     throw e;

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -263,9 +263,7 @@ files.statOrNull = function (path) {
   try {
     return files.stat(path);
   } catch (e) {
-    if (e.code === "ENOENT" ||
-        (process.platform === "win32" &&
-         e.code === "UNKNOWN")) {
+    if (e.code == "ENOENT") {
       return null;
     }
     throw e;

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2461,7 +2461,12 @@ Find out more about Meteor at meteor.com.
  * will point somewhere else -- into the app (if any) whose packages
  * you are testing!
  */
-exports.bundle = function ({
+
+exports.bundle = function (options) {
+  return files.withCache(() => bundle(options));
+};
+
+function bundle({
   projectContext,
   outputPath,
   includeNodeModules,

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -173,16 +173,18 @@ compiler.compile = Profile(function (packageSource, options) {
       return;
     }
 
-    var unibuildResult = compileUnibuild({
-      isopack: isopk,
-      sourceArch: architecture,
-      isopackCache: isopackCache,
-      nodeModulesPath: nodeModulesPath,
-      noLineNumbers: options.noLineNumbers
-    });
+    files.withCache(() => {
+      var unibuildResult = compileUnibuild({
+        isopack: isopk,
+        sourceArch: architecture,
+        isopackCache: isopackCache,
+        nodeModulesPath: nodeModulesPath,
+        noLineNumbers: options.noLineNumbers
+      });
 
-    _.extend(pluginProviderPackageNames,
-             unibuildResult.pluginProviderPackageNames);
+      _.extend(pluginProviderPackageNames,
+               unibuildResult.pluginProviderPackageNames);
+    });
   });
 
   if (options.includePluginProviderPackageMap) {

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1544,7 +1544,7 @@ _.extend(PackageSource.prototype, {
       return sources;
     }
 
-    return find("", 0, false);
+    return files.withCache(() => find("", 0, false));
   },
 
   _findAssets({


### PR DESCRIPTION
This release fixes [bugs](https://github.com/meteor/meteor/milestones/Release%201.3.4) reported in Meteor 1.3.3 and 1.3.3.1:

- [x] #7250
- [x] #7247
- [x] #7225
- [x] #7243
- [x] #7253
- [x] #7008

Most notably, #7247 and other similar problems will be fixed by upgrading the version of `npm` used by Meteor to the latest version, 3.9.6, which is a major upgrade from 2.15.1, but should not cause any breaking changes for existing Meteor apps. For that reason, I think it's appropriate to call this release 1.3.4 and not 1.3.3.2.