### PR TITLE
Allow global headless setting

### DIFF
--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -309,7 +309,7 @@ var ProgressDisplayFull = function (console) {
   self._progressBarRenderer = new ProgressBarRenderer(PROGRESS_BAR_FORMAT, options);
   self._progressBarRenderer.start = new Date();
 
-  self._headless = !!(process.env.METEOR_HEADLESS && process.env.METEOR_HEADLESS != '0');
+  self._headless = !!(process.env.METEOR_HEADLESS && JSON.parse(process.env.METEOR_HEADLESS));
 
   self._spinnerRenderer = new SpinnerRenderer();
 

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -309,7 +309,7 @@ var ProgressDisplayFull = function (console) {
   self._progressBarRenderer = new ProgressBarRenderer(PROGRESS_BAR_FORMAT, options);
   self._progressBarRenderer.start = new Date();
 
-  self._headless = false;
+  self._headless = !!(process.env.METEOR_HEADLESS && process.env.METEOR_HEADLESS != '0');
 
   self._spinnerRenderer = new SpinnerRenderer();
 


### PR DESCRIPTION
This is a followup to https://github.com/meteor/meteor/pull/7814. There are simply many reasons why would various commands be run inside CI and other automatic environments. Spinner is not needed there. Instead of adding `--headless` arguments to various commands, let's have a global environment variable and this is it.

BTW, this also seems to improve speed of whole Meteor tool experience. I would even say that probably this should be the default. No need for a spinner at all. It slows down things too much.