### PR TITLE
Readme: Make clear how to run your app with a local checkout of Meteor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ can run Meteor directly from a Git checkout using these steps:
 
 0. **_(Optional)_ Compile dependencies**
 
-    > This optional step requires `git`, a C and C++ compiler, autotools, and scons.
+    > This optional step requires a C and C++ compiler, autotools, and scons.
     > If this step is skipped, Meteor will simply download pre-built binaries.
 
     To build everything from scratch (`node`, `npm`, `mongodb`, etc.) run the following:

--- a/README.md
+++ b/README.md
@@ -107,23 +107,13 @@ Now you can run meteor directly from the checkout (if you did not
 build the dependency bundle above, this will take a few moments to
 download a pre-build version).
 
+Run at least one Meteor command to install required dependencies, like:
+
 ```bash
 ./meteor --help
 ```
 
-### Local docs
-
-From your checkout, you can read the docs locally. The `/docs` directory is a
-meteor application, so simply change into the `/docs` directory and launch
-the app:
-
-```bash
-cd docs/
-../meteor
-```
-
-You'll then be able to read the docs locally in your browser at
-`http://localhost:3000/`.
+You local Meteor checkout is now ready for use.
 
 Note that if you run Meteor from a git checkout, you cannot pin apps to specific
 Meteor releases or run using different Meteor releases using `--release`.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Run at least one Meteor command to install required dependencies, like:
 ./meteor --help
 ```
 
-You local Meteor checkout is now ready for use.
+Your local Meteor checkout is now ready for use.
 
 Note that if you run Meteor from a git checkout, you cannot pin apps to specific
 Meteor releases or run using different Meteor releases using `--release`.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ can run Meteor directly from a Git checkout using these steps:
     anywhere you would normally call the system `meteor`.  For example,:
 
     ```sh
-    any-app-directory $ /path/to/meteor-checkout/meteor
+    $ cd my-app/
+    $ /path/to/meteor-checkout/meteor run
     ```
 
     > _Note:_ When running from a `git` checkout, you cannot pin apps to specific

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ structure:
 Create the demo app by running:
 
 ```bash
