### PR TITLE
Stop minifying server files

### DIFF
--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -1,60 +1,94 @@
 {
   "dependencies": {
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "from": "align-text@>=0.1.3 <0.2.0"
+    },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "from": "async@>=0.2.6 <0.3.0"
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "from": "camelcase@>=1.0.2 <2.0.0"
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "from": "center-align@>=0.1.1 <0.2.0"
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "from": "cliui@>=2.1.0 <3.0.0"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "from": "decamelize@>=1.0.0 <2.0.0"
+    },
+    "is-buffer": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+      "from": "is-buffer@>=1.0.2 <2.0.0"
+    },
+    "kind-of": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+      "from": "kind-of@>=3.0.2 <4.0.0"
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "from": "lazy-cache@>=1.0.3 <2.0.0"
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "from": "longest@>=1.0.1 <2.0.0"
+    },
+    "repeat-string": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+      "from": "repeat-string@>=1.5.2 <2.0.0"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "from": "right-align@>=0.1.1 <0.2.0"
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "from": "source-map@>=0.5.1 <0.6.0"
+    },
     "uglify-js": {
-      "version": "2.4.20",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.20.tgz",
-      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.20.tgz",
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        },
-        "source-map": {
-          "version": "0.1.34",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-        },
-        "yargs": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "dependencies": {
-            "camelcase": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-            },
-            "decamelize": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
-              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-            },
-            "window-size": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-            },
-            "wordwrap": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            }
-          }
-        }
-      }
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
+      "from": "uglify-js@2.7.0"
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "from": "window-size@0.1.0"
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "from": "wordwrap@0.0.2"
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "from": "yargs@>=3.10.0 <3.11.0"
     }
   }
 }

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,14 +1,14 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "1.2.13"
+  version: "1.2.14"
 });
 
 Npm.depends({
-  "uglify-js": "2.4.20",
+  "uglify-js": "2.7.0"
 });
 
 Npm.strip({
-  "uglify-js": ["test/"],
+  "uglify-js": ["test/"]
 });
 
 Package.onUse(function (api) {

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.1.8',
+  version: '1.2.0',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -1,7 +1,8 @@
 var sourcemap = Npm.require('source-map');
 
 Plugin.registerMinifier({
-  extensions: ["css"]
+  extensions: ["css"],
+  archMatching: "web"
 }, function () {
   var minifier = new CssToolsMinifier();
   return minifier;

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '1.1.8',
+  version: '1.2.0',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md'
 });

--- a/packages/standard-minifier-js/plugin/minify-js.js
+++ b/packages/standard-minifier-js/plugin/minify-js.js
@@ -1,5 +1,6 @@
 Plugin.registerMinifier({
-  extensions: ["js"]
+  extensions: ["js"],
+  archMatching: "web"
 }, function () {
   var minifier = new UglifyJSMinifier();
   return minifier;


### PR DESCRIPTION
Though UglifyJS unfortunately does not support many new ES2015+ features, and its `harmony` branch is [not quite stable yet](https://github.com/meteor/meteor/pull/7517), we can mitigate part of the problem by avoiding using the `uglify-js` package for server files.