### PR TITLE
use fs.move() from fs-extra to fix EXDEV cross device error in docker builds (issue 7852)

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.7.14
+BUNDLE_VERSION=4.7.13
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.7.13
+BUNDLE_VERSION=4.7.14
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -18,6 +18,7 @@ var packageJson = {
     "meteor-promise": "0.8.0",
     fibers: "1.0.15",
     promise: "7.1.1",
+    "fs-extra": "2.1.0",
     // So that Babel 6 can emit require("babel-runtime/helpers/...") calls.
     "babel-runtime": "6.9.2",
     // For various ES2015 polyfills, such as Map and Set.

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -5,7 +5,9 @@
 ///
 
 var assert = require("assert");
-var fs = require("fs");
+var fs = require('fs');
+fs.move = require('fs-extra').move;
+fs.moveSync = require('fs-extra').moveSync;
 var path = require('path');
 var os = require('os');
 var util = require('util');
@@ -962,7 +964,7 @@ files.renameDirAlmostAtomically = function (fromDir, toDir) {
   // Get old dir out of the way, if it exists.
   var movedOldDir = true;
   try {
-    files.rename(toDir, garbageDir);
+    files.move(toDir, garbageDir);
   } catch (e) {
     if (e.code !== 'ENOENT') {
       throw e;
@@ -971,7 +973,7 @@ files.renameDirAlmostAtomically = function (fromDir, toDir) {
   }
 
   // Now rename the directory.
-  files.rename(fromDir, toDir);
+  files.move(fromDir, toDir);
 
   // ... and delete the old one.
   if (movedOldDir) {
@@ -1589,6 +1591,7 @@ wrapFsFunc("readFile", [0], {
 wrapFsFunc("stat", [0]);
 wrapFsFunc("lstat", [0]);
 wrapFsFunc("rename", [0, 1]);
+wrapFsFunc("move", [0]);
 
 // After the outermost files.withCache call returns, the withCacheCache is
 // reset to null so that it does not survive server restarts.


### PR DESCRIPTION
This PR addresses the following `EXDEV` error (#7852) that consistently happens for me when running `meteor build` inside a Docker container.  (see https://github.com/meteor/meteor/issues/7852#issuecomment-284925574 for my reproduction steps)

```sh
Error: EXDEV: cross-device link not permitted, rename '/opt/meteor/dist/bundle' -> '/opt/meteor/dist/bundle-garbage-1vn2pov'
    at Error (native)
    at Object.fs.renameSync (fs.js:681:18)
    at Object.wrapper [as rename] (/tools/fs/files.js:1535:35)
    at Object.files.renameDirAlmostAtomically (/tools/fs/files.js:965:11)
    at Builder.complete (/tools/isobuild/builder.js:690:13)
    at /tools/isobuild/bundler.js:2529:13
    at /tools/isobuild/bundler.js:2436:7
    at /tools/isobuild/bundler.js:2837:22
    at /tools/utils/buildmessage.js:271:13
    at [object Object]._.extend.withValue (/tools/utils/fiber-helpers.js:89:14)
    at /tools/utils/buildmessage.js:264:29
    at [object Object]._.extend.withValue (/tools/utils/fiber-helpers.js:89:14)
    at /tools/utils/buildmessage.js:262:18
    at [object Object]._.extend.withValue (/tools/utils/fiber-helpers.js:89:14)
    at /tools/utils/buildmessage.js:253:23
    at [object Object]._.extend.withValue (/tools/utils/fiber-helpers.js:89:14)
    at Object.capture (/tools/utils/buildmessage.js:252:19)
    at bundle (/tools/isobuild/bundler.js:2670:31)
    at /tools/isobuild/bundler.js:2617:32
    at Object.withCache (/tools/fs/files.js:1601:12)
    at Object.exports.bundle (/tools/isobuild/bundler.js:2617:16)
    at buildCommand (/tools/cli/commands.js:954:30)
    at Command.func (/tools/cli/commands.js:829:12)
    at /tools/cli/main.js:1483:23
```

This issue started happening for us intermittently around Nov 2016, but it only appeared to be when doing Docker builds on a CoreOS host (the CoreOS part admittedly may have been a coincidence).  The recent release of Docker 1.13 started causing it to happen consistently when I build locally on macOS or on [the build server I use in our Kubernetes deployment](https://github.com/deis/dockerbuilder).

The code in the Meteor build tool that has been throwing this is `files.renameDirAlmostAtomically()` here:
https://github.com/meteor/meteor/blob/devel/tools/fs/files.js#L952-L982

Some background on the AUFS root cause from Docker:
https://docs.docker.com/engine/userguide/storagedriver/aufs-driver/#/renaming-directories-with-the-aufs-storage-driver

> Calling rename(2) for a directory is not fully supported on AUFS. It returns `EXDEV` (“cross-device link not permitted”), even when both of the source and the destination path are on a same AUFS layer, unless the directory has no children.
> So your application has to be designed so that it can handle `EXDEV` and fall back to a “copy and unlink” strategy.

Earlier in the discussion in #7852, it was mentioned that there's a possibility that using the `fs.move()` method from `fs-extra` may fix it (since there's error handling specifically for that error - see [source](https://github.com/jprichardson/node-fs-extra/blob/master/lib/move/index.js#L67-L70))

I ran with that assumption and extended `fs` with `move/moveSync` in `tools/fs/files.js` and then switched `files.renameDirAlmostAtomically` to use `files.move` instead of `files.rename`.  I can now confirm that it fixed the problem in every environment that was having this issue.

As you can see from the PR, I changed the absolute smallest amount of code I could to get it working, so I'm really hoping this is something we can get into Meteor.  We have a lot of build environments that rely on this change to work at this point, so we have to run a fork of Meteor until this (hopefully) gets merged.  Let me know if there's anything I missed and I'll be happy to get it taken care of immediately.  

Thanks!


