### PR TITLE
can resolve private npm package when adding cordova plugin

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1908,8 +1908,7 @@ main.registerCommand({
     let changed = false;
 
     for (target of pluginsToAdd) {
-      let [id, version] = target.split('@');
-
+      let [id, version] = [target.substring(0,target.lastIndexOf('@')), target.substring(target.lastIndexOf('@')+1)];
       const newId = cordova.newPluginId(id);
 
       if (!(version && utils.isValidVersion(version, {forCordova: true}))) {

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1211,7 +1211,7 @@ _.extend(exports.CordovaPluginsFile.prototype, {
       // We just do a standard split here, not utils.parsePackageConstraint,
       // since cordova plugins don't necessary obey the same naming conventions
       // as Meteor packages.
-      var parts = line.split('@');
+      var parts = [line.substring(0,line.lastIndexOf('@')), line.substring(line.lastIndexOf('@')+1)];
       if (parts.length !== 2) {
         buildmessage.error("Cordova plugin must specify version: " + line, {
           // XXX should this be relative?


### PR DESCRIPTION
This change will enable our use case of having several private cordova plugins hosted on npm while also following the new scoped packages npm mechanism to avoid duplicate naming issues. For example @mycompany/cordova-plugin-somecoolthing.

`meteor add cordova:@mycompany/cordova-plugin-somecoolthing@1.0.0`

I have tested this with the above command and checked to ensure the build tool with pull the npm package into the local cordova-build plugins folder.

This change is simply described as using only the last instance of @ in a package add command to split id from version.

Closes #7336