### PR TITLE
Adjusted force-ssl to work with the forwarded header (RFC 7239).

### DIFF
--- a/packages/force-ssl-common/.npm/package/.gitignore
+++ b/packages/force-ssl-common/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/force-ssl-common/.npm/package/README
+++ b/packages/force-ssl-common/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/force-ssl-common/.npm/package/npm-shrinkwrap.json
+++ b/packages/force-ssl-common/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,254 @@
+{
+  "dependencies": {
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "from": "arr-diff@>=2.0.0 <3.0.0"
+    },
+    "arr-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+      "from": "arr-flatten@>=1.0.1 <2.0.0"
+    },
+    "arr-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+      "from": "arr-map@>=2.0.0 <3.0.0"
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "from": "array-unique@>=0.2.1 <0.3.0"
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "from": "braces@>=1.8.2 <2.0.0"
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "from": "commander@>=2.8.1 <3.0.0"
+    },
+    "debug": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
+      "from": "debug@>=2.2.0 <3.0.0"
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "from": "deep-equal@>=1.0.1 <2.0.0"
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "from": "expand-brackets@>=0.1.4 <0.2.0"
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "from": "expand-range@>=1.8.1 <2.0.0"
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "from": "extglob@>=0.3.1 <0.4.0"
+    },
+    "filename-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+      "from": "filename-regex@>=2.0.0 <3.0.0"
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "from": "fill-range@>=2.1.0 <3.0.0"
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "from": "for-in@>=1.0.1 <2.0.0"
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "from": "for-own@>=0.1.4 <0.2.0"
+    },
+    "forwarded-http": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/forwarded-http/-/forwarded-http-0.3.0.tgz",
+      "from": "forwarded-http@0.3.0"
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "from": "glob-base@>=0.3.0 <0.4.0"
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "from": "glob-parent@>=2.0.0 <3.0.0"
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "from": "graceful-readlink@>=1.0.0"
+    },
+    "ip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
+      "from": "ip@>=0.3.2 <0.4.0"
+    },
+    "ip-filter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ip-filter/-/ip-filter-1.0.2.tgz",
+      "from": "ip-filter@>=1.0.0 <2.0.0"
+    },
+    "ip-port-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ip-port-regex/-/ip-port-regex-1.0.0.tgz",
+      "from": "ip-port-regex@>=1.0.0 <2.0.0"
+    },
+    "ip-regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
+      "from": "ip-regex@>=1.0.3 <2.0.0"
+    },
+    "is-arguments": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.2.tgz",
+      "from": "is-arguments@>=1.0.2 <2.0.0"
+    },
+    "is-buffer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+      "from": "is-buffer@>=1.0.2 <2.0.0"
+    },
+    "is-dotfile": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+      "from": "is-dotfile@>=1.0.0 <2.0.0"
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "from": "is-equal-shallow@>=0.1.3 <0.2.0"
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "from": "is-extendable@>=0.1.1 <0.2.0"
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "from": "is-extglob@>=1.0.0 <2.0.0"
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "from": "is-glob@>=2.0.1 <3.0.0"
+    },
+    "is-match": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/is-match/-/is-match-0.4.1.tgz",
+      "from": "is-match@>=0.4.0 <0.5.0"
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "from": "is-number@>=2.1.0 <3.0.0"
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "from": "is-posix-bracket@>=0.1.0 <0.2.0"
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "from": "is-primitive@>=2.0.0 <3.0.0"
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "from": "isarray@1.0.0"
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "from": "isobject@>=2.0.0 <3.0.0"
+    },
+    "kind-of": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+      "from": "kind-of@>=3.0.2 <4.0.0"
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "from": "lazy-cache@>=1.0.3 <2.0.0"
+    },
+    "make-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
+      "from": "make-iterator@>=1.0.0 <2.0.0"
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "from": "micromatch@>=2.3.7 <3.0.0"
+    },
+    "ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "from": "ms@0.7.2"
+    },
+    "normalize-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+      "from": "normalize-path@>=2.0.1 <3.0.0"
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "from": "object.omit@>=2.0.0 <3.0.0"
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "from": "parse-glob@>=3.0.4 <4.0.0"
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "from": "preserve@>=0.2.0 <0.3.0"
+    },
+    "randomatic": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+      "from": "randomatic@>=1.1.3 <2.0.0"
+    },
+    "regex-cache": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "from": "regex-cache@>=0.4.2 <0.5.0"
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "from": "repeat-element@>=1.1.2 <2.0.0"
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "from": "repeat-string@>=1.5.2 <2.0.0"
+    },
+    "to-file-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-file-path/-/to-file-path-1.0.0.tgz",
+      "from": "to-file-path@>=1.0.0 <2.0.0"
+    }
+  }
+}

