### PR TITLE
Change "max open files" logic in launcher

### DIFF
--- a/meteor
+++ b/meteor
@@ -113,16 +113,24 @@ fi
 DEV_BUNDLE="$SCRIPT_DIR/dev_bundle"
 METEOR="$SCRIPT_DIR/tools/index.js"
 
+# Set the nofile ulimit as high as permitted by the hard-limit/kernel
+if [ "$(ulimit -Sn)" != "unlimited" ]; then
+    if [ "$(uname -s)" = "Darwin" ]; then
+        maxfilesuse="$(sysctl -n kern.maxfilesperproc)"
+    else
+        maxfilesuse="$(ulimit -Hn)"
+    fi
 
-# Try higher ulimit maxfiles settings until permitted by the kernel
-if [ "$(ulimit -n)" != "unlimited" ] && ! [ "$(ulimit -n)" -gt 32768 ] ; then
-    ulimit -n 32768 > /dev/null 2>&1 || \
-    ulimit -n 16384 > /dev/null 2>&1 || \
-    ulimit -n 8192 > /dev/null 2>&1 || \
-    ulimit -n 4096 > /dev/null 2>&1 || \
-    ulimit -n 2048 > /dev/null 2>&1 || \
-    ulimit -n 1024 > /dev/null 2>&1 || \
-    ulimit -n 512 > /dev/null 2>&1
+    if [ -n "${maxfilesuse}" ] && [ "${maxfilesuse}" != "unlimited" ]; then
+        if ! ulimit -Sn ${maxfilesuse} > /dev/null 2>&1; then
+            echo "Warning: Meteor was unable to raise the limit for number of open files"
+            echo "for the current user.  Please consider filing an issue at:"
+            echo ""
+            echo "  https://github.com/meteor/meteor/issues"
+            echo ""
+            echo "Please include the output of 'uname -a', 'ulimit -H' and 'ulimit -S'"
+        fi
+    fi
 fi
 
 # We used to set $NODE_PATH here to include the node_modules from the dev

--- a/meteor
+++ b/meteor
@@ -122,14 +122,7 @@ if [ "$(ulimit -Sn)" != "unlimited" ]; then
     fi
 
     if [ -n "${maxfilesuse}" ] && [ "${maxfilesuse}" != "unlimited" ]; then
-        if ! ulimit -Sn ${maxfilesuse} > /dev/null 2>&1; then
-            echo "Warning: Meteor was unable to raise the limit for number of open files"
-            echo "for the current user.  Please consider filing an issue at:"
-            echo ""
-            echo "  https://github.com/meteor/meteor/issues"
-            echo ""
-            echo "Please include the output of 'uname -a', 'ulimit -H' and 'ulimit -S'"
-        fi
+        ulimit -Sn ${maxfilesuse} > /dev/null 2>&1
     fi
 fi
 

--- a/meteor
+++ b/meteor
@@ -114,10 +114,8 @@ DEV_BUNDLE="$SCRIPT_DIR/dev_bundle"
 METEOR="$SCRIPT_DIR/tools/index.js"
 
 
-# Bump our file descriptor ulimit as high as it will go. This is a
-# temporary workaround for dependancy watching holding open too many
-# files: https://app.asana.com/0/364581412985/472479912325
-if [ "$(ulimit -n)" != "unlimited" ] ; then
+# Try higher ulimit maxfiles settings until permitted by the kernel
+if [ "$(ulimit -n)" != "unlimited" ] && ! [ "$(ulimit -n)" -gt 16384 ] ; then
     ulimit -n 16384 > /dev/null 2>&1 || \
     ulimit -n 8192 > /dev/null 2>&1 || \
     ulimit -n 4096 > /dev/null 2>&1 || \

--- a/meteor
+++ b/meteor
@@ -115,7 +115,8 @@ METEOR="$SCRIPT_DIR/tools/index.js"
 
 
 # Try higher ulimit maxfiles settings until permitted by the kernel
-if [ "$(ulimit -n)" != "unlimited" ] && ! [ "$(ulimit -n)" -gt 16384 ] ; then
+if [ "$(ulimit -n)" != "unlimited" ] && ! [ "$(ulimit -n)" -gt 32768 ] ; then
+    ulimit -n 32768 > /dev/null 2>&1 || \
     ulimit -n 16384 > /dev/null 2>&1 || \
     ulimit -n 8192 > /dev/null 2>&1 || \
     ulimit -n 4096 > /dev/null 2>&1 || \


### PR DESCRIPTION
This makes a couple changes to the `ulimit` calls of the Meteor launch script.

This will hopefully be less necessary with future changes to the watcher, but as long as polling mechanisms are in place for the files (e.g. `file.watchFile`), this seems helpful as changes to `ulimit -n` could be necessary.  This POSIX-compatible PR does two things:

* Don't lower `ulimit` max open files if it's already higher than desired  …
 * Previously, if the default ulimit was set to a value higher than 16384, it was lowering it.  While this doesn't do much for users with default OS settings, those that have modified their ulimit settings will have their settings maintained.
* Increase the value of the first `ulimit` max open files change attempt  …
 * Make the first attempt 32768 instead of 16384 since some users have large numbers of files or node_modules trees (meteor/meteor#6952).  This hasn't been raised since Meteor started watching many more files nor since the addition of native NPM.

I know the second bullet point wasn't discussed, but I thought it was close enough to bundle with little concern for side effect.

I think another option for this would be to use the system hard limits (Linux: `ulimit -Hn`, Mac: `sysctl -n kern.maxfiles`) and just set the limit to that, [like FB's `watchman` does](https://github.com/facebook/watchman/blob/e59f2f52e80147ee6639579efacae4b892af932a/listener.cpp#L611-L671).