### PR TITLE
Add crossorigin="anonymous" to script tags

### DIFF
--- a/packages/boilerplate-generator/boilerplate_web.browser.html
+++ b/packages/boilerplate-generator/boilerplate_web.browser.html
@@ -12,7 +12,7 @@
 {{else}}
 <script type='text/javascript' src='{{rootUrlPathPrefix}}/meteor_runtime_config.js'></script>
 {{/if}}
-{{#each js}}  <script type="text/javascript" src="{{../bundledJsCssUrlRewriteHook url}}"></script>
+{{#each js}}  <script type="text/javascript" crossorigin="anonymous" src="{{../bundledJsCssUrlRewriteHook url}}"></script>
 {{/each}}
 {{#each additionalStaticJs}}
   {{#if ../inlineScriptsAllowed}}


### PR DESCRIPTION
If you serve your JS through a CDN, then most errors will report out to Kadira (or a similar tracking tool) as "Script error" because the JS file is hosted on another domain. Adding crossorigin="anonymous" to each script tag enables CORS (as long as the CDN is properly configured and the Meteor app also sets the Access-Control-Allow-Origin headers on JS files).
