### PR TITLE
Added additional BrowserPolicy exports to help with ES2015 import support.

### DIFF
--- a/packages/browser-policy-content/browser-policy-content.js
+++ b/packages/browser-policy-content/browser-policy-content.js
@@ -50,6 +50,7 @@ var keywords = {
 // If false, we set the X-Content-Type-Options header to 'nosniff'.
 var contentSniffingAllowed = false;
 
+const BrowserPolicy = require("meteor/browser-policy-common").BrowserPolicy;
 BrowserPolicy.content = {};
 
 var parseCsp = function (csp) {
@@ -300,3 +301,5 @@ _.each(resources,  function (resource) {
 });
 
 setDefaultPolicy();
+
+exports.BrowserPolicy = BrowserPolicy;

--- a/packages/browser-policy-content/package.js
+++ b/packages/browser-policy-content/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   summary: "Configure content security policies",
-  version: "1.0.13-beta.1"
+  version: "1.1.0"
 });
 
 Package.onUse(function (api) {
-  api.imply(["browser-policy-common"], "server");
-  api.addFiles("browser-policy-content.js", "server");
+  api.use("modules");
   api.use(["underscore", "browser-policy-common", "webapp"], "server");
-  api.export('BrowserPolicy', 'server');
+  api.imply(["browser-policy-common"], "server");
+  api.mainModule("browser-policy-content.js", "server");
 });

--- a/packages/browser-policy-content/package.js
+++ b/packages/browser-policy-content/package.js
@@ -7,4 +7,5 @@ Package.onUse(function (api) {
   api.imply(["browser-policy-common"], "server");
   api.addFiles("browser-policy-content.js", "server");
   api.use(["underscore", "browser-policy-common", "webapp"], "server");
+  api.export('BrowserPolicy', 'server');
 });

--- a/packages/browser-policy-framing/browser-policy-framing.js
+++ b/packages/browser-policy-framing/browser-policy-framing.js
@@ -9,6 +9,7 @@
 var defaultXFrameOptions = "SAMEORIGIN";
 var xFrameOptions = defaultXFrameOptions;
 
+const BrowserPolicy = require("meteor/browser-policy-common").BrowserPolicy;
 BrowserPolicy.framing = {};
 
 _.extend(BrowserPolicy.framing, {
@@ -37,3 +38,5 @@ _.extend(BrowserPolicy.framing, {
     xFrameOptions = null;
   }
 });
+
+exports.BrowserPolicy = BrowserPolicy;

--- a/packages/browser-policy-framing/package.js
+++ b/packages/browser-policy-framing/package.js
@@ -7,4 +7,5 @@ Package.onUse(function (api) {
   api.imply(["browser-policy-common"], "server");
   api.use(["underscore", "browser-policy-common"], "server");
   api.addFiles("browser-policy-framing.js", "server");
+  api.export('BrowserPolicy', 'server');
 });

--- a/packages/browser-policy-framing/package.js
+++ b/packages/browser-policy-framing/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   summary: "Restrict which websites can frame your app",
-  version: "1.0.12"
+  version: "1.1.0"
 });
 
 Package.onUse(function (api) {
-  api.imply(["browser-policy-common"], "server");
+  api.use("modules");
   api.use(["underscore", "browser-policy-common"], "server");
-  api.addFiles("browser-policy-framing.js", "server");
-  api.export('BrowserPolicy', 'server');
+  api.imply(["browser-policy-common"], "server");
+  api.mainModule("browser-policy-framing.js", "server");
 });

--- a/packages/browser-policy/browser-policy.js
+++ b/packages/browser-policy/browser-policy.js
@@ -1,0 +1,1 @@
+exports.BrowserPolicy = require("meteor/browser-policy-common").BrowserPolicy;

--- a/packages/browser-policy/package.js
+++ b/packages/browser-policy/package.js
@@ -1,12 +1,13 @@
 Package.describe({
   summary: "Configure security policies enforced by the browser",
-  version: "1.0.10-beta.1"
+  version: "1.1.0"
 });
 
 Package.onUse(function (api) {
+  api.use('modules');
   api.use(['browser-policy-content', 'browser-policy-framing'], 'server');
   api.imply(['browser-policy-common'], 'server');
-  api.export('BrowserPolicy', 'server');
+  api.mainModule('browser-policy.js', 'server');
 });
 
 Package.onTest(function (api) {

--- a/packages/browser-policy/package.js
+++ b/packages/browser-policy/package.js
@@ -6,6 +6,7 @@ Package.describe({
 Package.onUse(function (api) {
   api.use(['browser-policy-content', 'browser-policy-framing'], 'server');
   api.imply(['browser-policy-common'], 'server');
+  api.export('BrowserPolicy', 'server');
 });
 
 Package.onTest(function (api) {


### PR DESCRIPTION
This PR is intended to help close issue #6766. Developers expect to be able to use the following import:

```
import { BrowserPolicy } from 'meteor/browser-policy';
```

but due to the way the `browser-policy*` family of packages are setup, actually have to use the following import:

```
import { BrowserPolicy } from 'meteor/browser-policy-common';
```

This PR re-exports the `BrowserPolicy` variable within each of the `browser-policy*` packages that can be used on their own:

- `browser-policy-content`
- `browser-policy-framing`
- `browser-policy`

This way each one of the following imports will work:

```js
import { BrowserPolicy } from 'meteor/browser-policy';
import { BrowserPolicy } from 'meteor/browser-policy-content';
import { BrowserPolicy } from 'meteor/browser-policy-framing';
```

Thanks!