### PR TITLE
`meteor shell` should pass its TTY width to the server on connect

### DIFF
--- a/tools/shell-client.js
+++ b/tools/shell-client.js
@@ -137,6 +137,7 @@ Cp.setUpSocket = function setUpSocket(sock, key) {
     // Sending a JSON-stringified options object (even just an empty
     // object) over the socket is required to start the REPL session.
     sock.write(JSON.stringify({
+      columns: process.stdout.columns,
       terminal: ! process.env.EMACS,
       key: key
     }) + "\n");


### PR DESCRIPTION
This is a partial alleviation of the issue explained/reproduced in #5346.

Previously, the width (or "columns") for the readline shell was being obtained on the server.  This causes problems for clients which are connecting to the server which are sized differently (like WebStorm)

The client will still have problems if they resize AFTER they are connected to the REPL, but at least they have the option of being a different size.

A more complete solution would be to have the client listen on process.stdout "resize" and pass that to the server when it occurs, but I'm not sure of an easy way to do that with the current communication (perhaps pause-reconfigure-unpause?)

Addresses meteor/meteor#5346