### PR TITLE
Added postSignUpHook call in the AccountsServer.updateOrCreateUserFromExternalService

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1388,9 +1388,21 @@ Ap.updateOrCreateUserFromExternalService = function (
     // insertUserDoc.
     user = {services: {}};
     user.services[serviceName] = serviceData;
+
+    var userId = this.insertUserDoc(options, user);
+
+    console.log("User created, calling postSignUpHook");
+    // Call postSignUpHook, if any...
+    if(!!userId) {
+      var postSignUpHook = AccountsTemplates.options.postSignUpHook;
+      if (postSignUpHook) {
+        postSignUpHook(userId, options);
+      }
+    }
+
     return {
       type: serviceName,
-      userId: this.insertUserDoc(options, user)
+      userId: userId
     };
   }
 };

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1394,9 +1394,11 @@ Ap.updateOrCreateUserFromExternalService = function (
     console.log("User created, calling postSignUpHook");
     // Call postSignUpHook, if any...
     if(!!userId) {
-      var postSignUpHook = AccountsTemplates.options.postSignUpHook;
-      if (postSignUpHook) {
-        postSignUpHook(userId, options);
+      if(!!AccountsTemplates) {
+        var postSignUpHook = AccountsTemplates.options.postSignUpHook;
+        if (postSignUpHook) {
+          postSignUpHook(userId, options);
+        }
       }
     }
 


### PR DESCRIPTION
Added a call to AccountsTemplates.options.postSignUpHook in the AccountsServer.updateOrCreateUserFromExternalService function so that postSignUpHook is correctly called even when users sign up using an OAuth service.

This has been a big issue for those of us using OAuth services that had code that relied on the postSignUpHook.  This issue was discussed in the meteor-useraccounts/core repository, but actually had to be fixed in the accounts-base package, which is part of the main Meteor repo.  Discussion on this issue can be found here: https://github.com/meteor-useraccounts/core/issues/669#issuecomment-226339972