### PR TITLE
Refactor template of `resetPassword` email

### DIFF
--- a/packages/accounts-password/email_templates.js
+++ b/packages/accounts-password/email_templates.js
@@ -26,18 +26,7 @@ Accounts.emailTemplates = {
     subject: function(user) {
       return "How to reset your password on " + Accounts.emailTemplates.siteName;
     },
-    text: function(user, url) {
-      var greeting = (user.profile && user.profile.name) ?
-            ("Hello " + user.profile.name + ",") : "Hello,";
-      return `${greeting}
-
-To reset your password, simply click the link below.
-
-${url}
-
-Thanks.
-`;
-    }
+    text: greet("To reset your password")
   },
   verifyEmail: {
     subject: function(user) {


### PR DESCRIPTION
As I see, current realization of `Accounts.emailTemplates.verifyEmail.text` are equal to result of already defined `greet` function with `"To reset your password"` param. So I suggest to use it instead.