### PR TITLE
#6058: linker/sourcemap optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ cache:
     - "dev_bundle"
     - ".meteor"
     - ".babel-cache"
-install: ./meteor --get-ready
 script: TEST_PACKAGES_EXCLUDE="less" ./packages/test-in-console/run.sh
 sudo: false

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -558,8 +558,7 @@ class File {
 
     // XXX replacing colons with underscores as colon is hard to escape later
     // on different targets and generally is not a good separator for web.
-    url = url.replace(/:/g, '_');
-    this.url = url;
+    this.url = url.replace(/:/g, '_');
   }
 
   setTargetPathFromRelPath(relPath) {

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -174,7 +174,7 @@ import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 // files to ignore when bundling. node has no globs, so use regexps
 exports.ignoreFiles = [
     /~$/, /^\.#/,
-    /^\(\.meteor\/|\.git\/|Thumbs\.db|\.DS_Store\/?|Icon.|ehthumbs\.db|\..*\.sw.|#.*#)$/, 
+    /^(\.meteor\/|\.git\/|Thumbs\.db|\.DS_Store\/?|Icon.|ehthumbs\.db|\..*\.sw.|#.*#)$/, 
       /* .meteor => avoids scanning N^2 files when bundling all packages
         .git => often has too many files to watch 
         ....sw(.) => vim swap files

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -563,7 +563,7 @@ class File {
 
   setTargetPathFromRelPath(relPath) {
     // XXX hack
-    if (relPath.match(/^packages\//) || relPath.match(/^assets\//)) {
+    if (relPath.match(/^(packages|assets)\//)) {
       this.targetPath = relPath;
     } else {
       this.targetPath = files.pathJoin('app', relPath);

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -173,11 +173,13 @@ import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 
 // files to ignore when bundling. node has no globs, so use regexps
 exports.ignoreFiles = [
-    /~$/, /^\.#/, /^#.*#$/,  // emacs swap files
-    /^\..*\.sw.$/,  // vim swap files
-    /^\.DS_Store\/?$/, /^ehthumbs\.db$/, /^Icon.$/, /^Thumbs\.db$/,
-    /^\.meteor\/$/, /* avoids scanning N^2 files when bundling all packages */
-    /^\.git\/$/ /* often has too many files to watch */
+    /~$/, /^\.#/,
+    /^\(\.meteor\/|\.git\/|Thumbs\.db|\.DS_Store\/?|Icon.|ehthumbs\.db|\..*\.sw.|#.*#)$/, 
+      /* .meteor => avoids scanning N^2 files when bundling all packages
+        .git => often has too many files to watch 
+        ....sw(.) => vim swap files
+        #.*# => emacs swap files
+      */
 ];
 
 function rejectBadPath(p) {

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -916,11 +916,15 @@ export class PackageSourceBatch {
 
     sourceBatches.forEach(batch => {
       const name = batch.unibuild.pkg.name || null;
-      const inputFiles = [];
-
-      batch.resourceSlots.forEach(slot => {
-        inputFiles.push(...slot.jsOutputResources);
-      });
+      let inputFiles = [];
+      let slot, i, len;
+      for (i = 0; len = batch.resourceSlots.length ; i++) {
+        let slot = batch.resourceSlots[i];
+        // this will be translated into babel runtime toConsumableArray, which 
+        // is more expensive
+        //    inputFiles.push(...slot.jsOutputResources);
+        inputFiles = inputFiles.concat(slot.jsOutputResources);
+      }
 
       map.set(name, {
         files: inputFiles,

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -987,6 +987,20 @@ export class PackageSourceBatch {
     const allRelocatedNodeModules = Object.create(null);
     const scannerMap = new Map;
 
+
+    function buildExternalNodeModulesPaths(batch) {
+      const nodeModulesPaths = [];
+      _.each(batch.unibuild.nodeModulesDirectories, (nmd, sourcePath) => {
+        if (! nmd.local) {
+          // Local node_modules directories will be found by the
+          // ImportScanner, but we need to tell it about any external
+          // node_modules directories (e.g. .npm/package/node_modules).
+          nodeModulesPaths.push(sourcePath);
+        }
+      });
+      return nodeModulesPaths;
+    }
+
     sourceBatches.forEach(batch => {
       const name = batch.unibuild.pkg.name || null;
       const isApp = ! name;
@@ -997,16 +1011,7 @@ export class PackageSourceBatch {
         return;
       }
 
-      const nodeModulesPaths = [];
-      _.each(batch.unibuild.nodeModulesDirectories, (nmd, sourcePath) => {
-        if (! nmd.local) {
-          // Local node_modules directories will be found by the
-          // ImportScanner, but we need to tell it about any external
-          // node_modules directories (e.g. .npm/package/node_modules).
-          nodeModulesPaths.push(sourcePath);
-        }
-      });
-
+      const nodeModulesPaths = buildExternalNodeModulesPaths(batch);
       const scanner = new ImportScanner({
         name,
         bundleArch: batch.processor.arch,

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -918,12 +918,13 @@ export class PackageSourceBatch {
       const name = batch.unibuild.pkg.name || null;
       let inputFiles = [];
       var slot, i, len;
-      for (i = 0; len = batch.resourceSlots.length ; i++) {
+      for (i = 0, len = batch.resourceSlots.length; i < len ; i++) {
         slot = batch.resourceSlots[i];
         // this will be translated into babel runtime toConsumableArray, which 
         // is more expensive
         //    inputFiles.push(...slot.jsOutputResources);
-        inputFiles = inputFiles.concat(slot.jsOutputResources);
+        // inputFiles = inputFiles.concat(slot.jsOutputResources);
+        inputFiles.push.apply(inputFiles, slot.jsOutputResources);
       }
 
       map.set(name, {

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -941,6 +941,12 @@ export class PackageSourceBatch {
       return map;
     }
 
+
+    function findMainModule(info, name) {
+      let mainModule = _.find(info.files, file => file.mainModule);
+      return mainModule ?  `meteor/${name}/${mainModule.targetPath}` : false;
+    }
+
     // Append install(<name>) calls to the install-packages.js file in the
     // modules package for every Meteor package name used.
     map.get("modules").files.some(file => {
@@ -952,11 +958,7 @@ export class PackageSourceBatch {
 
       map.forEach((info, name) => {
         if (! name) return;
-
-        let mainModule = _.find(info.files, file => file.mainModule);
-        mainModule = mainModule ?
-          `meteor/${name}/${mainModule.targetPath}` : false;
-
+        let mainModule = findMainModule(info,name);
         meteorPackageInstalls.push(
           "install(" + JSON.stringify(name) +
             (mainModule ? ", " + JSON.stringify(mainModule) : '') +

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -910,10 +910,9 @@ export class PackageSourceBatch {
     return sourceProcessorSet;
   }
 
-  // Returns a map from package names to arrays of JS output files.
-  static computeJsOutputFilesMap(sourceBatches) {
-    const map = new Map;
 
+  static buildJsOutputFilesMap(sourceBatches) {
+    const map = new Map;
     sourceBatches.forEach(batch => {
       const name = batch.unibuild.pkg.name || null;
       let inputFiles = [];
@@ -922,17 +921,19 @@ export class PackageSourceBatch {
         slot = batch.resourceSlots[i];
         // this will be translated into babel runtime toConsumableArray, which 
         // is more expensive
-        //    inputFiles.push(...slot.jsOutputResources);
-        // inputFiles = inputFiles.concat(slot.jsOutputResources);
         inputFiles.push.apply(inputFiles, slot.jsOutputResources);
       }
-
       map.set(name, {
         files: inputFiles,
         importExtensions: batch.importExtensions,
       });
     });
+    return map;
+  }
 
+  // Returns a map from package names to arrays of JS output files.
+  static computeJsOutputFilesMap(sourceBatches) {
+    const map = PackageSourceBatch.buildJsOutputFilesMap(sourceBatches);
     if (! map.has("modules")) {
       // In the unlikely event that no package is using the modules
       // package, then the map is already complete, and we don't need to

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -917,9 +917,9 @@ export class PackageSourceBatch {
     sourceBatches.forEach(batch => {
       const name = batch.unibuild.pkg.name || null;
       let inputFiles = [];
-      let slot, i, len;
+      var slot, i, len;
       for (i = 0; len = batch.resourceSlots.length ; i++) {
-        let slot = batch.resourceSlots[i];
+        slot = batch.resourceSlots[i];
         // this will be translated into babel runtime toConsumableArray, which 
         // is more expensive
         //    inputFiles.push(...slot.jsOutputResources);

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -35,7 +35,17 @@ function tryToParse(source, hash) {
   return ast;
 }
 
-var dependencyKeywordPattern = /\b(require|import|export)\b/g;
+const dependencyKeywordPattern = /\b(require|import|export)\b/g;
+
+function parsePossibleIndexes(source) {
+  let match;
+  var possibleIndexes = [];
+  dependencyKeywordPattern.lastIndex = 0;
+  while ((match = dependencyKeywordPattern.exec(source))) {
+    possibleIndexes.push(match.index);
+  }
+  return possibleIndexes;
+}
 
 /**
  * The `findImportedModuleIdentifiers` function takes a string of module
@@ -53,14 +63,7 @@ var dependencyKeywordPattern = /\b(require|import|export)\b/g;
  */
 export function findImportedModuleIdentifiers(source, hash) {
   const identifiers = {};
-  const possibleIndexes = [];
-  let match;
-
-  dependencyKeywordPattern.lastIndex = 0;
-  while ((match = dependencyKeywordPattern.exec(source))) {
-    possibleIndexes.push(match.index);
-  }
-
+  const possibleIndexes = parsePossibleIndexes(source);
   if (!possibleIndexes.length) {
     return {};
   }

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -373,8 +373,9 @@ var buildSymbolTree = function (symbolMap) {
         walk[part] = {};
       walk = walk[part];
     }
-    if (value)
+    if (value) {
       walk[lastPart] = value;
+    }
   }
   return ret;
 };
@@ -644,7 +645,8 @@ _.extend(File.prototype, {
         });
       }
 
-      for (var line = 1; line <= lines.length; ++line) {
+      var lineCount = lines.length;
+      for (var line = 1; line <= lineCount; ++line) {
         addIdentityMapping({ line, column: 0 });
       }
 
@@ -1015,8 +1017,8 @@ export var fullLink = Profile("linker.fullLink", function (inputFiles, {
     noLineNumbers
   });
 
-  var i = 0, inputFile;
-  for ( ; i < inputFiles.length ; i++) {
+  var i = 0, inputFile, _len;
+  for (_len = inputFiles.length ; i < _len ; i++) {
     module.addFile(inputFiles[i]);
   }
 

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -942,7 +942,12 @@ var getFooter = function ({
       chunks.push(pkgInit, ";\n");
     } else {
       const scratch = {};
-      _.each(exported, symbol => scratch[symbol] = symbol);
+      // _.each(exported, symbol => scratch[symbol] = symbol);
+      for (var i = 0 ; i < exported.length ; i++) {
+        var symbol = exported[i];
+        scratch[symbol] = symbol;
+      }
+
       const symbolTree = writeSymbolTree(buildSymbolTree(scratch));
       chunks.push("(function (pkg, symbols) {\n",
                   "  for (var s in symbols)\n",

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -908,14 +908,13 @@ var getImportCode = function (imports, header, omitvar) {
 
   // Imports
   var scratch = {};
-  _.each(imports, function (name, symbol) {
-    scratch[symbol] = packageDot(name) + "." + symbol;
-  });
+  for (var symbol in imports) {
+    scratch[symbol] = packageDot(imports[symbol]) + "." + symbol;
+  }
   var tree = buildSymbolTree(scratch);
 
   // Generate output
-  var buf = header;
-  var node;
+  var buf = header, node;
   for (var key in tree) {
     node = tree[key];
     buf += (omitvar ? "" : "var ") +

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -703,9 +703,8 @@ _.extend(File.prototype, {
     var pathNoSlash = self.servePath.replace(/^\//, "");
 
     if (! self.bare) {
-      var closureHeader = self._getClosureHeader();
       chunks.push(
-        closureHeader,
+        self._getClosureHeader(),
         preserveLineNumbers ? "" : "\n\n"
       );
     }

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -100,10 +100,11 @@ _.extend(Module.prototype, {
 
     // Find all global references in any files
     var assignedVariables = [];
-    _.each(self.files, function (file) {
-      assignedVariables = assignedVariables.concat(
-        file.computeAssignedVariables());
-    });
+    var i = 0, len = self.files.length, file;
+    for (; i < len ; i++) {
+      file = self.files[i];
+      assignedVariables.push.apply(assignedVariables, file.computeAssignedVariables());
+    }
     return _.uniq(assignedVariables);
   }),
 

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -850,9 +850,10 @@ export var prelink = Profile("linker.prelink", function (options) {
     noLineNumbers: options.noLineNumbers
   });
 
-  _.each(options.inputFiles, function (inputFile) {
-    module.addFile(inputFile);
-  });
+  var i = 0, inputFile;
+  for ( ; i < options.inputFiles.length ; i++) {
+    module.addFile(options.inputFiles[i]);
+  }
 
   // Do static analysis to compute module-scoped variables. Error recovery from
   // the static analysis mutates the sources, so this has to be done before

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -1072,6 +1072,26 @@ export var fullLink = Profile("linker.fullLink", function (inputFiles, {
 
   return _.map(prelinkedFiles, function (file) {
     if (file.sourceMap) {
+
+      // ===Question===
+      // The header variable is reused, and concat to itself repeatedly,
+      // but we are returning "header" + source + "footer" for every file.
+      // 
+      //    source: header + file.source + footer,
+      //
+      // so the: 
+      //   file1.source = header1 + source + footer
+      //
+      //   file2.source = header1 + SOURCE_MAP_INSTRUCTIONS_COMMENT + header1 
+      //                    + source + footer
+      //
+      //   file3.source = header1 
+      //                    + SOURCE_MAP_INSTRUCTIONS_COMMENT + header1 
+      //                    + SOURCE_MAP_INSTRUCTIONS_COMMENT + header1
+      //                    + source + footer
+      //
+      // is this expected?
+      //
       if (includeSourceMapInstructions) {
         header = SOURCE_MAP_INSTRUCTIONS_COMMENT + "\n\n" + header;
       }

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -61,21 +61,28 @@ _.extend(Module.prototype, {
   },
 
 
+  // Calculate max line length over multiple files
   maxLineLength: function (ignoreOver) {
-    var self = this;
+    var maxInFile = 0;
+    var file, i = 0;
+    var lines, line, j, m;
+    for ( ; i < this.files.length ; i++) {
+      file = this.files[i];
+      m = 0;
 
-    var maxInFile = [];
-    _.each(self.files, function (file) {
-      var m = 0;
-      _.each(file.source.split('\n'), function (line) {
+      lines = this.sourceLines || file.source.split('\n');
+      for (j = 0; j < lines.length ; j++) {
+        line = lines[j];
         if (line.length <= ignoreOver && line.length > m) {
           m = line.length;
         }
-      });
-      maxInFile.push(m);
-    });
+      }
 
-    return _.max(maxInFile);
+      if (m > maxInFile) {
+        maxInFile = m;
+      }
+    }
+    return maxInFile;
   },
 
   // Figure out which vars need to be specifically put in the module

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -360,23 +360,22 @@ _.extend(Module.prototype, {
 var buildSymbolTree = function (symbolMap) {
   var ret = {};
 
-  _.each(symbolMap, function (value, symbol) {
+  for (var symbol in symbolMap) {
+    var value = symbolMap[symbol];
     var parts = symbol.split('.');
     var lastPart = parts.pop();
 
     var walk = ret;
-    _.each(parts, function (part) {
-      if (! (part in walk)) {
+    var i = 0, part;
+    for (; i < parts.length ; i++) {
+      part = parts[i];
+      if (! (part in walk))
         walk[part] = {};
-      }
       walk = walk[part];
-    });
-
-    if (value) {
-      walk[lastPart] = value;
     }
-  });
-
+    if (value)
+      walk[lastPart] = value;
+  }
   return ret;
 };
 

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -915,12 +915,13 @@ var getImportCode = function (imports, header, omitvar) {
 
   // Generate output
   var buf = header;
-  _.each(tree, function (node, key) {
-    buf += (omitvar ? "" : "var " ) +
+  var node;
+  for (var key in tree) {
+    node = tree[key];
+    buf += (omitvar ? "" : "var ") +
       key + " = " + writeSymbolTree(node) + ";\n";
-  });
+  }
   buf += "\n";
-
   return buf;
 };
 

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -1015,7 +1015,10 @@ export var fullLink = Profile("linker.fullLink", function (inputFiles, {
     noLineNumbers
   });
 
-  _.each(inputFiles, file => module.addFile(file));
+  var i = 0, inputFile;
+  for ( ; i < inputFiles.length ; i++) {
+    module.addFile(inputFiles[i]);
+  }
 
   var prelinkedFiles = module.getPrelinkedFiles();
 

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -411,6 +411,7 @@ var File = function (inputFile, module) {
 
   // source code for this file (a string)
   self.source = inputFile.data.toString('utf8');
+  self.sourceLines = self.source.split(/\r?\n/);
 
   // hash of source (precalculated for *.js files, calculated here for files
   // produced by plugins)
@@ -633,7 +634,7 @@ _.extend(File.prototype, {
         file: self.servePath
       });
 
-      lines = self.source.split(/\r?\n/);
+      lines = self.sourceLines || self.source.split(/\r?\n/);
 
       function addIdentityMapping(pos) {
         smg.addMapping({

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -859,12 +859,9 @@ export var prelink = Profile("linker.prelink", function (options) {
   // Do static analysis to compute module-scoped variables. Error recovery from
   // the static analysis mutates the sources, so this has to be done before
   // concatenation.
-  var assignedVariables = module.computeAssignedVariables();
-  var files = module.getPrelinkedFiles();
-
   return {
-    files: files,
-    assignedVariables: assignedVariables
+    files: module.getPrelinkedFiles(),
+    assignedVariables: module.computeAssignedVariables()
   };
 });
 

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1461,13 +1461,13 @@ _.extend(PackageSource.prototype, {
       controlFiles.push('package.js');
     }
 
-    const anyLevelExcludes = [
+    let anyLevelExcludes = [
       /^tests\/$/,
       archinfo.matches(arch, "os")
         ? /^client\/$/
         : /^server\/$/,
-      ...sourceReadOptions.exclude,
     ];
+    anyLevelExcludes.push.apply(anyLevelExcludes, sourceReadOptions.exclude);
 
     const topLevelExcludes = isApp ? [
       ...anyLevelExcludes,
@@ -1552,7 +1552,7 @@ _.extend(PackageSource.prototype, {
           nodeModulesDir = subdir;
 
         } else {
-          sources.push(...find(subdir, depth + 1, inNodeModules));
+          sources.push.apply(sources, find(subdir, depth + 1, inNodeModules));
         }
       });
 
@@ -1566,7 +1566,7 @@ _.extend(PackageSource.prototype, {
         // Meteor package), continue searching this node_modules
         // directory, so that any non-.js(on) files it contains can be
         // imported by the app (#6037).
-        sources.push(...find(nodeModulesDir, depth + 1, true));
+        sources.push.apply(sources, find(nodeModulesDir, depth + 1, true));
       }
 
       if (cacheKey) {

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1442,7 +1442,7 @@ _.extend(PackageSource.prototype, {
     // 'names').
     sourceReadOptions.exclude.push(/^\./);
     // Ignore the usual ignorable files.
-    sourceReadOptions.exclude.push(...ignoreFiles);
+    sourceReadOptions.exclude.push.apply(sourceReadOptions.exclude, ignoreFiles);
 
     // Unless we're running tests, ignore all test filenames and if we are, ignore the
     // type of file we *aren't* running


### PR DESCRIPTION
## Summary

1. The linker split the source code by lines repeatedly (at least twice), since splitting the code into lines is a must, we simply split the lines in the constructor and get the lines from the File object.

2. This PR also rewrites some `_.each` loop, since symbols and lines (N) could be huge, iterating the array elements with the native javascript for loop is faster.

3. ES6 spread operator is more expansive if it's translated into es5 by babel.  push.apply reduces a lot of computation costs.

## Fixes

Issue #6058

### Benchmark Result

The benchmark was tested with our real application, the test command is to clean all linker cache and re-run the build:

```
rm -rf .meteor/local/bundler-cache && METEOR_PROFILE=500 ~/work/meteor/meteor run
```

Before
```
(#1) Total: 18,569 ms (ProjectContext prepareProjectForBuild)
(#2) Total: 175,310 ms (Build App)
```

After
```
(#1) Total: 17,786 ms (ProjectContext prepareProjectForBuild)
(#2) Total: 164,798 ms (Build App)
```

https://gist.github.com/c9s/cc5891c0d9050c7b9a8f47ee7c0f072e