### PR TITLE
Switch to concat stream

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.2.0
+BUNDLE_VERSION=4.2.1
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -55,7 +55,7 @@ var packageJson = {
     'lru-cache': '2.6.4',
     'cordova-lib': "6.0.0",
     longjohn: '0.2.11',
-    'stream-buffers': '3.0.0'
+    'concat-stream': '1.5.1'
   }
 };
 

--- a/tools/tests/utils-tests.js
+++ b/tools/tests/utils-tests.js
@@ -177,6 +177,7 @@ selftest.define("resume downloads", ['net'], function () {
             ++interruptCount;
             request.emit('error', 'pretend-http-error');
             request.emit('end');
+            request.abort();
           }
         });
       }

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -14,7 +14,7 @@ var release = require('../packaging/release.js');
 var Console = require('../console/console.js').Console;
 var timeoutScaleFactor = require('./utils.js').timeoutScaleFactor;
 
-import { WritableStreamBuffer } from 'stream-buffers';
+import concatStream from 'concat-stream';
 
 // Helper that tracks bytes written to a writable
 var WritableWithProgress = function (writable, listener) {
@@ -393,8 +393,6 @@ _.extend(exports, {
       url: urlOrOptions,
     };
 
-    const outputStream = new WritableStreamBuffer();
-
     const maxAttempts =
       _.has(options, "maxAttempts")
       ? options.maxAttempts : 10;
@@ -404,13 +402,13 @@ _.extend(exports, {
       ? options.retryDelaySecs : 5;
 
     const masterProgress = options.progress;
+    const outputStream = concatStream();
 
-    let lastSize = 0;
-    function attempt(triesRemaining) {
-      if (lastSize > 0) {
+    function attempt(triesRemaining = maxAttempts, startAt = 0) {
+      if (startAt > 0) {
         options.headers = {
           ...options.headers,
-          Range: `bytes=${outputStream.size()}-`
+          Range: `bytes=${startAt}-`
         };
       }
 
@@ -428,10 +426,9 @@ _.extend(exports, {
         }));
 
       } catch (e) {
-        const size = outputStream.size();
-        const useTry = size === lastSize;
-        const change = size - lastSize;
-        lastSize = outputStream.size();
+        const size = _.reduce(outputStream.body, (s, buf) => s + buf.length, 0);
+        const useTry = size === startAt;
+        const change = size - startAt;
 
         if (!useTry || triesRemaining > 0) {
           if (useTry) {
@@ -442,7 +439,7 @@ _.extend(exports, {
 
           return new Promise(
             resolve => setTimeout(resolve, retryDelaySecs * 1000)
-          ).then(() => attempt(triesRemaining - (useTry ? 1 : 0)));
+          ).then(() => attempt(triesRemaining - (useTry ? 1 : 0), size));
         }
 
         Console.debug(`Request failed ${maxAttempts} times: failing`);
@@ -450,13 +447,14 @@ _.extend(exports, {
       }
     }
 
-    const result = attempt(maxAttempts).await();
+
+    const result = attempt().await();
     const response = result.response
     if (response.statusCode >= 400 && response.statusCode < 600) {
       const href = response.request.href;
       throw Error(`Could not get ${href}; server returned [${response.statusCode}]`);
     }
 
-    return outputStream.getContents();
+    return outputStream.getBody();
   }
 });


### PR DESCRIPTION
Use `concat-stream` instead of `stream-buffers`

`concat-stream` is efficient and uses `Buffer.concat` once, rather than a continuous re-allocation and strcpy into new buffers.