### PR TITLE
Added an index for the users collection

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -1061,4 +1061,5 @@ Meteor.users._ensureIndex('services.email.verificationTokens.token',
                           {unique: 1, sparse: 1});
 Meteor.users._ensureIndex('services.password.reset.token',
                           {unique: 1, sparse: 1});
-Meteor.users._ensureIndex('services.password.reset.when');
+Meteor.users._ensureIndex('services.password.reset.when',
+                          {sparse: 1});


### PR DESCRIPTION
An example of a slow query that was slowing down my entire database that this PR should fix:

```
query wc_draft.users query: { $or: [ { services.password.reset.when: { $lt: new Date(1481501706951) } }, { services.password.reset.when: { $lt: 1481501706951.0 } } ] } plan
Summary: COLLSCAN ntoreturn:1000 ntoskip:0 nscanned:64642 nscannedObjects:64642 keyUpdates:0 numYields:208 locks(micros) r:1782624 nreturned:0 reslen:20 1028ms
```

See the discussion here:
https://github.com/meteor/meteor/issues/8158#issuecomment-267456752