### PR TITLE
Upgrade node to 4.4.7 LTS

### DIFF
--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -5,7 +5,7 @@ set -u
 
 UNAME=$(uname)
 ARCH=$(uname -m)
-NODE_VERSION=0.10.46
+NODE_VERSION=4.4.7
 NPM_VERSION=3.10.5
 
 if [ "$UNAME" == "Linux" ] ; then


### PR DESCRIPTION
This fixes #7460 to upgrade the WAY TOO OLD node 0.10 to 4.4.7 LTS. (long term support version)