### PR TITLE
Add ambiguous error messages option to Accounts config

### DIFF
--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -86,6 +86,9 @@ export class AccountsCommon {
   // - passwordResetTokenExpirationInDays {Number}
   //     Number of days since password reset token creation until the
   //     token cannt be used any longer (password reset token expires).
+  // - ambiguousErrorMessages {Boolean}
+  //     Return ambiguous error messages from login failures to prevent
+  //     user enumeration.
 
   /**
    * @summary Set global accounts options.
@@ -98,6 +101,7 @@ export class AccountsCommon {
    * @param {String} options.oauthSecretKey When using the `oauth-encryption` package, the 16 byte key using to encrypt sensitive account credentials in the database, encoded in base64.  This option may only be specifed on the server.  See packages/oauth-encryption/README.md for details.
    * @param {Number} options.passwordResetTokenExpirationInDays The number of days from when a link to reset password is sent until token expires and user can't reset password with the link anymore. Defaults to 3.
    * @param {Number} options.passwordEnrollTokenExpirationInDays The number of days from when a link to set inital password is sent until token expires and user can't set password with the link anymore. Defaults to 30.
+   * @param {Boolean} options.ambiguousErrorMessages Return ambiguous error messages from login failures to prevent user enumeration. Defaults to false.
    */
   config(options) {
     var self = this;
@@ -130,7 +134,8 @@ export class AccountsCommon {
 
     // validate option keys
     var VALID_KEYS = ["sendVerificationEmail", "forbidClientAccountCreation", "passwordEnrollTokenExpirationInDays",
-                      "restrictCreationByEmailDomain", "loginExpirationInDays", "passwordResetTokenExpirationInDays"];
+                      "restrictCreationByEmailDomain", "loginExpirationInDays", "passwordResetTokenExpirationInDays",
+                      "ambiguousErrorMessages"];
     _.each(_.keys(options), function (key) {
       if (!_.contains(VALID_KEYS, key)) {
         throw new Error("Accounts.config: Invalid key: " + key);

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -65,8 +65,9 @@ Accounts._checkPassword = function (user, password) {
 
   password = getPasswordString(password);
 
-  if (! bcryptCompare(password, user.services.password.bcrypt)) 
+  if (! bcryptCompare(password, user.services.password.bcrypt)) {
     result.error = handleError("Incorrect password", false);
+  }
 
   return result;
 };
@@ -216,8 +217,9 @@ var checkForCaseInsensitiveDuplicates = function (fieldName, displayName, fieldV
         (!ownUserId ||
         // Otherwise, check to see if there are multiple matches or a match
         // that is not us
-        (matchedUsers.length > 1 || matchedUsers[0]._id !== ownUserId))) 
-          handleError(displayName + " already exists.");
+        (matchedUsers.length > 1 || matchedUsers[0]._id !== ownUserId))) {
+      handleError(displayName + " already exists.");
+    }
   }
 };
 
@@ -268,12 +270,14 @@ Accounts.registerLoginHandler("password", function (options) {
 
 
   var user = Accounts._findUserByQuery(options.user);
-  if (!user) 
+  if (!user) {
     handleError("User not found");
-    
+  }
+
   if (!user.services || !user.services.password ||
-      !(user.services.password.bcrypt || user.services.password.srp)) 
+      !(user.services.password.bcrypt || user.services.password.srp)) {
     handleError("User has no password set");
+  }
 
   if (!user.services.password.bcrypt) {
     if (typeof options.password === "string") {
@@ -285,11 +289,12 @@ Accounts.registerLoginHandler("password", function (options) {
       var newVerifier = SRP.generateVerifier(options.password, {
         identity: verifier.identity, salt: verifier.salt});
 
-      if (verifier.verifier !== newVerifier.verifier) 
+      if (verifier.verifier !== newVerifier.verifier) {
         return {
           userId: Accounts._options.ambiguousErrorMessages ? null : user._id,
           error: handleError("Incorrect password", false)
-        }
+        };
+      }
 
       return {userId: user._id};
     } else {
@@ -323,8 +328,9 @@ Accounts.registerLoginHandler("password", function (options) {
 //
 // XXX COMPAT WITH 0.8.1.3
 Accounts.registerLoginHandler("password", function (options) {
-  if (!options.srp || !options.password)
+  if (!options.srp || !options.password) {
     return undefined; // don't handle
+  }
 
   check(options, {
     user: userQueryValidator,
@@ -333,16 +339,19 @@ Accounts.registerLoginHandler("password", function (options) {
   });
 
   var user = Accounts._findUserByQuery(options.user);
-  if (!user) 
+  if (!user) {
     handleError("User not found");
+  }
 
   // Check to see if another simultaneous login has already upgraded
   // the user record to bcrypt.
-  if (user.services && user.services.password && user.services.password.bcrypt)
+  if (user.services && user.services.password && user.services.password.bcrypt) {
     return checkPassword(user, options.password);
+  }
 
-  if (!(user.services && user.services.password && user.services.password.srp)) 
-    handleError("User has no password set"); 
+  if (!(user.services && user.services.password && user.services.password.srp)) {
+    handleError("User has no password set");
+  }
 
   var v1 = user.services.password.srp.verifier;
   var v2 = SRP.generateVerifier(
@@ -352,11 +361,12 @@ Accounts.registerLoginHandler("password", function (options) {
       salt: user.services.password.srp.salt
     }
   ).verifier;
-  if (v1 !== v2) 
+  if (v1 !== v2) {
     return {
       userId: Accounts._options.ambiguousErrorMessages ? null : user._id,
       error: handleError("Incorrect password", false)
-    }
+    };
+  }
 
   // Upgrade to bcrypt on successful login.
   var salted = hashPassword(options.password);
@@ -390,8 +400,9 @@ Accounts.setUsername = function (userId, newUsername) {
   check(newUsername, NonEmptyString);
 
   var user = Meteor.users.findOne(userId);
-  if (!user) 
+  if (!user) {
     handleError("User not found");
+  }
 
   var oldUsername = user.username;
 
@@ -430,16 +441,19 @@ Meteor.methods({changePassword: function (oldPassword, newPassword) {
   check(oldPassword, passwordValidator);
   check(newPassword, passwordValidator);
 
-  if (!this.userId)
+  if (!this.userId) {
     throw new Meteor.Error(401, "Must be logged in");
+  }
 
   var user = Meteor.users.findOne(this.userId);
-  if (!user) 
-    handleError("User not found");  
+  if (!user) {
+    handleError("User not found");
+  }
 
   if (!user.services || !user.services.password ||
-      (!user.services.password.bcrypt && !user.services.password.srp)) 
+      (!user.services.password.bcrypt && !user.services.password.srp)) {
     handleError("User has no password set");
+  }
 
   if (! user.services.password.bcrypt) {
     throw new Meteor.Error(400, "old password format", EJSON.stringify({
@@ -449,8 +463,9 @@ Meteor.methods({changePassword: function (oldPassword, newPassword) {
   }
 
   var result = checkPassword(user, oldPassword);
-  if (result.error)
+  if (result.error) {
     throw result.error;
+  }
 
   var hashed = hashPassword(newPassword);
 
@@ -489,8 +504,9 @@ Accounts.setPassword = function (userId, newPlaintextPassword, options) {
   options = _.extend({logout: true}, options);
 
   var user = Meteor.users.findOne(userId);
-  if (!user)
+  if (!user) {
     throw new Meteor.Error(403, "User not found");
+  }
 
   var update = {
     $unset: {
@@ -518,8 +534,9 @@ Meteor.methods({forgotPassword: function (options) {
   check(options, {email: String});
 
   var user = Accounts.findUserByEmail(options.email);
-  if (!user) 
+  if (!user) {
     handleError("User not found");
+  }
 
   const emails = _.pluck(user.emails || [], 'address');
   const caseSensitiveEmail = _.find(emails, email => {
@@ -542,15 +559,19 @@ Meteor.methods({forgotPassword: function (options) {
 Accounts.sendResetPasswordEmail = function (userId, email) {
   // Make sure the user exists, and email is one of their addresses.
   var user = Meteor.users.findOne(userId);
-  if (!user) 
+  if (!user) {
     handleError("Can't find user");
+  }
 
   // pick the first email if we weren't passed an email.
-  if (!email && user.emails && user.emails[0])
+  if (!email && user.emails && user.emails[0]) {
     email = user.emails[0].address;
+  }
+
   // make sure we have a valid email
-  if (!email || !_.contains(_.pluck(user.emails || [], 'address'), email)) 
+  if (!email || !_.contains(_.pluck(user.emails || [], 'address'), email)) {
     handleError("No such email for user.");
+  }
 
   var token = Random.secret();
   var when = new Date();
@@ -581,9 +602,10 @@ Accounts.sendResetPasswordEmail = function (userId, email) {
       Accounts.emailTemplates.resetPassword.text(user, resetPasswordUrl);
   }
 
-  if (typeof Accounts.emailTemplates.resetPassword.html === 'function')
+  if (typeof Accounts.emailTemplates.resetPassword.html === 'function') {
     options.html =
       Accounts.emailTemplates.resetPassword.html(user, resetPasswordUrl);
+  }
 
   if (typeof Accounts.emailTemplates.headers === 'object') {
     options.headers = Accounts.emailTemplates.headers;
@@ -612,14 +634,17 @@ Accounts.sendEnrollmentEmail = function (userId, email) {
 
   // Make sure the user exists, and email is in their addresses.
   var user = Meteor.users.findOne(userId);
-  if (!user)
+  if (!user) {
     throw new Error("Can't find user");
+  }
   // pick the first email if we weren't passed an email.
-  if (!email && user.emails && user.emails[0])
+  if (!email && user.emails && user.emails[0]) {
     email = user.emails[0].address;
+  }
   // make sure we have a valid email
-  if (!email || !_.contains(_.pluck(user.emails || [], 'address'), email))
+  if (!email || !_.contains(_.pluck(user.emails || [], 'address'), email)) {
     throw new Error("No such email for user.");
+  }
 
   var token = Random.secret();
   var when = new Date();
@@ -651,9 +676,10 @@ Accounts.sendEnrollmentEmail = function (userId, email) {
       Accounts.emailTemplates.enrollAccount.text(user, enrollAccountUrl);
   }
 
-  if (typeof Accounts.emailTemplates.enrollAccount.html === 'function')
+  if (typeof Accounts.emailTemplates.enrollAccount.html === 'function') {
     options.html =
       Accounts.emailTemplates.enrollAccount.html(user, enrollAccountUrl);
+  }
 
   if (typeof Accounts.emailTemplates.headers === 'object') {
     options.headers = Accounts.emailTemplates.headers;
@@ -678,8 +704,9 @@ Meteor.methods({resetPassword: function (token, newPassword) {
 
       var user = Meteor.users.findOne({
         "services.password.reset.token": token});
-      if (!user)
+      if (!user) {
         throw new Meteor.Error(403, "Token expired");
+      }
       var when = user.services.password.reset.when;
       var reason = user.services.password.reset.reason;
       var tokenLifetimeMs = Accounts._getPasswordResetTokenLifetimeMs();


### PR DESCRIPTION
User account enumeration is a security concern for *some* people. In our bug bounty program @LegalRobot, we've had 17 different reports on user enumeration. It got annoying, so we started using this code in local forks of accounts-core and accounts-password but are now happy to share this with the community. This PR addresses some of the simpler attack vectors: different error messages returned from the server upon various login failures or pw reset failures. 

By default, we leave the existing behavior alone but provide a simple mechanism to enable this by setting the ```ambiguousErrorMessages``` key to ```true``` in Accounts.config on the server, like this:
```
Accounts.config({
  ambiguousErrorMessages: true
})
```
Enabling this option sends the same, rather ambiguous, error message to the client upon various login and reset failures. The specific text isn't really important, just that it can be identical across different failures. Perhaps as an extension of this, we could allow people to configure the message?

As @glasser and @lorensr discussed a few years ago in #2139, user enumeration is still possible via inference upon registration failure - the only way to prevent this is allowing duplicate accounts for the same email, but that opens up a whole mess of UX issues; and that can still be mitigated through rate limiting on those methods. So, this PR does not tackle the whole user enumeration problem, but at least we’re not being as explicit about every failure.

Unfortunately, we're not really able to write tests for this change since it seems that [server-side testing is not isolated](https://github.com/meteor/meteor/blob/devel/packages/accounts-password/password_tests_setup.js#L107-L118) (PR anyone?). We can either run the tests with this new option disabled (which is more common and the default) or enabled, but not both.

Looping in @guide for documentation changes, and @data since we're messing with some pretty important stuff in Meteor accounts.