### PR TITLE
Recommendation to switch `fs-extra` for an alternate implementation.

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -18,7 +18,6 @@ var packageJson = {
     "meteor-promise": "0.8.0",
     fibers: "1.0.15",
     promise: "7.1.1",
-    "fs-extra": "2.1.2",
     // So that Babel 6 can emit require("babel-runtime/helpers/...") calls.
     "babel-runtime": "6.9.2",
     // For various ES2015 polyfills, such as Map and Set.

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -687,7 +687,16 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     // case of renameDirAlmostAtomically since that one is constructing files to
     // be checked in to version control, but here we could get away with it.
     if (this.buildPath !== this.outputPath) {
-      files.renameDirAlmostAtomically(this.buildPath, this.outputPath);
+      try {
+        files.rename(this.buildPath, this.outputPath);
+      } catch (e) {
+        if (e.code === "EXDEV") {
+          files.rm_recursive(this.outputPath);
+          files.cp_r(this.buildPath, this.outputPath);
+        } else {
+          throw e;
+        }
+      }
     }
   }
 

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -688,7 +688,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     // be checked in to version control, but here we could get away with it.
     if (this.buildPath !== this.outputPath) {
       try {
-        files.rename(this.buildPath, this.outputPath);
+        files.renameDirAlmostAtomically(this.buildPath, this.outputPath);
       } catch (e) {
         if (e.code === "EXDEV") {
           files.rm_recursive(this.outputPath);

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -687,16 +687,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     // case of renameDirAlmostAtomically since that one is constructing files to
     // be checked in to version control, but here we could get away with it.
     if (this.buildPath !== this.outputPath) {
-      try {
-        files.renameDirAlmostAtomically(this.buildPath, this.outputPath);
-      } catch (e) {
-        if (e.code === "EXDEV") {
-          files.rm_recursive(this.outputPath);
-          files.cp_r(this.buildPath, this.outputPath);
-        } else {
-          throw e;
-        }
-      }
+      files.renameDirAlmostAtomically(this.buildPath, this.outputPath);
     }
   }
 


### PR DESCRIPTION
This proposes reverting/replacing #8491, which has been problematic in the 1.4.4 series of RCs, specifically on Windows.  More so, I believe that `fs-extra` could be overboard and we could go with a much more simple implementation to accomplish the goal of fixing cross-device copies.

Unfortunately, `fs-extra` is still not as perfect at handling various file system conditions as would be ideal.  It seemed sensical to try and use a library like this, however it turns out that the Meteor suite of file system functions performs better on Windows.  For example, `fs-extra` still tries to create symlinks as an unprivileged user – a forbidden task on Windows unless running as Administrator.

In addition, I ran into a constant stream of other errors: `ENOTEMPTY`, `EBUSY`, `EEXIST` and `EPERM` (on an `open`, no less) – all for various, Windows-only (from what I can gather) reasons.

My current recommendation is that we remove `fs-extra` and replace the [`Builder#complete` `renameDirAlmostAtomically` call](/tools/isobuild/builder.js) (which does not absolutely _have_ to be done atomically; "fast" is the goal) with a `try`/`catch` which resorts to a basic copy if `err.code === 'EXDEV'`.  All other functionality stays the same.

I've crudely implemented it with 523c7ce9d4d47442becc307817a35d6bb9800915 but would be open to other suggestions.

This reverts commits:

* d49f3e2
* 3257baf
* 74cb8eb
* 5bbdcc9
* 6a0767b

/cc @jshimko 