### PR TITLE
Improve helpfulness of error message when combining different files

### DIFF
--- a/tools/isobuild/import-scanner.js
+++ b/tools/isobuild/import-scanner.js
@@ -296,8 +296,13 @@ export default class ImportScanner {
       }
 
       if (oldFile[name] !== newFile[name]) {
+        const fuzzyCase =
+          oldFile.sourcePath.toLowerCase() === newFile.sourcePath.toLowerCase();
+
         throw new Error(
-          "Attempting to combine different files:\n" +
+          "Attempting to combine different files" +
+            ( fuzzyCase ? " (is the filename case slightly different?)" : "") +
+            ":\n" +
             inspect(omit(oldFile, "dataString")) + "\n" +
             inspect(omit(newFile, "dataString")) + "\n"
         );


### PR DESCRIPTION
Make the error message displayed to the developer more helpful in a situation like meteor/meteor#7859 where the `package.js` inadvertently referred to an imProPeRly-CaSeD version of the file it was importing.

No functionality change, just developer experience.

Fixes #7859