### PR TITLE
Use CoffeeScript 1.12.0

### DIFF
--- a/packages/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
+++ b/packages/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "coffee-script": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
-      "from": "coffee-script@1.11.1"
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.0.tgz",
+      "from": "coffee-script@1.12.0"
     },
     "source-map": {
       "version": "0.5.6",

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.11.1_4"
+  version: "1.12.0_1"
 });
 
 Package.registerBuildPlugin({
@@ -8,7 +8,7 @@ Package.registerBuildPlugin({
   use: ['caching-compiler', 'ecmascript'],
   sources: ['plugin/compile-coffeescript.js'],
   npmDependencies: {
-    "coffee-script": "1.11.1",
+    "coffee-script": "1.12.0",
     "source-map": "0.5.6"
   }
 });

--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -88,29 +88,29 @@ export class CoffeeCompiler extends CachingCompiler {
       inputFile.getDeclaredExports().map(e => e.name)
     );
 
-    if (/`|\b(?:import|export|yield)\b/.test(source)) {
-      // If source contains backticks or features that output as ES2015+,
-      // pass the coffee output through babel-compiler
-      const doubleRoastedCoffee =
-        this.babelCompiler.processOneFileForTarget(inputFile, output.js);
+    // CoffeeScript contains a handful of features that output as ES2015+,
+    // such as modules, generator functions, for…of, and tagged template
+    // literals. Because they’re too varied to detect, pass all CoffeeScript
+    // compiler output through the Babel compiler.
+    const doubleRoastedCoffee =
+      this.babelCompiler.processOneFileForTarget(inputFile, output.js);
 
-      if (doubleRoastedCoffee != null &&
-          doubleRoastedCoffee.data != null) {
-        output.js = doubleRoastedCoffee.data;
+    if (doubleRoastedCoffee != null &&
+        doubleRoastedCoffee.data != null) {
+      output.js = doubleRoastedCoffee.data;
 
-        if (doubleRoastedCoffee.sourceMap) {
-          // Combine the original CoffeeScript source map with the one
-          // produced by this.babelCompiler.processOneFileForTarget.
-          const smg = new SourceMapGenerator(
-            new SourceMapConsumer(doubleRoastedCoffee.sourceMap));
-          smg.applySourceMap(new SourceMapConsumer(sourceMap));
-          sourceMap = smg.toJSON();
-        } else {
-          // If the .coffee file is contained by a node_modules directory,
-          // then BabelCompiler will not transpile it, and there will be
-          // no sourceMap, but that's fine because the original
-          // CoffeeScript sourceMap will still be valid.
-        }
+      if (doubleRoastedCoffee.sourceMap) {
+        // Combine the original CoffeeScript source map with the one
+        // produced by this.babelCompiler.processOneFileForTarget.
+        const smg = new SourceMapGenerator(
+          new SourceMapConsumer(doubleRoastedCoffee.sourceMap));
+        smg.applySourceMap(new SourceMapConsumer(sourceMap));
+        sourceMap = smg.toJSON();
+      } else {
+        // If the .coffee file is contained by a node_modules directory,
+        // then BabelCompiler will not transpile it, and there will be
+        // no sourceMap, but that's fine because the original
+        // CoffeeScript sourceMap will still be valid.
       }
     }
 

--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -67,6 +67,7 @@ export class CoffeeCompiler extends CachingCompiler {
 
   setDiskCacheDirectory(cacheDir) {
     this.babelCompiler.setDiskCacheDirectory(cacheDir);
+    return super.setDiskCacheDirectory(cacheDir);
   }
 
   compileOneFile(inputFile) {

--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -65,6 +65,10 @@ export class CoffeeCompiler extends CachingCompiler {
     ];
   }
 
+  setDiskCacheDirectory(cacheDir) {
+    this.babelCompiler.setDiskCacheDirectory(cacheDir);
+  }
+
   compileOneFile(inputFile) {
     const source = inputFile.getContentsAsString();
     const compileOptions = this._getCompileOptions(inputFile);


### PR DESCRIPTION
[CoffeeScript 1.12.0 is out](http://coffeescript.org/#changelog). This updates Meteor’s package to use the new version.

I removed the `if` check that passed through the CoffeeScript compiler’s output to `ecmascript` only if certain ES2015+ features were recognized in the original source. Now all coffee output is parsed by `ecmascript`. With the addition of tagged template literals and `for…of` in CoffeeScript 1.12.0, I don’t think it’s possible anymore to reliably detect when ES2015+ features are being used. We should just always assume there could be ES2015+ syntax in the CoffeeScript compiler output, unfortunate though that is from a performance perspective.