### PR TITLE
Fix console glitch when using some admin package functions

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -2617,7 +2617,7 @@ main.registerCommand({
   try {
     Console.rawInfo(
         "Changing homepage on "
-          + name + " to " + url + "...");
+          + name + " to " + url + "...\n");
       packageClient.callPackageServer(conn,
           '_changePackageHomepage', name, url);
       Console.info(" done");
@@ -2670,7 +2670,7 @@ main.registerCommand({
     _.each(versions, function (version) {
       Console.rawInfo(
         "Setting " + name + "@" + version + " as " +
-         status + " migrated ... ");
+         status + " migrated ...\n");
       packageClient.callPackageServer(
         conn,
         '_changeVersionMigrationStatus',


### PR DESCRIPTION
Tiny fix for an old issue where the console output would get corrupted when running `meteor admin set-unmigrated` or `meteor admin change-homepage` due to missing newline on `rawInfo` command.

Fixes meteor/meteor#4054