### PR TITLE
Link directly to style guide

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -156,7 +156,7 @@ these guidelines:
  * Include tests that prove your code works.
 
  * Follow the
-   [MDG style guide](https://github.com/meteor/meteor/wiki/Meteor-Style-Guide)
+   [MDG style guide](https://guide.meteor.com/code-style.html#javascript)
    for code and commit messages.
 
  * Be sure your author field in git is properly filled out with your full name


### PR DESCRIPTION
The style guide link pointed to content that was moved to the meteor guide, where you needed to click again. This links directly to that target.

