### PR TITLE
Extract new isPlainObject function from JQuery v3.1.1

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -126,6 +126,7 @@ jquery: https://github.com/jquery/jquery
 ----------
 
 Copyright (c) 2011 John Resig, http://jquery.com/
+Copyright JS Foundation and other contributors, https://js.foundation/
 
 
 ----------

--- a/packages/check/match_test.js
+++ b/packages/check/match_test.js
@@ -100,6 +100,10 @@ Tinytest.add("check - check", function (test) {
   fails({a: 1, b:2}, Match.ObjectIncluding({b: String}));
   fails({a: 1, b:2}, Match.ObjectIncluding({c: String}));
   fails({}, {a: Number});
+  matches({nodeType: 1}, {nodeType: Match.Any});
+  matches({nodeType: 1}, Match.ObjectIncluding({nodeType: Match.Any}));
+  fails({nodeType: 1}, {nodeType: String});
+  fails({}, Match.ObjectIncluding({nodeType: Match.Any}));
 
   // Match.Optional does not match on a null value, unless the allowed type is itself "null"
   fails(null, Match.Optional(String));


### PR DESCRIPTION
Update `isPlainObject` function used in `check` package to newer version. This new function is extracted from [JQuery v3.1.1 isPlainObject](https://github.com/jquery/jquery/blob/3.1.1/src/core.js#L238-L257).
I also add some tests to make sure it solve this issue #7354.