### PR TITLE
Bump the coffeescript package version

### DIFF
--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.2.5-beta.5"
+  version: "1.2.6"
 });
 
 Package.registerBuildPlugin({


### PR DESCRIPTION
By doing a version bump of this package, anyone who wants to can update to version `1.2.6` and enjoy coffeescript `1.11.0`.

As discussed here: https://forums.meteor.com/t/coffeescript-1-11-0-now-supports-es6-modules/29750/8