### PR TITLE
Cordova project preparation must occur before copying to the build

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1016,12 +1016,22 @@ ${cordova.displayNameForPlatform(platform)}` }, () => {
               'platforms', platform);
             const platformOutputPath = files.pathJoin(outputPath, platform);
 
+            // Prepare the project once again to ensure that it is up to date
+            // with current build options.  For example, --server=example.com
+            // is utilized in the Cordova builder to write boilerplate HTML and
+            // various config.xml settings (e.g. access policies)
+            if (platform === 'ios') {
+              cordovaProject.prepareForPlatform(platform, buildOptions);
+            } else if (platform === 'android') {
+              cordovaProject.buildForPlatform(platform, buildOptions);
+            }
+
+            // Once prepared, copy the bundle to the final location.
             files.cp_r(buildPath,
               files.pathJoin(platformOutputPath, 'project'));
 
+            // Make some platform-specific adjustments to the resulting build.
             if (platform === 'ios') {
-              cordovaProject.prepareForPlatform(platform, buildOptions);
-
               files.writeFile(
                 files.pathJoin(platformOutputPath, 'README'),
 `This is an auto-generated XCode project for your iOS application.
@@ -1030,8 +1040,6 @@ Instructions for publishing your iOS app to App Store can be found at:
 https://github.com/meteor/meteor/wiki/How-to-submit-your-iOS-app-to-App-Store
 `, "utf8");
             } else if (platform === 'android') {
-              cordovaProject.buildForPlatform(platform, buildOptions);
-
               const apkPath = files.pathJoin(buildPath, 'build/outputs/apk',
                 options.debug ? 'android-debug.apk' : 'android-release-unsigned.apk')
 


### PR DESCRIPTION
This fixes a regression caused by 88d43a0f16a484a5716050cb7de8066b126c7b28 which is demonstrated in meteor/meteor#7849.

Essentially, with the current implementation some Cordova build elements are "stale" when the build is copied.  For example, if you execute a `meteor run ios` and then `meteor build . --server=http://example.com/` (note: `example.com`) the `config.xml` (`<access origin />`), the boilerplate HTML (`__meteor_runtime_config__`) and other elements of the bundle (`Info.plist` on iOS) will still contain the previously used `http://<local_ip>:3000` address instead of `http://example.com` as they should.

Additionally, it would appear that it's impossible to actually checkout a project and immediately run `meteor build` without running `meteor run (android|ios)` first.

Various work-arounds for this seem to exist, such as running `meteor build` twice, or running `meteor run --server=http://production.com` first.

Ultimately, this is occurring because the bundle is being copied before the Cordova `prepareForPlatform` occurs which I believe was not intended.

There is already a test in place which fails without this fix, but marked as `slow` and therefore not executed on CircleCI.  Specifically, `cordova builds with server options` would have caught this.  Forcibly running this test locally now passes with this change.

Fixes meteor/meteor#7849
Fixes meteor/meteor#7291
Fixes meteor/meteor#6756

Fix-Maybe #7112 