### PR TITLE
Explicit error in modules-runtime when loading client file on server

### DIFF
--- a/packages/modules-runtime/modules-runtime.js
+++ b/packages/modules-runtime/modules-runtime.js
@@ -26,11 +26,25 @@ options.fallback = function (id, parentId, error) {
 };
 
 options.fallback.resolve = function (id, parentId, error) {
-  if (Meteor.isServer &&
-      topLevelIdPattern.test(id)) {
-    // Allow any top-level identifier to resolve to itself on the server,
-    // so that options.fallback can have a chance to handle it.
-    return id;
+  if (Meteor.isServer) {
+    if (topLevelIdPattern.test(id)) {
+      // Allow any top-level identifier to resolve to itself on the server,
+      // so that options.fallback can have a chance to handle it.
+      return id;
+    }else{
+      // Try to give a specific error in known cases
+      if (parentId.startsWith("/imports/ui")) {
+        throw new Error("Cannot find module " + 
+          "'" + id + "' from " + parentId + " on the server." + 
+          " Are you sure this file is intended to load on the server?");
+      }
+
+      if (parentId.startsWith("/client")) {
+        throw new Error("Cannot find module " + 
+          "'" + id + "' from " + parentId + " on the server." + 
+          " Are you sure this file is intended to load on the server?");
+      }
+    }
   }
 
   throw error;


### PR DESCRIPTION
While following the tutorial (https://www.meteor.com/tutorials/blaze/templates) this issue occurred:

https://github.com/meteor/tutorials/issues/45#issuecomment-222033814

**Background**

Consider the knowledge of the user: This is his first attempt to work with Meteor and imports.

**The issue: developer-error**

This issue is a developer-error: Loading a client side intended file on the server.

The normal error you will receive is:

`Error: Cannot find module './body.html'
`

This proposal will show the following error:

`Cannot find module './body.html' from /imports/ui/body.js on the server. Are you sure this file is intended to load on the server?`

The logical thing for the developer is to check their import, see if the file exists etc. but because you have 2 main.js files it’s very easy to make the error to load it in the server main.js file.

**Solution: More explicit error message**

To prevent this issue and make it easier to find the fix I propose to show more explicit errors to help the developer find the issue quicker.

My proposition has just 2 scenarios currently, it only detects paths which start with with:
1. /client
2. /imports/ui

Off course more specific errors may be introduced when needed.

**Performance**

I expect there is no performance penalty with this because Meteor is already throwing an error and Meteor will crash anyway.

**Flexibility for expert users**

This change will not block expert users to do custom things as this error will crash Meteor. It only adds more explicit error messages to the console.

**Tests**

There are no tests included in the modules-runtime package. If we want this error to be tested I need some direction in where to put tests for this error message.
