### PR TITLE
Adding gap: into CSP

### DIFF
--- a/packages/boilerplate-generator/boilerplate_web.cordova.html
+++ b/packages/boilerplate-generator/boilerplate_web.cordova.html
@@ -4,7 +4,7 @@
   <meta name="format-detection" content="telephone=no">
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height">
   <meta name="msapplication-tap-highlight" content="no">
-  <meta http-equiv="Content-Security-Policy" content="default-src * data: blob: 'unsafe-inline' 'unsafe-eval' ws: wss:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src * gap: data: blob: 'unsafe-inline' 'unsafe-eval' ws: wss:;">
 
 {{! We are explicitly not using bundledJsCssUrlRewriteHook: in cordova we serve assets up directly from disk, so rewriting the URL does not make sense }}
 


### PR DESCRIPTION
In UIWebView on iOS10 we get CSP failure to load gap://ready, this resolves it on both simulator and device. This is an urgent fix.