### PR TITLE
Improve the meteor build speed on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - "dev_bundle"
     - ".meteor"
     - ".babel-cache"
-install: ./meteor --get-ready
 script: TEST_PACKAGES_EXCLUDE="less" ./packages/test-in-console/run.sh
 sudo: false
 env:


### PR DESCRIPTION
This is a simple quick fix for the travis yml config file.

## Summary

run.sh already runs ./meteor --self-test

so the install section defined in travis config can be remove.