### PR TITLE
Improve minifiers to capture error from UglifyJS.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## v.NEXT
 
+* The `standard-minifier-js` and `minifier-js` packages now have improved
+  error capturing to provide more information on otherwise unhelpful errors
+  thrown when UglifyJS encounters ECMAScript grammar it is not familiar with.
+  [#8414](https://github.com/meteor/meteor/pull/8414)
+
 ## v1.4.3.1, 2017-02-14
 
 * The `meteor-babel` npm package has been upgraded to version 0.14.4,

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -12,7 +12,6 @@ Npm.strip({
 });
 
 Package.onUse(function (api) {
-  api.use('underscore', 'server');
   api.export(['UglifyJSMinify', 'UglifyJS']);
   api.addFiles(['minifier.js'], 'server');
 });

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "1.2.17"
+  version: "1.2.18"
 });
 
 Npm.depends({

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "1.2.18-beta.0"
+  version: "1.2.18"
 });
 
 Npm.depends({

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "1.2.18"
+  version: "1.2.18-beta.0"
 });
 
 Npm.depends({

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '1.2.2',
+  version: '1.2.3',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md'
 });

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "minifyStdJS",
   use: [
-    'minifier-js'
+    'minifier-js@1.2.18-beta.0'
   ],
   sources: [
     'plugin/minify-js.js'

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '1.2.3',
+  version: '1.2.3-beta.0',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md'
 });

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '1.2.3-beta.0',
+  version: '1.2.3',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md'
 });
@@ -8,7 +8,7 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "minifyStdJS",
   use: [
-    'minifier-js@1.2.18-beta.0'
+    'minifier-js@1.2.18'
   ],
   sources: [
     'plugin/minify-js.js'

--- a/packages/standard-minifier-js/plugin/minify-js.js
+++ b/packages/standard-minifier-js/plugin/minify-js.js
@@ -94,8 +94,7 @@ UglifyJSMinifier.prototype.processFilesForBundle = function (files, options) {
             // So in that case, 2 lines back is the file path.
             var parseErrorPath = contents[c - 2]
               .substring(3)
-              .replace(/\s+\/\//, "")
-            ;
+              .replace(/\s+\/\//, "");
 
             var minError = new Error(
               "UglifyJS minification error: \n\n" +

--- a/packages/standard-minifier-js/plugin/minify-js.js
+++ b/packages/standard-minifier-js/plugin/minify-js.js
@@ -121,7 +121,7 @@ UglifyJSMinifier.prototype.processFilesForBundle = function (files, options) {
       var minified;
       try {
         minified = UglifyJSMinify(file.getContentsAsString(), minifyOptions);
-        if (! minified.code) {
+        if (!(minified && typeof minified.code === "string")) {
           throw new Error();
         }
       } catch (err) {

--- a/packages/standard-minifier-js/plugin/minify-js.js
+++ b/packages/standard-minifier-js/plugin/minify-js.js
@@ -32,13 +32,110 @@ UglifyJSMinifier.prototype.processFilesForBundle = function (files, options) {
     }
   };
 
+  function maybeThrowMinifyErrorBySourceFile(error, file) {
+    var minifierErrorRegex = /\(line: (\d+), col: (\d+), pos: (\d+)\)/;
+    var parseError = minifierErrorRegex.exec(error.toString());
+
+    if (parseError) {
+      var lineErrorMessage = parseError[0];
+      var lineErrorLineNumber = parseError[1];
+
+      var parseErrorContentIndex = lineErrorLineNumber - 1;
+
+      // Unlikely, since we have a multi-line fixed header in this file.
+      if (parseErrorContentIndex < 0) {
+        return;
+      }
+
+      /*
+
+      What we're parsing looks like this:
+
+      /////////////////////////////////////////
+      //                                     //
+      // path/to/file.js                     //
+      //                                     //
+      /////////////////////////////////////////
+                                             // 1
+         var illegalECMAScript = true;       // 2
+                                             // 3
+      /////////////////////////////////////////
+
+      Btw, the above code is intentionally not newer ECMAScript so
+      we don't break ourselves.
+
+      */
+
+      var contents = file.getContentsAsString().split(/\n/);
+      var lineContent = contents[parseErrorContentIndex];
+
+      // Try to grab the line number, which sometimes doesn't exist on
+      // line, abnormally-long lines in a larger block.
+      var lineSrcLineParts = /^(.*?)(?:\s*\/\/ (\d+))?$/.exec(lineContent);
+
+      // The line didn't match at all?  Let's just not try.
+      if (!lineSrcLineParts) {
+        return;
+      }
+
+      var lineSrcLineContent = lineSrcLineParts[1];
+      var lineSrcLineNumber = lineSrcLineParts[2];
+
+      // Count backward from the failed line to find the filename.
+      for (var c = parseErrorContentIndex - 1; c >= 0; c--) {
+        var sourceLine = contents[c];
+
+        // If the line is a boatload of slashes, we're in the right place.
+        if (/^\/\/\/{6,}$/.test(sourceLine)) {
+
+          // If 4 lines back is the same exact line, we've found the framing.
+          if (contents[c - 4] === sourceLine) {
+
+            // So in that case, 2 lines back is the file path.
+            var parseErrorPath = contents[c - 2]
+              .substring(3)
+              .replace(/\s+\/\//, "")
+            ;
+
+            var minError = new Error(
+              "UglifyJS minification error: \n\n" +
+              error.message + " at " + parseErrorPath +
+              (lineSrcLineNumber ? " line " + lineSrcLineNumber + "\n\n" : "") +
+              " within " + file.getPathInBundle() + " " +
+              lineErrorMessage + ":\n\n" +
+              lineSrcLineContent + "\n"
+            );
+
+            throw minError;
+          }
+        }
+      }
+    }
+  }
+
   var allJs = '';
   files.forEach(function (file) {
     // Don't reminify *.min.js.
     if (/\.min\.js$/.test(file.getPathInBundle())) {
       allJs += file.getContentsAsString();
     } else {
-      allJs += UglifyJSMinify(file.getContentsAsString(), minifyOptions).code;
+      var minified;
+      try {
+        minified = UglifyJSMinify(file.getContentsAsString(), minifyOptions);
+        if (! minified.code) {
+          throw new Error();
+        }
+      } catch (err) {
+        var filePath = file.getPathInBundle();
+
+        // Try to catch the ugly Uglify error.
+        maybeThrowMinifyErrorBySourceFile(err, file);
+
+        err.message += " while minifying " + filePath;
+        throw err;
+      }
+
+      allJs += minified.code;
     }
     allJs += '\n\n';
 
@@ -49,5 +146,3 @@ UglifyJSMinifier.prototype.processFilesForBundle = function (files, options) {
     files[0].addJavaScript({ data: allJs });
   }
 };
-
-


### PR DESCRIPTION
This is a stop-gap until #8378 is complete.

The error messages which come from UglifyJS tend to be quite cryptic, as
seen in issues like meteor/meteor#8370 or meteor/meteor#8020.  The file,
line, and column are provided, however the message is garbled and the
stacktrace long and acutely harrowing.  Since these errors are occurring
on automatically concatenated files, even the line number is sometimes
not helpful.  Additionally, sourceMaps are not available in production
builds, intentionally.  (I wasn't able to access them from
`file.getSourceMap()` or `file.sourceMap` at all.)

In addition to actually providing the name of the encapsulating file,
which provides _some_visibility, this commit implements a parser around
the UglifyJS error which detects the error and location information of
the error, seeks to the line in the concatenated source, reads the
inline filename, and provides it in the output.

Crude, but incredibly helpful in diagnosing this problem until a better
solution is reached.