### PR TITLE
Ability to override the default warehouse url base

### DIFF
--- a/tools/packaging/tropohouse.js
+++ b/tools/packaging/tropohouse.js
@@ -299,6 +299,12 @@ _.extend(exports.Tropohouse.prototype, {
   // XXX: Error handling.
   _downloadBuildToTempDir: function (versionInfo, buildRecord) {
     var url = buildRecord.build.url;
+    
+    // Override the download domain name and protocol if METEOR_WAREHOUSE_URLBASE
+    // provided.
+    if (process.env.METEOR_WAREHOUSE_URLBASE) {
+      url = url.replace(/^[a-zA-Z]+:\/\/[^\/]+/, process.env.METEOR_WAREHOUSE_URLBASE);
+    }
 
     // XXX: We use one progress for download & untar; this isn't ideal:
     // it relies on extractTarGz being fast and not reporting any progress.


### PR DESCRIPTION
> Discussed about it at #6944. This PR gives you ability to override the default warehouse urlbase (warehouse.meteor.com) by setting METEOR_WAREHOUSE_URLBASE.

Previous PR #7054 didn't achieve this and hope this will work.

PS: Does this function only used to download packages? Will the url not begins with `https://warehouse.meteor.com`?

cc @n1mmy