### PR TITLE
code style changes for skel-full

### DIFF
--- a/tools/static-assets/skel-full/imports/api/links/links.js
+++ b/tools/static-assets/skel-full/imports/api/links/links.js
@@ -2,4 +2,6 @@
 
 import { Mongo } from 'meteor/mongo';
 
-export const Links = new Mongo.Collection('links');
+const Links = new Mongo.Collection('links');
+
+export { Links };

--- a/tools/static-assets/skel-full/imports/api/links/links.js
+++ b/tools/static-assets/skel-full/imports/api/links/links.js
@@ -2,6 +2,4 @@
 
 import { Mongo } from 'meteor/mongo';
 
-const Links = new Mongo.Collection('links');
-
-export { Links };
+export const Links = new Mongo.Collection('links');

--- a/tools/static-assets/skel-full/imports/api/links/links.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/links.tests.js
@@ -2,9 +2,6 @@
 //
 // https://guide.meteor.com/testing.html
 
-/* eslint-env mocha */
-/* eslint-disable func-names, prefer-arrow-callback, no-underscore-dangle */
-
 import { Meteor } from 'meteor/meteor';
 import { assert } from 'meteor/practicalmeteor:chai';
 import { Links } from './links.js';

--- a/tools/static-assets/skel-full/imports/api/links/links.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/links.tests.js
@@ -2,6 +2,9 @@
 //
 // https://guide.meteor.com/testing.html
 
+/* eslint-env mocha */
+/* eslint-disable func-names, prefer-arrow-callback, no-underscore-dangle */
+
 import { Meteor } from 'meteor/meteor';
 import { assert } from 'meteor/practicalmeteor:chai';
 import { Links } from './links.js';
@@ -9,13 +12,16 @@ import { Links } from './links.js';
 if (Meteor.isServer) {
   describe('links collection', function () {
     it('insert correctly', function () {
-      const link = Links.insert({ title:'meteor homepage', url: 'https://www.meteor.com'});
-      const added = Links.find({_id: link});
+      const linkId = Links.insert({
+        title: 'meteor homepage',
+        url: 'https://www.meteor.com',
+      });
+      const added = Links.find({ _id: linkId });
       const collectionName = added._getCollectionName();
       const count = added.count();
 
       assert.equal(collectionName, 'links');
       assert.equal(count, 1);
-    })
-  })
+    });
+  });
 }

