### PR TITLE
Fix typo in coffeescript compiler options. Fixes #8281

### DIFF
--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -45,7 +45,7 @@ export class CoffeeCompiler extends CachingCompiler {
       // Return a source map.
       sourceMap: true,
       // Include the original source in the source map (sourcesContent field).
-      inline: true,
+      inlineMap: true,
       // This becomes the "file" field of the source map.
       generatedFile: '/' + this._outputFilePath(inputFile),
       // This becomes the "sources" field of the source map.


### PR DESCRIPTION
This change, suggested by @abernix, fixes an issue (see #8281) where CoffeeScript source maps were not being generated (they appeared as blank files in the browser sources panel).

It's worth noting that these source files move from `top -> 💻app -> packages` to `top -> localhost:XXXX -> packages` in the sources list when this patch is applied (presumably because CoffeeScript files are now also passed through Babel).
