### PR TITLE
Finalize replacement NPM@3 at generate-dev-bundle.sh script

### DIFF
--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -136,11 +136,8 @@ mv BrowserStackLocal "$DIR/bin/"
 # Sanity check to see if we're not breaking anything by replacing npm
 INSTALLED_NPM_VERSION=$(cat "$DIR/lib/node_modules/npm/package.json" |
 xargs -0 node -e "console.log(JSON.parse(process.argv[1]).version)")
-if [ "$INSTALLED_NPM_VERSION" != "3.9.6" ]; then
+if [ "$INSTALLED_NPM_VERSION" != "$NPM_VERSION" ]; then
   echo "Unexpected NPM version in lib/node_modules: $INSTALLED_NPM_VERSION"
-  echo "We will be replacing it with our own version because the bundled node"
-  echo "is built using PORTABLE=1, which makes npm look for node relative to"
-  echo "its own directory."
   echo "Update this check if you know what you're doing."
   exit 1
 fi


### PR DESCRIPTION
With release 1.3.4 there was a new variable `$NPM_VERSION` defined in `build-dev-bundle-common.sh`.

Instead checking the right version inside the `generate-dev-bundle.sh` this var is better to use.

In addition, the message is not correct anymore because no special node is delivered anymore. The npm is not build via PORTABLE=1 in the binaries of nodejs.

In case that the NPM is replaced during the bulid this content should be deleted.

Hope that fits to you
Tom