### PR TITLE
Change Facebook oAuth param from `authType` to `auth_type`

### DIFF
--- a/packages/facebook/facebook_client.js
+++ b/packages/facebook/facebook_client.js
@@ -37,8 +37,8 @@ Facebook.requestCredential = function (options, credentialRequestCompleteCallbac
         '&state=' + OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl);
 
   // Handle authentication type (e.g. for force login you need authType: "reauthenticate")
-  if (options && options.authType) {
-    loginUrl += "&authType=" + encodeURIComponent(options.authType);
+  if (options && options.auth_type) {
+    loginUrl += "&auth_type=" + encodeURIComponent(options.auth_type);
   }
 
   OAuth.launchLogin({


### PR DESCRIPTION
According to the Facebook docs:

https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow

The parameter should be `auth_type`, not `authType`.  A cursory look through their API history didn't show anything about it being changed, but I can confirm that using this feature does not work with `authType` in the current implementation.

I don't think this has ever worked.

Related meteor/docs#94
Related meteor/meteor#7584
Closes meteor/meteor#7078