### PR TITLE
Added autoprefixer to stylus

### DIFF
--- a/packages/stylus/.npm/plugin/compileStylusBatch/npm-shrinkwrap.json
+++ b/packages/stylus/.npm/plugin/compileStylusBatch/npm-shrinkwrap.json
@@ -1,9 +1,19 @@
 {
   "dependencies": {
     "amdefine": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "from": "amdefine@>=0.0.4"
+    },
+    "autoprefixer": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.7.tgz",
+      "from": "autoprefixer@6.3.7"
+    },
+    "autoprefixer-stylus": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer-stylus/-/autoprefixer-stylus-0.9.4.tgz",
+      "from": "autoprefixer-stylus@0.9.4"
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -14,6 +24,16 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
       "from": "brace-expansion@>=1.0.0 <2.0.0"
+    },
+    "browserslist": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.6.tgz",
+      "from": "browserslist@>=1.3.4 <1.4.0"
+    },
+    "caniuse-db": {
+      "version": "1.0.30000585",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000585.tgz",
+      "from": "caniuse-db@>=1.0.30000488 <2.0.0"
     },
     "concat-map": {
       "version": "0.0.1",
@@ -26,8 +46,8 @@
       "from": "css-parse@>=1.7.0 <1.8.0"
     },
     "debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
       "from": "debug@*"
     },
     "fs.realpath": {
@@ -40,15 +60,25 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
       "from": "glob@>=7.0.0 <7.1.0"
     },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "from": "has-flag@>=1.0.0 <2.0.0"
+    },
     "inflight": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "from": "inflight@>=1.0.4 <2.0.0"
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "from": "inherits@>=2.0.0 <3.0.0"
+    },
+    "js-base64": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "from": "js-base64@>=2.1.9 <3.0.0"
     },
     "minimatch": {
       "version": "3.0.3",
@@ -66,14 +96,29 @@
       "from": "mkdirp@>=0.5.0 <0.6.0"
     },
     "ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "from": "ms@0.7.1"
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "from": "ms@0.7.2"
+    },
+    "multi-stage-sourcemap": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.2.1.tgz",
+      "from": "multi-stage-sourcemap@0.2.1"
     },
     "nib": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/nib/-/nib-1.1.2.tgz",
       "from": "nib@1.1.2"
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "from": "normalize-range@>=0.1.2 <0.2.0"
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "from": "num2fraction@>=1.2.2 <2.0.0"
     },
     "once": {
       "version": "1.4.0",
@@ -81,9 +126,26 @@
       "from": "once@>=1.3.0 <2.0.0"
     },
     "path-is-absolute": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "from": "path-is-absolute@>=1.0.0 <2.0.0"
+    },
+    "postcss": {
+      "version": "5.0.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.21.tgz",
+      "from": "postcss@5.0.21",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "from": "source-map@>=0.5.5 <0.6.0"
+        }
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "from": "postcss-value-parser@>=3.2.3 <4.0.0"
     },
     "sax": {
       "version": "0.5.8",
@@ -99,6 +161,11 @@
       "version": "0.54.5",
       "resolved": "https://github.com/meteor/stylus/tarball/bb47a357d132ca843718c63998eb37b90013a449",
       "from": "https://github.com/meteor/stylus/tarball/bb47a357d132ca843718c63998eb37b90013a449"
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "from": "supports-color@>=3.1.2 <4.0.0"
     },
     "wrappy": {
       "version": "1.0.2",

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -11,7 +11,8 @@ Package.registerBuildPlugin({
   ],
   npmDependencies: {
     stylus: "https://github.com/meteor/stylus/tarball/bb47a357d132ca843718c63998eb37b90013a449", // fork of 0.54.5
-    nib: "1.1.2"
+    nib: "1.1.2",
+    "autoprefixer-stylus": "0.9.4"
   }
 });
 

--- a/packages/stylus/plugin/compile-stylus.js
+++ b/packages/stylus/plugin/compile-stylus.js
@@ -157,7 +157,7 @@ class StylusCompiler extends MultiFileCachingCompiler {
 
     const style = stylus(inputFile.getContentsAsString())
             .use(nib())
-            .use(autoprefixer(fileOptions.autoprefixer || {}))
+            .use(autoprefixer(fileOptions.autoprefixer || {browsers: []}))
             .set('filename', inputFile.getPathInPackage())
             .set('sourcemap', { inline: false, comment: false })
             .set('cache', false)

--- a/packages/stylus/plugin/compile-stylus.js
+++ b/packages/stylus/plugin/compile-stylus.js
@@ -155,13 +155,16 @@ class StylusCompiler extends MultiFileCachingCompiler {
 
     const f = new Future;
 
-    const style = stylus(inputFile.getContentsAsString())
-            .use(nib())
-            .use(autoprefixer(fileOptions.autoprefixer || {browsers: []}))
-            .set('filename', inputFile.getPathInPackage())
-            .set('sourcemap', { inline: false, comment: false })
-            .set('cache', false)
-            .set('importer', importer);
+    let style = stylus(inputFile.getContentsAsString()).use(nib())
+
+    if (fileOptions.autoprefixer) {
+      style = style.use(autoprefixer(fileOptions.autoprefixer))
+    }
+
+    style = style.set('filename', inputFile.getPathInPackage())
+                 .set('sourcemap', { inline: false, comment: false })
+                 .set('cache', false)
+                 .set('importer', importer);
 
     style.render(f.resolver());
     let css;

--- a/packages/stylus/plugin/compile-stylus.js
+++ b/packages/stylus/plugin/compile-stylus.js
@@ -1,5 +1,6 @@
 const stylus = Npm.require('stylus');
 const nib = Npm.require('nib');
+const autoprefixer = Npm.require('autoprefixer-stylus');
 const Future = Npm.require('fibers/future');
 const fs = Plugin.fs;
 const path = Plugin.path;
@@ -19,7 +20,10 @@ class StylusCompiler extends MultiFileCachingCompiler {
   }
 
   getCacheKey(inputFile) {
-    return inputFile.getSourceHash();
+    return [
+      inputFile.getSourceHash(),
+      inputFile.getFileOptions(),
+    ];
   }
 
   compileResultSize(compileResult) {
@@ -147,10 +151,13 @@ class StylusCompiler extends MultiFileCachingCompiler {
       return sourcemap;
     }
 
+    const fileOptions = inputFile.getFileOptions();
+
     const f = new Future;
 
     const style = stylus(inputFile.getContentsAsString())
             .use(nib())
+            .use(autoprefixer(fileOptions.autoprefixer || {}))
             .set('filename', inputFile.getPathInPackage())
             .set('sourcemap', { inline: false, comment: false })
             .set('cache', false)


### PR DESCRIPTION
Nib is very outdated. I was mostly using it to add vendor prefixes. But now people use autoprefixer for that. So I added it to the package.

One can configure which browsers to support using file options:

``` javascript
  api.addFiles([
    'file.styl'
  ], 'client', {
    autoprefixer: {
      browsers: ['last 3 Chrome versions', 'Firefox >= 7', 'Explorer >= 8', 'last 2 versions', '> 1%', 'Firefox ESR', 'Safari >= 4']
    }
  });
```

[See defaults here](https://github.com/ai/browserslist#queries).
