### PR TITLE
Be more understanding of Windows' filesystem limitations.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 checkout:
   post:
-    - git submodule update --init
+    # https://discuss.circleci.com/t/git-submodule-url-isnt-playing-nice-with-the-cache/549/3
+    - git submodule sync
+    - git submodule update --init --recursive || (rm -fr .git/config .git/modules && git submodule deinit -f . && git submodule update --init --recursive)
 
 dependencies:
   pre:

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -1664,7 +1664,7 @@ files.existsSync = function (path, callback) {
   return !! files.statOrNull(path);
 };
 
-if (process.platform === "win32") {
+if (files.isWindowsLikeFilesystem()) {
   var rename = files.rename;
 
   files.rename = function (from, to) {
@@ -1677,7 +1677,7 @@ if (process.platform === "win32") {
         rename(from, to);
         success = true;
       } catch (err) {
-        if (err.code !== 'EPERM') {
+        if (err.code !== 'EPERM' && err.code !== 'EACCES') {
           throw err;
         }
       }

--- a/tools/static-assets/server/mini-files.js
+++ b/tools/static-assets/server/mini-files.js
@@ -13,6 +13,14 @@ var assert = require("assert");
 // after bootup (since they block all concurrency!)
 var files = module.exports;
 
+// Detect that we are on a Windows-like Filesystem, such as that in a WSL
+// (Windows Subsystem for Linux) even if it otherwise looks like we're on Unix.
+// https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364
+var isWindowsLikeFilesystem = function () {
+  return process.platform === "win32" ||
+    (os.release().indexOf("Microsoft") > -1);
+};
+
 var toPosixPath = function (p, partialPath) {
   // Sometimes, you can have a path like \Users\IEUser on windows, and this
   // actually means you want C:\Users\IEUser
@@ -114,6 +122,8 @@ files.pathIsAbsolute = wrapPathFunction("isAbsolute");
 files.pathSep = '/';
 files.pathDelimiter = ':';
 files.pathOsDelimiter = path.delimiter;
+
+files.isWindowsLikeFilesystem = isWindowsLikeFilesystem;
 
 files.convertToStandardPath = convertToStandardPath;
 files.convertToOSPath = convertToOSPath;


### PR DESCRIPTION
Presently, the renaming of directories that are in-use will fail on Windows.  This is already compensated for when `process.platform` is
set to `win32`.  However, within [BashOnWindows](https://github.com/Microsoft/BashOnWindows)/WSL (Windows Subsystem for Linux), `process.platform` is equal to `linux`, though the underlying filesystem is still the same and subject to similar limitations.

Microsoft has stated that it is [unlikely that they will remove "`Microsoft`"](https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364) from the `os.release()` value so this checks for that in a similar fashion to how we used to check for `process.platform === "win32"`.  Also, this change causes `EACCES` to be tolerated in the same was as `EPERM` was already.  (`EACCES` is another type of permission error)

I would point out that this change might contribute to breaking atomicity in `files.renameDirAlmostAtomically` since it uses `files.rename` but I'd argue that it was already jeopardized (on Windows and only on Windows) with the previous exception and this change simply provides consistent behavior across Windows implementations.

Probably worth mentioning that this seems to make Meteor work under BashOnWindows on the latest Windows Insider Build (15058) which I believe is a release candidate for [Windows Creators Update](https://www.microsoft.com/en-us/windows/upcoming-features) which is expected to come out later this month, but I'm hesitant to suggest this constitutes support for BashOnWindows (like #7583).

Hopefully issues like this are fixed by https://github.com/Microsoft/BashOnWindows/issues/1529 and https://github.com/Microsoft/BashOnWindows/issues/1420, but I'm not sure what the timeline on those getting resolved is.