### PR TITLE
Add support for `--no-release-check` to `meteor test` command

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1796,6 +1796,7 @@ var runTestAppForPackages = function (projectContext, options) {
       oplogUrl: process.env.MONGO_OPLOG_URL,
       mobileServerUrl: options.mobileServerUrl,
       once: options.once,
+      noReleaseCheck: options['no-release-check'] || process.env.METEOR_NO_RELEASE_CHECK,
       recordPackageUsage: false,
       selenium: options.selenium,
       seleniumBrowser: options['selenium-browser'],


### PR DESCRIPTION
This functionality for the `test` command was overlooked when meteor/meteor#7445 was implemented.

Closes meteor/meteor#7026