### PR TITLE
Fix #7491 by wrapping child process in `script` on OSX

### DIFF
--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.4.0'
+  version: '1.4.0-1-rc.2'
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.4-rc.2",
+ "version": "1.4.0.1-rc.2",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -493,6 +493,14 @@ var springboard = function (rel, options) {
     }).await());
   }
 
+  // On OSX, there is a bug in node 4 when launching out to a node 0.10 process
+  // This should be fixed in the next release of node (we should then revert
+  // this change) https://github.com/meteor/meteor/issues/7491
+  if (process.platform === 'darwin') {
+    newArgv.unshift('-q', '/dev/null', executable);
+    executable = 'script';
+  }
+
   // Now exec; we're not coming back.
   require('kexec')(executable, newArgv);
   throw Error('exec failed?');


### PR DESCRIPTION
See https://github.com/meteor/meteor/issues/7491#issuecomment-235887764

NOTE: this issue should be fixed in the next release of node v4
(4.4.8 or 4.5). When we include that in the dev bundle we should
revert this change