### PR TITLE
Don't allow websockets to indefinitely wait for DDP handshake

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -302,6 +302,9 @@ var Session = function (server, version, socket, options) {
   }).run();
 
   if (version !== 'pre1' && options.heartbeatInterval !== 0) {
+    // We no longer need the low level timeout because we have heartbeating.
+    socket.setWebsocketTimeout(0);
+
     self.heartbeat = new DDPCommon.Heartbeat({
       heartbeatInterval: options.heartbeatInterval,
       heartbeatTimeout: options.heartbeatTimeout,


### PR DESCRIPTION
In general, we try to avoid allowing TCP connections to be open with no
traffic on it indefinitely.  We place timeouts on incoming HTTP
connections in webapp_server.js (which we adjust to longer values when
there's an HTTP request pending), and once a DDP connection is fully
established we require heartbeats.

However, if the incoming connection is a websocket, the faye-websocket
package used by SockJS calls setTimeout(0) on the underlying socket when
it initializes the WebSocket object:

https://github.com/faye/faye-websocket-node/blob/3148348a3/lib/faye/websocket/api.js#L111

So if a client does the WebSocket handshake with the server but never
sends a valid DDP connect message, the socket can be held open
indefinitely. (To add insult to injury, a 1MB Buffer object is retained
on such sockets due to something in the faye-websocket code, at least on
older versions of Node like 0.10.)

This commit restores a timeout on the socket for this in-between period.

(We actually saw this issue in production on the Meteor Developer
Accounts server --- hundreds of such broken connections would accumulate
over time.  This may be triggered by a particular setup we use involving
proxies for the accounts server, or it may be a more generally
applicable issue.)