### PR TITLE
Publish CSS documents for autoupdate after rewriting for #7149

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -128,7 +128,7 @@ Autoupdate._retrySubscription = function () {
                 newLink.setAttribute("rel", "stylesheet");
                 newLink.setAttribute("type", "text/css");
                 newLink.setAttribute("class", "__meteor-css__");
-                newLink.setAttribute("href", Meteor._relativeToSiteRootUrl(css.url));
+                newLink.setAttribute("href", css.url);
                 attachStylesheetLink(newLink);
               });
             } else {

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -36,7 +36,11 @@ WebApp.clientPrograms = {};
 // XXX maps archs to program path on filesystem
 var archPath = {};
 
-var bundledJsCssUrlRewriteHook;
+var bundledJsCssUrlRewriteHook = function (url) {
+  var bundledPrefix =
+     __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
+  return bundledPrefix + url;
+};
 
 var sha1 = function (contents) {
   var hash = crypto.createHash('sha1');
@@ -283,13 +287,6 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
     _.clone(__meteor_runtime_config__),
     additionalOptions.runtimeConfigOverrides || {}
   );
-
-  var jsCssUrlRewriteHook = bundledJsCssUrlRewriteHook || function (url) {
-    var bundledPrefix =
-       __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
-    return bundledPrefix + url;
-  };
-
   return new Boilerplate(arch, manifest,
     _.extend({
       pathMapper: function (itemPath) {
@@ -313,7 +310,7 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
         meteorRuntimeConfig: JSON.stringify(
           encodeURIComponent(JSON.stringify(runtimeConfig))),
         rootUrlPathPrefix: __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '',
-        bundledJsCssUrlRewriteHook: jsCssUrlRewriteHook,
+        bundledJsCssUrlRewriteHook: bundledJsCssUrlRewriteHook,
         inlineScriptsAllowed: WebAppInternals.inlineScriptsAllowed(),
         inline: additionalOptions.inline
       }
@@ -574,9 +571,13 @@ var runWebAppServer = function () {
 
       // Configure CSS injection for the default arch
       // XXX implement the CSS injection for all archs?
-      WebAppInternals.refreshableAssets = {
-        allCss: boilerplateByArch[WebApp.defaultArch].baseData.css
-      };
+      var cssFiles = boilerplateByArch[WebApp.defaultArch].baseData.css;
+      // Rewrite all CSS files (which are written directly to <style> tags)
+      // by autoupdate_client to use the CDN prefix/etc
+      var allCss = _.map(cssFiles, function(cssFile) {
+        return { url: bundledJsCssUrlRewriteHook(cssFile.url) };
+      });
+      WebAppInternals.refreshableAssets = { allCss };
     });
   };
 


### PR DESCRIPTION
A fix for #7149 

Previously we did not take the JsCssRewriteHook (i.e. CDN host)
into account when doing CSS-only "version-refreshable" HCP.

It is not possible on the client to rewrite CSS urls to take the
hook into account (as it is a function), so instead, we just
publish those CSS URLs post-transform.