### PR TITLE
Update node-mongodb driver to 2.2.10

### DIFF
--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '1.5.49',
+  version: '1.5.50',
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "2.2.9"
+  mongodb: "2.2.10"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
This release of the node-mongodb driver finally fixed performance issues we were having on our Compose MongoDB 3.2 deployment.