### PR TITLE
Added missing docs for Meteor.apply's options.throwStubExceptions.

### DIFF
--- a/packages/ddp-client/livedata_connection.js
+++ b/packages/ddp-client/livedata_connection.js
@@ -761,6 +761,7 @@ _.extend(Connection.prototype, {
    * @param {Boolean} options.wait (Client only) If true, don't send this method until all previous method calls have completed, and don't send any subsequent method calls until this one is completed.
    * @param {Function} options.onResultReceived (Client only) This callback is invoked with the error or result of the method (just like `asyncCallback`) as soon as the error or result is available. The local cache may not yet reflect the writes performed by the method.
    * @param {Boolean} options.noRetry (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
+   * @param {Boolean} options.throwStubExceptions (Client only) If true, exceptions thrown by method stubs will be thrown instead of logged, and the method will not be invoked on the server.
    * @param {Function} [asyncCallback] Optional callback; same semantics as in [`Meteor.call`](#meteor_call).
    */
   apply: function (name, args, options, callback) {


### PR DESCRIPTION
Hi all - this PR is intended to help resolve #8435, by adding in the missing `options.throwStubExceptions` jsdoc line. Thanks!

