### PR TITLE
Improvement facebook-oauth with clientId

### DIFF
--- a/packages/facebook-oauth/facebook_client.js
+++ b/packages/facebook-oauth/facebook_client.js
@@ -31,7 +31,7 @@ Facebook.requestCredential = function (options, credentialRequestCompleteCallbac
   var loginStyle = OAuth._loginStyle('facebook', config, options);
 
   var loginUrl =
-        'https://www.facebook.com/v2.2/dialog/oauth?client_id=' + config.appId +
+        'https://www.facebook.com/v2.2/dialog/oauth?client_id=' + (config.appId || config.clientId) +
         '&redirect_uri=' + OAuth._redirectUri('facebook', config) +
         '&display=' + display + '&scope=' + scope +
         '&state=' + OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl);


### PR DESCRIPTION
For better development with multi Oauth Login we could alleviate the pain for developers with **clientId** instead of **appId** for facebook-oauth package while maintaining the ability to use **appId**

Refers to : 
- PR https://github.com/meteor/meteor/pull/8384
- Issue https://github.com/meteor/meteor/issues/8381
