### PR TITLE
Update `installNpmModule` to properly capture newer `npm` error formats.

### DIFF
--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -1,13 +1,15 @@
-var selftest = require('../tool-testing/selftest.js');
-var Sandbox = selftest.Sandbox;
-var _ = require('underscore');
+import selftest from '../tool-testing/selftest.js';
+import files from '../fs/files.js';
+import { installNpmModule } from '../isobuild/meteor-npm.js';
 
-var MONGO_LISTENING =
+const Sandbox = selftest.Sandbox;
+
+const MONGO_LISTENING =
   { stdout: " [initandlisten] waiting for connections on port" };
 
-selftest.define("npm", ["net"], function () {
-  var s = new Sandbox({ fakeMongo: true });
-  var run;
+selftest.define("npm", ["net"], () => {
+  const s = new Sandbox({ fakeMongo: true });
+  let run;
 
   s.createApp("npmtestapp", "npmtest", { dontPrepareApp: true });
   s.cd("npmtestapp");
@@ -16,10 +18,10 @@ selftest.define("npm", ["net"], function () {
   // Regression test for https://github.com/meteor/meteor/pull/1808
   // Before this fix, the module would work on the first execution but not on a
   // subsequent one.
-  _.times(2, function (i) {
+  [1, 2].forEach(i => {
     run = s.run("--once", "--raw-logs");
     run.tellMongo(MONGO_LISTENING);
-    if (i === 0) {
+    if (i === 1) {
       run.waitSecs(30);
       // use match instead of read because on a built release we can
       // also get an update message here.
@@ -30,4 +32,34 @@ selftest.define("npm", ["net"], function () {
     run.match("null; From shell script\n");
     run.expectExit(0);
   });
+});
+
+function testThatNpmInstallThrows(name, version, regexMatcher) {
+  const tmpDir = files.convertToOSPath(files.mkdtemp());
+  let didThrow = false;
+  try {
+    installNpmModule(name, version, tmpDir);
+  } catch (err) {
+    didThrow = true;
+    selftest.expectTrue(regexMatcher.test(err.message));
+  }
+  selftest.expectTrue(didThrow);
+}
+
+selftest.define("npm - install - messages - error installing package", ["net"], () => {
+  // the 'error-prone' npm intentionally errors in the preinstall script.
+  testThatNpmInstallThrows("error-prone", "1.0.0",
+    /couldn't install npm package error-prone@1.0.0/);
+});
+
+selftest.define("npm - install - messages - npm doesn't exist", ["net"], () => {
+  // this test is obviously prone to sabotage.
+  testThatNpmInstallThrows("non-existant-package-gggg", "100.0.0",
+    /no npm package named 'non-existant-package-gggg' in the npm registry/);
+});
+
+selftest.define("npm - install - messages - npm version doesn't exist", ["net"], () => {
+  // the 'cost-of-modules' npm really exists but hopefully never this minor ver.
+  testThatNpmInstallThrows("cost-of-modules", "0.999.2",
+    /cost-of-modules version 0.999.2 is not available in the npm registry/);
 });


### PR DESCRIPTION
Previously, we captured and displayed shorter error messages for the
more complicated and unnecessarily verbose messages which npm produced.

While updating npm to 4.4.4, I observed the changelog for 4.4.0
indicated it would now produce less verbose messages.  In searching for
possible Meteor conflicts with this, I discovered that
`installNpmModule` had already regressed on providing pretty messages.

This fixes those messages to be parsed properly and adds tests which
ensure if npm changes again that we can capture them.

Follows-up on: https://github.com/meteor/meteor/pull/8562