### PR TITLE
Preserve true "main" and "browser" fields of package.json modules.

### DIFF
--- a/History.md
+++ b/History.md
@@ -22,7 +22,16 @@
 * Added support for frame-ancestors CSP option in browser-policy.
   [#7970](https://github.com/meteor/meteor/pull/7970)
   
-* You can now use autoprefixer with stylus files added via packages [#7727](https://github.com/meteor/meteor/pull/7727)
+* You can now use autoprefixer with stylus files added via packages.
+  [#7727](https://github.com/meteor/meteor/pull/7727)
+
+* The `"main"` field of `package.json` modules will no longer be
+  overwritten with the value of the optional `"browser"` field, now that
+  the `install` npm package can make sense of the `"browser"` field at
+  runtime. If you experience module resolution failures on the client
+  after updating Meteor, make sure you've updated the `modules-runtime`
+  Meteor package to at least version 0.7.8.
+  [#8213](https://github.com/meteor/meteor/pull/8213)
 
 ## v1.4.2.3
 

--- a/packages/modules-runtime/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules-runtime/.npm/package/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "install": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.8.2.tgz",
-      "from": "install@0.8.2"
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.8.4.tgz",
+      "from": "install@0.8.4"
     }
   }
 }

--- a/packages/modules-runtime/modules-runtime.js
+++ b/packages/modules-runtime/modules-runtime.js
@@ -13,6 +13,10 @@ if (typeof Profile === "function" &&
   };
 }
 
+// On the client, make package resolution prefer the "browser" field of
+// package.json files to the "main" field.
+options.browser = Meteor.isClient;
+
 // This function will be called whenever a module identifier that hasn't
 // been installed is required. For backwards compatibility, and so that we
 // can require binary dependencies on the server, we implement the

--- a/packages/modules-runtime/package.js
+++ b/packages/modules-runtime/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: "modules-runtime",
-  version: "0.7.7",
+  version: "0.7.8",
   summary: "CommonJS module system",
   git: "https://github.com/benjamn/install",
   documentation: "README.md"
 });
 
 Npm.depends({
-  install: "0.8.2"
+  install: "0.8.4"
 });
 
 Package.onUse(function(api) {

--- a/tools/isobuild/resolver.js
+++ b/tools/isobuild/resolver.js
@@ -285,26 +285,30 @@ export default class Resolver {
       return null;
     }
 
-    let main = pkg.main;
+    // Output a JS module that exports just the "name", "version", "main",
+    // and "browser" properties (if defined) from the package.json file.
+    const pkgSubset = {};
 
-    if (archMatches(this.targetArch, "web") &&
-        isString(pkg.browser)) {
-      main = pkg.browser;
+    if (has(pkg, "name")) {
+      pkgSubset.name = pkg.name;
     }
-
-    // Output a JS module that exports just the "name", "version", and
-    // "main" properties defined in the package.json file.
-    const pkgSubset = {
-      name: pkg.name,
-    };
 
     if (has(pkg, "version")) {
       pkgSubset.version = pkg.version;
     }
 
-    if (isString(main)) {
-      pkgSubset.main = main;
+    let main = pkg.main;
+    if (has(pkg, "main")) {
+      pkgSubset.main = pkg.main;
+    }
 
+    if (archMatches(this.targetArch, "web") &&
+        isString(pkg.browser)) {
+      main = pkg.browser;
+      pkgSubset.browser = pkg.browser;
+    }
+
+    if (isString(main)) {
       // The "main" field of package.json does not have to begin with ./
       // to be considered relative, so first we try simply appending it to
       // the directory path before falling back to a full resolve, which


### PR DESCRIPTION
Previously, when building a JavaScript bundle for the client, if a `package.json` file had a string-valued `"browser"` field, we would replace the value of the `"main"` field of the bundled `package.json` module with the value of the `"browser"` field. This trick was important because it allowed an npm package to have a different entry point on the client than it had on the server.

However, that approach became inconsistent if the `package.json` file was also explicitly imported as a module, because the `package.json` stub used for module resolution prevented the real contents of `package.json` from getting bundled, and disagreed with the original `package.json` module about the value of the `"main"` field.

To resolve that inconsistency, it seems better to avoid modifying the `"main"` field of `package.json` modules, and instead rely on the runtime module system to make sense of the `"browser"` field, regardless of whether the `package.json` module is a stub used only for module resolution or contains the full contents of the original `package.json` file.

The ability to understand `"browser"` fields of `package.json` modules was introduced in install@0.8.3: https://github.com/benjamn/install/commit/377d1a3b5138904d63f4594fd4c12f756454d277

This is potentially a backwards-incompatible change for developers using this version of `ImportScanner` and `Resolver` who have not yet upgraded their `modules-runtime` package to at least version 0.7.8. The solution is to upgrade `modules-runtime`, though it would be nice to enforce that better somehow.