### PR TITLE
Don't rewrite network path references in CSS URLs.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 ## v.NEXT
 
+* Fix for regression caused by #5837 which incorrectly rewrote
+  network-path references (i.e. //domain.com/image.gif) in CSS URLs
+  [#7416](https://github.com/meteor/meteor/issues/7416)
+
 ## v1.3.4.4
 
 * Fixed [#7374](https://github.com/meteor/meteor/issues/7374).

--- a/History.md
+++ b/History.md
@@ -53,6 +53,9 @@
 * `App.appendToConfig` allows adding custom tags to config.xml.
   [#7307](https://github.com/meteor/meteor/pull/7307)
 
+* When using `ROOT_URL` with a path, relative CSS URLs are rewriten
+  accordingly. [#5837](https://github.com/meteor/meteor/issues/5837)
+
 * Fixed bugs:
   [#7149](https://github.com/meteor/meteor/issues/7149)
   [#7296](https://github.com/meteor/meteor/issues/7296)

--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -136,8 +136,9 @@ var rewriteRules = function (rules, mergedCssPath) {
 
 
         // We don't rewrite URLs starting with a protocol definition such as
-        // http, https, or data.
-        if (resource.protocol !== null) {
+        // http, https, or data, or those with network-path references
+        // i.e. //img.domain.com/cat.gif
+        if (resource.protocol !== null || resource.href.startsWith('//')) {
           continue;
         }
 

--- a/packages/minifier-css/urlrewriting-tests.js
+++ b/packages/minifier-css/urlrewriting-tests.js
@@ -78,6 +78,7 @@ Tinytest.add("minifier-css - url rewriting with media queries (ast rule recursio
   t("'/image.png'", "'image.png'", 'single quoted url');
   t('"./../image.png"', '"packages/image.png"', 'quoted parent directory');
   t('http://i.imgur.com/fBcdJIh.gif', 'http://i.imgur.com/fBcdJIh.gif', 'complete URL');
+  t('//i.imgur.com/fBcdJIh.gif', '//i.imgur.com/fBcdJIh.gif', 'network-path reference');
   t('"http://i.imgur.com/fBcdJIh.gif"', '"http://i.imgur.com/fBcdJIh.gif"', 'complete quoted URL');
   t('data:image/png;base64,iVBORw0K=', 'data:image/png;base64,iVBORw0K=', 'data URI');
   t('http://', 'http://', 'malformed URL');
@@ -90,6 +91,7 @@ Tinytest.add("minifier-css - url rewriting with media queries (ast rule recursio
   t('"/image.png"', '"image.png"', 'double quoted url');
   t("'/image.png'", "'image.png'", 'single quoted url');
   t('http://i.imgur.com/fBcdJIh.gif', 'http://i.imgur.com/fBcdJIh.gif', 'complete URL');
+  t('//i.imgur.com/fBcdJIh.gif', '//i.imgur.com/fBcdJIh.gif', 'network-path reference');
   t('"http://i.imgur.com/fBcdJIh.gif"', '"http://i.imgur.com/fBcdJIh.gif"', 'complete quoted URL');
   t('data:image/png;base64,iVBORw0K=', 'data:image/png;base64,iVBORw0K=', 'data URI');
   t('http://', 'http://', 'malformed URL');


### PR DESCRIPTION
Fixes regression caused in 1.3.4.1 which caused network path reference URLs
(i.e. //img.domain.com/path/font.eot) used in CSS `url()`'s' to be stripped
of their leading slashes causing them to become relative URL paths.

Closes meteor/meteor#7416