### PR TITLE
Custom config.xml tags with App.appendToConfig

### DIFF
--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -104,6 +104,9 @@ export class CordovaBuilder {
       }
     };
 
+    // Custom elements that will be appended into config.xml's widgets
+    this.custom = [];
+
     const packageMap = this.projectContext.packageMap;
 
     if (packageMap && packageMap.getInfo('launch-screen')) {
@@ -247,6 +250,17 @@ export class CordovaBuilder {
       config.element('preference', {
         name: key,
         value: value.toString()
+      });
+    });
+
+    // Set custom tags into widget element
+    _.each(this.custom, elementSet => {
+      let tag = config
+        .element(elementSet.name, elementSet.contents.attrs);
+
+      _.each(elementSet.contents.children, child => {
+        tag.element(child.name, child.attrs);
+        if(child.txt) tag.txt(child.txt);
       });
     });
 
@@ -628,6 +642,22 @@ configuration. The key may be deprecated.`);
       }
 
       builder.accessRules[pattern] = options;
+    },
+
+    /**
+     * @summary Append custom tags into config's widget element.
+     *
+     * `App.appendToConfig('custom-tag', {attrs: '', children: {}});`
+     *
+     * @param  {String} elementName The tag name
+     * @param  {Object} contents    The contents
+     * @memberOf App
+     */
+    appendToConfig: function (name, contents) {
+      builder.custom.push({
+        name,
+        contents
+      });
     }
   };
 }

--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -255,13 +255,7 @@ export class CordovaBuilder {
 
     // Set custom tags into widget element
     _.each(this.custom, elementSet => {
-      let tag = config
-        .element(elementSet.name, elementSet.contents.attrs);
-
-      _.each(elementSet.contents.children, child => {
-        tag.element(child.name, child.attrs);
-        if(child.txt) tag.txt(child.txt);
-      });
+      const tag = config.raw(elementSet);
     });
 
     config.element('content', { src: this.metadata.contentUrl });
@@ -647,17 +641,13 @@ configuration. The key may be deprecated.`);
     /**
      * @summary Append custom tags into config's widget element.
      *
-     * `App.appendToConfig('custom-tag', {attrs: '', children: {}});`
+     * `App.appendToConfig('<any-xml-content/>');`
      *
-     * @param  {String} elementName The tag name
-     * @param  {Object} contents    The contents
+     * @param  {String} element The XML you want to include 
      * @memberOf App
      */
-    appendToConfig: function (name, contents) {
-      builder.custom.push({
-        name,
-        contents
-      });
-    }
+    appendToConfig: function (xml) {
+      builder.custom.push(xml);
+    },
   };
 }

--- a/tools/tests/cordova-append-config.js
+++ b/tools/tests/cordova-append-config.js
@@ -1,0 +1,35 @@
+var files = require('../fs/files.js');
+var selftest = require('../tool-testing/selftest.js');
+var testUtils = require('../tool-testing/test-utils.js');
+var Sandbox = selftest.Sandbox;
+
+var cleanUpBuild = function (s) {
+  files.rm_recursive(files.pathJoin(s.cwd, "android"));
+  files.unlink(files.pathJoin(s.cwd, "myapp.tar.gz"));
+};
+
+selftest.define("cordova builds extended config.xml", ["cordova", "slow"], function () {
+  var s = new Sandbox();
+  var run;
+
+  s.createApp("myapp", "standard-app");
+  s.cd("myapp");
+
+  run = s.run("add-platform", "android");
+  run.waitSecs(100);
+  run.match("added");
+  run.expectExit(0);
+
+  // Write mobile-config.js
+  var mobileConfig = "App.appendToConfig('<something/>')";
+  files.writeFile(s.cwd + '/mobile-config.js', mobileConfig, "utf8");
+
+  run = s.run("build", ".", "--server", "example.com");
+  run.waitSecs(300);
+  run.expectExit(0);
+
+  // Read and check if custom XML was included
+  var configXML = files.readFile(s.cwd + '/.meteor/local/cordova-build/config.xml');
+  selftest.expectEqual((/<something\/>/g).test(configXML), true);
+  cleanUpBuild(s);
+});


### PR DESCRIPTION
Re-open #5846, as requested by @zol :

As I also needed a solution for https://github.com/meteor/meteor/issues/5756, I attempted to implement it.
So now you're able to append custom tags to `config.xml`. Eg:

```js
App.appendToConfig(`
  <universal-links>
    <host name="myhost.com"/>
  </universal-links>
`);
```

and `config.xml` will get:

```
<?xml version="1.0"?>
<widget id="com.example.ul" version="1.5.5" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
  <name>UniversalLinks</name>
  <description>Another app</description>
  <author href="twitter.com/_gabrielrubens" email="grsabreu@gmail.com">Gabriel Rubens</author>

  <universal-links>
    <host name="myhost.com"/>
  </universal-links>
</widget>
```
Let me know how I can improve something!
Cheers