### PR TITLE
Optimize ignoreFiles patterns

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -174,7 +174,7 @@ import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 // files to ignore when bundling. node has no globs, so use regexps
 exports.ignoreFiles = [
     /~$/, /^\.#/,
-    /^(\.meteor\/|\.git\/|Thumbs\.db|\.DS_Store\/?|Icon.|ehthumbs\.db|\..*\.sw.|#.*#)$/, 
+    /^(\.meteor\/|\.git\/|Thumbs\.db|\.DS_Store\/?|Icon\.|ehthumbs\.db|\..*\.sw.|#.*#)$/,
       /* .meteor => avoids scanning N^2 files when bundling all packages
         .git => often has too many files to watch 
         ....sw(.) => vim swap files

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -174,7 +174,7 @@ import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 // files to ignore when bundling. node has no globs, so use regexps
 exports.ignoreFiles = [
     /~$/, /^\.#/,
-    /^(\.meteor\/|\.git\/|Thumbs\.db|\.DS_Store\/?|Icon\.|ehthumbs\.db|\..*\.sw.|#.*#)$/,
+    /^(\.meteor\/|\.git\/|Thumbs\.db|\.DS_Store\/?|Icon\r|ehthumbs\.db|\..*\.sw.|#.*#)$/,
       /* .meteor => avoids scanning N^2 files when bundling all packages
         .git => often has too many files to watch 
         ....sw(.) => vim swap files

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -173,11 +173,13 @@ import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 
 // files to ignore when bundling. node has no globs, so use regexps
 exports.ignoreFiles = [
-    /~$/, /^\.#/, /^#.*#$/,  // emacs swap files
-    /^\..*\.sw.$/,  // vim swap files
-    /^\.DS_Store\/?$/, /^ehthumbs\.db$/, /^Icon.$/, /^Thumbs\.db$/,
-    /^\.meteor\/$/, /* avoids scanning N^2 files when bundling all packages */
-    /^\.git\/$/ /* often has too many files to watch */
+    /~$/, /^\.#/,
+    /^(\.meteor\/|\.git\/|Thumbs\.db|\.DS_Store\/?|Icon.|ehthumbs\.db|\..*\.sw.|#.*#)$/, 
+      /* .meteor => avoids scanning N^2 files when bundling all packages
+        .git => often has too many files to watch 
+        ....sw(.) => vim swap files
+        #.*# => emacs swap files
+      */
 ];
 
 function rejectBadPath(p) {

--- a/tools/tests/bundle-ignore-files.js
+++ b/tools/tests/bundle-ignore-files.js
@@ -1,22 +1,15 @@
-var _ = require('underscore');
-var selftest = require('../tool-testing/selftest.js');
-var Sandbox = selftest.Sandbox;
-var files = require('../fs/files.js');
-var bundler = require('../isobuild/bundler.js');
+const selftest = require('../tool-testing/selftest.js');
+const bundler = require('../isobuild/bundler.js');
 
 selftest.define("bundle-ignore-files", () => {
-  var patterns = bundler.ignoreFiles;
-  var inputs = [
+  const patterns = bundler.ignoreFiles;
+  const matchingInputs = [
     '.git/',
     '.meteor/',
     '.DS_Store',
     '.aaabbb.swp',
-    'Thumbs.db',
+    'Thumbs.db'
   ];
-  _.each(inputs, (input) => {
-    let matched = _.any(patterns, (ptn) => {
-      return ptn.test(input);
-    });
-    selftest.expectEqual(matched, true);
-  });
+
+  matchingInputs.forEach(input => selftest.expectEqual(patterns.some(p => p.test(input)),true));
 });

--- a/tools/tests/bundle-ignore-files.js
+++ b/tools/tests/bundle-ignore-files.js
@@ -1,0 +1,20 @@
+var selftest = require('../tool-testing/selftest.js');
+var Sandbox = selftest.Sandbox;
+var files = require('../fs/files.js');
+var bundler = require('../isobuild/bundle.js');
+
+selftest.define("bundle-ignore-files", () => {
+  var patterns = bundler.ignoreFiles;
+  var inputs = [
+    '.git/refs',
+    '.git/HEAD',
+    '.meteor/local',
+    '.meteor/packages',
+  ];
+  _.each(inputs, (input) => {
+    let matched = _.any(patterns, (ptn) => {
+      return ptn.test(input);
+    });
+    selftest.expectEqual(matched, true);
+  });
+});

--- a/tools/tests/bundle-ignore-files.js
+++ b/tools/tests/bundle-ignore-files.js
@@ -12,4 +12,10 @@ selftest.define("bundle-ignore-files", () => {
   ];
 
   matchingInputs.forEach(input => selftest.expectEqual(patterns.some(p => p.test(input)),true));
+
+  const nonMatchingInputs = [
+    '/imports/components/Icon/index.js',
+  ];
+
+  nonMatchingInputs.forEach(input => selftest.expectEqual(patterns.some(p => p.test(input)),false));
 });

--- a/tools/tests/bundle-ignore-files.js
+++ b/tools/tests/bundle-ignore-files.js
@@ -8,13 +8,14 @@ selftest.define("bundle-ignore-files", () => {
     '.meteor/',
     '.DS_Store',
     '.aaabbb.swp',
+    'Icon.',
     'Thumbs.db'
   ];
 
   matchingInputs.forEach(input => selftest.expectEqual(patterns.some(p => p.test(input)),true));
 
   const nonMatchingInputs = [
-    '/imports/components/Icon/index.js',
+    'Icon',
   ];
 
   nonMatchingInputs.forEach(input => selftest.expectEqual(patterns.some(p => p.test(input)),false));

--- a/tools/tests/bundle-ignore-files.js
+++ b/tools/tests/bundle-ignore-files.js
@@ -7,10 +7,11 @@ var bundler = require('../isobuild/bundle.js');
 selftest.define("bundle-ignore-files", () => {
   var patterns = bundler.ignoreFiles;
   var inputs = [
-    '.git/refs',
-    '.git/HEAD',
-    '.meteor/local',
-    '.meteor/packages',
+    '.git/',
+    '.meteor/',
+    '.DS_Store',
+    '.aaabbb.swp',
+    'Thumbs.db',
   ];
   _.each(inputs, (input) => {
     let matched = _.any(patterns, (ptn) => {

--- a/tools/tests/bundle-ignore-files.js
+++ b/tools/tests/bundle-ignore-files.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 var files = require('../fs/files.js');
-var bundler = require('../isobuild/bundle.js');
+var bundler = require('../isobuild/bundler.js');
 
 selftest.define("bundle-ignore-files", () => {
   var patterns = bundler.ignoreFiles;

--- a/tools/tests/bundle-ignore-files.js
+++ b/tools/tests/bundle-ignore-files.js
@@ -8,7 +8,7 @@ selftest.define("bundle-ignore-files", () => {
     '.meteor/',
     '.DS_Store',
     '.aaabbb.swp',
-    'Icon.',
+    'Icon\r',
     'Thumbs.db'
   ];
 

--- a/tools/tests/bundle-ignore-files.js
+++ b/tools/tests/bundle-ignore-files.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 var files = require('../fs/files.js');


### PR DESCRIPTION
This is a continuation of @c9s work (https://github.com/meteor/meteor/pull/7483) to fix (https://github.com/meteor/meteor/issues/7482)

Merging the different regex to one is quite a bit faster than executing them one-by-one (see: https://github.com/meteor/meteor/pull/7483#issuecomment-249938794 for a rough estimate).