### PR TITLE
Rename PACKAGE_DIRS to METEOR_PACKAGE_DIRS

### DIFF
--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -505,7 +505,7 @@ modified.
 Packages may be specified by name or by path. If a package argument
 contains a '/', it is loaded from a directory of that name; otherwise,
 the package name is resolved according to the usual package search
-algorithm ('packages' subdirectory of the current app, $PACKAGE_DIRS
+algorithm ('packages' subdirectory of the current app, $METEOR_PACKAGE_DIRS
 directories, and core packages in that order). You can test any number
 of packages simultaneously. If you don't specify any package names
 then all available packages will be tested.
@@ -778,7 +778,7 @@ and rebuilds the package from scratch. Packages are specified by name.
 
 If you pass no arguments, this will rebuild all local packages.
 That includes packages found through the
-PACKAGE_DIRS environment variable, local packages in the current
+METEOR_PACKAGE_DIRS environment variable, local packages in the current
 application, and, if running Meteor from a checkout, the packages in
 the checkout. It doesn't include any packages for which we don't have
 the source.

--- a/tools/packaging/warehouse.js
+++ b/tools/packaging/warehouse.js
@@ -33,7 +33,7 @@
 ///
 /// The warehouse is not used at all when running from a
 /// checkout. Only local packages will be loaded (from
-/// CHECKOUT/packages or within a directory in the PACKAGE_DIRS
+/// CHECKOUT/packages or within a directory in the METEOR_PACKAGE_DIRS or PACKAGE_DIRS
 /// environment variable). The setup of that is handled by release.js.
 
 var os = require("os");

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 var _ = require('underscore');
+var path = require('path');
 
 var archinfo = require('./utils/archinfo.js');
 var buildmessage = require('./utils/buildmessage.js');
@@ -596,10 +597,21 @@ _.extend(ProjectContext.prototype, {
     var self = this;
     var searchDirs = [files.pathJoin(self._projectDirForLocalPackages, 'packages')];
 
-    if (! self._ignorePackageDirsEnvVar && process.env.PACKAGE_DIRS) {
-      // User can provide additional package directories to search in
-      // PACKAGE_DIRS (colon-separated).
-      _.each(process.env.PACKAGE_DIRS.split(':'), function (p) {
+    // User can provide additional package directories to search in
+    // METEOR_PACKAGE_DIRS (colon-separated),
+    // This was added after 1.4.0.1
+    var envPackageDirs = process.env.METEOR_PACKAGE_DIRS || process.env.PACKAGE_DIRS;
+
+    // If the PACKAGE_DIRS, warn users to migrate to the new env vars.
+    if (process.env.PACKAGE_DIRS) {
+      console.warn("For compatibility reasons, the 'PACKAGE_DIRS' environment"
+                   + " variable is deprecated and will be removed in a future"
+                   + " release of Meteor.  Developers should now use"
+                   + " 'METEOR_PACKAGE_DIRS'.");
+    }
+    if (! self._ignorePackageDirsEnvVar && envPackageDirs) {
+      // path.delimiter was added in v0.9.3
+      _.each(envPackageDirs.split(path.delimiter), function (p) {
         searchDirs.push(files.pathResolve(p));
       });
     }


### PR DESCRIPTION
Fix #7585 

Prefer `METEOR_PACKAGE_DIRS` over `PACKAGE_DIRS`. This is a backward compatible change.