### PR TITLE
Fix Travis CI tests by setting mongoOptions.server.reconnectTries = Infinity.

### DIFF
--- a/packages/mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/mongo/.npm/package/npm-shrinkwrap.json
@@ -3,7 +3,7 @@
     "mongodb-uri": {
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
-      "from": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz"
+      "from": "mongodb-uri@0.9.7"
     }
   }
 }

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -131,14 +131,17 @@ MongoConnection = function (url, options) {
   self._onFailoverHook = new Hook;
 
   var mongoOptions = _.extend({
-      db: { safe: true },
-      // Set reconnectTries to 0 which means keep trying to reconnect forever,
-      // rather than the default of losing the connection permanently after 30
-      // retries (separated by 1000ms).
-      server: { reconnectTries: 0 },
-      replSet: {}
+    db: { safe: true },
+    // http://mongodb.github.io/node-mongodb-native/2.2/api/Server.html
+    server: {
+      // Reconnect on error.
+      autoReconnect: true,
+      // Try to reconnect forever, instead of stopping after 30 tries (the
+      // default), with each attempt separated by 1000ms.
+      reconnectTries: Infinity
     },
-    Mongo._connectionOptions);
+    replSet: {}
+  }, Mongo._connectionOptions);
 
   // Disable the native parser by default, unless specifically enabled
   // in the mongo URL.

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.1.12_4'
+  version: '1.1.12_5'
 });
 
 Npm.depends({

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.1.12_3'
+  version: '1.1.12_4'
 });
 
 Npm.depends({
@@ -21,7 +21,7 @@ Npm.strip({
 });
 
 Package.onUse(function (api) {
-  api.use('npm-mongo@1.5.48_1', 'server');
+  api.use('npm-mongo@2.2.10_1', 'server');
   api.use('allow-deny');
 
   api.use([

--- a/packages/npm-mongo/.versions
+++ b/packages/npm-mongo/.versions
@@ -1,3 +1,0 @@
-meteor@1.0.3
-npm-mongo@1.5.49
-underscore@1.0.0

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,7 +3,7 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '1.5.48_1',
+  version: '2.2.10_1',
   documentation: null
 });
 


### PR DESCRIPTION
Travis CI builds have been failing intermittently [since around the time #7880 was merged](https://travis-ci.org/meteor/meteor/builds).

I'm going to use this pull request to try to fix those tests. As a start, I've merely bumped the `npm-mongo` and `mongo` package versions. I don't expect that to solve the problem, but it's a start.