### PR TITLE
Update generated Readme file in builded app

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2312,7 +2312,7 @@ var writeSiteArchive = Profile("bundler writeSiteArchive", function (
 
       builder.write('README', { data: new Buffer(
 `This is a Meteor application bundle. It has only one external dependency:
-Node.js 0.10.40 or newer. To run the application:
+Node.js 4.4.7 or newer. To run the application:
 
   $ (cd programs/server && npm install)
   $ export MONGO_URL='mongodb://user:password@host:port/databasename'


### PR DESCRIPTION
After running `meteor build` in created archive `Readme` file currently has next content:

```text
This is a Meteor application bundle. It has only one external dependency:
Node.js 0.10.40 or newer. To run the application:

  $ (cd programs/server && npm install)
  $ export MONGO_URL='mongodb://user:password@host:port/databasename'
  $ export ROOT_URL='http://example.com'
  $ export MAIL_URL='smtp://user:password@mailhost:port/'
  $ node main.js

Use the PORT environment variable to set the port where the
application will listen. The default is 80, but that will require
root on most systems.

Find out more about Meteor at meteor.com.
```

Since `Meteor@1.4` requires `nodejs@4.4.7` and fails on `nodejs@0.10.*`, generated `Readme` must be updated