### PR TITLE
Automatically trim `DEPLOY_HOSTNAME` of leading/trailing spaces.

### DIFF
--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -844,7 +844,7 @@ const galaxyDiscoveryCache = new Map;
 function getDeployURL(site) {
   // Always trust explicitly configuration via env.
   if (process.env.DEPLOY_HOSTNAME) {
-    return Promise.resolve(addScheme(process.env.DEPLOY_HOSTNAME));
+    return Promise.resolve(addScheme(process.env.DEPLOY_HOSTNAME.trim()));
   }
 
   const defaultURL = "https://us-east-1.galaxy-deploy.meteor.com";


### PR DESCRIPTION
This simple fix prevents the disappointment of trying to deploy your app
but failing because there's a space on the end of the `DEPLOY_HOSTNAME`
environment variable.

`process.env` always contains string values and assigning a property on
`process.env` implicitly converts the value to a string so it should not
be necessary to check if `typeof` is a `string`.

Fixes Dev Experience.