### PR TITLE
Install npm dependencies automatically when creating apps.

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -744,6 +744,8 @@ main.registerCommand({
   // the packages (or maybe an unpredictable subset based on what happens to be
   // in the template's versions file).
 
+  require("./default-npm-deps.js").install(appPath);
+
   var appNameToDisplay = appPathAsEntered === "." ?
     "current directory" : `'${appPathAsEntered}'`;
 

--- a/tools/cli/default-npm-deps.js
+++ b/tools/cli/default-npm-deps.js
@@ -6,7 +6,7 @@ import {
   unlink,
 } from "../fs/files.js";
 
-const INSTALL_JOB_MESSAGE = "installing dependencies from package.json";
+const INSTALL_JOB_MESSAGE = "installing npm dependencies";
 
 export function install(appDir) {
   const packageJsonPath = pathJoin(appDir, "package.json");


### PR DESCRIPTION
Although I have said I do not think Meteor should run `npm install` automatically to update application `node_modules`, my real concern is that Meteor should not interfere with your preferred `node_modules`-related workflow, be it `npm`, `npm-shinkwrap.json`, `shrinkpack`, `yarn` + `yarn.lock`, checking your `node_modules` into git/mercurial/cvs, or whatever other scheme you currently have (or might adopt in the future).

Automatically installing `node_modules` from the default `package.json` file when a new app is created will eliminate real confusion, and should not interfere with any workflows, because there is no opportunity to establish another workflow before Meteor runs `npm install` the very first time.

Addresses https://github.com/meteor/meteor/issues/6848.
May make https://github.com/meteor/meteor/issues/8095 unnecessary?