### PR TITLE
Run Reify before Babel to fix #8021 and #7662

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,7 +13,7 @@
   [Issue #7715](https://github.com/meteor/meteor/issues/7715)
   [PR #7728](https://github.com/meteor/meteor/pull/7728)
 
-* The `meteor-babel` npm package has been upgraded to version 0.14.2,
+* The `meteor-babel` npm package has been upgraded to version 0.14.3,
   fixing [#8021](https://github.com/meteor/meteor/issues/8021) and
   [#7662](https://github.com/meteor/meteor/issues/7662).
 

--- a/History.md
+++ b/History.md
@@ -13,6 +13,10 @@
   [Issue #7715](https://github.com/meteor/meteor/issues/7715)
   [PR #7728](https://github.com/meteor/meteor/pull/7728)
 
+* The `meteor-babel` npm package has been upgraded to version 0.14.2,
+  fixing [#8021](https://github.com/meteor/meteor/issues/8021) and
+  [#7662](https://github.com/meteor/meteor/issues/7662).
+
 ## v1.4.2.3
 
 * Style improvements for `meteor create --full`.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.7.3
+BUNDLE_VERSION=4.7.4
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.7.1
+BUNDLE_VERSION=4.7.2
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.7.2
+BUNDLE_VERSION=4.7.3
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -391,8 +391,8 @@
       "from": "jsesc@>=1.3.0 <2.0.0"
     },
     "json5": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "from": "json5@>=0.5.0 <0.6.0"
     },
     "lodash": {
@@ -411,9 +411,9 @@
       "from": "magic-string@>=0.16.0 <0.17.0"
     },
     "meteor-babel": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.14.2.tgz",
-      "from": "meteor-babel@0.14.2"
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.14.3.tgz",
+      "from": "meteor-babel@0.14.3"
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -498,8 +498,8 @@
       }
     },
     "reify": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.3.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.4.tgz",
       "from": "reify@>=0.4.0 <0.5.0"
     },
     "repeating": {

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -6,9 +6,9 @@
       "from": "acorn@>=3.3.0 <3.4.0"
     },
     "acorn-es7-plugin": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.0.18.tgz",
-      "from": "acorn-es7-plugin@>=1.0.17 <1.1.0"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.3.tgz",
+      "from": "acorn-es7-plugin@>=1.1.0 <1.2.0"
     },
     "ansi-regex": {
       "version": "2.0.0",
@@ -21,8 +21,8 @@
       "from": "ansi-styles@>=2.2.1 <3.0.0"
     },
     "ast-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.0.tgz",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz",
       "from": "ast-types@>=0.9.0 <0.10.0"
     },
     "babel-code-frame": {
@@ -31,59 +31,59 @@
       "from": "babel-code-frame@>=6.16.0 <7.0.0"
     },
     "babel-core": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-      "from": "babel-core@>=6.17.0 <6.18.0"
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
+      "from": "babel-core@>=6.18.2 <7.0.0"
     },
     "babel-generator": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-      "from": "babel-generator@>=6.17.0 <7.0.0"
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.19.0.tgz",
+      "from": "babel-generator@>=6.18.0 <7.0.0"
     },
     "babel-helper-builder-react-jsx": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.9.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.18.0.tgz",
       "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0"
     },
     "babel-helper-call-delegate": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-      "from": "babel-helper-call-delegate@>=6.8.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
+      "from": "babel-helper-call-delegate@>=6.18.0 <7.0.0"
     },
     "babel-helper-define-map": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-      "from": "babel-helper-define-map@>=6.9.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
+      "from": "babel-helper-define-map@>=6.18.0 <7.0.0"
     },
     "babel-helper-function-name": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-      "from": "babel-helper-function-name@>=6.8.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+      "from": "babel-helper-function-name@>=6.18.0 <7.0.0"
     },
     "babel-helper-get-function-arity": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-      "from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+      "from": "babel-helper-get-function-arity@>=6.18.0 <7.0.0"
     },
     "babel-helper-hoist-variables": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-      "from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
+      "from": "babel-helper-hoist-variables@>=6.18.0 <7.0.0"
     },
     "babel-helper-optimise-call-expression": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-      "from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
+      "from": "babel-helper-optimise-call-expression@>=6.18.0 <7.0.0"
     },
     "babel-helper-regex": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
       "from": "babel-helper-regex@>=6.8.0 <7.0.0"
     },
     "babel-helper-replace-supers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-      "from": "babel-helper-replace-supers@>=6.14.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
