### PR TITLE
Extract .tar.gz files using native tar or 7z.exe when possible

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.1.4
+BUNDLE_VERSION=4.2.0
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -35,6 +35,16 @@ cd bin
 $webclient = New-Object System.Net.WebClient
 $shell = New-Object -com shell.application
 
+mkdir "$DIR\7z"
+cd "$DIR\7z"
+$webclient.DownloadFile("http://www.7-zip.org/a/7z1602.msi", "$DIR\7z\7z.msi")
+$webclient.DownloadFile("http://www.7-zip.org/a/7z1602-extra.7z", "$DIR\7z\extra.7z")
+msiexec /i 7z.msi /quiet /qn /norestart
+ping -n 4 127.0.0.1 | out-null
+& "C:\Program Files*\7-Zip\7z.exe" x extra.7z
+mv 7za.exe "$DIR\bin\7z.exe"
+cd "$DIR\bin"
+
 # download node
 # same node on 32bit vs 64bit?
 $node_link = "http://nodejs.org/dist/v${NODE_VERSION}/win-x86/node.exe"
@@ -63,6 +73,7 @@ foreach($item in $zip.items()) {
 }
 
 rm -Recurse -Force $npm_zip
+rm -Recurse -Force "$DIR\7z"
 
 # add bin to the front of the path so we can use our own node for building
 $env:PATH = "${DIR}\bin;${env:PATH}"

