### PR TITLE
Fix comment about unordered imports

### DIFF
--- a/tools/isobuild/package-api.js
+++ b/tools/isobuild/package-api.js
@@ -127,9 +127,8 @@ _.extend(PackageAPI.prototype, {
   // options can include:
   //
   // - unordered: if true, don't require this package to load
-  //   before us -- just require it to be loaded anytime. Also
-  //   don't bring this package's imports into our
-  //   namespace. If false, override a true value specified in
+  //   before us -- just require it to be loaded anytime. If
+  //   false, override a true value specified in
   //   a previous call to use for this package name. (A
   //   limitation of the current implementation is that this
   //   flag is not tracked per-environment or per-role.)  This


### PR DESCRIPTION
Delete a misleading comment as discussed in https://github.com/meteor/meteor/issues/5279#issuecomment-146018275

Resolves #5279