### PR TITLE
Make sure DDP._CurrentInvocation is never set inside publish functions

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -801,23 +801,32 @@ _.extend(Session.prototype, {
     self.collectionViews = {};
     self.userId = userId;
 
-    // Save the old named subs, and reset to having no subscriptions.
-    var oldNamedSubs = self._namedSubs;
-    self._namedSubs = {};
-    self._universalSubs = [];
+    // _setUserId is normally called from a Meteor method with
+    // DDP._CurrentInvocation set. But DDP._CurrentInvocation is not expected
+    // to be set inside a publish function, so we temporary unset it.
+    // Otherwise, this can lead to a problem that if a publish function is
+    // calling server-side Meteor methods, their this.connection property is
+    // set when publish function is restarted here, but the property should
+    // not be set.
+    DDP._CurrentInvocation.withValue(null, function () {
+      // Save the old named subs, and reset to having no subscriptions.
+      var oldNamedSubs = self._namedSubs;
+      self._namedSubs = {};
+      self._universalSubs = [];
 
-    _.each(oldNamedSubs, function (sub, subscriptionId) {
-      self._namedSubs[subscriptionId] = sub._recreate();
-      // nb: if the handler throws or calls this.error(), it will in fact
-      // immediately send its 'nosub'. This is OK, though.
-      self._namedSubs[subscriptionId]._runHandler();
+      _.each(oldNamedSubs, function (sub, subscriptionId) {
+        self._namedSubs[subscriptionId] = sub._recreate();
+        // nb: if the handler throws or calls this.error(), it will in fact
+        // immediately send its 'nosub'. This is OK, though.
+        self._namedSubs[subscriptionId]._runHandler();
+      });
+
+      // Allow newly-created universal subs to be started on our connection in
+      // parallel with the ones we're spinning up here, and spin up universal
+      // subs.
+      self._dontStartNewUniversalSubs = false;
+      self.startUniversalSubs();
     });
-
-    // Allow newly-created universal subs to be started on our connection in
-    // parallel with the ones we're spinning up here, and spin up universal
-    // subs.
-    self._dontStartNewUniversalSubs = false;
-    self.startUniversalSubs();
 
     // Start sending messages again, beginning with the diff from the previous
     // state of the world to the current state. No yields are allowed during

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -85,7 +85,7 @@ testAsyncMulti(
 
 Meteor.methods({
   livedata_server_test_inner: function () {
-    return this.connection.id;
+    return this.connection && this.connection.id;
   },
 
   livedata_server_test_outer: function () {
@@ -152,6 +152,57 @@ Tinytest.addAsync(
           onComplete();
         };
         clientConn.subscribe("livedata_server_test_sub", serverConn.id);
+      }
+    );
+  }
+);
+
+var methodCallResults = {};
+
+Meteor.publish("livedata_server_test_sub_with_method", function (connectionId) {
+  if (! methodCallResults[connectionId]) {
+    methodCallResults[connectionId] = [];
+  }
+  methodCallResults[connectionId].push(Meteor.call('livedata_server_test_inner'));
+  this.ready();
+});
+
+Meteor.methods({
+  livedata_server_test_setuserid: function (userId) {
+    this.setUserId(userId);
+  }
+});
+
+Tinytest.addAsync(
+  "livedata server - no connection in a method called from a publish function",
+  function (test, onComplete) {
+    makeTestConnection(
+      test,
+      function (clientConn, serverConn) {
+        clientConn.call('livedata_server_test_setuserid', null);
+
+        var handle = clientConn.subscribe("livedata_server_test_sub_with_method", serverConn.id, {
+          onStop: function (error) {
+            test.isFalse(error, error);
+            clientConn.disconnect();
+
+            // Both times, also after rerun, connection should be null
+            // inside a server-side called method should be null.
+            test.equal(methodCallResults[serverConn.id], [null, null]);
+            delete methodCallResults[serverConn.id];
+
+            onComplete();
+          },
+          onReady: function () {
+            // Connection inside a server-side called method should be null.
+            test.equal(methodCallResults[serverConn.id], [null]);
+
+            // With this call we force publish function to rerun.
+            clientConn.call('livedata_server_test_setuserid', 'someUserId');
+
+            handle.stop()
+          }
+        });
       }
     );
   }


### PR DESCRIPTION
`_setUserId` is normally called from a Meteor method with `DDP._CurrentInvocation` set. But `DDP._CurrentInvocation` is not expected to be set inside a publish function, so we have to temporary unset it.

Otherwise, this can lead to a problem that if a publish function is calling server-side Meteor methods, their `this.connection` property is set when publish function is restarted here, but the property should not be set.