### PR TITLE
Keep Hashes in URL when rewriting relative URLs

### DIFF
--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -145,7 +145,7 @@ var rewriteRules = function (rules, mergedCssPath) {
         // Rewrite relative paths (that refers to the internal application tree)
         // to absolute paths (addressable from the public build).
         if (isRelative(resource.path)) {
-          absolutePath = pathJoin(basePath, resource.path);
+          absolutePath = pathJoin(basePath, resource.path + resource.hash);
         } else {
           absolutePath = resource.path;
         }

--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -145,13 +145,13 @@ var rewriteRules = function (rules, mergedCssPath) {
         // Rewrite relative paths (that refers to the internal application tree)
         // to absolute paths (addressable from the public build).
         if (isRelative(resource.path)) {
-          if(resource.hash){
-            absolutePath = pathJoin(basePath, resource.path + resource.hash);
-          }else{
-            absolutePath = pathJoin(basePath, resource.path);
-          }
+          absolutePath = pathJoin(basePath, resource.path);
         } else {
           absolutePath = resource.path;
+        }
+        
+        if(resource.hash){
+          absolutePath += resource.hash;
         }
 
         // We used to finish the rewriting process at the absolute path step

--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -138,7 +138,7 @@ var rewriteRules = function (rules, mergedCssPath) {
         // We don't rewrite URLs starting with a protocol definition such as
         // http, https, or data, or those with network-path references
         // i.e. //img.domain.com/cat.gif
-        if (resource.protocol !== null || resource.href.startsWith('//')) {
+        if (resource.protocol !== null || resource.href.startsWith('//') || resource.href.startsWith('#')) {
           continue;
         }
 

--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -150,7 +150,7 @@ var rewriteRules = function (rules, mergedCssPath) {
           absolutePath = resource.path;
         }
         
-        if(resource.hash){
+        if (resource.hash) {
           absolutePath += resource.hash;
         }
 

--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -145,7 +145,11 @@ var rewriteRules = function (rules, mergedCssPath) {
         // Rewrite relative paths (that refers to the internal application tree)
         // to absolute paths (addressable from the public build).
         if (isRelative(resource.path)) {
-          absolutePath = pathJoin(basePath, resource.path + resource.hash);
+          if(resource.hash){
+            absolutePath = pathJoin(basePath, resource.path + resource.hash);
+          }else{
+            absolutePath = pathJoin(basePath, resource.path);
+          }
         } else {
           absolutePath = resource.path;
         }

--- a/packages/minifier-css/urlrewriting-tests.js
+++ b/packages/minifier-css/urlrewriting-tests.js
@@ -6,13 +6,13 @@ Tinytest.add("minifier-css - url rewriting when merging", function (test) {
 
   var parseOptions = { source: null, position: true };
 
-  var t = function(relativeUrl, absoluteUrl, desc) {
+  function t(relativeUrl, absoluteUrl, desc) {
     var ast1 = CssTools.parseCss(stylesheet(relativeUrl), parseOptions);
     var ast2 = CssTools.parseCss(stylesheet(absoluteUrl), parseOptions);
     CssTools.rewriteCssUrls(ast1);
 
     test.equal(CssTools.stringifyCss(ast1), CssTools.stringifyCss(ast2), desc);
-  };
+  }
 
   parseOptions.source = 'packages/nameOfPackage/style.css';
   t('../image.png', 'packages/image.png', 'parent directory');
@@ -42,7 +42,6 @@ Tinytest.add("minifier-css - url rewriting when merging", function (test) {
   t('"http://i.imgur.com/fBcdJIh.gif"', '"http://i.imgur.com/fBcdJIh.gif"', 'complete quoted URL');
   t('data:image/png;base64,iVBORw0K=', 'data:image/png;base64,iVBORw0K=', 'data URI');
   t('http://', 'http://', 'malformed URL');
-
 });
 
 Tinytest.add("minifier-css - url rewriting with media queries (ast rule recursion)", function (test) {

--- a/packages/minifier-css/urlrewriting-tests.js
+++ b/packages/minifier-css/urlrewriting-tests.js
@@ -97,3 +97,51 @@ Tinytest.add("minifier-css - url rewriting with media queries (ast rule recursio
   t('http://', 'http://', 'malformed URL');
 
 });
+
+Tinytest.add("minifier-css - url rewriting with hash symbols", function (test) {
+  var stylesheet = function(backgroundPath) {
+    return "body { background-image: url(" + backgroundPath + ")}"
+  };
+
+  var parseOptions = { source: null, position: true };
+
+  var t = function(relativeUrl, absoluteUrl, desc) {
+    var ast1 = CssTools.parseCss(stylesheet(relativeUrl), parseOptions);
+    var ast2 = CssTools.parseCss(stylesheet(absoluteUrl), parseOptions);
+    CssTools.rewriteCssUrls(ast1);
+
+    test.equal(CssTools.stringifyCss(ast1), CssTools.stringifyCss(ast2), desc);
+  };
+
+  parseOptions.source = 'packages/nameOfPackage/style.css';
+  t('../filters.svg#theFilterId', 'packages/filters.svg#theFilterId', 'parent directory');
+  t('./../filters.svg#theFilterId', 'packages/filters.svg#theFilterId', 'parent directory');
+  t('../nameOfPackage2/filters.svg#theFilterId', 'packages/nameOfPackage2/filters.svg#theFilterId', 'cousin directory');
+  t('../../filters.svg#theFilterId', 'filters.svg#theFilterId', 'grand parent directory');
+  t('./filters.svg#theFilterId', 'packages/nameOfPackage/filters.svg#theFilterId', 'current directory');
+  t('./child/filters.svg#theFilterId', 'packages/nameOfPackage/child/filters.svg#theFilterId', 'child directory');
+  t('child/filters.svg#theFilterId', 'packages/nameOfPackage/child/filters.svg#theFilterId', 'child directory');
+  t('/filters.svg#theFilterId', 'filters.svg#theFilterId', 'absolute url');
+  t('"/filters.svg#theFilterId"', '"filters.svg#theFilterId"', 'double quoted url');
+  t("'/filters.svg#theFilterId'", "'filters.svg#theFilterId'", 'single quoted url');
+  t('"./../filters.svg#theFilterId"', '"packages/filters.svg#theFilterId"', 'quoted parent directory');
+  t('http://i.imgur.com/filters.svg#theFilterId', 'http://i.imgur.com/filters.svg#theFilterId', 'complete URL');
+  t('"http://i.imgur.com/filters.svg#theFilterId"', '"http://i.imgur.com/filters.svg#theFilterId"', 'complete quoted URL');
+  t('data:image/png;base64,iVBORw0K=#theFilterId', 'data:image/png;base64,iVBORw0K=#theFilterId', 'data URI');
+  t('http://', 'http://', 'malformed URL');
+  t('#theFilterId', '#theFilterId', 'URL starting with a #');
+
+  parseOptions.source = 'application/client/dir/other-style.css';
+  t('./filters.svg#theFilterId', 'filters.svg#theFilterId', 'base path is root');
+  t('./child/filters.svg#theFilterId', 'child/filters.svg#theFilterId', 'child directory from root');
+  t('child/filters.svg#theFilterId', 'child/filters.svg#theFilterId', 'child directory from root');
+  t('/filters.svg#theFilterId', 'filters.svg#theFilterId', 'absolute url');
+  t('"/filters.svg#theFilterId"', '"filters.svg#theFilterId"', 'double quoted url');
+  t("'/filters.svg#theFilterId'", "'filters.svg#theFilterId'", 'single quoted url');
+  t('http://i.imgur.com/filters.svg#theFilterId', 'http://i.imgur.com/filters.svg#theFilterId', 'complete URL');
+  t('"http://i.imgur.com/filters.svg#theFilterId"', '"http://i.imgur.com/filters.svg#theFilterId"', 'complete quoted URL');
+  t('data:image/png;base64,iVBORw0K=#theFilterId', 'data:image/png;base64,iVBORw0K=#theFilterId', 'data URI');
+  t('http://', 'http://', 'malformed URL');
+  t('#theFilterId', '#theFilterId', 'URL starting with a #');
+
+});


### PR DESCRIPTION
For certain use cases, like SVG filters, the url needs to have a # symbol. For example, the following css property : 

```filter:url("filters.svg#lightGreen")```

In the current version of the codebase, gets rewritten to : 

```filter:url("http://myapp.com/filters.svg")```

Whereas the proper behaviour should be: 

```filter:url("http://myapp.com/filters.svg#lightGreen")```

This simple change will fix the issue.