### PR TITLE
User defined mongo connection options API for #6958

### DIFF
--- a/packages/mongo/connection_options.js
+++ b/packages/mongo/connection_options.js
@@ -1,0 +1,10 @@
+/**
+ * @summary Allows for user specified connection options
+ * @example http://mongodb.github.io/node-mongodb-native/2.1/reference/connecting/connection-settings/
+ * @locus Server
+ * @param {Object} options User specified Mongo connection options
+ */
+Mongo.setConnectionOptions = function setConnectionOptions (options) {
+  check(options, Object);
+  Mongo._connectionOptions = options;
+}

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -130,7 +130,8 @@ MongoConnection = function (url, options) {
   self._observeMultiplexers = {};
   self._onFailoverHook = new Hook;
 
-  var mongoOptions = {db: {safe: true}, server: {}, replSet: {}};
+  var mongoOptions = _.extend({db: {safe: true}, server: {}, replSet: {}},
+                               Mongo._connectionOptions);
 
   // Set autoReconnect to true, unless passed on the URL. Why someone
   // would want to set autoReconnect to false, I'm not really sure, but
@@ -151,8 +152,8 @@ MongoConnection = function (url, options) {
     mongoOptions.db.native_parser = false;
   }
 
-  // XXX maybe we should have a better way of allowing users to configure the
-  // underlying Mongo driver
+  // Internally the oplog connections specify their own poolSize
+  // which we don't want to overwrite with any user defined value
   if (_.has(options, 'poolSize')) {
     // If we just set this for "server", replSet will override it. If we just
     // set it for replSet, it will be ignored if we're not using a replSet.

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -74,6 +74,7 @@ Package.onUse(function (api) {
   api.addFiles('local_collection_driver.js', ['client', 'server']);
   api.addFiles('remote_collection_driver.js', 'server');
   api.addFiles('collection.js', ['client', 'server']);
+  api.addFiles('connection_options.js', 'server');
 });
 
 Package.onTest(function (api) {


### PR DESCRIPTION
For #6958

I noticed the API has changed for a bunch of the existing options used in `mongo_driver.js` such as `{ safe: true }` now replaced by: https://docs.mongodb.com/manual/core/replica-set-write-concern/ but that is a bit out of scope for this PR. Maybe something to be looked at though.