### PR TITLE
Adjusted query string array representation to remove indices.

### DIFF
--- a/packages/url/package.js
+++ b/packages/url/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Utility code for constructing URLs",
-  version: "1.0.11"
+  version: "2.0.0"
 });
 
 Package.onUse(function(api) {

--- a/packages/url/url_common.js
+++ b/packages/url/url_common.js
@@ -8,9 +8,11 @@ var encodeString = function (str) {
 // arrays properly.
 URL._encodeParams = function (params, prefix) {
   var str = [];
+  var isParamsArray = Array.isArray(params);
   for (var p in params) {
     if (Object.prototype.hasOwnProperty.call(params, p)) {
-      var k = prefix ? prefix + '[' + p + ']' : p, v = params[p];
+      var k = prefix ? prefix + '[' + (isParamsArray ? '' : p) + ']' : p;
+      var v = params[p];
       if (typeof v === 'object') {
         str.push(this._encodeParams(v, k));
       } else {

--- a/packages/url/url_tests.js
+++ b/packages/url/url_tests.js
@@ -8,7 +8,7 @@ Tinytest.add('url - serializes params to query correctly', function (test) {
     hasOwnProperty: 'horrible param name',
   };
   var query =
-    'filter[type]=Foo&filter[id_eq]=15&array[0]=1&array[1]=a'
-    + '&array[2]=dirty%5B%5D&hasOwnProperty=horrible+param+name';
+    'filter[type]=Foo&filter[id_eq]=15&array[]=1&array[]=a'
+    + '&array[]=dirty%5B%5D&hasOwnProperty=horrible+param+name';
   test.equal(URL._encodeParams(hash), query);
 });


### PR DESCRIPTION
Hi guys - after some discussion about the implementation provided in PR #8261, it looks like we should adjust the implemented array handling a bit. Right now arrays are encoded with indices like:

```
some_array[0]=value1&some_array[1]=value2&some_array[2]=value3
```

While this implementation is somewhat supported by external languages and frameworks, it's not as well supported (by default) as the following query string representation for arrays:

```
some_array[]=value1&some_array[]=value2&some_array[]=value3
```

For example, PHP and Rails both expect **no indices** for arrays.

This PR adjusts the `url` package to make sure query string encoded arrays do not include indices. Thanks!