### PR TITLE
Fix an error in Accounts.__expirePasswordResetTokens

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1140,14 +1140,7 @@ Ap._expirePasswordResetTokens = function (oldestValidDate, userId) {
       { "services.password.reset.when": { $lt: +oldestValidDate } }
     ]
   }), {
-    $pull: {
-      "services.password.reset": {
-        $or: [
-          { when: { $lt: oldestValidDate } },
-          { when: { $lt: +oldestValidDate } }
-        ]
-      }
-    }
+    $unset: { 'services.password.reset': 1 }
   }, { multi: true });
 }
 


### PR DESCRIPTION
As noted in https://github.com/meteor/meteor/pull/7534#discussion_r74602906 there's an error in `Accounts._expirePasswordResetTokens`

This PR contains the fix and a test for `_expirePasswordResetTokens`

cc @benjamn 