### PR TITLE
Release 1.3.5

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,10 @@
 
 ## v1.3.5
 
+* Failed Meteor package downloads are now automatically resumed from the
+  point of failure, up to ten times, with a five-second delay between
+  attempts. [#7399](https://github.com/meteor/meteor/pull/7399)
+
 * If an app has no `package.json` file, all packages in `node_modules`
   will be built into the production bundle. In other words, make sure you
   have a `package.json` file if you want to benefit from `devDependencies`
@@ -23,6 +27,10 @@
   receives the flags `--update-binary` and `--no-bin-links`, in addition
   to respecting the `$METEOR_NPM_REBUILD_FLAGS` environment variable.
   [#7401](https://github.com/meteor/meteor/issues/7401)
+
+* The last solution found by the package version constraint solver is now
+  stored in `.meteor/local/resolver-result-cache.json` so that it need not
+  be recomputed every time Meteor starts up.
 
 ## v1.3.4.4
 

--- a/History.md
+++ b/History.md
@@ -1,5 +1,25 @@
 ## v.NEXT
 
+## v1.3.5
+
+* If an app has no `package.json` file, all packages in `node_modules`
+  will be built into the production bundle. In other words, make sure you
+  have a `package.json` file if you want to benefit from `devDependencies`
+  pruning. 7b2193188fc9e297eefc841ce6035825164f0684
+
+* Binary npm dependencies of compiler plugins are now automatically
+  rebuilt when Node/V8 versions change.
+  [#7297](https://github.com/meteor/meteor/issues/7297)
+
+* The `.meteor/dev_bundle` link now corresponds exactly to
+  `.meteor/release` even when an app is using an older version of
+  Meteor. d732c2e649794f350238d515153f7fb71969c526
+
+* When recompiling binary npm packages, the `npm rebuild` command now
+  receives the flags `--update-binary` and `--no-bin-links`, in addition
+  to respecting the `$METEOR_NPM_REBUILD_FLAGS` environment variable.
+  [#7401](https://github.com/meteor/meteor/issues/7401)
+
 ## v1.3.4.4
 
 * Fixed [#7374](https://github.com/meteor/meteor/issues/7374).

--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 ## v.NEXT
 
+## v1.3.5.1
+
+* This release fixed a small bug in 1.3.5 that prevented updating apps
+  whose `.meteor/release` files refer to releases no longer installed in
+  `~/.meteor/packages/meteor-tool`. 576468eae8d8dd7c1fe2fa381ac51dee5cb792cd
+
 ## v1.3.5
 
 * Failed Meteor package downloads are now automatically resumed from the

--- a/History.md
+++ b/History.md
@@ -32,6 +32,10 @@
   stored in `.meteor/local/resolver-result-cache.json` so that it need not
   be recomputed every time Meteor starts up.
 
+* If the `$GYP_MSVS_VERSION` environment variable is not explicitly
+  provided to `meteor {node,npm}`, the `node-gyp` tool will infer the
+  appropriate version (though it still defaults to "2015").
+
 ## v1.3.4.4
 
 * Fixed [#7374](https://github.com/meteor/meteor/issues/7374).

--- a/History.md
+++ b/History.md
@@ -11,7 +11,11 @@
   rebuilt when Node/V8 versions change.
   [#7297](https://github.com/meteor/meteor/issues/7297)
 
-* The `.meteor/dev_bundle` link now corresponds exactly to
+* Because `.meteor/local` is where purely local information should be
+  stored, the `.meteor/dev_bundle` link has been renamed to
+  `.meteor/local/dev_bundle`.
+
+* The `.meteor/local/dev_bundle` link now corresponds exactly to
   `.meteor/release` even when an app is using an older version of
   Meteor. d732c2e649794f350238d515153f7fb71969c526
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,7 @@
 dependencies:
+  pre:
+    # https://github.com/meteor/docs/blob/version-NEXT/long-form/file-change-watcher-efficiency.md
+    - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
   cache_directories:
     - "dev_bundle"
     - ".meteor"

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=0.6.18
+BUNDLE_VERSION=0.6.19
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.1.13-rc.1"
+  version: "1.1.13-rc.2"
 });
 
 Package.onUse(function(api) {

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.1.13-rc.2"
+  version: "1.1.13-rc.3"
 });
 
 Package.onUse(function(api) {

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.1.13-rc.3"
+  version: "1.1.13"
 });
 
 Package.onUse(function(api) {

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.1.12"
+  version: "1.1.13-rc.1"
 });
 
 Package.onUse(function(api) {
-  api.use('npm-bcrypt@=0.8.6_2');
+  api.use('npm-bcrypt@=0.8.6_3');
 
   api.use([
     'accounts-base',

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.5-rc.1'
+  version: '6.8.5-rc.2'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.5-beta.0'
+  version: '6.8.5-rc.0'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.5-rc.0'
+  version: '6.8.5-rc.1'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.4'
+  version: '6.8.5-beta.0'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.5-rc.3'
+  version: '6.8.5'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.8.5-rc.2'
+  version: '6.8.5-rc.3'
 });
 
 Npm.depends({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.4-rc.1"
+  version: "1.1.4-rc.2"
 });
 
 Package.registerBuildPlugin({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.4-rc.3"
+  version: "1.1.4"
 });
 
 Package.registerBuildPlugin({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.4-rc.0"
+  version: "1.1.4-rc.1"
 });
 
 Package.registerBuildPlugin({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.4-beta.0"
+  version: "1.1.4-rc.0"
 });
 
 Package.registerBuildPlugin({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.4-rc.2"
+  version: "1.1.4-rc.3"
 });
 
 Package.registerBuildPlugin({

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.1.3"
+  version: "1.1.4-beta.0"
 });
 
 Package.registerBuildPlugin({

--- a/packages/constraint-solver/constraint-solver-input.js
+++ b/packages/constraint-solver/constraint-solver-input.js
@@ -171,20 +171,23 @@ CS.Input.prototype.isEqual = function (otherInput) {
   // to reload the entire relevant part of the catalog from SQLite on
   // every rebuild!
   return _.isEqual(
-    _.omit(a.toJSONable(), "catalogCache"),
-    _.omit(b.toJSONable(), "catalogCache")
+    a.toJSONable(true),
+    b.toJSONable(true)
   );
 };
 
-CS.Input.prototype.toJSONable = function () {
+CS.Input.prototype.toJSONable = function (omitCatalogCache) {
   var self = this;
   var obj = {
     dependencies: self.dependencies,
     constraints: _.map(self.constraints, function (c) {
       return c.toString();
-    }),
-    catalogCache: self.catalogCache.toJSONable()
+    })
   };
+
+  if (! omitCatalogCache) {
+    obj.catalogCache = self.catalogCache.toJSONable();
+  }
 
   // For readability of the resulting JSON, only include optional
   // properties that aren't the default.

--- a/packages/constraint-solver/constraint-solver.js
+++ b/packages/constraint-solver/constraint-solver.js
@@ -60,8 +60,10 @@ CS.PackagesResolver.prototype.resolve = function (dependencies, constraints,
   });
 
   var resultCache = self._options.resultCache;
-  if (resultCache && resultCache.lastInput &&
-      input.isEqual(resultCache.lastInput)) {
+  if (resultCache &&
+      resultCache.lastInput &&
+      _.isEqual(resultCache.lastInput,
+                input.toJSONable(true))) {
     return resultCache.lastOutput;
   }
 
@@ -127,7 +129,7 @@ CS.PackagesResolver.prototype.resolve = function (dependencies, constraints,
   }
 
   if (resultCache) {
-    resultCache.lastInput = input;
+    resultCache.lastInput = input.toJSONable(true);
     resultCache.lastOutput = output;
   }
 

--- a/packages/constraint-solver/package.js
+++ b/packages/constraint-solver/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Given the set of the constraints, picks a satisfying configuration",
-  version: "1.0.27-rc.0"
+  version: "1.0.27-rc.1"
 });
 
 Package.onUse(function (api) {

--- a/packages/constraint-solver/package.js
+++ b/packages/constraint-solver/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Given the set of the constraints, picks a satisfying configuration",
-  version: "1.0.27-rc.3"
+  version: "1.0.27"
 });
 
 Package.onUse(function (api) {

--- a/packages/constraint-solver/package.js
+++ b/packages/constraint-solver/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Given the set of the constraints, picks a satisfying configuration",
-  version: "1.0.27-rc.2"
+  version: "1.0.27-rc.3"
 });
 
 Package.onUse(function (api) {

--- a/packages/constraint-solver/package.js
+++ b/packages/constraint-solver/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Given the set of the constraints, picks a satisfying configuration",
-  version: "1.0.27-rc.1"
+  version: "1.0.27-rc.2"
 });
 
 Package.onUse(function (api) {

--- a/packages/constraint-solver/package.js
+++ b/packages/constraint-solver/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Given the set of the constraints, picks a satisfying configuration",
-  version: "1.0.27-beta.0"
+  version: "1.0.27-rc.0"
 });
 
 Package.onUse(function (api) {

--- a/packages/constraint-solver/package.js
+++ b/packages/constraint-solver/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Given the set of the constraints, picks a satisfying configuration",
-  version: "1.0.26"
+  version: "1.0.27-beta.0"
 });
 
 Package.onUse(function (api) {

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '1.2.10-rc.2',
+  version: '1.2.10-rc.3',
   documentation: null
 });
 

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '1.2.10-rc.0',
+  version: '1.2.10-rc.1',
   documentation: null
 });
 

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '1.2.10-beta.0',
+  version: '1.2.10-rc.0',
   documentation: null
 });
 

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '1.2.10-rc.1',
+  version: '1.2.10-rc.2',
   documentation: null
 });
 

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '1.2.10-rc.3',
+  version: '1.2.10',
   documentation: null
 });
 

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '1.2.9',
+  version: '1.2.10-beta.0',
   documentation: null
 });
 

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.8-rc.1',
+  version: '0.4.8-rc.2',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.8-rc.2',
+  version: '0.4.8-rc.3',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.8-beta.0',
+  version: '0.4.8-rc.0',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.7',
+  version: '0.4.8-beta.0',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.8-rc.0',
+  version: '0.4.8-rc.1',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.4.8-rc.3',
+  version: '0.4.8',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.0.15"
+  version: "1.0.16-beta.0"
 });
 
 Npm.depends({

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.0.16-rc.1"
+  version: "1.0.16-rc.2"
 });
 
 Npm.depends({

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.0.16-rc.0"
+  version: "1.0.16-rc.1"
 });
 
 Npm.depends({

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.0.16-beta.0"
+  version: "1.0.16-rc.0"
 });
 
 Npm.depends({

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.0.16-rc.2"
+  version: "1.0.16-rc.3"
 });
 
 Npm.depends({

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.0.16-rc.3"
+  version: "1.0.16"
 });
 
 Npm.depends({

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.5-rc.3',
+  version: '2.6.5',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.5-rc.0',
+  version: '2.6.5-rc.1',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.5-rc.1',
+  version: '2.6.5-rc.2',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.4',
+  version: '2.6.5-beta.0',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.5-rc.2',
+  version: '2.6.5-rc.3',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.6.5-beta.0',
+  version: '2.6.5-rc.0',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.5-rc.2'
+  version: '1.3.5-rc.3'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.5-1-rc.0'
+  version: '1.3.5-1-rc.1'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.5-rc.3'
+  version: '1.3.5'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.5-1-rc.1'
+  version: '1.3.5_1'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.5-rc.0'
+  version: '1.3.5-rc.1'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.4_4'
+  version: '1.3.5-beta.0'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.5-beta.0'
+  version: '1.3.5-rc.0'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.5-rc.1'
+  version: '1.3.5-rc.2'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.3.5'
+  version: '1.3.5-1-rc.0'
 });
 
 Package.includeTool();

