### PR TITLE
Remove autopublish and insecure from the bare skeleton app

### DIFF
--- a/tools/static-assets/skel-bare/.meteor/packages
+++ b/tools/static-assets/skel-bare/.meteor/packages
@@ -17,6 +17,3 @@ standard-minifier-js    # JS minifier run for production mode
 es5-shim                # ECMAScript 5 compatibility for older browsers.
 ecmascript              # Enable ECMAScript2015+ syntax in app code
 shell-server            # Server-side component of the `meteor shell` command
-
-autopublish             # Publish all data to the clients (for prototyping)
-insecure                # Allow all DB writes from clients (for prototyping)


### PR DESCRIPTION
Fixes #8145

As described in the issue, `meteor create --bare` should not add the autopublish and insecure packages because it's for developers who want the bare minimum start.
