### PR TITLE
Adjusted the url package to encode nested objects and arrays (to help address #5065).

### DIFF
--- a/packages/http/httpcall_tests.js
+++ b/packages/http/httpcall_tests.js
@@ -419,8 +419,8 @@ testAsyncMulti("httpcall - params", [
     do_test("GET", "/", {foo:"bar", fruit:"apple"}, "/?foo=bar&fruit=apple", "");
     do_test("POST", "/", {foo:"bar", fruit:"apple"}, "/", "foo=bar&fruit=apple");
     do_test("POST", "/", {foo:"bar", fruit:"apple"}, "/", "foo=bar&fruit=apple");
-    do_test("GET", "/", {'foo!':"bang!"}, {}, "/?foo%21=bang%21", "");
-    do_test("POST", "/", {'foo!':"bang!"}, {}, "/", "foo%21=bang%21");
+    do_test("GET", "/", {'foo?':"bang?"}, {}, "/?foo%3F=bang%3F", "");
+    do_test("POST", "/", {'foo?':"bang?"}, {}, "/", "foo%3F=bang%3F");
     do_test("POST", "/", {foo:"bar", fruit:"apple"}, {
       content: "stuff!"}, "/?foo=bar&fruit=apple", "stuff!");
     do_test("POST", "/", {foo:"bar", greeting:"Hello World"}, {

--- a/packages/url/package.js
+++ b/packages/url/package.js
@@ -11,4 +11,9 @@ Package.onUse(function(api) {
   api.addFiles('url_server.js', 'server');
 });
 
-// tests are in the http package
+Package.onTest(function (api) {
+  api.use(['tinytest', 'url']);
+  api.addFiles('url_tests.js');
+});
+
+// More tests can be found in the http package

--- a/packages/url/url_common.js
+++ b/packages/url/url_common.js
@@ -1,20 +1,27 @@
 URL = {};
 
-var encodeString = function(str) {
-  return encodeURIComponent(str).replace(/[!'()]/g, escape).replace(/\*/g, "%2A");
+var encodeString = function (str) {
+  return encodeURIComponent(str).replace(/\*/g, '%2A');
 };
 
-
-URL._encodeParams = function(params) {
-  var buf = [];
-  _.each(params, function(value, key) {
-    if (buf.length)
-      buf.push('&');
-    buf.push(encodeString(key), '=', encodeString(value));
-  });
-  return buf.join('').replace(/%20/g, '+');
+// Encode URL paramaters into a query string, handling nested objects and
+// arrays properly.
+URL._encodeParams = function (params, prefix) {
+  var str = [];
+  for (var p in params) {
+    if (params.hasOwnProperty(p)) {
+      var k = prefix ? prefix + '[' + p + ']' : p, v = params[p];
+      if (typeof v === 'object') {
+        str.push(this._encodeParams(v, k));
+      } else {
+        var encodedKey =
+          encodeString(k).replace('%5B', '[').replace('%5D', ']');
+        str.push(encodedKey + '=' + encodeString(v));
+      }
+    }
+  }
+  return str.join('&').replace(/%20/g, '+');
 };
-
 
 buildUrl = function(before_qmark, from_qmark, opt_query, opt_params) {
   var url_without_query = before_qmark;

--- a/packages/url/url_common.js
+++ b/packages/url/url_common.js
@@ -9,7 +9,7 @@ var encodeString = function (str) {
 URL._encodeParams = function (params, prefix) {
   var str = [];
   for (var p in params) {
-    if (params.hasOwnProperty(p)) {
+    if (Object.prototype.hasOwnProperty.call(params, p)) {
       var k = prefix ? prefix + '[' + p + ']' : p, v = params[p];
       if (typeof v === 'object') {
         str.push(this._encodeParams(v, k));

--- a/packages/url/url_tests.js
+++ b/packages/url/url_tests.js
@@ -1,0 +1,12 @@
+Tinytest.add('url - serializes params to query correctly', function (test) {
+  var hash = {
+    filter: {
+      type: 'Foo',
+      id_eq: 15,
+    },
+    array: ['1', 'a', 'dirty[]']
+  };
+  var query =
+    'filter[type]=Foo&filter[id_eq]=15&array[0]=1&array[1]=a&array[2]=dirty%5B%5D';
+  test.equal(URL._encodeParams(hash), query);
+});

--- a/packages/url/url_tests.js
+++ b/packages/url/url_tests.js
@@ -4,9 +4,11 @@ Tinytest.add('url - serializes params to query correctly', function (test) {
       type: 'Foo',
       id_eq: 15,
     },
-    array: ['1', 'a', 'dirty[]']
+    array: ['1', 'a', 'dirty[]'],
+    hasOwnProperty: 'horrible param name',
   };
   var query =
-    'filter[type]=Foo&filter[id_eq]=15&array[0]=1&array[1]=a&array[2]=dirty%5B%5D';
+    'filter[type]=Foo&filter[id_eq]=15&array[0]=1&array[1]=a'
+    + '&array[2]=dirty%5B%5D&hasOwnProperty=horrible+param+name';
   test.equal(URL._encodeParams(hash), query);
 });


### PR DESCRIPTION
Hi all - this PR is intended to help address issue #5065. I've extracted @aldeed's proposed code from the [dispatch:url-encode-params](https://github.com/DispatchMe/meteor-url-encode-params) package, adding it to the `url` package. As mentioned in the original issue, this isn't a perfect solution since Node handles this differently, but it's definitely better than the current behaviour (and can always be extended later if/as needed). Anyways, it's a start - let the discussions begin! :-)