### PR TITLE
Use tokens from Google Sign-In instead of calling getTokens.

### DIFF
--- a/packages/google-oauth/package.js
+++ b/packages/google-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Google OAuth flow",
-  version: "1.2.2"
+  version: "1.2.3"
 });
 
 var cordovaPluginGooglePlusURL =


### PR DESCRIPTION
Follow-up to https://github.com/meteor/meteor/pull/8588.

While testing #8588, I noticed that `request.serverAuthCode` was sometimes/always an empty string (on iOS, at least), so the `query` that was passed to `getServiceData` didn't have a usable `.code` property.

I then realized that the response from Google Sign-In already contains the tokens that would be returned from `getTokens`, so this PR avoids calling `getTokens` in that case, though it still shares most of the `serviceData` logic.

cc @realyze @ramezrafla @abernix 