### PR TITLE
Refactored reset password and enroll account methods

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -830,8 +830,8 @@ Accounts.sendVerificationEmail = function (userId, email) {
 
   const {email: realEmail, user, tokenRecord} = Accounts.generateVerificationTokenRecord(userId, email);
   Accounts.saveVerificationTokenRecord(user, tokenRecord);
-  var url = Accounts.urls.verifyEmail(tokenRecord.token);
-  var options = Accounts.generateOptionsForEmail(realEmail, user, url, 'verifyEmail');
+  const url = Accounts.urls.verifyEmail(tokenRecord.token);
+  const options = Accounts.generateOptionsForEmail(realEmail, user, url, 'verifyEmail');
   Email.send(options);
   return {email: realEmail, user, tokenRecord, url, options};
 };

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -546,6 +546,16 @@ Meteor.methods({forgotPassword: function (options) {
   Accounts.sendResetPasswordEmail(user._id, caseSensitiveEmail);
 }});
 
+/**
+ * @summary Generates a reset token record.
+ * @locus Server
+ * @param {String} userId The id of the user to generate the reset token record for.
+ * @param {String} email Which address of the user to generate the reset token record for. This address must be in the user's `emails` list. If `null`, defaults to the first email in the list.
+ * @param {String} reason `resetPassword` or `enrollAccount`.
+ * @param {Object} [extraTokenData] Optional additional data to be added into the token record.
+ * @returns {Object} Object with {email, user, tokenRecord} values.
+ * @importFromPackage accounts-base
+ */
 Accounts.generateResetTokenRecord = function (userId, email, reason, extraTokenData) {
   // Make sure the user exists, and email is one of their addresses.
   var user = Meteor.users.findOne(userId);
@@ -587,6 +597,15 @@ Accounts.generateResetTokenRecord = function (userId, email, reason, extraTokenD
   return {email, user, tokenRecord};
 };
 
+/**
+ * @summary Generates an e-mail verification token record.
+ * @locus Server
+ * @param {String} userId The id of the user to generate the  e-mail verification token record for.
+ * @param {String} email Which address of the user to generate the e-mail verification token record for. This address must be in the user's `emails` list. If `null`, defaults to the first unverified email in the list.
+ * @param {Object} [extraTokenData] Optional additional data to be added into the token record.
+ * @returns {Object} Object with {email, user, tokenRecord} values.
+ * @importFromPackage accounts-base
+ */
 Accounts.generateVerificationTokenRecord = function (userId, email, extraTokenData) {
   // Make sure the user exists, and email is one of their addresses.
   var user = Meteor.users.findOne(userId);
@@ -624,13 +643,9 @@ Accounts.generateVerificationTokenRecord = function (userId, email, extraTokenDa
 };
 
 /**
- * @summary Creates options for email sending for reset password and enroll account emails.
- * You can use this function when customizing a reset password or enroll account email sending.
- * @locus Server
- * @param {String} userId The id of the user to send email to.
- * @param {String} email Which address of the user's to send the email to. This address must be in the user's `emails` list. If `null`, defaults to the first email in the list.
- * @param {String} reason String `resetPassword` or `enrollAccount`.
- * @returns {Object} Object with {email, user, token, url} values.
+ * @summary Saves the reset token record into database in user's document.
+ * @param {Object} user User for which to save the reset token record for.
+ * @param {Object} tokenRecord The reset token record to be saved.
  * @importFromPackage accounts-base
  */
 Accounts.saveResetTokenRecord = function (user, tokenRecord) {
@@ -642,6 +657,12 @@ Accounts.saveResetTokenRecord = function (user, tokenRecord) {
   Meteor._ensure(user, 'services', 'password').reset = tokenRecord;
 };
 
+/**
+ * @summary Saves the e-mail verification token record into database in user's document.
+ * @param {Object} user User for which to save the e-mail verification token record for.
+ * @param {Object} tokenRecord The e-mail verification token record to be saved.
+ * @importFromPackage accounts-base
+ */
 Accounts.saveVerificationTokenRecord = function (user, tokenRecord) {
   Meteor.users.update({_id: userId}, {$push: {
     'services.email.verificationTokens': tokenRecord
@@ -662,7 +683,7 @@ Accounts.saveVerificationTokenRecord = function (user, tokenRecord) {
  * @param {Object} email Which address of the user's to send the email to.
  * @param {Object} user The user object to generate options for.
  * @param {String} url URL to which user is directed to confirm the email.
- * @param {String} reason generateOptionsForEmail`resetPassword` or `enrollAccount`.
+ * @param {String} reason `resetPassword` or `enrollAccount`.
  * @returns {Object} Options which can be passed to `Email.send`.
  * @importFromPackage accounts-base
  */
@@ -698,7 +719,7 @@ Accounts.generateOptionsForEmail = function (email, user, url, reason) {
  * @locus Server
  * @param {String} userId The id of the user to send email to.
  * @param {String} [email] Optional. Which address of the user's to send the email to. This address must be in the user's `emails` list. Defaults to the first email in the list.
- * @returns {Object} Object with {email, user, token, url, options} values.
+ * @returns {Object} Object with {email, user, tokenRecord, url, options} values.
  * @importFromPackage accounts-base
  */
 Accounts.sendResetPasswordEmail = function (userId, email, extraTokenData) {
@@ -723,7 +744,7 @@ Accounts.sendResetPasswordEmail = function (userId, email, extraTokenData) {
  * @locus Server
  * @param {String} userId The id of the user to send email to.
  * @param {String} [email] Optional. Which address of the user's to send the email to. This address must be in the user's `emails` list. Defaults to the first email in the list.
- * @returns {Object} Object with {email, user, token, url, options} values.
+ * @returns {Object} Object with {email, user, tokenRecord, url, options} values.
  * @importFromPackage accounts-base
  */
 Accounts.sendEnrollmentEmail = function (userId, email, extraTokenData) {
@@ -829,6 +850,7 @@ Meteor.methods({resetPassword: function (token, newPassword) {
  * @locus Server
  * @param {String} userId The id of the user to send email to.
  * @param {String} [email] Optional. Which address of the user's to send the email to. This address must be in the user's `emails` list. Defaults to the first unverified email in the list.
+ * @returns {Object} Object with {email, user, tokenRecord, url, options} values.
  * @importFromPackage accounts-base
  */
 Accounts.sendVerificationEmail = function (userId, email, extraTokenData) {

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -649,7 +649,7 @@ Accounts.generateVerificationTokenRecord = function (userId, email, extraTokenDa
  * @importFromPackage accounts-base
  */
 Accounts.saveResetTokenRecord = function (user, tokenRecord) {
-  Meteor.users.update(user._id, {$set: {
+  Meteor.users.update({_id: user._id}, {$set: {
     'services.password.reset': tokenRecord
   }});
 
@@ -664,7 +664,7 @@ Accounts.saveResetTokenRecord = function (user, tokenRecord) {
  * @importFromPackage accounts-base
  */
 Accounts.saveVerificationTokenRecord = function (user, tokenRecord) {
-  Meteor.users.update({_id: userId}, {$push: {
+  Meteor.users.update({_id: user._id}, {$push: {
     'services.email.verificationTokens': tokenRecord
   }});
 
@@ -748,7 +748,7 @@ Accounts.sendResetPasswordEmail = function (userId, email, extraTokenData) {
  * @importFromPackage accounts-base
  */
 Accounts.sendEnrollmentEmail = function (userId, email, extraTokenData) {
-  const {email: realEmail, user, tokenRecord} = Accounts.generatResetTokenRecord(userId, email, 'enrollAccount', extraTokenData);
+  const {email: realEmail, user, tokenRecord} = Accounts.generateResetTokenRecord(userId, email, 'enrollAccount', extraTokenData);
   Accounts.saveResetTokenRecord(user, tokenRecord);
   const url = Accounts.urls.enrollAccount(tokenRecord.token);
   const options = Accounts.generateOptionsForEmail(realEmail, user, url, 'enrollAccount');

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -625,13 +625,11 @@ Accounts.generateOptionsForEmail = function (email, user, url, reason) {
   };
 
   if (typeof Accounts.emailTemplates[reason].text === 'function') {
-    options.text =
-      Accounts.emailTemplates[reason].text(user, url);
+    options.text = Accounts.emailTemplates[reason].text(user, url);
   }
 
   if (typeof Accounts.emailTemplates[reason].html === 'function') {
-    options.html =
-      Accounts.emailTemplates[reason].html(user, url);
+    options.html = Accounts.emailTemplates[reason].html(user, url);
   }
 
   if (typeof Accounts.emailTemplates.headers === 'object') {
@@ -653,8 +651,8 @@ Accounts.generateOptionsForEmail = function (email, user, url, reason) {
  * @importFromPackage accounts-base
  */
 Accounts.sendResetPasswordEmail = function (userId, email) {
-  let {email: realEmail, user, token, url} = Accounts.createPasswordToken(userId, email, 'resetPassword');
-  let options = Accounts.generateOptionsForEmail(realEmail, user, url, 'resetPassword');
+  const {email: realEmail, user, token, url} = Accounts.createPasswordToken(userId, email, 'resetPassword');
+  const options = Accounts.generateOptionsForEmail(realEmail, user, url, 'resetPassword');
   Email.send(options);
   return {email: realEmail, user, token, url, options};
 };
@@ -676,8 +674,8 @@ Accounts.sendResetPasswordEmail = function (userId, email) {
  * @importFromPackage accounts-base
  */
 Accounts.sendEnrollmentEmail = function (userId, email) {
-  let {email: realEmail, user, token, url} = Accounts.createPasswordToken(userId, email, 'enrollAccount');
-  let options = Accounts.generateOptionsForEmail(realEmail, user, url, 'enrollAccount');
+  const {email: realEmail, user, token, url} = Accounts.createPasswordToken(userId, email, 'enrollAccount');
+  const options = Accounts.generateOptionsForEmail(realEmail, user, url, 'enrollAccount');
   Email.send(options);
   return {email: realEmail, user, token, url, options};
 };

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -581,11 +581,9 @@ Accounts.generateResetTokenRecord = function (userId, email, reason, extraTokenD
 
   if (reason === 'resetPassword') {
     tokenRecord.reason = 'reset';
-  }
-  else if (reason === 'enrollAccount') {
+  } else if (reason === 'enrollAccount') {
     tokenRecord.reason = 'enroll';
-  }
-  else if (reason) {
+  } else if (reason) {
     // fallback so that this function can be used for unknown reasons as well
     tokenRecord.reason = reason;
   }

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -611,11 +611,11 @@ Accounts.createPasswordToken = function (userId, email, reason) {
  * @param {Object} email Which address of the user's to send the email to.
  * @param {Object} user The user object to generate options for.
  * @param {String} url URL to which user is directed to confirm the email.
- * @param {String} reason String `resetPassword` or `enrollAccount`.
+ * @param {String} reason generateOptionsForEmail`resetPassword` or `enrollAccount`.
  * @returns {Object} Options which can be passed to `Email.send`.
  * @importFromPackage accounts-base
  */
-Accounts.tokenEmailOptions = function (email, user, url, reason) {
+Accounts.generateOptionsForEmail = function (email, user, url, reason) {
   var options = {
     to: email,
     from: Accounts.emailTemplates[reason].from
@@ -654,7 +654,7 @@ Accounts.tokenEmailOptions = function (email, user, url, reason) {
  */
 Accounts.sendResetPasswordEmail = function (userId, email) {
   let {email: realEmail, user, token, url} = Accounts.createPasswordToken(userId, email, 'resetPassword');
-  let options = Accounts.tokenEmailOptions(realEmail, user, url, 'resetPassword');
+  let options = Accounts.generateOptionsForEmail(realEmail, user, url, 'resetPassword');
   Email.send(options);
   return {email: realEmail, user, token, url, options};
 };
@@ -677,7 +677,7 @@ Accounts.sendResetPasswordEmail = function (userId, email) {
  */
 Accounts.sendEnrollmentEmail = function (userId, email) {
   let {email: realEmail, user, token, url} = Accounts.createPasswordToken(userId, email, 'enrollAccount');
-  let options = Accounts.tokenEmailOptions(realEmail, user, url, 'enrollAccount');
+  let options = Accounts.generateOptionsForEmail(realEmail, user, url, 'enrollAccount');
   Email.send(options);
   return {email: realEmail, user, token, url, options};
 };

--- a/tools/tests/apps/dynamic-import/.meteor/packages
+++ b/tools/tests/apps/dynamic-import/.meteor/packages
@@ -6,21 +6,21 @@
 
 meteor-base@1.1.0             # Packages every Meteor app needs to have
 mobile-experience@1.0.4       # Packages for a great mobile UX
-mongo@1.1.18                   # The database Meteor supports right now
+mongo@1.1.19                   # The database Meteor supports right now
 blaze-html-templates@1.0.4 # Compile .html files into Meteor Blaze views
 reactive-var@1.0.11            # Reactive variable for tracker
 jquery@1.11.10                  # Helpful client-side library
 tracker@1.1.3                 # Meteor's client-side reactive programming library
 
 standard-minifier-css@1.3.4   # CSS minifier run for production mode
-standard-minifier-js@2.1.0    # JS minifier run for production mode
+standard-minifier-js@2.1.1    # JS minifier run for production mode
 es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers.
-ecmascript@0.8.0              # Enable ECMAScript2015+ syntax in app code
-shell-server@0.2.3            # Server-side component of the `meteor shell` command
+ecmascript@0.8.2              # Enable ECMAScript2015+ syntax in app code
+shell-server@0.2.4            # Server-side component of the `meteor shell` command
 
 autopublish@1.0.7             # Publish all data to the clients (for prototyping)
 insecure@1.0.7                # Allow all DB writes from clients (for prototyping)
-dynamic-import
+dynamic-import@0.1.1
 dispatch:mocha-phantomjs
 dispatch:mocha-browser
 lazy-test-package

--- a/tools/tests/apps/dynamic-import/.meteor/release
+++ b/tools/tests/apps/dynamic-import/.meteor/release
@@ -1,1 +1,1 @@
-METEOR@1.5
+METEOR@1.5.1

--- a/tools/tests/apps/modules/.meteor/packages
+++ b/tools/tests/apps/modules/.meteor/packages
@@ -6,22 +6,22 @@
 
 meteor-base@1.1.0             # Packages every Meteor app needs to have
 mobile-experience@1.0.4       # Packages for a great mobile UX
-mongo@1.1.18                   # The database Meteor supports right now
+mongo@1.1.19                   # The database Meteor supports right now
 blaze-html-templates    # Compile .html files into Meteor Blaze views
 session@1.1.7                 # Client-side reactive dictionary for your app
 jquery@1.11.10                  # Helpful client-side library
 tracker@1.1.3                 # Meteor's client-side reactive programming library
 
 es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers.
-ecmascript@0.8.0              # Enable ECMAScript2015+ syntax in app code
+ecmascript@0.8.2              # Enable ECMAScript2015+ syntax in app code
 
 coffeescript
 modules-test-package
 dispatch:mocha-phantomjs
 dispatch:mocha-browser
 standard-minifier-css@1.3.4
-standard-minifier-js@2.1.0
+standard-minifier-js@2.1.1
 client-only-ecmascript
 modules-test-plugin
-shell-server@0.2.3
-dynamic-import
+shell-server@0.2.4
+dynamic-import@0.1.1

--- a/tools/tests/apps/modules/.meteor/release
+++ b/tools/tests/apps/modules/.meteor/release
@@ -1,1 +1,1 @@
-METEOR@1.5
+METEOR@1.5.1


### PR DESCRIPTION
To allow easier customization email sending of tokens.

More or less just moving code around.

A new version of #8065 and #8038.