### PR TITLE
Use UglifyJS when possible, but fall back to Babel.minify.

### DIFF
--- a/packages/minifier-js/.npm/package/.gitignore
+++ b/packages/minifier-js/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/minifier-js/.npm/package/README
+++ b/packages/minifier-js/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,89 @@
+{
+  "dependencies": {
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "from": "align-text@>=0.1.3 <0.2.0"
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "from": "camelcase@>=1.0.2 <2.0.0"
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "from": "center-align@>=0.1.1 <0.2.0"
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "from": "cliui@>=2.1.0 <3.0.0"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "from": "decamelize@>=1.0.0 <2.0.0"
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "from": "is-buffer@>=1.0.2 <2.0.0"
+    },
+    "kind-of": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+      "from": "kind-of@>=3.0.2 <4.0.0"
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "from": "lazy-cache@>=1.0.3 <2.0.0"
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "from": "longest@>=1.0.1 <2.0.0"
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "from": "repeat-string@>=1.5.2 <2.0.0"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "from": "right-align@>=0.1.1 <0.2.0"
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "from": "source-map@>=0.5.1 <0.6.0"
+    },
+    "uglify-js": {
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.16.tgz",
+      "from": "uglify-js@2.8.16"
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "from": "window-size@0.1.0"
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "from": "wordwrap@0.0.2"
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "from": "yargs@>=3.10.0 <3.11.0"
+    }
+  }
+}

--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -1,1 +1,25 @@
-meteorBabelMinify = Babel.minify;
+var uglify;
+
+meteorJsMinify = function (source) {
+  var result = {};
+  uglify = uglify || Npm.require("uglify-js");
+
+  try {
+    result.code = uglify.minify(source, {
+      fromString: true,
+      compress: {
+        drop_debugger: false,
+        unused: false,
+        dead_code: false
+      }
+    }).code;
+
+  } catch (e) {
+    // Although Babel.minify can handle a wider variety of ECMAScript
+    // 2015+ syntax, it is substantially slower than UglifyJS, so we use
+    // it only as a fallback.
+    result.code = Babel.minify(source).code;
+  }
+
+  return result;
+};

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -3,8 +3,12 @@ Package.describe({
   version: "2.0.0-rc.1"
 });
 
+Npm.depends({
+  "uglify-js": "2.8.16"
+});
+
 Package.onUse(function (api) {
   api.use('babel-compiler');
-  api.export(['meteorBabelMinify']);
+  api.export(['meteorJsMinify']);
   api.addFiles(['minifier.js'], 'server');
 });

--- a/packages/standard-minifier-js/plugin/minify-js.js
+++ b/packages/standard-minifier-js/plugin/minify-js.js
@@ -117,7 +117,7 @@ MeteorBabelMinifier.prototype.processFilesForBundle = function(files, options) {
         var minified;
 
         try {
-          minified = meteorBabelMinify(file.getContentsAsString());
+          minified = meteorJsMinify(file.getContentsAsString());
 
           if (!(minified && typeof minified.code === "string")) {
             throw new Error();


### PR DESCRIPTION
This gives us all the benefits of @sethmurphy18's great work without the additional performance hit of using Babili for everything.

With this commit:
```sh
% meteor create min-test
% cd min-test
% time meteor build ../min-build
meteor build ../min-build  39.26s user 5.49s system 112% cpu 39.647 total
```

Without this commit:
```sh
meteor build ../min-build  59.28s user 5.23s system 107% cpu 1:00.08 total
```

Keep in mind this is the best-case scenario for Babili (a very small app). Larger apps take much longer for Babili to minify.

cc @abernix @glasser @sethmurphy18