+      "from": "babel-helper-replace-supers@>=6.18.0 <7.0.0"
     },
     "babel-helpers": {
       "version": "6.16.0",
@@ -111,13 +111,13 @@
       "from": "babel-plugin-syntax-async-generators@>=6.13.0 <7.0.0"
     },
     "babel-plugin-syntax-flow": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.13.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "from": "babel-plugin-syntax-flow@>=6.13.0 <7.0.0"
     },
     "babel-plugin-syntax-jsx": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.13.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0"
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -141,13 +141,13 @@
       "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz",
       "from": "babel-plugin-transform-es2015-block-scoping@>=6.15.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-classes": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
       "from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -156,19 +156,14 @@
       "from": "babel-plugin-transform-es2015-computed-properties@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz",
       "from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-for-of": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz",
       "from": "babel-plugin-transform-es2015-for-of@>=6.8.0 <7.0.0"
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.8.0",
@@ -176,9 +171,9 @@
       "from": "babel-plugin-transform-es2015-literals@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.16.0 <6.17.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.18.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.8.0",
@@ -186,13 +181,13 @@
       "from": "babel-plugin-transform-es2015-object-super@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz",
       "from": "babel-plugin-transform-es2015-parameters@>=6.17.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz",
       "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-spread": {
@@ -211,8 +206,8 @@
       "from": "babel-plugin-transform-es2015-template-literals@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz",
       "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -220,24 +215,19 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
       "from": "babel-plugin-transform-es2015-unicode-regex@>=6.11.0 <7.0.0"
     },
-    "babel-plugin-transform-es3-member-expression-literals": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.8.0.tgz",
-      "from": "babel-plugin-transform-es3-member-expression-literals@>=6.8.0 <7.0.0"
-    },
     "babel-plugin-transform-es3-property-literals": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.8.0.tgz",
       "from": "babel-plugin-transform-es3-property-literals@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-flow-strip-types": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.14.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.18.0.tgz",
       "from": "babel-plugin-transform-flow-strip-types@>=6.14.0 <7.0.0"
     },
     "babel-plugin-transform-object-rest-spread": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.19.0.tgz",
       "from": "babel-plugin-transform-object-rest-spread@>=6.16.0 <7.0.0"
     },
     "babel-plugin-transform-react-display-name": {
@@ -268,52 +258,52 @@
     "babel-plugin-transform-runtime": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.15.0.tgz",
-      "from": "babel-plugin-transform-runtime@>=6.15.0 <6.16.0"
+      "from": "babel-plugin-transform-runtime@>=6.15.0 <7.0.0"
     },
     "babel-plugin-transform-strict-mode": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-      "from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
+      "from": "babel-plugin-transform-strict-mode@>=6.18.0 <7.0.0"
     },
     "babel-preset-meteor": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-meteor/-/babel-preset-meteor-6.13.0.tgz",
-      "from": "babel-preset-meteor@6.13.0"
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-meteor/-/babel-preset-meteor-6.14.0.tgz",
+      "from": "babel-preset-meteor@6.14.0"
     },
     "babel-preset-react": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
-      "from": "babel-preset-react@>=6.16.0 <6.17.0"
+      "from": "babel-preset-react@>=6.16.0 <7.0.0"
     },
     "babel-register": {
-      "version": "6.16.3",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-      "from": "babel-register@>=6.16.0 <7.0.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
+      "from": "babel-register@>=6.18.0 <7.0.0"
     },
     "babel-runtime": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-      "from": "babel-runtime@>=6.11.6 <6.12.0"
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
+      "from": "babel-runtime@>=6.18.0 <7.0.0"
     },
     "babel-template": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-      "from": "babel-template@>=6.16.0 <6.17.0"
+      "from": "babel-template@>=6.16.0 <7.0.0"
     },
     "babel-traverse": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-      "from": "babel-traverse@>=6.16.0 <6.17.0"
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
+      "from": "babel-traverse@>=6.18.0 <7.0.0"
     },
     "babel-types": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-      "from": "babel-types@>=6.16.0 <6.17.0"
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+      "from": "babel-types@>=6.18.0 <7.0.0"
     },
     "babylon": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-      "from": "babylon@>=6.11.4 <6.12.0"
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+      "from": "babylon@>=6.13.1 <7.0.0"
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -338,7 +328,7 @@
     "convert-source-map": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-      "from": "convert-source-map@>=1.3.0 <1.4.0"
+      "from": "convert-source-map@>=1.3.0 <2.0.0"
     },
     "core-js": {
       "version": "2.4.1",
@@ -346,14 +336,14 @@
       "from": "core-js@>=2.4.0 <3.0.0"
     },
     "debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
       "from": "debug@>=2.1.1 <3.0.0"
     },
     "detect-indent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-      "from": "detect-indent@>=3.0.1 <4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "from": "detect-indent@>=4.0.0 <5.0.0"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -365,15 +355,10 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "from": "esutils@>=2.0.2 <3.0.0"
     },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "from": "get-stdin@>=4.0.1 <5.0.0"