--- a/tools/static-assets/skel-full/imports/api/links/methods.js
+++ b/tools/static-assets/skel-full/imports/api/links/methods.js
@@ -9,12 +9,6 @@ Meteor.methods({
     check(url, String);
     check(title, String);
 
-    // Check if this is a valid url
-    const re = /((http|https)\:\/\/)+[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z0-9\&\.\/\?\:@\-_=#])*/g;
-    if (!url.match(re)) {
-      throw new Meteor.Error('Invalid URL.');
-    }
-
     return Links.insert({
       url,
       title,

--- a/tools/static-assets/skel-full/imports/api/links/methods.js
+++ b/tools/static-assets/skel-full/imports/api/links/methods.js
@@ -1,8 +1,8 @@
 // Methods related to links
 
 import { Meteor } from 'meteor/meteor';
-import { Links } from './links.js';
 import { check } from 'meteor/check';
+import { Links } from './links.js';
 
 Meteor.methods({
   'links.insert'(title, url) {
@@ -10,10 +10,15 @@ Meteor.methods({
     check(title, String);
 
     // Check if this is a valid url
-    if (!url.match(/((http|https)\:\/\/)+[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z0-9\&\.\/\?\:@\-_=#])*/g)){
-      throw new Meteor.Error('Bad url. I.e https://www.meteor.com');
+    const re = /((http|https)\:\/\/)+[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z0-9\&\.\/\?\:@\-_=#])*/g;
+    if (!url.match(re)) {
+      throw new Meteor.Error('Invalid URL.');
     }
 
-    return Links.insert({url, title, createdAt: new Date()});
-  }
+    return Links.insert({
+      url,
+      title,
+      createdAt: new Date(),
+    });
+  },
 });

--- a/tools/static-assets/skel-full/imports/api/links/methods.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/methods.tests.js
@@ -2,25 +2,28 @@
 //
 // https://guide.meteor.com/testing.html
 
+/* eslint-env mocha */
+/* eslint-disable func-names, prefer-arrow-callback */
+
 import { Meteor } from 'meteor/meteor';
-import { chai, assert } from 'meteor/practicalmeteor:chai';
+import { assert } from 'meteor/practicalmeteor:chai';
 import { Links } from './links.js';
 import './methods.js';
 
 if (Meteor.isServer) {
   describe('links methods', function () {
-
-    beforeEach(() => {
+    beforeEach(function () {
       Links.remove({});
-    })
+    });
 
-    it('can add new link', function () {
+    it('can add a new link', function () {
       const addLink = Meteor.server.method_handlers['links.insert'];
 
       addLink.apply({}, ['meteor.com', 'https://www.meteor.com']);
 
       assert.equal(Links.find().count(), 1);
-    })
+    });
+
     it('insert link method validation', function () {
       const addLink = Meteor.server.method_handlers['links.insert'];
 
@@ -30,22 +33,22 @@ if (Meteor.isServer) {
       try {
         addLink.apply({}, ['meteor.com', 2]);
       } catch (e) {
-        errors++;
+        errors += 1;
       }
       // Check title is String
       try {
         addLink.apply({}, [1, 'meteor.com']);
       } catch (e) {
-        errors++;
+        errors += 1;
       }
       // Check url is valid
       try {
         addLink.apply({}, ['meteor.com', 'meteor.com']);
       } catch (e) {
-        errors++;
+        errors += 1;
       }
 
       assert.equal(errors, 3);
-    })
-  })
+    });
+  });
 }

--- a/tools/static-assets/skel-full/imports/api/links/methods.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/methods.tests.js
@@ -23,32 +23,5 @@ if (Meteor.isServer) {
 
       assert.equal(Links.find().count(), 1);
     });
-
-    it('insert link method validation', function () {
-      const addLink = Meteor.server.method_handlers['links.insert'];
-
-      let errors = 0;
-
-      // Check url is String
-      try {
-        addLink.apply({}, ['meteor.com', 2]);
-      } catch (e) {
-        errors += 1;
-      }
-      // Check title is String
-      try {
-        addLink.apply({}, [1, 'meteor.com']);
-      } catch (e) {
-        errors += 1;
-      }
-      // Check url is valid
-      try {
-        addLink.apply({}, ['meteor.com', 'meteor.com']);
-      } catch (e) {
-        errors += 1;
-      }
-
-      assert.equal(errors, 3);
-    });
   });
 }

--- a/tools/static-assets/skel-full/imports/api/links/methods.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/methods.tests.js
@@ -2,9 +2,6 @@
 //
 // https://guide.meteor.com/testing.html
 
-/* eslint-env mocha */
-/* eslint-disable func-names, prefer-arrow-callback */
-
 import { Meteor } from 'meteor/meteor';
 import { assert } from 'meteor/practicalmeteor:chai';
 import { Links } from './links.js';

--- a/tools/static-assets/skel-full/imports/api/links/server/publications.js
+++ b/tools/static-assets/skel-full/imports/api/links/server/publications.js
@@ -1,10 +1,10 @@
-//All links-related publications
+// All links-related publications
+
+/* eslint-disable func-names, prefer-arrow-callback */
 
 import { Meteor } from 'meteor/meteor';
 import { Links } from '../links.js';
 
-Meteor.publish({
-  'links.all': function () {
-    return Links.find({});
-  }
+Meteor.publish('links.all', function () {
+  return Links.find();
 });

--- a/tools/static-assets/skel-full/imports/api/links/server/publications.js
+++ b/tools/static-assets/skel-full/imports/api/links/server/publications.js
@@ -1,7 +1,5 @@
 // All links-related publications
 
-/* eslint-disable func-names, prefer-arrow-callback */
-
 import { Meteor } from 'meteor/meteor';
 import { Links } from '../links.js';
 

--- a/tools/static-assets/skel-full/imports/api/links/server/publications.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/server/publications.tests.js
@@ -2,18 +2,22 @@
 //
 // https://guide.meteor.com/testing.html
 
-import { Meteor } from 'meteor/meteor';
+/* eslint-env mocha */
+/* eslint-disable func-names, prefer-arrow-callback */
+
 import { assert } from 'meteor/practicalmeteor:chai';
 import { Links } from '../links.js';
 import { PublicationCollector } from 'meteor/johanbrook:publication-collector';
 import './publications.js';
 
 describe('links publications', function () {
-
-  beforeEach(() => {
+  beforeEach(function () {
     Links.remove({});
-    Links.insert({ title: 'meteor homepage', url: 'https://www.meteor.com'});
-  })
+    Links.insert({
+      title: 'meteor homepage',
+      url: 'https://www.meteor.com',
+    });
+  });
 
   describe('links.all', function () {
     it('sends all links', function (done) {
@@ -24,4 +28,4 @@ describe('links publications', function () {
       });
     });
   });
-})
+});

--- a/tools/static-assets/skel-full/imports/api/links/server/publications.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/server/publications.tests.js
@@ -2,9 +2,6 @@
 //
 // https://guide.meteor.com/testing.html
 
-/* eslint-env mocha */
-/* eslint-disable func-names, prefer-arrow-callback */
-
 import { assert } from 'meteor/practicalmeteor:chai';
 import { Links } from '../links.js';
 import { PublicationCollector } from 'meteor/johanbrook:publication-collector';

--- a/tools/static-assets/skel-full/imports/startup/both/index.js
+++ b/tools/static-assets/skel-full/imports/startup/both/index.js
@@ -1,1 +1,2 @@
-// Import modules used by both client and server through a single index entry point (i.e. useraccounts configuration file).
+// Import modules used by both client and server through a single index entry point
+// e.g. useraccounts configuration file.

--- a/tools/static-assets/skel-full/imports/startup/server/fixtures.js
+++ b/tools/static-assets/skel-full/imports/startup/server/fixtures.js
@@ -4,34 +4,31 @@ import { Meteor } from 'meteor/meteor';
 import { Links } from '../../api/links/links.js';
 
 Meteor.startup(() => {
-
   // if the Links collection is empty
   if (Links.find().count() === 0) {
     const data = [
       {
-        'title': 'Do the Tutorial',
-        'url': 'https://www.meteor.com/try',
-        'createdAt': new Date()
+        title: 'Do the Tutorial',
+        url: 'https://www.meteor.com/try',
+        createdAt: new Date(),
       },
       {
-        'title': 'Follow the Guide',
-        'url': 'http://guide.meteor.com',
-        'createdAt': new Date()
+        title: 'Follow the Guide',
+        url: 'http://guide.meteor.com',
+        createdAt: new Date(),
       },
       {
-        'title': 'Read the Docs',
-        'url': 'https://docs.meteor.com',
-        'createdAt': new Date()
+        title: 'Read the Docs',
+        url: 'https://docs.meteor.com',
+        createdAt: new Date(),
       },
       {
-        'title': 'Discussions',
-        'url': 'https://forums.meteor.com',
-        'createdAt': new Date()
+        title: 'Discussions',
+        url: 'https://forums.meteor.com',
+        createdAt: new Date(),
       },
     ];
 
-    data.forEach((link) => {
-      Links.insert(link);
-    });
+    data.forEach(link => Links.insert(link));
   }
 });

--- a/tools/static-assets/skel-full/imports/ui/components/info/info.html
+++ b/tools/static-assets/skel-full/imports/ui/components/info/info.html
@@ -8,8 +8,8 @@
         <input type="submit" name="submit" value="Add new link">
       </form>
     </li>
-  {{#each links}}
-    <li><a href="{{url}}" target="_blank">{{title}}</a></li>
-  {{/each}}
+    {{#each links}}
+      <li><a href="{{url}}" target="_blank">{{title}}</a></li>
+    {{/each}}
   </ul>
 </template>

--- a/tools/static-assets/skel-full/imports/ui/components/info/info.js
+++ b/tools/static-assets/skel-full/imports/ui/components/info/info.js
@@ -2,8 +2,6 @@ import { Links } from '/imports/api/links/links.js';
 import { Meteor } from 'meteor/meteor';
 import './info.html';
 
-/* eslint-disable func-names, prefer-arrow-callback */
-
 Template.info.onCreated(function () {
   Meteor.subscribe('links.all');
 });

--- a/tools/static-assets/skel-full/imports/ui/components/info/info.js
+++ b/tools/static-assets/skel-full/imports/ui/components/info/info.js
@@ -1,8 +1,10 @@
+import { Links } from '/imports/api/links/links.js';
+import { Meteor } from 'meteor/meteor';
 import './info.html';
-import { Links } from '/imports/api/links/links.js'
-import { Meteor } from 'meteor/meteor'
 
-Template.info.onCreated(function infoOnCreated() {
+/* eslint-disable func-names, prefer-arrow-callback */
+
+Template.info.onCreated(function () {
   Meteor.subscribe('links.all');
 });
 
@@ -13,21 +15,20 @@ Template.info.helpers({
 });
 
 Template.info.events({
-  'submit .info-link-add': function (e){
-    e.preventDefault();
+  'submit .info-link-add'(event) {
+    event.preventDefault();
 
-    const target = e.target;
+    const target = event.target;
     const title = target.title;
     const url = target.url;
 
-    Meteor.call('links.insert', title.value, url.value, function (error) {
-      if(error){
+    Meteor.call('links.insert', title.value, url.value, (error) => {
+      if (error) {
         alert(error.error);
-      }
-      else{
+      } else {
         title.value = '';
         url.value = '';
       }
     });
-  }
-})
+  },
+});

--- a/tools/static-assets/skel-full/imports/ui/pages/not-found/not-found.html
+++ b/tools/static-assets/skel-full/imports/ui/pages/not-found/not-found.html
@@ -8,5 +8,4 @@
       <a href="/" class="gotohomepage">Go to home</a>
     </div>
   </div>
-
 </template>

--- a/tools/static-assets/skel-full/imports/ui/stylesheets/not-found.less
+++ b/tools/static-assets/skel-full/imports/ui/stylesheets/not-found.less
@@ -1,11 +1,11 @@
-#not-found{
+#not-found {
   width: 700px;
   margin: 0 auto;
-  .not-found-image{
+  .not-found-image {
     width: 25%;
     float: left;
   }
-  .not-found-title{
+  .not-found-title {
     width: 70%;
     float: right;
     background: url(/img/bg-footer.svg);
@@ -13,13 +13,13 @@
     background-position: center;
     background-size: contain;
     min-height: 400px;
-    h1{
+    h1 {
       font-size: 30px;
       color: #1f2128;
       margin-bottom: 20px;
       margin-top: 155px;
     }
-    a.gotohomepage{
+    a.gotohomepage {
       background-color: #de4f4f;
       color: #fff;
       width: 180px;

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -5,6 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "meteor-node-stubs": "~0.2.0"
+    "babel-runtime": "^6.18.0",
+    "meteor-node-stubs": "~0.2.3"
   }
 }


### PR DESCRIPTION
Updated the code style (and dependencies) for the full scaffold to match (as best as seems reasonable) the Meteor guide.

There is some discrepancy with the recommended eslint configuration. For example there are a number of rules that make sense within the context of a Meteor project, which is exactly why [these have been added](https://github.com/meteor/todos/blob/master/package.json#L41-L61) in the todos example. So to address that I've added a few `eslint-disable` comments where it makes sense, though it's not ideal.

In [some cases like this](https://github.com/meteor/meteor/blob/devel/tools/static-assets/skel-full/imports/ui/components/hello/hello.js#L3) it is pretty much standard practise (in Meteor) to not bother with naming function expressions (`func-names`). So we should probably change that, but as you can see it's not great that it then conflicts with the recommended (stock) linter config.

Perhaps a solution is that it can be handled by the [eslint meteor plugin](https://github.com/dferber90/eslint-plugin-meteor), though I'm not totally sure how that might work since it's designed to work independently to the airbnb rules. @dferber90 any thoughts? :)

So in the meantime until there's a solution like above should we remove the `eslint-disable` comments for the sake of simplicity?