### PR TITLE
Remove skipped CI tests which don't exist anymore

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,7 +13,7 @@
 export TIMEOUT_SCALE_FACTOR=${TIMEOUT_SCALE_FACTOR:-15}
 
 # Skip these tests always.  Add other tests with ADDL_SELF_TEST_EXCLUDE.
-SELF_TEST_EXCLUDE="^can't publish package with colons|^old cli tests|^logs - logged (in|out)|^mongo - logged (in|out)|^minifiers can't register non-js|^minifiers: apps can't use|^compiler plugins - addAssets"
+SELF_TEST_EXCLUDE="^old cli tests|^minifiers can't register non-js|^minifiers: apps can't use|^compiler plugins - addAssets"
 
 # If no SELF_TEST_EXCLUDE is defined, use those defined here by default
 if ! [ -z "$ADDL_SELF_TEST_EXCLUDE" ]; then


### PR DESCRIPTION
As a follow-up to cleaning up `ci.sh` yesterday in #8122, I found some tests that don't exist anymore but were still "excluded" from running.  This removes the exceptions for these non-existent tests:

* ^mongo - logged (in|out)
* ^logs - logged (in|out)
* ^can't publish package with colons