-    },
     "globals": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-      "from": "globals@>=8.3.0 <9.0.0"
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
+      "from": "globals@>=9.0.0 <10.0.0"
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -381,13 +366,13 @@
       "from": "has-ansi@>=2.0.0 <3.0.0"
     },
     "home-or-tmp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-      "from": "home-or-tmp@>=1.0.0 <2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "from": "home-or-tmp@>=2.0.0 <3.0.0"
     },
     "invariant": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "from": "invariant@>=2.2.0 <3.0.0"
     },
     "is-finite": {
@@ -406,26 +391,19 @@
       "from": "jsesc@>=1.3.0 <2.0.0"
     },
     "json5": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "from": "json5@>=0.4.0 <0.5.0"
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
+      "from": "json5@>=0.5.0 <0.6.0"
     },
     "lodash": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-      "from": "lodash@>=4.16.4 <4.17.0"
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
+      "from": "lodash@>=4.16.4 <5.0.0"
     },
     "loose-envify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-      "from": "loose-envify@>=1.0.0 <2.0.0",
-      "dependencies": {
-        "js-tokens": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-          "from": "js-tokens@>=1.0.1 <2.0.0"
-        }
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
+      "from": "loose-envify@>=1.0.0 <2.0.0"
     },
     "magic-string": {
       "version": "0.16.0",
@@ -433,9 +411,9 @@
       "from": "magic-string@>=0.16.0 <0.17.0"
     },
     "meteor-babel": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.13.0.tgz",
-      "from": "meteor-babel@0.13.0"
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.14.2.tgz",
+      "from": "meteor-babel@0.14.2"
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",
@@ -448,41 +426,34 @@
       "from": "minimatch@>=3.0.2 <4.0.0"
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "from": "minimist@>=1.1.0 <2.0.0"
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "from": "minimist@0.0.8"
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "from": "minimist@0.0.8"
-        }
-      }
+      "from": "mkdirp@>=0.5.1 <0.6.0"
     },
     "ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "from": "ms@0.7.1"
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "from": "ms@0.7.2"
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "from": "number-is-nan@>=1.0.0 <2.0.0"
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "from": "os-homedir@>=1.0.0 <2.0.0"
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "from": "os-tmpdir@>=1.0.1 <2.0.0"
-    },
-    "path-exists": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-      "from": "path-exists@>=1.0.0 <2.0.0"
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -495,13 +466,13 @@
       "from": "private@>=0.1.6 <0.2.0"
     },
     "regenerate": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
       "from": "regenerate@>=1.2.1 <2.0.0"
     },
     "regenerator-runtime": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
       "from": "regenerator-runtime@>=0.9.5 <0.10.0"
     },
     "regexpu-core": {
@@ -527,19 +498,14 @@
       }
     },
     "reify": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.3.8.tgz",
-      "from": "reify@>=0.3.6 <0.4.0"
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.3.tgz",
+      "from": "reify@>=0.4.0 <0.5.0"
     },
     "repeating": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "from": "repeating@>=1.1.0 <2.0.0"
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "from": "shebang-regex@>=1.0.0 <2.0.0"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "from": "repeating@>=2.0.0 <3.0.0"
     },
     "slash": {
       "version": "1.0.0",
@@ -552,8 +518,8 @@
       "from": "source-map@>=0.5.0 <0.6.0"
     },
     "source-map-support": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
       "from": "source-map-support@>=0.4.2 <0.5.0"
     },
     "strip-ansi": {
@@ -570,11 +536,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
       "from": "to-fast-properties@>=1.0.1 <2.0.0"
-    },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "from": "user-home@>=1.1.1 <2.0.0"
     },
     "vlq": {
       "version": "0.2.1",

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -10,7 +10,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'meteor-babel': '0.14.2'
+  'meteor-babel': '0.14.3'
 });
 
 Package.onUse(function (api) {

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,11 +6,11 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.13.0'
+  version: '6.14.0'
 });
 
 Npm.depends({
-  'meteor-babel': '0.13.0'
+  'meteor-babel': '0.14.2'
 });
 
 Package.onUse(function (api) {

--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -1,24 +1,29 @@
 {
   "dependencies": {
     "acorn": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz",
-      "from": "acorn@>=3.2.0 <3.3.0"
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "from": "acorn@>=3.3.0 <3.4.0"
+    },
+    "acorn-es7-plugin": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.3.tgz",
+      "from": "acorn-es7-plugin@>=1.1.0 <1.2.0"
     },
     "ast-types": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.17.tgz",
-      "from": "ast-types@>=0.8.16 <0.9.0"
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz",
+      "from": "ast-types@>=0.9.0 <0.10.0"
     },
     "magic-string": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.2.tgz",
-      "from": "magic-string@>=0.15.0 <0.16.0"
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
+      "from": "magic-string@>=0.16.0 <0.17.0"
     },
     "reify": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.3.6.tgz",
