### PR TITLE
Fix history and add history for #7970

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,8 +1,382 @@
 ## v.NEXT
 
-* Add support for frame-ancestors CSP option in browser-policy [#7970](https://github.com/meteor/meteor/pull/7970)
+* The `facebook` package has been split into:
+  - `facebook-oauth` (the part that allows oauth w/ FB directly) and
+  - `facebook-config-ui` (the Blaze configuration templates for accounts-ui)
+
+  This means you can now use `[accounts-]facebook` without needing Blaze.
+
+  If you are using `accounts-ui` and `accounts-facebook`, you will probably
+  need to install the `facebook-config-ui` package if you want to configure it
+  using the Accounts UI.
+
+  [Issue #7715](https://github.com/meteor/meteor/issues/7715)
+  [PR #7728](https://github.com/meteor/meteor/pull/7728)
+
+## v1.4.2.3
+
+* Style improvements for `meteor create --full`.
+  [#8045](https://github.com/meteor/meteor/pull/8045)
+
+> Note: Meteor 1.4.2.2 was finalized before
+  [#8045](https://github.com/meteor/meteor/pull/8045) was merged, but
+  those changes were [deemed important
+  enough](https://github.com/meteor/meteor/pull/8044#issuecomment-260913739)
+  to skip recommending 1.4.2.2 and instead immediately release 1.4.2.3.
+
+## v1.4.2.2
+
+* Node has been upgraded to version 4.6.2.
+
+* `meteor create` now has a new `--full` option, which generates an larger app,
+  demonstrating development techniques highlighted in the
+  [Meteor Guide](http://guide.meteor.com)
+
+  [Issue #6974](https://github.com/meteor/meteor/issues/6974)
+  [PR #7807](https://github.com/meteor/meteor/pull/7807)
+
+* Minimongo now supports `$min`, `$max` and partially supports `$currentDate`.
+
+  [Issue #7857](https://github.com/meteor/meteor/issues/7857)
+  [PR #7858](https://github.com/meteor/meteor/pull/7858)
+
+* Fix for [Issue #5676](https://github.com/meteor/meteor/issues/5676)
+  [PR #7968](https://github.com/meteor/meteor/pull/7968)
+
+* It is now possible for packages to specify a *lazy* main module:
+  ```js
+  Package.onUse(function (api) {
+    api.mainModule("client.js", "client", { lazy: true });
+  });
+  ```
+  This means the `client.js` module will not be evaluated during app
+  startup unless/until another module imports it, and will not even be
+  included in the client bundle if no importing code is found. **Note 1:**
+  packages with lazy main modules cannot use `api.export` to export global
+  symbols to other packages/apps. **Note 2:** packages with lazy main
+  modules should be restricted to Meteor 1.4.2.2 or later via
+  `api.versionsFrom("1.4.2.2")`, since older versions of Meteor cannot
+  import lazy main modules using `import "meteor/<package name>"` but must
+  explicitly name the module: `import "meteor/<package name>/client.js"`.
+
+## v1.4.2.1
+
+* Installing the `babel-runtime` npm package in your application
+  `node_modules` directory is now required for most Babel-transformed code
+  to work, as the Meteor `babel-runtime` package no longer attempts to
+  provide custom implementations of Babel helper functions. To install
+  the `babel-runtime` package, simply run the command
+  ```sh
+  meteor npm install --save babel-runtime
+  ```
+  in any Meteor application directory. The Meteor `babel-runtime` package
+  version has been bumped to 1.0.0 to reflect this major change.
+  [#7995](https://github.com/meteor/meteor/pull/7995)
+
+* File system operations performed by the command-line tool no longer use
+  fibers unless the `METEOR_DISABLE_FS_FIBERS` environment variable is
+  explicitly set to a falsy value. For larger apps, this change results in
+  significant build performance improvements due to the creation of fewer
+  fibers and the avoidance of unnecessary asyncronous delays.
+  https://github.com/meteor/meteor/pull/7975/commits/ca4baed90ae0675e55c93976411d4ed91f12dd63
+
+* Running Meteor as `root` is still discouraged, and results in a fatal
+  error by default, but the `--allow-superuser` flag now works as claimed.
+  [#7959](https://github.com/meteor/meteor/issues/7959)
+
+* The `dev_bundle\python\python.exe` executable has been restored to the
+  Windows dev bundle, which may help with `meteor npm rebuild` commands.
+  [#7960](https://github.com/meteor/meteor/issues/7960)
+
+* Changes within linked npm packages now trigger a partial rebuild,
+  whereas previously (in 1.4.2) they were ignored.
+  [#7978](https://github.com/meteor/meteor/issues/7978)
+
+* Miscellaneous fixed bugs:
+  [#2876](https://github.com/meteor/meteor/issues/2876)
+  [#7154](https://github.com/meteor/meteor/issues/7154)
+  [#7956](https://github.com/meteor/meteor/issues/7956)
+  [#7974](https://github.com/meteor/meteor/issues/7974)
+  [#7999](https://github.com/meteor/meteor/issues/7999)
+  [#8005](https://github.com/meteor/meteor/issues/8005)
+  [#8007](https://github.com/meteor/meteor/issues/8007)
+
+## v1.4.2
+
+* This release implements a number of rebuild performance optimizations.
+  As you edit files in development, the server should restart and rebuild
+  much more quickly, especially if you have many `node_modules` files.
+  See https://github.com/meteor/meteor/pull/7668 for more details.
+
+> Note: the `METEOR_PROFILE` environment variable now provides data for
+  server startup time as well as build time, which should make it easier
+  to tell which of your packages are responsible for slow startup times.
+  Please include the output of `METEOR_PROFILE=10 meteor run` with any
+  GitHub issue about rebuild performance.
+
+* `npm` has been upgraded to version 3.10.9.
+
+* The `cordova-lib` npm package has been updated to 6.3.1, along with
+  cordova-android (5.2.2) and cordova-ios (4.2.1), and various plugins.
+
+* The `node-pre-gyp` npm package has been updated to 0.6.30.
+
+* The `lru-cache` npm package has been updated to 4.0.1.
+
+* The `meteor-promise` npm package has been updated to 0.8.0 for better
+  asynchronous stack traces.
+
+* The `meteor` tool is now prevented from running as `root` as this is
+  not recommended and can cause issues with permissions.  In some environments,
+  (e.g. Docker), it may still be desired to run as `root` and this can be
+  permitted by passing `--unsafe-perm` to the `meteor` command.
+  [#7821](https://github.com/meteor/meteor/pull/7821)
+
+* Blaze-related packages have been extracted to
+  [`meteor/blaze`](https://github.com/meteor/blaze), and the main
+  [`meteor/meteor`](https://github.com/meteor/meteor) repository now
+  refers to them via git submodules (see
+  [#7633](https://github.com/meteor/meteor/pull/7633)).
+  When running `meteor` from a checkout, you must now update these
+  submodules by running
+  ```sh
+  git submodule update --init --recursive
+  ```
+  in the root directory of your `meteor` checkout.
+
+* Accounts.forgotPassword and .verifyEmail no longer throw errors if callback is provided. [Issue #5664](https://github.com/meteor/meteor/issues/5664) [Origin PR #5681](https://github.com/meteor/meteor/pull/5681) [Merged PR](https://github.com/meteor/meteor/pull/7117)
+
+* The default content security policy (CSP) for Cordova now includes `ws:`
+  and `wss:` WebSocket protocols.
+  [#7774](https://github.com/meteor/meteor/pull/7774)
+
+* `meteor npm` commands are now configured to use `dev_bundle/.npm` as the
+  npm cache directory by default, which should make npm commands less
+  sensitive to non-reproducible factors in the external environment.
+  https://github.com/meteor/meteor/pull/7668/commits/3313180a6ff33ee63602f7592a9506012029e919
+
+* The `meteor test` command now supports the `--no-release-check` flag.
+  https://github.com/meteor/meteor/pull/7668/commits/7097f78926f331fb9e70a06300ce1711adae2850
+
+* JavaScript module bundles on the server no longer include transitive
+  `node_modules` dependencies, since those dependencies can be evaluated
+  directly by Node. This optimization should improve server rebuild times
+  for apps and packages with large `node_modules` directories.
+  https://github.com/meteor/meteor/pull/7668/commits/03c5346873849151cecc3e00606c6e5aa13b3bbc
+
+* The `standard-minifier-css` package now does basic caching for the
+  expensive `mergeCss` function.
+  https://github.com/meteor/meteor/pull/7668/commits/bfa67337dda1e90610830611fd99dcb1bd44846a
+
+* The `coffeescript` package now natively supports `import` and `export`
+  declarations. [#7818](https://github.com/meteor/meteor/pull/7818)
+
+## v1.4.1.3
+
+* Node has been updated to version 4.6.1:
+  https://nodejs.org/en/blog/release/v4.6.1/
+
+* The `mongodb` npm package used by the `npm-mongo` Meteor package has
+  been updated to version 2.2.11.
+  [#7780](https://github.com/meteor/meteor/pull/7780)
+
+* The `fibers` npm package has been upgraded to version 1.0.15.
+
+* Running Meteor with a different `--port` will now automatically
+  reconfigure the Mongo replica set when using the WiredTiger storage
+  engine, instead of failing to start Mongo.
+  [#7840](https://github.com/meteor/meteor/pull/7840).
+
+* When the Meteor development server shuts down, it now attempts to kill
+  the `mongod` process it spawned, in addition to killing any running
+  `mongod` processes when the server first starts up.
+  https://github.com/meteor/meteor/pull/7668/commits/295d3d5678228f06ee0ab6c0d60139849a0ea192
+
+* The `meteor <command> ...` syntax will now work for any command
+  installed in `dev_bundle/bin`, except for Meteor's own commands.
+
+* Incomplete package downloads will now fail (and be retried several
+  times) instead of silently succeeding, which was the cause of the
+  dreaded `Error: ENOENT: no such file or directory, open... os.json`
+  error. [#7806](https://github.com/meteor/meteor/issues/7806)
+
+## v1.4.1.2
+
+* Node has been upgraded to version 4.6.0, a recommended security release:
+  https://nodejs.org/en/blog/release/v4.6.0/
+
+* `npm` has been upgraded to version 3.10.8.
+
+## v1.4.1.1
+
+* Update the version of our Node MongoDB driver to 2.2.8 to fix a bug in
+  reconnection logic, leading to some `update` and `remove` commands being
+  treated as `insert`s. [#7594](https://github.com/meteor/meteor/issues/7594)
+
+## v1.4.1
+
+* Node has been upgraded to 4.5.0.
+
+* `npm` has been upgraded to 3.10.6.
+
+* The `meteor publish-for-arch` command is no longer necessary when
+  publishing Meteor packages with binary npm dependencies. Instead, binary
+  dependencies will be rebuilt automatically on the installation side.
+  Meteor package authors are not responsible for failures due to compiler
+  toolchain misconfiguration, and any compilation problems with the
+  underlying npm packages should be taken up with the authors of those
+  packages. That said, if a Meteor package author really needs or wants to
+  continue using `meteor publish-for-arch`, she should publish her package
+  using an older release: e.g. `meteor --release 1.4 publish`.
+  [#7608](https://github.com/meteor/meteor/pull/7608)
+
+* The `.meteor-last-rebuild-version.json` files that determine if a binary
+  npm package needs to be rebuilt now include more information from the
+  `process` object, namely `process.{platform,arch,versions}` instead of
+  just `process.versions`. Note also that the comparison of versions now
+  ignores differences in patch versions, to avoid needless rebuilds.
+
+* The `npm-bcrypt` package now uses a pure-JavaScript implementation by
+  default, but will prefer the native `bcrypt` implementation if it is
+  installed in the application's `node_modules` directory. In other words,
+  run `meteor install --save bcrypt` in your application if you need or
+  want to use the native implementation of `bcrypt`.
+  [#7595](https://github.com/meteor/meteor/pull/7595)
+
+* After Meteor packages are downloaded from Atmosphere, they will now be
+  extracted using native `tar` or `7z.exe` on Windows, instead of the
+  https://www.npmjs.com/package/tar library, for a significant performance
+  improvement. [#7457](https://github.com/meteor/meteor/pull/7457)
+
+* The npm `tar` package has been upgraded to 2.2.1, though it is now only
+  used as a fallback after native `tar` and/or `7z.exe`.
+
+* The progress indicator now distinguishes between downloading,
+  extracting, and loading newly-installed Meteor packages, instead of
+  lumping all of that work into a "downloading" status message.
+
+* Background Meteor updates will no longer modify the `~/.meteor/meteor`
+  symbolic link (or `AppData\Local\.meteor\meteor.bat` on Windows).
+  Instead, developers must explicitly type `meteor update` to begin using
+  a new version of the `meteor` script.
+
+* Password Reset tokens now expire (after 3 days by default -- can be modified via `Accounts.config({ passwordResetTokenExpirationInDays: ...}`). [PR #7534](https://github.com/meteor/meteor/pull/7534)
+
+* The `google` package now uses the `email` scope as a mandatory field instead
+  of the `profile` scope. The `profile` scope is still added by default if the
+  `requestPermissions` option is not specified to maintain backward
+  compatibility, but it is now possible to pass an empty array to
+  `requestPermissions` in order to only request the `email` scope, which
+  reduces the amount of permissions requested from the user in the Google
+  popup. [PR #6975](https://github.com/meteor/meteor/pull/6975)
+
+* Added `Facebook.handleAuthFromAccessToken` in the case where you get the FB
+  accessToken in some out-of-band way. [PR #7550](https://github.com/meteor/meteor/pull/7550)
+
+* `Accounts.onLogout` gets `{ user, connection }` context in a similar fashion
+  to `Accounts.onLogin`. [Issue #7397](https://github.com/meteor/meteor/issues/7397) [PR #7433](https://github.com/meteor/meteor/pull/7433)
+
+* The `node-gyp` and `node-pre-gyp` tools will now be installed in
+  `bundle/programs/server/node_modules`, to assist with rebuilding binary
+  npm packages when deploying an app to Galaxy or elsewhere.
+  [#7571](https://github.com/meteor/meteor/pull/7571)
+
+* The `standard-minifier-{js,css}` packages no longer minify .js or .css
+  files on the server. [#7572](https://github.com/meteor/meteor/pull/7572)
+
+* Multi-line input to `meteor shell`, which was broken by changes to the
+  `repl` module in Node 4, works again.
+  [#7562](https://github.com/meteor/meteor/pull/7562)
+
+* The implementation of the command-line `meteor` tool now forbids
+  misbehaving polyfill libraries from overwriting `global.Promise`.
+  [#7569](https://github.com/meteor/meteor/pull/7569)
+
+* The `oauth-encryption` package no longer depends on the
+  `npm-node-aes-gcm` package (or any special npm packages), because the
+  Node 4 `crypto` library natively supports the `aes-128-gcm` algorithm.
+  [#7548](https://github.com/meteor/meteor/pull/7548)
+
+* The server-side component of the `meteor shell` command has been moved
+  into a Meteor package, so that it can be developed independently from
+  the Meteor release process, thanks to version unpinning.
+  [#7624](https://github.com/meteor/meteor/pull/7624)
+
+* The `meteor shell` command now works when running `meteor test`.
+
+* The `meteor debug` command no longer pauses at the first statement
+  in the Node process, yet still reliably stops at custom breakpoints
+  it encounters later.
+
+* The `meteor-babel` package has been upgraded to 0.12.0.
+
+* The `meteor-ecmascript-runtime` package has been upgraded to 0.2.9, to
+  support several additional [stage 4
+  proposals](https://github.com/meteor/ecmascript-runtime/pull/4).
+
+* A bug that prevented @-scoped npm packages from getting bundled for
+  deployed apps has been fixed.
+  [#7609](https://github.com/meteor/meteor/pull/7609).
+
+* The `meteor update` command now supports an `--all-packages` flag to
+  update all packages (including indirect dependencies) to their latest
+  compatible versions, similar to passing the names of all your packages
+  to the `meteor update` command.
+  [#7653](https://github.com/meteor/meteor/pull/7653)
+
+* Background release updates can now be disabled by invoking either
+  `meteor --no-release-check` or `METEOR_NO_RELEASE_CHECK=1 meteor`.
+  [#7445](https://github.com/meteor/meteor/pull/7445)
+
+## v1.4.0.1
+
+* Fix issue with the 1.4 tool springboarding to older releases (see [Issue #7491](https://github.com/meteor/meteor/issues/7491))
+
+* Fix issue with running in development on Linux 32bit [Issue #7511](https://github.com/meteor/meteor/issues/7511)
+
+## v1.4
+
+* Node has been upgraded to 4.4.7.
+
+* The `meteor-babel` npm package has been upgraded to 0.11.7.
+
+* The `reify` npm package has been upgraded to 0.3.6.
+
+* The `bcrypt` npm package has been upgraded to 0.8.7.
+
+* Nested `import` declarations are now enabled for package code as well as
+  application code. 699cf1f38e9b2a074169515d23983f74148c7223
+
+* Meteor has been upgraded to support Mongo 3.2 by default (the bundled version
+  used by `meteor run` has been upgraded). Internally it now uses the 2.2.4
+  version of the `mongodb` npm driver, and has been tested against at Mongo 3.2
+  server. [Issue #6957](https://github.com/meteor/meteor/issues/6957)
+
+  Mongo 3.2 defaults to the new WiredTiger storage engine. You can update your
+  database following the instructions here:
+  https://docs.mongodb.com/v3.0/release-notes/3.0-upgrade/.
+  In development, you can also just use `meteor reset` to remove your old
+  database, and Meteor will create a new WiredTiger database for you. The Mongo
+  driver will continue to work with the old MMAPv1 storage engine however.
+
+  The new version of the Mongo driver has been tested with MongoDB versions from
+  2.6 up. Mongo 2.4 has now reached end-of-life
+  (https://www.mongodb.com/support-policy), and is no longer supported.
+
+  If you are setting `MONGO_OPLOG_URL`, especially in production, ensure you are
+  passing in the `replicaSet` argument (see [#7450]
+    (https://github.com/meteor/meteor/issues/7450))
+
+* Custom Mongo options can now be specified using the
+  `Mongo.setConnectionOptions(options)` API.
+  [#7277](https://github.com/meteor/meteor/pull/7277)
+
+* On the server, cursor.count() now takes a single argument `applySkipLimit`
+  (see the corresponding [Mongo documentation]
+    (http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#count))
+
 * Fix for regression caused by #5837 which incorrectly rewrote
-  network-path references (i.e. //domain.com/image.gif) in CSS URLs
+  network-path references (e.g. `//domain.com/image.gif`) in CSS URLs.
   [#7416](https://github.com/meteor/meteor/issues/7416)
 * Added Angular2 boilerplate example [#7364](https://github.com/meteor/meteor/pull/7363)
 
@@ -10,7 +384,7 @@
 
 * This release fixed a small bug in 1.3.5 that prevented updating apps
   whose `.meteor/release` files refer to releases no longer installed in
-  `~/.meteor/packages/meteor-tool`. 576468eae8d8dd7c1fe2fa381ac51dee5cb792cd
+  `~/.meteor/packages/meteor-tool`. [576468eae8d8dd7c1fe2fa381ac51dee5cb792cd](https://github.com/meteor/meteor/commit/576468eae8d8dd7c1fe2fa381ac51dee5cb792cd)
 
 ## v1.3.5
 
@@ -21,7 +395,7 @@
 * If an app has no `package.json` file, all packages in `node_modules`
   will be built into the production bundle. In other words, make sure you
   have a `package.json` file if you want to benefit from `devDependencies`
-  pruning. 7b2193188fc9e297eefc841ce6035825164f0684
+  pruning. [7b2193188fc9e297eefc841ce6035825164f0684](https://github.com/meteor/meteor/commit/7b2193188fc9e297eefc841ce6035825164f0684)
 
 * Binary npm dependencies of compiler plugins are now automatically
   rebuilt when Node/V8 versions change.
@@ -56,7 +430,7 @@
   `Npm.depends`) has been set to "error" instead of "warn". Note that this
   change does not affect `meteor npm ...` commands, which can be easily
   configured using `.npmrc` files or command-line flags.
-  https://github.com/meteor/meteor/commit/0689cae25a3e0da3615a402cdd0bec94ce8455c8
+  [0689cae25a3e0da3615a402cdd0bec94ce8455c8](https://github.com/meteor/meteor/commit/0689cae25a3e0da3615a402cdd0bec94ce8455c8)
 
 ## v1.3.4.3
 
@@ -87,7 +461,7 @@
   invoke. Note that you must `meteor update` to 1.3.4.2 before this logic
   will take effect, but it will work in all app directories after
   updating, even those pinned to older versions.
-  [#7338](https://github.com/meteor/meteor/issue/7338)
+  [#7338](https://github.com/meteor/meteor/issues/7338)
 
 * The Meteor installer now has the ability to resume downloads, so
   installing Meteor on a spotty internet connection should be more

--- a/History.md
+++ b/History.md
@@ -13,6 +13,8 @@
   [Issue #7715](https://github.com/meteor/meteor/issues/7715)
   [PR #7728](https://github.com/meteor/meteor/pull/7728)
 
+* Add support for frame-ancestors CSP option in browser-policy [#7970](https://github.com/meteor/meteor/pull/7970)
+
 ## v1.4.2.3
 
 * Style improvements for `meteor create --full`.


### PR DESCRIPTION
As a correction to 8e22818 which inadvertently removed 1.4 from existence.

Good catch by @mitar.  https://github.com/meteor/meteor/commit/8e228180e66a9808f268f1de1b9ead2ec21a8751?diff=unified#commitcomment-20013960

/cc @zol – I think this is what you wanted.