### PR TITLE
Support additional params on oAuth1 authorize URL

### DIFF
--- a/packages/twitter/package.js
+++ b/packages/twitter/package.js
@@ -18,6 +18,8 @@ Package.onUse(function(api) {
     ['twitter_configure.html', 'twitter_configure.js'],
     'client');
 
+  api.addFiles('twitter_common.js', ['server', 'client']);
+
   api.addFiles('twitter_server.js', 'server');
   api.addFiles('twitter_client.js', 'client');
 });

--- a/packages/twitter/twitter_client.js
+++ b/packages/twitter/twitter_client.js
@@ -37,11 +37,13 @@ Twitter.requestCredential = function (options, credentialRequestCompleteCallback
   }
 
   // Support additional, permitted parameters
-  var addlParams = Twitter.validParamsAuthenticate;
-  for (var i = 0, len = addlParams.length; i < len; i++) {
-    if (options && options[addlParams[i]]) {
-      loginPath += "&" + addlParams[i] + "=" + encodeURIComponent(options[addlParams[i]]);
-    }
+  if (options) {
+    var hasOwn = Object.prototype.hasOwnProperty;
+    Twitter.validParamsAuthenticate.forEach(function (param) {
+      if (hasOwn.call(options, param)) {
+        loginPath += "&" + param + "=" + encodeURIComponent(options[param]);
+      }
+    });
   }
 
   var loginUrl = Meteor.absoluteUrl(loginPath);

--- a/packages/twitter/twitter_client.js
+++ b/packages/twitter/twitter_client.js
@@ -1,5 +1,3 @@
-Twitter = {};
-
 // Request Twitter credentials for the user
 // @param options {optional}  XXX support options.requestPermissions
 // @param credentialRequestCompleteCallback {Function} Callback function to call on
@@ -38,9 +36,12 @@ Twitter.requestCredential = function (options, credentialRequestCompleteCallback
     }
   }
 
-  // Handle force login (request the user to enter their credentials)
-  if (options && options.force_login) {
-    loginPath += "&force_login=true";
+  // Support additional, permitted parameters
+  var addlParams = Twitter.validParamsAuthenticate;
+  for (var i = 0, len = addlParams.length; i < len; i++) {
+    if (options && options[addlParams[i]]) {
+      loginPath += "&" + addlParams[i] + "=" + encodeURIComponent(options[addlParams[i]]);
+    }
   }
 
   var loginUrl = Meteor.absoluteUrl(loginPath);

--- a/packages/twitter/twitter_common.js
+++ b/packages/twitter/twitter_common.js
@@ -1,0 +1,6 @@
+Twitter = {};
+
+Twitter.validParamsAuthenticate = [
+  'force_login',
+  'screen_name'
+];

--- a/packages/twitter/twitter_server.js
+++ b/packages/twitter/twitter_server.js
@@ -1,12 +1,16 @@
-Twitter = {};
-
 var urls = {
   requestToken: "https://api.twitter.com/oauth/request_token",
   authorize: "https://api.twitter.com/oauth/authorize",
   accessToken: "https://api.twitter.com/oauth/access_token",
-  authenticate: "https://api.twitter.com/oauth/authenticate"
+  authenticate: function (oauthBinding, params) {
+    return OAuth._queryParamsWithAuthTokenUrl(
+      "https://api.twitter.com/oauth/authenticate",
+      oauthBinding,
+      params,
+      Twitter.validParamsAuthenticate
+    );
+  }
 };
-
 
 // https://dev.twitter.com/docs/api/1.1/get/account/verify_credentials
 Twitter.whitelistedFields = ['profile_image_url', 'profile_image_url_https', 'lang', 'email'];


### PR DESCRIPTION
Ok, please bear with this description...

This PR is meant to fix a previous broken implementation of the `force_login` parameter for Twitter (link below) which was reported in #6987.   This appears to be first attempted by very-old PR #1566 as a two-in-one-PR but turned into abandonware and never got merged.

#5693 (another attempt) also never landed but was resurrected into #6987 which did land but unfortunately, there is no way that it could work as the `force_login` parameter would be lost when passed to the Meteor oAuth server before the redirect to the actual service (e.g. Twitter, other oAuth1 implementations) which needs to see this param.

So, with a little help from code from #2404 and using the previously-supported ability to pass a function (versus a string) for an oAuth1 URL, this commit implements (and relocates) a function which safely applies whitelisted params to that URL.

This is slightly different implementation than desired in the original PR, but I'm not sure the facilities I mentioned above existed at that point (or weren't acknowledged).

This introduces a `twitter_common.js` file shared between server and client which indicates which Twitter-supported params are permitted on the authorize step.  The two params which Twitter supports right now are `force_login` and `screen_name`.  (See: https://dev.twitter.com/oauth/reference/get/oauth/authenticate)

This commit removes the non-functional implementation of `force_login` introduced by meteor/meteor#6987 and implements it via the aforementioned method.

As a precaution (and since neither `ecmascript` nor `es5-shim` are used by this package), I stuck with JS ES3.

Closes meteor/meteor#7584
Relates to meteor/docs#94