### PR TITLE
Make CI test runner more defensive and a bit more flexible

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,6 +1,24 @@
-export TIMEOUT_SCALE_FACTOR=15
-export TEST_PACKAGES_EXCLUDE="less"
-export SELF_TEST_EXCLUDE="^can't publish package with colons|^old cli tests|^logs - logged (in|out)|^mongo - logged (in|out)|^minifiers can't register non-js|^minifiers: apps can't use|^compiler plugins - addAssets"
+#!/bin/sh
+
+#
+# Optional Environment Variables for Configuration
+#
+# - TIMEOUT_SCALE_FACTOR: (default: 15)
+#   A multiplation factor that can be used to raise the wait-time on
+#   various longer-running tests.  Useful for slower (or faster!) hardware.
+# - ADDL_SELF_TEST_EXCLUDE: (optional)
+#   A regex or list of additional regexes to skip.
+
+# Export this one so it's available in the node environment.
+export TIMEOUT_SCALE_FACTOR=${TIMEOUT_SCALE_FACTOR:-15}
+
+# Skip these tests always.  Add other tests with ADDL_SELF_TEST_EXCLUDE.
+SELF_TEST_EXCLUDE="^can't publish package with colons|^old cli tests|^logs - logged (in|out)|^mongo - logged (in|out)|^minifiers can't register non-js|^minifiers: apps can't use|^compiler plugins - addAssets"
+
+# If no SELF_TEST_EXCLUDE is defined, use those defined here by default
+if ! [ -z "$ADDL_SELF_TEST_EXCLUDE" ]; then
+  SELF_TEST_EXCLUDE="${SELF_TEST_EXCLUDE}|${ADDL_SELF_TEST_EXCLUDE}"
+fi
 
 # Don't print as many progress indicators
 export EMACS=t

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,42 +7,17 @@
 #   A multiplation factor that can be used to raise the wait-time on
 #   various longer-running tests.  Useful for slower (or faster!) hardware.
 # - ADDL_SELF_TEST_EXCLUDE: (optional)
-#   A list of additional regexes to skip, in addition to the defaults.
+#   A regex or list of additional regexes to skip.
 
 # Export this one so it's available in the node environment.
 export TIMEOUT_SCALE_FACTOR=${TIMEOUT_SCALE_FACTOR:-15}
 
-# Define the default tests which will be skipped.  One per line.
-test -z "$SELF_TEST_EXCLUDE" && read -r -d '' SELF_TEST_EXCLUDE <<-'EOF'
-^can't publish package with colons
-^compiler plugins - addAssets
-^logs - logged (in|out)
-^minifiers can't register non-js
-^minifiers: apps can't use
-^mongo - logged (in|out)
-^old cli tests
-EOF
+# Skip these tests always.  Add other tests with ADDL_SELF_TEST_EXCLUDE.
+SELF_TEST_EXCLUDE="^can't publish package with colons|^old cli tests|^logs - logged (in|out)|^mongo - logged (in|out)|^minifiers can't register non-js|^minifiers: apps can't use|^compiler plugins - addAssets"
 
-# Helper function to join lines.
-joinLines () {
-  joined=""
-  IFS="$(printf '\n ')" && IFS="${IFS% }"
-  for add in $1
-  do
-    joined="${joined:+${joined}${2:-,}}${add}"
-  done
-  unset IFS
-  echo "$joined"
-}
-
-# Merge tests into a single, one-line regex.
-SELF_TEST_EXCLUDE=$(joinLines "$SELF_TEST_EXCLUDE" "|")
-
-# Add additional tests.
+# If no SELF_TEST_EXCLUDE is defined, use those defined here by default
 if ! [ -z "$ADDL_SELF_TEST_EXCLUDE" ]; then
-  SELF_TEST_EXCLUDE=(
-    "${SELF_TEST_EXCLUDE}|$(joinLines "$ADDL_SELF_TEST_EXCLUDE")"
-  )
+  SELF_TEST_EXCLUDE="${SELF_TEST_EXCLUDE}|${ADDL_SELF_TEST_EXCLUDE}"
 fi
 
 # Don't print as many progress indicators

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -49,11 +49,20 @@ should_run_test () {
   test $(($1 % $CIRCLE_NODE_TOTAL)) -eq $CIRCLE_NODE_INDEX
 }
 
