### PR TITLE
Throw error when EJSON.clone circular structure

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -454,6 +454,27 @@ EJSON.equals = function (a, b, options) {
   }
 };
 
+function isCyclic (obj) {
+  var seenObjects = [];
+
+  function detect (obj) {
+    if (obj && typeof obj === 'object') {
+      if (seenObjects.indexOf(obj) !== -1) {
+        return true;
+      }
+      seenObjects.push(obj);
+      for (var key in obj) {
+        if (obj.hasOwnProperty(key) && detect(obj[key])) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  return detect(obj);
+}
+
 /**
  * @summary Return a deep copy of `val`.
  * @locus Anywhere
@@ -496,6 +517,11 @@ EJSON.clone = function (v) {
     return EJSON.fromJSONValue(EJSON.clone(EJSON.toJSONValue(v)), true);
   }
   // handle other objects
+
+  if (isCyclic(v)) {
+    throw new Error("EJSON.clone can not clone circular structure");
+  }
+
   ret = {};
   _.each(v, function (value, key) {
     ret[key] = EJSON.clone(value);

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -454,25 +454,25 @@ EJSON.equals = function (a, b, options) {
   }
 };
 
-function isCyclic (obj) {
-  var seenObjects = [];
+function isCyclic (obj, seen) {
+  if (typeof obj !== 'object') {
+    return false;
+  }
 
-  function detect (obj) {
-    if (obj && typeof obj === 'object') {
-      if (seenObjects.indexOf(obj) !== -1) {
-        return true;
-      }
-      seenObjects.push(obj);
-      for (var key in obj) {
-        if (obj.hasOwnProperty(key) && detect(obj[key])) {
+  seen.push(obj);
+
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      var val = obj[key];
+      if (typeof val === 'object') {
+        if (seen.indexOf(val) > -1 || isCyclic(val, seen.slice())) {
           return true;
         }
       }
     }
-    return false;
   }
 
-  return detect(obj);
+  return false;
 }
 
 /**
@@ -518,7 +518,7 @@ EJSON.clone = function (v) {
   }
   // handle other objects
 
-  if (isCyclic(v)) {
+  if (isCyclic(v, [])) {
     throw new Error("EJSON.clone can not clone circular structure");
   }
 

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -475,6 +475,18 @@ function isCyclic (obj, seen) {
   return false;
 }
 
+EJSON.isCyclic = function(v) {
+  if (typeof v !== 'object' || v === null || v instanceof Date || v instanceof RegExp) {
+    return false;
+  }
+
+  if (EJSON._isCustomType(v)) {
+    return EJSON.isCyclic(EJSON.toJSONValue(v));
+  }
+
+  return isCyclic(v, []);
+}
+
 /**
  * @summary Return a deep copy of `val`.
  * @locus Anywhere
@@ -517,10 +529,6 @@ EJSON.clone = function (v) {
     return EJSON.fromJSONValue(EJSON.clone(EJSON.toJSONValue(v)), true);
   }
   // handle other objects
-
-  if (isCyclic(v, [])) {
-    throw new Error("EJSON.clone can not clone circular structure");
-  }
 
   ret = {};
   _.each(v, function (value, key) {

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -96,17 +96,6 @@ Tinytest.add("ejson - clone", function (test) {
     test.equal(clonedArgs, [1, 2, "foo", [4]]);
   };
   testCloneArgs(1, 2, "foo", [4]);
-
-  test.throws(
-    function() {
-      var obj1 = {};
-      var obj2 = {obj1: obj1};
-      obj1.obj2 = obj2;
-
-      EJSON.clone(obj1);
-    },
-    /can not clone circular structure/
-  );
 });
 
 Tinytest.add("ejson - stringify", function (test) {
@@ -240,4 +229,34 @@ Tinytest.add("ejson - custom types", function (test) {
   var clone = EJSON.clone(obj);
   clone.address.city = 'Sherbrooke';
   test.notEqual( obj, clone );
+});
+
+Tinytest.add("ejson - isCyclic", function (test) {
+  test.isFalse(EJSON.isCyclic(1));
+  test.isFalse(EJSON.isCyclic('1'));
+  test.isFalse(EJSON.isCyclic(new Date));
+  test.isFalse(EJSON.isCyclic(/regex/));
+  test.isFalse(EJSON.isCyclic(function f() {}));
+
+  var normalObj1 = {a: 1, b: '2', c: {d: {}}};
+  test.isFalse(EJSON.isCyclic(normalObj1));
+
+  var normalObj2 = {};
+  var normalObj3 = {};
+  normalObj2.a = normalObj3;
+  normalObj2.b = normalObj3;
+  normalObj2.c = {d: normalObj3};
+  test.isFalse(EJSON.isCyclic(normalObj2));
+
+  var normalObj4 = new EJSONTest.Address('HCM', 'VN');
+  test.isFalse(EJSON.isCyclic(normalObj4));
+
+  var cyclicObj1 = {};
+  cyclicObj1.obj = cyclicObj1;
+  test.isTrue(EJSON.isCyclic(cyclicObj1));
+
+  var t = {};
+  t.t = t;
+  var cyclicObj2 = new EJSONTest.Holder(t);
+  test.isTrue(EJSON.isCyclic(cyclicObj2));
 });

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -96,6 +96,17 @@ Tinytest.add("ejson - clone", function (test) {
     test.equal(clonedArgs, [1, 2, "foo", [4]]);
   };
   testCloneArgs(1, 2, "foo", [4]);
+
+  test.throws(
+    function() {
+      var obj1 = {};
+      var obj2 = {obj1: obj1};
+      obj1.obj2 = obj2;
+
+      EJSON.clone(obj1);
+    },
+    /can not clone circular structure/
+  );
 });
 
 Tinytest.add("ejson - stringify", function (test) {


### PR DESCRIPTION
Check for circular structure of objects passed to `EJSON.clone`, throw error if exists.
In reference to #5964