### PR TITLE
Allow incorrect `package.json` when determining binary dependencies.

### DIFF
--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -475,7 +475,13 @@ const isPortable = Profile("meteorNpm.isPortable", dir => {
     fs.unlink(portableFile, error => {});
   }
 
-  const pkgJson = canCache && optimisticReadJsonOrNull(pkgJsonPath);
+  const pkgJson = canCache && optimisticReadJsonOrNull(pkgJsonPath, {
+    // A syntactically incorrect `package.json` isn't likely to have other
+    // effects since the npm itself likely won't install but the developer has
+    // no control over that happening so we should allow this.
+    allowSyntaxError: true
+  });
+
   const hasBuildScript =
     pkgJson &&
     pkgJson.scripts &&


### PR DESCRIPTION
We now check `package.json` (thanks to bcffe53d14463322109baa4eb2632ed15a4cd3e8) in order to help make an educated decision as to whether or not a package has binary dependencies which need to be rebuilt.  In some cases, such as the `npmconf` npm which is included as a dependency of `flow-router`, a [`package.json` used as a test fixture](https://github.com/npm/npmconf/blob/master/test/fixtures/package.json) exists but is empty.  We should silently permit this.

Fixes meteor/meteor#8427