### PR TITLE
Remove jQuery from default dependencies.

### DIFF
--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -27,7 +27,6 @@ Package.onTest(function (api) {
   api.use('webapp', 'server');
   api.use('underscore');
   api.use('random');
-  api.use('jquery', 'client');
   api.use('http', ['client', 'server']);
   api.use('tinytest');
   api.use('test-helpers', ['client', 'server']);

--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -27,6 +27,7 @@ Package.onTest(function (api) {
   api.use('webapp', 'server');
   api.use('underscore');
   api.use('random');
+  api.use('jquery', 'client');
   api.use('http', ['client', 'server']);
   api.use('tinytest');
   api.use('test-helpers', ['client', 'server']);

--- a/tools/static-assets/skel-bare/.meteor/packages
+++ b/tools/static-assets/skel-bare/.meteor/packages
@@ -9,7 +9,6 @@ mobile-experience       # Packages for a great mobile UX
 mongo                   # The database Meteor supports right now
 blaze-html-templates    # Compile .html files into Meteor Blaze views
 reactive-var            # Reactive variable for tracker
-jquery                  # Helpful client-side library
 tracker                 # Meteor's client-side reactive programming library
 
 standard-minifier-css   # CSS minifier run for production mode

--- a/tools/static-assets/skel-full/.meteor/packages
+++ b/tools/static-assets/skel-full/.meteor/packages
@@ -9,7 +9,6 @@ mobile-experience       # Packages for a great mobile UX
 mongo                   # The database Meteor supports right now
 blaze-html-templates    # Compile .html files into Meteor Blaze views
 reactive-var            # Reactive variable for tracker
-jquery                  # Helpful client-side library
 tracker                 # Meteor's client-side reactive programming library
 
 standard-minifier-css   # CSS minifier run for production mode

--- a/tools/static-assets/skel/.meteor/packages
+++ b/tools/static-assets/skel/.meteor/packages
@@ -9,7 +9,6 @@ mobile-experience       # Packages for a great mobile UX
 mongo                   # The database Meteor supports right now
 blaze-html-templates@1.0.4 # Compile .html files into Meteor Blaze views
 reactive-var            # Reactive variable for tracker
-jquery                  # Helpful client-side library
 tracker                 # Meteor's client-side reactive programming library
 
 standard-minifier-css   # CSS minifier run for production mode


### PR DESCRIPTION
This pull request removes jQuery package from default project skeletons.
Also removes it from http package because it didn't use it at all.