### PR TITLE
Replaced core references to document.location with window.location.

### DIFF
--- a/packages/reload-safetybelt/safetybelt.js
+++ b/packages/reload-safetybelt/safetybelt.js
@@ -2,5 +2,5 @@ if (typeof Package === 'undefined' ||
     ! Package.webapp ||
     ! Package.webapp.WebApp ||
     ! Package.webapp.WebApp._isCssLoaded()) {
-  document.location.reload();
+  window.location.reload();
 }

--- a/packages/test-in-console/driver.js
+++ b/packages/test-in-console/driver.js
@@ -59,7 +59,7 @@ var expected = 0;
 var resultSet = {};
 var toReport = [];
 
-var hrefPath = document.location.href.split("/");
+var hrefPath = window.location.href.split("/");
 var platform = decodeURIComponent(hrefPath.length && hrefPath[hrefPath.length - 1]);
 if (!platform)
   platform = "local";


### PR DESCRIPTION
Hi all - this small PR is intended to help address issue #2380. There are only 2 core files remaining in the current codebase that reference `document.location`:

- `packages/reload-safetybelt/safetybelt.js`
- `packages/test-in-console/drivers.js`

This PR switches these over to `window.location`. All existing tests are passing, but I haven't included any new tests to verify these changes (as this is a difficult change to test for, and other than the issue outlined in http://stackoverflow.com/a/12098898/1756909, these are really just semantic changes). Let me know if you feel this should be handled differently - thanks!