### PR TITLE
Meteor should check if is running as root and prevent it on Unix

### DIFF
--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -594,7 +594,7 @@ Fiber(function () {
   // tight timetable for 1.0 and there is no advantage to doing it now
   // rather than later. #ImprovingCrossVersionOptionParsing
 
-  var isBoolean = { "--help": true };
+  var isBoolean = { "--help": true, "--unsafe-perm": true };
   var walkCommands = function (node) {
     _.each(node, function (value, key) {
       if (value instanceof Command) {
@@ -744,6 +744,35 @@ Fiber(function () {
 
     // It is a plain old argument!
     rawArgs.push(term);
+  }
+  
+  // Check if meteor is run as root only on UNIX platforms
+  var unixPlatforms = { 
+    'darwin': true,
+    'linux': true,
+    'freebsd': true
+  };
+  var platform = process.platform;
+
+  if (_.has(unixPlatforms, platform)){
+    var isRoot = process.env.USERNAME == 'root';
+    var isRootSafe = _.has(rawOptions, '--unsafe-perm');
+
+    if(isRoot && !isRootSafe){
+      Console.error("");
+      Console.error("It seems that you are running meteor as root, if you really know what you are doing, add the unsafe-perm flag.");
+      Console.error("");
+      Console.error("meteor --unsafe-perm <command>");
+      Console.error("");
+      process.exit(1);
+    }
+    if (isRoot && isRootSafe) {
+      Console.info("");
+      Console.info("You are running meteor as root, don't forget to chown your .meteor directory back to yourself.");
+      Console.info("");
+      Console.info("chown -Rh <username> ~/.meteor");
+      Console.info("");
+    }
   }
 
   // Figure out if we're running in a directory that is part of a Meteor

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -747,17 +747,9 @@ Fiber(function () {
   }
 
   // Prevent running meteor as root
-
-  var unixPlatforms = {
-    'darwin': true,
-    'linux': true,
-    'freebsd': true
-  };
-  var platform = process.platform;
-
-  if (_.has(unixPlatforms, platform)){
+  if (process.getuid) {
     // On UNIX platforms.
-    if (process.getgid() === 0 && process.getuid() === 0){
+    if (process.getuid() === 0){
       if (_.has(rawOptions, '--unsafe-perm')) {
         // Meteor is running as root and has the --unsafe-perm flag, just notice.
         Console.info("");

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -747,6 +747,7 @@ Fiber(function () {
   }
   
   // Check if meteor is run as root only on UNIX platforms.
+  
   var unixPlatforms = { 
     'darwin': true,
     'linux': true,
@@ -756,15 +757,10 @@ Fiber(function () {
 
   if (_.has(unixPlatforms, platform)){
     // On UNIX platforms.
-    var isRoot = process.getgid() === 0 && process.getuid() === 0;
     var isSudo = !_.isUndefined(process.env.SUDO_UID);
-    var isRootSafe = _.has(rawOptions, '--unsafe-perm');
     
-    // Issue when running `sudo meteor --unsafe-perm`, --unsafe-perm: unknown option.
-    // TODO: remove the --unsafe-perm flag.
-    
-    if (isRoot){
-      if (isRootSafe) {
+    if (process.getgid() === 0 && process.getuid() === 0){
+      if (_.has(rawOptions, '--unsafe-perm')) {
         // Meteor is running as root and has the --unsafe-perm flag, just notice.
         Console.info("");
         Console.info("You have run Meteor as root.", 
@@ -800,6 +796,9 @@ Fiber(function () {
         }
       }
     }
+    
+    // Issue when running `sudo meteor --unsafe-perm`, --unsafe-perm: unknown option.
+    // TODO: remove the --unsafe-perm flag.
   }
 
   // Figure out if we're running in a directory that is part of a Meteor


### PR DESCRIPTION
Hi,

This is a solution for #7631

```
$ sudo meteor

It seems that you are running meteor as root, if you really know what you are
doing, add the unsafe-perm flag.

meteor --unsafe-perm <command>

```
```
$ sudo meteor --unsafe-perm

You are running meteor as root, don't forget to chown your .meteor directory
back to yourself.

chown -Rh <username> ~/.meteor

...

```