### PR TITLE
Release 1.4.3.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,12 @@
 ## v.NEXT
 
+## v1.4.3.1
+
+* The `meteor-babel` npm package has been upgraded to version 0.14.4,
+  fixing [#8349](https://github.com/meteor/meteor/issues/8349).
+
+* The `reify` npm package has been upgraded to version 0.4.9.
+
 * Partial `npm-shrinkwrap.json` files are now disregarded when
   (re)installing npm dependencies of Meteor packages, fixing
   [#8349](https://github.com/meteor/meteor/issues/8349). Further

--- a/History.md
+++ b/History.md
@@ -13,7 +13,7 @@
   discussion of the new `npm` behavior can be found
   [here](https://github.com/npm/npm/blob/latest/CHANGELOG.md#no-more-partial-shrinkwraps-breaking).
 
-## v1.4.3
+## v1.4.3, 2017-02-13
 
 * Versions of Meteor [core
   packages](https://github.com/meteor/meteor/tree/release-1.4.3/packages)

--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 ## v.NEXT
 
+* Partial `npm-shrinkwrap.json` files are now disregarded when
+  (re)installing npm dependencies of Meteor packages, fixing
+  [#8349](https://github.com/meteor/meteor/issues/8349). Further
+  discussion of the new `npm` behavior can be found
+  [here](https://github.com/npm/npm/blob/latest/CHANGELOG.md#no-more-partial-shrinkwraps-breaking).
+
 ## v1.4.3
 
 * Versions of Meteor [core

--- a/History.md
+++ b/History.md
@@ -65,6 +65,10 @@
   npm package contains any `.node` files. Discussion
   [here](https://github.com/meteor/meteor/issues/8225#issuecomment-275044900).
 
+* The `meteor create` command now runs `meteor npm install` automatically
+  to install dependencies specified in the default `package.json` file.
+  [#8108](https://github.com/meteor/meteor/pull/8108)
+
 ## v1.4.2.7, 2017-02-13
 
 * The `npm` npm package has been *downgraded* from version 4.1.2 back to

--- a/History.md
+++ b/History.md
@@ -1,6 +1,6 @@
 ## v.NEXT
 
-## v1.4.3.1
+## v1.4.3.1, 2017-02-14
 
 * The `meteor-babel` npm package has been upgraded to version 0.14.4,
   fixing [#8349](https://github.com/meteor/meteor/issues/8349).

--- a/History.md
+++ b/History.md
@@ -54,6 +54,14 @@
   - [PR(`meetup`) #8321](https://github.com/meteor/meteor/pull/8321)
   - [PR(`weibo`) #8302](https://github.com/meteor/meteor/pull/8302)
 
+* The `url` and `http` packages now encode to a less error-prone
+  format which more closely resembles that used by PHP, Ruby, `jQuery.param`
+  and others. `Object`s and `Array`s can now be encoded, however, if you have
+  previously relied on `Array`s passed as `params` being simply `join`-ed with
+  commas, you may need to adjust your `HTTP.call` implementations.
+  [#8261](https://github.com/meteor/meteor/pull/8261) and
+  [#8342](https://github.com/meteor/meteor/pull/8342).
+
 * The `npm` npm package is still at version 4.1.2 (as it was when Meteor
   1.4.3 was originally published), even though `npm` was downgraded to
   3.10.9 in Meteor 1.4.2.7.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.7.11
+BUNDLE_VERSION=4.7.12
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -1,18 +1,18 @@
 {
   "dependencies": {
     "acorn": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "from": "acorn@>=3.3.0 <3.4.0"
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
+      "from": "acorn@>=4.0.5 <4.1.0"
     },
     "acorn-es7-plugin": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.3.tgz",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.5.tgz",
       "from": "acorn-es7-plugin@>=1.1.0 <1.2.0"
     },
     "ansi-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "from": "ansi-regex@>=2.0.0 <3.0.0"
     },
     "ansi-styles": {
@@ -21,83 +21,83 @@
       "from": "ansi-styles@>=2.2.1 <3.0.0"
     },
     "ast-types": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz",
-      "from": "ast-types@>=0.9.0 <0.10.0"
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.5.tgz",
+      "from": "ast-types@>=0.9.5 <0.10.0"
     },
     "babel-code-frame": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-      "from": "babel-code-frame@>=6.16.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "from": "babel-code-frame@>=6.22.0 <7.0.0"
     },
     "babel-core": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
+      "version": "6.22.1",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.22.1.tgz",
       "from": "babel-core@>=6.18.2 <7.0.0"
     },
     "babel-generator": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.19.0.tgz",
-      "from": "babel-generator@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.22.0.tgz",
+      "from": "babel-generator@>=6.22.0 <7.0.0"
     },
     "babel-helper-builder-react-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.18.0.tgz",
-      "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.22.0.tgz",
+      "from": "babel-helper-builder-react-jsx@>=6.22.0 <7.0.0"
     },
     "babel-helper-call-delegate": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
-      "from": "babel-helper-call-delegate@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz",
+      "from": "babel-helper-call-delegate@>=6.22.0 <7.0.0"
     },
     "babel-helper-define-map": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
-      "from": "babel-helper-define-map@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.22.0.tgz",
+      "from": "babel-helper-define-map@>=6.22.0 <7.0.0"
     },
     "babel-helper-function-name": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-      "from": "babel-helper-function-name@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.22.0.tgz",
+      "from": "babel-helper-function-name@>=6.22.0 <7.0.0"
     },
     "babel-helper-get-function-arity": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-      "from": "babel-helper-get-function-arity@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz",
+      "from": "babel-helper-get-function-arity@>=6.22.0 <7.0.0"
     },
     "babel-helper-hoist-variables": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
-      "from": "babel-helper-hoist-variables@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
+      "from": "babel-helper-hoist-variables@>=6.22.0 <7.0.0"
     },
     "babel-helper-optimise-call-expression": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
-      "from": "babel-helper-optimise-call-expression@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.22.0.tgz",
+      "from": "babel-helper-optimise-call-expression@>=6.22.0 <7.0.0"
     },
     "babel-helper-regex": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
-      "from": "babel-helper-regex@>=6.8.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
+      "from": "babel-helper-regex@>=6.22.0 <7.0.0"
     },
     "babel-helper-replace-supers": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
-      "from": "babel-helper-replace-supers@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.22.0.tgz",
+      "from": "babel-helper-replace-supers@>=6.22.0 <7.0.0"
     },
     "babel-helpers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-      "from": "babel-helpers@>=6.16.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.22.0.tgz",
