### PR TITLE
Remove jQuery dependency from http package

### DIFF
--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -27,7 +27,6 @@ Package.onTest(function (api) {
   api.use('webapp', 'server');
   api.use('underscore');
   api.use('random');
-  api.use('jquery', 'client');
   api.use('http', ['client', 'server']);
   api.use('tinytest');
   api.use('test-helpers', ['client', 'server']);


### PR DESCRIPTION
This is to remove jQuery as a default dependency from `http` package, as a part of removing jQuery altogether as a default dependency from Meteor. See #8388 for more details.