### PR TITLE
Remove version constraint from minifier-css in standard-minifier-css.

### DIFF
--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "minifyStdCSS",
   use: [
-    'minifier-css@1.2.14'
+    'minifier-css'
   ],
   npmDependencies: {
     "source-map": "0.5.6",

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.3.3',
+  version: '1.3.4',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });


### PR DESCRIPTION
It appears that an older version constraint was left in place during the publishing of `standard-minifier-css` which prevented it from getting the fixes included in https://github.com/meteor/meteor/pull/8048.

Since packages which depend on compiler plugins have their compiler built into them, this has prevented the new version from being released as was planned in ~#7523~ #8048.

This was mentioned in https://github.com/meteor/meteor/issues/7523#issuecomment-280930819

/cc @jeanfredrik