+      "from": "babel-helpers@>=6.22.0 <7.0.0"
     },
     "babel-messages": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-      "from": "babel-messages@>=6.8.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz",
+      "from": "babel-messages@>=6.22.0 <7.0.0"
     },
     "babel-plugin-check-es2015-constants": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "from": "babel-plugin-check-es2015-constants@>=6.8.0 <7.0.0"
     },
     "babel-plugin-syntax-async-functions": {
@@ -126,144 +126,144 @@
       "from": "babel-plugin-syntax-object-rest-spread@>=6.13.0 <7.0.0"
     },
     "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "from": "babel-plugin-syntax-trailing-function-commas@>=6.13.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-arrow-functions@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-block-scoping@>=6.15.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-classes": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-computed-properties@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-for-of": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-for-of@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-literals": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-literals@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.18.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-object-super": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-object-super@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-parameters@>=6.17.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-spread": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-spread@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-sticky-regex@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-template-literals@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz",
       "from": "babel-plugin-transform-es2015-unicode-regex@>=6.11.0 <7.0.0"
     },
     "babel-plugin-transform-es3-property-literals": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.8.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
       "from": "babel-plugin-transform-es3-property-literals@>=6.8.0 <7.0.0"
     },
     "babel-plugin-transform-flow-strip-types": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "from": "babel-plugin-transform-flow-strip-types@>=6.14.0 <7.0.0"
     },
     "babel-plugin-transform-object-rest-spread": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.19.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.22.0.tgz",
       "from": "babel-plugin-transform-object-rest-spread@>=6.16.0 <7.0.0"
     },
     "babel-plugin-transform-react-display-name": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
-      "from": "babel-plugin-transform-react-display-name@>=6.3.13 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.22.0.tgz",
+      "from": "babel-plugin-transform-react-display-name@>=6.22.0 <7.0.0"
     },
     "babel-plugin-transform-react-jsx": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
-      "from": "babel-plugin-transform-react-jsx@>=6.3.13 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.22.0.tgz",
+      "from": "babel-plugin-transform-react-jsx@>=6.22.0 <7.0.0"
     },
     "babel-plugin-transform-react-jsx-self": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
