### PR TITLE
Add support for frame-ancestors CSP option in browser-policy

### DIFF
--- a/packages/browser-policy-content/browser-policy-content.js
+++ b/packages/browser-policy-content/browser-policy-content.js
@@ -17,7 +17,7 @@
 // disallowEval()
 //
 // For each type of content (script, object, image, media, font, connect,
-// style), there are the following functions:
+// style, frame, frame-ancestors), there are the following functions:
 // allow<content type>Origin(origin): allows the type of content to be loaded
 // from the given origin
 // allow<content type>DataUrl(): allows the content to be loaded from data: URLs
@@ -248,53 +248,55 @@ _.extend(BrowserPolicy.content, {
 
 // allow<Resource>Origin, allow<Resource>Data, allow<Resource>self, and
 // disallow<Resource> methods for each type of resource.
-_.each(["script", "object", "img", "media",
-        "font", "connect", "style", "frame"],
-       function (resource) {
-         var directive = resource + "-src";
-         var methodResource;
-         if (resource !== "img") {
-           methodResource = resource.charAt(0).toUpperCase() +
-             resource.slice(1);
-         } else {
-           methodResource = "Image";
-         }
-         var allowMethodName = "allow" + methodResource + "Origin";
-         var disallowMethodName = "disallow" + methodResource;
-         var allowDataMethodName = "allow" + methodResource + "DataUrl";
-         var allowBlobMethodName = "allow" + methodResource + "BlobUrl";
-         var allowSelfMethodName = "allow" + methodResource + "SameOrigin";
+var resources = [
+  { methodResource: "Script", directive: "script-src" },
+  { methodResource: "Object", directive: "object-src" },
+  { methodResource: "Image", directive: "img-src" },
+  { methodResource: "Media", directive: "media-src" },
+  { methodResource: "Font", directive: "font-src" },
+  { methodResource: "Connect", directive: "connect-src" },
+  { methodResource: "Style", directive: "style-src" },
+  { methodResource: "Frame", directive: "frame-src" },
+  { methodResource: "FrameAncestors", directive: "frame-ancestors" }
+];
+_.each(resources,  function (resource) {
+  var directive = resource.directive; 
+  var methodResource = resource.methodResource; 
+  var allowMethodName = "allow" + methodResource + "Origin";
+  var disallowMethodName = "disallow" + methodResource;
+  var allowDataMethodName = "allow" + methodResource + "DataUrl"; 
+  var allowBlobMethodName = "allow" + methodResource + "BlobUrl";
+  var allowSelfMethodName = "allow" + methodResource + "SameOrigin";
 
-         var disallow = function () {
-           cachedCsp = null;
-           cspSrcs[directive] = [];
-         };
+  var disallow = function () {
+    cachedCsp = null;
+    cspSrcs[directive] = [];
+  };
 
-         BrowserPolicy.content[allowMethodName] = function (src) {
-           prepareForCspDirective(directive);
-           addSourceForDirective(directive, src);
-         };
-         if (resource === "script") {
-           BrowserPolicy.content[disallowMethodName] = function () {
-             disallow();
-             setWebAppInlineScripts(false);
-           };
-         } else {
-           BrowserPolicy.content[disallowMethodName] = disallow;
-         }
-         BrowserPolicy.content[allowDataMethodName] = function () {
-           prepareForCspDirective(directive);
-           cspSrcs[directive].push("data:");
-         };
-         BrowserPolicy.content[allowBlobMethodName] = function () {
-           prepareForCspDirective(directive);
-           cspSrcs[directive].push("blob:");
-         };
-         BrowserPolicy.content[allowSelfMethodName] = function () {
-           prepareForCspDirective(directive);
-           cspSrcs[directive].push(keywords.self);
-         };
-       });
-
+  BrowserPolicy.content[allowMethodName] = function (src) {
+    prepareForCspDirective(directive);
+    addSourceForDirective(directive, src);
+  };
+  if (resource === "script") {
+    BrowserPolicy.content[disallowMethodName] = function () {
+      disallow();
+      setWebAppInlineScripts(false);
+    };
+  } else {
+    BrowserPolicy.content[disallowMethodName] = disallow;
+  }
+  BrowserPolicy.content[allowDataMethodName] = function () {
+    prepareForCspDirective(directive);
+    cspSrcs[directive].push("data:");
+  };
+  BrowserPolicy.content[allowBlobMethodName] = function () {
+    prepareForCspDirective(directive);
+    cspSrcs[directive].push("blob:");
+  };
+  BrowserPolicy.content[allowSelfMethodName] = function () {
+    prepareForCspDirective(directive);
+    cspSrcs[directive].push(keywords.self);
+  };
+});
 
 setDefaultPolicy();

--- a/packages/browser-policy-content/package.js
+++ b/packages/browser-policy-content/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Configure content security policies",
-  version: "1.0.12"
+  version: "1.0.13"
 });
 
 Package.onUse(function (api) {

--- a/packages/browser-policy/README.md
+++ b/packages/browser-policy/README.md
@@ -66,7 +66,10 @@ that are allowed to frame your app. (This is a limitation of the
 X-Frame-Options header.) Example values of <code>origin</code> include
 "http://example.com" and "https://foo.example.com". <b>This value of
 the X-Frame-Options header is not yet supported in Chrome or Safari
-and will be ignored in those browsers.</b>
+and will be ignored in those browsers. If you need Chrome and/or Safari
+support, or need to allow multiple domains to frame your application,
+you can use the frame-ancestors CSP option via the
+BrowserPolicy.content.allowFrameAncestorsOrigin() function </b>
 </dd>
 
 
@@ -126,7 +129,7 @@ Disallows inline CSS.
 
 Finally, you can configure a whitelist of allowed requests that various types of
 content can make. The following functions are defined for the content types
-script, object, image, media, font, frame, style, and connect.
+script, object, image, media, font, frame, frame-ancestors, style, and connect.
 
 <dl>
 

--- a/packages/browser-policy/browser-policy-test.js
+++ b/packages/browser-policy/browser-policy-test.js
@@ -136,6 +136,13 @@ Tinytest.add("browser-policy - csp", function (test) {
   test.isTrue(cspsEqual(BrowserPolicy.content._constructCsp(),
                         "default-src 'none'; frame-src https://foo.com; " +
                         "object-src http://foo.com https://foo.com;"));
+
+  // Check that frame-ancestors property is set correctly. 
+  BrowserPolicy.content.allowFrameAncestorsOrigin("https://foo.com/"); 
+  test.isTrue(cspsEqual(BrowserPolicy.content._constructCsp(), 
+                        "default-src 'none'; frame-src https://foo.com; " + 
+                        "object-src http://foo.com https://foo.com; " + 
+                        "frame-ancestors https://foo.com;"));
 });
 
 Tinytest.add("browser-policy - x-frame-options", function (test) {

--- a/packages/browser-policy/package.js
+++ b/packages/browser-policy/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Configure security policies enforced by the browser",
-  version: "1.0.9"
+  version: "1.0.10"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
This Pull Request adds support for for the frame-ancestors CSP option in the browser-policy package. Right now, there is no easy way to allow and/or restrict specific domains from framing your app. Using the X-Frame-Options header has the following problems:
- You are only allowed to restrict all domains, only allow same domain, or only allow one other domain. So, if you need to allow multiple domains to frame your app, you can't.
- The X-Frame-Options header does not work in Chrome or Safari. So even if you want to allow another domain to frame your app, you can't guarantee that it will work in those browsers.

As a result of the above, to allow other domains to frame your app, you have to allow _all_ domains to frame your app. 

However, there is a [frame-ancestors CSP](https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#frame-ancestors) that allows you to specify which domains can frame your application. This pull request adds an API to do that. 

Calling `BrowserPolicy.content.allowFrameAncestorsOrigin("https://foo.com/"); ` will allow `foo.com` to frame your application. Calling `BrowserPolicy.content.disallowFrameAncestors()` will forbid other domains from framing your application.

A test has been added to verify that the frame-ancestors CSP is added correctly.

There are also some documentation changes to make note of the new policy.
