### PR TITLE
Replaced _.each with Object.keys().forEach to fix objects with length properties being used as Mongo selectors

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -378,7 +378,8 @@ Mongo.Collection._rewriteSelector = function (selector) {
     return {_id: Random.id()};
 
   var ret = {};
-  _.each(selector, function (value, key) {
+  Object.keys(selector).forEach((key) => {
+    const value = selector[key];
     // Mongo supports both {field: /foo/} and {field: {$regex: /foo/}}
     if (value instanceof RegExp) {
       ret[key] = convertRegexpToMongoSelector(value);
@@ -388,8 +389,7 @@ Mongo.Collection._rewriteSelector = function (selector) {
       // override the ones set on $regex.
       if (value.$options !== undefined)
         ret[key].$options = value.$options;
-    }
-    else if (_.contains(['$or','$and','$nor'], key)) {
+    } else if (_.contains(['$or','$and','$nor'], key)) {
       // Translate lower levels of $and/$or/$nor
       ret[key] = _.map(value, function (v) {
         return Mongo.Collection._rewriteSelector(v);

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -2198,6 +2198,18 @@ Tinytest.add('mongo-livedata - rewrite selector', function (test) {
   var oid = new Mongo.ObjectID();
   test.equal(Mongo.Collection._rewriteSelector(oid),
              {_id: oid});
+
+  // Make sure selectors with "length" properties are handled properly
+  // (verifies issue #8329 has been resolved).
+  const SomeSelector = function (length) {
+    this.length = length;
+  };
+  const length = 2;
+  const testSelector = new SomeSelector(length);
+  test.equal(
+    Mongo.Collection._rewriteSelector(testSelector),
+    { length }
+  );
 });
 
 testAsyncMulti('mongo-livedata - specified _id', [


### PR DESCRIPTION
Hi guys - this PR is intended to help address issue #8329. Objects that contain a `length` property are causing issues when passed into the [`Mongo.Collection._rewriteSelector`](https://github.com/meteor/meteor/blob/907e1d91833eace7e40cc1d796cc7f9d171ceab1/packages/mongo/collection.js#L365) function. This is because the `_rewriteSelector` function is making a `_.each` call that is inappropriately treating the incoming selector object as an array. This PR replaces the `_.each` call with a `Object.keys(selector).forEach` call, which properly handles objects that have `length` properties.

I've updated the issue with the full troubleshooting details. Standing by for feedback - thanks!