### PR TITLE
CoffeeScript now supports ES2015 modules

### DIFF
--- a/packages/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
+++ b/packages/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
     "coffee-script": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
-      "from": "coffee-script@1.10.0"
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.0.tgz",
+      "from": "coffee-script@1.11.0"
     },
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      "from": "source-map@0.5.6"
     }
   }
 }

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -37,6 +37,7 @@ Package.onTest(function (api) {
     'tests/coffeescript_test_setup.js',
     'tests/coffeescript_tests.coffee',
     'tests/coffeescript_strict_tests.coffee',
+    'tests/coffeescript_module.coffee',
     'tests/es2015_module.js',
     'tests/litcoffeescript_tests.litcoffee',
     'tests/litcoffeescript_tests.coffee.md',

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -8,7 +8,7 @@ Package.registerBuildPlugin({
   use: ['caching-compiler', 'ecmascript'],
   sources: ['plugin/compile-coffeescript.js'],
   npmDependencies: {
-    "coffee-script": "1.10.0",
+    "coffee-script": "1.11.0",
     "source-map": "0.5.6"
   }
 });
@@ -18,10 +18,10 @@ Package.onUse(function (api) {
   api.use('babel-compiler');
 
   // Because the CoffeeScript plugin now calls
-  // BabelCompiler.prototype.processOneFileForTarget for any raw
-  // JavaScript enclosed by backticks, it must provide the same runtime
-  // environment that the 'ecmascript' package provides. The following
-  // api.imply calls should match those in ../ecmascript/package.js,
+  // BabelCompiler.prototype.processOneFileForTarget for any ES2015+
+  // JavaScript or JavaScript enclosed by backticks, it must provide the
+  // same runtime environment that the 'ecmascript' package provides.
+  // The following api.imply calls should match those in ../ecmascript/package.js,
   // except that coffeescript does not api.imply('modules').
   api.imply('ecmascript-runtime');
   api.imply('babel-runtime');

--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -83,8 +83,9 @@ export class CoffeeCompiler extends CachingCompiler {
 
     let sourceMap = JSON.parse(output.v3SourceMap);
 
-    if (source.indexOf('`') !== -1) {
-      // If source contains backticks, pass the coffee output through babel-compiler
+    if (source.match(/(`|import|export|function\*)/)) {
+      // If source contains backticks or ES2015+ features,
+      // pass the coffee output through babel-compiler
       const doubleRoastedCoffee =
         this.babelCompiler.processOneFileForTarget(inputFile, output.js);
 

--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -83,8 +83,8 @@ export class CoffeeCompiler extends CachingCompiler {
 
     let sourceMap = JSON.parse(output.v3SourceMap);
 
-    if (source.match(/(`|import|export|function\*)/)) {
-      // If source contains backticks or ES2015+ features,
+    if (source.match(/`|\bimport\b|\bexport\b|\byield\b/)) {
+      // If source contains backticks or features that output as ES2015+,
       // pass the coffee output through babel-compiler
       const doubleRoastedCoffee =
         this.babelCompiler.processOneFileForTarget(inputFile, output.js);

--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -83,7 +83,7 @@ export class CoffeeCompiler extends CachingCompiler {
 
     let sourceMap = JSON.parse(output.v3SourceMap);
 
-    if (source.match(/`|\bimport\b|\bexport\b|\byield\b/)) {
+    if (source.match(/`|\b(?:import|export|yield)\b/)) {
       // If source contains backticks or features that output as ES2015+,
       // pass the coffee output through babel-compiler
       const doubleRoastedCoffee =

--- a/packages/coffeescript/tests/coffeescript_module.coffee
+++ b/packages/coffeescript/tests/coffeescript_module.coffee
@@ -1,0 +1,1 @@
+export testingForNativeImportedModule123456789 = true

--- a/packages/coffeescript/tests/coffeescript_tests.coffee
+++ b/packages/coffeescript/tests/coffeescript_tests.coffee
@@ -7,10 +7,19 @@ Tinytest.add "coffeescript - compile", (test) -> test.isTrue true
 
 
 # import/export statements must be top-level
-`import { Meteor as testingForImportedSymbol123456789 } from "meteor/meteor";`
-Tinytest.add "coffeescript - import external package via backticks", (test) ->
-  test.isTrue testingForImportedSymbol123456789?
+`import { Meteor as testingForBacktickedImportedSymbol } from "meteor/meteor";`
+Tinytest.add "coffeescript - import external package via backticked import statement", (test) ->
+  test.isTrue testingForBacktickedImportedSymbol?
 
 `import { testingForImportedModule987654321 } from "./es2015_module.js";`
-Tinytest.add "coffeescript - import local module via backticks", (test) ->
+Tinytest.add "coffeescript - import local module via backticked import statement", (test) ->
   test.isTrue testingForImportedModule987654321?
+
+
+import { Meteor as testingForNativeImportedSymbol } from "meteor/meteor"
+Tinytest.add "coffeescript - import external package via native import statement", (test) ->
+  test.isTrue testingForNativeImportedSymbol?
+
+import { testingForImportedModule123456789 } from "./es2015_module.js";
+Tinytest.add "coffeescript - import local module via native import statement", (test) ->
+  test.isTrue testingForImportedModule123456789?

--- a/packages/coffeescript/tests/coffeescript_tests.coffee
+++ b/packages/coffeescript/tests/coffeescript_tests.coffee
@@ -23,3 +23,8 @@ Tinytest.add "coffeescript - import external package via native import statement
 import { testingForImportedModule123456789 } from "./es2015_module.js";
 Tinytest.add "coffeescript - import local module via native import statement", (test) ->
   test.isTrue testingForImportedModule123456789?
+
+
+import { testingForNativeImportedModule123456789 } from "./coffeescript_module.coffee";
+Tinytest.add "coffeescript - import local module exported by a CoffeeScript native export statement, via native import statement", (test) ->
+  test.isTrue testingForNativeImportedModule123456789?

--- a/packages/coffeescript/tests/es2015_module.js
+++ b/packages/coffeescript/tests/es2015_module.js
@@ -1,1 +1,2 @@
+export const testingForImportedModule123456789 = true;
 export const testingForImportedModule987654321 = true;


### PR DESCRIPTION
CoffeeScript 1.11.0 is out, and this release adds [native support for `import` and `export` statements](http://coffeescript.org/#modules). There’s no need to wrap such statements in backticks anymore.

This pull request updates Meteor’s `coffeescript` package as follows:
- The version of CoffeeScript is bumped to 1.11.0.
- Previously, any CoffeeScript file that contained at least one backtick was passed to the `ecmascript` package for further compilation by Babel. Now CoffeeScript files that contain backticks or the substrings `import`, `export` or `function*` are passed to `ecmascript`.
- New tests are added to check that the native `import` and `export` statements work.

Regarding when to pass to `ecmascript`, technically CoffeeScript currently has two features that are output as ES2015 rather than ES5: modules, and [generator functions](http://coffeescript.org/#fat-arrow). It was a bug in the previous version of the package that generators were passed through to the runtime, rather than getting further processing by `ecmascript`/Babel. We might want to consider eliminating this check and simply pass everything output by CoffeeScript to `ecmascript`, rather than continuing to expand this list as CoffeeScript adds more features that it outputs in ESNext syntax. For now I’ve left it, since it should improve performance and the list of ESNext syntax features is still fairly short.