### PR TITLE
Fastclick will break selects on Chrome mobile

### DIFF
--- a/packages/fastclick/README.md
+++ b/packages/fastclick/README.md
@@ -2,9 +2,7 @@
 [Source code of released version](https://github.com/meteor/meteor/tree/master/packages/fastclick) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/fastclick)
 ***
 
-```
-As of late 2015 most mobile browsers - notably Chrome and Safari - no longer have a 300ms touch delay, so fastclick offers no benefit on newer browsers, and risks introducing [bugs](https://github.com/ftlabs/fastclick/issues) into your application. Consider carefully whether you really need to use it.
-```
+> **Warning:** As of late 2015 most mobile browsers - notably Chrome and Safari - no longer have a 300ms touch delay, so fastclick offers no benefit on newer browsers, and risks introducing [bugs](https://github.com/ftlabs/fastclick/issues) into your application. Consider carefully whether you really need to use it.
 
 FastClick is a simple, easy-to-use library for eliminating the 300ms delay
 between a physical tap and the firing of a `click` event on mobile browsers. The

--- a/packages/fastclick/README.md
+++ b/packages/fastclick/README.md
@@ -2,6 +2,10 @@
 [Source code of released version](https://github.com/meteor/meteor/tree/master/packages/fastclick) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/fastclick)
 ***
 
+```
+As of late 2015 most mobile browsers - notably Chrome and Safari - no longer have a 300ms touch delay, so fastclick offers no benefit on newer browsers, and risks introducing [bugs](https://github.com/ftlabs/fastclick/issues) into your application. Consider carefully whether you really need to use it.
+```
+
 FastClick is a simple, easy-to-use library for eliminating the 300ms delay
 between a physical tap and the firing of a `click` event on mobile browsers. The
 aim is to make your application feel less laggy and more responsive while


### PR DESCRIPTION
See here:
https://github.com/ftlabs/fastclick/issues/497
And here:
https://productforums.google.com/forum/#!topic/chrome/Q4Rt6d0C4Qo

I just spent hours trying to figure out why selects haven't been working on my site, and finally found out it was fastclick.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/meteor/meteor/blob/devel/Contributing.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
