### PR TITLE
[EJSON] support for equality in Arrays, including unordered arrays

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -405,9 +405,28 @@ EJSON.equals = function (a, b, options) {
       return false;
     if (a.length !== b.length)
       return false;
-    for (i = 0; i < a.length; i++) {
-      if (!EJSON.equals(a[i], b[i], options))
-        return false;
+    if (keyOrderSensitive) {
+      for (i = 0; i < a.length; i++) {
+        if (!EJSON.equals(a[i], b[i], options)) {
+          return false;
+        }
+      }
+    } else {
+      var _a = a.slice();
+      var _b = b.slice();
+      for (i = _a.length - 1; i >= 0; i--) {
+        var result = false;
+        for (var j = _b.length - 1; j >= 0; j--) {
+          if (EJSON.equals(_a[i], _b[j], options)) {
+            result = true;
+            _a.splice(i, 1);
+            _b.splice(j, 1);
+          }
+        }
+
+        if (!result)
+          return false;
+      }
     }
     return true;
   }

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -421,6 +421,7 @@ EJSON.equals = function (a, b, options) {
             result = true;
             _a.splice(i, 1);
             _b.splice(j, 1);
+            break;
           }
         }
 

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -26,6 +26,13 @@ Tinytest.add("ejson - keyOrderSensitive", function (test) {
   test.isFalse(EJSON.equals({a: {b:2}}, {a: {}}, {keyOrderSensitive: true}));
 });
 
+Tinytest.add('ejson - Arrays - keyOrderSensitive', function (test) {
+  test.isFalse(EJSON.equals({a: ['a', 'b', 'c']}, {a: ['a', 'c', 'b']}, {keyOrderSensitive: true}));
+  test.isTrue(EJSON.equals({a: [{c: 1, d: 2}]}, {a: [{c: 1, d: 2}]}, {keyOrderSensitive: true}));
+  test.isFalse(EJSON.equals({a: [{c: 1, d: 2}]}, {a: [{d: 2, c: 1}]}, {keyOrderSensitive: true}));
+  test.isTrue(EJSON.equals({a: ['a', 'b', 'c']}, {a: ['a', 'b', 'c']}, {keyOrderSensitive: true}));
+});
+
 Tinytest.add("ejson - nesting and literal", function (test) {
   var d = new Date;
   var obj = {$date: d};
@@ -41,6 +48,20 @@ Tinytest.add("ejson - some equality tests", function (test) {
   test.isFalse(EJSON.equals({a: 1, b: 2, c: 3}, {a: 1, c: 3, b: 4}));
   test.isFalse(EJSON.equals({a: {}}, {a: {b:2}}));
   test.isFalse(EJSON.equals({a: {b:2}}, {a: {}}));
+  test.isFalse(EJSON.equals({a: {b:2}}, {a: {}}));
+});
+
+Tinytest.add('ejson - Arrays - equality tests', function (test) {
+  test.isTrue(EJSON.equals({a: ['a', 'b', 'c']}, {a: ['a', 'c', 'b']}));
+  test.isTrue(EJSON.equals(['a', 'b', 'c'], ['a', 'b', 'c']));
+
+  test.isTrue(EJSON.equals({a: [{c: 1, d: 2}]}, {a: [{c: 1, d: 2}]}));
+  test.isTrue(EJSON.equals({a: [{c: 1, d: 2}]}, {a: [{d: 2, c: 1}]}));
+
+  test.isFalse(EJSON.equals({a: ['d', 'b', 'c']}, {a: ['a', 'd', 'b']}));
+  test.isTrue(EJSON.equals({a: ['d', 'b', 'c']}, {a: ['c', 'd', 'b']}));
+  test.isFalse(EJSON.equals(['a', 'b', 'd'], ['d', 'b', 'c']));
+  test.isFalse(EJSON.equals(['a', 'a', 'b'], ['b', 'b', 'a']));
 });
 
 Tinytest.add("ejson - equality and falsiness", function (test) {
@@ -50,6 +71,13 @@ Tinytest.add("ejson - equality and falsiness", function (test) {
   test.isFalse(EJSON.equals(null, {foo: "foo"}));
   test.isFalse(EJSON.equals(undefined, {foo: "foo"}));
   test.isFalse(EJSON.equals({foo: "foo"}, undefined));
+});
+
+Tinytest.add('ejson - Arrays - equality and falsiness', function (test) {
+  test.isTrue(EJSON.equals({a: []}, {a: []}));
+  test.isTrue(EJSON.equals([], []));
+  test.isFalse(EJSON.equals([false], [null]));
+  test.isTrue(EJSON.equals([false], [false]));
 });
 
 Tinytest.add("ejson - NaN and Inf", function (test) {

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -31,6 +31,8 @@ Tinytest.add('ejson - Arrays - keyOrderSensitive', function (test) {
   test.isTrue(EJSON.equals({a: [{c: 1, d: 2}]}, {a: [{c: 1, d: 2}]}, {keyOrderSensitive: true}));
   test.isFalse(EJSON.equals({a: [{c: 1, d: 2}]}, {a: [{d: 2, c: 1}]}, {keyOrderSensitive: true}));
   test.isTrue(EJSON.equals({a: ['a', 'b', 'c']}, {a: ['a', 'b', 'c']}, {keyOrderSensitive: true}));
+  test.isTrue(EJSON.equals(['a', 'b', 'c'], ['a', 'b', 'c'], {keyOrderSensitive: true}));
+  test.isFalse(EJSON.equals(['a', 'c', 'b'], ['a', 'b', 'c'], {keyOrderSensitive: true}));
 });
 
 Tinytest.add("ejson - nesting and literal", function (test) {
@@ -62,6 +64,7 @@ Tinytest.add('ejson - Arrays - equality tests', function (test) {
   test.isTrue(EJSON.equals({a: ['d', 'b', 'c']}, {a: ['c', 'd', 'b']}));
   test.isFalse(EJSON.equals(['a', 'b', 'd'], ['d', 'b', 'c']));
   test.isFalse(EJSON.equals(['a', 'a', 'b'], ['b', 'b', 'a']));
+  test.isTrue(EJSON.equals(['a', 'b', 'a', 'b'], ['b', 'b', 'a', 'a']));
 });
 
 Tinytest.add("ejson - equality and falsiness", function (test) {

--- a/packages/ejson/package.js
+++ b/packages/ejson/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Extended and Extensible JSON library",
-  version: '1.0.12'
+  version: '1.1.0'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Old behaviour:

```js
  EJSON.equals({a: ['a', 'b', 'c']}, {a: ['c', 'a', 'b']}); // false
  EJSON.equals(['a', 'b', 'c'], ['c', 'a', 'b']); // false
```

New behaviour:
```js
  EJSON.equals({a: ['a', 'b', 'c']}, {a: ['c', 'a', 'b']}); // true
  EJSON.equals(['a', 'b', 'c'], ['c', 'a', 'b']); // true
```

 1. Support for `keyOrderSensitive` option
 2. Support deeply nested arrays
 3. Minor version update, as this is new feature
 4. All required tests is added, old tests not broken