### PR TITLE
Clarify mis-leading wording in the `stylus` README

### DIFF
--- a/packages/stylus/README.md
+++ b/packages/stylus/README.md
@@ -6,12 +6,12 @@
 simple syntax and expressive dynamic behavior. It allows for more compact
 stylesheets and helps reduce code duplication in CSS files.
 
-With the `stylus` package installed, `.main.styl` files in your application are
-automatically compiled to CSS and the results are included in the client CSS
-bundle.
+With the `stylus` package installed, files with the `.styl` extension are sent
+through the `stylus` CSS pre-processor and the results are included in the
+client CSS bundle.
 
-The `stylus` package also includes `nib` support. Add `@import 'nib'` to your
-`.main.styl` files to enable cross-browser mixins such as `linear-gradient` and
+The `stylus` package also includes `nib` support. Add `@import 'nib'` to any
+`*.styl` file to enable cross-browser mixins such as `linear-gradient` and
 `border-radius`.
 
 If you want to `@import` a file, give it the extension `.import.styl`


### PR DESCRIPTION
Make it clear that all files with the `.styl` extension are processed and not just `.main.styl` files based on the comment from meteor/meteor#6337.

I believe this `main.styl` syntax might be residue from some ancient version but Meteor definitely processes all `styl` extensions, as seen [here](https://github.com/meteor/meteor/blob/7858fb2431321a11d22cc87bbf1ea591d7594d77/packages/stylus/plugin/compile-stylus.js#L7-L10).

Fixes meteor/meteor#6337