### PR TITLE
Fix for `Console.failInfo` and `Console.failWarn` when `pretty` is false

### DIFF
--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -958,7 +958,7 @@ _.extend(Console.prototype, {
     var self = this;
 
     if (! self._pretty) {
-      return printFn(message);
+      return self[printFn](message);
     }
 
     var xmark = chalk.red('\u2717');


### PR DESCRIPTION
`Console.failInfo` and `Console.failWarn` functions were both using the `Console._fail` function which is passed a severity of failure as a string (e.g. "warn", "error", etc.) which corresponds to the appropriate `Console` function.  Previously, the string was just being called as if it was a function.

Fixes meteor/meteor#7882