+# Keep track of errors, but let the tests all finish. This is necessary since
+# more than one of the following tests may be executed from a single run if
+# parallelism is lower than the number of tests.
+exit_code=0
+
+# Also, if any uncaught errors slip through, fail the build.
+set -e
+
 if should_run_test 0; then
   echo "Running warehouse self-tests"
   ./meteor self-test --headless \
       --with-tag "custom-warehouse" \
-      --exclude "$SELF_TEST_EXCLUDE"
+      --exclude "$SELF_TEST_EXCLUDE" \
+    || exit_code=$?
 fi
 
 if should_run_test 1; then
@@ -61,7 +70,8 @@ if should_run_test 1; then
   ./meteor self-test --headless \
       --file "^[a-b]|^c[a-n]|^co[a-l]|^compiler-plugins" \
       --without-tag "custom-warehouse" \
-      --exclude "$SELF_TEST_EXCLUDE"
+      --exclude "$SELF_TEST_EXCLUDE" \
+    || exit_code=$?
 fi
 
 if should_run_test 2; then
@@ -69,7 +79,8 @@ if should_run_test 2; then
   ./meteor self-test --headless \
       --file "^co[n-z]|^c[p-z]|^[d-k]" \
       --without-tag "custom-warehouse" \
-      --exclude "$SELF_TEST_EXCLUDE"
+      --exclude "$SELF_TEST_EXCLUDE" \
+    || exit_code=$?
 fi
 
 if should_run_test 3; then
@@ -77,7 +88,8 @@ if should_run_test 3; then
   ./meteor self-test --headless \
       --file "^[l-o]" \
       --without-tag "custom-warehouse" \
-      --exclude "$SELF_TEST_EXCLUDE"
+      --exclude "$SELF_TEST_EXCLUDE" \
+    || exit_code=$?
 fi
 
 if should_run_test 4; then
@@ -85,7 +97,8 @@ if should_run_test 4; then
   ./meteor self-test --headless \
       --file "^p" \
       --without-tag "custom-warehouse" \
-      --exclude "$SELF_TEST_EXCLUDE"
+      --exclude "$SELF_TEST_EXCLUDE" \
+    || exit_code=$?
 fi
 
 if should_run_test 5; then
@@ -93,7 +106,8 @@ if should_run_test 5; then
   ./meteor self-test --headless \
       --file "^run" \
       --without-tag "custom-warehouse" \
-      --exclude "$SELF_TEST_EXCLUDE"
+      --exclude "$SELF_TEST_EXCLUDE" \
+    || exit_code=$?
 fi
 
 if should_run_test 6; then
@@ -101,7 +115,8 @@ if should_run_test 6; then
   ./meteor self-test --headless \
       --file "^r(?!un)|^s" \
       --without-tag "custom-warehouse" \
-      --exclude "$SELF_TEST_EXCLUDE"
+      --exclude "$SELF_TEST_EXCLUDE" \
+    || exit_code=$?
 fi
 
 if should_run_test 7; then
@@ -109,5 +124,8 @@ if should_run_test 7; then
   ./meteor self-test --headless \
       --file "^[t-z]|^command-line" \
       --without-tag "custom-warehouse" \
-      --exclude "$SELF_TEST_EXCLUDE"
+      --exclude "$SELF_TEST_EXCLUDE" \
+    || exit_code=$?
 fi
+
+exit $exit_code

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -5,6 +5,16 @@ export SELF_TEST_EXCLUDE="^can't publish package with colons|^old cli tests|^log
 # Don't print as many progress indicators
 export EMACS=t
 
+if [ -z "$CIRCLE_NODE_TOTAL" ] || [ -z "$CIRCLE_NODE_INDEX" ]; then
+  # In the case where these aren't set, just pretend like we're a single node.
+  # This is also handy if the user is using another CI service besides CircleCI
+  CIRCLE_NODE_TOTAL=1
+  CIRCLE_NODE_INDEX=0
+
+  echo "[warn] CIRCLE_NODE_TOTAL or CIRCLE_NODE_INDEX was not defined.  \c"
+  echo "Running all tests!"
+fi
+
 # Clear dev_bundle/.npm to ensure consistent test runs.
 ./meteor npm cache clear
 
