### PR TITLE
Updated meteor build CLI help to include os.windows.x86_32 --architecture option.

### DIFF
--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -315,13 +315,12 @@ Options:
                       developer machine's architecture. Valid architectures
                       include os.osx.x86_64, os.linux.x86_64, os.linux.x86_32,
                       and os.windows.x86_32. Note: This option selects the
-                      architecture matching version of binary-dependent
-                      Atmosphere packages you would like bundled into your
-                      application, when those packages were specifically
-                      published for multiple architectures (i.e. with
-                      meteor publish-for-arch). If your project doesn't use
-                      any Atmosphere packages that have binary dependencies,
-                      --architecture has no effect.
+                      architecture of the binary-dependent Atmosphere packages
+                      you would like bundled into your application, when those
+                      packages were specifically published for multiple
+                      architectures (i.e. with meteor publish-for-arch). If
+                      your project doesn't use any Atmosphere packages that
+                      have binary dependencies, --architecture has no effect.
   --allow-incompatible-update   Allow packages in your project to be upgraded or
                       downgraded to versions that are potentially incompatible
                       with the current versions, if required to satisfy all

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -313,8 +313,8 @@ Options:
                       (for example, --server=https://example.com:443).
   --architecture      Builds the server for a different architecture than your
                       developer machine's architecture. Valid architectures
-                      include os.osx.x86_64, os.linux.x86_64, and
-                      os.linux.x86_32.
+                      include os.osx.x86_64, os.linux.x86_64, os.linux.x86_32,
+                      and os.windows.x86_32.
   --allow-incompatible-update   Allow packages in your project to be upgraded or
                       downgraded to versions that are potentially incompatible
                       with the current versions, if required to satisfy all

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -314,7 +314,14 @@ Options:
   --architecture      Builds the server for a different architecture than your
                       developer machine's architecture. Valid architectures
                       include os.osx.x86_64, os.linux.x86_64, os.linux.x86_32,
-                      and os.windows.x86_32.
+                      and os.windows.x86_32. Note: This option selects the
+                      architecture matching version of binary-dependent
+                      Atmosphere packages you would like bundled into your
+                      application, when those packages were specifically
+                      published for multiple architectures (i.e. with
+                      meteor publish-for-arch). If your project doesn't use
+                      any Atmosphere packages that have binary dependencies,
+                      --architecture has no effect.
   --allow-incompatible-update   Allow packages in your project to be upgraded or
                       downgraded to versions that are potentially incompatible
                       with the current versions, if required to satisfy all


### PR DESCRIPTION
Hi guys - this small PR is intended to help address issue #8241, by adding the missing `os.windows.x86_32` option to the `meteor help build` architecture section. This brings the help listed architecture options inline with the supported architectures defined in https://github.com/meteor/meteor/blob/90f7efd98b87da080955398688fd0d82e3f62fe0/tools/cli/commands.js#L34-L39. Thanks!