### PR TITLE
add function to expose tracker inFlush variable

### DIFF
--- a/packages/tracker/tracker.js
+++ b/packages/tracker/tracker.js
@@ -456,6 +456,15 @@ Tracker.flush = function (options) {
                       throwFirstError: options && options._throwFirstError });
 };
 
+/**
+ * @summary True if we are computing a computation now, either first time or recompute.  This matches Tracker.active unless we are inside Tracker.nonreactive, which nullfies currentComputation even though an enclosing computation may still be running.
+ * @locus Client
+ * @returns {Boolean}
+ */
+Tracker.inFlush = function () {
+  return inFlush;
+}
+
 // Run all pending computations and afterFlush callbacks.  If we were not called
 // directly via Tracker.flush, this may return before they're all done to allow
 // the event loop to run a little before continuing.
@@ -471,7 +480,7 @@ Tracker._runFlush = function (options) {
   // any useful notion of a nested flush.
   //
   // https://app.asana.com/0/159908330244/385138233856
-  if (inFlush)
+  if (Tracker.inFlush())
     throw new Error("Can't call Tracker.flush while flushing");
 
   if (inCompute)


### PR DESCRIPTION
`inFlush` indicates wether a flush is active or not. Slightly the same like `Tracker.active` with one big difference. `Tracker.active` gets unset inside `Tracker.nonreactive`.
I want to savely call `Tracker.flush()` without getting the `Can't call Tracker.flush while flushing` error.
`Tracker.active` doesn't work for me, since I don't know if the flush was called inside `Tracker.nonreactive`. I think I need to access the `inFlush` variable to get the global flushing state.

Background:
I'm writing a package to connect reactive data to react components. In direct comparison with `react-meteor-data`, I want to reduce the reruns of the reactive function if the props of the component change. To avoid unnecessary renders, I'm calling `Tracker.flush()` inside of `componentWillReceiveProps` to run the reactive function and set the new state.