### PR TITLE
Fix #7827 - Fix link in Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -61,9 +61,8 @@ for more details on proposing changes to core code.
 As of May 2016, we use GitHub to track feature requests. Feature request issues get the `feature` label, as well as a label
 corresponding to the Meteor subproject that they are a part of.
 
-Meteor is a big project with [many](https://www.meteor.com/projects)
-[subprojects](https://github.com/meteor/meteor/labels). Right now, the project
-doesn't have as many
+Meteor is a big project with [many subprojects](https://github.com/meteor/meteor/tree/devel/packages). 
+Right now, the project doesn't have as many
 [core developers (we're hiring!)](https://www.meteor.com/jobs/core-developer)
 as subprojects, so we're not able to work on every single subproject every
 month.  We use our [roadmap](Roadmap.md) to communicate the high level features we're prioritizing over the near and medium term.


### PR DESCRIPTION
Link to Meteor website was broken and there were 2 links which looked
like one. Replaced with a link to the list of packages in the Meteor
repository to give the best currently available overview of the parts
of Meteor.