### PR TITLE
Update the 1.4.2 release notes to clarify Cordova `buildNumber` changes.

### DIFF
--- a/History.md
+++ b/History.md
@@ -306,9 +306,9 @@
   declarations. [#7818](https://github.com/meteor/meteor/pull/7818)
 
 * Due to changes in how Cordova generates version numbers for iOS and Android
-  apps, you may experience issues with apps updates on user devices.  To avoid
+  apps, you may experience issues with apps updating on user devices.  To avoid
   this, consider managing the `buildNumber` manually using
-  `App.info('buildNumber', 'XXX');` in `mobile-config.js. There are additional
+  `App.info('buildNumber', 'XXX');` in `mobile-config.js`. There are additional
   considerations if you have been setting `android:versionCode` or
   `ios-CFBundleVersion`.  See
   [#7205](https://github.com/meteor/meteor/issues/7205) and

--- a/History.md
+++ b/History.md
@@ -305,6 +305,15 @@
 * The `coffeescript` package now natively supports `import` and `export`
   declarations. [#7818](https://github.com/meteor/meteor/pull/7818)
 
+* Due to changes in how Cordova generates version numbers for iOS and Android
+  apps, you may experience issues with apps updates on user devices.  To avoid
+  this, consider managing the `buildNumber` manually using
+  `App.info('buildNumber', 'XXX');` in `mobile-config.js. There are additional
+  considerations if you have been setting `android:versionCode` or
+  `ios-CFBundleVersion`.  See
+  [#7205](https://github.com/meteor/meteor/issues/7205) and
+  [#6978](https://github.com/meteor/meteor/issues/6978) for more information.
+
 ## v1.4.1.3, 2016-10-21
 
 * Node has been updated to version 4.6.1:


### PR DESCRIPTION
Cordova was updated to 6.2.0 in Meteor 1.4.2 and Cordova (itself) changed the way the `buildNumber` was generated.  Some users experienced problems with the various app stores having version number clashes due to this change but Cordova insists it was mandatory.

This was brought up in a discussion on https://github.com/meteor/meteor/issues/7205.

Resolves https://github.com/meteor/meteor/issues/7205

Not sure if I should `git cherry-pick` this into `release-1.4.2` for prosperities sake or not, but happy to do so (if it won't break any of our versioning history).

Resolves #7205 