### PR TITLE
[dx] Provide warning when `METEOR_SETTINGS` are used in development.

### DIFF
--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -184,12 +184,26 @@ _.extend(AppProcess.prototype, {
     if (self.settings) {
       env.METEOR_SETTINGS = self.settings;
     } else {
+      // Warn the developer that we are not going to use their environment var.
+      if (env.METEOR_SETTINGS) {
+        runLog.log(
+          "WARNING: The 'METEOR_SETTINGS' environment variable is ignored " +
+          "when running in development (as you are doing now).  Instead, use " +
+          "the '--settings settings.json' option to see reactive changes " +
+          "when settings are changed.  For more information, see the " +
+          "documentation for 'Meteor.settings': " +
+          "https://docs.meteor.com/api/core.html#Meteor-settings" +
+          "\n");
+      }
+
+      // To provide a consistent, reactive experience in development, do
+      // not use settings provided via the environment variable.
       delete env.METEOR_SETTINGS;
     }
     if (self.testMetadata) {
       env.TEST_METADATA = JSON.stringify(self.testMetadata);
     } else {
-      delete env.TEST_METADATA; 
+      delete env.TEST_METADATA;
     }
     if (self.listenHost) {
       env.BIND_IP = self.listenHost;


### PR DESCRIPTION
This is a developer experience (DX) change.

In production, the `METEOR_SETTINGS` environment variable is used to
pass parameters which will be available in the `Meteor.settings` within
the app.  However, `METEOR_SETTINGS` is ignored when using the
`meteor-tool` itself as in development, environment variables are
often less desirable.  Additionally, there would be no reactivity when
changing settings was necessary, instead requiring that the `meteor`
tool be restarted entirely.

On more than one occasion, developers have been confused as to why the
`METEOR_SETTINGS` are not respected in development.  To make it more
clear when this is attempted (and clarify that they will _not_ be used),
provide the a clear warning before ignoring the `METEOR_SETTINGS`
variable.

Aims to avoid meteor/meteor#8455.