### PR TITLE
Adjust Mongo.Collection._rewriteSelector to allow a custom fallback _id.

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -548,21 +548,23 @@ Mongo.Collection.prototype.insert = function insert(doc, callback) {
 Mongo.Collection.prototype.update = function update(selector, modifier, ...optionsAndCallback) {
   const callback = popCallbackFromArgs(optionsAndCallback);
 
-  const insertedId = this._makeNewID();
-  selector = Mongo.Collection._rewriteSelector(selector, insertedId);
-
   // We've already popped off the callback, so we are left with an array
   // of one or zero items
   const options = _.clone(optionsAndCallback[0]) || {};
+  let insertedId;
   if (options && options.upsert) {
     // set `insertedId` if absent.  `insertedId` is a Meteor extension.
     if (options.insertedId) {
       if (!(typeof options.insertedId === 'string' || options.insertedId instanceof Mongo.ObjectID))
         throw new Error("insertedId must be string or ObjectID");
+      insertedId = options.insertedId;
     } else if (! selector._id) {
+      insertedId = this._makeNewID();
       options.insertedId = insertedId;
     }
   }
+
+  selector = Mongo.Collection._rewriteSelector(selector, insertedId);
 
   const wrappedCallback = wrapCallback(callback);
 

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -361,8 +361,10 @@ Mongo.Collection._publishCursor = function (cursor, sub, collection) {
 // protect against dangerous selectors.  falsey and {_id: falsey} are both
 // likely programmer error, and not what you want, particularly for destructive
 // operations.  JS regexps don't serialize over DDP but can be trivially
-// replaced by $regex.
-Mongo.Collection._rewriteSelector = function (selector) {
+// replaced by $regex. If a falsey _id is sent in, a new string _id will be
+// generated and returned; if a fallbackId is provided, it will be returned
+// instead.
+Mongo.Collection._rewriteSelector = (selector, fallbackId) => {
   // shorthand -- scalars match _id
   if (LocalCollection._selectorIsId(selector))
     selector = {_id: selector};
@@ -373,9 +375,10 @@ Mongo.Collection._rewriteSelector = function (selector) {
     throw new Error("Mongo selector can't be an array.");
   }
 
-  if (!selector || (('_id' in selector) && !selector._id))
+  if (!selector || (('_id' in selector) && !selector._id)) {
     // can't match anything
-    return {_id: Random.id()};
+    return { _id: fallbackId || Random.id() };
+  }
 
   var ret = {};
   Object.keys(selector).forEach((key) => {
@@ -545,7 +548,8 @@ Mongo.Collection.prototype.insert = function insert(doc, callback) {
 Mongo.Collection.prototype.update = function update(selector, modifier, ...optionsAndCallback) {
   const callback = popCallbackFromArgs(optionsAndCallback);
 
-  selector = Mongo.Collection._rewriteSelector(selector);
+  const insertedId = this._makeNewID();
+  selector = Mongo.Collection._rewriteSelector(selector, insertedId);
 
   // We've already popped off the callback, so we are left with an array
   // of one or zero items
@@ -556,7 +560,7 @@ Mongo.Collection.prototype.update = function update(selector, modifier, ...optio
       if (!(typeof options.insertedId === 'string' || options.insertedId instanceof Mongo.ObjectID))
         throw new Error("insertedId must be string or ObjectID");
     } else if (! selector._id) {
-      options.insertedId = this._makeNewID();
+      options.insertedId = insertedId;
     }
   }
 

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -364,7 +364,7 @@ Mongo.Collection._publishCursor = function (cursor, sub, collection) {
 // replaced by $regex. If a falsey _id is sent in, a new string _id will be
 // generated and returned; if a fallbackId is provided, it will be returned
 // instead.
-Mongo.Collection._rewriteSelector = (selector, fallbackId) => {
+Mongo.Collection._rewriteSelector = (selector, { fallbackId } = {}) => {
   // shorthand -- scalars match _id
   if (LocalCollection._selectorIsId(selector))
     selector = {_id: selector};
@@ -564,7 +564,8 @@ Mongo.Collection.prototype.update = function update(selector, modifier, ...optio
     }
   }
 
-  selector = Mongo.Collection._rewriteSelector(selector, insertedId);
+  selector =
+    Mongo.Collection._rewriteSelector(selector, { fallbackId: insertedId });
 
   const wrappedCallback = wrapCallback(callback);
 

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -2210,6 +2210,19 @@ Tinytest.add('mongo-livedata - rewrite selector', function (test) {
     Mongo.Collection._rewriteSelector(testSelector),
     { length }
   );
+
+  test.matches(
+    Mongo.Collection._rewriteSelector({ _id: null })._id,
+    /^\S+$/,
+    'Passing in a falsey selector _id should return a selector with a new '
+    + 'auto-generated _id string'
+  );
+  test.equal(
+    Mongo.Collection._rewriteSelector({ _id: null }, oid),
+    { _id: oid },
+    'Passing in a falsey selector _id and a fallback ID should return a '
+    + 'selector with an _id using the fallback ID'
+  );
 });
 
 testAsyncMulti('mongo-livedata - specified _id', [

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -2218,7 +2218,7 @@ Tinytest.add('mongo-livedata - rewrite selector', function (test) {
     + 'auto-generated _id string'
   );
   test.equal(
-    Mongo.Collection._rewriteSelector({ _id: null }, oid),
+    Mongo.Collection._rewriteSelector({ _id: null }, { fallbackId: oid }),
     { _id: oid },
     'Passing in a falsey selector _id and a fallback ID should return a '
     + 'selector with an _id using the fallback ID'


### PR DESCRIPTION
Hi all - this PR is intended to help resolve #6599. Currently when a `{ _id: falsey }` selector is passed into the `Mongo.Collection._rewriteSelector` function, a new selector is returned with an auto-generated string `_id`. This causes a problem if a Collection has been configured to use a `options.idGeneration` value of `MONGO`, meaning `Mongo.ObjectID`'s should be used for `_id`'s. These changes allow a fallback ID of any type (string or ObjectID) to be passed into `Mongo.Collection._rewriteSelector`, that will be used instead of the auto-generated string `_id`, if present. I've then updated the main source of this problem, `Mongo.Collection.prototype.update` (when upserting), to make sure a proper fallback ID of either string or `ObjectID` type is passed into `Mongo.Collection._rewriteSelector`. Thanks!