### PR TITLE
Update links to MongoDB driver docs

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -704,7 +704,7 @@ Mongo.Collection.prototype._createCappedCollection = function (byteSize, maxDocu
 };
 
 /**
- * @summary Returns the [`Collection`](http://mongodb.github.io/node-mongodb-native/1.4/api-generated/collection.html) object corresponding to this collection from the [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
+ * @summary Returns the [`Collection`](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html) object corresponding to this collection from the [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
  * @locus Server
  */
 Mongo.Collection.prototype.rawCollection = function () {
@@ -716,7 +716,7 @@ Mongo.Collection.prototype.rawCollection = function () {
 };
 
 /**
- * @summary Returns the [`Db`](http://mongodb.github.io/node-mongodb-native/1.4/api-generated/db.html) object corresponding to this collection's database connection from the [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
+ * @summary Returns the [`Db`](http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html) object corresponding to this collection's database connection from the [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
  * @locus Server
  */
 Mongo.Collection.prototype.rawDatabase = function () {

--- a/packages/mongo/connection_options.js
+++ b/packages/mongo/connection_options.js
@@ -1,6 +1,6 @@
 /**
  * @summary Allows for user specified connection options
- * @example http://mongodb.github.io/node-mongodb-native/2.1/reference/connecting/connection-settings/
+ * @example http://mongodb.github.io/node-mongodb-native/2.2/reference/connecting/connection-settings/
  * @locus Server
  * @param {Object} options User specified Mongo connection options
  */


### PR DESCRIPTION
The JSDoc linked to older versions (1.4 and 2.1) of the MongoDB driver docs.

Related PR: https://github.com/meteor/docs/pull/98