### PR TITLE
[TEST] Updating tests for accounts-password

### DIFF
--- a/packages/accounts-password/email_tests_setup.js
+++ b/packages/accounts-password/email_tests_setup.js
@@ -26,7 +26,7 @@ Accounts.emailTemplates.headers = {
 
 EmailTest.hookSend(function (options) {
   var to = options.to;
-  if (!to || to.indexOf('intercept') === -1) {
+  if (!to || to.toUpperCase().indexOf('INTERCEPT') === -1) {
     return true; // go ahead and send
   } else {
     if (!interceptedEmails[to])


### PR DESCRIPTION
Hello,

In order to reproduce the following issue https://github.com/meteor/meteor/issues/8532 I updated the tests but I couldn’t reproduce the bug.

Unless I am mistaken, it seems there is no issue when calling the `Accounts.verifyEmail` for the same mail in upper case because the verification token is correctly removed and the email is marked as _verified_.

Regards