### PR TITLE
Upgrade to mailcomposer@4 and smtp-connection@2

### DIFF
--- a/packages/email/.npm/package/npm-shrinkwrap.json
+++ b/packages/email/.npm/package/npm-shrinkwrap.json
@@ -1,34 +1,79 @@
 {
   "dependencies": {
+    "addressparser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+      "from": "addressparser@1.0.1"
+    },
+    "buildmail": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-4.0.1.tgz",
+      "from": "buildmail@4.0.1"
+    },
+    "httpntlm": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
+      "from": "httpntlm@1.6.1"
+    },
+    "httpreq": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.23.tgz",
+      "from": "httpreq@>=0.4.22"
+    },
+    "iconv-lite": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+      "from": "iconv-lite@0.4.15"
+    },
+    "libbase64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
+      "from": "libbase64@0.1.0"
+    },
+    "libmime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
+      "from": "libmime@3.0.0"
+    },
+    "libqp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
+      "from": "libqp@1.1.0"
+    },
     "mailcomposer": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.1.15.tgz",
-      "from": "mailcomposer@0.1.15"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-4.0.1.tgz",
+      "from": "mailcomposer@4.0.1"
     },
-    "mimelib-noiconv": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/mimelib-noiconv/-/mimelib-noiconv-0.1.9.tgz",
-      "from": "mimelib-noiconv@*"
+    "nodemailer-fetch": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
+      "from": "nodemailer-fetch@1.6.0"
     },
-    "rai": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.12.tgz",
-      "from": "rai@>=0.1.11 <0.2.0"
+    "nodemailer-shared": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
+      "from": "nodemailer-shared@1.1.0"
     },
-    "simplesmtp": {
-      "version": "0.3.34",
-      "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.34.tgz",
-      "from": "simplesmtp@0.3.34"
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "from": "punycode@1.4.1"
+    },
+    "smtp-connection": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.2.tgz",
+      "from": "smtp-connection@2.12.2"
     },
     "stream-buffers": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.5.tgz",
       "from": "stream-buffers@0.2.5"
     },
-    "xoauth2": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz",
-      "from": "xoauth2@>=0.1.8 <0.2.0"
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "from": "underscore@>=1.7.0 <1.8.0"
     }
   }
 }

--- a/packages/email/email_tests.js
+++ b/packages/email/email_tests.js
@@ -18,6 +18,13 @@ function smokeEmailTest(testFunction) {
   }
 }
 