-      "from": "babel-plugin-transform-react-jsx-self@>=6.11.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+      "from": "babel-plugin-transform-react-jsx-self@>=6.22.0 <7.0.0"
     },
     "babel-plugin-transform-react-jsx-source": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
-      "from": "babel-plugin-transform-react-jsx-source@>=6.3.13 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+      "from": "babel-plugin-transform-react-jsx-source@>=6.22.0 <7.0.0"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
       "from": "babel-plugin-transform-regenerator@>=6.16.1 <7.0.0"
     },
     "babel-plugin-transform-runtime": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.15.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.22.0.tgz",
       "from": "babel-plugin-transform-runtime@>=6.15.0 <7.0.0"
     },
     "babel-plugin-transform-strict-mode": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
-      "from": "babel-plugin-transform-strict-mode@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz",
+      "from": "babel-plugin-transform-strict-mode@>=6.22.0 <7.0.0"
     },
     "babel-preset-meteor": {
       "version": "6.14.0",
@@ -271,38 +271,38 @@
       "from": "babel-preset-meteor@6.14.0"
     },
     "babel-preset-react": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.22.0.tgz",
       "from": "babel-preset-react@>=6.16.0 <7.0.0"
     },
     "babel-register": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
-      "from": "babel-register@>=6.18.0 <7.0.0"
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.22.0.tgz",
+      "from": "babel-register@>=6.22.0 <7.0.0"
     },
     "babel-runtime": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
       "from": "babel-runtime@>=6.18.0 <7.0.0"
     },
     "babel-template": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
       "from": "babel-template@>=6.16.0 <7.0.0"
     },
     "babel-traverse": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
+      "version": "6.22.1",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
       "from": "babel-traverse@>=6.18.0 <7.0.0"
     },
     "babel-types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
       "from": "babel-types@>=6.18.0 <7.0.0"
     },
     "babylon": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz",
       "from": "babylon@>=6.13.1 <7.0.0"
     },
     "balanced-match": {
@@ -326,8 +326,8 @@
       "from": "concat-map@0.0.1"
     },
     "convert-source-map": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz",
       "from": "convert-source-map@>=1.3.0 <2.0.0"
     },
     "core-js": {
@@ -336,8 +336,8 @@
       "from": "core-js@>=2.4.0 <3.0.0"
     },
     "debug": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
       "from": "debug@>=2.1.1 <3.0.0"
     },
     "detect-indent": {
@@ -381,9 +381,9 @@
       "from": "is-finite@>=1.0.0 <2.0.0"
     },
     "js-tokens": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-      "from": "js-tokens@>=2.0.0 <3.0.0"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+      "from": "js-tokens@>=3.0.0 <4.0.0"
     },
     "jsesc": {
       "version": "1.3.0",
@@ -396,24 +396,24 @@
       "from": "json5@>=0.5.0 <0.6.0"
     },
     "lodash": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "from": "lodash@>=4.16.4 <5.0.0"
     },
     "loose-envify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "from": "loose-envify@>=1.0.0 <2.0.0"
     },
     "magic-string": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
-      "from": "magic-string@>=0.16.0 <0.17.0"
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.0.tgz",
+      "from": "magic-string@>=0.19.0 <0.20.0"
     },
     "meteor-babel": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.14.3.tgz",
-      "from": "meteor-babel@0.14.3"
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.14.4.tgz",
+      "from": "meteor-babel@0.14.4"
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",
@@ -461,8 +461,8 @@
       "from": "path-is-absolute@>=1.0.0 <2.0.0"
     },
     "private": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
       "from": "private@>=0.1.6 <0.2.0"
     },
     "regenerate": {
@@ -471,9 +471,14 @@
       "from": "regenerate@>=1.2.1 <2.0.0"
     },
     "regenerator-runtime": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-      "from": "regenerator-runtime@>=0.9.5 <0.10.0"
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
+      "from": "regenerator-runtime@>=0.10.0 <0.11.0"
+    },
+    "regenerator-transform": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
+      "from": "regenerator-transform@0.9.8"
     },
     "regexpu-core": {
       "version": "2.0.0",
@@ -498,9 +503,9 @@
       }
     },
     "reify": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.4.tgz",
