### PR TITLE
Prevent error w/ no hash in oauth redirect url

### DIFF
--- a/packages/oauth/oauth_cordova.js
+++ b/packages/oauth/oauth_cordova.js
@@ -48,7 +48,7 @@ OAuth.showPopup = function (url, callback, dimensions) {
       setTimeout(function () {
         popup.close();
         callback();
-      }, 500);
+      }, 100);
     }
   };
 

--- a/packages/oauth/oauth_cordova.js
+++ b/packages/oauth/oauth_cordova.js
@@ -44,7 +44,6 @@ OAuth.showPopup = function (url, callback, dimensions) {
       // https://issues.apache.org/jira/browse/CB-2285.
       //
       // XXX Can we make this timeout smaller?
-
       setTimeout(function () {
         popup.close();
         callback();

--- a/packages/oauth/oauth_cordova.js
+++ b/packages/oauth/oauth_cordova.js
@@ -29,13 +29,10 @@ OAuth.showPopup = function (url, callback, dimensions) {
       var splitUrl = event.url.split("#");
       var hashFragment = splitUrl[1];
 
-      if (! hashFragment) {
-        throw new Error("No hash fragment in OAuth popup?");
+      if (hashFragment) {
+        var credentials = JSON.parse(decodeURIComponent(hashFragment));
+        OAuth._handleCredentialSecret(credentials.credentialToken,credentials.credentialSecret);
       }
-
-      var credentials = JSON.parse(decodeURIComponent(hashFragment));
-      OAuth._handleCredentialSecret(credentials.credentialToken,
-                                    credentials.credentialSecret);
 
       oauthFinished = true;
 
@@ -47,10 +44,11 @@ OAuth.showPopup = function (url, callback, dimensions) {
       // https://issues.apache.org/jira/browse/CB-2285.
       //
       // XXX Can we make this timeout smaller?
+
       setTimeout(function () {
         popup.close();
         callback();
-      }, 100);
+      }, 500);
     }
   };
 


### PR DESCRIPTION
We have a case where the returned oauth redirect does not have a hash. We propose a graceful exit when that happens. We also propose to increase the timeout to 500ms for closing the popup, to give the server the chance to react to the oauth redirect.
