### PR TITLE
force-ssl: update README

### DIFF
--- a/packages/force-ssl/README.md
+++ b/packages/force-ssl/README.md
@@ -15,6 +15,12 @@ certificate. A proxy server that terminates SSL in front of a Meteor
 bundle must set the standard `x-forwarded-proto` header for the
 `force-ssl` package to work.
 
-Applications deployed to `meteor.com` subdomains with
-`meteor deploy` are automatically served via HTTPS using Meteor's
-certificate.
+If you're deploying your app to [Galaxy](https://www.meteor.com/hosting), we
+recommend using Galaxy's built-in "Force HTTPS" setting (on the specific domain
+in the "Domains & Encryption" section of your app's Settings tab) instead of
+this package.  This package read a header to guess whether or not a connection
+arrived over HTTPS, and uses a heuristic to guess if it's running in development
+mode; the Galaxy feature can directly observe which port the connection arrived
+on and by its nature is not involved in development mode.  We recommend this
+package only for deployment platforms that do not have their own "Force HTTPS"
+feature.

--- a/packages/force-ssl/README.md
+++ b/packages/force-ssl/README.md
@@ -7,20 +7,20 @@ Meteor to redirect insecure connections (HTTP) to a secure URL
 (HTTPS). Use this package to ensure that communication to the server
 is always encrypted to protect users from active spoofing attacks.
 
-To simplify development, unencrypted connections from `localhost` are
-always accepted over HTTP.
-
-Application bundles (`meteor bundle`) do not include an HTTPS server or
+Meteor bundles (i.e. `meteor build`) do not include an HTTPS server or
 certificate. A proxy server that terminates SSL in front of a Meteor
-bundle must set the standard `x-forwarded-proto` header for the
-`force-ssl` package to work.
+bundle must set the standard `x-forwarded-proto` header for this package to work.
 
-If you're deploying your app to [Galaxy](https://www.meteor.com/hosting), we
-recommend using Galaxy's built-in "Force HTTPS" setting (on the specific domain
-in the "Domains & Encryption" section of your app's Settings tab) instead of
-this package.  This package read a header to guess whether or not a connection
-arrived over HTTPS, and uses a heuristic to guess if it's running in development
-mode; the Galaxy feature can directly observe which port the connection arrived
-on and by its nature is not involved in development mode.  We recommend this
-package only for deployment platforms that do not have their own "Force HTTPS"
-feature.
+The `x-forwarded-proto` header is used to determine if the connection arrived
+over HTTPS and a heuristic is used to guess if it's running in development. To
+simplify development, unencrypted connections from `localhost` are always
+accepted over HTTP.
+
+We recommend this package only for deployment platforms that do not have their
+own ability to force SSL. If you're deploying with
+[Galaxy](https://www.meteor.com/hosting), you should instead use the "Force
+HTTPS" setting (on the specific domain in the "Domains & Encryption" section
+of your application's "Settings" tab). If you're using another deployment
+platform, you should attempt to provide this redirection on the proxy which
+terminates your SSL (e.g. HAProxy, nginx, etc.), outside of Meteor and without
+this package.


### PR DESCRIPTION
- Drop reference to *.meteor.com apps (no longer exist)

- Clarify that this is a separate feature from Galaxy's "Force HTTPS" setting,
  and that MDG recommends the latter for apps on Galaxy.

If this PR is merged, I'd appreciate publishing a new version quickly to update Atmosphere, as this is a constant source of confusion.