-      "from": "reify@>=0.4.0 <0.5.0"
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.9.tgz",
+      "from": "reify@>=0.4.8 <0.5.0"
     },
     "repeating": {
       "version": "2.0.1",
@@ -518,8 +523,8 @@
       "from": "source-map@>=0.5.0 <0.6.0"
     },
     "source-map-support": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.11.tgz",
       "from": "source-map-support@>=0.4.2 <0.5.0"
     },
     "strip-ansi": {

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,11 +6,11 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.14.0'
+  version: '6.14.1'
 });
 
 Npm.depends({
-  'meteor-babel': '0.14.3'
+  'meteor-babel': '0.14.4'
 });
 
 Package.onUse(function (api) {

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.14.1-rc.0'
+  version: '6.14.1-rc.1'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.14.1-rc.1'
+  version: '6.14.1'
 });
 
 Npm.depends({

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.14.1'
+  version: '6.14.1-rc.0'
 });
 
 Npm.depends({

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.6.2',
+  version: '0.6.3-rc.1',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.6.3-rc.1',
+  version: '0.6.3',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.4.3'
+  version: '1.4.3-1-rc.0'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.4.3-1-rc.1'
+  version: '1.4.3_1'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.4.3-1-rc.0'
+  version: '1.4.3-1-rc.1'
 });
 
 Package.includeTool();

--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -1,29 +1,29 @@
 {
   "dependencies": {
     "acorn": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "from": "acorn@>=3.3.0 <3.4.0"
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
+      "from": "acorn@>=4.0.5 <4.1.0"
     },
     "acorn-es7-plugin": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.3.tgz",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.5.tgz",
       "from": "acorn-es7-plugin@>=1.1.0 <1.2.0"
     },
     "ast-types": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz",
-      "from": "ast-types@>=0.9.0 <0.10.0"
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.5.tgz",
+      "from": "ast-types@>=0.9.5 <0.10.0"
     },
     "magic-string": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
-      "from": "magic-string@>=0.16.0 <0.17.0"
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.0.tgz",
+      "from": "magic-string@>=0.19.0 <0.20.0"
     },
     "reify": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.4.tgz",
-      "from": "reify@0.4.4"
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.4.9.tgz",
+      "from": "reify@0.4.9"
     },
     "vlq": {
       "version": "0.2.1",

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: "0.7.9-rc.1",
+  version: "0.7.9",
   summary: "CommonJS module system",
   documentation: "README.md"
 });

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: "0.7.9-rc.0",
+  version: "0.7.9-rc.1",
   summary: "CommonJS module system",
   documentation: "README.md"
 });

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: "0.7.9",
+  version: "0.7.9-rc.0",
   summary: "CommonJS module system",
   documentation: "README.md"
 });

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   name: "modules",
-  version: "0.7.8",
+  version: "0.7.9",
   summary: "CommonJS module system",
   documentation: "README.md"
 });
 
 Npm.depends({
-  reify: "0.4.4"
+  reify: "0.4.9"
 });
 
 Package.onUse(function(api) {

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.4.3.1-rc.0",
+ "version": "1.4.3.1-rc.1",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.4.3-rc.6",
+ "version": "1.4.3.1-rc.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.4.3",
+  "version": "1.4.3.1",
   "recommended": false,
   "official": true,
   "description": "The Official Meteor Distribution"

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,7 +14,7 @@ var packageJson = {
     npm: "4.1.2",
     "node-gyp": "3.4.0",
     "node-pre-gyp": "0.6.30",
-    "meteor-babel": "0.14.3",
+    "meteor-babel": "0.14.4",
     "meteor-promise": "0.8.0",
     fibers: "1.0.15",
     promise: "7.1.1",


### PR DESCRIPTION
Whereas [Meteor 1.4.2.7](https://github.com/meteor/meteor/pull/8361) fixed #8349 by reverting `npm` from version 4.1.2 to version 3.10.9, this release fixes the same bug by keeping `npm@4.1.2` but dealing with the consequences of [this breaking change](https://github.com/npm/npm/blob/latest/CHANGELOG.md#no-more-partial-shrinkwraps-breaking).

This release will also fix #8312, which could have been fixed independently (since it involves only packages), but was easier to fix after fixing the problem described above.

Note that Meteor 1.4.3 has been published, but we have not (and will not) "recommend" it, because of the problem with upgrading npm dependencies of Meteor packages.