### PR TITLE
[Work in Progress] Support Google Sign-In in google-oauth package.

### DIFF
--- a/packages/accounts-google/google.js
+++ b/packages/accounts-google/google.js
@@ -8,6 +8,15 @@ if (Meteor.isClient) {
       options = null;
     }
 
+    if (Meteor.isCordova &&
+        Google.signIn) {
+      // After 20 April 2017, Google OAuth login will no longer work from
+      // a WebView, so Cordova apps must use Google Sign-In instead.
+      // https://github.com/meteor/meteor/issues/8253
+      Google.signIn(options, callback);
+      return;
+    }
+
     // Use Google's domain-specific login page if we want to restrict creation to
     // a particular email domain. (Don't use it if restrictCreationByEmailDomain
     // is a function.) Note that all this does is change Google's UI ---

--- a/packages/accounts-google/package.js
+++ b/packages/accounts-google/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Login service for Google accounts",
-  version: "1.1.1"
+  version: "1.1.2"
 });
 
 Package.onUse(function(api) {

--- a/packages/google-oauth/google_client.js
+++ b/packages/google-oauth/google_client.js
@@ -1,4 +1,4 @@
-Google = {};
+var Google = require("./namespace.js");
 
 // Request Google credentials for the user
 // @param options {optional}

--- a/packages/google-oauth/google_sign-in.js
+++ b/packages/google-oauth/google_sign-in.js
@@ -1,0 +1,84 @@
+var Google = require("./namespace.js");
+
+var gplusPromise = new Promise(function (resolve, reject) {
+  if (! Meteor.isCordova) {
+    reject(new Error("plugins.googleplus requires Cordova"));
+    return;
+  }
+
+  document.addEventListener("deviceready", function () {
+    var plugins = global.plugins;
+    var gplus = plugins && plugins.googleplus;
+    if (gplus) {
+      resolve(gplus);
+    } else {
+      reject(new Error("plugins.googleplus not defined"));
+    }
+  }, false);
+});
+
+function tolerateUnhandledRejection() {}
+gplusPromise.catch(tolerateUnhandledRejection);
+
+// After 20 April 2017, Google OAuth login will no longer work from a
+// WebView, so Cordova apps must use Google Sign-In instead.
+// https://github.com/meteor/meteor/issues/8253
+exports.signIn = Google.signIn = function (options, callback) {
+  // support a callback without options
+  if (! callback && typeof options === "function") {
+    callback = options;
+    options = null;
+  }
+
+  gplusPromise.then(function (gplus) {
+    var config = ServiceConfiguration.configurations.findOne({
+      service: "google"
+    });
+
+    if (! config) {
+      throw new ServiceConfiguration.ConfigError();
+    }
+
+    options = Object.assign(Object.create(null), options);
+
+    gplus.login({
+      scopes: getScopes(options).join(" "),
+      webClientId: config.clientId,
+      offline: true
+    }, function (response) {
+      Accounts.callLoginMethod({
+        methodArguments: [Object.assign({
+          googleSignIn: true
+        }, response)],
+        userCallback: callback
+      });
+    }, callback);
+
+  }).catch(callback);
+};
+
+function getScopes(options) {
+  // we need the email scope to get user id from google.
+  var requiredScopes = ['email'];
+  var scopes = ['profile'];
+  if (options && options.requestPermissions) {
+    scopes = options.requestPermissions;
+  }
+  return _.union(scopes, requiredScopes);
+}
+
+exports.signOut = Google.signOut = function () {
+  return gplusPromise.then(function (gplus) {
+    return new Promise(function (resolve) {
+      gplus.logout(resolve);
+    });
+  });
+};
+
+// Make sure we don't stay logged in with Google Sign-In after the client
+// calls Meteor.logout().
+Meteor.startup(function () {
+  Accounts.onLogout(function () {
+    Google.signOut().catch(tolerateUnhandledRejection);
+  });
+});

--- a/packages/google-oauth/google_sign-in.js
+++ b/packages/google-oauth/google_sign-in.js
@@ -6,7 +6,7 @@ var gplusPromise = new Promise(function (resolve, reject) {
     return;
   }
 
-  document.addEventListener("deviceready", function () {
+  Meteor.startup(function () {
     var plugins = global.plugins;
     var gplus = plugins && plugins.googleplus;
     if (gplus) {
@@ -14,7 +14,7 @@ var gplusPromise = new Promise(function (resolve, reject) {
     } else {
       reject(new Error("plugins.googleplus not defined"));
     }
-  }, false);
+  });
 });
 
 function tolerateUnhandledRejection() {}

--- a/packages/google-oauth/namespace.js
+++ b/packages/google-oauth/namespace.js
@@ -1,0 +1,6 @@
+// The module.exports object of this module becomes the Google namespace
+// for other modules in this package.
+Google = module.exports;
+
+// So that api.export finds the "Google" property.
+Google.Google = Google;

--- a/packages/google-oauth/package.js
+++ b/packages/google-oauth/package.js
@@ -3,7 +3,13 @@ Package.describe({
   version: "1.2.0"
 });
 
+Cordova.depends({
+  "cordova-plugin-googleplus": "5.1.1"
+});
+
 Package.onUse(function(api) {
+  api.use("modules");
+  api.use("promise");
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
   api.use('http', ['server']);
@@ -12,6 +18,9 @@ Package.onUse(function(api) {
 
   api.addFiles('google_server.js', 'server');
   api.addFiles('google_client.js', 'client');
+  api.addFiles('google_sign-in.js', 'web.cordova');
+
+  api.mainModule('namespace.js');
 
   api.export('Google');
 });

--- a/packages/google-oauth/package.js
+++ b/packages/google-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Google OAuth flow",
-  version: "1.2.0"
+  version: "1.2.1"
 });
 
 Cordova.depends({

--- a/tools/cordova/README.md
+++ b/tools/cordova/README.md
@@ -111,7 +111,7 @@ app bundle (`pluginVersionsFromStarManifest`, a combination of
 `.meteor/cordova-plugins` for stand-alone plugin installs and the plugins added
 as dependencies of packages through `Cordova.depends`).
 The `pluginsConfiguration` comes from `App.configurePlugin` calls in
-`meteor-config.js`.
+`mobile-config.js`.
 
 Uses methods `CordovaProject#listInstalledPluginVersions()`,
 `CordovaProject#addPlugin(name, version, config)`,


### PR DESCRIPTION
Addresses #8253.

This implementation makes heavy use of https://www.npmjs.com/package/cordova-plugin-googleplus and takes loose inspiration from https://github.com/sujith3g/meteor-cordova-google-plus.

I have not yet figured out exactly how we should bump the version numbers, or whether a new `google-sign-in` package should be created (instead of modifying `google-oauth`).

cc @ramezrafla @realyze @stubailo 