### PR TITLE
Check options exist in twitter package

### DIFF
--- a/packages/twitter/twitter_client.js
+++ b/packages/twitter/twitter_client.js
@@ -39,7 +39,7 @@ Twitter.requestCredential = function (options, credentialRequestCompleteCallback
   }
 
   // Handle force login (request the user to enter their credentials)
-  if (options.force_login) {
+  if (options && options.force_login) {
     loginPath += "&force_login=true";
   }
 


### PR DESCRIPTION
Trying to login with Twitter package give an error:
`Uncaught TypeError: Cannot read property 'force_login' of null`

Make the same thing than #7256 but for twitter package.
This issue was introduced by commit https://github.com/meteor/meteor/commit/001a3f3128d1eaebdea431bf35707748b5dc185e