### PR TITLE
Add --raw-logs option for meteor test

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1421,6 +1421,7 @@ testCommandOptions = {
     // like progress bars and spinners are unimportant.
     headless: { type: Boolean },
     verbose: { type: Boolean, short: "v" },
+    'raw-logs': { type: Boolean },
 
     // Undocumented. See #Once
     once: { type: Boolean },
@@ -1518,6 +1519,10 @@ function doTestCommand(options) {
   var serverArchitectures = [archinfo.host()];
   if (options.deploy && DEPLOY_ARCH !== archinfo.host()) {
     serverArchitectures.push(DEPLOY_ARCH);
+  }
+
+  if (options['raw-logs']) {
+    runLog.setRawLogs(true);
   }
 
   var projectContextOptions = {

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -579,6 +579,7 @@ Options:
                     port that the Meteor server binds to. Can include a
                     URL scheme (for example,
                     --mobile-server=https://example.com:443).
+  --raw-logs        Run without parsing logs from stdout and stderr.
   --settings        Set optional data for Meteor.settings on the server
 
   --ios,            Run tests in an emulator or on a mobile device. All of


### PR DESCRIPTION
Fixes #7396 by adding an option to output directly to stdout, without adding a timestamp or parsing.