### PR TITLE
Remove need for registry http get check by tuning npm retry parameters

### DIFF
--- a/tools/isobuild/meteor-npm-userconfig
+++ b/tools/isobuild/meteor-npm-userconfig
@@ -6,3 +6,10 @@
 
 loglevel = error
 progress = false
+
+# By default if the NPM registry is unavailable, it will timeout after more than 60s.
+# These settings make sure we throw an error faster
+fetch-retries = 1
+fetch-retry-factor = 4
+fetch-retry-mintimeout = 1000
+fetch-retry-maxtimeout = 10000

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -886,7 +886,6 @@ var getShrinkwrappedDependencies = function (dir) {
 };
 
 var installNpmModule = function (name, version, dir) {
-  ensureConnected();
 
   var installArg = utils.isNpmUrl(version)
     ? version : (name + "@" + version);
@@ -959,8 +958,6 @@ var installFromShrinkwrap = function (dir) {
       "Can't call `npm install` without a npm-shrinkwrap.json file present");
   }
 
-  ensureConnected();
-
   const tempPkgJsonPath = files.pathJoin(dir, "package.json");
   const pkgJsonExisted = files.exists(tempPkgJsonPath);
   if (! pkgJsonExisted) {
@@ -990,19 +987,6 @@ var installFromShrinkwrap = function (dir) {
       recordLastRebuildVersions(pkgDir);
     }
   });
-};
-
-// ensure we can reach http://npmjs.org before we try to install
-// dependencies. `npm install` times out after more than a minute.
-var ensureConnected = function () {
-  try {
-    httpHelpers.getUrl(process.env.NPM_CONFIG_REGISTRY || "http://registry.npmjs.org");
-  } catch (e) {
-    buildmessage.error("Can't install npm dependencies. " +
-                       "Are you connected to the internet?");
-    // Recover by returning false from updateDependencies
-    throw new NpmFailure;
-  }
 };
 
 // `npm shrinkwrap`


### PR DESCRIPTION
This PR follows out of the discussion of https://github.com/meteor/meteor/pull/7637

Basically Meteor did a check to see if the npm registry url is available because NPM only times out after more than a minute by default.

However the NPM retry parameters are configurable and by tuning them we can remove this check.
This has a couple of advantages:
1. It works for registries that require HTTP get authentication, thus fixing https://github.com/meteor/meteor/issues/7636
2. It makes builds a bit faster since the ensureConnected check can be called quite a lot (~25 times in @abernix  test environment, see: https://github.com/meteor/meteor/pull/7637#issuecomment-249105535 ). 
3. We end up with less code to maintain.
4. More flexible behavior. Currently it will retry once, which in my tests throws an error after about 20s for an unreachable host. You could disable retries altogether or allow for more retries.