### PR TITLE
Fix for issue 8309

### DIFF
--- a/packages/google-config-ui/google_configure.html
+++ b/packages/google-config-ui/google_configure.html
@@ -22,7 +22,7 @@
      Set Authorized Javascript Origins to: <span class="url">{{siteUrl}}</span>
     </li>
     <li>
-      Set Authorized Redirect URI to: <span class="url">{{siteUrl}}_oauth/google</span>
+      Set Authorized Redirect URI to: <span class="url">{{siteUrl}}/_oauth/google</span>
     </li>
     <li>
       Finish by clicking "Create".

--- a/packages/google-config-ui/google_configure.js
+++ b/packages/google-config-ui/google_configure.js
@@ -1,6 +1,10 @@
 Template.configureLoginServiceDialogForGoogle.helpers({
   siteUrl: function () {
-    return Meteor.absoluteUrl();
+    var url = Meteor.absoluteUrl();
+    if (url.slice(-1) === "/") {
+      url = url.slice(0,-1)
+    }
+    return url;
   }
 });
 


### PR DESCRIPTION
Issue https://github.com/meteor/meteor/issues/8309 is about a trailing / not being allowed by Google's OAuth registration form. This patch makes a quick change so the Meteor package google-config-ui shows a value for the OAuth origin that is copy-pasteable directly to Google. 

