### PR TITLE
Use the harmony branch of uglify-js

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 ## v.NEXT
 
+* The `minifier-js` package now uses the "harmony" branch of `uglify-js`.
+
 ## v1.4
 
 * Node has been upgraded to 4.4.7.

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -1,60 +1,94 @@
 {
   "dependencies": {
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "from": "align-text@>=0.1.3 <0.2.0"
+    },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "from": "async@>=0.2.6 <0.3.0"
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "from": "camelcase@>=1.0.2 <2.0.0"
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "from": "center-align@>=0.1.1 <0.2.0"
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "from": "cliui@>=2.1.0 <3.0.0"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "from": "decamelize@>=1.0.0 <2.0.0"
+    },
+    "is-buffer": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+      "from": "is-buffer@>=1.0.2 <2.0.0"
+    },
+    "kind-of": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
+      "from": "kind-of@>=3.0.2 <4.0.0"
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "from": "lazy-cache@>=1.0.3 <2.0.0"
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "from": "longest@>=1.0.1 <2.0.0"
+    },
+    "repeat-string": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+      "from": "repeat-string@>=1.5.2 <2.0.0"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "from": "right-align@>=0.1.1 <0.2.0"
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "from": "source-map@>=0.5.1 <0.6.0"
+    },
     "uglify-js": {
-      "version": "2.4.20",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.20.tgz",
-      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.20.tgz",
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        },
-        "source-map": {
-          "version": "0.1.34",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-        },
-        "yargs": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "dependencies": {
-            "camelcase": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-            },
-            "decamelize": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
-              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-            },
-            "window-size": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-            },
-            "wordwrap": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            }
-          }
-        }
-      }
+      "version": "2.6.4",
+      "resolved": "https://github.com/mishoo/UglifyJS2/tarball/3f8fc3a316a60b67acf09b2b2cf887f0209c7d71",
+      "from": "uglify-js@https://github.com/mishoo/UglifyJS2/tarball/3f8fc3a316a60b67acf09b2b2cf887f0209c7d71"
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "from": "window-size@0.1.0"
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "from": "wordwrap@0.0.2"
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "from": "yargs@>=3.10.0 <3.11.0"
     }
   }
 }

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -4,11 +4,11 @@ Package.describe({
 });
 
 Npm.depends({
-  "uglify-js": "2.4.20",
+  "uglify-js": "https://github.com/mishoo/UglifyJS2/tarball/3f8fc3a316a60b67acf09b2b2cf887f0209c7d71"
 });
 
 Npm.strip({
-  "uglify-js": ["test/"],
+  "uglify-js": ["test/"]
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Even though Node 4 supports basic ES2015 features like `const` and `let`, the UglifyJS minifier does not understand those features.

They've been [working on ES2015 support](https://github.com/mishoo/UglifyJS2/issues/448) since back when it was called ES6, and the new version is available on the [`harmony`](https://github.com/mishoo/UglifyJS2/tree/harmony) branch, but that work hasn't been published to npm yet.

Fixes #7479 and #7441.