### PR TITLE
fix version number of Node MongoDB driver in History.md (v1.4.1.1)

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@
 
 ## v1.4.1.1
 
-* Update the version of our Node MongoDB driver to 2.2.7 to fix a bug in
+* Update the version of our Node MongoDB driver to 2.2.8 to fix a bug in
   reconnection logic, leading to some `update` and `remove` commands being
   treated as `insert`s. [#7594](https://github.com/meteor/meteor/issue/7594)
 


### PR DESCRIPTION
This is just a small fix for the version number of Node MongoDB driver in History.md.

The correct version in Meteor 1.4.1.1 is 2.2.8, not 2.2.7.