@@ -17,60 +27,69 @@ export EMACS=t
 git submodule update --init --recursive
 
 # run different jobs based on CicleCI parallel container index
-case $CIRCLE_NODE_INDEX in
-0)
+should_run_test () {
+  test $(($1 % $CIRCLE_NODE_TOTAL)) -eq $CIRCLE_NODE_INDEX
+}
+
+if should_run_test 0; then
   echo "Running warehouse self-tests"
   ./meteor self-test --headless \
       --with-tag "custom-warehouse" \
       --exclude "$SELF_TEST_EXCLUDE"
-  ;;
-1)
+fi
+
+if should_run_test 1; then
   echo "Running self-test (1): A-Com"
   ./meteor self-test --headless \
       --file "^[a-b]|^c[a-n]|^co[a-l]|^compiler-plugins" \
       --without-tag "custom-warehouse" \
       --exclude "$SELF_TEST_EXCLUDE"
-  ;;
-2)
+fi
+
+if should_run_test 2; then
   echo "Running self-test (2): Con-K"
   ./meteor self-test --headless \
       --file "^co[n-z]|^c[p-z]|^[d-k]" \
       --without-tag "custom-warehouse" \
       --exclude "$SELF_TEST_EXCLUDE"
-  ;;
-3)
+fi
+
+if should_run_test 3; then
   echo "Running self-test (3): L-O"
   ./meteor self-test --headless \
       --file "^[l-o]" \
       --without-tag "custom-warehouse" \
       --exclude "$SELF_TEST_EXCLUDE"
-  ;;
-4)
+fi
+
+if should_run_test 4; then
   echo "Running self-test (4): P"
   ./meteor self-test --headless \
       --file "^p" \
       --without-tag "custom-warehouse" \
       --exclude "$SELF_TEST_EXCLUDE"
-  ;;
-5)
+fi
+
+if should_run_test 5; then
   echo "Running self-test (5): Run"
   ./meteor self-test --headless \
       --file "^run" \
       --without-tag "custom-warehouse" \
       --exclude "$SELF_TEST_EXCLUDE"
-  ;;
-6)
+fi
+
+if should_run_test 6; then
   echo "Running self-test (6): R-S"
   ./meteor self-test --headless \
       --file "^r(?!un)|^s" \
       --without-tag "custom-warehouse" \
       --exclude "$SELF_TEST_EXCLUDE"
-  ;;
-7)
+fi
+
+if should_run_test 7; then
   echo "Running self-test (7): Sp-Z"
   ./meteor self-test --headless \
       --file "^[t-z]|^command-line" \
       --without-tag "custom-warehouse" \
       --exclude "$SELF_TEST_EXCLUDE"
-  ;;
-esac
+fi


### PR DESCRIPTION
General improvements to the CI script:

* Changes the CI script to make sure it runs all tests, regardless of the environment configuration while still allowing flexibility in the size of the container parallelism.

  While not having any effect on the Meteor configuration this will now run all 8 test groups across a fewer number of containers, if necessary.

  This fixes issues where false-positives are achieved on contributor PRs, like seen on meteor/meteor#7963 and for the reason I explained here: https://github.com/meteor/meteor/pull/7963#issuecomment-264188162

* Permits changing `TIMEOUT_SCALE_FACTOR` using a variable instead of hard-coding it in the script and adds `ADDL_SELF_TEST_EXCLUDE` to define environment specific tests which must be skipped.  For example:

  ```sh
  $ TIMEOUT_SCALE_FACTOR=20 ./scripts/ci.sh # take your time!
  ```

  ```sh
  $ ADDL_SELF_TEST_EXCLUDE="^stubborn-(run-)?test$" ./scripts/ci.sh
  ```

  For example, I run my preliminary (personal) Meteor tests on SemaphoreCI, but there is a particular test that just _will not work_.  This allows to skip that without a hack-y `sed` parse.

* (reverted) 6701357c41078e1e8a90384e4fc71ba0ab3301ff was probably overboard and just cleaned up the way the skipped tests were defined.  I reverted it as one of the features I was used was a `bash`-ism and in the spirit of making `meteor` work in as many places as possible I didn't want to force that.

(We'll see if this PR passes on my own CircleCI with just 4 containers)

/cc @hwillson @benjamn 