### PR TITLE
Relative path resolves to project directory when use METEOR_LOCAL_DIR.

### DIFF
--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 var _ = require('underscore');
+var path = require('path');
 
 var archinfo = require('./utils/archinfo.js');
 var buildmessage = require('./utils/buildmessage.js');
@@ -89,9 +90,11 @@ _.extend(ProjectContext.prototype, {
     // writes to; used by `meteor test` so that you can test your
     // app in parallel to writing it, with an isolated database.
     // You can override the default .meteor/local by specifying
-    // METEOR_LOCAL_DIR.
+    // METEOR_LOCAL_DIR. You can use relative path if you want it
+    // relative to your project directory.
     self.projectLocalDir = process.env.METEOR_LOCAL_DIR ?
-      process.env.METEOR_LOCAL_DIR : (options.projectLocalDir ||
+      path.resolve(options.projectLocalDir, process.env.METEOR_LOCAL_DIR)
+      : (options.projectLocalDir ||
       files.pathJoin(self.projectDir, '.meteor', 'local'));
 
     // Used by 'meteor rebuild'; true to rebuild all packages, or a list of

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var _ = require('underscore');
-var path = require('path');
 
 var archinfo = require('./utils/archinfo.js');
 var buildmessage = require('./utils/buildmessage.js');
@@ -93,9 +92,10 @@ _.extend(ProjectContext.prototype, {
     // METEOR_LOCAL_DIR. You can use relative path if you want it
     // relative to your project directory.
     self.projectLocalDir = process.env.METEOR_LOCAL_DIR ?
-      path.resolve(options.projectLocalDir, process.env.METEOR_LOCAL_DIR)
+      files.pathResolve(options.projectDir,
+        files.convertToStandardPath(process.env.METEOR_LOCAL_DIR))
       : (options.projectLocalDir ||
-      files.pathJoin(self.projectDir, '.meteor', 'local'));
+        files.pathJoin(self.projectDir, '.meteor', 'local'));
 
     // Used by 'meteor rebuild'; true to rebuild all packages, or a list of
     // package names.  Deletes the isopacks and their plugin caches.


### PR DESCRIPTION
Issue #7292 

Use `path.resolve` to resolve the relative path to project. May need to take this down to `History.md`.