### PR TITLE
Improve `fs-extra`s `move` calls for Windows platform.

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -18,7 +18,7 @@ var packageJson = {
     "meteor-promise": "0.8.0",
     fibers: "1.0.15",
     promise: "7.1.1",
-    "fs-extra": "2.1.0",
+    "fs-extra": "2.1.2",
     // So that Babel 6 can emit require("babel-runtime/helpers/...") calls.
     "babel-runtime": "6.9.2",
     // For various ES2015 polyfills, such as Map and Set.


### PR DESCRIPTION
This is a follow-up to meteor/meteor#8491 which worked properly on Unix platforms, but failed in a variety of ways on Windows due to its lack of Fiber-awareness and desire to create symlinks as unprivileged users (something not always possible on Windows).

The Fiber issue was observed when trying to remove "src" directories within the `move` function (which tries a variety of OS/OS/arch-specific techniques to accomplish its goal) after they had been copied to "dest".  On Windows, this resulted in `EDIRNOTEMPTY` errors since Windows appears to temporarily cache the file-handle or doesn't release the file-handle until the next tick.

The symlink issue will hopefully improve in an upcoming release of Windows (Creator Edition) when Microsoft makes it possible to create symlinks as an unprivileged user, however it will still require enabling "Developer" mode in Windows settings.  This implements the same catch which was already in place for `fs.rename` on the `fs.move` provided by `fs-extra`.

Performance was the same in tests comparing before and after these changes.

I've targeted this PR for `release-1.4.3.x`.
**Edit:** The `fs-extra` update to `2.1.2` seemed relevant enough to include so I'll rebuild `dev_bundle` accordingly if this lands.

Relates to:
https://github.com/meteor/meteor/issues/8558#issuecomment-291194385

/cc @jshimko
