### PR TITLE
Fully implement `--no-release-check` for `meteor test`

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1441,6 +1441,7 @@ testCommandOptions = {
     // XXX COMPAT WITH 0.9.2.2
     'mobile-port': { type: String },
     'debug-port': { type: String },
+    'no-release-check': { type: Boolean },
     deploy: { type: String },
     production: { type: Boolean },
     settings: { type: String, short: 's' },


### PR DESCRIPTION
I accidentally a line when I committed/submitted meteor/meteor#7799, as reported in this comment:

https://github.com/meteor/meteor/issues/7026#issuecomment-256728729

The `METEOR_NO_RELEASE_CHECK` environment variable did/does work properly, but both were meant to work.