--- a/packages/non-core/npm-bcrypt/.versions
+++ b/packages/non-core/npm-bcrypt/.versions
@@ -1,3 +1,3 @@
 meteor@1.1.16
-npm-bcrypt@0.8.6_2
+npm-bcrypt@0.8.6_3
 underscore@1.0.9

--- a/packages/non-core/npm-bcrypt/package.js
+++ b/packages/non-core/npm-bcrypt/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Wrapper around the bcrypt npm package",
-  version: '0.8.6_2',
+  version: '0.8.6_3',
   documentation: null
 });
 

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.12-beta.0',
+  version: '1.0.12-rc.0',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.12-rc.3',
+  version: '1.0.12',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.12-rc.0',
+  version: '1.0.12-rc.1',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.12-rc.1',
+  version: '1.0.12-rc.2',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.11',
+  version: '1.0.12-beta.0',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.12-rc.2',
+  version: '1.0.12-rc.3',
   // Brief, one-line summary of the package.
   summary: 'Define static page content in .html files',
   git: 'https://github.com/meteor/meteor',

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.5-rc.1"
+  version: "2.512.5-rc.2"
 });
 
 Package.registerBuildPlugin({

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.4"
+  version: "2.512.5-beta.0"
 });
 
 Package.registerBuildPlugin({

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.5-rc.3"
+  version: "2.512.5"
 });
 
 Package.registerBuildPlugin({

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.5-beta.0"
+  version: "2.512.5-rc.0"
 });
 
 Package.registerBuildPlugin({

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.5-rc.0"
+  version: "2.512.5-rc.1"
 });
 
 Package.registerBuildPlugin({

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.512.5-rc.2"
+  version: "2.512.5-rc.3"
 });
 
 Package.registerBuildPlugin({

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.14-rc.3'
+  version: '1.1.14'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.14-beta.0'
+  version: '1.1.14-rc.0'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.13'
+  version: '1.1.14-beta.0'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.14-rc.0'
+  version: '1.1.14-rc.1'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.14-rc.1'
+  version: '1.1.14-rc.2'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows templates to be defined in .html files",
-  version: '1.1.14-rc.2'
+  version: '1.1.14-rc.3'
 });
 
 // Today, this package is closely intertwined with Handlebars, meaning

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dependency tracker to allow reactive callbacks",
-  version: '1.0.15-rc.0'
+  version: '1.0.15-rc.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dependency tracker to allow reactive callbacks",
-  version: '1.0.15-rc.2'
+  version: '1.0.15-rc.3'
 });
 
 Package.onUse(function (api) {

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dependency tracker to allow reactive callbacks",
-  version: '1.0.15-rc.3'
+  version: '1.0.15'
 });
 
 Package.onUse(function (api) {

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dependency tracker to allow reactive callbacks",
-  version: '1.0.15-rc.1'
+  version: '1.0.15-rc.2'
 });
 
 Package.onUse(function (api) {

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dependency tracker to allow reactive callbacks",
-  version: '1.0.14'
+  version: '1.0.15-beta.0'
 });
 
 Package.onUse(function (api) {

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dependency tracker to allow reactive callbacks",
-  version: '1.0.15-beta.0'
+  version: '1.0.15-rc.0'
 });
 
 Package.onUse(function (api) {

--- a/packages/webapp/.npm/package/npm-shrinkwrap.json
+++ b/packages/webapp/.npm/package/npm-shrinkwrap.json
@@ -1,611 +1,455 @@
 {
   "dependencies": {
+    "accepts": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+      "from": "accepts@>=1.2.12 <1.3.0"
+    },
+    "base64-url": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz",
+      "from": "base64-url@1.2.2"
+    },
+    "basic-auth": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
+      "from": "basic-auth@>=1.0.3 <1.1.0"
+    },
+    "basic-auth-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+      "from": "basic-auth-connect@1.0.0"
+    },
+    "batch": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+      "from": "batch@0.5.3"
+    },
+    "body-parser": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
+      "from": "body-parser@>=1.13.3 <1.14.0"
+    },
+    "bytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+      "from": "bytes@2.1.0"
+    },
+    "compressible": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.8.tgz",
+      "from": "compressible@>=2.0.5 <2.1.0"
+    },
+    "compression": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
+      "from": "compression@>=1.5.2 <1.6.0"
+    },
     "connect": {
       "version": "2.30.2",
       "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
-      "from": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
+      "from": "connect@2.30.2"
+    },
+    "connect-timeout": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
+      "from": "connect-timeout@>=1.6.2 <1.7.0"
+    },
+    "content-type": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+      "from": "content-type@>=1.0.1 <1.1.0"
+    },
+    "cookie": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+      "from": "cookie@0.1.3"
+    },
+    "cookie-parser": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
+      "from": "cookie-parser@>=1.3.5 <1.4.0"
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "from": "cookie-signature@1.0.6"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "from": "core-util-is@>=1.0.0 <1.1.0"
+    },
+    "crc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
+      "from": "crc@3.3.0"
+    },
+    "csrf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.3.tgz",
+      "from": "csrf@>=3.0.0 <3.1.0"
+    },
+    "csurf": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
+      "from": "csurf@>=1.8.3 <1.9.0"
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "from": "debug@>=2.2.0 <2.3.0"
+    },
+    "depd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+      "from": "depd@>=1.0.1 <1.1.0"
+    },
+    "destroy": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
+      "from": "destroy@1.0.3"
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "from": "ee-first@1.1.1"
+    },
+    "errorhandler": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
+      "from": "errorhandler@>=1.4.2 <1.5.0",
       "dependencies": {
-        "basic-auth-connect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-          "from": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+        "accepts": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "from": "accepts@>=1.3.0 <1.4.0"
         },
