### PR TITLE
Allow `Meteor.publish` to take an object

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1472,6 +1472,8 @@ _.extend(Server.prototype, {
    * @locus Server
    * @param {String} name Name of the record set.  If `null`, the set has no name, and the record set is automatically sent to all connected clients.
    * @param {Function} func Function called on the server each time a client subscribes.  Inside the function, `this` is the publish handler object, described below.  If the client passed arguments to `subscribe`, the function is called with the same arguments.
+
+   TODO: https://github.com/meteor/meteor/issues/6649
    */
   publish: function (name, handler, options) {
     var self = this;

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1529,7 +1529,7 @@ _.extend(Server.prototype, {
     else{
       _.each(name, function(value, key) {
         self.publish(key, value, {});
-      })
+      });
     }
   },
 

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1472,7 +1472,6 @@ _.extend(Server.prototype, {
    * @locus Server
    * @param {String|Object} name If String, name of the record set.  If Object, publications Dictionary of publish functions by name.  If `null`, the set has no name, and the record set is automatically sent to all connected clients.
    * @param {Function} func Function called on the server each time a client subscribes.  Inside the function, `this` is the publish handler object, described below.  If the client passed arguments to `subscribe`, the function is called with the same arguments.
-
    */
   publish: function (name, handler, options) {
     var self = this;

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1464,56 +1464,7 @@ _.extend(Server.prototype, {
    *    (it lets us determine whether to print a warning suggesting
    *    that you turn off autopublish.)
    */
-   publish_handler: function (name, handler, options){
-     var self = this;
-     options = options || {};
 
-     if (name && name in self.publish_handlers) {
-       Meteor._debug("Ignoring duplicate publish named '" + name + "'");
-       return;
-     }
-
-     if (Package.autopublish && !options.is_auto) {
-       // They have autopublish on, yet they're trying to manually
-       // picking stuff to publish. They probably should turn off
-       // autopublish. (This check isn't perfect -- if you create a
-       // publish before you turn on autopublish, it won't catch
-       // it. But this will definitely handle the simple case where
-       // you've added the autopublish package to your app, and are
-       // calling publish from your app code.)
-       if (!self.warned_about_autopublish) {
-         self.warned_about_autopublish = true;
-         Meteor._debug(
-   "** You've set up some data subscriptions with Meteor.publish(), but\n" +
-   "** you still have autopublish turned on. Because autopublish is still\n" +
-   "** on, your Meteor.publish() calls won't have much effect. All data\n" +
-   "** will still be sent to all clients.\n" +
-   "**\n" +
-   "** Turn off autopublish by removing the autopublish package:\n" +
-   "**\n" +
-   "**   $ meteor remove autopublish\n" +
-   "**\n" +
-   "** .. and make sure you have Meteor.publish() and Meteor.subscribe() calls\n" +
-   "** for each collection that you want clients to see.\n");
-       }
-     }
-
-     if (name)
-       self.publish_handlers[name] = handler;
-     else {
-       self.universal_publish_handlers.push(handler);
-       // Spin up the new publisher on any existing session too. Run each
-       // session's subscription in a new Fiber, so that there's no change for
-       // self.sessions to change while we're running this loop.
-       _.each(self.sessions, function (session) {
-         if (!session._dontStartNewUniversalSubs) {
-           Fiber(function() {
-             session._startSubscription(handler);
-           }).run();
-         }
-       });
-     }
-   },
   /**
    * @summary Publish a record set.
    * @memberOf Meteor
@@ -1527,12 +1478,58 @@ _.extend(Server.prototype, {
     var self = this;
 
     if (! _.isObject(name)) {
-      self.publish_handler(name, handler, options);
+      options = options || {};
+
+      if (name && name in self.publish_handlers) {
+        Meteor._debug("Ignoring duplicate publish named '" + name + "'");
+        return;
+      }
+
+      if (Package.autopublish && !options.is_auto) {
+        // They have autopublish on, yet they're trying to manually
+        // picking stuff to publish. They probably should turn off
+        // autopublish. (This check isn't perfect -- if you create a
+        // publish before you turn on autopublish, it won't catch
+        // it. But this will definitely handle the simple case where
+        // you've added the autopublish package to your app, and are
+        // calling publish from your app code.)
+        if (!self.warned_about_autopublish) {
+          self.warned_about_autopublish = true;
+          Meteor._debug(
+    "** You've set up some data subscriptions with Meteor.publish(), but\n" +
+    "** you still have autopublish turned on. Because autopublish is still\n" +
+    "** on, your Meteor.publish() calls won't have much effect. All data\n" +
+    "** will still be sent to all clients.\n" +
+    "**\n" +
+    "** Turn off autopublish by removing the autopublish package:\n" +
+    "**\n" +
+    "**   $ meteor remove autopublish\n" +
+    "**\n" +
+    "** .. and make sure you have Meteor.publish() and Meteor.subscribe() calls\n" +
+    "** for each collection that you want clients to see.\n");
+        }
+      }
+
+      if (name)
+        self.publish_handlers[name] = handler;
+      else {
+        self.universal_publish_handlers.push(handler);
+        // Spin up the new publisher on any existing session too. Run each
+        // session's subscription in a new Fiber, so that there's no change for
+        // self.sessions to change while we're running this loop.
+        _.each(self.sessions, function (session) {
+          if (!session._dontStartNewUniversalSubs) {
+            Fiber(function() {
+              session._startSubscription(handler);
+            }).run();
+          }
+        });
+      }
     }
     else{
-      for (var k in name){
-        self.publish_handler(k, name[k], {});
-      }
+      _.each(name, function(value, key) {
+        self.publish(key, value, {});
+      })
     }
   },
 

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -157,6 +157,57 @@ Tinytest.addAsync(
   }
 );
 
+let onSubscriptions = {};
+
+Meteor.publish({
+  publicationObject () {
+    let callback = onSubscriptions;
+    if (callback)
+      callback();
+    this.stop();
+  }
+});
+
+Meteor.publish({
+  "publication_object": function () {
+    let callback = onSubscriptions;
+    if (callback)
+      callback();
+    this.stop();
+  }
+});
+
+Meteor.publish("publication_compatibility", function () {
+  let callback = onSubscriptions;
+  if (callback)
+    callback();
+  this.stop();
+});
+
+Tinytest.addAsync(
+  "livedata server - publish object",
+  function (test, onComplete) {
+    makeTestConnection(
+      test,
+      function (clientConn, serverConn) {
+        let testsLength = 0;
+
+        onSubscriptions = function (subscription) {
+          delete onSubscriptions;
+          clientConn.disconnect();
+          testsLength++;
+          if(testsLength == 3){
+            onComplete();
+          }
+        };
+        clientConn.subscribe("publicationObject");
+        clientConn.subscribe("publication_object");
+        clientConn.subscribe("publication_compatibility");
+      }
+    );
+  }
+);
+
 Meteor.methods({
   testResolvedPromise(arg) {
     const invocation1 = DDP._CurrentInvocation.get();


### PR DESCRIPTION
Hi,

I'm happy to publish my first PR on the meteor project, hope that you will enjoy it.

This is an answer for the issue #6649.

It allows this three syntaxes for publications

```
Meteor.publish({
  something() {
    //something
  }
});
```

```
Meteor.publish({
  "something": function() {
    //something
  }
});
```

```
Meteor.publish("something", function() {
  //something
});
```