--- a/packages/force-ssl-common/README.md
+++ b/packages/force-ssl-common/README.md
@@ -1,0 +1,5 @@
+# force-ssl-common
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/force-ssl-common) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/force-ssl-common)
+***
+
+This is an internal Meteor package.

--- a/packages/force-ssl-common/force_ssl_common.js
+++ b/packages/force-ssl-common/force_ssl_common.js
@@ -1,0 +1,29 @@
+import forwarded from 'forwarded-http';
+
+// Determine if the connection is only over localhost. Both we
+// received it on localhost, and all proxies involved received on
+// localhost (supports "forwarded" and "x-forwarded-for").
+const isLocalConnection = (req) => {
+  const localhostRegexp = /^\s*(127\.0\.0\.1|\[?::1\]?)\s*$/;
+  const request = Object.assign(req);
+  request.connection.remoteAddress =
+    request.connection.remoteAddress || req.socket.remoteAddress;
+  const forwardedParams = forwarded(request);
+  let isLocal = true;
+  Object.keys(forwardedParams.for).forEach((forKey) => {
+    if (!localhostRegexp.test(forKey)) {
+      isLocal = false;
+    }
+  });
+  return isLocal;
+};
+
+// Determine if the connection was over SSL at any point. Either we
+// received it as SSL, or a proxy did and translated it for us.
+const isSslConnection = (req) => {
+  const forwardedParams = forwarded(req);
+  return req.connection.pair
+      || forwardedParams.proto && forwardedParams.proto.indexOf('https') !== -1;
+};
+
+export { isLocalConnection, isSslConnection };

