### PR TITLE
Detect dev_bundle download errors and fail appropriately on Windows.

### DIFF
--- a/meteor.bat
+++ b/meteor.bat
@@ -16,6 +16,10 @@ IF EXIST "%~dp0\.git" (
     REM need `< con` so that we can run this file from Node
     REM (See http://stackoverflow.com/questions/9155289/calling-powershell-from-nodejs)
     PowerShell.exe -executionpolicy ByPass -file "%~dp0\scripts\windows\download-dev-bundle.ps1" < con
+    IF errorlevel 1 (
+      echo An error occurred while obtaining the dev_bundle.  Please try again.
+      exit /b 1
+    )
   )
 
   rem if dev_bundle is the wrong version, remove it and get a new one
@@ -28,6 +32,10 @@ IF EXIST "%~dp0\.git" (
       exit /b 1
     )
     PowerShell.exe -executionpolicy ByPass -file "%~dp0\scripts\windows\download-dev-bundle.ps1" < con
+    IF errorlevel 1 (
+      echo An error occurred while obtaining the dev_bundle.  Please try again.
+      exit /b 1
+    )
   )
 
   rem Only set this when we're in a checkout. When running from a release,

--- a/scripts/windows/download-dev-bundle.ps1
+++ b/scripts/windows/download-dev-bundle.ps1
@@ -42,6 +42,9 @@ if (Test-Path $devbundle_zip) {
 Write-Host "Extracting $TARBALL to the dev_bundle directory"
 
 cmd /C "7z.exe x $devbundle_zip -so | 7z.exe x -aoa -si -ttar -o$CHECKOUT_DIR\dev_bundle_XXX" | out-null
+if ($LASTEXITCODE -ne 0) {
+  Exit 1
+}
 
 $downloaded_tmp = $CHECKOUT_DIR + "\dev_bundle_XXX"
 $downloaded_path = $downloaded_tmp + "\dev_bundle_" + $PLATFORM + "_" + $BUNDLE_VERSION


### PR DESCRIPTION
This resolves a rare situation which could occur when the extraction of the `dev_bundle.tar` (the latter half of the [7-zip extraction pipe in `download-dev-bundle.ps1`](https://github.com/meteor/meteor/blob/devel/scripts/windows/download-dev-bundle.ps1#L44)) fails with an unexpected end-of-file (EOF) error, but the publish tool continued as if the file was fine.  Ultimately, (from what I understand) the error preference (`$ErrorActionPreference = "Stop"`) set in the PS1 script is only observed in the case of PowerShell ErrorLevel (on PowerShell cmdlets) and not just an error condition encountered on an arbitrary command.

This error condition occurred to me during the publishing of Meteor `1.4.4-rc.4`.  Since the error was not caught, it resulted in the publishing of an `rc.4` for Windows which is missing important parts of Python (which is bundled for binary dependency compilation reasons).

### During publishing
```
Will get you a dev_bundle for windows_x86 version 4.7.20
Going to download the dependency kit from the Internet
... downloaded
Extracting dev_bundle_windows_x86_4.7.20.tar.gz to the dev_bundle directory
ERROR: Unexpected end of data : dev_bundle.tar
ERROR: Data Error : dev_bundle_windows_x86_4.7.20\python\Lib\test\test_xrange.py
Removing dev_bundle tarball. You can preserve this in the future by setting 'SAVE_DEV_BUNDLE_TARBALL' in your environment.
meteor: updating npm dependencies -- meteor—deque... modules—runtime: updating npm dependencies -- install...
...snipped...
```

### During Windows Test
```
PS C:\Users\abern\test-1111> meteor add nodets:mysql@2.8.6
 => Errors while adding packages:

While loading package nodets:mysql@2.8.6:
error: Command failed: C:\Users\abern\AppData\Local\.meteor\packages\meteor-tool\1.4.4-rc.4\mt-os.windows.x86_32\dev_bundle\bin\npm.cmd rebuild --update-binary
gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable "C:\Users\abern\AppData\Local\.meteor\packages\meteor-tool\1.4.4-rc.4\mt-os.windows.x86_32\dev_bundle\python\python.exe", you can set the PYTHON env
variable.
gyp ERR! stack     at Object.failNoPython
```

#### The actual `python` folder
```
PS C:\Users\abern\AppData\local\.meteor\packages\meteor-tool> dir .\1.4.4-rc.4\mt-os.windows.x86_32\dev_bundle\python


    Directory: C:\Users\abern\AppData\local\.meteor\packages\meteor-tool\1.4.4-rc.4\mt-os.windows.x86_32\dev_bundle\python


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----        3/29/2017   6:51 PM                DLLs
d-----        3/29/2017   6:51 PM                include
d-----        3/29/2017   6:51 PM                Lib
d-----        3/29/2017   6:51 PM                libs
```

#### An example of what `python` folder should look like
```
PS C:\Users\abern\AppData\local\.meteor\packages\meteor-tool> dir .\1.4.3_2\mt-os.windows.x86_32\dev_bundle\python


    Directory: C:\Users\abern\AppData\local\.meteor\packages\meteor-tool\1.4.3_2\mt-os.windows.x86_32\dev_bundle\python


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----        3/17/2017  10:31 AM                DLLs
d-----        3/17/2017  10:31 AM                include
d-----        3/17/2017  10:36 AM                Lib
d-----        3/17/2017  10:31 AM                libs
d-----        3/14/2017   5:04 AM                Logs
d-----        3/17/2017  10:31 AM                Scripts
d-----        3/17/2017  10:31 AM                Tools
-a----        3/14/2017   5:04 AM          38591 LICENSE.txt
-a----        3/14/2017   5:04 AM            537 Microsoft.VC90.CRT.manifest
-a----        3/14/2017   5:04 AM         224768 msvcm90.dll
-a----        3/14/2017   5:04 AM         568832 msvcp90.dll
-a----        3/14/2017   5:04 AM         655872 msvcr90.dll
-a----        3/14/2017   5:04 AM         460946 NEWS.txt
-a----        3/14/2017   5:04 AM          27136 python.exe
-a----        3/14/2017   5:04 AM        2631168 python27.dll
-a----        3/14/2017   5:04 AM          27648 pythonw.exe
-a----        3/14/2017   5:04 AM          55299 README.txt
-a----        3/14/2017   5:04 AM         111616 w9xpopen.exe
```