### PR TITLE
fix for #8160 Part 2

### DIFF
--- a/packages/observe-sequence/observe_sequence.js
+++ b/packages/observe-sequence/observe_sequence.js
@@ -94,7 +94,7 @@ ObserveSequence = {
 
         if (!seq) {
           seqArray = seqChangedToEmpty(lastSeqArray, callbacks);
-        } else if (_.isArray(seq)) {
+        } else if (seq instanceof Array || _.isArray(seq)) {
           seqArray = seqChangedToArray(lastSeqArray, seq, callbacks);
         } else if (isStoreCursor(seq)) {
           var result /* [seqArray, activeObserveHandle] */ =
@@ -126,7 +126,7 @@ ObserveSequence = {
   fetch: function (seq) {
     if (!seq) {
       return [];
-    } else if (_.isArray(seq)) {
+    } else if (seq instanceof Array || _.isArray(seq)) {
       return seq;
     } else if (isStoreCursor(seq)) {
       return seq.fetch();


### PR DESCRIPTION
@ManuelDeLeon, discovered a flaw with PR https://github.com/meteor/meteor/pull/8166 which is a fix for #8160.  It did not work for sub-classes of an Array.

Changed all instances of checking the array to be `seq instanceof Array || _.isArray(seq)`.

Passes all observe-sequence tests.

**PS** : I thought I would add a test for a sub-classed array.  But, whoa!  It is hard to [sub-class an array](http://perfectionkills.com/how-ecmascript-5-still-does-not-allow-to-subclass-an-array/) in javascript.  Coffeescript makes it easy apparently and the [viewmodel](https://github.com/ManuelDeLeon/viewmodel) package uses Coffeescript.