### PR TITLE
Reorganize and categorize DDP messages

### DIFF
--- a/packages/ddp/DDP.md
+++ b/packages/ddp/DDP.md
@@ -99,17 +99,22 @@ a `pong` message. If the received `ping` message includes an `id` field, the
 ## Managing Data:
 
 ### Messages:
-
+#### Subscription
  * `sub` (client -> server):
    - `id`: string (an arbitrary client-determined identifier for this subscription)
    - `name`: string (the name of the subscription)
    - `params`: optional array of EJSON items (parameters to the subscription)
  * `unsub` (client -> server):
    - `id`: string (the id passed to 'sub')
+ * `ready` (server -> client):
+   - `subs`: array of strings (ids passed to 'sub' which have sent their
+     initial batch of data)
  * `nosub` (server -> client):
    - `id`: string (the id passed to 'sub')
    - `error`: optional Error (an error raised by the subscription as it
     concludes, or sub-not-found)
+
+#### Collections
  * `added` (server -> client):
    - `collection`: string (collection name)
    - `id`: string (document ID)
@@ -122,9 +127,6 @@ a `pong` message. If the received `ping` message includes an `id` field, the
  * `removed` (server -> client):
    - `collection`: string (collection name)
    - `id`: string (document ID)
- * `ready` (server -> client):
-   - `subs`: array of strings (ids passed to 'sub' which have sent their
-     initial batch of data)
  * `addedBefore` (server -> client):
    - `collection`: string (collection name)
    - `id`: string (document ID)


### PR DESCRIPTION
Categorize the DDP messages to separate subscription from collection messages.
The prior DDP documentation intersperses the two types of messages, and this is a simple reorganization of the bullet points to help with understanding the message types.
No real content change.