### PR TITLE
Fix for requiring long relative path

### DIFF
--- a/tools/static-assets/server/mini-files.js
+++ b/tools/static-assets/server/mini-files.js
@@ -88,6 +88,10 @@ var wrapPathFunction = function (name, partialPaths) {
       var result = f.apply(path, args);
       if (typeof result === "string") {
         result = toPosixPath(result, partialPaths);
+        // if final path is without root, add it from initial argument
+        if (name === 'join' && ! /^\/[A-Za-z](\/|$)/.test(result) && /^\/[A-Za-z](\/|$)/.test(arguments[0])) {
+          result = '/' + arguments[0][1] + result;
+        }
       }
 
       return result;


### PR DESCRIPTION
Fix for issue https://github.com/meteor/meteor/issues/7605

**Meteor version:** 1.4.0.1
**OS:** Windows 10 64bit
**Bug repository & steps to reproduce:** https://github.com/Kurounin/meteor-absolute-path-bug
**Description of bug:** If you use an npm module in the project with a long relative path (e.g.: _../../../build/Release/kerberos_) and you place the project in the drive root, when building the project meteor will join the current absolute file path and the required relative path and the resulting path will be _/build/Release/kerberos_ which will cause it to crash with a fatal error.
