### PR TITLE
Set stopped computation to null instead of delete (#7326)

### DIFF
--- a/packages/promise/.npm/package/npm-shrinkwrap.json
+++ b/packages/promise/.npm/package/npm-shrinkwrap.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "meteor-promise": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/meteor-promise/-/meteor-promise-0.7.2.tgz",
       "from": "meteor-promise@0.7.2"
     },
     "promise": {

--- a/packages/tracker/tracker.js
+++ b/packages/tracker/tracker.js
@@ -301,7 +301,7 @@ Tracker.Computation.prototype.stop = function () {
     self.stopped = true;
     self.invalidate();
     // Unregister from global Tracker.
-    delete Tracker._computations[self._id];
+    Tracker._computations[self._id] = null;
     for(var i = 0, f; f = self._onStopCallbacks[i]; i++) {
       Tracker.nonreactive(function () {
         withNoYieldsAllowed(f)(self);

--- a/packages/tracker/tracker.js
+++ b/packages/tracker/tracker.js
@@ -26,13 +26,6 @@ Tracker.active = false;
  */
 Tracker.currentComputation = null;
 
-// References to all computations created within the Tracker by id.
-// Keeping these references on an underscore property gives more control to
-// tooling and packages extending Tracker without increasing the API surface.
-// These can used to monkey-patch computations, their functions, use
-// computation ids for tracking, etc.
-Tracker._computations = {};
-
 var setCurrentComputation = function (c) {
   Tracker.currentComputation = c;
   Tracker.active = !! c;
@@ -203,9 +196,6 @@ Tracker.Computation = function (f, parent, onError) {
   self._onError = onError;
   self._recomputing = false;
 
-  // Register the computation within the global Tracker.
-  Tracker._computations[self._id] = self;
-
   var errored = true;
   try {
     self._compute();
@@ -300,8 +290,6 @@ Tracker.Computation.prototype.stop = function () {
   if (! self.stopped) {
     self.stopped = true;
     self.invalidate();
-    // Unregister from global Tracker.
-    Tracker._computations[self._id] = null;
     for(var i = 0, f; f = self._onStopCallbacks[i]; i++) {
       Tracker.nonreactive(function () {
         withNoYieldsAllowed(f)(self);


### PR DESCRIPTION
Fix for issues https://github.com/meteor/meteor/issues/7326 and https://github.com/meteor/blaze/issues/44

This change in Tracker speeds up the removal of Blaze templates with many sub-templates by approximately 5-10x.

It replaces the `delete` of a stopped computation by setting it to `null`. Read more [here](http://bertanguven.com/preventing-memory-leaks-in-javascript-null-vs-delete)

Reproduction of the issue used as a benchmark (and a test to verify the effect): https://github.com/arggh/blaze-tmpl-destroy/tree/nosubs

Without the fix in Tracker, the first time hiding the table with 550 rows took about **1.5 seconds**. On the second go it took about **2.6 seconds**. Then **3.5 seconds**. Then **~5 seconds** and so on, which is really strange - as if things just got incremented instead of removed.

With the fix applied, hiding the same table takes a constant **300-450ms.**