### PR TITLE
Update node-mongodb driver to 2.2.16

### DIFF
--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "bson": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-0.5.6.tgz",
-      "from": "bson@>=0.5.6 <0.6.0"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.1.tgz",
+      "from": "bson@>=1.0.1 <1.1.0"
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -31,14 +31,14 @@
       "from": "isarray@>=1.0.0 <1.1.0"
     },
     "mongodb": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.11.tgz",
-      "from": "mongodb@2.2.11"
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.16.tgz",
+      "from": "mongodb@2.2.16"
     },
     "mongodb-core": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.0.13.tgz",
-      "from": "mongodb-core@2.0.13"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.2.tgz",
+      "from": "mongodb-core@2.1.2"
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '2.2.11_2',
+  version: '2.2.16_1',
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "2.2.11"
+  mongodb: "2.2.16"
 });
 
 Package.onUse(function (api) {

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -591,8 +591,12 @@ var launchMongo = function (options) {
       // Connect to the intended primary and start a replset.
       var db = new mongoNpmModule.Db(
         'meteor',
-        new mongoNpmModule.Server('127.0.0.1', options.port, {poolSize: 1}),
+        new mongoNpmModule.Server('127.0.0.1', options.port, {
+          poolSize: 1,
+          socketOptions: {connectTimeoutMS: 30000},
+        }),
         {safe: true});
+
       yieldingMethod(db, 'open');
       if (stopped) {
         return;


### PR DESCRIPTION
This fixes an issue where the driver fails to recover from unresponsive primary in a replica set.

Relevant commit in `mongodb-core`:
https://github.com/christkv/mongodb-core/commit/6611ea48e2a9e195fdef1572d3f94db5924b3ee9