### PR TITLE
`Development.md`: How to Develop Meteor Itself

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -18,7 +18,7 @@ There are many ways to contribute to the Meteor Project. Here’s a list of tech
 
 There are also several ways to contribute to the Meteor Project outside of GitHub, like organizing or speaking at [Meetups](https://www.meetup.com/topics/meteor/) and events and helping to moderate our [forums](https://forums.meteor.com/). Stay tuned for more documentation around non-code contributions. 
 
-If you can think of any changes to the project or documentation that would improve the contributor experience, let us know by opening an issue!
+If you can think of any changes to the project or [documentation](https://github.com/meteor/docs) that would improve the contributor experience, let us know by opening an issue!
 
 ### Project roles
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -247,36 +247,3 @@ Meteor now has groups defined to cover different areas of the codebase. If you n
 * Documentation - This includes the Guide, the Docs, and any supporting material. You can mention @guide in the PR.
 
 Including the people above is no guarantee that you will get a response, or ultimately that your pull request will be accepted. This section exists to give some minor guidance on internal Meteor Development Group team structures.
-
-### Running tests on Meteor core
-
-When you are working with code in the core Meteor packages, you will want to make sure you run the
-full test-suite (including the tests you added) to ensure you haven't broken anything in Meteor. The
-`test-packages` command will do just that for you.
-
-The test packages command will start up a Meteor app with TinyTest setup, just connect to
-http://localhost:3000 or your specified port, like you would do with a normal meteor app.
-
-#### Run against your local meteor copy
-
-When running `test-packages`, be sure that you use the current directory copy of Meteor instead of
-the installed version. Here is the INCORRECT way: `meteor test-packages`.
-
-The CORRECT way is to use `./meteor test-packages` to run the full test suite against the branch you
-are on.
-
-This is important because you want to make sure you are running the test-packages command against
-the Meteor code on the branch you have pulled from GitHub, rather than the stable Meteor release you
-have installed on your computer.
-
-#### Running a subset of tests
-
-You can also just run a subset of tests from one package to speed up testing time. Let's say for
-example that you just want to run the Spacebars test suite. Just simple do `./meteor test-packages
-./packages/spacebars-tests` and it will just run the test files from that one package. You can
-examine the `package.js` file for the `onTest` block, it outlines all the test files that should be
-run.
-
-### Running Meteor Tool tests
-
-While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system. For details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).

--- a/Contributing.md
+++ b/Contributing.md
@@ -12,7 +12,7 @@ There are many ways to contribute to the Meteor Project. Here’s a list of tech
 - [Reporting a bug](https://github.com/meteor/meteor/blob/devel/Contributing.md#reporting-a-bug-in-meteor)
 - [Triaging issues](https://github.com/meteor/meteor/blob/devel/IssueTriage.md)
 - [Contributing to documentation](https://github.com/meteor/docs/blob/master/Contributing.md) 
-- [Submitting pull requests](https://github.com/meteor/meteor/blob/devel/Contributing.md#making-changes-to-meteor-core) 
+- [Submitting pull requests](https://github.com/meteor/meteor/blob/devel/Contributing.md#making-changes-to-meteor-core) (See "Finding work" below)
 - [Reviewing pull requests](https://github.com/meteor/meteor/blob/devel/Contributing.md#reviewer) 
 - [Maintaining a community package](https://github.com/meteor/meteor/blob/devel/Contributing.md#community-package-maintainer)
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -78,7 +78,7 @@ Current Community Manager:
 
 ### Tracking project work
 
-Right now, the best place to track the work being done on Meteor is to take a look at the latest release milestone [here](https://github.com/meteor/meteor/milestones).
+Right now, the best place to track the work being done on Meteor is to take a look at the latest release milestone [here](https://github.com/meteor/meteor/milestones).  Also, the [Meteor Roadmap](Roadmap.md) contains high-level information on the current priorities of the project.
 
 ### Finding work
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -20,6 +20,14 @@ There are also several ways to contribute to the Meteor Project outside of GitHu
 
 If you can think of any changes to the project or [documentation](https://github.com/meteor/docs) that would improve the contributor experience, let us know by opening an issue!
 
+### Finding work
+
+We curate specific issues that would make great pull requests for community contributors by applying the [`pull-requests-encouraged` label](https://github.com/meteor/meteor/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged).
+
+Issues which *also* have the [`confirmed` label](https://github.com/meteor/meteor/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) are considered to have their details clear enough to begin working on.
+
+Any issue which does not have the `confirmed` label still requires discussion on implementation details but input and positive commentary is welcome!  Any pull-request opened on an issue which is not `confirmed` is still welcome, however the pull-request is more likely to be sent back for reworking than a `confirmed` issue.  If in doubt about the best way to implement something, please create additional conversation on the issue.
+
 ### Project roles
 
 We’ve just begun to create more defined project roles for Meteor. Here are descriptions of the existing project roles, along with the current contributors taking on those roles today. 
@@ -79,14 +87,6 @@ Current Community Manager:
 ### Tracking project work
 
 Right now, the best place to track the work being done on Meteor is to take a look at the latest release milestone [here](https://github.com/meteor/meteor/milestones).  Also, the [Meteor Roadmap](Roadmap.md) contains high-level information on the current priorities of the project.
-
-### Finding work
-
-We curate specific issues that would make great pull requests for community contributors by applying the [`pull-requests-encouraged` label](https://github.com/meteor/meteor/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged).
-
-Issues which *also* have the [`confirmed` label](https://github.com/meteor/meteor/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) are considered to have their details clear enough to begin working on.
-
-Any issue which does not have the `confirmed` label still requires discussion on implementation details but input and positive commentary is welcome!  Any pull-request opened on an issue which is not `confirmed` is still welcome, however the pull-request is more likely to be sent back for reworking than a `confirmed` issue.  If in doubt about the best way to implement something, please create additional conversation on the issue.
 
 <h2 id="reporting-bug">Reporting a bug in Meteor</h2>
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -39,6 +39,7 @@ Current Issue Triagers:
 Our most regular and experienced Issue Triagers sometimes move on to doing code reviews for pull requests, and have input into which pull requests should be merged. 
 
 Current Reviewers:
+- [@hwillson](https://github.com/hwillson)
 - [@lorensr](https://github.com/lorensr)
 - [@abernix](https://github.com/abernix)
 
@@ -49,8 +50,7 @@ For now, the only contributors with commit access to meteor/meteor are employees
 Project Lead: [@benjamn](https://github.com/benjamn)
 
 Current Core Committers: 
-- [@tmeasday](https://github.com/tmeasday)
-- [@zol](https://github.com/zol)
+- [@abernix](https://github.com/abernix)
 - [@glasser](https://github.com/glasser)
 - [@stubailo](https://github.com/stubailo)
 
@@ -59,7 +59,7 @@ Current Core Committers:
 Documentation Maintainers are regular documentation contributors that have been given the ability to merge docs changes on [meteor/docs](https://github.com/meteor/docs). 
 
 Current Documentation Maintainers:
-- [@tmeasday](https://github.com/tmeasday)
+- [@abernix](https://github.com/abernix)
 - [@lorensr](https://github.com/lorensr)
 
 #### Community Package Maintainer:

--- a/Contributing.md
+++ b/Contributing.md
@@ -18,7 +18,7 @@ There are many ways to contribute to the Meteor Project. Here’s a list of tech
 
 There are also several ways to contribute to the Meteor Project outside of GitHub, like organizing or speaking at [Meetups](https://www.meetup.com/topics/meteor/) and events and helping to moderate our [forums](https://forums.meteor.com/). Stay tuned for more documentation around non-code contributions. 
 
-If you can think of any changes to the project or [documentation](https://github.com/meteor/docs) that would improve the contributor experience, let us know by opening an issue!
+If you can think of any changes to the project, [documentation](https://github.com/meteor/docs), or [guide](https://github.com/meteor/guide) that would improve the contributor experience, let us know by opening an issue!
 
 ### Finding work
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -78,7 +78,15 @@ Current Community Manager:
 
 ### Tracking project work
 
-Right now, the best place to track the work being done on Meteor is to take a look at the latest release milestone [here](https://github.com/meteor/meteor/milestones). We also curate specific issues that would make great pull requests for community contributors with the [pull requests encouraged tag](https://github.com/meteor/meteor/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged).
+Right now, the best place to track the work being done on Meteor is to take a look at the latest release milestone [here](https://github.com/meteor/meteor/milestones).
+
+### Finding work
+
+We curate specific issues that would make great pull requests for community contributors by applying the [`pull-requests-encouraged` label](https://github.com/meteor/meteor/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged).
+
+Issues which *also* have the [`confirmed` label](https://github.com/meteor/meteor/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) are considered to have their details clear enough to begin working on.
+
+Any issue which does not have the `confirmed` label still requires discussion on implementation details but input and positive commentary is welcome!  Any pull-request opened on an issue which is not `confirmed` is still welcome, however the pull-request is more likely to be sent back for reworking than a `confirmed` issue.  If in doubt about the best way to implement something, please create additional conversation on the issue.
 
 <h2 id="reporting-bug">Reporting a bug in Meteor</h2>
 

--- a/Development.md
+++ b/Development.md
@@ -59,10 +59,15 @@ can run Meteor directly from a Git checkout using these steps:
 
 When you are working with code in the core Meteor packages, you will want to make sure you run the
 full test-suite (including the tests you added) to ensure you haven't broken anything in Meteor. The
-`test-packages` command will do just that for you.
+`test-packages` command will do just that for you:
 
-The test packages command will start up a Meteor app with TinyTest setup, just connect to
-http://localhost:3000 or your specified port, like you would do with a normal meteor app.
+    ./meteor test-packages
+
+Exactly in the same way that [`test-packages` works in standalone Meteor apps](https://guide.meteor.com/writing-atmosphere-packages.html#testing), the `test-packages` command will start up a Meteor app with [TinyTest](./packages/tinytest/README.md).  To view the results, just connect to `http://localhost:3000` (or your specified port) and view the results.
+
+Specific portions of package tests can be run by passing a `<package name>` to the `test-packages` command. For example, to run `mongo` tests, it's possible to run:
+
+    ./meteor test-packages mongo
 
 #### Run against your local meteor copy
 

--- a/Development.md
+++ b/Development.md
@@ -78,7 +78,19 @@ Specific portions of package tests can be run by passing a `<package name>` or `
 
 ### Running Meteor Tool self-tests
 
-While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system. For details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
+While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system.
+
+To reduce the size of the Meteor distribution, some parts of the self-test system must be installed separately, including `phantomjs-prebuilt` and `browserstack-webdriver`.
+
+A notification will be displayed when attempting to use the `self-test` commands if these dependencies are not installed.  Make sure to install them into your checkout when prompted:
+
+    ./meteor npm install -g phantomjs-prebuilt browserstack-webdriver
+
+To see a list of the tests which are included in the self-test system, list them with the `--list` option:
+
+    ./meteor self-test --list
+
+For more details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
 
 ### Continuous integration
 

--- a/Development.md
+++ b/Development.md
@@ -143,3 +143,11 @@ To enable CircleCI for your development:
 0. On the right, find `meteor`
 0. Click on the "Build project" button next to `meteor`.
 0. Your build will start automatically!
+
+## Code style
+
+* New contributions should follow the [Meteor Style Guide](https://github.com/meteor/javascript/) as closely as possible.
+  * The Meteor Style Guide is very close to the [Airbnb Style Guide](https://github.com/airbnb/javascript) with a few notable changes.
+* New code should match existing code (in the same vicinity) when the context of a change is minimal, but larger amounts of new code should follow the guide.
+* Do not change code that doesn't directly relate to the feature/bug that you're working on.
+* Basic linting is accomplished (via ESLint) by running `./scripts/admin/eslint/eslint.sh`.

--- a/Development.md
+++ b/Development.md
@@ -160,4 +160,4 @@ Good commit messages are very important and you should make sure to explain what
 * A short and helpful commit title (maximum 80 characters).
 * A commit description which clearly explains the change if it's not super-obvious by the title.  Some description always helps!
 * Reference related issues and pull-requests by number in the description body (e.g. "#9999").
-* Add "Fixes", "Closes" or "Resolves" if that the addition of that commit fully fixes the issue.
+* Add "Fixes" before the issue number if the addition of that commit fully resolves the issue.

--- a/Development.md
+++ b/Development.md
@@ -55,6 +55,13 @@ can run Meteor directly from a Git checkout using these steps:
 
 ## Tests
 
+#### Test against the local meteor copy
+
+When running any of tests, be sure run them against the checked-out copy of Meteor instead of
+the globally-installed version.  This means ensuring that the command being ran is `path-to-meteor-checkout/meteor` and not just `meteor`.
+
+This is important so that tests are ran against the version in development and not the stable Meteor release.
+
 ### Running tests on Meteor core
 
 When you are working with code in the core Meteor packages, you will want to make sure you run the
@@ -68,18 +75,6 @@ Exactly in the same way that [`test-packages` works in standalone Meteor apps](h
 Specific portions of package tests can be run by passing a `<package name>` to the `test-packages` command. For example, to run `mongo` tests, it's possible to run:
 
     ./meteor test-packages mongo
-
-#### Run against your local meteor copy
-
-When running `test-packages`, be sure that you use the current directory copy of Meteor instead of
-the installed version. Here is the INCORRECT way: `meteor test-packages`.
-
-The CORRECT way is to use `./meteor test-packages` to run the full test suite against the branch you
-are on.
-
-This is important because you want to make sure you are running the test-packages command against
-the Meteor code on the branch you have pulled from GitHub, rather than the stable Meteor release you
-have installed on your computer.
 
 #### Running a subset of tests
 

--- a/Development.md
+++ b/Development.md
@@ -1,5 +1,9 @@
 # Development
 
+This document is intended to provide instructions and helpful information for developers who are [contributing](Contributing.md) [pull-requests](https://github.com/meteor/meteor/pulls/) (or otherwise making changes) to **Meteor Core itself (not Meteor apps)**.
+
+As the first suggestion to the reader of this document: If, during the course of development, a Meteor-specific process is revealed which is helpful and not documented here, please consider editing this document and submitting a pull-request.  Another developer will be thankful!
+
 ## Running from a Git checkout
 
 If you want to run on the bleeding edge, or [help contribute to Meteor](Contributing.md), you

--- a/Development.md
+++ b/Development.md
@@ -1,5 +1,58 @@
 # Development
 
+## Running from a Git checkout
+
+If you want to run on the bleeding edge, or [help contribute to Meteor](Contributing.md), you
+can run Meteor directly from a Git checkout using these steps:
+
+0. **Clone from GitHub**
+
+    ```sh
+    $ git clone --recursive https://github.com/meteor/meteor.git
+    $ cd meteor
+    ```
+
+    > ##### Important note about Git submodules!
+    >
+    > This repository uses Git submodules.  If you clone without the `--recursive` flag,
+    > re-fetch with `git pull` or experience "`Depending on unknown package`" errors,
+    > run the following in the repository root to sync things up again:
+    >
+    >     $ git submodule update --init --recursive
+
+0. **_(Optional)_ Compile dependencies**
+
+    > This optional step requires a C and C++ compiler, autotools, and scons.
+    > If this step is skipped, Meteor will simply download pre-built binaries.
+
+    To build everything from scratch (`node`, `npm`, `mongodb`, etc.) run the following:
+
+    ```sh
+    $ ./scripts/generate-dev-bundle.sh # OPTIONAL!
+    ```
+
+0. **Run a Meteor command to install dependencies**
+
+    > If you did not compile dependencies above, this will also download the binaries.
+
+
+    ```sh
+    $ ./meteor --help
+    ```
+
+0. **Ready to Go!**
+
+    Your local Meteor checkout is now ready to use!  You can use this `./meteor`
+    anywhere you would normally call the system `meteor`.  For example,:
+
+    ```sh
+    $ cd my-app/
+    $ /path/to/meteor-checkout/meteor run
+    ```
+
+    > _Note:_ When running from a `git` checkout, you cannot pin apps to specific
+    > Meteor releases or change the release using `--release`.
+
 ## Tests
 
 ### Running tests on Meteor core

--- a/Development.md
+++ b/Development.md
@@ -20,17 +20,6 @@ can run Meteor directly from a Git checkout using these steps:
     >
     >     $ git submodule update --init --recursive
 
-0. **_(Optional)_ Compile dependencies**
-
-    > This optional step requires a C and C++ compiler, autotools, and scons.
-    > If this step is skipped, Meteor will simply download pre-built binaries.
-
-    To build everything from scratch (`node`, `npm`, `mongodb`, etc.) run the following:
-
-    ```sh
-    $ ./scripts/generate-dev-bundle.sh # OPTIONAL!
-    ```
-
 0. **Run a Meteor command to install dependencies**
 
     > If you did not compile dependencies above, this will also download the binaries.
@@ -62,6 +51,38 @@ can run Meteor directly from a Git checkout using these steps:
 The following are some distict differences you must pay attention to when running Meteor from a checkout:
 
   * You cannot pin apps to specific Meteor releases or change the release using `--release`.
+  
+## The "Dev Bundle"
+
+The "dev bundle" (identified as the `dev_bundle` in the folder structure) is a generated bundle of code, packages and tools which are essential to providing the functionality of the Meteor tool (`meteor`) and the app bundles which it builds.
+
+When `meteor` is run from a checkout, a `dev_bundle` is automatically downloaded and should be sufficient for most development.  However, some more substantial changes will require rebuilding the `dev_bundle`.  This include changes to the:
+
+* Node version
+* NPM version
+* Mongo version
+* Packages [used by `meteor-tool`](scripts/dev-bundle-tool-package.js)
+* Packages [used by the server bundle](scripts/dev-bundle-server-package.js)
+
+While it may be tempting to make changes to these variables, please consider the repercussions (including compatibility and stability) and make sure to test changes extensively.  For example, major version changes (especially to Node and Mongo) usually requires substantial changes to other components.
+
+### "Dev Bundle" versions
+
+The working version number of the `dev_bundle` to be downloaded (or generated) is stored as `BUNDLE_VERSION` at the top of the [`meteor`](./meteor) script.  When submitting a pull request which changes components of the `dev_bundle`, the minor version should be bumped (at the very least).  In local development, it is advisable to use a different major version (e.g. `100.0.0`) so as not to clash with the official versions which cached locally.
+
+Cached versions of the `dev_bundle` are stored in the root directory of the checkout.  Keeping them around will prevent the need to re-download them when switching between branches, but they do become quite large as they collect so delete them as necessary!
+
+### Rebuilding the "Dev Bundle"
+
+Rebuilding requires a C and C++ compiler, `autotools`, and `scons`.
+
+To build everything from scratch (`node`, `npm`, `mongodb`, etc.) and re-package NPM modules, simply run the following script:
+
+```sh
+$ ./scripts/generate-dev-bundle.sh
+```
+
+This will generate a new tarball (`dev_bundle_<Platform>_<arch>_<version>.tar.gz`) in the root of the checkout.  Assuming you bumped the `BUNDLE_VERSION`, the new version will be extracted automatically when you run `./meteor`.  If you are rebuilding the same version (or didn't bump the version number), you should delete the existing `dev_bundle` directory to ensure the new tarball is extracted when you run `./meteor`.
 
 ## Additional documentation
 

--- a/Development.md
+++ b/Development.md
@@ -96,6 +96,21 @@ To see a list of the tests which are included in the self-test system, list them
 
     ./meteor self-test --list
 
+#### Running specific tests
+
+The self-test commands support a regular-expression syntax in order to specific/search for specific tests.  For example, to search for tests starting with `a` or `b`, it's possible to run:
+
+    ./meteor self-test "^[a-b]" --list
+
+Simply remove the `--list` flag to actually run the matching tests.
+
+#### Excluding specific tests
+
+In a similar way to the method of specifying which tests TO run, there is a way to specify which tests should NOT run.  Again, using regular-expressions, this command will NOT list any tests which start with `a` or `b`:
+
+    ./meteor self-test --exclude "^[a-b]" --list
+
+Simply remove the `--list` flag to actually run the matching tests.
 
 ### Continuous integration
 

--- a/Development.md
+++ b/Development.md
@@ -48,7 +48,7 @@ can run Meteor directly from a Git checkout using these steps:
 
 ## Notes when running from a checkout
 
-The following are some distict differences you must pay attention to when running Meteor from a checkout:
+The following are some distinct differences you must pay attention to when running Meteor from a checkout:
 
   * You cannot pin apps to specific Meteor releases or change the release using `--release`.
   
@@ -58,13 +58,13 @@ The "dev bundle" (identified as the `dev_bundle` in the folder structure) is a g
 
 When `meteor` is run from a checkout, a `dev_bundle` is automatically downloaded and should be sufficient for most development.  However, some more substantial changes will require rebuilding the `dev_bundle`.  This include changes to the:
 
-* Node version
-* NPM version
-* Mongo version
+* Node.js version
+* npm version
+* MongoDB version
 * Packages [used by `meteor-tool`](scripts/dev-bundle-tool-package.js)
 * Packages [used by the server bundle](scripts/dev-bundle-server-package.js)
 
-While it may be tempting to make changes to these variables, please consider the repercussions (including compatibility and stability) and make sure to test changes extensively.  For example, major version changes (especially to Node and Mongo) usually requires substantial changes to other components.
+While it may be tempting to make changes to these variables, please consider the repercussions (including compatibility and stability) and make sure to test changes extensively.  For example, major version changes (especially to Node.js and MongoDB) usually requires substantial changes to other components.
 
 ### "Dev Bundle" versions
 
@@ -76,7 +76,7 @@ Cached versions of the `dev_bundle` are stored in the root directory of the chec
 
 Rebuilding requires a C and C++ compiler, `autotools`, and `scons`.
 
-To build everything from scratch (`node`, `npm`, `mongodb`, etc.) and re-package NPM modules, simply run the following script:
+To build everything from scratch and re-package dependencies, simply run the following script:
 
 ```sh
 $ ./scripts/generate-dev-bundle.sh
@@ -109,7 +109,7 @@ full test-suite (including the tests you added) to ensure you haven't broken any
 
     ./meteor test-packages
 
-Exactly in the same way that [`test-packages` works in standalone Meteor apps](https://guide.meteor.com/writing-atmosphere-packages.html#testing), the `test-packages` command will start up a Meteor app with [TinyTest](./packages/tinytest/README.md).  To view the results, just connect to `http://localhost:3000` (or your specified port) and view the results.
+Exactly in the same way that [`test-packages` works in standalone Meteor apps](https://guide.meteor.com/writing-atmosphere-packages.html#testing), the `test-packages` command will start up a Meteor app with [TinyTest](./packages/tinytest/README.md).  To view the results, just connect to `http://localhost:3000`.
 
 Specific portions of package tests can be run by passing a `<package name>` or `<package path>` to the `test-packages` command. For example, to run `mongo` tests, it's possible to run:
 
@@ -118,8 +118,6 @@ Specific portions of package tests can be run by passing a `<package name>` or `
 ### Running Meteor Tool self-tests
 
 While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system.
-
-For even more details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
 
 #### Prerequisites
 
@@ -151,9 +149,11 @@ In a similar way to the method of specifying which tests TO run, there is a way 
 
 Simply remove the `--list` flag to actually run the matching tests.
 
+For even more details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
+
 ### Continuous integration
 
-Any time a pull-request is submitted or a commit is pushed directly to the `devel` branch, continuous integration tests will be started automatically by the CI server.  These are run by [Circle CI](https://circleci.com/) and defined in the [`circle.yml` file](./circle.yml) file.  Even more specifically, the tests to run and the containers to run them under are defined in the [`/scripts/ci.sh`](scripts/ci.sh) script, which is a script which can run locally to replicate the exact tests.
+Any time a pull-request is submitted or a commit is pushed directly to the `devel` branch, continuous integration tests will be started automatically by the CI server.  These are run by [Circle CI](https://circleci.com/) and defined in the [`circle.yml` file](./circle.yml).  Even more specifically, the tests to run and the containers to run them under are defined in the [`/scripts/ci.sh`](scripts/ci.sh) script, which is a script which can run locally to replicate the exact tests.
 
 Not every test which is defined in a test spec is actually ran by the CI server.  Some tests are simply too long-running and some tests are just no longer relevant.  As one particular example, there is a suite of very slow tests grouped into a `slow` designator within the test framework.  These can be executed by adding the `--slow` option to the `self-test` command.
 

--- a/Development.md
+++ b/Development.md
@@ -72,17 +72,9 @@ full test-suite (including the tests you added) to ensure you haven't broken any
 
 Exactly in the same way that [`test-packages` works in standalone Meteor apps](https://guide.meteor.com/writing-atmosphere-packages.html#testing), the `test-packages` command will start up a Meteor app with [TinyTest](./packages/tinytest/README.md).  To view the results, just connect to `http://localhost:3000` (or your specified port) and view the results.
 
-Specific portions of package tests can be run by passing a `<package name>` to the `test-packages` command. For example, to run `mongo` tests, it's possible to run:
+Specific portions of package tests can be run by passing a `<package name>` or `<package path>` to the `test-packages` command. For example, to run `mongo` tests, it's possible to run:
 
     ./meteor test-packages mongo
-
-#### Running a subset of tests
-
-You can also just run a subset of tests from one package to speed up testing time. Let's say for
-example that you just want to run the Spacebars test suite. Just simple do `./meteor test-packages
-./packages/spacebars-tests` and it will just run the test files from that one package. You can
-examine the `package.js` file for the `onTest` block, it outlines all the test files that should be
-run.
 
 ### Running Meteor Tool tests
 

--- a/Development.md
+++ b/Development.md
@@ -53,6 +53,14 @@ can run Meteor directly from a Git checkout using these steps:
     > _Note:_ When running from a `git` checkout, you cannot pin apps to specific
     > Meteor releases or change the release using `--release`.
 
+## Additional documentation
+
+The Meteor core is best documented within the code itself, however, many components also have a `README.md` in their respective directories.
+
+Some compartmentalized portions of Meteor are broken into packages ([see a list of packages](packages/)) and they almost all have a `README.md` within their directory.  For example, [`ddp`](packages/ddp/README.md), [`ecmascript`](packages/ecmascript/README.md) and [`tinytest`](packages/tinytest/README.md).
+
+For the rest, try looking nearby for a `README.md`.  For example, [`isobuild`](tools/isobuild/README.md) or [`cordova`](tools/cordova/README.md).
+
 ## Tests
 
 ### Test against the local meteor copy

--- a/Development.md
+++ b/Development.md
@@ -55,7 +55,7 @@ can run Meteor directly from a Git checkout using these steps:
 
 ## Tests
 
-#### Test against the local meteor copy
+### Test against the local meteor copy
 
 When running any of tests, be sure run them against the checked-out copy of Meteor instead of
 the globally-installed version.  This means ensuring that the command being ran is `path-to-meteor-checkout/meteor` and not just `meteor`.

--- a/Development.md
+++ b/Development.md
@@ -79,3 +79,13 @@ Specific portions of package tests can be run by passing a `<package name>` or `
 ### Running Meteor Tool tests
 
 While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system. For details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
+
+### Continuous integration
+
+Any time a pull-request is submitted or a commit is pushed directly to the `devel` branch, continuous integration tests will be started automatically by the CI server.  These are run by [Circle CI](https://circleci.com/) and defined in the [`circle.yml` file](./circle.yml) file.  Even more specifically, the tests to run and the containers to run them under are defined in the [`/scripts/ci.sh`](scripts/ci.sh) script, which is a script which can run locally to replicate the exact tests.
+
+Not every test which is defined in a test spec is actually ran by the CI server.  Some tests are simply too long-running and some tests are just no longer relevant.  As one particular example, there is a suite of very slow tests grouped into a `slow` designator within the test framework.  These can be executed by adding the `--slow` argument to the `self-test` command.
+
+> Please Note: Windows
+>
+> There is not currently a continuous integration system setup for Windows.  Additionally, not all tests are known to work on Windows.  If you're able to take time to improve those tests, it would be greatly appreciated.  Currently, there isn't an official list of known tests which do not run on Windows, but a PR to note those here and get them fixed would be ideal!

--- a/Development.md
+++ b/Development.md
@@ -151,3 +151,12 @@ To enable CircleCI for your development:
 * New code should match existing code (in the same vicinity) when the context of a change is minimal, but larger amounts of new code should follow the guide.
 * Do not change code that doesn't directly relate to the feature/bug that you're working on.
 * Basic linting is accomplished (via ESLint) by running `./scripts/admin/eslint/eslint.sh`.
+
+## Commit messages
+
+Good commit messages are very important and you should make sure to explain what is changing and why.  The commit message should include:
+
+* A short and helpful commit title (maximum 80 characters).
+* A commit description which clearly explains the change if it's not super-obvious by the title.  Some description always helps!
+* Reference related issues and pull-requests by number in the description body (e.g. "#9999").
+* Add "Fixes", "Closes" or "Resolves" if that the addition of that commit fully fixes the issue.

--- a/Development.md
+++ b/Development.md
@@ -80,6 +80,8 @@ Specific portions of package tests can be run by passing a `<package name>` or `
 
 While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system.
 
+For even more details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
+
 To reduce the size of the Meteor distribution, some parts of the self-test system must be installed separately, including `phantomjs-prebuilt` and `browserstack-webdriver`.
 
 A notification will be displayed when attempting to use the `self-test` commands if these dependencies are not installed.  Make sure to install them into your checkout when prompted:
@@ -90,7 +92,6 @@ To see a list of the tests which are included in the self-test system, list them
 
     ./meteor self-test --list
 
-For more details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
 
 ### Continuous integration
 

--- a/Development.md
+++ b/Development.md
@@ -129,3 +129,17 @@ Not every test which is defined in a test spec is actually ran by the CI server.
 > Please Note: Windows
 >
 > There is not currently a continuous integration system setup for Windows.  Additionally, not all tests are known to work on Windows.  If you're able to take time to improve those tests, it would be greatly appreciated.  Currently, there isn't an official list of known tests which do not run on Windows, but a PR to note those here and get them fixed would be ideal!
+
+#### Running your own CircleCI
+
+Since Meteor is a free, open-source project, you can run tests in the context of your own CircleCI account at no cost (up to the maximum number of containers allowed by them) during development and prior to submitting a pull-request.  For some, this may be quicker or more convenient than running tests on their own workstation.  As an added advantage, when your tests are "green", that status will be immediately shown (as passing) when a pull-request is opened with the official Meteor repository.
+
+To enable CircleCI for your development:
+
+0. Make sure you have an account with [CircleCI](https://circleci.com)
+0. Make sure you have [forked](https://help.github.com/articles/fork-a-repo/) [Meteor](https://github.com/meteor/meteor) into your own GitHub account.
+0. Go to the [Add Projects](https://circleci.com/add-projects) page on CircleCI.
+0. On the left, click on your GitHub username.
+0. On the right, find `meteor`
+0. Click on the "Build project" button next to `meteor`.
+0. Your build will start automatically!

--- a/Development.md
+++ b/Development.md
@@ -76,7 +76,7 @@ Specific portions of package tests can be run by passing a `<package name>` or `
 
     ./meteor test-packages mongo
 
-### Running Meteor Tool tests
+### Running Meteor Tool self-tests
 
 While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system. For details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
 

--- a/Development.md
+++ b/Development.md
@@ -1,0 +1,36 @@
+# Development
+
+## Tests
+
+### Running tests on Meteor core
+
+When you are working with code in the core Meteor packages, you will want to make sure you run the
+full test-suite (including the tests you added) to ensure you haven't broken anything in Meteor. The
+`test-packages` command will do just that for you.
+
+The test packages command will start up a Meteor app with TinyTest setup, just connect to
+http://localhost:3000 or your specified port, like you would do with a normal meteor app.
+
+#### Run against your local meteor copy
+
+When running `test-packages`, be sure that you use the current directory copy of Meteor instead of
+the installed version. Here is the INCORRECT way: `meteor test-packages`.
+
+The CORRECT way is to use `./meteor test-packages` to run the full test suite against the branch you
+are on.
+
+This is important because you want to make sure you are running the test-packages command against
+the Meteor code on the branch you have pulled from GitHub, rather than the stable Meteor release you
+have installed on your computer.
+
+#### Running a subset of tests
+
+You can also just run a subset of tests from one package to speed up testing time. Let's say for
+example that you just want to run the Spacebars test suite. Just simple do `./meteor test-packages
+./packages/spacebars-tests` and it will just run the test files from that one package. You can
+examine the `package.js` file for the `onTest` block, it outlines all the test files that should be
+run.
+
+### Running Meteor Tool tests
+
+While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system. For details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).

--- a/Development.md
+++ b/Development.md
@@ -50,8 +50,18 @@ can run Meteor directly from a Git checkout using these steps:
     $ /path/to/meteor-checkout/meteor run
     ```
 
-    > _Note:_ When running from a `git` checkout, you cannot pin apps to specific
-    > Meteor releases or change the release using `--release`.
+    > _Tip:_ Consider making an easy-to-run alias for frequent use:
+    >
+    >     alias mymeteor=/path/to-meteor-checkout/meteor
+    >
+    > This allows the use of `mymeteor` in place of `meteor`.  To persist this
+    > across shell logouts, simply add it to `~/.bashrc` or `.zshrc`.
+
+## Notes when running from a checkout
+
+The following are some distict differences you must pay attention to when running Meteor from a checkout:
+
+  * You cannot pin apps to specific Meteor releases or change the release using `--release`.
 
 ## Additional documentation
 

--- a/Development.md
+++ b/Development.md
@@ -151,6 +151,7 @@ To enable CircleCI for your development:
 * New code should match existing code (in the same vicinity) when the context of a change is minimal, but larger amounts of new code should follow the guide.
 * Do not change code that doesn't directly relate to the feature/bug that you're working on.
 * Basic linting is accomplished (via ESLint) by running `./scripts/admin/eslint/eslint.sh`.
+  * Many files have not been converted yet and are thus [excluded](https://github.com/meteor/meteor/blob/master/.eslintignore).
 
 ## Commit messages
 

--- a/Development.md
+++ b/Development.md
@@ -58,9 +58,9 @@ can run Meteor directly from a Git checkout using these steps:
 ### Test against the local meteor copy
 
 When running any of tests, be sure run them against the checked-out copy of Meteor instead of
-the globally-installed version.  This means ensuring that the command being ran is `path-to-meteor-checkout/meteor` and not just `meteor`.
+the globally-installed version.  This means ensuring that the command is `path-to-meteor-checkout/meteor` and not just `meteor`.
 
-This is important so that tests are ran against the version in development and not the stable Meteor release.
+This is important so that tests are run against the version in development and not the stable (installed) Meteor release.
 
 ### Running tests on Meteor core
 

--- a/Development.md
+++ b/Development.md
@@ -149,6 +149,8 @@ In a similar way to the method of specifying which tests TO run, there is a way 
 
 Simply remove the `--list` flag to actually run the matching tests.
 
+#### More reading
+
 For even more details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
 
 ### Continuous integration

--- a/Development.md
+++ b/Development.md
@@ -82,11 +82,15 @@ While TinyTest and the `test-packages` command can be used to test internal Mete
 
 For even more details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
 
+#### Prerequisites
+
 To reduce the size of the Meteor distribution, some parts of the self-test system must be installed separately, including `phantomjs-prebuilt` and `browserstack-webdriver`.
 
 A notification will be displayed when attempting to use the `self-test` commands if these dependencies are not installed.  Make sure to install them into your checkout when prompted:
 
     ./meteor npm install -g phantomjs-prebuilt browserstack-webdriver
+
+#### Listing available tests
 
 To see a list of the tests which are included in the self-test system, list them with the `--list` option:
 

--- a/Development.md
+++ b/Development.md
@@ -96,7 +96,7 @@ For more details on how to run Meteor Tool "self tests", please refer to the [Te
 
 Any time a pull-request is submitted or a commit is pushed directly to the `devel` branch, continuous integration tests will be started automatically by the CI server.  These are run by [Circle CI](https://circleci.com/) and defined in the [`circle.yml` file](./circle.yml) file.  Even more specifically, the tests to run and the containers to run them under are defined in the [`/scripts/ci.sh`](scripts/ci.sh) script, which is a script which can run locally to replicate the exact tests.
 
-Not every test which is defined in a test spec is actually ran by the CI server.  Some tests are simply too long-running and some tests are just no longer relevant.  As one particular example, there is a suite of very slow tests grouped into a `slow` designator within the test framework.  These can be executed by adding the `--slow` argument to the `self-test` command.
+Not every test which is defined in a test spec is actually ran by the CI server.  Some tests are simply too long-running and some tests are just no longer relevant.  As one particular example, there is a suite of very slow tests grouped into a `slow` designator within the test framework.  These can be executed by adding the `--slow` option to the `self-test` command.
 
 > Please Note: Windows
 >

--- a/Development.md
+++ b/Development.md
@@ -50,7 +50,7 @@ can run Meteor directly from a Git checkout using these steps:
     > This allows the use of `mymeteor` in place of `meteor`.  To persist this
     > across shell logouts, simply add it to `~/.bashrc` or `.zshrc`.
 
-## Notes when running from a checkout
+### Notes when running from a checkout
 
 The following are some distinct differences you must pay attention to when running Meteor from a checkout:
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ If you're interested in developing Meteor itself, or running unreleased,
 bleeding-edge code, please refer to the details found in
 [Development.md](Development.md).
 
+To find more information about contributing to Meteor (whether fixing bugs or
+adding features), please see [Contributing.md](Contributing.md).
+
 ## Uninstalling Meteor
 
 Aside from a short launcher shell script, Meteor installs itself inside your

--- a/README.md
+++ b/README.md
@@ -41,56 +41,9 @@ meteor
 
 ## Slow Start (for developers)
 
-If you want to run on the bleeding edge, or [help contribute to Meteor](Contributing.md), you
-can run Meteor directly from a Git checkout using these steps:
-
-0. **Clone from GitHub**
-
-    ```sh
-    $ git clone --recursive https://github.com/meteor/meteor.git
-    $ cd meteor
-    ```
-
-    > ##### Important note about Git submodules!
-    >
-    > This repository uses Git submodules.  If you clone without the `--recursive` flag,
-    > re-fetch with `git pull` or experience "`Depending on unknown package`" errors,
-    > run the following in the repository root to sync things up again:
-    >
-    >     $ git submodule update --init --recursive
-
-0. **_(Optional)_ Compile dependencies**
-
-    > This optional step requires a C and C++ compiler, autotools, and scons.
-    > If this step is skipped, Meteor will simply download pre-built binaries.
-
-    To build everything from scratch (`node`, `npm`, `mongodb`, etc.) run the following:
-
-    ```sh
-    $ ./scripts/generate-dev-bundle.sh # OPTIONAL!
-    ```
-
-0. **Run a Meteor command to install dependencies**
-
-    > If you did not compile dependencies above, this will also download the binaries.
-
-
-    ```sh
-    $ ./meteor --help
-    ```
-
-0. **Ready to Go!**
-
-    Your local Meteor checkout is now ready to use!  You can use this `./meteor`
-    anywhere you would normally call the system `meteor`.  For example,:
-
-    ```sh
-    $ cd my-app/
-    $ /path/to/meteor-checkout/meteor run
-    ```
-
-    > _Note:_ When running from a `git` checkout, you cannot pin apps to specific
-    > Meteor releases or change the release using `--release`.
+If you're interested in developing Meteor itself, or running unreleased,
+bleeding-edge code, please refer to the details found in
+[Development.md](Development.md).
 
 ## Uninstalling Meteor
 


### PR DESCRIPTION
The current edition of [Contributing.md](https://github.com/meteor/meteor/blob/devel/Contributing.md) is great in that it's beginning to offer a lot of information on the various ways to contribute to Meteor aside from just code contributions including Issue Triaging, PR help, etc.

It falls a bit short when it comes to actual development though as there is also quite a bit that is undocumented in that aspect.  There's a bit of a section on [running Meteor tests](https://github.com/meteor/meteor/blob/devel/Contributing.md#running-tests-on-meteor-core), but aside from the "[Slow start for developers](https://github.com/meteor/meteor/#slow-start-for-developers)" section of the `README.md` there isn't much breaking down the nitty gritty – what a dev bundle is, how you run specific tests, style expectations, etc.  These might be better documented in a `Development.md` (or any other name we believe is reasonable) which would specifically be for developers making code contributions to the repo and would assist in helping users actually running Meteor from a checkout.

The initial straw-man proposal here is:

- [x] Move the "[Running Meteor tests](https://github.com/meteor/meteor/blob/devel/Contributing.md#running-tests-on-meteor-core)" section to this new document.
- [x] Move the "[Slow start for developers](https://github.com/meteor/meteor/#slow-start-for-developers)" section to this new document
- [x] Elaborate on different ways to run the tests
- [x] Explain how the current CI runs tests
- [x] Make it clear that tests don't work on Windows
- [x] Briefly provide links to different parts of the Meteor Build system which have documentation hiding in the code/repo (for example the `README` files of the various [packages](https://github.com/meteor/meteor/tree/devel/packages), or the [Isobuild README](https://github.com/meteor/meteor/blob/devel/tools/isobuild/README.md))
- [x] Add information on how to run your tests on your own CircleCI
- [x] Add information about the style expectations for new code

Contributing.md can then gain some additional information like where to find work:

- [x] Show `pull-requests-encouraged`
- [x] ~~Mention some "first contribution ideas" (style?)~~

There are a number of community contributors (myself included) who I think might have some great perspective on this ~~, so I'm tempted to start a PR with a blank `Development.md` and then~~ (**EDIT: I've done this, PRs welcome!**) and encourage contributors to submit a PR against _that_ PR so we can work through it.

Then again, if we just want to gather all the suggestions here and I can try to go at it in one caffeine-induced pass.

Thoughts?  What are we missing to make it easier to contribute here.

/cc Current issue triagers and recent/frequent contributors: @hwillson @mitar @laosb @dburles @merlinpatt @sebakerckhof @GeoffreyBooth @lucfranken 

Inspired by:
* https://forums.meteor.com/t/meteor-community-coding/31116
* https://forums.meteor.com/t/community-involvement-setup/29538/