### PR TITLE
Added Angular2 to the example repositories

### DIFF
--- a/tools/cli/example-repositories.js
+++ b/tools/cli/example-repositories.js
@@ -14,4 +14,7 @@ export const EXAMPLE_REPOSITORIES = {
     'repo': 'https://github.com/meteor/todos',
     'branch': 'react',
   },
+  angular2: {
+    repo: 'https://github.com/bsliran/angular2-meteor-base'
+  }
 };

--- a/tools/cli/example-repositories.js
+++ b/tools/cli/example-repositories.js
@@ -14,7 +14,7 @@ export const EXAMPLE_REPOSITORIES = {
     'repo': 'https://github.com/meteor/todos',
     'branch': 'react',
   },
-  angular2: {
+  'angular2-boilerplate': {
     repo: 'https://github.com/bsliran/angular2-meteor-base'
   }
 };


### PR DESCRIPTION
I added a new base application example, it includes Meteor 1.3 application with Angular2 and Angular2-Meteor applications, along with basic "Hello World" example with unit tests and all the required dependencies for Angular2-Meteor applications.

The idea is to get an easy start for new Angular2-Meteor developers, by providing the command:
`meteor create angular2`.

Thanks.