### PR TITLE
Await `Promise` when running `npm install`

### DIFF
--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -727,7 +727,7 @@ Profile("meteorNpm.runNpmCommand", function (args, cwd) {
           });
         }
       );
-    });
+    }).await();
 
   }).await();
 });


### PR DESCRIPTION
This subtle change appears to be the fix for the (recent) CI server timeouts.  Previously, the `await` was only on the `Promise` from `getEnv` and this adds it to the `Promise` for the `npm install` as well.

It's entirely possible that the `await()` would be better suited to be [in the `getEnv` method](https://github.com/meteor/meteor/blob/942221d07f7197e449855a70e526f454ee46887b/tools/cli/dev-bundle-bin-helpers.js#L16) but I'm not certain that would be desired.

#### Note!
There is still a completely separate failure which is still occurring (_far_ less often) which produces the error:

```
Can't install npm dependencies. Are you connected to the internet?
```

...but that appears that it might actually be a _legitimate_ problem with the connection.  More on that later, maybe.