### PR TITLE
Prevent accounts configuration UI warning from showing when using service-configuration.

### DIFF
--- a/packages/accounts-facebook/notice.js
+++ b/packages/accounts-facebook/notice.js
@@ -1,4 +1,6 @@
-if (Package['accounts-ui'] && !Package.hasOwnProperty('facebook-config-ui')) {
+if (Package['accounts-ui']
+    && !Package['service-configuration']
+    && !Package.hasOwnProperty('facebook-config-ui')) {
   console.warn(
     "Note: You're using accounts-ui and accounts-facebook,\n" +
     "but didn't install the configuration UI for the Facebook\n" +

--- a/packages/accounts-github/notice.js
+++ b/packages/accounts-github/notice.js
@@ -1,4 +1,6 @@
-if (Package['accounts-ui'] && !Package.hasOwnProperty('github-config-ui')) {
+if (Package['accounts-ui']
+    && !Package['service-configuration']
+    && !Package.hasOwnProperty('github-config-ui')) {
   console.warn(
     "Note: You're using accounts-ui and accounts-github,\n" +
     "but didn't install the configuration UI for the GitHub\n" +

--- a/packages/accounts-google/notice.js
+++ b/packages/accounts-google/notice.js
@@ -1,4 +1,6 @@
-if (Package['accounts-ui'] && !Package.hasOwnProperty('google-config-ui')) {
+if (Package['accounts-ui']
+    && !Package['service-configuration']
+    && !Package.hasOwnProperty('google-config-ui')) {
   console.warn(
     "Note: You're using accounts-ui and accounts-google,\n" +
     "but didn't install the configuration UI for the Google\n" +

--- a/packages/accounts-meetup/notice.js
+++ b/packages/accounts-meetup/notice.js
@@ -1,4 +1,6 @@
-if (Package['accounts-ui'] && !Package.hasOwnProperty('meetup-config-ui')) {
+if (Package['accounts-ui']
+    && !Package['service-configuration']
+    && !Package.hasOwnProperty('meetup-config-ui')) {
   console.warn(
     "Note: You're using accounts-ui and accounts-meetup,\n" +
     "but didn't install the configuration UI for the Meetup\n" +

--- a/packages/accounts-meteor-developer/notice.js
+++ b/packages/accounts-meteor-developer/notice.js
@@ -1,4 +1,5 @@
 if (Package['accounts-ui']
+    && !Package['service-configuration']
     && !Package.hasOwnProperty('meteor-developer-config-ui')) {
   console.warn(
     "Note: You're using accounts-ui and accounts-meteor-developer,\n" +

--- a/packages/accounts-twitter/notice.js
+++ b/packages/accounts-twitter/notice.js
@@ -1,4 +1,6 @@
-if (Package['accounts-ui'] && !Package.hasOwnProperty('twitter-config-ui')) {
+if (Package['accounts-ui']
+    && !Package['service-configuration']
+    && !Package.hasOwnProperty('twitter-config-ui')) {
   console.warn(
     "Note: You're using accounts-ui and accounts-twitter,\n" +
     "but didn't install the configuration UI for Twitter\n" +

--- a/packages/accounts-weibo/notice.js
+++ b/packages/accounts-weibo/notice.js
@@ -1,4 +1,6 @@
-if (Package['accounts-ui'] && !Package.hasOwnProperty('weibo-config-ui')) {
+if (Package['accounts-ui']
+    && !Package['service-configuration']
+    && !Package.hasOwnProperty('weibo-config-ui')) {
   console.warn(
     "Note: You're using accounts-ui and accounts-weibo,\n" +
     "but didn't install the configuration UI for the Weibo\n" +


### PR DESCRIPTION
Hi guys - this PR is intended to help address issue #8366. We shouldn't be showing the "you didn't install the accounts configuration UI" warning if an app is already using `service-configuration`. Thanks!