### PR TITLE
Adjusted Minimongo to prohibit dot based field name inserts, to fix issue #3786

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -544,6 +544,16 @@ LocalCollection.prototype.insert = function (doc, callback) {
   var self = this;
   doc = EJSON.clone(doc);
 
+  // Make sure field names do not contain dots to line up with Mongo's
+  // field name restrictions:
+  // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+  if (doc) {
+    const invalidFieldMatches = JSON.stringify(doc).match(/"([^"]*\.[^"]*)":/);
+    if (invalidFieldMatches && invalidFieldMatches.length === 2) {
+      throw MinimongoError(`Field ${invalidFieldMatches[1]} must not contain '.'`);
+    }
+  }
+
   if (!_.has(doc, '_id')) {
     // if you really want to use ObjectIDs, set this global.
     // Mongo.Collection specifies its own ids and does not use this code.
@@ -1110,4 +1120,3 @@ LocalCollection.prototype.resumeObservers = function () {
   }
   self._observeQueue.drain();
 };
-

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -549,7 +549,7 @@ LocalCollection.prototype.insert = function (doc, callback) {
   // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
   if (doc) {
     JSON.stringify(doc, (key, value) => {
-      if (key.indexOf('.') > -1) {
+      if (_.isString(key) && key.indexOf('.') > -1) {
         throw MinimongoError(`Field ${key} must not contain '.'`);
       }
       return value;

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -544,13 +544,19 @@ LocalCollection.prototype.insert = function (doc, callback) {
   var self = this;
   doc = EJSON.clone(doc);
 
-  // Make sure field names do not contain dots to line up with Mongo's
-  // field name restrictions:
+  // Make sure field names do not contain Mongo restricted
+  // characters ('.', '$', '\0').
   // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
   if (doc) {
+    const invalidCharMsg = {
+      '.': "contain '.'",
+      '$': "start with '$'",
+      '\0': "contain null bytes",
+    };
     JSON.stringify(doc, (key, value) => {
-      if (_.isString(key) && key.indexOf('.') > -1) {
-        throw MinimongoError(`Field ${key} must not contain '.'`);
+      let match;
+      if (_.isString(key) && (match = key.match(/^\$|\.|\0/))) {
+        throw MinimongoError(`Key ${key} must not ${invalidCharMsg[match[0]]}`);
       }
       return value;
     });

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -548,10 +548,12 @@ LocalCollection.prototype.insert = function (doc, callback) {
   // field name restrictions:
   // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
   if (doc) {
-    const invalidFieldMatches = JSON.stringify(doc).match(/"([^"]*\.[^"]*)":/);
-    if (invalidFieldMatches && invalidFieldMatches.length === 2) {
-      throw MinimongoError(`Field ${invalidFieldMatches[1]} must not contain '.'`);
-    }
+    JSON.stringify(doc, (key, value) => {
+      if (key.indexOf('.') > -1) {
+        throw MinimongoError(`Field ${key} must not contain '.'`);
+      }
+      return value;
+    });
   }
 
   if (!_.has(doc, '_id')) {

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -244,6 +244,11 @@ var MODIFIERS = {
       e.setPropertyError = true;
       throw e;
     }
+    if (_.isString(field) && field.indexOf('\0') > -1) {
+      // Null bytes are not allowed in Mongo field names
+      // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+      throw MinimongoError(`Key ${field} must not contain null bytes`);
+    }
     target[field] = arg;
   },
   $setOnInsert: function (target, field, arg) {
@@ -457,6 +462,11 @@ var MODIFIERS = {
       throw MinimongoError("$rename source field invalid");
     if (typeof arg !== "string")
       throw MinimongoError("$rename target must be a string");
+    if (arg.indexOf('\0') > -1) {
+      // Null bytes are not allowed in Mongo field names
+      // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+      throw MinimongoError("The 'to' field for $rename cannot contain an embedded null byte");
+    }
     if (target === undefined)
       return;
     var v = target[field];

--- a/packages/minimongo/package.js
+++ b/packages/minimongo/package.js
@@ -7,8 +7,17 @@ Package.onUse(function (api) {
   api.export('LocalCollection');
   api.export('Minimongo');
   api.export('MinimongoTest', { testOnly: true });
-  api.use(['underscore', 'ejson', 'id-map', 'ordered-dict', 'tracker',
-           'mongo-id', 'random', 'diff-sequence']);
+  api.use([
+    'underscore',
+    'ejson',
+    'id-map',
+    'ordered-dict',
+    'tracker',
+    'mongo-id',
+    'random',
+    'diff-sequence',
+    'ecmascript'
+  ]);
   // This package is used for geo-location queries such as $near
   api.use('geojson-utils');
   // This package is used to get diff results on arrays and objects
@@ -39,8 +48,17 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   api.use('minimongo', ['client', 'server']);
   api.use('test-helpers', 'client');
-  api.use(['tinytest', 'underscore', 'ejson', 'ordered-dict',
-           'random', 'tracker', 'reactive-var', 'mongo-id']);
+  api.use([
+    'tinytest',
+    'underscore',
+    'ejson',
+    'ordered-dict',
+    'random',
+    'tracker',
+    'reactive-var',
+    'mongo-id',
+    'ecmascript'
+  ]);
   api.addFiles('minimongo_tests.js', 'client');
   api.addFiles('wrap_transform_tests.js');
   api.addFiles('minimongo_server_tests.js', 'server');


### PR DESCRIPTION
Hi all - this PR is intended to help address issue #3786. Right now Minimongo allows inserts with dot (".") containing field names, which is against [Mongo's field name restrictions](https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names). The changes in this PR will cause a new exception to be thrown if dot containing field inserts are attempted by Minimongo, with the exception thrown matching the exception thrown by Mongo on the server side. Thanks!