### PR TITLE
Ensure `babel-runtime` is included in "skeleton" variations

### DIFF
--- a/tools/static-assets/skel-bare/package.json
+++ b/tools/static-assets/skel-bare/package.json
@@ -5,6 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "meteor-node-stubs": "~0.2.0"
+    "babel-runtime": "^6.20.0",
+    "meteor-node-stubs": "~0.2.4"
   }
 }

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "babel-runtime": "^6.18.0",
-    "meteor-node-stubs": "~0.2.3"
+    "babel-runtime": "^6.20.0",
+    "meteor-node-stubs": "~0.2.4"
   }
 }

--- a/tools/static-assets/skel/package.json
+++ b/tools/static-assets/skel/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "meteor-node-stubs": "~0.2.0",
-    "babel-runtime": "6.18.0"
+    "babel-runtime": "^6.20.0",
+    "meteor-node-stubs": "~0.2.4"
   }
 }


### PR DESCRIPTION
The `bare` skeleton didn't include the `babel-runtime` in `package.json`, thus making the instructions for starting the project (`meteor npm install` & `meteor`) inaccurate.

This change makes the `bare` skeleton the same as the `full` and "default" versions.

As an unnecessary liberty, since the latest version would be installed anyway, I bumped `meteor-node-stubs` and `babel-runtime` to the latest published version numbers and standardized the format of all three `package.json` files.

Closes meteor/meteor#8202