### PR TITLE
Add Cordova Platform Dependency Tests

### DIFF
--- a/tools/tests/cordova-platforms.js
+++ b/tools/tests/cordova-platforms.js
@@ -4,7 +4,7 @@ var files = require('../fs/files.js');
 
 selftest.define("add cordova platforms", ["cordova"], function () {
   var s = new Sandbox();
-  var run;
+  let run;
 
   // Starting a run
   s.createApp("myapp", "package-tests");
@@ -15,7 +15,7 @@ selftest.define("add cordova platforms", ["cordova"], function () {
   run.match("meteor add-platform android");
   run.expectExit(1);
 
-  var run = s.run("add-platform", "android");
+  run = s.run("add-platform", "android");
   // Cordova may need to download cordova-android if it's not already
   // cached (in ~/.cordova).
   run.waitSecs(30);

--- a/tools/tests/cordova-platforms.js
+++ b/tools/tests/cordova-platforms.js
@@ -22,6 +22,10 @@ selftest.define("add cordova platforms", ["cordova"], function () {
   run.match("added platform");
   run.expectExit(0);
 
+  run = s.run("add-platform", "android");
+  run.matchErr("android: platform is already added");
+  run.expectExit(1);
+
   run = s.run("remove-platform", "foo");
   run.matchErr("foo: platform is not");
   run.expectExit(1);

--- a/tools/tests/cordova-platforms.js
+++ b/tools/tests/cordova-platforms.js
@@ -32,4 +32,27 @@ selftest.define("add cordova platforms", ["cordova"], function () {
   run.matchErr("Please add the Android platform to your project first");
   run.match("meteor add-platform android");
   run.expectExit(1);
+
+  if (process.platform !== 'win32') {
+    const originalAndroidHome = process.env.ANDROID_HOME;
+    const originalPath = process.env.PATH;
+
+    // Hide the fact that Android is installed (as it is on CircleCI) by providing
+    // access to only bare system functionality. Android is installed globally in /usr/local/
+    // on CircleCI and on Mac.
+    s.set("ANDROID_HOME", undefined);
+    s.set("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+
+    run = s.run("add-platform", "android");
+    run.match("added platform");
+    run.match("Your system does not yet seem to fulfill all requirements to build apps for Android");
+    run.expectExit(0);
+
+    run = s.run("remove-platform", "android");
+    run.match("removed");
+    run.expectExit(0);
+
+    s.set("ANDROID_HOME", originalAndroidHome);
+    s.set("PATH", originalPath);
+  }
 });


### PR DESCRIPTION
* Adds test which would have caught #7884 (fails without it, passes with it)
* Adds (Unix-only) test which checks for message when platform is already added (previously no test)
* Fix incorrectly redeclared `var` + s/`var`/`let`/
