### PR TITLE
Don't touch ~/.meteor/meteor after background updates.

### DIFF
--- a/tools/packaging/updater.js
+++ b/tools/packaging/updater.js
@@ -61,8 +61,6 @@ var checkForUpdate = function (showBanner, printErrors) {
     return;
   }
 
-  updateMeteorToolSymlink(printErrors);
-
   maybeShowBanners();
 };
 


### PR DESCRIPTION
Just because the background updater manages to download a new release, we should not necessarily update the `~/.meteor/meteor` symlink (or `AppData\Local\.meteor\meteor.bat` on Windows) to refer to the new release. That should happen only when the user explicitly runs `meteor update`, i.e. [here](https://github.com/meteor/meteor/blob/eebf538ee00434edeae60ed2ad053e3f76d1b6a6/tools/cli/commands-packages.js#L1346).