-        "body-parser": {
-          "version": "1.13.3",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
-          "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
-          "dependencies": {
-            "iconv-lite": {
-              "version": "0.4.11",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
-            },
-            "on-finished": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "dependencies": {
-                "ee-first": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                }
-              }
-            },
-            "raw-body": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
-              "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
-              "dependencies": {
-                "bytes": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-                  "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
-                },
-                "iconv-lite": {
-                  "version": "0.4.13",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-                },
-                "unpipe": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "bytes": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-          "from": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
-        },
-        "compression": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
-          "from": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.2.13",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-              "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-              "dependencies": {
-                "mime-types": {
-                  "version": "2.1.9",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.21.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                    }
-                  }
-                },
-                "negotiator": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
-                }
-              }
-            },
-            "compressible": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz",
-              "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                }
-              }
-            },
-            "vary": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-              "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
-            }
-          }
-        },
-        "connect-timeout": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
-          "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            }
-          }
-        },
-        "content-type": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
-        },
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
-        },
-        "cookie-parser": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
-          "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz"
-        },
-        "cookie-signature": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-        },
-        "csurf": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
-          "from": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
-          "dependencies": {
-            "csrf": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.0.tgz",
-              "from": "https://registry.npmjs.org/csrf/-/csrf-3.0.0.tgz",
-              "dependencies": {
-                "base64-url": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-                  "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
-                },
-                "rndm": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz",
-                  "from": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz"
-                },
-                "scmp": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz",
-                  "from": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
-                },
-                "uid-safe": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
-                  "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            }
-          }
-        },
-        "depd": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
-        },
-        "errorhandler": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz",
-          "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.2.13",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-              "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-              "dependencies": {
-                "mime-types": {
-                  "version": "2.1.9",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.21.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                    }
-                  }
-                },
-                "negotiator": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
-                }
-              }
-            },
-            "escape-html": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
-            }
-          }
-        },
-        "express-session": {
-          "version": "1.11.3",
-          "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
-          "from": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
-          "dependencies": {
-            "crc": {
-              "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
-              "from": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz"
-            },
-            "uid-safe": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
-              "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
-              "dependencies": {
-                "base64-url": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-                  "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "finalhandler": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
-          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
-          "dependencies": {
-            "escape-html": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
-            },
-            "on-finished": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "dependencies": {
-                "ee-first": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                }
-              }
-            },
-            "unpipe": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-            }
-          }
-        },
-        "fresh": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "statuses": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
-            }
-          }
-        },
-        "method-override": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.5.tgz",
-          "from": "https://registry.npmjs.org/method-override/-/method-override-2.3.5.tgz",
-          "dependencies": {
-            "methods": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz",
-              "from": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
-            },
-            "vary": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-              "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
-            }
-          }
-        },
-        "morgan": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
-          "from": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
-          "dependencies": {
-            "basic-auth": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz",
-              "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
-            },
-            "on-finished": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "dependencies": {
-                "ee-first": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "multiparty": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
-          "from": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "stream-counter": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
-              "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
-            }
-          }
-        },
-        "on-headers": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-          "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
-        },
-        "pause": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
-          "from": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz"
-        },
-        "qs": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-          "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
-        },
-        "response-time": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz",
-          "from": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz"
-        },
-        "serve-favicon": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
-          "from": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
-          "dependencies": {
-            "etag": {
-              "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-              "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
-            },
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            }
-          }
-        },
-        "serve-index": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz",
-          "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.2.13",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-              "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-              "dependencies": {
-                "negotiator": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
-                }
-              }
-            },
-            "batch": {
-              "version": "0.5.2",
-              "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz",
-              "from": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
-            },
-            "escape-html": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "serve-static": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz",
-          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz",
-          "dependencies": {
-            "escape-html": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
-            }
-          }
-        },
-        "type-is": {
-          "version": "1.6.10",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz",
-          "dependencies": {
-            "media-typer": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "utils-merge": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-        },
-        "vhost": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
-          "from": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz"
+        "negotiator": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+          "from": "negotiator@0.6.1"
         }
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "from": "escape-html@>=1.0.3 <1.1.0"
+    },
+    "etag": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+      "from": "etag@>=1.7.0 <1.8.0"
+    },
+    "express-session": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
+      "from": "express-session@>=1.11.3 <1.12.0",
+      "dependencies": {
+        "base64-url": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+          "from": "base64-url@1.2.1"
+        },
+        "uid-safe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
+          "from": "uid-safe@>=2.0.0 <2.1.0"
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
+      "from": "finalhandler@0.4.0",
+      "dependencies": {
+        "escape-html": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
+          "from": "escape-html@1.0.2"
+        }
+      }
+    },
+    "fresh": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+      "from": "fresh@0.3.0"
+    },
+    "http-errors": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+      "from": "http-errors@>=1.3.1 <1.4.0"
+    },
+    "iconv-lite": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
+      "from": "iconv-lite@0.4.11"
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "from": "inherits@>=2.0.1 <2.1.0"
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "from": "isarray@0.0.1"
+    },
+    "lru-cache": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+      "from": "lru-cache@>=2.2.0 <2.3.0"
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "from": "media-typer@0.3.0"
+    },
+    "method-override": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.6.tgz",
+      "from": "method-override@>=2.3.5 <2.4.0",
+      "dependencies": {
+        "parseurl": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "from": "parseurl@>=1.3.1 <1.4.0"
+        },
+        "vary": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+          "from": "vary@>=1.1.0 <1.2.0"
+        }
+      }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "from": "methods@>=1.1.2 <1.2.0"
+    },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "from": "mime@1.3.4"
+    },
+    "mime-db": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+      "from": "mime-db@>=1.23.0 <1.24.0"
+    },
+    "mime-types": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+      "from": "mime-types@>=2.1.11 <2.2.0"
+    },
+    "morgan": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
+      "from": "morgan@>=1.6.1 <1.7.0"
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "from": "ms@0.7.1"
+    },
+    "multiparty": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+      "from": "multiparty@3.3.2"
+    },
+    "negotiator": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+      "from": "negotiator@0.5.3"
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "from": "on-finished@>=2.3.0 <2.4.0"
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "from": "on-headers@>=1.0.0 <1.1.0"
     },
     "parseurl": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
-      "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+      "from": "parseurl@1.3.0"
+    },
+    "pause": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
+      "from": "pause@0.1.0"
+    },
+    "qs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+      "from": "qs@4.0.0"
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "from": "random-bytes@>=1.0.0 <1.1.0"
+    },
+    "range-parser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+      "from": "range-parser@>=1.0.3 <1.1.0"
+    },
+    "raw-body": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+      "from": "raw-body@>=2.1.2 <2.2.0",
+      "dependencies": {
+        "bytes": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+          "from": "bytes@2.4.0"
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "from": "iconv-lite@0.4.13"
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "from": "readable-stream@>=1.1.9 <1.2.0"
+    },
+    "response-time": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz",
+      "from": "response-time@>=2.3.1 <2.4.0"
+    },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "from": "rndm@1.2.0"
     },
     "send": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
-      "from": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
+      "from": "send@0.13.0",
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "depd": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
-        },
-        "destroy": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
-          "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
-        },
         "escape-html": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
-        },
-        "etag": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-          "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
-        },
-        "fresh": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        },
-        "on-finished": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-          "dependencies": {
-            "ee-first": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-            }
-          }
-        },
-        "range-parser": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+          "from": "escape-html@1.0.2"
         },
         "statuses": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-          "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+          "from": "statuses@>=1.2.1 <1.3.0"
         }
       }
+    },
+    "serve-favicon": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
+      "from": "serve-favicon@>=2.3.0 <2.4.0"
+    },
+    "serve-index": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
+      "from": "serve-index@>=1.7.2 <1.8.0",
+      "dependencies": {
+        "parseurl": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "from": "parseurl@>=1.3.1 <1.4.0"
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+      "from": "serve-static@>=1.10.0 <1.11.0",
+      "dependencies": {
+        "depd": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "from": "depd@>=1.1.0 <1.2.0"
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+          "from": "destroy@>=1.0.4 <1.1.0"
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "from": "parseurl@>=1.3.1 <1.4.0"
+        },
+        "send": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+          "from": "send@0.13.2"
+        },
+        "statuses": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+          "from": "statuses@~1.2.1"
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+      "from": "statuses@>=1.0.0 <2.0.0"
+    },
+    "stream-counter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+      "from": "stream-counter@>=0.2.0 <0.3.0"
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "from": "string_decoder@>=0.10.0 <0.11.0"
+    },
+    "tsscmp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
+      "from": "tsscmp@1.0.5"
+    },
+    "type-is": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+      "from": "type-is@>=1.6.6 <1.7.0"
+    },
+    "uid-safe": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.1.tgz",
+      "from": "uid-safe@2.1.1"
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "from": "unpipe@1.0.0"
     },
     "useragent": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.7.tgz",
