### PR TITLE
[WIP] Perform fewer EJSON.clone's during a LocalCollection update

### DIFF
--- a/packages/diff-sequence/diff.js
+++ b/packages/diff-sequence/diff.js
@@ -27,10 +27,9 @@ DiffSequence.diffQueryUnorderedChanges = function (oldResults, newResults,
     var oldDoc = oldResults.get(id);
     if (oldDoc) {
       if (observer.changed && !EJSON.equals(oldDoc, newDoc)) {
-        var projectedNew = projectionFn(newDoc);
-        var projectedOld = projectionFn(oldDoc);
-        var changedFields =
-              DiffSequence.makeChangedFields(projectedNew, projectedOld);
+        var projectedNew = projectionFn(newDoc, false);
+        var projectedOld = projectionFn(oldDoc, false);
+        var changedFields = DiffSequence.makeChangedFields(projectedNew, projectedOld);
         if (! _.isEmpty(changedFields)) {
           observer.changed(id, changedFields);
         }
@@ -175,8 +174,8 @@ DiffSequence.diffQueryOrderedChanges = function (old_results, new_results,
       } else {
         // moved
         oldDoc = old_results[old_index_of_id[newDoc._id]];
-        projectedNew = projectionFn(newDoc);
-        projectedOld = projectionFn(oldDoc);
+        projectedNew = projectionFn(newDoc, false);
+        projectedOld = projectionFn(oldDoc, false);
         fields = DiffSequence.makeChangedFields(projectedNew, projectedOld);
         if (!_.isEmpty(fields)) {
           observer.changed && observer.changed(newDoc._id, fields);
@@ -187,8 +186,8 @@ DiffSequence.diffQueryOrderedChanges = function (old_results, new_results,
     if (groupId) {
       newDoc = new_results[endOfGroup];
       oldDoc = old_results[old_index_of_id[newDoc._id]];
-      projectedNew = projectionFn(newDoc);
-      projectedOld = projectionFn(oldDoc);
+      projectedNew = projectionFn(newDoc, false);
+      projectedOld = projectionFn(oldDoc, false);
       fields = DiffSequence.makeChangedFields(projectedNew, projectedOld);
       if (!_.isEmpty(fields)) {
         observer.changed && observer.changed(newDoc._id, fields);

--- a/packages/diff-sequence/diff.js
+++ b/packages/diff-sequence/diff.js
@@ -27,9 +27,10 @@ DiffSequence.diffQueryUnorderedChanges = function (oldResults, newResults,
     var oldDoc = oldResults.get(id);
     if (oldDoc) {
       if (observer.changed && !EJSON.equals(oldDoc, newDoc)) {
-        var projectedNew = projectionFn(newDoc, false);
-        var projectedOld = projectionFn(oldDoc, false);
-        var changedFields = DiffSequence.makeChangedFields(projectedNew, projectedOld);
+        var projectedNew = projectionFn(newDoc);
+        var projectedOld = projectionFn(oldDoc);
+        var changedFields =
+              DiffSequence.makeChangedFields(projectedNew, projectedOld);
         if (! _.isEmpty(changedFields)) {
           observer.changed(id, changedFields);
         }
@@ -174,8 +175,8 @@ DiffSequence.diffQueryOrderedChanges = function (old_results, new_results,
       } else {
         // moved
         oldDoc = old_results[old_index_of_id[newDoc._id]];
-        projectedNew = projectionFn(newDoc, false);
-        projectedOld = projectionFn(oldDoc, false);
+        projectedNew = projectionFn(newDoc);
+        projectedOld = projectionFn(oldDoc);
         fields = DiffSequence.makeChangedFields(projectedNew, projectedOld);
         if (!_.isEmpty(fields)) {
           observer.changed && observer.changed(newDoc._id, fields);
@@ -186,8 +187,8 @@ DiffSequence.diffQueryOrderedChanges = function (old_results, new_results,
     if (groupId) {
       newDoc = new_results[endOfGroup];
       oldDoc = old_results[old_index_of_id[newDoc._id]];
-      projectedNew = projectionFn(newDoc, false);
-      projectedOld = projectionFn(oldDoc, false);
+      projectedNew = projectionFn(newDoc);
+      projectedOld = projectionFn(oldDoc);
       fields = DiffSequence.makeChangedFields(projectedNew, projectedOld);
       if (!_.isEmpty(fields)) {
         observer.changed && observer.changed(newDoc._id, fields);

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -103,7 +103,7 @@ LocalCollection.Cursor = function (collection, selector, options) {
   self.limit = options.limit;
   self.fields = options.fields;
 
-  self._projectionFn = LocalCollection._compileProjection(self.fields || {});
+  self._projectionFn = LocalCollection._compileProjection(self.fields || {}, _.clone);
 
   self._transform = LocalCollection.wrapTransform(options.transform);
 
@@ -937,8 +937,8 @@ LocalCollection._updateInResults = function (query, doc, old_doc) {
   if (!EJSON.equals(doc._id, old_doc._id))
     throw new Error("Can't change a doc's _id while updating");
   var projectionFn = query.projectionFn;
-  var changedFields = EJSON.clone(DiffSequence.makeChangedFields(
-    projectionFn(doc, false), projectionFn(old_doc, false)));
+  var changedFields = DiffSequence.makeChangedFields(
+    projectionFn(doc), projectionFn(old_doc));
 
   if (!query.ordered) {
     if (!_.isEmpty(changedFields)) {
@@ -1001,7 +1001,7 @@ LocalCollection.prototype._recomputeResults = function (query, oldResults) {
   if (! self.paused) {
     LocalCollection._diffQueryChanges(
       query.ordered, oldResults, query.results, query,
-      { projectionFn: doc => query.projectionFn(doc, _.clone) });
+      { projectionFn: query.projectionFn });
   }
 };
 
@@ -1122,7 +1122,7 @@ LocalCollection.prototype.resumeObservers = function () {
       // pass the query object for its observer callbacks.
       LocalCollection._diffQueryChanges(
         query.ordered, query.resultsSnapshot, query.results, query,
-        {projectionFn: doc => query.projectionFn(doc, _.clone)});
+        {projectionFn: query.projectionFn});
     }
     query.resultsSnapshot = null;
   }

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -937,8 +937,8 @@ LocalCollection._updateInResults = function (query, doc, old_doc) {
   if (!EJSON.equals(doc._id, old_doc._id))
     throw new Error("Can't change a doc's _id while updating");
   var projectionFn = query.projectionFn;
-  var changedFields = DiffSequence.makeChangedFields(
-    projectionFn(doc), projectionFn(old_doc));
+  var changedFields = EJSON.clone(DiffSequence.makeChangedFields(
+    projectionFn(doc, false), projectionFn(old_doc, false)));
 
   if (!query.ordered) {
     if (!_.isEmpty(changedFields)) {

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -1001,7 +1001,7 @@ LocalCollection.prototype._recomputeResults = function (query, oldResults) {
   if (! self.paused) {
     LocalCollection._diffQueryChanges(
       query.ordered, oldResults, query.results, query,
-      { projectionFn: query.projectionFn });
+      { projectionFn: doc => query.projectionFn(doc, _.clone) });
   }
 };
 
@@ -1122,7 +1122,7 @@ LocalCollection.prototype.resumeObservers = function () {
       // pass the query object for its observer callbacks.
       LocalCollection._diffQueryChanges(
         query.ordered, query.resultsSnapshot, query.results, query,
-        {projectionFn: query.projectionFn});
+        {projectionFn: doc => query.projectionFn(doc, _.clone)});
     }
     query.resultsSnapshot = null;
   }

--- a/packages/minimongo/projection.js
+++ b/packages/minimongo/projection.js
@@ -12,12 +12,13 @@ LocalCollection._compileProjection = function (fields) {
   var details = projectionDetails(fields);
 
   // returns transformed doc according to ruleTree
-  var transform = function (doc, ruleTree) {
+  var transform = function (doc, ruleTree, clone=true) {
     // Special case for "sets"
     if (_.isArray(doc))
       return _.map(doc, function (subdoc) { return transform(subdoc, ruleTree); });
 
-    var res = details.including ? {} : EJSON.clone(doc);
+    var skipClone = !clone && _.size(ruleTree) === 0;
+    var res = details.including ? {} : (skipClone ? doc : EJSON.clone(doc));
     _.each(ruleTree, function (rule, key) {
       if (!_.has(doc, key))
         return;
@@ -35,8 +36,8 @@ LocalCollection._compileProjection = function (fields) {
     return res;
   };
 
-  return function (obj) {
-    var res = transform(obj, details.tree);
+  return function (obj, clone=true) {
+    var res = transform(obj, details.tree, clone);
 
     if (_idProjection && _.has(obj, '_id'))
       res._id = obj._id;


### PR DESCRIPTION
The purpose of this PR is to speed up LocalCollection updates (in the same vein as #5627). In Qualia's primary application, certain collection updates can take a really really long time (100-500ms). The majority of that time is spent calling `EJSON.clone`. This behavior will really only be present when there are either (a) a large number of active queries on the collection being updated or (b) the documents in the collection are extremely large.

This PR decreases the number of clones that happen during an update (and in Qualia decreases the length of collection updates by 3-6x). I am not entirely convinced that it is a safe change, but would like to run the changes against Meteor's test suite. There are also some further optimizations I might add, so consider this a WIP.
