### PR TITLE
[fix #8218] cleaning up reset tokens also cleans up enroll tokens

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1078,11 +1078,13 @@ Ap._generateStampedLoginToken = function () {
 function expirePasswordToken(accounts, oldestValidDate, tokenFilter, userId) {
   var userFilter = userId ? {_id: userId} : {};
 
-  accounts.users.update(_.extend(userFilter, tokenFilter, {
-    $or: [
-      { "services.password.reset.when": { $lt: oldestValidDate } },
-      { "services.password.reset.when": { $lt: +oldestValidDate } }
-    ]
+  accounts.users.update(_.extend(userFilter, 
+    {$and: [tokenFilter, {
+      $or: [
+        { "services.password.reset.when": { $lt: oldestValidDate } },
+        { "services.password.reset.when": { $lt: +oldestValidDate } }
+      ]
+    }]
   }), {
     $unset: {
       "services.password.reset": ""

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1076,16 +1076,16 @@ Ap._generateStampedLoginToken = function () {
 ///
 
 function expirePasswordToken(accounts, oldestValidDate, tokenFilter, userId) {
-  var userFilter = userId ? {_id: userId} : {};
+  const userFilter = userId ? {_id: userId} : {};
+  const resetRangeOr = { 
+    $or: [
+      { "services.password.reset.when": { $lt: oldestValidDate } },
+      { "services.password.reset.when": { $lt: +oldestValidDate } }
+    ]
+  };
+  const expireFilter = { $and: [tokenFilter, resetRangeOr] };
 
-  accounts.users.update(_.extend(userFilter, 
-    {$and: [tokenFilter, {
-      $or: [
-        { "services.password.reset.when": { $lt: oldestValidDate } },
-        { "services.password.reset.when": { $lt: +oldestValidDate } }
-      ]
-    }]
-  }), {
+  accounts.users.update({...userFilter, ...expireFilter}, {
     $unset: {
       "services.password.reset": ""
     }

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1474,7 +1474,7 @@ if (Meteor.isServer) (function () {
   );
 
   Tinytest.add(
-    'passwords - reset password doesn\t work if email changed after email sent',
+    "passwords - reset password doesn't work if email changed after email sent",
     function (test) {
       var username = Random.id();
       var email = username + '-intercept@example.com';
@@ -1688,31 +1688,31 @@ if (Meteor.isServer) (function () {
     function (test) {
       var email = test.id + '-intercept@example.com';
       var userId = Accounts.createUser({email: email, password: 'password'});
+      
       Accounts.sendEnrollmentEmail(userId, email);
       test.isTrue(!!Meteor.users.findOne(userId).services.password.reset);
 
       Accounts._expirePasswordEnrollTokens(new Date(), userId);
-
       test.isUndefined(Meteor.users.findOne(userId).services.password.reset);
     }
   )
 
   Tinytest.add(
-    'passwords - enroll tokens don\'t get cleaned up when reset tokens are cleaned up',
+    "passwords - enroll tokens don't get cleaned up when reset tokens are cleaned up",
     function (test) {
       var email = test.id + '-intercept@example.com';
       var userId = Accounts.createUser({email: email, password: 'password'});
+      
       Accounts.sendEnrollmentEmail(userId, email);
       test.isTrue(!!Meteor.users.findOne(userId).services.password.reset);
 
       Accounts._expirePasswordResetTokens(new Date(), userId);
-
       test.isTrue(Meteor.users.findOne(userId).services.password.reset);
     }
   )
 
   Tinytest.add(
-    'passwords - reset tokens don\'t get cleaned up when enroll tokens are cleaned up',
+    "passwords - reset tokens don't get cleaned up when enroll tokens are cleaned up",
     function (test) {
       var email = test.id + '-intercept@example.com';
       var userId = Accounts.createUser({email: email, password: 'password'});

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1704,10 +1704,11 @@ if (Meteor.isServer) (function () {
       var userId = Accounts.createUser({email: email, password: 'password'});
       
       Accounts.sendEnrollmentEmail(userId, email);
-      test.isTrue(!!Meteor.users.findOne(userId).services.password.reset);
+      var enrollToken = Meteor.users.findOne(userId).services.password.reset;
+      test.isTrue(enrollToken);
 
       Accounts._expirePasswordResetTokens(new Date(), userId);
-      test.isTrue(Meteor.users.findOne(userId).services.password.reset);
+      test.equal(enrollToken, Meteor.users.findOne(userId).services.password.reset);
     }
   )
 
@@ -1716,12 +1717,13 @@ if (Meteor.isServer) (function () {
     function (test) {
       var email = test.id + '-intercept@example.com';
       var userId = Accounts.createUser({email: email, password: 'password'});
+
       Accounts.sendResetPasswordEmail(userId, email);
-      test.isTrue(!!Meteor.users.findOne(userId).services.password.reset);
+      var resetToken = Meteor.users.findOne(userId).services.password.reset;
+      test.isTrue(resetToken);
 
       Accounts._expirePasswordEnrollTokens(new Date(), userId);
-
-      test.isTrue(Meteor.users.findOne(userId).services.password.reset);
+      test.equal(resetToken,Meteor.users.findOne(userId).services.password.reset);
     }
   )
 

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1697,6 +1697,34 @@ if (Meteor.isServer) (function () {
     }
   )
 
+  Tinytest.add(
+    'passwords - enroll tokens don\'t get cleaned up when reset tokens are cleaned up',
+    function (test) {
+      var email = test.id + '-intercept@example.com';
+      var userId = Accounts.createUser({email: email, password: 'password'});
+      Accounts.sendEnrollmentEmail(userId, email);
+      test.isTrue(!!Meteor.users.findOne(userId).services.password.reset);
+
+      Accounts._expirePasswordResetTokens(new Date(), userId);
+
+      test.isTrue(Meteor.users.findOne(userId).services.password.reset);
+    }
+  )
+
+  Tinytest.add(
+    'passwords - reset tokens don\'t get cleaned up when enroll tokens are cleaned up',
+    function (test) {
+      var email = test.id + '-intercept@example.com';
+      var userId = Accounts.createUser({email: email, password: 'password'});
+      Accounts.sendResetPasswordEmail(userId, email);
+      test.isTrue(!!Meteor.users.findOne(userId).services.password.reset);
+
+      Accounts._expirePasswordEnrollTokens(new Date(), userId);
+
+      test.isTrue(Meteor.users.findOne(userId).services.password.reset);
+    }
+  )
+
   // We should be able to change the username
   Tinytest.add("passwords - change username", function (test) {
     var username = Random.id();


### PR DESCRIPTION
The issue was with _.extend overriding two documents (a token filter by reason and a time filter) with the same key ($or). Put the two filters in an ($add) to solve the issue, and added two tests to ensure no interference between those two.

Fixes #8218