### PR TITLE
add onMessage hook

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -547,6 +547,11 @@ _.extend(Session.prototype, {
           processNext();
         };
 
+        self.server.onMessageHook.each(function (callback) {
+          callback(msg, self);
+          return true;
+        });
+
         if (_.has(self.protocol_handlers, msg.msg))
           self.protocol_handlers[msg.msg].call(self, msg, unblock);
         else
@@ -1320,6 +1325,11 @@ Server = function (options) {
     debugPrintExceptions: "onConnection callback"
   });
 
+  // Map of callbacks to call when a new message comes in.
+  self.onMessageHook = new Hook({
+    debugPrintExceptions: "onMessage callback"
+  });
+
   self.publish_handlers = {};
   self.universal_publish_handlers = [];
 
@@ -1401,6 +1411,18 @@ _.extend(Server.prototype, {
   onConnection: function (fn) {
     var self = this;
     return self.onConnectionHook.register(fn);
+  },
+
+  /**
+   * @summary Register a callback to be called when a new DDP message is received.
+   * @locus Server
+   * @param {function} callback The function to call when a new DDP message is received.
+   * @memberOf Meteor
+   * @importFromPackage meteor
+   */
+  onMessage: function (fn) {
+    var self = this;
+    return self.onMessageHook.register(fn);
   },
 
   _handleConnect: function (socket, msg) {

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -82,7 +82,6 @@ testAsyncMulti(
   }]
 );
 
-
 Meteor.methods({
   livedata_server_test_inner: function () {
     return this.connection.id;
@@ -92,6 +91,28 @@ Meteor.methods({
     return Meteor.call('livedata_server_test_inner');
   }
 });
+
+
+Tinytest.addAsync(
+    "livedata server - onMessage hook",
+    function (test, onComplete) {
+
+        var cb = Meteor.onMessage(function (msg, session) {
+            test.equal(msg.method, 'livedata_server_test_inner');
+            cb.stop();
+            onComplete();
+        });
+
+        makeTestConnection(
+            test,
+            function (clientConn, serverConn) {
+                clientConn.call('livedata_server_test_inner');
+                clientConn.disconnect();
+            },
+            onComplete
+        );
+    }
+);
 
 
 Tinytest.addAsync(

--- a/packages/ddp-server/server_convenience.js
+++ b/packages/ddp-server/server_convenience.js
@@ -11,7 +11,7 @@ Meteor.refresh = function (notification) {
 
 // Proxy the public methods of Meteor.server so they can
 // be called directly on Meteor.
-_.each(['publish', 'methods', 'call', 'apply', 'onConnection'],
+_.each(['publish', 'methods', 'call', 'apply', 'onConnection', 'onMessage'],
        function (name) {
          Meteor[name] = _.bind(Meteor.server[name], Meteor.server);
        });


### PR DESCRIPTION
Like the `onConnection` hook, this is called for every DDP message received. We have a large meteor app and would like to centralise authorisation for publications and methods in the least error-prone way possible. Without any documented way to hook into the server core, the best we can do is monkey-patch `Session`. This PR provides a better way.
