### PR TITLE
Remove version constraint from `standard-minifier-js`.

### DIFF
--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "minifyStdJS",
   use: [
-    'minifier-js@1.2.18'
+    'minifier-js'
   ],
   sources: [
     'plugin/minify-js.js'


### PR DESCRIPTION
This was only intended to be there during the publishing of
`standard-minifier-js` as part of meteor/meteor#8414 and is normally
not necessary as part of the `meteor publish-release` process.