### PR TITLE
Switch to modern nodemailer 4, Node 4 version. Fix #8591

### DIFF
--- a/packages/email/.npm/package/npm-shrinkwrap.json
+++ b/packages/email/.npm/package/npm-shrinkwrap.json
@@ -1,79 +1,14 @@
 {
   "dependencies": {
-    "addressparser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
-      "from": "addressparser@1.0.1"
-    },
-    "buildmail": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-4.0.1.tgz",
-      "from": "buildmail@4.0.1"
-    },
-    "httpntlm": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
-      "from": "httpntlm@1.6.1"
-    },
-    "httpreq": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.23.tgz",
-      "from": "httpreq@>=0.4.22"
-    },
-    "iconv-lite": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-      "from": "iconv-lite@0.4.15"
-    },
-    "libbase64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
-      "from": "libbase64@0.1.0"
-    },
-    "libmime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
-      "from": "libmime@3.0.0"
-    },
-    "libqp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
-      "from": "libqp@1.1.0"
-    },
-    "mailcomposer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-4.0.1.tgz",
-      "from": "mailcomposer@4.0.1"
-    },
-    "nodemailer-fetch": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
-      "from": "nodemailer-fetch@1.6.0"
-    },
-    "nodemailer-shared": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
-      "from": "nodemailer-shared@1.1.0"
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "from": "punycode@1.4.1"
-    },
-    "smtp-connection": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.2.tgz",
-      "from": "smtp-connection@2.12.2"
+    "node4mailer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/node4mailer/-/node4mailer-4.0.2.tgz",
+      "from": "node4mailer@4.0.2"
     },
     "stream-buffers": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.5.tgz",
       "from": "stream-buffers@0.2.5"
-    },
-    "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "from": "underscore@>=1.7.0 <1.8.0"
     }
   }
 }

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -37,9 +37,9 @@ var makeTransport = function (mailUrlString) {
     mailUrl.query.pool = 'true';
   }
 
-  mailUrlString = urlModule.format(mailUrl);
+  var transport = nodemailer.createTransport(
+    urlModule.format(mailUrl));
 
-  var transport = nodemailer.createTransport(mailUrlString);
   transport._syncSendMail = Meteor.wrapAsync(transport.sendMail, transport);
   return transport;
 };

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,17 +1,14 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.2.0"
+  version: "1.2.1"
 });
 
 Npm.depends({
-  mailcomposer: "4.0.1",
-  // Using smtp-connection@2 (instead of latest) because it shares
-  // nodemailer-shared with mailcomposer@4:
-  "smtp-connection": "2.12.2",
-  "stream-buffers": "0.2.5"});
+  node4mailer: "4.0.2",
+  "stream-buffers": "0.2.5"
+});
 
 Package.onUse(function (api) {
-  api.use('underscore', 'server');
   api.export(['Email', 'EmailInternals'], 'server');
   api.export('EmailTest', 'server', {testOnly: true});
   api.addFiles('email.js', 'server');


### PR DESCRIPTION
* Most critically, use a pool instead of direct SMTP connection, to handle dropped connections and increase throughput, like mail module 1.1.  (#8591)
* New nodemailer's sendMail wants an options object, not a MailComposer object.  Luckily, a MailComposer object has a "mail" field that remembers the original options, so we can keep original behavior.
* However, we no longer support the mailComposer option set to a compiled MailComposer object (functionality that was briefly added in 1.2.0).
* nodemailer does SMTP URL parsing now automatically for us, simplifying code.
* Tests' outputs now end with additional "\r\n"
* Drop underscore package dependency (no longer needed)