### PR TITLE
Add TOOL_NODE_FLAGS support for Windows in the same way as Unix.

### DIFF
--- a/meteor.bat
+++ b/meteor.bat
@@ -38,7 +38,7 @@ IF EXIST "%~dp0\.git" (
 SET NODE_PATH=%~dp0\dev_bundle\lib\node_modules
 SET BABEL_CACHE_DIR=%~dp0\.babel-cache
 
-"%~dp0\dev_bundle\bin\node.exe" "%~dp0\tools\index.js" %*
+"%~dp0\dev_bundle\bin\node.exe" %TOOL_NODE_FLAGS% "%~dp0\tools\index.js" %*
 ENDLOCAL
 
 EXIT /b %ERRORLEVEL%


### PR DESCRIPTION
In Unix we support adding `TOOL_NODE_FLAGS` when debugging the Meteor
tool itself, however Windows did not currently support it.  This should
add that support.  As this is a .bat file, I have every reason to
believe that this syntax should work on older versions of Windows as the
syntax of .bat files hasn't changed much, but I only tested on Windows 10.

Helps with meteor/meteor#8513.