### PR TITLE
Fix CSP2 script digests in browser policy

### DIFF
--- a/packages/browser-policy-content/browser-policy-content.js
+++ b/packages/browser-policy-content/browser-policy-content.js
@@ -105,7 +105,7 @@ var addSourceForDirective = function (directive, src) {
     var toAdd = [];
 
     //Only add single quotes to CSP2 script digests
-    if (/^((sha)(256|384|512)-)/.test(src)) {
+    if (/^(sha(256|384|512)-)/i.test(src)) {
       toAdd.push("'" + src + "'");
     } else {
       src = src.toLowerCase();

--- a/packages/browser-policy-content/browser-policy-content.js
+++ b/packages/browser-policy-content/browser-policy-content.js
@@ -102,19 +102,26 @@ var addSourceForDirective = function (directive, src) {
   if (_.contains(_.values(keywords), src)) {
     cspSrcs[directive].push(src);
   } else {
-    src = src.toLowerCase();
-
-    // Trim trailing slashes.
-    src = src.replace(/\/+$/, '');
-
     var toAdd = [];
-    // If there is no protocol, add both http:// and https://.
-    if (! /^([a-z0-9.+-]+:)/.test(src)) {
-      toAdd.push("http://" + src);
-      toAdd.push("https://" + src);
+
+    //Only add single quotes to CSP2 script digests
+    if (/^((sha)(256|384|512)-)/.test(src)) {
+      toAdd.push("'" + src + "'");
     } else {
-      toAdd.push(src);
+      src = src.toLowerCase();
+
+      // Trim trailing slashes.
+      src = src.replace(/\/+$/, '');
+
+      // If there is no protocol, add both http:// and https://.
+      if (! /^([a-z0-9.+-]+:)/.test(src)) {
+        toAdd.push("http://" + src);
+        toAdd.push("https://" + src);
+      } else {
+        toAdd.push(src);
+      }
     }
+
     _.each(toAdd, function (s) {
       cspSrcs[directive].push(s);
     });

--- a/packages/browser-policy-content/package.js
+++ b/packages/browser-policy-content/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Configure content security policies",
-  version: "1.0.11"
+  version: "1.0.12"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
The browser-policy package (which uses this browser-policy-content package) currently mangles Content Security Policy directives that use script hashes by lowercasing everything and prefixing with http:// and https://. This PR allows us to use script hashes in CSP directives like this: ```BrowserPolicy.content.allowScriptOrigin("sha256-GDC9/9jgPn1yw8uLtmYD5tMZokPGGBERrBP/tC7arOw=");```. 

There is now support for CSP Level 2 across [~70% of browsers](http://caniuse.com/#feat=contentsecuritypolicy2), and it's certainly an improvement over CSP Level 1. For more information, see the [W3C spec](https://www.w3.org/TR/CSP2/).

As a further improvement, we should add nonce's, report-uri, and other important CSP2 features.