### PR TITLE
Improve build plugin error when asset is added with empty contents

### DIFF
--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -726,7 +726,8 @@ class ResourceSlot {
       if (_.isString(options.data)) {
         options.data = new Buffer(options.data);
       } else {
-        throw new Error("'data' option to addAsset must be a Buffer or String.");
+        throw new Error("'data' option to addAsset must be a Buffer or " +
+                        "String: " + self.inputResource.path);
       }
     }
 


### PR DESCRIPTION
While not a Meteor bug, this makes the error message more helpful when a build plugin tries adding an asset (`ResourceSlot.addAsset`) without data.  For example, [this file](https://raw.githubusercontent.com/Urigo/meteor-rxjs/28ac86a29b957b705b78425b49285eb7d90db324/examples/angular2/client/imports/app/app.component.scss) when run through `angular2-compiler` (which has since had the bug fixed, but it was harder to find because this error was not verbose enough).  This was as demonstrated in meteor/meteor#8034.

With this change, `ResourceSlot.addAsset` behaves the same as [`ResourceSlot.addHtml`](https://github.com/meteor/meteor/blob/b1df3ed0ed2b686e96d89ee66252f447b3c3b87e/tools/isobuild/compiler-plugin.js#L756-L760) which provides the `path` (of the file attempting to be compiled) in the error message.

Thanks to @sdarnell for this suggestion.

Closes meteor/meteor#8034