+function canonicalize(string) {
+  // Remove generated content for test.equal to succeed.
+  return string.replace(/Message-ID: <[^<>]*>\r\n/, "Message-ID: <...>\r\n")
+               .replace(/Date: (?!dummy).*\r\n/, "Date: ...\r\n")
+               .replace(/----[^\s"]+/g, "----...");
+}
+
 Tinytest.add("email - fully customizable", function (test) {
   smokeEmailTest(function(stream) {
     Email.send({
@@ -32,22 +39,23 @@ Tinytest.add("email - fully customizable", function (test) {
       },
     });
     // XXX brittle if mailcomposer changes header order, etc
-    test.equal(stream.getContentsAsString("utf8"),
+    test.equal(canonicalize(stream.getContentsAsString("utf8")),
                "====== BEGIN MAIL #0 ======\n" +
                devWarningBanner +
-               "MIME-Version: 1.0\r\n" +
+               "Content-Type: text/plain\r\n" +
                "X-Meteor-Test: a custom header\r\n" +
                "Date: dummy\r\n" +
                "From: foo@example.com\r\n" +
                "To: bar@example.com\r\n" +
                "Cc: friends@example.com, enemies@example.com\r\n" +
                "Subject: This is the subject\r\n" +
-               "Content-Type: text/plain; charset=utf-8\r\n" +
-               "Content-Transfer-Encoding: quoted-printable\r\n" +
+               "Message-ID: <...>\r\n" +
+               "Content-Transfer-Encoding: 7bit\r\n" +
+               "MIME-Version: 1.0\r\n" +
                "\r\n" +
-               "This is the body\r\n" +
-               "of the message\r\n" +
-               "From us.\r\n" +
+               "This is the body\n" +
+               "of the message\n" +
+               "From us." +
                "====== END MAIL #0 ======\n");
   });
 });
@@ -61,7 +69,7 @@ Tinytest.add("email - undefined headers sends properly", function (test) {
       text: "This is the body\nof the message\nFrom us.",
     });
 
-    test.matches(stream.getContentsAsString("utf8"),
+    test.matches(canonicalize(stream.getContentsAsString("utf8")),
       /^====== BEGIN MAIL #0 ======$[\s\S]+^To: bar@example.com$/m);
   });
 });
@@ -77,7 +85,7 @@ Tinytest.add("email - multiple e-mails same stream", function (test) {
 
     var contents;
 
-    contents = stream.getContentsAsString("utf8");
+    contents = canonicalize(stream.getContentsAsString("utf8"));
     test.matches(contents, /^====== BEGIN MAIL #0 ======$/m);
     test.matches(contents, /^From: foo@example.com$/m);
     test.matches(contents, /^To: bar@example.com$/m);
@@ -89,7 +97,7 @@ Tinytest.add("email - multiple e-mails same stream", function (test) {
       text: "This is another message\nFrom Qux.",
     });
 
-    contents = stream.getContentsAsString("utf8");
+    contents = canonicalize(stream.getContentsAsString("utf8"));
     test.matches(contents, /^====== BEGIN MAIL #1 ======$/m);
     test.matches(contents, /^From: qux@example.com$/m);
     test.matches(contents, /^To: baz@example.com$/m);
@@ -100,28 +108,39 @@ Tinytest.add("email - multiple e-mails same stream", function (test) {
 Tinytest.add("email - using mail composer", function (test) {
   smokeEmailTest(function (stream) {
     // Test direct MailComposer usage.
-    var mc = new EmailInternals.NpmModules.mailcomposer.module.MailComposer;
-    mc.setMessageOption({
-      from: "a@b.com",
-      text: "body"
-    });
-    Email.send({mailComposer: mc});
-    test.equal(stream.getContentsAsString("utf8"),
-               "====== BEGIN MAIL #0 ======\n" +
-               devWarningBanner +
-               "MIME-Version: 1.0\r\n" +
-               "From: a@b.com\r\n" +
-               "Content-Type: text/plain; charset=utf-8\r\n" +
-               "Content-Transfer-Encoding: quoted-printable\r\n" +
-               "\r\n" +
-               "body\r\n" +
-               "====== END MAIL #0 ======\n");
+    var mcs = [
+      // Test with MailComposer object (without compiling).
+      new EmailInternals.NpmModules.mailcomposer.module.MailComposer({
+        from: "a@b.com",
+        text: "body"
+      }),
+      // Test calling module as a function, which compiles MailComposer object.
+      EmailInternals.NpmModules.mailcomposer.module({
+        from: "a@b.com",
+        text: "body"
+      })
+    ];
+    for (var i = 0; i < mcs.length; i++) {
+      Email.send({mailComposer: mcs[i]});
+      test.equal(canonicalize(stream.getContentsAsString("utf8")),
+                 "====== BEGIN MAIL #"+i+" ======\n" +
+                 devWarningBanner +
+                 "Content-Type: text/plain\r\n" +
+                 "From: a@b.com\r\n" +
+                 "Message-ID: <...>\r\n" +
+                 "Content-Transfer-Encoding: 7bit\r\n" +
+                 "Date: ...\r\n" +
+                 "MIME-Version: 1.0\r\n" +
+                 "\r\n" +
+                 "body" +
+                 "====== END MAIL #"+i+" ======\n");
+    }
   });
 });
 
 Tinytest.add("email - date auto generated", function (test) {
   smokeEmailTest(function (stream) {
-    // Test if date header is automaticall generated, if not specified
+    // Test if date header is automatically generated, if not specified
     Email.send({
       from: "foo@example.com",
       to: "bar@example.com",
@@ -132,7 +151,100 @@ Tinytest.add("email - date auto generated", function (test) {
       },
     });
 
-    test.matches(stream.getContentsAsString("utf8"),
+    test.matches(canonicalize(stream.getContentsAsString("utf8")),
                  /^Date: .+$/m);
+  });
+});
+
+Tinytest.add("email - long lines", function (test) {
+  smokeEmailTest(function (stream) {
+    // Test that long header lines get wrapped with single leading whitespace,
+    // and that long body lines get wrapped with quoted-printable conventions.
+    Email.send({
+      from: "foo@example.com",
+      to: "bar@example.com",
+      subject: "This is a very very very very very very very very very very very very long subject",
+      text: "This is a very very very very very very very very very very very very long text",
+    });
+
+    test.equal(canonicalize(stream.getContentsAsString("utf8")),
+               "====== BEGIN MAIL #0 ======\n" +
+               devWarningBanner +
+               "Content-Type: text/plain\r\n" +
+               "From: foo@example.com\r\n" +
+               "To: bar@example.com\r\n" +
+               "Subject: This is a very very very very very very very very " +
+               "very very very\r\n very long subject\r\n" +
+               "Message-ID: <...>\r\n" +
+               "Content-Transfer-Encoding: quoted-printable\r\n" +
+               "Date: ...\r\n" +
+               "MIME-Version: 1.0\r\n" +
+               "\r\n" +
+               "This is a very very very very very very very very very very " +
+               "very very long =\r\ntext" +
+               "====== END MAIL #0 ======\n");
+  });
+});
+
+Tinytest.add("email - unicode", function (test) {
+  smokeEmailTest(function (stream) {
+    // Test that unicode characters in header and body get encoded.
+    Email.send({
+      from: "foo@example.com",
+      to: "bar@example.com",
+      subject: "\u263a",
+      text: "I \u2665 Meteor",
+    });
+
+    test.equal(canonicalize(stream.getContentsAsString("utf8")),
+               "====== BEGIN MAIL #0 ======\n" +
+               devWarningBanner +
+               "Content-Type: text/plain; charset=utf-8\r\n" +
+               "From: foo@example.com\r\n" +
+               "To: bar@example.com\r\n" +
+               "Subject: =?UTF-8?B?4pi6?=\r\n" +
+               "Message-ID: <...>\r\n" +
+               "Content-Transfer-Encoding: quoted-printable\r\n" +
+               "Date: ...\r\n" +
+               "MIME-Version: 1.0\r\n" +
+               "\r\n" +
+               "I =E2=99=A5 Meteor" +
+               "====== END MAIL #0 ======\n");
+  });
+});
+
+Tinytest.add("email - text and html", function (test) {
+  smokeEmailTest(function (stream) {
+    // Test including both text and HTML versions of message.
+    Email.send({
+      from: "foo@example.com",
+      to: "bar@example.com",
+      text: "*Cool*, man",
+      html: "<i>Cool</i>, man",
+    });
+
+    test.equal(canonicalize(stream.getContentsAsString("utf8")),
+               "====== BEGIN MAIL #0 ======\n" +
+               devWarningBanner +
+               "Content-Type: multipart/alternative;\r\n" +
+               ' boundary="----..."\r\n' +
+               "From: foo@example.com\r\n" +
+               "To: bar@example.com\r\n" +
+               "Message-ID: <...>\r\n" +
+               "Date: ...\r\n" +
+               "MIME-Version: 1.0\r\n" +
+               "\r\n" +
+               "----...\r\n" +
+               "Content-Type: text/plain\r\n" +
+               "Content-Transfer-Encoding: 7bit\r\n" +
+               "\r\n" +
+               "*Cool*, man\r\n" +
+               "----...\r\n" +
+               "Content-Type: text/html\r\n" +
+               "Content-Transfer-Encoding: 7bit\r\n" +
+               "\r\n" +
+               "<i>Cool</i>, man\r\n" +
+               "----...\r\n" +
+               "====== END MAIL #0 ======\n");
   });
 });

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.1.18"
+  version: "1.2.0"
 });
 
 Npm.depends({
-  // Pinned at older version. 0.1.16+ uses mimelib, not mimelib-noiconv which is
-  // much bigger. We need a better solution.
-  mailcomposer: "0.1.15",
-  simplesmtp: "0.3.34",
+  mailcomposer: "4.0.1",
+  // Using smtp-connection@2 (instead of latest) because it shares
+  // nodemailer-shared with mailcomposer@4:
+  "smtp-connection": "2.12.2",
   "stream-buffers": "0.2.5"});
 
 Package.onUse(function (api) {


### PR DESCRIPTION
I wrote this patch to fix #8425, namely, to fix how long header lines get encoded.  Main discussion is there.

* Switch from mailcomposer 0.1.15 -> 4.0.1 (latest, still MIT license).
* Switch from simplesmtp (which only supports mailcomposer 0.1) to smtp-connection (which supports any mail composer).
* Use smtp-connection@2 (instead of latest) which shares nodemailer-shared codebase with mailcomposer 4.0.1.
* Add test for long header lines (the original bug being fixed here)
* Add extra test for HTML + text messages
* Document some extra options arguments supported by new mailcomposer.  (I didn't add [them all](https://github.com/nodemailer/mailcomposer/blob/v4.0.1/README.md#e-mail-message-fields) -- let me know if I should, or link to that in some way...)
