### PR TITLE
Pass object with error to onLoginFailure hooks

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -191,7 +191,7 @@ Ap.callLoginMethod = function (options) {
       });
     } else {
       self._onLoginFailureHook.each(function (callback) {
-        callback();
+        callback({ error: error });
         return true;
       });
     }

--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -191,7 +191,7 @@ Ap.callLoginMethod = function (options) {
       });
     } else {
       self._onLoginFailureHook.each(function (callback) {
-        callback({ error: error });
+        callback({ error });
         return true;
       });
     }


### PR DESCRIPTION
Fixes #7385 

For consistency with the server methods, this passes an object to the onLoginFailure hooks, but unlike on the server it contains only the error associated with the failed login attempt.