### PR TITLE
Expose the function that gets fb data from an access token

### DIFF
--- a/packages/facebook/facebook_server.js
+++ b/packages/facebook/facebook_server.js
@@ -2,12 +2,7 @@ Facebook = {};
 
 var querystring = Npm.require('querystring');
 
-
-OAuth.registerService('facebook', 2, null, function(query) {
-
-  var response = getTokenResponse(query);
-  var accessToken = response.accessToken;
-
+Facebook.handleAuthFromAccessToken = function handleAuthFromAccessToken(accessToken, expiresAt) {
   // include all fields from facebook
   // http://developers.facebook.com/docs/reference/login/public-profile-and-friend-list/
   var whitelisted = ['id', 'email', 'name', 'first_name',
@@ -17,9 +12,8 @@ OAuth.registerService('facebook', 2, null, function(query) {
 
   var serviceData = {
     accessToken: accessToken,
-    expiresAt: (+new Date) + (1000 * response.expiresIn)
+    expiresAt: expiresAt
   };
-
 
   var fields = _.pick(identity, whitelisted);
   _.extend(serviceData, fields);
@@ -28,6 +22,14 @@ OAuth.registerService('facebook', 2, null, function(query) {
     serviceData: serviceData,
     options: {profile: {name: identity.name}}
   };
+};
+
+OAuth.registerService('facebook', 2, null, function(query) {
+  var response = getTokenResponse(query);
+  var accessToken = response.accessToken;
+  var expiresIn = response.expiresIn;
+
+  return Facebook.handleAuthFromAccessToken(accessToken, (+new Date) + (1000 * expiresIn));
 });
 
 // checks whether a string parses as JSON


### PR DESCRIPTION
It's possible to get an access token directly, for instance with mobile application. To make it easier to handle those access tokens on the backend, I split the function that handles the token from the larger function that starts with the code.

This enables things like handling fb login directly from an access token:

```js
let fbAppId = null;
export const loginWithFacebook = (params, req, res) => {
  const fbAccessToken = req.body.token;

  // make sure the access token is for our app
  const fbAppIdForToken = JSON.parse(HTTP.get(
    "https://graph.facebook.com/app", {
      params: { access_token: fbAccessToken }
    }).content).id;
  // get our app id
  if (!fbAppId) {
    const config = ServiceConfiguration.configurations.findOne({service: 'facebook'});
    fbAppId = config.appId;
  }
  if (fbAppId !== fbAppIdForToken) {
    // handle incorrect token
    return;
  }

  const expiresAt = req.body.expiresAt;
  const authResult = Facebook.handleAuthFromAccessToken(fbAccessToken, expiresAt);

  const { userId } = Accounts.updateOrCreateUserFromExternalService(
    'facebook',
    authResult.serviceData,
    authResult.options
  );
  ...
};
```