### PR TITLE
Pipe stdio rather than inheriting

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 ## v.NEXT
 
+* Fix an issue where springboarding to older releases caused CPU load [Issue #7491](https://github.com/meteor/meteor/issues/7491)
+
 ## v1.4
 
 * Node has been upgraded to 4.4.7.

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.4.0-1-rc.0'
+  version: '1.4.0-1-rc.1'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.4.0'
+  version: '1.4.0-1-rc.0'
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.4.0.1-rc.0",
+ "version": "1.4.0.1-rc.1",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.4-rc.2",
+ "version": "1.4.0.1-rc.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -484,18 +484,15 @@ var springboard = function (rel, options) {
   }
 
   if (process.platform === 'win32') {
-    process.exit(new Promise(function (resolve) {
-      var batPath = files.convertToOSPath(executable + ".bat");
-      var child = require("child_process").spawn(batPath, newArgv, {
-        env: process.env,
-        stdio: 'inherit'
-      }).on('exit', resolve);
-    }).await());
+    executable = files.convertToOSPath(executable + ".bat");
   }
 
-  // Now exec; we're not coming back.
-  require('kexec')(executable, newArgv);
-  throw Error('exec failed?');
+  process.exit(new Promise(function (resolve) {
+    var child = require("child_process").spawn(executable, newArgv, {
+      env: process.env,
+      stdio: 'inherit'
+    }).on('exit', resolve);
+  }).await());
 };
 
 // Springboard to a pre-0.9.0 release.

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -490,8 +490,14 @@ var springboard = function (rel, options) {
   process.exit(new Promise(function (resolve) {
     var child = require("child_process").spawn(executable, newArgv, {
       env: process.env,
-      stdio: 'inherit'
+      stdio: 'pipe'
     }).on('exit', resolve);
+
+    // We pipe here because for some (unknown) reason, passing stdio: 'inherit'
+    // above causes the process to max out
+    child.stdout.pipe(process.stdout);
+    child.stdin.pipe(process.stdin);
+    child.stderr.pipe(process.stderr);
   }).await());
 };
 


### PR DESCRIPTION
For https://github.com/meteor/meteor/issues/7491 it seems using `kexec` or `spawn` with `{stdio: 'inherit'}` caused a high constant CPU load on Node 4. Using `{stdio: 'pipe'}` and manually piping seems fine though.

I haven't figured out what the explanation for it is and why it's not a known node issue (I'm going to investigate further).

One positive of this change is unifying some windows/unix code.