-      "from": "https://registry.npmjs.org/useragent/-/useragent-2.0.7.tgz",
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
-        }
-      }
+      "from": "useragent@2.0.7"
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "from": "utils-merge@1.0.0"
+    },
+    "vary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+      "from": "vary@>=1.0.1 <1.1.0"
+    },
+    "vhost": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
+      "from": "vhost@>=3.0.1 <3.1.0"
     }
   }
 }

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.2.11-rc.2'
+  version: '1.2.11-rc.3'
 });
 
 Npm.depends({connect: "2.30.2",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.2.11-rc.3'
+  version: '1.2.11'
 });
 
 Npm.depends({connect: "2.30.2",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.2.11-beta.0'
+  version: '1.2.11-rc.0'
 });
 
 Npm.depends({connect: "2.30.2",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.2.10'
+  version: '1.2.11-beta.0'
 });
 
 Npm.depends({connect: "2.30.2",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.2.11-rc.1'
+  version: '1.2.11-rc.2'
 });
 
 Npm.depends({connect: "2.30.2",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.2.11-rc.0'
+  version: '1.2.11-rc.1'
 });
 
 Npm.depends({connect: "2.30.2",

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.5-beta.0",
+ "version": "1.3.5-rc.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.5-rc.3",
+ "version": "1.3.5.1-rc.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.5.1-rc.0",
+ "version": "1.3.5.1-rc.1",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.5-rc.1",
+ "version": "1.3.5-rc.2",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.5-rc.2",
+ "version": "1.3.5-rc.3",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.4.4-rc.0",
+ "version": "1.3.5-beta.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.3.5-rc.0",
+ "version": "1.3.5-rc.1",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.3.5",
+  "version": "1.3.5.1",
   "recommended": false,
   "official": true,
   "description": "The Official Meteor Distribution"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.3.4.4",
+  "version": "1.3.5",
   "recommended": false,
   "official": true,
   "description": "The Official Meteor Distribution"

--- a/scripts/admin/publish-meteor-tool.bat
+++ b/scripts/admin/publish-meteor-tool.bat
@@ -22,7 +22,7 @@ REM GITSHA is replaced by the script transferring this file
 C:\git\bin\git.exe checkout $GITSHA
 
 REM install 7-zip, required for running meteor from checkout
-C:\git\bin\curl -L http://downloads.sourceforge.net/sevenzip/7z920.msi ^> C:\7z.msi
+C:\git\bin\curl -L http://www.7-zip.org/a/7z1602.msi ^> C:\7z.msi
 msiexec /i C:\7z.msi /quiet /qn /norestart
 set PATH=^%PATH^%;"C:\Program Files\7-Zip"
 REM wait 3 seconds to avoid races with the 7-zip installation

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -54,7 +54,8 @@ var packageJson = {
     runas: "3.1.1",
     'lru-cache': '2.6.4',
     'cordova-lib': "6.0.0",
-    longjohn: '0.2.11'
+    longjohn: '0.2.11',
+    'stream-buffers': '3.0.0'
   }
 };
 

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -1,6 +1,7 @@
 // Note that this file is required before we install our Babel hooks in
 // ../tool-env/install-babel.js, so we can't use ES2015+ syntax here.
 
+var path = require("path");
 var win32Extensions = {
   node: ".exe",
   npm: ".cmd"
@@ -24,11 +25,12 @@ function getChildProcess() {
   }
 
   return Promise.all([
-    helpers.getCommandPath(devBundleBinCommand),
+    helpers.getDevBundle(),
     helpers.getEnv()
-  ]).then(function (cmdAndEnv) {
-    var cmd = cmdAndEnv[0];
-    var env = cmdAndEnv[1];
+  ]).then(function (devBundleAndEnv) {
+    var devBundleDir = devBundleAndEnv[0];
+    var cmd = path.join(devBundleDir, "bin", devBundleBinCommand);
+    var env = devBundleAndEnv[1];
     var child = require("child_process").spawn(cmd, args, {
       stdio: "inherit",
       env: env

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -36,6 +36,10 @@ function getChildProcess() {
 
     require("./flush-buffers-on-exit-in-windows.js");
 
+    child.on("error", function (error) {
+      console.log(error.stack || error);
+    });
+
     child.on("exit", function (exitCode) {
       process.exit(exitCode);
     });

--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -34,17 +34,67 @@ exports.getEnv = function() {
     env.PATH = paths.join(path.delimiter);
 
     if (process.platform === "win32") {
-      // On Windows we provide a reliable version of python.exe for use by
-      // node-gyp (the tool that rebuilds binary node modules). #WinPy
-      env.PYTHON = env.PYTHON || path.join(
-        devBundleDir, "python", "python.exe");
-
-      // While the original process.env object allows for case insensitive
-      // access on Windows, Object.create interferes with that behavior,
-      // so here we ensure env.PATH === env.Path on Windows.
-      env.Path = env.PATH;
+      return addWindowsVariables(devBundleDir, env);
     }
 
     return env;
   });
 };
+
+// Caching env.GYP_MSVS_VERSION allows us to avoid invoking Python every
+// time Meteor runs an npm command. TODO Store this on disk?
+var cachedMSVSVersion;
+
+function addWindowsVariables(devBundleDir, env) {
+  // On Windows we provide a reliable version of python.exe for use by
+  // node-gyp (the tool that rebuilds binary node modules). #WinPy
+  env.PYTHON = env.PYTHON || path.join(
+    devBundleDir, "python", "python.exe");
+
+  // While the original process.env object allows for case insensitive
+  // access on Windows, Object.create interferes with that behavior,
+  // so here we ensure env.PATH === env.Path on Windows.
+  env.Path = env.PATH;
+
+  if (cachedMSVSVersion) {
+    env.GYP_MSVS_VERSION = cachedMSVSVersion;
+  }
+
+  if (env.GYP_MSVS_VERSION) {
+    return Promise.resolve(env);
+  }
+
+  // If $GYP_MSVS_VERSION was not provided, use the gyp Python library to
+  // infer it, or default to 2015 if that doesn't work.
+  return new Promise(function (resolve) {
+    var nodeGypPylibDir = path.join(
+      devBundleDir, "lib", "node_modules", "node-gyp", "gyp", "pylib"
+    );
+
+    var child = require("child_process").spawn(env.PYTHON, ["-c", [
+      "from gyp.MSVSVersion import SelectVisualStudioVersion",
+      "try:",
+      "  print SelectVisualStudioVersion(allow_fallback=False).short_name",
+      "except:",
+      "  print 2015"
+    ].join("\n")], {
+      env: env,
+      cwd: nodeGypPylibDir,
+      stdio: "pipe"
+    });
+
+    var chunks = [];
+    child.stdout.on("data", function (chunk) {
+      chunks.push(chunk.toString("utf8"));
+    });
+
+    function finish(codeOrError) {
+      env.GYP_MSVS_VERSION = cachedMSVSVersion =
+        codeOrError ? "2015" : chunks.join("").replace(/^\s+|\s+$/g, "");
+      resolve(env);
+    }
+
+    child.on("error", finish);
+    child.on("exit", finish);
+  });
+}

--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -84,12 +84,20 @@ function addWindowsVariables(devBundleDir, env) {
 
     var chunks = [];
     child.stdout.on("data", function (chunk) {
-      chunks.push(chunk.toString("utf8"));
+      chunks.push(chunk);
     });
 
     function finish(codeOrError) {
-      env.GYP_MSVS_VERSION = cachedMSVSVersion =
-        codeOrError ? "2015" : chunks.join("").replace(/^\s+|\s+$/g, "");
+      if (codeOrError) {
+        // In the event of any kind of error, default to 2015.
+        cachedMSVSVersion = "2015";
+      } else {
+        cachedMSVSVersion = Buffer.concat(chunks)
+          .toString("utf8").replace(/^\s+|\s+$/g, "");
+      }
+
+      env.GYP_MSVS_VERSION = cachedMSVSVersion;
+
       resolve(env);
     }
 

--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -78,7 +78,6 @@ function addWindowsVariables(devBundleDir, env) {
       "except:",
       "  print 2015"
     ].join("\n")], {
-      env: env,
       cwd: nodeGypPylibDir,
       stdio: "pipe"
     });

--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -39,10 +39,6 @@ exports.getEnv = function() {
       env.PYTHON = env.PYTHON || path.join(
         devBundleDir, "python", "python.exe");
 
-      // We don't try to install a compiler toolchain on the developer's
-      // behalf, but setting GYP_MSVS_VERSION helps select the right one.
-      env.GYP_MSVS_VERSION = env.GYP_MSVS_VERSION || "2015";
-
       // While the original process.env object allows for case insensitive
       // access on Windows, Object.create interferes with that behavior,
       // so here we ensure env.PATH === env.Path on Windows.

--- a/tools/cli/dev-bundle-links.js
+++ b/tools/cli/dev-bundle-links.js
@@ -22,6 +22,7 @@ exports.makeLink = function (target, linkPath) {
   }
 };
 
+// Note: this function returns an OS-specific path!
 exports.readLink = function (linkPath) {
   linkPath = files.convertToOSPath(linkPath);
 
@@ -32,5 +33,5 @@ exports.readLink = function (linkPath) {
     linkPath = fs.readFileSync(linkPath, "utf8");
   }
 
-  return files.convertToStandardPath(linkPath);
+  return linkPath;
 };

--- a/tools/cli/dev-bundle-links.js
+++ b/tools/cli/dev-bundle-links.js
@@ -13,7 +13,13 @@ exports.makeLink = function (target, linkPath) {
     fs.writeFileSync(tempPath, target, "utf8");
   }
 
-  fs.renameSync(tempPath, linkPath);
+  try {
+    fs.renameSync(tempPath, linkPath);
+  } catch (e) {
+    // If renaming fails, try unlinking first.
+    fs.unlinkSync(linkPath);
+    fs.renameSync(tempPath, linkPath);
+  }
 };
 
 exports.readLink = function (linkPath) {

--- a/tools/cli/dev-bundle.js
+++ b/tools/cli/dev-bundle.js
@@ -106,26 +106,31 @@ function getDevBundleForRelease(release) {
       "SELECT content FROM releaseVersions WHERE track=? AND version=?",
       [track, version],
       function (error, data) {
-        if (error) {
-          reject(error);
-        } else {
-          var tool = JSON.parse(data.content).tool;
-          var devBundleDir = path.join(
-            meteorToolDir,
-            tool.split("@").slice(1).join("@"),
-            "mt-" + getHostArch(),
-            "dev_bundle"
-          );
-
-          var devBundleStat = statOrNull(devBundleDir, "isDirectory");
-          if (devBundleStat) {
-            resolve(devBundleDir);
-          } else {
-            resolve(null);
-          }
-        }
+        error ? reject(error) : resolve(data);
       }
     );
+
+  }).then(function (data) {
+    if (data) {
+      var tool = JSON.parse(data.content).tool;
+      var devBundleDir = path.join(
+        meteorToolDir,
+        tool.split("@").slice(1).join("@"),
+        "mt-" + getHostArch(),
+        "dev_bundle"
+      );
+
+      var devBundleStat = statOrNull(devBundleDir, "isDirectory");
+      if (devBundleStat) {
+        return devBundleDir;
+      }
+    }
+
+    return null;
+
+  }).catch(function (error) {
+    console.error(error.stack || error);
+    return null;
   });
 }
 

--- a/tools/cli/dev-bundle.js
+++ b/tools/cli/dev-bundle.js
@@ -198,4 +198,6 @@ function getHostArch() {
   }
 }
 
