### PR TITLE
Replace forkJoin with enterJob to avoid fiber issues

### DIFF
--- a/tools/packaging/catalog/catalog-local.js
+++ b/tools/packaging/catalog/catalog-local.js
@@ -404,15 +404,11 @@ _.extend(LocalCatalog.prototype, {
 
     // Load the package sources for packages and their tests into
     // self.packages.
-    //
-    // XXX We should make this work with parallel: true; right now it seems to
-    // hit node problems.
-    buildmessage.forkJoin(
-      { 'title': 'initializing packages', parallel: false },
-      self.effectiveLocalPackageDirs,
-      function (dir) {
+    buildmessage.enterJob('initializing packages', function() {
+      _.each(self.effectiveLocalPackageDirs, function (dir) {
         initSourceFromDir(dir);
       });
+    });
   },
 
   getPackageSource: function (name) {


### PR DESCRIPTION
Presently, `buildmessage.forkJoin` is being used to loop over the packages and initialize them. I believe the original intent was to run the package initializations in parallel, but apparently this was causing issues and was disabled. So it is logically equivalent to just iterating over each package and initializing them in serial. However, using `forkJoin` causes each package initialization to run in its own fiber, which can cause serious performance problems. This PR replaces the `forkJoin` with a plain loop, and decreased the runtime of `LocalCatalog#_loadLocalPackages` from around 5s to about .1s on [Qualia](http://qualia.com)'s very large application. 

I'm not entirely certain (I should probably test this), but this PR may only be effective in conjunction with `METEOR_DISABLE_FS_FIBERS=1` because otherwise lots of fibers will still be spawned for every package while being loaded. Setting this environment variable has had drastically positive effects on reload times (7+ seconds) even without this optimization.

Excessive use of fibers introduces a lot of overhead, and I think the effect may be super-linear (which is why some large projects have such ridiculously long reload times). It's hard to see the fiber switching costs with just `METEOR_PROFILE=1`, but if you use `v8-profiler` (as described [here](https://medium.com/@lucashansen/faster-meteor-reloads-62cca5b56460)) to get a full CPU profile of the build tool you can see it very clearly. I think that @benjamn's implementation of optimistic file IO may render the use of fibers in file IO obsolete.