### PR TITLE
Do not check connection with protected npm registries

### DIFF
--- a/tools/isobuild/meteor-npm-userconfig
+++ b/tools/isobuild/meteor-npm-userconfig
@@ -6,3 +6,10 @@
 
 loglevel = error
 progress = false
+
+# By default if the NPM registry is unavailable, it will timeout after more than 60s.
+# These settings make sure we throw an error faster
+fetch-retries = 1
+fetch-retry-factor = 4
+fetch-retry-mintimeout = 1000
+fetch-retry-maxtimeout = 10000

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -996,7 +996,9 @@ var installFromShrinkwrap = function (dir) {
 // dependencies. `npm install` times out after more than a minute.
 var ensureConnected = function () {
   try {
-    httpHelpers.getUrl(process.env.NPM_CONFIG_REGISTRY || "http://registry.npmjs.org");
+    if(!process.env["NPM_CONFIG_ALWAYS-AUTH"]){
+      httpHelpers.getUrl(process.env.NPM_CONFIG_REGISTRY || "http://registry.npmjs.org");
+    }
   } catch (e) {
     buildmessage.error("Can't install npm dependencies. " +
                        "Are you connected to the internet?");

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -886,7 +886,6 @@ var getShrinkwrappedDependencies = function (dir) {
 };
 
 var installNpmModule = function (name, version, dir) {
-  ensureConnected();
 
   var installArg = utils.isNpmUrl(version)
     ? version : (name + "@" + version);
@@ -959,8 +958,6 @@ var installFromShrinkwrap = function (dir) {
       "Can't call `npm install` without a npm-shrinkwrap.json file present");
   }
 
-  ensureConnected();
-
   const tempPkgJsonPath = files.pathJoin(dir, "package.json");
   const pkgJsonExisted = files.exists(tempPkgJsonPath);
   if (! pkgJsonExisted) {
@@ -990,21 +987,6 @@ var installFromShrinkwrap = function (dir) {
       recordLastRebuildVersions(pkgDir);
     }
   });
-};
-
-// ensure we can reach http://npmjs.org before we try to install
-// dependencies. `npm install` times out after more than a minute.
-var ensureConnected = function () {
-  try {
-    if(!process.env["NPM_CONFIG_ALWAYS-AUTH"]){
-      httpHelpers.getUrl(process.env.NPM_CONFIG_REGISTRY || "http://registry.npmjs.org");
-    }
-  } catch (e) {
-    buildmessage.error("Can't install npm dependencies. " +
-                       "Are you connected to the internet?");
-    // Recover by returning false from updateDependencies
-    throw new NpmFailure;
-  }
 };
 
 // `npm shrinkwrap`


### PR DESCRIPTION
Fixes https://github.com/meteor/meteor/issues/7636

Now it just doesn't check the connection if we need to authenticate for get requests (according to the `always-auth` npm setting). This is because there are multiple ways to authenticate to NPM servers (http auth, certs, bearer tokens?) and it'd be hard to make all of them work.