### PR TITLE
7267 use request retry

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=0.6.16
+BUNDLE_VERSION=0.6.17
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=0.6.15
+BUNDLE_VERSION=0.6.16
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -28,7 +28,7 @@ var packageJson = {
     underscore: "1.5.2",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
     semver: "4.1.0",
-    request: "2.47.0",
+    requestretry: "1.9.0",
     fstream: "https://github.com/meteor/fstream/tarball/d11b9ec4a13918447c8af7559c243c190744dd1c",
     tar: "1.0.2",
     kexec: "2.0.2",

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -256,10 +256,18 @@ _.extend(exports, {
       delete options.timeout;
     }
 
+    // Configure requestretry
+    if (! _.has(options, "maxAttempts")) {
+      options.maxAttempts = 3;   // try 3 times
+    }
+    if (! _.has(options, "retryDelay")) {
+      options.retryDelay = 30 * 1000;  // wait for 30s before trying again
+    }
+
     // request is the most heavy-weight of the tool's npm dependencies; don't
     // require it until we definitely need it.
     Console.debug("Doing HTTP request: ", options.method || 'GET', options.url);
-    var request = require('request');
+    var request = require('requestretry');
     var req = request(options, callback);
 
 


### PR DESCRIPTION
Based on #7344. Use the `requestretry` package to make package downloads more resistant to CDN/internet flakiness.

We should consider what values to use for `maxAttempts` and `retryDelay`.