### PR TITLE
Export "app"

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -788,6 +788,7 @@ var runWebAppServer = function () {
     connectHandlers: packageAndAppHandlers,
     rawConnectHandlers: rawConnectHandlers,
     httpServer: httpServer,
+    connectMiddleware: app,
     // For testing.
     suppressConnectErrors: function () {
       suppressConnectErrors = true;

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -788,7 +788,7 @@ var runWebAppServer = function () {
     connectHandlers: packageAndAppHandlers,
     rawConnectHandlers: rawConnectHandlers,
     httpServer: httpServer,
-    connectMiddleware: app,
+    connectApp: app,
     // For testing.
     suppressConnectErrors: function () {
       suppressConnectErrors = true;


### PR DESCRIPTION
As per the comment on line 653, this appears to be the best (only?) way to let users do things like set up a custom error page to catch app-rendering-time exceptions.

This purports to solve [#8402](https://github.com/meteor/meteor/issues/8402)

