### PR TITLE
Add option to skip release check

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -375,7 +375,7 @@ function doRunCommand(options) {
     oplogUrl: process.env.MONGO_OPLOG_URL,
     mobileServerUrl: utils.formatUrl(parsedMobileServerUrl),
     once: options.once,
-    noReleaseCheck: options['no-release-check'],
+    noReleaseCheck: options['no-release-check'] || process.env.METEOR_NO_RELEASE_CHECK,
     cordovaRunner: cordovaRunner
   });
 }

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -256,6 +256,7 @@ var runCommandOptions = {
     'mobile-port': { type: String },
     'app-port': { type: String },
     'debug-port': { type: String },
+    'no-release-check': { type: Boolean },
     production: { type: Boolean },
     'raw-logs': { type: Boolean },
     settings: { type: String },
@@ -374,6 +375,7 @@ function doRunCommand(options) {
     oplogUrl: process.env.MONGO_OPLOG_URL,
     mobileServerUrl: utils.formatUrl(parsedMobileServerUrl),
     once: options.once,
+    noReleaseCheck: options['no-release-check'],
     cordovaRunner: cordovaRunner
   });
 }

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -58,6 +58,7 @@ Options:
   --release        Specify the release of Meteor to use.
   --verbose        Print all output from builds logs.
   --no-lint        Don't run linters used by the app on every rebuild.
+  --no-release-check            Don't run the release updater to check for new releases.
   --allow-incompatible-update   Allow packages in your project to be upgraded or
                    downgraded to versions that are potentially incompatible with
                    the current versions, if required to satisfy all package

--- a/tools/runners/run-all.js
+++ b/tools/runners/run-all.js
@@ -31,6 +31,7 @@ class Runner {
     rootUrl,
     selenium,
     seleniumBrowser,
+    noReleaseCheck,
     ...optionsForAppRunner
   }) {
     const self = this;
@@ -46,6 +47,7 @@ class Runner {
     self.regenerateAppPort();
 
     self.stopped = false;
+    self.noReleaseCheck = noReleaseCheck;
     self.quiet = quiet;
     self.banner = banner || files.convertToOSPath(
       files.prettyPath(self.projectContext.projectDir)
@@ -125,7 +127,7 @@ class Runner {
     var unblockAppRunner = self.appRunner.makeBeforeStartPromise();
     self._startMongoAsync().then(unblockAppRunner);
 
-    if (! self.stopped) {
+    if (!self.noReleaseCheck && ! self.stopped) {
       self.updater.start();
     }
 


### PR DESCRIPTION
## Summary

In issue #7026, the release updater is not a part of the catalog update, therefore it still runs the updater even if `METEOR_OFFLINE_CATALOG` is specified.

The reason that we really really need this option is, meteor runs way too slow on travis-ci, it spents almost 7 minutes to just *prepare* the application.

## Changes

A `--no-release-check` option is added to the run command in this PR.