### PR TITLE
Upgrade Facebook Graph API to use v2.8

### DIFF
--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -1,7 +1,5 @@
 Facebook = {};
 
-var querystring = Npm.require('querystring');
-
 Facebook.handleAuthFromAccessToken = function handleAuthFromAccessToken(accessToken, expiresAt) {
   // include all fields from facebook
   // http://developers.facebook.com/docs/reference/login/public-profile-and-friend-list/
@@ -54,30 +52,21 @@ var getTokenResponse = function (query) {
   try {
     // Request an access token
     responseContent = HTTP.get(
-      "https://graph.facebook.com/v2.2/oauth/access_token", {
+      "https://graph.facebook.com/v2.8/oauth/access_token", {
         params: {
           client_id: config.appId,
           redirect_uri: OAuth._redirectUri('facebook', config),
           client_secret: OAuth.openSecret(config.secret),
           code: query.code
         }
-      }).content;
+      }).data;
   } catch (err) {
     throw _.extend(new Error("Failed to complete OAuth handshake with Facebook. " + err.message),
                    {response: err.response});
   }
 
-  // If 'responseContent' parses as JSON, it is an error.
-  // XXX which facebook error causes this behvaior?
-  if (isJSON(responseContent)) {
-    throw new Error("Failed to complete OAuth handshake with Facebook. " + responseContent);
-  }
-
-  // Success!  Extract the facebook access token and expiration
-  // time from the response
-  var parsedResponse = querystring.parse(responseContent);
-  var fbAccessToken = parsedResponse.access_token;
-  var fbExpires = parsedResponse.expires;
+  var fbAccessToken = responseContent.access_token;
+  var fbExpires = responseContent.expires_in;
 
   if (!fbAccessToken) {
     throw new Error("Failed to complete OAuth handshake with facebook " +
@@ -91,7 +80,7 @@ var getTokenResponse = function (query) {
 
 var getIdentity = function (accessToken, fields) {
   try {
-    return HTTP.get("https://graph.facebook.com/v2.4/me", {
+    return HTTP.get("https://graph.facebook.com/v2.8/me", {
       params: {
         access_token: accessToken,
         fields: fields


### PR DESCRIPTION
In testing for #7715, I discovered that the v2.2 Graph API endpoint was still in use in the `facebook` package which was due to sunset on 2017-03-25.

See Facebook Graph API Changelog here:
  https://developers.facebook.com/docs/apps/changelog

When a Graph API endpoint is sunset, it (is claimed) to automatically turn over to the next more recent version, in this case v2.3.

v2.3 has a breaking-change over v2.2, notably listed in "Changes from v2.2 to v2.3":

> [Oauth Access Token] Format - The response format of https://www.facebook.com/v2.3/oauth/access_token returned when you exchange a code for an access_token now return valid JSON instead of being URL encoded. The new format of this response is {"access_token": {TOKEN}, "token_type":{TYPE}, "expires_in":{TIME}}. We made this update to be compliant with section 5.1 of RFC 6749.

This change updates both Graph APIs to v2.8 which has LTS until "At least October 2018".