-module.exports = getDevBundleDir();
+module.exports = getDevBundleDir().catch(function (error) {
+  return defaultDevBundlePromise;
+});

--- a/tools/cli/dev-bundle.js
+++ b/tools/cli/dev-bundle.js
@@ -27,11 +27,12 @@ function getDevBundleDir() {
     return defaultDevBundlePromise;
   }
 
-  var devBundleLink = path.join(
-    path.dirname(releaseFile),
-    "dev_bundle"
-  );
+  var localDir = path.join(path.dirname(releaseFile), "local");
+  if (! statOrNull(localDir, "isDirectory")) {
+    return defaultDevBundlePromise;
+  }
 
+  var devBundleLink = path.join(localDir, "dev_bundle");
   var devBundleStat = statOrNull(devBundleLink);
   if (devBundleStat) {
     return new Promise(function (resolve) {

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -836,9 +836,14 @@ files.renameDirAlmostAtomically = Profile("files.renameDirAlmostAtomically",
                                           files.renameDirAlmostAtomically);
 
 files.writeFileAtomically = function (filename, contents) {
-  var tmpFile = files.pathJoin(
-    files.pathDirname(filename),
-    '.' + files.pathBasename(filename) + '.' + utils.randomToken());
+  const parentDir = files.pathDirname(filename);
+  files.mkdir_p(parentDir);
+
+  const tmpFile = files.pathJoin(
+    parentDir,
+    '.' + files.pathBasename(filename) + '.' + utils.randomToken()
+  );
+
   files.writeFile(tmpFile, contents);
   files.rename(tmpFile, filename);
 };

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2149,6 +2149,7 @@ class ServerTarget extends JsImageTarget {
       "mini-files.js",
       "npm-require.js",
       "npm-rebuild.js",
+      "npm-rebuild-args.js",
     ], function (filename) {
       builder.write(filename, {
         file: files.pathJoin(

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1953,6 +1953,9 @@ class JsImage {
 
     ret.arch = json.arch;
 
+    // Rebuild binary npm packages if unibuild arch matches host arch.
+    const rebuildBinaries = archinfo.matches(archinfo.host(), ret.arch);
+
     _.each(json.load, function (item) {
       rejectBadPath(item.path);
 
@@ -1962,7 +1965,8 @@ class JsImage {
           ret.nodeModulesDirectories,
           nodeModulesDirectories =
             NodeModulesDirectory.readDirsFromJSON(item.node_modules, {
-              sourceRoot: dir
+              sourceRoot: dir,
+              rebuildBinaries,
             })
         );
       }

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1953,7 +1953,7 @@ class JsImage {
 
     ret.arch = json.arch;
 
-    // Rebuild binary npm packages if unibuild arch matches host arch.
+    // Rebuild binary npm packages if host arch matches image arch.
     const rebuildBinaries = archinfo.matches(archinfo.host(), ret.arch);
 
     _.each(json.load, function (item) {

--- a/tools/isobuild/isopack.js
+++ b/tools/isobuild/isopack.js
@@ -1085,13 +1085,17 @@ _.extend(Isopack.prototype, {
         }
       });
 
+      // Rebuild binary npm packages if unibuild arch matches host arch.
+      const rebuildBinaries = archinfo.matches(
+        archinfo.host(),
+        unibuildMeta.arch
+      );
+
       const nodeModulesDirectories = bundler.NodeModulesDirectory
         .readDirsFromJSON(unibuildJson.node_modules, {
           packageName: self.name,
           sourceRoot: unibuildBasePath,
-          // Rebuild binaries if unibuild arch matches host arch.
-          rebuildBinaries: archinfo.matches(
-            archinfo.host(), unibuildMeta.arch)
+          rebuildBinaries,
         });
 
       self.unibuilds.push(new Unibuild(self, {

--- a/tools/isobuild/meteor-npm-userconfig
+++ b/tools/isobuild/meteor-npm-userconfig
@@ -5,3 +5,4 @@
 # and we certainly don't want them to obscure actual errors.
 
 loglevel = error
+progress = false

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -542,16 +542,14 @@ const npmUserConfigFile = files.pathJoin(
 
 var runNpmCommand = meteorNpm.runNpmCommand =
 Profile("meteorNpm.runNpmCommand", function (args, cwd) {
-  const nodeBinDir = files.getCurrentNodeBinDir();
-  const isWindows = process.platform === "win32";
-  var npmPath;
+  import { getEnv } from "../cli/dev-bundle-bin-helpers.js";
 
-  if (isWindows) {
-    npmPath = files.convertToOSPath(
-      files.pathJoin(nodeBinDir, "npm.cmd"));
-  } else {
-    npmPath = files.pathJoin(nodeBinDir, "npm");
-  }
+  const devBundleDir = files.getDevBundle();
+  const isWindows = process.platform === "win32";
+  const npmPath = files.convertToOSPath(files.pathJoin(
+    devBundleDir, "bin",
+    isWindows ? "npm.cmd" : "npm"
+  ));
 
   if (meteorNpm._printNpmCalls) {
     // only used by test-bundler.js
@@ -559,21 +557,20 @@ Profile("meteorNpm.runNpmCommand", function (args, cwd) {
                          args.join(' ') + ' ...\n');
   }
 
-  if (cwd) {
-    cwd = files.convertToOSPath(cwd);
-  }
-
-  var getEnv = require("../cli/dev-bundle-bin-helpers.js").getEnv;
-
-  return getEnv().then(env => {
-    // Make sure we don't honor any user-provided configuration files.
-    env.npm_config_userconfig = npmUserConfigFile;
-
-    var opts = {
-      cwd: cwd,
+  return getEnv({
+    devBundle: devBundleDir
+  }).then(env => {
+    const opts = {
       env: env,
       maxBuffer: 10 * 1024 * 1024
     };
+
+    if (cwd) {
+      opts.cwd = files.convertToOSPath(cwd);
+    }
+
+    // Make sure we don't honor any user-provided configuration files.
+    env.npm_config_userconfig = npmUserConfigFile;
 
     return new Promise(function (resolve) {
       require('child_process').execFile(
@@ -591,6 +588,7 @@ Profile("meteorNpm.runNpmCommand", function (args, cwd) {
         }
       );
     });
+
   }).await();
 });
 

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -780,8 +780,21 @@ var installFromShrinkwrap = function (dir) {
 
   ensureConnected();
 
+  const tempPkgJsonPath = files.pathJoin(dir, "package.json");
+  const pkgJsonExisted = files.exists(tempPkgJsonPath);
+  if (! pkgJsonExisted) {
+    // Writing an empty package.json file prevents ENOENT warnings about
+    // package.json not existing, which are noisy at best and sometimes
+    // seem to interfere with the install.
+    files.writeFile(tempPkgJsonPath, "{}\n", "utf8");
+  }
+
   // `npm install`, which reads npm-shrinkwrap.json.
   var result = runNpmCommand(["install"], dir);
+
+  if (! pkgJsonExisted) {
+    files.rm_recursive(tempPkgJsonPath);
+  }
 
   if (! result.success) {
     buildmessage.error(`couldn't install npm packages from npm-shrinkwrap: ${result.error}`);

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -119,9 +119,22 @@ meteorNpm.updateDependencies = function (packageName,
 // Returns a flattened list of npm package names used in production.
 meteorNpm.getProdPackageNames = function (nodeModulesDir) {
   var names = Object.create(null);
-  var lsResult = runNpmCommand([
-    "ls", "--json", "--production"
-  ], nodeModulesDir);
+  var lsCmdArgs = ["ls", "--json"];
+
+  const packageJsonPath = files.pathJoin(
+    files.pathDirname(nodeModulesDir),
+    "package.json"
+  );
+
+  const packageJsonStat = files.statOrNull(packageJsonPath);
+  if (packageJsonStat &&
+      packageJsonStat.isFile()) {
+    // If there is no package.json file, adding --production will cause
+    // the names object to be empty, which is not what we want.
+    lsCmdArgs.push("--production");
+  }
+
+  var lsResult = runNpmCommand(lsCmdArgs, nodeModulesDir);
 
   function walk(deps) {
     if (! deps) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -15,6 +15,9 @@ var utils = require('../utils/utils.js');
 var runLog = require('../runners/run-log.js');
 var Profile = require('../tool-env/profile.js').Profile;
 import { execFileAsync } from "../utils/processes.js";
+import {
+  get as getRebuildArgs
+} from "../static-assets/server/npm-rebuild-args.js";
 
 var meteorNpm = exports;
 
@@ -235,7 +238,7 @@ Profile("meteorNpm.rebuildIfNonPortable", function (nodeModulesDir) {
 
   // The `npm rebuild` command must be run in the parent directory of the
   // relevant node_modules directory, which in this case is tempDir.
-  const rebuildResult = runNpmCommand(["rebuild"], tempDir);
+  const rebuildResult = runNpmCommand(getRebuildArgs(), tempDir);
   if (! rebuildResult.success) {
     buildmessage.error(rebuildResult.error);
     files.rm_recursive(tempDir);

--- a/tools/packaging/tropohouse.js
+++ b/tools/packaging/tropohouse.js
@@ -304,7 +304,7 @@ _.extend(exports.Tropohouse.prototype, {
     // it relies on extractTarGz being fast and not reporting any progress.
     // Really, we should create two subtasks
     // (and, we should stream the download to the tar extractor)
-    var packageTarball = httpHelpers.getUrl({
+    var packageTarball = httpHelpers.getUrlWithResuming({
       url: url,
       encoding: null,
       progress: buildmessage.getCurrentProgressTracker(),

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1427,7 +1427,9 @@ _.extend(exports.ReleaseFile.prototype, {
     const newTarget = this.getDevBundle();
 
     try {
-      if (newTarget === readLink(devBundleLink)) {
+      const oldOSPath = readLink(devBundleLink);
+      const oldTarget = files.convertToStandardPath(oldOSPath);
+      if (newTarget === oldTarget) {
         // Don't touch .meteor/local/dev_bundle if it already points to
         // the right target path.
         return;

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1402,33 +1402,34 @@ _.extend(exports.ReleaseFile.prototype, {
     return files.realpath(devBundle);
   },
 
+  // Make a symlink from .meteor/local/dev_bundle to the actual dev_bundle.
   ensureDevBundleLink() {
     import { makeLink, readLink } from "./cli/dev-bundle-links.js";
 
-    // Make a symlink from .meteor/dev_bundle to the actual dev_bundle.
-    const devBundleLink = files.pathJoin(
-      files.pathDirname(this.filename),
-      "dev_bundle"
-    );
+    const dotMeteorDir = files.pathDirname(this.filename);
+    const localDir = files.pathJoin(dotMeteorDir, "local");
+    const devBundleLink = files.pathJoin(localDir, "dev_bundle");
 
     if (this.isCheckout()) {
-      // Only create the .meteor/dev_bundle symlink if .meteor/release
-      // refers to an actual release, and remove it otherwise.
+      // Only create .meteor/local/dev_bundle if .meteor/release refers to
+      // an actual release, and remove it otherwise.
       files.rm_recursive(devBundleLink);
       return;
     }
 
     if (files.inCheckout()) {
-      // Never update .meteor/dev_bundle to point to a checkout.
+      // Never update .meteor/local/dev_bundle to point to a checkout.
       return;
     }
+
+    files.mkdir_p(localDir);
 
     const newTarget = this.getDevBundle();
 
     try {
       if (newTarget === readLink(devBundleLink)) {
-        // Don't touch .meteor/dev_bundle if it already points to the
-        // right target path.
+        // Don't touch .meteor/local/dev_bundle if it already points to
+        // the right target path.
         return;
       }
 

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -315,7 +315,8 @@ _.extend(ProjectContext.prototype, {
 
       // Read .meteor/release.
       self.releaseFile = new exports.ReleaseFile({
-        projectDir: self.projectDir
+        projectDir: self.projectDir,
+        catalog: self._officialCatalog,
       });
       if (buildmessage.jobHasMessages())
         return;
@@ -1282,6 +1283,8 @@ exports.ReleaseFile = function (options) {
   var self = this;
 
   self.filename = files.pathJoin(options.projectDir, '.meteor', 'release');
+  self.catalog = options.catalog || catalog.official;
+
   self.watchSet = null;
   // The release name actually written in the file.  Null if no fill.  Empty if
   // the file is empty.
@@ -1347,6 +1350,29 @@ _.extend(exports.ReleaseFile.prototype, {
     self.ensureDevBundleLink();
   },
 
+  // Returns an absolute path to the dev_bundle appropriate for the
+  // release specified in the .meteor/release file.
+  getDevBundle() {
+    let devBundle = files.getDevBundle();
+    const devBundleParts = devBundle.split(files.pathSep);
+    const meteorToolIndex = devBundleParts.lastIndexOf("meteor-tool");
+
+    if (meteorToolIndex >= 0) {
+      const releaseVersion = this.catalog.getReleaseVersion(
+        this.releaseTrack,
+        this.releaseVersion
+      );
+
+      if (releaseVersion) {
+        const meteorToolVersion = releaseVersion.tool.split("@").pop();
+        devBundleParts[meteorToolIndex + 1] = meteorToolVersion;
+        devBundle = devBundleParts.join(files.pathSep);
+      }
+    }
+
+    return files.realpath(devBundle);
+  },
+
   ensureDevBundleLink() {
     import { makeLink, readLink } from "./cli/dev-bundle-links.js";
 
@@ -1368,7 +1394,7 @@ _.extend(exports.ReleaseFile.prototype, {
       return;
     }
 
-    const newTarget = files.realpath(files.getDevBundle());
+    const newTarget = this.getDevBundle();
 
     try {
       if (newTarget === readLink(devBundleLink)) {

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -226,7 +226,7 @@ _.extend(ProjectContext.prototype, {
     // calls to the constraint solver, the constraint solver can be
     // more efficient by caching or memoizing its work.  We choose not
     // to reset this when reset() is called more than once.
-    self._resolverResultCache = (self._resolverResultCache || {});
+    self._readResolverResultCache();
   },
 
   readProjectMetadata: function () {
@@ -575,10 +575,39 @@ _.extend(ProjectContext.prototype, {
           anticipatedPrereleases: anticipatedPrereleases
         });
 
+        self._saveResolverResultCache();
+
         self._completedStage = STAGE.RESOLVE_CONSTRAINTS;
       });
     });
   }),
+
+  _readResolverResultCache() {
+    if (! this._resolverResultCache) {
+      try {
+        this._resolverResultCache =
+          JSON.parse(files.readFile(files.pathJoin(
+            this.projectLocalDir,
+            "resolver-result-cache.json"
+          )));
+      } catch (e) {
+        if (e.code !== "ENOENT") throw e;
+        this._resolverResultCache = {};
+      }
+    }
+
+    return this._resolverResultCache;
+  },
+
+  _saveResolverResultCache() {
+    files.writeFileAtomically(
+      files.pathJoin(
+        this.projectLocalDir,
+        "resolver-result-cache.json"
+      ),
+      JSON.stringify(this._resolverResultCache) + "\n"
+    );
+  },
 
   // When running test-packages for an app with local packages, this
   // method will return the original app dir, as opposed to the temporary

--- a/tools/static-assets/server/npm-rebuild-args.js
+++ b/tools/static-assets/server/npm-rebuild-args.js
@@ -17,7 +17,12 @@ var args = [
 // environment variable.
 var flags = process.env.METEOR_NPM_REBUILD_FLAGS;
 if (flags) {
-  args.push.apply(args, flags.split(/\s+/g));
+  args = ["rebuild"];
+  flags.split(/\s+/g).forEach(function (flag) {
+    if (flag) {
+      args.push(flag);
+    }
+  });
 }
 
 exports.get = function () {

--- a/tools/static-assets/server/npm-rebuild-args.js
+++ b/tools/static-assets/server/npm-rebuild-args.js
@@ -2,6 +2,11 @@
 var args = [
   "rebuild",
 
+  // The --no-bin-links flag tells npm not to create symlinks in the
+  // node_modules/.bin/ directory when rebuilding packages, which helps
+  // avoid problems like https://github.com/meteor/meteor/issues/7401.
+  "--no-bin-links",
+
   // The --update-binary flag tells node-pre-gyp to replace previously
   // installed local binaries with remote binaries:
   // https://github.com/mapbox/node-pre-gyp#options

--- a/tools/static-assets/server/npm-rebuild-args.js
+++ b/tools/static-assets/server/npm-rebuild-args.js
@@ -13,6 +13,13 @@ var args = [
   "--update-binary"
 ];
 
+// Allow additional flags to be passed via the $METEOR_NPM_REBUILD_FLAGS
+// environment variable.
+var flags = process.env.METEOR_NPM_REBUILD_FLAGS;
+if (flags) {
+  args.push.apply(args, flags.split(/\s+/g));
+}
+
 exports.get = function () {
   // Make a defensive copy.
   return args.slice(0);

--- a/tools/static-assets/server/npm-rebuild-args.js
+++ b/tools/static-assets/server/npm-rebuild-args.js
@@ -1,0 +1,14 @@
+// Command-line arguments passed to npm when rebuilding binary packages.
+var args = [
+  "rebuild",
+
+  // The --update-binary flag tells node-pre-gyp to replace previously
+  // installed local binaries with remote binaries:
+  // https://github.com/mapbox/node-pre-gyp#options
+  "--update-binary"
+];
+
+exports.get = function () {
+  // Make a defensive copy.
+  return args.slice(0);
+};

--- a/tools/static-assets/server/npm-rebuild.js
+++ b/tools/static-assets/server/npm-rebuild.js
@@ -40,7 +40,10 @@ function rebuild(i) {
     return;
   }
 
-  spawn("npm", ["rebuild"], {
+  // The --update-binary flag tells node-pre-gyp to replace previously
+  // installed local binaries with remote binaries:
+  // https://github.com/mapbox/node-pre-gyp#options
+  spawn("npm", ["rebuild", "--update-binary"], {
     cwd: path.join(__dirname, dir),
     stdio: "inherit",
     env: env

--- a/tools/static-assets/server/npm-rebuild.js
+++ b/tools/static-assets/server/npm-rebuild.js
@@ -7,6 +7,7 @@ if (process.env.METEOR_SKIP_NPM_REBUILD) {
 
 var path = require("path");
 var spawn = require("child_process").spawn;
+var rebuildArgs = require("./npm-rebuild-args.js").get();
 
 try {
   // This JSON file gets written in meteor/tools/isobuild/bundler.js.
@@ -40,10 +41,7 @@ function rebuild(i) {
     return;
   }
 
-  // The --update-binary flag tells node-pre-gyp to replace previously
-  // installed local binaries with remote binaries:
-  // https://github.com/mapbox/node-pre-gyp#options
-  spawn("npm", ["rebuild", "--update-binary"], {
+  spawn("npm", rebuildArgs, {
     cwd: path.join(__dirname, dir),
     stdio: "inherit",
     env: env

--- a/tools/tests/autoupdate.js
+++ b/tools/tests/autoupdate.js
@@ -56,9 +56,13 @@ selftest.define("autoupdate", ['checkout', 'custom-warehouse'], function () {
 
     // Run it and see the banner for the current version.
     run = s.run("--port", "21000");
-    run.waitSecs(30);
-    run.match("New hotness v2 being downloaded");
-    run.match("running at");
+    run.waitSecs(60);
+    var runningHotnessPattern = /running at|New hotness v2 being downloaded/;
+    // We're not sure in which order these messages will arrive, but we
+    // expect to see them both (and we're not worried about either message
+    // being printed more than once).
+    run.match(runningHotnessPattern);
+    run.match(runningHotnessPattern);
     require('../utils/utils.js').sleepMs(500);
     run.stop();
 

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -409,10 +409,12 @@ selftest.define("'meteor run --port' accepts/rejects proper values", function ()
   run.expectExit(1);
 
   run = s.run("run", "--port", "3500");
+  run.waitSecs(30);
   run.match('App running at: http://localhost:3500/');
   run.stop();
 
   run = s.run("run", "--port", "127.0.0.1:3500");
+  run.waitSecs(30);
   run.match('App running at: http://127.0.0.1:3500/');
   run.stop();
 });

--- a/tools/tests/test-modes.js
+++ b/tools/tests/test-modes.js
@@ -14,17 +14,17 @@ selftest.define("'meteor test --port' accepts/rejects proper values", function (
   runAddPackage.expectExit(0);
 
   run = s.run("test", "--port", "3700", "--driver-package", "practicalmeteor:mocha");
-  run.waitSecs(60);
+  run.waitSecs(120);
   run.match('App running at: http://localhost:3700/');
   run.stop();
 
   run = s.run("test", "--port", "127.0.0.1:3700", "--driver-package", "practicalmeteor:mocha");
-  run.waitSecs(60);
+  run.waitSecs(120);
   run.match('App running at: http://127.0.0.1:3700/');
   run.stop();
   
   run = s.run("test", "--port", "[::]:3700", "--driver-package", "practicalmeteor:mocha");
-  run.waitSecs(60);
+  run.waitSecs(120);
   run.match('App running at: http://[::]:3700/');
   run.stop();
 });

--- a/tools/tests/utils-tests.js
+++ b/tools/tests/utils-tests.js
@@ -160,11 +160,6 @@ selftest.define("resume downloads", ['net', 'slow'], function () {
   // and that we know the size of
   const url = 'http://warehouse.meteor.com/builds/Pr7L8f6PqXyqNJJn4/1443478653127/aRiirNrp4v/meteor-tool-1.1.9-os.osx.x86_64+web.browser+web.cordova.tgz';
 
-  setTimeout(() => {
-    httpHelpers._currentRequest.emit('error', 'pretend-http-error');
-    httpHelpers._currentRequest.emit('end');
-  }, 1000);
-
   const result = httpHelpers.getUrlWithResuming({
     // This doesn't affect the test, but if you remove the timeout above,
     // you can kill the connection manually by shutting down your network.
@@ -182,6 +177,12 @@ selftest.define("resume downloads", ['net', 'slow'], function () {
         }
       },
       reportProgressDone() {}
+    },
+    onRequest(request) {
+      setTimeout(() => {
+        request.emit('error', 'pretend-http-error');
+        request.emit('end');
+      }, 1000);
     }
   });
 

--- a/tools/tests/utils-tests.js
+++ b/tools/tests/utils-tests.js
@@ -152,3 +152,30 @@ selftest.define("parse url", function () {
     protocol: "https"
   });
 });
+
+// XXX: WIP -- I'm not sure how to properly test a failed connection.
+// At the moment, I'm thinking I'll just mark this test as "don't run"
+// and use it by hand for testing (which basically means run it, kill my
+// internet, start my internet again, watch what happens)
+selftest.define("resume downloads", function () {
+  const url = 'http://warehouse.meteor.com/builds/Pr7L8f6PqXyqNJJn4/1443478653127/aRiirNrp4v/meteor-tool-1.1.9-os.osx.x86_64+web.browser+web.cordova.tgz';
+
+  const result = require('../utils/http-helpers').getUrlWithResuming({
+    timeout: 1000,
+    url: url,
+    encoding: null,
+    wait: false,
+    progress: {
+      reportProgress({ current, end }) {
+        const percent = current / end * 100;
+        if (Math.random() < 0.1) {
+          console.log(`${percent} %`);
+        }
+      },
+      reportProgressDone() {
+        console.log('done');
+      }
+    }
+  });
+  console.log(result, result.toString().length)
+});

--- a/tools/tests/utils-tests.js
+++ b/tools/tests/utils-tests.js
@@ -1,6 +1,8 @@
 var selftest = require('../tool-testing/selftest.js');
 var utils = require('../utils/utils.js');
 
+import httpHelpers from '../utils/http-helpers';
+
 selftest.define('subset generator', function () {
   var out = [];
   utils.generateSubsetsOfIncreasingSize(['a', 'b', 'c'], function (x) {
@@ -157,9 +159,6 @@ selftest.define("resume downloads", ['net', 'slow'], function () {
   // A reasonably big file that (I think) should take more than 1s to download
   // and that we know the size of
   const url = 'http://warehouse.meteor.com/builds/Pr7L8f6PqXyqNJJn4/1443478653127/aRiirNrp4v/meteor-tool-1.1.9-os.osx.x86_64+web.browser+web.cordova.tgz';
-
-  let firstPass = true;
-  const httpHelpers = require('../utils/http-helpers');
 
   setTimeout(() => {
     httpHelpers._currentRequest.emit('error', 'pretend-http-error');

--- a/tools/tool-env/isopackets.js
+++ b/tools/tool-env/isopackets.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 var _ = require('underscore');
 
 var bundler = require('../isobuild/bundler.js');
@@ -12,6 +13,7 @@ var watch = require('../fs/watch.js');
 var Console = require('../console/console.js').Console;
 var fiberHelpers = require('../utils/fiber-helpers.js');
 var packageMapModule = require('../packaging/package-map.js');
+var archinfo = require('../utils/archinfo.js');
 var Profile = require('./profile.js').Profile;
 
 // TL;DR: Isopacket is a set of isopacks. Isopackets are used only inside
@@ -77,6 +79,12 @@ var loadedIsopackets = {};
 // disk. Does not do a build step: ensureIsopacketsLoadable must be called
 // first!
 export function load(isopacketName) {
+  // Small but necessary hack: because archinfo.host() calls execFileSync,
+  // it yields the first time we call it, which is a problem for the
+  // fiberHelpers.noYieldsAllowed block below. Calling it here ensures the
+  // result is cached, so no yielding occurs later.
+  assert.strictEqual(archinfo.host().split(".", 1)[0], "os");
+
   return fiberHelpers.noYieldsAllowed(function () {
     if (_.has(loadedIsopackets, isopacketName)) {
       if (loadedIsopackets[isopacketName]) {

--- a/tools/upgraders.js
+++ b/tools/upgraders.js
@@ -227,6 +227,12 @@ the guide about breaking changes here:`,
     packagesFile.writeIfModified();
   },
 
+  "1.4.0-remove-old-dev-bundle-link": function (projectContext) {
+    const oldDevBundleLink =
+      files.pathJoin(projectContext.projectDir, ".meteor", "dev_bundle");
+    files.rm_recursive(oldDevBundleLink);
+  },
+
   ////////////
   // PLEASE. When adding new upgraders that print mesasges, follow the
   // examples for 0.9.0 and 0.9.1 above. Specifically, formatting

--- a/tools/upgraders.js
+++ b/tools/upgraders.js
@@ -227,7 +227,7 @@ the guide about breaking changes here:`,
     packagesFile.writeIfModified();
   },
 
-  "1.4.0-remove-old-dev-bundle-link": function (projectContext) {
+  "1.3.5-remove-old-dev-bundle-link": function (projectContext) {
     const oldDevBundleLink =
       files.pathJoin(projectContext.projectDir, ".meteor", "dev_bundle");
     files.rm_recursive(oldDevBundleLink);

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -395,8 +395,14 @@ _.extend(exports, {
 
     const outputStream = new WritableStreamBuffer();
 
-    const MAX_ATTEMPTS = 10;
-    const RETRY_DELAY_SECS = 5;
+    const maxAttempts =
+      _.has(options, "maxAttempts")
+      ? options.maxAttempts : 10;
+
+    const retryDelaySecs =
+      _.has(options, "retryDelaySecs")
+      ? options.retryDelaySecs : 5;
+
     const masterProgress = options.progress;
 
     let lastSize = 0;
@@ -435,16 +441,17 @@ _.extend(exports, {
           }
 
           return new Promise(
-            resolve => setTimeout(resolve, RETRY_DELAY_SECS * 1000)
+            resolve => setTimeout(resolve, retryDelaySecs * 1000)
           ).then(() => attempt(triesRemaining - (useTry ? 1 : 0)));
         }
 
-        Console.debug(`Request failed ${MAX_ATTEMPTS} times: failing`);
+        Console.debug(`Request failed ${maxAttempts} times: failing`);
         return Promise.reject(new files.OfflineError(e));
       }
     }
 
-    const response = attempt(MAX_ATTEMPTS).await().response
+    const result = attempt(maxAttempts).await();
+    const response = result.response
     if (response.statusCode >= 400 && response.statusCode < 600) {
       const href = response.request.href;
       throw Error(`Could not get ${href}; server returned [${response.statusCode}]`);

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -378,6 +378,12 @@ _.extend(exports, {
     }
   },
 
+  // More or less as above, except with support for multiple attempts per
+  // request and resuming on retries. This means if the connection is bad,
+  // we can sometimes complete a request, even if each individual attempt fails.
+  // We only use this for package downloads. In theory we could use it for
+  // all requests but that seems like overkill and it isn't well tested in
+  // other scenarioes.
   getUrlWithResuming(urlOrOptions) {
     const options = _.isObject(urlOrOptions) ? _.clone(urlOrOptions) : {
       url: urlOrOptions,

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -136,7 +136,7 @@ _.extend(exports, {
 
     // Body stream length for progress
     var bodyStreamLength = 0;
-    if (_.has(options, 'bodyStream')) {
+    if (_.has(options, 'bodyStreamLength')) {
       bodyStreamLength = options.bodyStreamLength;
       delete options.bodyStreamLength;
     } else {

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -330,7 +330,7 @@ _.extend(exports, {
   // Adds progress callbacks to a request
   // Based on request-progress
   _addProgressEvents: function (request) {
-    var state;
+    var state = {};
 
     var emitProgress = function () {
       request.emit('progress', state);
@@ -338,7 +338,6 @@ _.extend(exports, {
 
     request
       .on('response', function (response) {
-        state = {};
         state.end = undefined;
         state.done = false;
         state.current = 0;
@@ -409,7 +408,8 @@ _.extend(exports, {
         };
       }
 
-      if (masterProgress) {
+      if (masterProgress &&
+          masterProgress.addChildTask) {
         options.progress = masterProgress.addChildTask({
           title: masterProgress._title
         });
@@ -419,7 +419,7 @@ _.extend(exports, {
         return Promise.resolve(httpHelpers.request({
           outputStream,
           ...options,
-        }).response);
+        }));
 
       } catch (e) {
         const size = outputStream.size();
@@ -444,7 +444,7 @@ _.extend(exports, {
       }
     }
 
-    const response = attempt(MAX_ATTEMPTS).await();
+    const response = attempt(MAX_ATTEMPTS).await().response
     if (response.statusCode >= 400 && response.statusCode < 600) {
       const href = response.request.href;
       throw Error(`Could not get ${href}; server returned [${response.statusCode}]`);


### PR DESCRIPTION
Various changes cherry-picked from the Meteor 1.4 release branch (#7218):

* Failed Meteor package downloads are now automatically resumed from the point of failure, up to ten times, with a five-second delay between attempts. [#7399](https://github.com/meteor/meteor/pull/7399)

* If an app has no `package.json` file, all packages in `node_modules` will be built into the production bundle. In other words, make sure you have a `package.json` file if you want to benefit from `devDependencies` pruning. 7b2193188fc9e297eefc841ce6035825164f0684

* Binary npm dependencies of compiler plugins are now automatically rebuilt when Node/V8 versions change. [#7297](https://github.com/meteor/meteor/issues/7297)

* Because `.meteor/local` is where purely local information should be stored, the `.meteor/dev_bundle` link has been renamed to `.meteor/local/dev_bundle`.

* The `.meteor/local/dev_bundle` link now corresponds exactly to `.meteor/release` even when an app is using an older version of Meteor. d732c2e649794f350238d515153f7fb71969c526

* When recompiling binary npm packages, the `npm rebuild` command now receives the flags `--update-binary` and `--no-bin-links`, in addition to respecting the `$METEOR_NPM_REBUILD_FLAGS` environment variable. [#7401](https://github.com/meteor/meteor/issues/7401)

* The last solution found by the package version constraint solver is now stored in `.meteor/local/resolver-result-cache.json` so that it need not be recomputed every time Meteor starts up. 69b100d21a33fd7ca58fc2fe2d8997ade4a36af6