### PR TITLE
Minor Bug: Fix error on accessing empty releaseRecordForConstraints var

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1718,9 +1718,13 @@ main.registerCommand({
     });
 
     var releaseConstrainedPkgSet = {}; // pinned core packages (to skip)
-    _.each(releaseRecordForConstraints.packages, function (v, packageName) {
-      releaseConstrainedPkgSet[packageName] = true;
-    });
+    // check releaseRecordForConstraints is not null, e.g. possible
+    // when running meteor from checkout
+    if (releaseRecordForConstraints) {
+      _.each(releaseRecordForConstraints.packages, function (v, packageName) {
+        releaseConstrainedPkgSet[packageName] = true;
+      });
+    }
 
     var nonlatestDirectDeps = [];
     var nonlatestIndirectDeps = [];


### PR DESCRIPTION
#### Minor bug from https://github.com/4commerce-technologies-AG/meteor/issues/49:

When running meteor from checkout (as we do for the ARM fork) and use `meteor update` or `meteor update --packages-only` you will get following error:

<pre>
packages/promise/.npm/package/node_modules/meteor-promise/promise_server.js:165
      throw error;
            ^
TypeError: Cannot read property 'packages' of null
    at Command.main.registerCommand.name [as func] (/tools/cli/commands-packages.js:1721:12)
    at /tools/cli/main.js:1402:23
</pre>

#### Steps to reproduce:

```bash
cd /tmp

git clone -b release/METEOR@1.3.4 https://github.com/meteor/meteor.git meteor-checkout

meteor-checkout/meteor create hello-world

cd hello-world

../meteor-checkout/meteor update
```

#### Reason

When running `meteor update` from checkout the var `releaseRecordForConstraints` ist set to `null` in case of `if (!files.inCheckout())` - [see source lines](https://github.com/meteor/meteor/blob/devel/tools/cli/commands-packages.js#L1652-L1659)

It will not get checked later, that this var is null and accessing the instance attribute raise an exception - [see source line](https://github.com/meteor/meteor/blob/devel/tools/cli/commands-packages.js#L1721).

#### Proposal

As a proposal I add a check before accessing the `null` instance.

Thanks for feedback or merge
Tom

