### PR TITLE
Fix misbehaving promise polyfill

### DIFF
--- a/tools/tool-env/install-promise.js
+++ b/tools/tool-env/install-promise.js
@@ -1,10 +1,24 @@
 // Install a global ES2015-compliant Promise constructor that knows how to
 // run all its callbacks in Fibers.
 
-var Promise = global.Promise = global.Promise ||
+var Promise = global.Promise ||
   require("promise/lib/es6-extensions");
 
-require("meteor-promise").makeCompatible(
-  Promise,
-  require("fibers")
-);
+function makeCompatible(newPromise) {
+  require("meteor-promise").makeCompatible(
+    newPromise,
+    require("fibers")
+  );
+}
+
+makeCompatible(Promise);
+
+Object.defineProperty(global, "Promise", {
+  get: function () {
+    return Promise;
+  },
+
+  // Make the new Promise compatible with Fibers, but do not allow further
+  // modifications to global.Promise, e.g. by misbehaving polyfills.
+  set: makeCompatible
+});

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -27,6 +27,8 @@ var release = require('../packaging/release.js');
 var projectContextModule = require('../project-context.js');
 var upgraders = require('../upgraders.js');
 
+require("../tool-env/install-runtime.js");
+
 try {
   var phantomjs = require('phantomjs-prebuilt');
 } catch (e) {

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -30,7 +30,7 @@ var upgraders = require('../upgraders.js');
 require("../tool-env/install-runtime.js");
 
 try {
-  var phantomjs = require('phantomjs-prebuilt');
+  var phantomPath = require.resolve('phantomjs-prebuilt');
 } catch (e) {
   throw new Error([
     "Please install PhantomJS by running the following command:",
@@ -41,6 +41,8 @@ try {
     ""
   ].join("\n"));
 }
+
+var phantomjs = require(phantomPath);
 
 // To allow long stack traces that cross async boundaries
 require('longjohn');


### PR DESCRIPTION
The `phantomjs-prebuilt` package (typically installed [here](https://github.com/meteor/meteor/blob/46b9f128ce113d16e304415600dbbb22b0989c59/scripts/ci.sh#L10)) now depends on a `Promise` polyfill package called `es6-promise`, which misbehaves by overwriting the `global.Promise` constructor. This becomes a problem when Meteor tools code attempts to call `Promise.prototype.await` that are [added](https://github.com/meteor/meteor/blob/46b9f128ce113d16e304415600dbbb22b0989c59/tools/tool-env/install-promise.js#L7-L10) by our (well-behaved) runtime setup code, because `global.Promise` is no longer the same as the version of `Promise` that we augmented.