### PR TITLE
Small content change to point to the Meteor Tool README for "self test" info

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -276,3 +276,7 @@ example that you just want to run the Spacebars test suite. Just simple do `./me
 ./packages/spacebars-tests` and it will just run the test files from that one package. You can
 examine the `package.js` file for the `onTest` block, it outlines all the test files that should be
 run.
+
+### Running Meteor Tool tests
+
+While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system. For details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).


### PR DESCRIPTION
Hi all - this small PR is intended to help address issue #3255. The [Contributing](https://github.com/meteor/meteor/blob/8a81e7156e07ca9e1a6c2b2b89870eb4abe72a2d/Contributing.md) guide already outlines how to test internal Meteor packages, but it doesn't provide any details concerning Meteor Tool "self tests". I've added a small section that mentions the "self tests" and refers people to the testing section of the Meteor Tool README for more details. Thanks!