--- a/packages/force-ssl-common/force_ssl_common.js
+++ b/packages/force-ssl-common/force_ssl_common.js
@@ -5,9 +5,12 @@ import forwarded from 'forwarded-http';
 // localhost (supports "forwarded" and "x-forwarded-for").
 const isLocalConnection = (req) => {
   const localhostRegexp = /^\s*(127\.0\.0\.1|\[?::1\]?)\s*$/;
-  const request = Object.assign(req);
-  request.connection.remoteAddress =
-    request.connection.remoteAddress || req.socket.remoteAddress;
+  const request = Object.create(req);
+  request.connection = Object.assign(
+    {},
+    req.connection,
+    { remoteAddress: req.connection.remoteAddress || req.socket.remoteAddress }
+  );
   const forwardedParams = forwarded(request);
   let isLocal = true;
   Object.keys(forwardedParams.for).forEach((forKey) => {

--- a/packages/force-ssl-common/force_ssl_tests.js
+++ b/packages/force-ssl-common/force_ssl_tests.js
@@ -1,0 +1,112 @@
+import { isLocalConnection, isSslConnection } from './force_ssl_common';
+import http from 'http';
+
+Tinytest.add('force-ssl - check for a local connection', function (test) {
+  const req = new http.IncomingMessage();
+  req.connection = { remoteAddress: null };
+  req.socket = { remoteAddress: null };
+
+  // Remote address check (connection)
+
+  ['127.0.0.1', '::1'].forEach((ip) => {
+    req.connection.remoteAddress = ip;
+    test.isTrue(isLocalConnection(req), 'Is a local connection');
+  });
+
+  ['1.2.3.4', '2001:0db8:0000:0042:0000:8a2e:0370:7334'].forEach((ip) => {
+    req.connection.remoteAddress = ip;
+    test.isFalse(isLocalConnection(req), 'Not a local connection');
+  });
+
+  // Remote address check (socket)
+
+  ['127.0.0.1', '::1'].forEach((ip) => {
+    req.connection = {};
+    req.socket.remoteAddress = ip;
+    test.isTrue(isLocalConnection(req), 'Is a local connection');
+  });
+
+  ['1.2.3.4', '2001:0db8:0000:0042:0000:8a2e:0370:7334'].forEach((ip) => {
+    req.connection = {};
+    req.socket.remoteAddress = ip;
+    test.isFalse(isLocalConnection(req), 'Not a local connection');
+  });
+
+  // Header check
+
+  const localHeaders = [
+    {
+      name: 'forwarded',
+      value: 'for=127.0.0.1; proto=http',
+      ip: '127.0.0.1',
+    },
+    {
+      name: 'forwarded',
+      value: 'for="[::1]"; proto=http',
+      ip: '::1',
+    },
+    {
+      name: 'x-forwarded-for',
+      value: '127.0.0.1',
+      ip: '127.0.0.1',
+    },
+  ];
+  localHeaders.forEach((header) => {
+    req.connection.remoteAddress = header.ip;
+    req.headers[header.name] = header.value;
+    test.isTrue(isLocalConnection(req), 'Is a local connection');
+  });
+
+  const remoteHeaders = [
+    {
+      name: 'forwarded',
+      value: 'for=1.2.3.4; proto=http',
+      ip: '1.2.3.4',
+    },
+    {
+      name: 'forwarded',
+      value: 'for=1.2.3.4; proto=http',
+      ip: '127.0.0.1',
+    },
+    {
+      name: 'forwarded',
+      value: 'for="[2001:0db8:0000:0042:0000:8a2e:0370:7334]"; proto=http',
+      ip: '2001:0db8:0000:0042:0000:8a2e:0370:7334',
+    },
+    {
+      name: 'x-forwarded-for',
+      value: '1.2.3.4',
+      ip: '1.2.3.4',
+    },
+    {
+      name: 'x-forwarded-for',
+      value: '2001:0db8:0000:0042:0000:8a2e:0370:7334',
+      ip: '2001:0db8:0000:0042:0000:8a2e:0370:7334',
+    },
+  ];
+  remoteHeaders.forEach((header) => {
+    req.connection.remoteAddress = header.ip;
+    req.headers[header.name] = header.value;
+    test.isFalse(isLocalConnection(req), 'Not a local connection');
+  });
+});
+
+Tinytest.add('force-ssl - check for an SSL based connection', function (test) {
+  const req = new http.IncomingMessage();
+
+  req.connection = { pair: {} };
+  test.isTrue(isSslConnection(req), 'Is an SSL based connection');
+
+  req.connection = {};
+  req.headers = { forwarded: 'for=127.0.0.1; proto=https' };
+  test.isTrue(isSslConnection(req), 'Is an SSL based connection');
+
+  req.headers = { 'x-forwarded-proto': 'https' };
+  test.isTrue(isSslConnection(req), 'Is an SSL based connection');
+
+  req.headers = { forwarded: 'for=127.0.0.1; proto=http' };
+  test.isFalse(isSslConnection(req), 'Is not an SSL based connection');
+
+  req.headers = { 'x-forwarded-proto': 'http' };
+  test.isFalse(isSslConnection(req), 'Is not an SSL based connection');
+});

--- a/packages/force-ssl-common/package.js
+++ b/packages/force-ssl-common/package.js
@@ -1,0 +1,19 @@
+Package.describe({
+  summary: 'Internal force-ssl common code.',
+  version: '1.0.14'
+});
+
+Npm.depends({
+  'forwarded-http': '0.3.0'
+});
+
+Package.onUse(function (api) {
+  api.use('ecmascript');
+  api.mainModule('force_ssl_common.js', 'server');
+});
+
+Package.onTest(function (api) {
+  api.use('ecmascript');
+  api.use('tinytest');
+  api.mainModule('force_ssl_tests.js', 'server');
+});

--- a/packages/force-ssl/README.md
+++ b/packages/force-ssl/README.md
@@ -9,12 +9,14 @@ is always encrypted to protect users from active spoofing attacks.
 
 Meteor bundles (i.e. `meteor build`) do not include an HTTPS server or
 certificate. A proxy server that terminates SSL in front of a Meteor
-bundle must set the standard `x-forwarded-proto` header for this package to work.
+bundle must set the `x-forwarded-proto` or `forwarded`
+([RFC 7239](https://tools.ietf.org/html/rfc7239)) header for this package to
+work.
 
-The `x-forwarded-proto` header is used to determine if the connection arrived
-over HTTPS and a heuristic is used to guess if it's running in development. To
-simplify development, unencrypted connections from `localhost` are always
-accepted over HTTP.
+The `x-forwarded-proto` or `forwarded` header is used to determine if the
+connection arrived over HTTPS and a heuristic is used to guess if it's running
+in development. To simplify development, unencrypted connections from
+`localhost` are always accepted over HTTP.
 
 We recommend this package only for deployment platforms that do not have their
 own ability to force SSL. If you're deploying with

--- a/packages/force-ssl/force_ssl_both.js
+++ b/packages/force-ssl/force_ssl_both.js
@@ -1,0 +1,1 @@
+Object.assign(Meteor.absoluteUrl.defaultOptions, { secure: true });

--- a/packages/force-ssl/force_ssl_common.js
+++ b/packages/force-ssl/force_ssl_common.js
@@ -1,1 +1,0 @@
-_.extend(Meteor.absoluteUrl.defaultOptions, {secure: true});

--- a/packages/force-ssl/force_ssl_server.js
+++ b/packages/force-ssl/force_ssl_server.js
@@ -1,4 +1,5 @@
 var url = Npm.require("url");
+import { isLocalConnection, isSslConnection } from 'meteor/force-ssl-common';
 
 // Unfortunately we can't use a connect middleware here since
 // sockjs installs itself prior to all existing listeners
@@ -16,29 +17,10 @@ httpServer.addListener('request', function (req, res) {
   // localhost (development mode).
   //
   // Note: someone could trick us into serving over non-ssl by setting
-  // x-forwarded-for or x-forwarded-proto. Not much we can do there if
-  // we still want to operate behind proxies.
+  // x-forwarded-for, x-forwarded-proto, forwarded, etc. Not much we can do
+  // there if we still want to operate behind proxies.
 
-  var remoteAddress =
-        req.connection.remoteAddress || req.socket.remoteAddress;
-  // Determine if the connection is only over localhost. Both we
-  // received it on localhost, and all proxies involved received on
-  // localhost.
-  var localhostRegexp = /^\s*(127\.0\.0\.1|::1)\s*$/;
-  var isLocal = (
-    localhostRegexp.test(remoteAddress) &&
-      (!req.headers['x-forwarded-for'] ||
-       _.all(req.headers['x-forwarded-for'].split(','), function (x) {
-         return localhostRegexp.test(x);
-       })));
-
-  // Determine if the connection was over SSL at any point. Either we
-  // received it as SSL, or a proxy did and translated it for us.
-  var isSsl = req.connection.pair ||
-      (req.headers['x-forwarded-proto'] &&
-       req.headers['x-forwarded-proto'].indexOf('https') !== -1);
-
-  if (!isLocal && !isSsl) {
+  if (!isLocalConnection(req) && !isSslConnection(req)) {
     // connection is not cool. send a 302 redirect!
 
     var host = url.parse(Meteor.absoluteUrl()).hostname;
@@ -57,7 +39,7 @@ httpServer.addListener('request', function (req, res) {
 
   // connection is OK. Proceed normally.
   var args = arguments;
-  _.each(oldHttpServerListeners, function(oldListener) {
+  oldHttpServerListeners.forEach((oldListener) => {
     oldListener.apply(httpServer, args);
   });
 });
@@ -67,8 +49,8 @@ httpServer.addListener('request', function (req, res) {
 //
 // Websockets come in via the 'upgrade' request. We can override this,
 // however the problem is we're not sure if the websocket is actually
-// encrypted. We don't get x-forwarded-for or x-forwarded-proto on
-// websockets. It's possible the 'sec-websocket-origin' header does
+// encrypted. We don't get x-forwarded-for, x-forwarded-proto, forwarded, etc.
+// on websockets. It's possible the 'sec-websocket-origin' header does
 // what we want, but that's not clear.
 //
 // For now, this package allows raw unencrypted DDP connections over

--- a/packages/force-ssl/package.js
+++ b/packages/force-ssl/package.js
@@ -1,18 +1,19 @@
 Package.describe({
   summary: "Require this application to use HTTPS",
-  version: "1.0.13",
+  version: "1.0.14",
   prodOnly: true
 });
 
 Package.onUse(function (api) {
+  api.use('ecmascript');
   api.use('webapp', 'server');
-  api.use('underscore');
   // make sure we come after livedata, so we load after the sockjs
   // server has been instantiated.
   api.use('ddp', 'server');
+  api.use('force-ssl-common', 'server');
 
-  api.addFiles('force_ssl_common.js', ['client', 'server']);
-  api.addFiles('force_ssl_server.js', 'server');
+  api.mainModule('force_ssl_both.js', ['client', 'server']);
+  api.mainModule('force_ssl_server.js', 'server');
 
   // Another thing we could do is add a force_ssl_client.js file that
   // makes sure document.location.protocol is 'https'. If it detected


### PR DESCRIPTION
Hi all - this PR is intended to help address issue #6120 (updating `force-ssl` to work with the `forwarded` header (see [RFC 7239](https://tools.ietf.org/html/rfc7239)), falling back on `x-forwarded-for` and `x-forwarded-proto`). I know there has been some discussion lately about whether or not it makes sense to use `force-ssl`, but for now it's still supported / included in core (hence these updates).

A few quick notes about these changes:

- To wire this up, I've leveraged the [`forwarded-http`](https://www.npmjs.com/package/forwarded-http) npm package. This package will look for any `*forwarded*` headers, then combine them all into a nice and clean forwarded object. This simplifies the `force-ssl` code a fair bit.
- I've included tests for the new `isLocalConnection` and `isSslConnection` functions I've added, but because `force-ssl` is a `prodOnly` package, these tests can't be run as part of the `force-ssl` package. Since I couldn't find a way to have package tests run against `prodOnly` packages, I've decided to split the package into 2 packages. `force-ssl` stays as the main `prodOnly` package, then uses a new internal `force-ssl-common` package. The `force-ssl-common` package contains the helper header code I've added, along with tests. Let me know if you would like to approach this differently - this was the cleanest approach I could come up with to work around the `prodOnly` testing restriction.
- Since I was in the code, I went ahead and removed the `underscore` dependency (and have added in `ecmascript`).

Thanks all - awaiting feedback! :-)