### PR TITLE
Add warning when login token is rejected

### DIFF
--- a/tools/meteor-services/auth.js
+++ b/tools/meteor-services/auth.js
@@ -65,6 +65,9 @@ var loggedInAccountsConnection = function (token) {
     connection.close();
 
     if (err.error === 403) {
+      // Better than saying nothing at all
+      Console.error("warning: login token was rejected by the server");
+
       // This is not an ideal value for the error code, but it means
       // "server rejected our access token". For example, it expired
       // or we revoked it from the web.


### PR DESCRIPTION
When using meteor deploy to galaxy via continuous integration, our deployments suddenly stopped working. We filed a support ticket with galaxy (4218) because our environment hadn't changed (so we thought). After investigating, we found our token simply expired. We only figured this out when we noticed that our CI deployments timed out during a login prompt.

The whole process could have been better if the meteor tool provided a better error message (actually, any error message) when there's a login fail caused by an expired token. This PR attempts to provide at least an indication the token could be the problem, rather than failing silently.
