### PR TITLE
`Console.success` should provide an indicator when pretty is disabled

### DIFF
--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -920,12 +920,12 @@ _.extend(Console.prototype, {
 
   // A wrapper around Console.info. Prints the message out in green (if pretty),
   // with the CHECKMARK as the bullet point in front of it.
-  success: function (message) {
+  success: function (message, uglySuccessKeyword = "success") {
     var self = this;
     var checkmark;
 
     if (! self._pretty) {
-      return self.info(message);
+      return self.info(`${message}: ${uglySuccessKeyword}`);
     }
 
     if (process.platform === "win32") {

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -314,7 +314,7 @@ to build apps for ${displayNameForPlatform(platform)}.`);
       for (requirement of requirements) {
         const name = requirement.name;
         if (requirement.installed) {
-          Console.success(name);
+          Console.success(name, "installed");
         } else {
           const reason = requirement.metadata && requirement.metadata.reason;
           if (reason) {


### PR DESCRIPTION
`Console.success` is currently called in only one place but it relies on the fact that `pretty` console mode is enabled for it to make any sense.  This adds the ability to pass an "ugly" (less pretty?) message to `Console.success` (default: "success") and changes the Cordova dependency checker to use "installed" when showing a met-dependency.

Fixes meteor/meteor#7883