### PR TITLE
Implement $min, $max, $currentDate modifiers

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2086,7 +2086,12 @@ Tinytest.add("minimongo - modify", function (test) {
     coll.update(query, mod);
     var actual = coll.findOne();
     delete actual._id;  // added by insert
-    test.equal(actual, expected, EJSON.stringify({input: doc, mod: mod}));
+
+    if(typeof expected === "function"){
+      expected(actual, EJSON.stringify({input: doc, mod: mod}));
+    }else{
+      test.equal(actual, expected, EJSON.stringify({input: doc, mod: mod}));
+    }
   };
   var modify = function (doc, mod, expected) {
     modifyWithQuery(doc, {}, mod, expected);
@@ -2234,6 +2239,53 @@ Tinytest.add("minimongo - modify", function (test) {
   modify({a: {b: 2}}, {$inc: {'a.b': 10}}, {a: {b: 12}});
   modify({a: {b: 2}}, {$inc: {'a.c': 10}}, {a: {b: 2, c: 10}});
   exception({}, {$inc: {_id: 1}});
+
+  // $currentDate
+  modify({}, {$currentDate: {a: true}}, (result, msg) => { test.instanceOf(result.a,Date,msg) });
+  modify({}, {$currentDate: {a: {$type: "date"}}}, (result, msg) => { test.instanceOf(result.a,Date,msg) });
+  exception({}, {$currentDate: {a: false}});
+  exception({}, {$currentDate: {a: {}}});
+  exception({}, {$currentDate: {a: {$type: "timestamp"}}});
+
+  // $min
+  modify({a: 1, b: 2}, {$min: {b: 1}}, {a: 1, b: 1});
+  modify({a: 1, b: 2}, {$min: {b: 3}}, {a: 1, b: 2});
+  modify({a: 1, b: 2}, {$min: {c: 10}}, {a: 1, b: 2, c: 10});
+  exception({a: 1}, {$min: {a: '10'}});
+  exception({a: 1}, {$min: {a: true}});
+  exception({a: 1}, {$min: {a: [10]}});
+  exception({a: '1'}, {$min: {a: 10}});
+  exception({a: [1]}, {$min: {a: 10}});
+  exception({a: {}}, {$min: {a: 10}});
+  exception({a: false}, {$min: {a: 10}});
+  exception({a: null}, {$min: {a: 10}});
+  modify({a: [1, 2]}, {$min: {'a.1': 1}}, {a: [1, 1]});
+  modify({a: [1, 2]}, {$min: {'a.1': 3}}, {a: [1, 2]});
+  modify({a: [1, 2]}, {$min: {'a.2': 10}}, {a: [1, 2, 10]});
+  modify({a: [1, 2]}, {$min: {'a.3': 10}}, {a: [1, 2, null, 10]});
+  modify({a: {b: 2}}, {$min: {'a.b': 1}}, {a: {b: 1}});
+  modify({a: {b: 2}}, {$min: {'a.c': 10}}, {a: {b: 2, c: 10}});
+  exception({}, {$min: {_id: 1}});
+
+  // $max
+  modify({a: 1, b: 2}, {$max: {b: 1}}, {a: 1, b: 2});
+  modify({a: 1, b: 2}, {$max: {b: 3}}, {a: 1, b: 3});
+  modify({a: 1, b: 2}, {$max: {c: 10}}, {a: 1, b: 2, c: 10});
+  exception({a: 1}, {$max: {a: '10'}});
+  exception({a: 1}, {$max: {a: true}});
+  exception({a: 1}, {$max: {a: [10]}});
+  exception({a: '1'}, {$max: {a: 10}});
+  exception({a: [1]}, {$max: {a: 10}});
+  exception({a: {}}, {$max: {a: 10}});
+  exception({a: false}, {$max: {a: 10}});
+  exception({a: null}, {$max: {a: 10}});
+  modify({a: [1, 2]}, {$max: {'a.1': 3}}, {a: [1, 3]});
+  modify({a: [1, 2]}, {$max: {'a.1': 1}}, {a: [1, 2]});
+  modify({a: [1, 2]}, {$max: {'a.2': 10}}, {a: [1, 2, 10]});
+  modify({a: [1, 2]}, {$max: {'a.3': 10}}, {a: [1, 2, null, 10]});
+  modify({a: {b: 2}}, {$max: {'a.b': 3}}, {a: {b: 3}});
+  modify({a: {b: 2}}, {$max: {'a.c': 10}}, {a: {b: 2, c: 10}});
+  exception({}, {$max: {_id: 1}});
 
   // $set
   modify({a: 1, b: 2}, {$set: {a: 10}}, {a: 10, b: 2});

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2087,9 +2087,9 @@ Tinytest.add("minimongo - modify", function (test) {
     var actual = coll.findOne();
     delete actual._id;  // added by insert
 
-    if(typeof expected === "function"){
+    if (typeof expected === "function") {
       expected(actual, EJSON.stringify({input: doc, mod: mod}));
-    }else{
+    } else {
       test.equal(actual, expected, EJSON.stringify({input: doc, mod: mod}));
     }
   };

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -184,33 +184,40 @@ var NO_CREATE_MODIFIERS = {
 var MODIFIERS = {
   $currentDate: function (target, field, arg) {
     if (typeof arg === "object" && arg.hasOwnProperty("$type")) {
-       if (arg.$type !== "date")
+       if (arg.$type !== "date") {
          throw MinimongoError("Minimongo does currently only support the date type in $currentDate modifiers");
-    } else if(arg !== true) {
+       }
+    } else if (arg !== true) {
       throw MinimongoError("Invalid $currentDate modifier");
     }
     target[field] = new Date();
   },
   $min: function (target, field, arg) {
-    if (typeof arg !== "number")
+    if (typeof arg !== "number") {
       throw MinimongoError("Modifier $min allowed for numbers only");
+    }
     if (field in target) {
-      if (typeof target[field] !== "number")
+      if (typeof target[field] !== "number") {
         throw MinimongoError("Cannot apply $min modifier to non-number");
-      if (target[field] > arg)
+      }
+      if (target[field] > arg) {
         target[field] = arg;
+      }
     } else {
       target[field] = arg;
     }
   },
   $max: function (target, field, arg) {
-    if (typeof arg !== "number")
+    if (typeof arg !== "number") {
       throw MinimongoError("Modifier $max allowed for numbers only");
+    }
     if (field in target) {
-      if (typeof target[field] !== "number")
+      if (typeof target[field] !== "number") {
         throw MinimongoError("Cannot apply $max modifier to non-number");
-      if (target[field] < arg)
-        target[field] = arg;
+      }
+      if (target[field] < arg) {
+         target[field] = arg;
+      }
     } else {
       target[field] = arg;
     }

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -182,35 +182,34 @@ var NO_CREATE_MODIFIERS = {
 };
 
 var MODIFIERS = {
-  $currentDate: function(target, field, arg){
-    if(typeof arg === "object" && arg.hasOwnProperty("$type")){
-       if(arg.$type !== "date"){
-        throw MinimongoError("Minimongo does currently only support the date type in $currentDate modifiers");
-       }
-    }else if(arg !== true){
+  $currentDate: function (target, field, arg) {
+    if (typeof arg === "object" && arg.hasOwnProperty("$type")) {
+       if (arg.$type !== "date")
+         throw MinimongoError("Minimongo does currently only support the date type in $currentDate modifiers");
+    } else if(arg !== true) {
       throw MinimongoError("Invalid $currentDate modifier");
     }
     target[field] = new Date();
   },
-  $min: function(target, field, arg){
+  $min: function (target, field, arg) {
     if (typeof arg !== "number")
       throw MinimongoError("Modifier $min allowed for numbers only");
     if (field in target) {
       if (typeof target[field] !== "number")
         throw MinimongoError("Cannot apply $min modifier to non-number");
-      if(target[field] > arg)
+      if (target[field] > arg)
         target[field] = arg;
     } else {
       target[field] = arg;
     }
   },
-  $max: function(target, field, arg){
+  $max: function (target, field, arg) {
     if (typeof arg !== "number")
       throw MinimongoError("Modifier $max allowed for numbers only");
     if (field in target) {
       if (typeof target[field] !== "number")
         throw MinimongoError("Cannot apply $max modifier to non-number");
-      if(target[field] < arg)
+      if (target[field] < arg)
         target[field] = arg;
     } else {
       target[field] = arg;

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -182,6 +182,40 @@ var NO_CREATE_MODIFIERS = {
 };
 
 var MODIFIERS = {
+  $currentDate: function(target, field, arg){
+    if(typeof arg === "object" && arg.hasOwnProperty("$type")){
+       if(arg.$type !== "date"){
+        throw MinimongoError("Minimongo does currently only support the date type in $currentDate modifiers");
+       }
+    }else if(arg !== true){
+      throw MinimongoError("Invalid $currentDate modifier");
+    }
+    target[field] = new Date();
+  },
+  $min: function(target, field, arg){
+    if (typeof arg !== "number")
+      throw MinimongoError("Modifier $min allowed for numbers only");
+    if (field in target) {
+      if (typeof target[field] !== "number")
+        throw MinimongoError("Cannot apply $min modifier to non-number");
+      if(target[field] > arg)
+        target[field] = arg;
+    } else {
+      target[field] = arg;
+    }
+  },
+  $max: function(target, field, arg){
+    if (typeof arg !== "number")
+      throw MinimongoError("Modifier $max allowed for numbers only");
+    if (field in target) {
+      if (typeof target[field] !== "number")
+        throw MinimongoError("Cannot apply $max modifier to non-number");
+      if(target[field] < arg)
+        target[field] = arg;
+    } else {
+      target[field] = arg;
+    }
+  },
   $inc: function (target, field, arg) {
     if (typeof arg !== "number")
       throw MinimongoError("Modifier $inc allowed for numbers only");


### PR DESCRIPTION
Related issue: https://github.com/meteor/meteor/issues/7857

This implements $min, $max and partially $currentDate + tests

I didn't implement $mul, since there can be [numeric type conversions](https://docs.mongodb.com/v2.6/faq/developers/#faq-developers-multiplication-type-conversion) which I don't know how to deal with in JS. There's also no support for `timestamp` type in $currentDate, since from what I understand of [the docs](https://docs.mongodb.com/manual/reference/bson-types/#document-bson-type-timestamp), this is an internal type I can't generate myself.
