### PR TITLE
Fix for console output in PowerShell on Win10

### DIFF
--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -68,7 +68,7 @@ var wordwrap = require('wordwrap');
 var PROGRESS_DEBUG = !!process.env.METEOR_PROGRESS_DEBUG;
 var FORCE_PRETTY=undefined;
 var CARRIAGE_RETURN =
-  (process.platform === 'win32' && process.stdout.isTTY ? new Array(249).join('\b') : '\r');
+  (process.platform === 'win32' && process.stdout.isTTY && process.title !== 'Windows PowerShell' ? new Array(249).join('\b') : '\r');
 
 if (process.env.METEOR_PRETTY_OUTPUT) {
   FORCE_PRETTY = process.env.METEOR_PRETTY_OUTPUT != '0';


### PR DESCRIPTION
See https://github.com/meteor/meteor/issues/6785

Basically, 
```
new Array(249).join('\b')
```
is not a good idea for a carriage return. Code has been tested with CMD, PowerShell and PowerShell in Legacy Mode and seems to solve the issue.