### PR TITLE
Replaces Meteor configured host with the original one coming in main request

### DIFF
--- a/packages/spiderable/package.js
+++ b/packages/spiderable/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Makes the application crawlable to web spiders",
-  version: "1.0.14-release-testing.0"
+  version: "1.0.15-release-testing.0"
 });
 
 Package.onUse(function (api) {

--- a/packages/spiderable/spiderable_server.js
+++ b/packages/spiderable/spiderable_server.js
@@ -65,7 +65,7 @@ WebApp.connectHandlers.use(function (req, res, next) {
       _.any(Spiderable.userAgentRegExps, function (re) {
         return re.test(req.headers['user-agent']); })) {
 
-    var url = Spiderable._urlForPhantom(Meteor.absoluteUrl(), req.url);
+    var url = Spiderable._urlForPhantom(Meteor.absoluteUrl().replace(/:\/\/.*/, '://' + req.headers.host + '/'), req.url);
 
     // This string is going to be put into a bash script, so it's important
     // that 'url' (which comes from the network) can neither exploit phantomjs


### PR DESCRIPTION
it takes the protocol (http or https) from Meteor.absoluteUrl() and
replaces the Meteor configured host with the original one coming in main request