-./meteor create demo-app
+./meteor/meteor create demo-app
 ```
 
 To run the demo-app with the local copy of Meteor:

--- a/README.md
+++ b/README.md
@@ -41,82 +41,55 @@ meteor
 
 ## Slow Start (for developers)
 
-If you want to run on the bleeding edge, or help develop Meteor, you
-can run Meteor directly from a git checkout.
+If you want to run on the bleeding edge, or [help contribute to Meteor](Contributing.md), you
+can run Meteor directly from a Git checkout using these steps:
 
-### Clone
+0. **Clone from GitHub**
 
-```bash
-git clone --recursive git://github.com/meteor/meteor.git
-cd meteor
-```
+    ```sh
+    $ git clone --recursive https://github.com/meteor/meteor.git
+    $ cd meteor
+    ```
 
-The `--recursive` flag ensures that submodules will be initialized and
-updated as part of the cloning process. If you cloned the `meteor`
-repository without the `--recursive` flag, you can equivalently run
+    > ##### Important note about Git submodules!
+    >
+    > This repository uses Git submodules.  If you clone without the `--recursive` flag,
+    > re-fetch with `git pull` or experience "`Depending on unknown package`" errors,
+    > run the following in the repository root to sync things up again:
+    >
+    >     $ git submodule update --init --recursive
 
-```bash
-git submodule update --init --recursive
-```
+0. **_(Optional)_ Compile dependencies**
 
-in the root of the `meteor` repository. The typical symptom of not
-updating submodules will be `Error: Depending on unknown package ...`
-when you run most Meteor commands.
+    > This optional step requires `git`, a C and C++ compiler, autotools, and scons.
+    > If this step is skipped, Meteor will simply download pre-built binaries.
 
-### Create testing app
+    To build everything from scratch (`node`, `npm`, `mongodb`, etc.) run the following:
 
-To create a local app to test with your Meteor checkout this is a good 
-structure:
+    ```sh
+    $ ./scripts/generate-dev-bundle.sh # OPTIONAL!
+    ```
 
-```
-./meteor
-./demo-app
-```
+0. **Run a Meteor command to install dependencies**
 
-Create the demo app by running:
+    > If you did not compile dependencies above, this will also download the binaries.
 
-```bash
-./meteor/meteor create demo-app
-```
 
-To run the demo-app with the local copy of Meteor:
+    ```sh
+    $ ./meteor --help
+    ```
 
-```bash
-cd demo-app
-../meteor/meteor
-```
+0. **Ready to Go!**
 
-The first time you will see a message which confirms running locally:
+    Your local Meteor checkout is now ready to use!  You can use this `./meteor`
+    anywhere you would normally call the system `meteor`.  For example,:
 
-> It's the first time you've run Meteor from a git checkout.
+    ```sh
+    any-app-directory $ /path/to/meteor-checkout/meteor
+    ```
 
-### Build from scratch
-
-If you're the sort of person who likes to build everything from scratch,
-you can build all the Meteor dependencies (node.js, npm, mongodb, etc)
-with the provided script. This requires git, a C and C++ compiler,
-autotools, and scons. If you do not run this script, Meteor will
-automatically download pre-compiled binaries when you first run it.
-
-```bash
-# OPTIONAL
-./scripts/generate-dev-bundle.sh
-```
-
-Now you can run meteor directly from the checkout (if you did not
-build the dependency bundle above, this will take a few moments to
-download a pre-build version).
-
-Run at least one Meteor command to install required dependencies, like:
-
-```bash
-./meteor --help
-```
-
-Your local Meteor checkout is now ready for use.
-
-Note that if you run Meteor from a git checkout, you cannot pin apps to specific
-Meteor releases or run using different Meteor releases using `--release`.
+    > _Note:_ When running from a `git` checkout, you cannot pin apps to specific
+    > Meteor releases or change the release using `--release`.
 
 ## Uninstalling Meteor
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ meteor
 If you want to run on the bleeding edge, or help develop Meteor, you
 can run Meteor directly from a git checkout.
 
+### Clone
+
 ```bash
 git clone --recursive git://github.com/meteor/meteor.git
 cd meteor
@@ -60,6 +62,35 @@ git submodule update --init --recursive
 in the root of the `meteor` repository. The typical symptom of not
 updating submodules will be `Error: Depending on unknown package ...`
 when you run most Meteor commands.
+
+### Create testing app
+
+To create a local app to test with your Meteor checkout this is a good 
+structure:
+
+```
+./meteor
+./demo-app
+```
+
+Create the demo app by running:
+
+```bash
+./meteor create demo-app
+```
+
+To run the demo-app with the local copy of Meteor:
+
+```bash
+cd demo-app
+../meteor/meteor
+```
+
+The first time you will see a message which confirms running locally:
+
+> It's the first time you've run Meteor from a git checkout.
+
+### Build from scratch
 
 If you're the sort of person who likes to build everything from scratch,
 you can build all the Meteor dependencies (node.js, npm, mongodb, etc)
@@ -79,6 +110,8 @@ download a pre-build version).
 ```bash
 ./meteor --help
 ```
+
+### Local docs
 
 From your checkout, you can read the docs locally. The `/docs` directory is a
 meteor application, so simply change into the `/docs` directory and launch


### PR DESCRIPTION
The README explained how to run Meteor from a checkout: 
https://github.com/meteor/meteor#slow-start-for-developers

The example used is the Meteor docs app, which is available in the Meteor repository itself. However it did not mention how you can run the local Meteor checkout from a local app.

That is the most basic use case, for example to reproduce or even fix a bug. 

That’s why this example is based on creating a new clean app with meteor create so we focus on creating a clean reproduction. That way we can point to it when people want to debug their own issue.

This change makes it easier for beginners to use while it does not negatively impact expert users in my opinion.

**Edit:** Another thing which I am not sure of mentioning: The process described does not work actually. You first have to Fork Meteor and you have to clone your own Fork to your local machine. Not sure if that goes into too much detail. Following the steps described will only work for Meteor maintainers since they do have actual access to the Meteor repository.