### PR TITLE
Add ws: and wss: sources to default CSP for Cordova

### DIFF
--- a/packages/boilerplate-generator/boilerplate_web.cordova.html
+++ b/packages/boilerplate-generator/boilerplate_web.cordova.html
@@ -4,7 +4,7 @@
   <meta name="format-detection" content="telephone=no">
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height">
   <meta name="msapplication-tap-highlight" content="no">
-  <meta http-equiv="Content-Security-Policy" content="default-src * data: blob: 'unsafe-inline' 'unsafe-eval';">
+  <meta http-equiv="Content-Security-Policy" content="default-src * data: blob: 'unsafe-inline' 'unsafe-eval' ws: wss:;">
 
 {{! We are explicitly not using bundledJsCssUrlRewriteHook: in cordova we serve assets up directly from disk, so rewriting the URL does not make sense }}
 


### PR DESCRIPTION
This PR should fix #7772 by adding ws: and wss: to the default CSP for Cordova.

