### PR TITLE
Exclude .min.js from babel compiling.

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -10,7 +10,7 @@ BabelCompiler = function BabelCompiler(extraFeatures) {
 };
 
 var BCp = BabelCompiler.prototype;
-var excludedFileExtensionPattern = /\.es5\.js$/i;
+var excludedFileExtensionPattern = /\.(es5|min)\.js$/i;
 var hasOwn = Object.prototype.hasOwnProperty;
 
 BCp.processFilesForTarget = function (inputFiles) {


### PR DESCRIPTION
Side PR for #7356.

`.min.js`es don't need to be compiled by babel.