--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -603,15 +603,21 @@ main.registerCommand({
 
   // Download the source to the package.
   var sourceTarball = buildmessage.enterJob("downloading package source", function () {
-    return httpHelpers.getUrl({
+    return httpHelpers.getUrlWithResuming({
       url: pkgVersion.source.url,
       encoding: null
     });
   });
 
+  if (buildmessage.hasMessages()) {
+    return 1;
+  }
+
   var sourcePath = files.mkdtemp('package-source');
-  // XXX check tarballHash!
-  files.extractTarGz(sourceTarball, sourcePath);
+  buildmessage.enterJob("extracting package source", () => {
+    // XXX check tarballHash!
+    files.extractTarGz(sourceTarball, sourcePath);
+  });
 
   // XXX Factor out with packageClient.bundleSource so that we don't
   // have knowledge of the tarball structure in two places.

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -727,7 +727,15 @@ files.extractTarGz = function (buffer, destPath, options) {
   files.rmdir(tempDir);
 };
 
+function ensureDirectoryEmpty(dir) {
+  files.readdir(dir).forEach(file => {
+    files.rm_recursive(files.pathJoin(dir, file));
+  });
+}
+
 function tryExtractWithNativeTar(buffer, tempDir) {
+  ensureDirectoryEmpty(tempDir);
+
   const tarProc = spawn("tar", ["xzf", "-"], {
     cwd: tempDir,
     stdio: "pipe"
@@ -743,6 +751,8 @@ function tryExtractWithNativeTar(buffer, tempDir) {
 }
 
 function tryExtractWithNative7z(buffer, tempDir) {
+  ensureDirectoryEmpty(tempDir);
+
   const exeOSPath = files.convertToOSPath(
     files.pathJoin(files.getCurrentNodeBinDir(), "7z.exe"));
   const tarGzBasename = "out.tar.gz";
@@ -796,6 +806,8 @@ function tryExtractWithNative7z(buffer, tempDir) {
 }
 
 function tryExtractWithNpmTar(buffer, tempDir) {
+  ensureDirectoryEmpty(tempDir);
+
   var tar = require("tar");
   var zlib = require("zlib");
 

--- a/tools/packaging/tropohouse.js
+++ b/tools/packaging/tropohouse.js
@@ -293,33 +293,6 @@ _.extend(exports.Tropohouse.prototype, {
     });
   },
 
-  // Contacts the package server, downloads and extracts a tarball for a given
-  // buildRecord into a temporary directory, whose path is returned.
-  //
-  // XXX: Error handling.
-  _downloadBuildToTempDir: function (versionInfo, buildRecord) {
-    var url = buildRecord.build.url;
-    
-    // Override the download domain name and protocol if METEOR_WAREHOUSE_URLBASE
-    // provided.
-    if (process.env.METEOR_WAREHOUSE_URLBASE) {
-      url = url.replace(/^[a-zA-Z]+:\/\/[^\/]+/, process.env.METEOR_WAREHOUSE_URLBASE);
-    }
-
-    // XXX: We use one progress for download & untar; this isn't ideal:
-    // it relies on extractTarGz being fast and not reporting any progress.
-    // Really, we should create two subtasks
-    // (and, we should stream the download to the tar extractor)
-    var packageTarball = httpHelpers.getUrlWithResuming({
-      url: url,
-      encoding: null,
-      progress: buildmessage.getCurrentProgressTracker(),
-      wait: false
-    });
-
-    return exports._extractAndConvert(packageTarball);
-  },
-
   // Given a package name and version, returns the architectures for
   // which we have downloaded this package
   //
@@ -493,36 +466,65 @@ _.extend(exports.Tropohouse.prototype, {
         // XXX how does concurrency work here?  we could just get errors if we
         // try to rename over the other thing?  but that's the same as in
         // warehouse?
-        _.each(buildsToDownload, function (build) {
-          buildmessage.enterJob({
+        _.each(buildsToDownload, ({ build: { url }}) => {
+          const packageTarball = buildmessage.enterJob({
             title: "downloading " + packageName + "@" + version + "..."
-          }, function() {
+          }, () => {
             try {
-              var buildTempDir = self._downloadBuildToTempDir(
-                { packageName: packageName, version: version }, build);
+              // Override the download domain name and protocol if METEOR_WAREHOUSE_URLBASE
+              // provided.
+              if (process.env.METEOR_WAREHOUSE_URLBASE) {
+                url = url.replace(
+                  /^[a-zA-Z]+:\/\/[^\/]+/,
+                  process.env.METEOR_WAREHOUSE_URLBASE
+                );
+              }
+
+              return httpHelpers.getUrlWithResuming({
+                url: url,
+                encoding: null,
+                progress: buildmessage.getCurrentProgressTracker(),
+                wait: false
+              });
+
             } catch (e) {
-              if (!(e instanceof files.OfflineError)) {
+              if (! (e instanceof files.OfflineError)) {
                 throw e;
               }
               buildmessage.error(e.error.message);
             }
+          });
+
+          if (buildmessage.jobHasMessages()) {
+            return;
+          }
+
+          buildmessage.enterJob({
+            title: "extracting " + packageName + "@" + version + "..."
+          }, () => {
+            const buildTempDir = exports._extractAndConvert(packageTarball);
             buildInputDirs.push(buildTempDir);
             buildTempDirs.push(buildTempDir);
           });
         });
+
         if (buildmessage.jobHasMessages()) {
           return;
         }
 
-        // We need to turn our builds into a single isopack.
-        var isopack = new Isopack();
-        _.each(buildInputDirs, function (buildTempDir, i) {
-          isopack._loadUnibuildsFromPath(packageName, buildTempDir, {
-            firstIsopack: i === 0,
+        buildmessage.enterJob({
+          title: "loading " + packageName + "@" + version + "..."
+        }, () => {
+          // We need to turn our builds into a single isopack.
+          var isopack = new Isopack();
+          _.each(buildInputDirs, (buildTempDir, i) => {
+            isopack._loadUnibuildsFromPath(packageName, buildTempDir, {
+              firstIsopack: i === 0,
+            });
           });
-        });
 
-        self._saveIsopack(isopack, packageName, version);
+          self._saveIsopack(isopack, packageName, version);
+        });
 
         // Delete temp directories now (asynchronously).
         _.each(buildTempDirs, function (buildTempDir) {

--- a/tools/packaging/warehouse.js
+++ b/tools/packaging/warehouse.js
@@ -394,8 +394,13 @@ _.extend(warehouse, {
               "/" + version +
               "/" + name + '-' + version + "-" + platform + ".tar.gz";
 
-        var tarball = httpHelpers.getUrl({url: packageUrl, encoding: null});
+        var tarball = httpHelpers.getUrlWithResuming({
+          url: packageUrl,
+          encoding: null
+        });
+
         files.extractTarGz(tarball, packageDir);
+
         if (!dontWriteFreshFile) {
           files.writeFile(warehouse.getPackageFreshFile(name, version), '');
         }


### PR DESCRIPTION
For the sake of portability, the `files.extractTarGz` method is currently implemented in terms of a pure-JavaScript library: https://www.npmjs.com/package/tar

Portability is nice, but speed is also nice. On my machine, it takes 25 seconds to extract the `fourseven:scss` package using the npm `tar` package, whereas it takes only *3.5 seconds* to extract it using the native `tar` command. On Windows, the time drops from 36 seconds to 8 seconds.

The time savings for even larger packages like `meteor-tool` are even more dramatic: 45 seconds vs. 4 seconds on my Mac.

This pull request uses the native commands when possible, but falls back to the npm `tar` library if the native commands don't work for any reason.

For Windows, we now include a standalone `7z.exe` binary in the dev bundle (i.e., `dev_bundle\bin\7z.exe`), though `tar` will also work on Windows if it's in the `$env:PATH`. This is the standard 7-Zip 16.02 program available [here](http://www.7-zip.org/download.html). I believe this usage is compatible with the 7-zip license, according to the [FAQ](http://www.7-zip.org/faq.html).

I think these changes may be too risky to ship with Meteor 1.4, given that it's now in the release candidate stage, but if all goes well we will ship them soon after that release (likely 1.4.1).

cc @tmeasday @zol @abernix