### PR TITLE
Purpose readme contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Meteor
+![Imgur](http://i.imgur.com/XwTwNPJ.png)
 
 [![TravisCI Status](https://travis-ci.org/meteor/meteor.svg?branch=devel)](https://travis-ci.org/meteor/meteor)
 [![CircleCI Status](https://circleci.com/gh/meteor/meteor/tree/devel.svg?style=shield&circle-token=c2d3c041506bd493ef3795ffa4448684cfce97b8)](https://circleci.com/gh/meteor/meteor/tree/devel)
@@ -24,11 +24,11 @@ Meteor is an open-source, production-ready, real-time full-stack web application
 
 Meteor has isomorphic APIs. This means that Meteor uses the same methods that work on the server to work on the client. Meteor makes it easier for an entire full-stack app to be built by only one developer, or for a team to easily collaborate and understand code across a project.
 
-##### Cross-Platform Code (Android, iOS, Web) 
+#### Cross-Platform Code (Android, iOS, Web) 
 
 Meteor allows for very rapid prototyping and produces cross-platform code for apps to run on the web, Android, and iOS. 
 
-##### Develop With One Language
+#### Develop With One Language
 
 Web developers often need to know different technologies and may become frustrated when working on the front-end, back-end, or the database. With Meteor, you can build and manage them all with JavaScript. 
 
@@ -42,10 +42,10 @@ Development using JavaScript in all environments:
 
 The default database already included in Meteor is the [MongoDB](https://github.com/mongodb/mongo) database, but there are alternatives:
 
-- [meteor-pg](https://github.com/Richie765/meteor-pg) - PostgreSQL
-- [numtel:pg](https://github.com/numtel/meteor-pg) - Reactive PostgreSQL 
-- [numtel:mysql](https://github.com/numtel/meteor-mysql) - Reactive MySQL
-- [simple:rethink](https://github.com/Slava/meteor-rethinkdb) - RethinkDB
+- [PostgreSQL](https://github.com/Richie765/meteor-pg)  
+- [Reactive PostgreSQL](https://github.com/numtel/meteor-pg)  
+- [Reactive MySQL](https://github.com/numtel/meteor-mysql) 
+- [RethinkDB](https://github.com/Slava/meteor-rethinkdb)  
 
 
 ### Meteor Works in Real-time
@@ -64,7 +64,7 @@ As part of Meteor's security, it uses the publish-subscribe messaging pattern to
 
 Meteor Galaxy is the cloud service platform for operating and managing Meteor applications. It offers a free [hosting](https://www.meteor.com/galaxy/signup) option for simple apps, smaller plans for projects that are not commercial level, and paid options for business plans.   
 
-##### Deploying Meteor Applications
+#### Deploying Meteor Applications
 
 Meteor Web Apps can be deployed using <code>meteor deploy</code>, and you can run as many copies of your app as you need. Features to manage your apps include application logs and SSL cert management. 
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ With Meteor you write apps:
 * that send data over the wire, rather than HTML
 * using your choice of popular open-source libraries
 
-Try the getting started [tutorial](https://www.meteor.com/try).
-
-Next, read the [guide](http://guide.meteor.com) or the reference documentation at http://docs.meteor.com/.
-
 ## What to Use Meteor.js for and When to Use It
 
 Meteor is an open-source, production-ready, real-time full-stack web application framework written using [Node.js](https://github.com/nodejs/node). Meteor takes the hard and complicated parts of building an app and puts them into an open-source platform to help developers focus on what's most important to them in order to get their apps built much faster.  
@@ -32,7 +28,7 @@ Meteor allows for very rapid prototyping and produces cross-platform code for ap
 
 Web developers often need to know different technologies and may become frustrated when working on the front-end, back-end, or the database. With Meteor, you can build and manage them all with JavaScript. 
 
-Development using JavaScript in all environments: 
+Develope with JavaScript in any environment: 
 
 - The application server
 - The web browser
@@ -40,7 +36,7 @@ Development using JavaScript in all environments:
 
 #### Databases
 
-The default database already included in Meteor is the [MongoDB](https://github.com/mongodb/mongo) database, but there are alternatives:
+The default database for Meteor is the [MongoDB](https://github.com/mongodb/mongo) database, but there are alternatives:
 
 - [PostgreSQL](https://github.com/Richie765/meteor-pg)  
 - [Reactive PostgreSQL](https://github.com/numtel/meteor-pg)  
@@ -50,7 +46,7 @@ The default database already included in Meteor is the [MongoDB](https://github.
 
 ### Meteor Works in Real-time
 
-Meteor will automatically update Apps and all client web browsers whenever files are changed and saved. When the database is updated, the data in your templates is updated. There's no need to reload pages in the browser because Meteor hot-pushes the changes out to the browser. This is what Meteor does when it *"sends data over the wire"*.
+Meteor will automatically update Apps and all client web browsers whenever files are changed and saved. When the database is updated, the data in your templates are updated. There's no need to reload pages in the browser because Meteor hot-pushes the changes out to the browser. This is what Meteor does when it *"sends data over the wire"*.
 
 The web is moving towards real-time Apps that work almost instantly. Users expect that when they click a button, change their settings, log out, or even when they submit forms, for the action to occur immediately. 
 
@@ -58,7 +54,7 @@ The web is moving towards real-time Apps that work almost instantly. Users expec
 
 The Meteor JavaScript framework created and uses DDP. A client-server protocol for querying and updating a server-side database. It synchronizes these updates among clients by using the [publish-subscribe](https://www.meteor.com/tutorials/blaze/publish-and-subscribe) messaging pattern. 
 
-As part of Meteor's security, it uses the publish-subscribe messaging pattern to control how privacy-sensitive data is stored and what is sent to the client-side database by the server. The functions in Meteor that do this are <code>Meteor.publish</code> and <code>Meteor.subscribe</code>.   
+As part of Meteor's security, it uses the publish-subscribe messaging pattern to control how privacy-sensitive data is stored and what is sent to the client-side database from the server. The functions in Meteor that do this are <code>Meteor.publish</code> and <code>Meteor.subscribe</code>.   
 
 ### Galaxy
 
@@ -69,6 +65,10 @@ Meteor Galaxy is the cloud service platform for operating and managing Meteor ap
 Meteor Web Apps can be deployed using <code>meteor deploy</code>, and you can run as many copies of your app as you need. Features to manage your apps include application logs and SSL cert management. 
 
 **Note:** Since updates are pushed right out to the clients by the server, it's important to test all changes made beforehand, because your users may end up experiencing major problems, or even data corruption.
+
+Try the getting started [tutorial](https://www.meteor.com/try).
+
+Next, read the [guide](http://guide.meteor.com) or the reference documentation at http://docs.meteor.com/.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,60 @@ Try the getting started [tutorial](https://www.meteor.com/try).
 
 Next, read the [guide](http://guide.meteor.com) or the reference documentation at http://docs.meteor.com/.
 
+## What to Use Meteor.js for and When to Use It
+
+Meteor is an open-source, production-ready, real-time full-stack web application framework written using [Node.js](https://github.com/nodejs/node). Meteor takes the hard and complicated parts of building an app and puts them into an open-source platform to help developers focus on what's most important to them in order to get their apps built much faster.  
+
+### Optimized for Developers  
+
+Meteor has isomorphic APIs. This means that Meteor uses the same methods that work on the server to work on the client. Meteor makes it easier for an entire full-stack app to be built by only one developer, or for a team to easily collaborate and understand code across a project.
+
+##### Cross-Platform Code (Android, iOS, Web) 
+
+Meteor allows for very rapid prototyping and produces cross-platform code for apps to run on the web, Android, and iOS. 
+
+##### Develop With One Language
+
+Web developers often need to know different technologies and may become frustrated when working on the front-end, back-end, or the database. With Meteor, you can build and manage them all with JavaScript. 
+
+Development using JavaScript in all environments: 
+
+- The application server
+- The web browser
+- On mobile devices
+
+#### Databases
+
+The default database already included in Meteor is the [MongoDB](https://github.com/mongodb/mongo) database, but there are alternatives:
+
+- [meteor-pg](https://github.com/Richie765/meteor-pg) - PostgreSQL
+- [numtel:pg](https://github.com/numtel/meteor-pg) - Reactive PostgreSQL 
+- [numtel:mysql](https://github.com/numtel/meteor-mysql) - Reactive MySQL
+- [simple:rethink](https://github.com/Slava/meteor-rethinkdb) - RethinkDB
+
+
+### Meteor Works in Real-time
+
+Meteor will automatically update Apps and all client web browsers whenever files are changed and saved. When the database is updated, the data in your templates is updated. There's no need to reload pages in the browser because Meteor hot-pushes the changes out to the browser. This is what Meteor does when it *"sends data over the wire"*.
+
+The web is moving towards real-time Apps that work almost instantly. Users expect that when they click a button, change their settings, log out, or even when they submit forms, for the action to occur immediately. 
+
+#### Distributed Data Protocol (DDP)
+
+The Meteor JavaScript framework created and uses DDP. A client-server protocol for querying and updating a server-side database. It synchronizes these updates among clients by using the [publish-subscribe](https://www.meteor.com/tutorials/blaze/publish-and-subscribe) messaging pattern. 
+
+As part of Meteor's security, it uses the publish-subscribe messaging pattern to control how privacy-sensitive data is stored and what is sent to the client-side database by the server. The functions in Meteor that do this are <code>Meteor.publish</code> and <code>Meteor.subscribe</code>.   
+
+### Galaxy
+
+Meteor Galaxy is the cloud service platform for operating and managing Meteor applications. It offers a free [hosting](https://www.meteor.com/galaxy/signup) option for simple apps, smaller plans for projects that are not commercial level, and paid options for business plans.   
+
+##### Deploying Meteor Applications
+
+Meteor Web Apps can be deployed using <code>meteor deploy</code>, and you can run as many copies of your app as you need. Features to manage your apps include application logs and SSL cert management. 
+
+**Note:** Since updates are pushed right out to the clients by the server, it's important to test all changes made beforehand, because your users may end up experiencing major problems, or even data corruption.
+
 ## Quick Start
 
 On Windows, simply go to https://www.meteor.com/install and use the Windows installer.


### PR DESCRIPTION
 To make Meteor more approachable to a larger number of users—from informed developers to curious passersby and new and interested visitors—I have added a new section to the Meteor README. The section is entitled What to Use Meteor for and When to Use It. As the name suggests, the new section, explains in plain and straightforward language what Meteor is used for and when one should use it.

Other repositories may begin to use this new informative and catchy section soon, as my colleagues contact open-source technologies in an effort to make them more accessible to the tens of thousands of new users learning to code and thousands joining GitHub every day. 