### PR TITLE
coffeescript: improve es6 regex performance

### DIFF
--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -83,7 +83,7 @@ export class CoffeeCompiler extends CachingCompiler {
 
     let sourceMap = JSON.parse(output.v3SourceMap);
 
-    if (source.match(/`|\b(?:import|export|yield)\b/)) {
+    if (/`|\b(?:import|export|yield)\b/.test(source)) {
       // If source contains backticks or features that output as ES2015+,
       // pass the coffee output through babel-compiler
       const doubleRoastedCoffee =


### PR DESCRIPTION
This commit improves the performance of the regex used to check if the coffeescript source should be passed to babel, by using `Regex#test` instead of `String#match` (see http://stackoverflow.com/a/10940138/3142952)
