### PR TITLE
Remove `meteor npm install` instruction

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -772,11 +772,6 @@ main.registerCommand({
   }
 
   Console.info(
-    Console.command("meteor npm install"),
-    Console.options({ indent: 2 }),
-  );
-
-  Console.info(
     Console.command("meteor"), Console.options({ indent: 2 }));
 
   Console.info("");


### PR DESCRIPTION
As of #8108, `meteor create` runs `meteor npm install`, so it doesn't need to tell you do to do so.