### PR TITLE
Upgrade `mongodb` npm package to version 2.2.15.

### DIFF
--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "bson": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-0.5.6.tgz",
-      "from": "bson@>=0.5.6 <0.6.0"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.1.tgz",
+      "from": "bson@>=1.0.1 <1.1.0"
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -31,14 +31,14 @@
       "from": "isarray@>=1.0.0 <1.1.0"
     },
     "mongodb": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.11.tgz",
-      "from": "mongodb@2.2.11"
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.15.tgz",
+      "from": "mongodb@2.2.15"
     },
     "mongodb-core": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.0.13.tgz",
-      "from": "mongodb-core@2.0.13"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.2.tgz",
+      "from": "mongodb-core@2.1.2"
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '2.2.11_2',
+  version: '2.2.15_1',
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "2.2.11"
+  mongodb: "2.2.15"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Trivial PR, but this bumps the `mongodb` version to [2.2.15](https://github.com/mongodb/node-mongodb-native/blob/2.2/HISTORY.md#2215-2016-12-10).  This brings in [`mongodb-core@2.1.2`](https://github.com/christkv/mongodb-core/blob/2.0/HISTORY.md#212-2016-12-10) which has a major version bump for `bson`, going from 0.5.7 to 1.0.1.

Fixes #8147
Relates to #7954 (already closed)