### PR TITLE
[docs] Clarify docs for handle returned by Meteor.setTimeout/setInterval

### DIFF
--- a/packages/meteor/timers.js
+++ b/packages/meteor/timers.js
@@ -44,7 +44,7 @@ _.extend(Meteor, {
    * @memberOf Meteor
    * @summary Cancel a repeating function call scheduled by `Meteor.setInterval`.
    * @locus Anywhere
-   * @param {Number} id The handle returned by `Meteor.setInterval`
+   * @param {Object} id The handle returned by `Meteor.setInterval`
    */
   clearInterval: function(x) {
     return clearInterval(x);
@@ -54,7 +54,7 @@ _.extend(Meteor, {
    * @memberOf Meteor
    * @summary Cancel a function call scheduled by `Meteor.setTimeout`.
    * @locus Anywhere
-   * @param {Number} id The handle returned by `Meteor.setTimeout`
+   * @param {Object} id The handle returned by `Meteor.setTimeout`
    */
   clearTimeout: function(x) {
     return clearTimeout(x);


### PR DESCRIPTION
Thanks to @CdavM for pointing out this JSdoc discrepancy in #7778.

The value passed into from `Meteor.clearTimeout` or `Meteor.clearInterval` is an opaque handle returned by `Meteor.setTimeout` and `Meteor.setInterval` accordingly.

That is to say, on some engines it will be a `Number` and on others an `Object` but you need not worry about the actual type.

Closes meteor/meteor#7778