### PR TITLE
Release 1.3.4.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,27 @@
 ## v.NEXT
 
+## v1.3.4.3
+
+* Node has been upgraded to 0.10.46.
+
+* `npm` has been upgraded to 3.10.5.
+
+* The `node-gyp` npm package has been upgraded to 3.4.0.
+
+* The `node-pre-gyp` npm package has been upgraded to 0.6.29.
+
+* The `~/.meteor/meteor` symlink (or `AppData\Local\.meteor\meteor.bat` on
+  Windows) will now be updated properly after `meteor update` succeeds. This was
+  promised in [v1.3.4.2](https://github.com/meteor/meteor/blob/devel/History.md#v1342)
+  but [not fully delivered](https://github.com/meteor/meteor/pull/7369#issue-164569763).
+
+* The `.meteor/dev_bundle` symbolic link introduced in
+  [v1.3.4.2](https://github.com/meteor/meteor/blob/devel/History.md#v1342)
+  is now updated whenever `.meteor/release` is read.
+
+* The `.meteor/dev_bundle` symbolic link is now ignored by
+  `.meteor/.gitignore`.
+
 ## v1.3.4.2
 
 * The `meteor node` and `meteor npm` commands now respect

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=0.6.16
+BUNDLE_VERSION=0.6.18
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.use('npm-bcrypt@0.8.6_2');
+  api.use('npm-bcrypt@=0.8.6_2');
 
   api.use([
     'accounts-base',

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.1.12"
+  version: "1.1.12-rc.2"
 });
 
 Package.onUse(function(api) {

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.1.11"
+  version: "1.1.12"
 });
 
 Package.onUse(function(api) {
-  api.use('npm-bcrypt@0.8.6_1');
+  api.use('npm-bcrypt@0.8.6_2');
 
   api.use([
     'accounts-base',

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.1.12-rc.2"
+  version: "1.1.12"
 });
 
 Package.onUse(function(api) {

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.4-3-rc.1'
+  version: '1.3.4-3-rc.2'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.4-3-rc.0'
+  version: '1.3.4-3-rc.1'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.4_2'
+  version: '1.3.4-3-rc.0'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.4-3-rc.2'
+  version: '1.3.4_3'
 });
 
 Package.includeTool();

--- a/packages/non-core/npm-bcrypt/.versions
+++ b/packages/non-core/npm-bcrypt/.versions
@@ -1,3 +1,3 @@
-meteor@1.1.14-rc.0
-npm-bcrypt@0.8.5
-underscore@1.0.8-rc.0
+meteor@1.1.16
+npm-bcrypt@0.8.6_2
+underscore@1.0.9

--- a/packages/non-core/npm-bcrypt/package.js
+++ b/packages/non-core/npm-bcrypt/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Wrapper around the bcrypt npm package",
-  version: '0.8.6_1',
+  version: '0.8.6_2',
   documentation: null
 });
 

--- a/packages/non-core/npm-node-aes-gcm/.versions
+++ b/packages/non-core/npm-node-aes-gcm/.versions
@@ -1,3 +1,3 @@
-meteor@1.1.15
-npm-node-aes-gcm@0.1.5_1
+meteor@1.1.16
+npm-node-aes-gcm@0.1.5_2
 underscore@1.0.9

--- a/packages/non-core/npm-node-aes-gcm/package.js
+++ b/packages/non-core/npm-node-aes-gcm/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Wrapper around the node-aes-gcm npm package",
-  version: '0.1.5_1',
+  version: '0.1.5_2',
   documentation: null
 });
 

--- a/packages/oauth-encryption/package.js
+++ b/packages/oauth-encryption/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Encrypt account secrets stored in the database",
-  version: '1.0.13'
+  version: '1.0.13-rc.2'
 });
 
 Package.onUse(function (api) {

--- a/packages/oauth-encryption/package.js
+++ b/packages/oauth-encryption/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Encrypt account secrets stored in the database",
-  version: '1.0.13-rc.2'
+  version: '1.0.13'
 });
 
 Package.onUse(function (api) {

--- a/packages/oauth-encryption/package.js
+++ b/packages/oauth-encryption/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Encrypt account secrets stored in the database",
-  version: '1.0.12'
+  version: '1.0.13'
 });
 
 Package.onUse(function (api) {
-  api.use("npm-node-aes-gcm@=0.1.5_1");
+  api.use("npm-node-aes-gcm@=0.1.5_2");
 
   api.export("OAuthEncryption", ["server"]);
   api.use([

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.4.2-rc.1",
+ "version": "1.3.4.3-rc.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.4.3-rc.0",
+ "version": "1.3.4.3-rc.1",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.4.3-rc.1",
+ "version": "1.3.4.3-rc.2",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.3.4.2",
+  "version": "1.3.4.3",
   "recommended": false,
   "official": true,
   "description": "The Official Meteor Distribution"

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -5,8 +5,8 @@ set -u
 
 UNAME=$(uname)
 ARCH=$(uname -m)
-NODE_VERSION=0.10.45
-NPM_VERSION=3.9.6
+NODE_VERSION=0.10.46
+NPM_VERSION=3.10.5
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -11,9 +11,9 @@ var packageJson = {
   dependencies: {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version
-    npm: "3.9.6",
-    "node-gyp": "3.3.1",
-    "node-pre-gyp": "0.6.26",
+    npm: "3.10.5",
+    "node-gyp": "3.4.0",
+    "node-pre-gyp": "0.6.29",
     "meteor-babel": "0.11.7",
     "meteor-promise": "0.7.2",
     fibers: "1.0.13",

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -2,8 +2,8 @@
 # use 32bit by default
 $PLATFORM = "windows_x86"
 $MONGO_VERSION = "2.6.7"
-$NODE_VERSION = "0.10.45"
-$NPM_VERSION = "3.9.6"
+$NODE_VERSION = "0.10.46"
+$NPM_VERSION = "3.10.5"
 $PYTHON_VERSION = "2.7.10" # For node-gyp
 
 # take it form the environment if exists

--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -24,6 +24,7 @@ var packageClient = require('../packaging/package-client.js');
 var tropohouse = require('../packaging/tropohouse.js');
 
 import * as cordova from '../cordova';
+import { updateMeteorToolSymlink } from "../packaging/updater.js";
 
 // For each release (or package), we store a meta-record with its name,
 // maintainers, etc. This function takes in a name, figures out if
@@ -1335,6 +1336,8 @@ var maybeUpdateRelease = function (options) {
   if (! release.current || ! release.current.isProperRelease()) {
     throw new Error("don't have a proper release?");
   }
+
+  updateMeteorToolSymlink(true);
 
   // If we're not in an app, then we're basically done. The only thing left to
   // do is print out some messages explaining what happened (and advising the

--- a/tools/packaging/updater.js
+++ b/tools/packaging/updater.js
@@ -152,7 +152,7 @@ var maybeShowBanners = function () {
 
 // Update ~/.meteor/meteor to point to the tool binary from the tools of the
 // latest recommended release on the default release track.
-var updateMeteorToolSymlink = function (printErrors) {
+export function updateMeteorToolSymlink(printErrors) {
   // Get the latest release version of METEOR. (*Always* of the default
   // track, not of whatever we happen to be running: we always want the tool
   // symlink to go to the default track.)
@@ -215,4 +215,4 @@ var updateMeteorToolSymlink = function (printErrors) {
     tropohouse.default.linkToLatestMeteor(files.pathJoin(
       relativeToolPath, toolRecord.path, 'meteor'));
   }
-};
+}

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -369,32 +369,7 @@ _.extend(ProjectContext.prototype, {
   // .meteor/dev_bundle symlink to the corresponding dev_bundle.
   writeReleaseFileAndDevBundleLink(releaseName) {
     assert.strictEqual(files.inCheckout(), false);
-
     this.releaseFile.write(releaseName);
-
-    // Make a symlink from .meteor/dev_bundle to the actual dev_bundle.
-    const devBundleLink = files.pathJoin(
-      files.pathDirname(this.releaseFile.filename),
-      "dev_bundle"
-    );
-
-    if (files.exists(devBundleLink)) {
-      files.rm_recursive(devBundleLink);
-    }
-
-    if (this.releaseFile.isCheckout()) {
-      // Only create the .meteor/dev_bundle symlink if it points to the
-      // dev_bundle of an actual release, but remove it first regardless.
-      return;
-    }
-
-    files.symlink(
-      files.getDevBundle(),
-      devBundleLink,
-      // Since the target is a directory, Windows can create a junction
-      // without needing administrator privileges.
-      "junction"
-    );
   },
 
   _ensureProjectDir: function () {
@@ -1368,6 +1343,56 @@ _.extend(exports.ReleaseFile.prototype, {
     self.displayReleaseName = catalogUtils.displayRelease(parts[0], parts[1]);
     self.releaseTrack = parts[0];
     self.releaseVersion = parts[1];
+
+    self.ensureDevBundleLink();
+  },
+
+  ensureDevBundleLink() {
+    // Make a symlink from .meteor/dev_bundle to the actual dev_bundle.
+    const devBundleLink = files.pathJoin(
+      files.pathDirname(this.filename),
+      "dev_bundle"
+    );
+
+    if (this.isCheckout()) {
+      // Only create the .meteor/dev_bundle symlink if .meteor/release
+      // refers to an actual release, and remove it otherwise.
+      files.rm_recursive(devBundleLink);
+      return;
+    }
+
+    if (files.inCheckout()) {
+      // Never update .meteor/dev_bundle to point to a checkout.
+      return;
+    }
+
+    const newTarget = files.realpath(files.getDevBundle());
+
+    try {
+      if (newTarget === files.realpath(devBundleLink)) {
+        // Don't touch .meteor/dev_bundle if it already points to the
+        // right target path.
+        return;
+      }
+
+      // Remove .meteor/dev_bundle so that we can recreate it below.
+      files.rm_recursive(devBundleLink);
+
+    } catch (e) {
+      if (e.code !== "ENOENT") {
+        // It's ok if files.realpath(devBundleLink) failed because the
+        // devBundleLink file does not exist.
+        throw e;
+      }
+    }
+
+    files.symlink(
+      newTarget,
+      devBundleLink,
+      // Since the target is a directory, Windows can create a junction
+      // without needing administrator privileges.
+      "junction"
+    );
   },
 
   write: function (releaseName) {

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -410,8 +410,19 @@ _.extend(ProjectContext.prototype, {
 
     // Let's also make sure we have a minimal gitignore.
     var gitignorePath = files.pathJoin(self.projectDir, '.meteor', '.gitignore');
-    if (! files.exists(gitignorePath)) {
-      files.writeFileAtomically(gitignorePath, 'local\n');
+    try {
+      var lines = files.readFile(gitignorePath, "utf8").split("\n");
+    } catch (e) {
+      if (e.code !== "ENOENT") throw e;
+      lines = [""];
+    }
+
+    var needLocal = lines.indexOf("local") < 0;
+    var needDevBundle = lines.indexOf("dev_bundle") < 0;
+    if (needDevBundle || needLocal) {
+      if (needDevBundle) lines.unshift("dev_bundle");
+      if (needLocal) lines.unshift("local");
+      files.writeFileAtomically(gitignorePath, lines.join("\n"));
     }
   },
 

--- a/tools/static-assets/skel/.meteor/.gitignore
+++ b/tools/static-assets/skel/.meteor/.gitignore
@@ -1,1 +1,2 @@
 local
+dev_bundle


### PR DESCRIPTION
Unfortunately, the following claim in the [release notes](https://github.com/meteor/meteor/blob/devel/History.md#v1342) for the [1.3.4.2 release](https://github.com/meteor/meteor/pull/7340) was not entirely true:

* The `meteor node` and `meteor npm` commands now respect `.meteor/release` when resolving which versions of `node` and `npm` to invoke. Note that you must `meteor update` to 1.3.4.2 before this logic will take effect, but it will work in all app directories after updating, even those pinned to older versions. [#7338](https://github.com/meteor/meteor/issue/7338)

Specifically, running `meteor update` to update to 1.3.4.2 was not actually enough to modify the `~/.meteor/meteor` symlink (or `AppData\Local\.meteor\meteor.bat` on Windows), which prevented the new behavior of `meteor node` and `meteor npm` from taking effect.

Thanks to @rhettlivingston for providing [quick feedback](https://github.com/meteor/meteor/pull/7340#issuecomment-231253317) on these concerns!