### PR TITLE
CoffeeScript 1.12.3

### DIFF
--- a/packages/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
+++ b/packages/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "coffee-script": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.0.tgz",
-      "from": "coffee-script@1.12.0"
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.3.tgz",
+      "from": "coffee-script@1.12.3"
     },
     "source-map": {
       "version": "0.5.6",

--- a/packages/coffeescript/package.js
+++ b/packages/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.12.0_1"
+  version: "1.12.3_1"
 });
 
 Package.registerBuildPlugin({
@@ -8,7 +8,7 @@ Package.registerBuildPlugin({
   use: ['caching-compiler', 'ecmascript'],
   sources: ['plugin/compile-coffeescript.js'],
   npmDependencies: {
-    "coffee-script": "1.12.0",
+    "coffee-script": "1.12.3",
     "source-map": "0.5.6"
   }
 });

--- a/packages/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/coffeescript/plugin/compile-coffeescript.js
@@ -45,7 +45,7 @@ export class CoffeeCompiler extends CachingCompiler {
       // Return a source map.
       sourceMap: true,
       // Include the original source in the source map (sourcesContent field).
-      inline: true,
+      inlineMap: true,
       // This becomes the "file" field of the source map.
       generatedFile: '/' + this._outputFilePath(inputFile),
       // This becomes the "sources" field of the source map.


### PR DESCRIPTION
Bumps the `coffeescript` package to use CoffeeScript [1.12.3](http://coffeescript.org/#changelog), and includes #8285 (which worked when I tested it).