### PR TITLE
Fix bad interaction between methods and buffering

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -977,7 +977,8 @@ _.extend(Connection.prototype, {
   // documents.
   _saveOriginals: function () {
     var self = this;
-    self._flushBufferedWrites();
+    if (!self._waitingForQuiescence())
+      self._flushBufferedWrites();
     _.each(self._stores, function (s) {
       s.saveOriginals();
     });

--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -844,8 +844,10 @@ _.extend(Connection.prototype, {
         randomSeed: function () { return randomSeedGenerator(); }
       });
 
-      if (!alreadyInSimulation)
+      if (!alreadyInSimulation) {
+        self._flushBufferedWrites();
         self._saveOriginals();
+      }
 
       try {
         // Note that unlike in the corresponding server code, we never audit

--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -844,10 +844,8 @@ _.extend(Connection.prototype, {
         randomSeed: function () { return randomSeedGenerator(); }
       });
 
-      if (!alreadyInSimulation) {
-        self._flushBufferedWrites();
+      if (!alreadyInSimulation)
         self._saveOriginals();
-      }
 
       try {
         // Note that unlike in the corresponding server code, we never audit
@@ -979,6 +977,7 @@ _.extend(Connection.prototype, {
   // documents.
   _saveOriginals: function () {
     var self = this;
+    self._flushBufferedWrites();
     _.each(self._stores, function (s) {
       s.saveOriginals();
     });


### PR DESCRIPTION
So it seems we introduced a bug with #5680.

The issue is the following scenario:
* you have a publish sending changes to a field `a`
* they get buffered
* at the same time a client runs a method with a stub which changes field `b`
* method is simulated and ends
* buffered changes are applied
* server-side confirms a method
* client-side switches to a state after a simulated method call using `replace` message with the old `a` value, without that published change being present

Or something like this. It is really tricky race condition when this happens. But the solution is simple. Methods should always run on the latest state of data, without any pending buffered state. So this pull requests applies pending buffered state. In retrospective this looks obvious.

I am unsure how to make a test for this to discover such cases in the future with tests.

cc @nathan-muir