-      "from": "reify@0.3.6"
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.3.tgz",
+      "from": "reify@0.4.3"
     },
     "vlq": {
       "version": "0.2.1",

--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -21,9 +21,9 @@
       "from": "magic-string@>=0.16.0 <0.17.0"
     },
     "reify": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.3.tgz",
-      "from": "reify@0.4.3"
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.4.tgz",
+      "from": "reify@0.4.4"
     },
     "vlq": {
       "version": "0.2.1",

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  reify: "0.4.3"
+  reify: "0.4.4"
 });
 
 Package.onUse(function(api) {

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  reify: "0.3.6"
+  reify: "0.4.3"
 });
 
 Package.onUse(function(api) {

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,7 +14,7 @@ var packageJson = {
     npm: "3.10.9",
     "node-gyp": "3.4.0",
     "node-pre-gyp": "0.6.30",
-    "meteor-babel": "0.14.2",
+    "meteor-babel": "0.14.3",
     "meteor-promise": "0.8.0",
     fibers: "1.0.15",
     promise: "7.1.1",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,7 +14,7 @@ var packageJson = {
     npm: "3.10.9",
     "node-gyp": "3.4.0",
     "node-pre-gyp": "0.6.30",
-    "meteor-babel": "0.13.0",
+    "meteor-babel": "0.14.2",
     "meteor-promise": "0.8.0",
     fibers: "1.0.15",
     promise: "7.1.1",

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -41,7 +41,7 @@ $webclient.DownloadFile("http://www.7-zip.org/a/7z1602.msi", "$DIR\7z\7z.msi")
 $webclient.DownloadFile("http://www.7-zip.org/a/7z1602-extra.7z", "$DIR\7z\extra.7z")
 msiexec /i 7z.msi /quiet /qn /norestart
 ping -n 4 127.0.0.1 | out-null
-& "C:\Program Files*\7-Zip\7z.exe" x extra.7z
+& "C:\Program Files\7-Zip\7z.exe" x extra.7z
 mv 7za.exe "$DIR\bin\7z.exe"
 cd "$DIR\bin"
 
@@ -168,8 +168,8 @@ cd "$DIR\.."
 # rename the folder with the devbundle
 cmd /c rename "$DIR" "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}"
 
-& "C:\Program Files*\7-zip\7z.exe" a -ttar dev_bundle.tar "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}"
-& "C:\Program Files*\7-zip\7z.exe" a -tgzip "${CHECKOUT_DIR}\dev_bundle_${PLATFORM}_${BUNDLE_VERSION}.tar.gz" dev_bundle.tar
+& "C:\Program Files\7-zip\7z.exe" a -ttar dev_bundle.tar "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}"
+& "C:\Program Files\7-zip\7z.exe" a -tgzip "${CHECKOUT_DIR}\dev_bundle_${PLATFORM}_${BUNDLE_VERSION}.tar.gz" dev_bundle.tar
 del dev_bundle.tar
 cmd /c rmdir "dev_bundle_${PLATFORM}_${BUNDLE_VERSION}" /s /q
 

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -186,7 +186,9 @@ function getImportedModuleId(node) {
   if (node.type === "CallExpression" &&
       node.callee.type === "MemberExpression" &&
       isIdWithName(node.callee.object, "module") &&
-      isIdWithName(node.callee.property, "import")) {
+      (isIdWithName(node.callee.property, "import") ||
+       (isStringLiteral(node.callee.property) &&
+        node.callee.property.value === "import"))) {
     const args = node.arguments;
     const argc = args.length;
     if (argc > 0) {


### PR DESCRIPTION
Currently, we run Reify to transpile all `import` and `export` declarations at the end of the `meteor-babel` compiler pipeline, as explained in [this comment](https://github.com/meteor/meteor/issues/8021#issuecomment-258888771).

That needs to change if we want Reify to be able to generate block-scoped `let` declarations for imported symbols (#8021) or to have a chance of handling `import` declarations before generator functions get transpiled (#7662).

I was hoping these changes might make it into Meteor 1.4.2.1, but (even though tests were passing) they introduced too much risk, as outlined in [this comment](https://github.com/meteor/meteor/issues/8021#issuecomment-259202160).