### PR TITLE
Implement CORDOVA_COMPATIBILITY_VERSION_IOS/ANDROID and EXCLUDE

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1525,11 +1525,16 @@ class ClientTarget extends Target {
 
       const cordovaCompatibilityVersions =
         _.object(_.map(CORDOVA_PLATFORM_VERSIONS, (version, platform) => {
-          let cordovaDependencies = Object.assign({}, this.cordovaDependencies);
-          let pluginsExcludedFromCompatibilityHash = process.env.CORDOVA_COMPATIBILITY_VERSION_EXCLUDE || '';
-          cordovaDependencies = _.omit(cordovaDependencies, pluginsExcludedFromCompatibilityHash.split(';'));
 
-          const hash = process.env[`CORDOVA_COMPATIBILITY_VERSION_${platform.toUpperCase()}`] ||
+          const pluginsExcludedFromCompatibilityHash = (process.env.METEOR_CORDOVA_COMPAT_VERSION_EXCLUDE || '')
+            .split(',');
+
+          const cordovaDependencies = Object.assign(
+            Object.create(null),
+            _.omit(this.cordovaDependencies, pluginsExcludedFromCompatibilityHash)
+          );
+
+          const hash = process.env[`METEOR_CORDOVA_COMPAT_VERSION_${platform.toUpperCase()}`] ||
               WebAppHashing.calculateCordovaCompatibilityHash(
                 version,
                 cordovaDependencies);

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1522,11 +1522,17 @@ class ClientTarget extends Target {
     if (this.arch === 'web.cordova') {
       const { WebAppHashing } =
         loadIsopacket('cordova-support')['webapp-hashing'];
+
       const cordovaCompatibilityVersions =
         _.object(_.map(CORDOVA_PLATFORM_VERSIONS, (version, platform) => {
-          const hash = WebAppHashing.calculateCordovaCompatibilityHash(
-            version,
-            this.cordovaDependencies);
+          let cordovaDependencies = Object.assign({}, this.cordovaDependencies);
+          let pluginsExcludedFromCompatibilityHash = process.env.CORDOVA_COMPATIBILITY_VERSION_EXCLUDE || '';
+          cordovaDependencies = _.omit(cordovaDependencies, pluginsExcludedFromCompatibilityHash.split(';'));
+
+          const hash = process.env[`CORDOVA_COMPATIBILITY_VERSION_${platform.toUpperCase()}`] ||
+              WebAppHashing.calculateCordovaCompatibilityHash(
+                version,
+                cordovaDependencies);
           return [platform, hash];
         }));
       program.cordovaCompatibilityVersions = cordovaCompatibilityVersions;

--- a/tools/tests/cordova-hcp.js
+++ b/tools/tests/cordova-hcp.js
@@ -39,3 +39,50 @@ selftest.define(
 
     run.stop();
 });
+
+selftest.define(
+  "cordova CORDOVA_COMPATIBILITY_VERSION_* works", ["cordova", "slow"], function () {
+    var s = new Sandbox();
+    var run;
+
+    var androidCompatibilityVersion = '2.0';
+
+    // Override the compatibility version for android with CORDOVA_COMPATIBILITY_VERSION_ANDROID.
+    s.env.CORDOVA_COMPATIBILITY_VERSION_ANDROID = androidCompatibilityVersion;
+
+    s.createApp("myapp", "standard-app");
+    s.cd("myapp");
+
+    var platforms = s.read(".meteor/platforms");
+    s.write(".meteor/platforms", platforms + "\nandroid\n");
+
+    run = s.run("run", "android", "--mobile-server", "example.com");
+    run.waitSecs(30);
+    run.match("Started your app");
+
+    var result = JSON.parse(httpHelpers.getUrl(
+        "http://localhost:3000/__cordova/manifest.json"));
+
+    // Check in the manifest if the overriden version was used.
+    selftest.expectEqual(result.cordovaCompatibilityVersions.android, androidCompatibilityVersion);
+
+    run.stop();
+    // Save the iOS compatibility version.
+    var iosCompatibilityVersion = result.cordovaCompatibilityVersions.ios;
+
+    // Now exclude one of the plugins from compatibility version calculation.
+    s.env.CORDOVA_COMPATIBILITY_VERSION_EXCLUDE = 'cordova-plugin-meteor-webapp';
+
+    run = s.run("run", "android", "--mobile-server", "example.com");
+    run.waitSecs(30);
+    run.match("Started your app");
+
+    result = JSON.parse(httpHelpers.getUrl(
+        "http://localhost:3000/__cordova/manifest.json"));
+
+    // Version should be different. There is no need to check if the particular plugin was not taken into account,
+    // if the version has changed it's proof enough.
+    selftest.expectFalse(result.cordovaCompatibilityVersions.ios === iosCompatibilityVersion);
+
+    run.stop();
+});

--- a/tools/tests/cordova-hcp.js
+++ b/tools/tests/cordova-hcp.js
@@ -41,14 +41,14 @@ selftest.define(
 });
 
 selftest.define(
-  "cordova CORDOVA_COMPATIBILITY_VERSION_* works", ["cordova", "slow"], function () {
+  "cordova METEOR_CORDOVA_COMPAT_VERSION_* works", ["cordova", "slow"], function () {
     var s = new Sandbox();
     var run;
 
     var androidCompatibilityVersion = '2.0';
 
-    // Override the compatibility version for android with CORDOVA_COMPATIBILITY_VERSION_ANDROID.
-    s.env.CORDOVA_COMPATIBILITY_VERSION_ANDROID = androidCompatibilityVersion;
+    // Override the compatibility version for android with METEOR_CORDOVA_COMPAT_VERSION_ANDROID.
+    s.env.METEOR_CORDOVA_COMPAT_VERSION_ANDROID = androidCompatibilityVersion;
 
     s.createApp("myapp", "standard-app");
     s.cd("myapp");
@@ -63,7 +63,7 @@ selftest.define(
     var result = JSON.parse(httpHelpers.getUrl(
         "http://localhost:3000/__cordova/manifest.json"));
 
-    // Check in the manifest if the overriden version was used.
+    // Check in the manifest if the overridden version was used.
     selftest.expectEqual(result.cordovaCompatibilityVersions.android, androidCompatibilityVersion);
 
     run.stop();
@@ -71,7 +71,7 @@ selftest.define(
     var iosCompatibilityVersion = result.cordovaCompatibilityVersions.ios;
 
     // Now exclude one of the plugins from compatibility version calculation.
-    s.env.CORDOVA_COMPATIBILITY_VERSION_EXCLUDE = 'cordova-plugin-meteor-webapp';
+    s.env.METEOR_CORDOVA_COMPAT_VERSION_EXCLUDE = 'cordova-plugin-meteor-webapp,any-other-plugin';
 
     run = s.run("run", "android", "--mobile-server", "example.com");
     run.waitSecs(30);


### PR DESCRIPTION
Hey,

quoting commit's message:
CORDOVA_COMPATIBILITY_VERSION_IOS or CORDOVA_COMPATIBILITY_VERSION_ANDROID allows to override compatibility version for a specified platform.

CORDOVA_COMPATIBILITY_VERSION_EXCLUDE provides a way of excluding a certain plugin from compatibility version calculation. You can pass several plugin names with ';'. For example: `CORDOVA_COMPATIBILITY_VERSION_EXCLUDE='cordova-plugin-crosswalk-webview;cordova-plugin-device'`

This addresses:
https://github.com/meteor/meteor/issues/7030
and somehow: https://github.com/meteor/meteor/issues/7183

Why **CORDOVA_COMPATIBILITY_VERSION_EXCLUDE**?
This can be used in many ways but the one crucial is crosswalk. Since it will no longer be developed https://crosswalk-project.org/blog/crosswalk-final-release.html this is crucial to be able to build two versions of the app while still being able to benefit from HCP on both. One can add the crosswalk plugin to exclude for instance and have the same compatibility version on both builds (the one with and without crosswalk).

@abernix, @martijnwalraven let me now what do you think about this 🙂 