### PR TITLE
Release 1.4.4.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,13 @@
 ## v.NEXT
 
+## v1.4.4.1, TBD
+
+* A change in Meteor 1.4.4 to remove "garbage" directories asynchronously
+  in `files.renameDirAlmostAtomically` had unintended consequences for
+  rebuilding some npm packages, so that change was reverted, and those
+  directories are now removed before `files.renameDirAlmostAtomically`
+  returns. [PR #8574](https://github.com/meteor/meteor/pull/8574)
+
 ## v1.4.4, 2017-04-07
 
 * Node has been upgraded to version 4.8.1.

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.18.0'
+  version: '6.18.1'
 });
 
 Npm.depends({

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.7.1',
+  version: '0.7.2',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.4.4'
+  version: '1.4.4-1-rc.0'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.4.4-1-rc.0'
+  version: '1.4.4_1'
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.4.4-rc.9",
+ "version": "1.4.4.1-rc.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.4.4",
+  "version": "1.4.4.1",
   "recommended": false,
   "official": true,
   "description": "The Official Meteor Distribution"

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -1038,7 +1038,7 @@ files.renameDirAlmostAtomically =
     // ... and take out the trash.
     if (cleanupGarbage) {
       // We don't care about how long this takes, so we'll let it go async.
-      files.rm_recursive_async(garbageDir);
+      files.rm_recursive(garbageDir);
     }
   });
 


### PR DESCRIPTION
Removing garbage directories asynchronously in `files.renameDirAlmostAtomically` (my idea, mea culpa) would have been a nice optimization if it had worked, but (in addition to leaving garbage directories lying around sometimes if the process was killed), it appears to have some unintended consequences for `meteorNpm.rebuildIfNonPortable` and related functions, since the garbage directories are easily confused for npm package directories.

Example stack trace:
```
  Error: ENOENT: no such file or directory, open '/home/travis/build/meteor/galaxy-server/node_modules/heapdump-garbage-1c2jqib/package.json'
      at Error (native)
   => awaited here:
      at Promise.await (/home/travis/.meteor/packages/less/.2.7.9.9fh5c1++os+web.browser+web.cordova/plugin.compileLessBatch.os/npm/node_modules/meteor/promise/node_modules/meteor-promise/promise_server.js:39:12)
      at copyFileHelper (/tools/fs/files.js:633:6)
      at Object.files.cp_r (/tools/fs/files.js:532:7)
      at /tools/isobuild/meteor-npm.js:393:11
      at Array.forEach (native)
      at copyNpmPackageWithSymlinkedNodeModules (/tools/isobuild/meteor-npm.js:386:29)
      at /tools/isobuild/meteor-npm.js:325:5
      at Array.forEach (native)
      at Object.rebuildIfNonPortable (/tools/isobuild/meteor-npm.js:315:17)
      at NodeModulesDirectory.rebuildIfNonPortable (/tools/isobuild/bundler.js:273:22)
      at /tools/isobuild/compiler.js:650:13
```