### PR TITLE
[Fix #5165] don't allow invalid field names

### DIFF
--- a/packages/minimongo/helpers.js
+++ b/packages/minimongo/helpers.js
@@ -43,28 +43,3 @@ isOperatorObject = function (valueSelector, inconsistentOK) {
 isNumericKey = function (s) {
   return /^[0-9]+$/.test(s);
 };
-
-// Make sure field names do not contain Mongo restricted
-// characters ('.', '$', '\0').
-// https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
-const invalidCharMsg = {
-  '.': "contain '.'",
-  '$': "start with '$'",
-  '\0': "contain null bytes",
-};
-isValidFieldName = function (key){
-      let match;
-      if (_.isString(key) && (match = key.match(/^\$|\.|\0/))) {
-        throw MinimongoError(`Key ${key} must not ${invalidCharMsg[match[0]]}`);
-      }
-}
-
-// checks if all field names in an object are valid
-hasValidFieldNames = function(doc){
-  if (doc && typeof doc === "object") {
-    JSON.stringify(doc, (key, value) => {
-      isValidFieldName(key);
-      return value;
-    });
-  }
-}

--- a/packages/minimongo/helpers.js
+++ b/packages/minimongo/helpers.js
@@ -43,3 +43,28 @@ isOperatorObject = function (valueSelector, inconsistentOK) {
 isNumericKey = function (s) {
   return /^[0-9]+$/.test(s);
 };
+
+// Make sure field names do not contain Mongo restricted
+// characters ('.', '$', '\0').
+// https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+const invalidCharMsg = {
+  '.': "contain '.'",
+  '$': "start with '$'",
+  '\0': "contain null bytes",
+};
+isValidFieldName = function (key){
+      let match;
+      if (_.isString(key) && (match = key.match(/^\$|\.|\0/))) {
+        throw MinimongoError(`Key ${key} must not ${invalidCharMsg[match[0]]}`);
+      }
+}
+
+// checks if all field names in an object are valid
+hasValidFieldNames = function(doc){
+  if (doc && typeof doc === "object") {
+    JSON.stringify(doc, (key, value) => {
+      isValidFieldName(key);
+      return value;
+    });
+  }
+}

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -548,23 +548,7 @@ LocalCollection.prototype.insert = function (doc, callback) {
   var self = this;
   doc = EJSON.clone(doc);
 
-  // Make sure field names do not contain Mongo restricted
-  // characters ('.', '$', '\0').
-  // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
-  if (doc) {
-    const invalidCharMsg = {
-      '.': "contain '.'",
-      '$': "start with '$'",
-      '\0': "contain null bytes",
-    };
-    JSON.stringify(doc, (key, value) => {
-      let match;
-      if (_.isString(key) && (match = key.match(/^\$|\.|\0/))) {
-        throw MinimongoError(`Key ${key} must not ${invalidCharMsg[match[0]]}`);
-      }
-      return value;
-    });
-  }
+  hasValidFieldNames(doc);
 
   if (!_.has(doc, '_id')) {
     // if you really want to use ObjectIDs, set this global.

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -1,3 +1,5 @@
+import { assertHasValidFieldNames } from './validation.js';
+
 // XXX type checking on selectors (graceful error if malformed)
 
 // LocalCollection: a set of documents that supports queries and modifiers.
@@ -540,15 +542,13 @@ LocalCollection.Cursor.prototype._depend = function (changers, _allow_unordered)
   }
 };
 
-// XXX enforce rule that field names can't start with '$' or contain '.'
-// (real mongodb does in fact enforce this)
 // XXX possibly enforce that 'undefined' does not appear (we assume
 // this in our handling of null and $exists)
 LocalCollection.prototype.insert = function (doc, callback) {
   var self = this;
   doc = EJSON.clone(doc);
 
-  hasValidFieldNames(doc);
+  assertHasValidFieldNames(doc);
 
   if (!_.has(doc, '_id')) {
     // if you really want to use ObjectIDs, set this global.

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2207,6 +2207,13 @@ Tinytest.add("minimongo - modify", function (test) {
     test.equal(actual, expected);
   };
 
+  var upsertException = function (query, mod) {
+    var coll = new LocalCollection;
+    test.throws(function(){
+      coll.upsert(query, mod);
+    });
+  };
+
   // document replacement
   modify({}, {}, {});
   modify({a: 12}, {}, {}); // tested against mongodb
@@ -2214,6 +2221,11 @@ Tinytest.add("minimongo - modify", function (test) {
   modify({a: 12, b: 99}, {a: 13}, {a:13});
   exception({a: 12}, {a: 13, $set: {b: 13}});
   exception({a: 12}, {$set: {b: 13}, a: 13});
+
+  exception({a: 12}, {$a: 13}); //invalid operator
+  exception({a: 12}, {b:{$a: 13}});
+  exception({a: 12}, {b:{'a.b': 13}});
+  exception({a: 12}, {b:{'\0a': 13}});
 
   // keys
   modify({}, {$set: {'a': 12}}, {a: 12});
@@ -2383,6 +2395,12 @@ Tinytest.add("minimongo - modify", function (test) {
   modify({}, {$set: {'x._id': 4}}, {x: {_id: 4}});
   exception({}, {$set: {_id: 4}});
   exception({_id: 4}, {$set: {_id: 4}});  // even not-changing _id is bad
+  //restricted field names
+  exception({a:{}}, {$set:{a:{$a:1}}}); 
+  exception({ a: {} }, { $set: { a: { c:
+              [{ b: { $a: 1 } }] } } });
+  exception({a:{}}, {$set:{a:{'\0a':1}}});
+  exception({a:{}}, {$set:{a:{'a.b':1}}});
 
   // $unset
   modify({}, {$unset: {a: 1}}, {});
@@ -2457,7 +2475,16 @@ Tinytest.add("minimongo - modify", function (test) {
     {$push: {a: {$each: [{x: 3}], $position: 0, $sort: {x: 1}, $slice: 0}}},
     {a: []}
   );
-
+  //restricted field names
+  exception({}, {$push: {$a: 1}});
+  exception({}, {$push: {'\0a': 1}});
+  exception({}, {$push: {a: {$a:1}}});
+  exception({}, {$push: {a: {$each: [{$a:1}]}}});
+  exception({}, {$push: {a: {$each: [{"a.b":1}]}}});
+  exception({}, {$push: {a: {$each: [{'\0a':1}]}}});
+  modify({}, {$push: {a: {$each: [{'':1}]}}}, {a: [ { '': 1 } ]});
+  modify({}, {$push: {a: {$each: [{' ':1}]}}}, {a: [ { ' ': 1 } ]});
+  exception({}, {$push: {a: {$each: [{'.':1}]}}});
 
   // $pushAll
   modify({}, {$pushAll: {a: [1]}}, {a: [1]});
@@ -2475,6 +2502,9 @@ Tinytest.add("minimongo - modify", function (test) {
   modify({a: []}, {$pushAll: {'a.1': []}}, {a: [null, []]});
   modify({a: {}}, {$pushAll: {'a.x': [99]}}, {a: {x: [99]}});
   modify({a: {}}, {$pushAll: {'a.x': []}}, {a: {x: []}});
+  exception({a: [1]}, {$pushAll: {a: [{$a:1}]}});
+  exception({a: [1]}, {$pushAll: {a: [{'\0a':1}]}});
+  exception({a: [1]}, {$pushAll: {a: [{"a.b":1}]}});
 
   // $addToSet
   modify({}, {$addToSet: {a: 1}}, {a: [1]});
@@ -2493,14 +2523,25 @@ Tinytest.add("minimongo - modify", function (test) {
   modify({a: [{x: 1, y: 2}]}, {$addToSet: {a: {y: 2, x: 1}}},
          {a: [{x: 1, y: 2}, {y: 2, x: 1}]});
   modify({a: [1, 2]}, {$addToSet: {a: {$each: [3, 1, 4]}}}, {a: [1, 2, 3, 4]});
-  modify({a: [1, 2]}, {$addToSet: {a: {$each: [3, 1, 4], b: 12}}},
-         {a: [1, 2, 3, 4]}); // tested
-  modify({a: [1, 2]}, {$addToSet: {a: {b: 12, $each: [3, 1, 4]}}},
-         {a: [1, 2, {b: 12, $each: [3, 1, 4]}]}); // tested
   modify({}, {$addToSet: {a: {$each: []}}}, {a: []});
   modify({}, {$addToSet: {a: {$each: [1]}}}, {a: [1]});
   modify({a: []}, {$addToSet: {'a.1': 99}}, {a: [null, [99]]});
   modify({a: {}}, {$addToSet: {'a.x': 99}}, {a: {x: [99]}});
+  
+  // invalid field names
+  exception({}, {$addToSet: {a: {$b:1}}});
+  exception({}, {$addToSet: {a: {"a.b":1}}});
+  exception({}, {$addToSet: {a: {"a.":1}}});
+  exception({}, {$addToSet: {a: {'\u0000a':1}}});
+  exception({a: [1, 2]}, {$addToSet: {a:{$each: [3, 1, {$a:1}]}}}); 
+  exception({a: [1, 2]}, {$addToSet: {a:{$each: [3, 1, {'\0a':1}]}}}); 
+  exception({a: [1, 2]}, {$addToSet: {a:{$each: [3, 1, [{$a:1}]]}}}); 
+  exception({a: [1, 2]}, {$addToSet: {a:{$each: [3, 1, [{b:{c:[{a:1},{"d.s":2}]}}]]}}}); 
+  exception({a: [1, 2]}, {$addToSet: {a:{b: [3, 1, [{b:{c:[{a:1},{"d.s":2}]}}]]}}});
+  //$each is first element and thus an operator
+  modify({a: [1, 2]}, {$addToSet: {a: {$each: [3, 1, 4], b: 12}}},{a: [ 1, 2, 3, 4 ]});
+  // this should fail because $each is now a field name (not first in object) and thus invalid field name with $
+  exception({a: [1, 2]}, {$addToSet: {a: {b: 12, $each: [3, 1, 4]}}}); 
 
   // $pop
   modify({}, {$pop: {a: 1}}, {}); // tested
@@ -2574,11 +2615,19 @@ Tinytest.add("minimongo - modify", function (test) {
   exception({}, {$rename: {'a': 'a'}});
   exception({}, {$rename: {'a.b': 'a.b'}});
   modify({a: 12, b: 13}, {$rename: {a: 'b'}}, {b: 12});
+  exception({a: [12]}, {$rename: {a: '$b'}});
+  exception({a: [12]}, {$rename: {a: '\0a'}});
 
   // $setOnInsert
   modify({a: 0}, {$setOnInsert: {a: 12}}, {a: 0});
   upsert({a: 12}, {$setOnInsert: {b: 12}}, {a: 12, b: 12});
   upsert({a: 12}, {$setOnInsert: {_id: 'test'}}, {_id: 'test', a: 12});
+  upsertException({a: 0}, {$setOnInsert: {$a: 12}});
+  upsertException({a: 0}, {$setOnInsert: {'\0a': 12}});
+  upsert({a: 0}, {$setOnInsert: {b: {a:1}}}, {a:0, b:{a:1}});
+  upsertException({a: 0}, {$setOnInsert: {b: {$a:1}}});
+  upsertException({a: 0}, {$setOnInsert: {b: {'a.b':1}}});
+  upsertException({a: 0}, {$setOnInsert: {b: {'\0a':1}}});
 
   exception({}, {$set: {_id: 'bad'}});
 

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -1,3 +1,5 @@
+import { assertHasValidFieldNames, assertIsValidFieldName } from './validation.js';
+
 // XXX need a strategy for passing the binding of $ into this
 // function, from the compiled selector
 //
@@ -27,7 +29,7 @@ LocalCollection._modify = function (doc, mod, options) {
       throw MinimongoError("Cannot change the _id of a document");
 
     // replace the whole document
-    hasValidFieldNames(mod);
+    assertHasValidFieldNames(mod);
     newDoc = mod;
   } else {
     // apply modifiers to the doc.
@@ -151,7 +153,7 @@ var findModTarget = function (doc, keyparts, options) {
                       "' of list value " + JSON.stringify(doc[keypart]));
       }
     } else {
-      isValidFieldName(keypart);
+      assertIsValidFieldName(keypart);
       if (!(keypart in doc)) {
         if (options.noCreate)
           return undefined;
@@ -246,7 +248,7 @@ var MODIFIERS = {
       e.setPropertyError = true;
       throw e;
     }
-    hasValidFieldNames(arg);
+    assertHasValidFieldNames(arg);
     target[field] = arg;
   },
   $setOnInsert: function (target, field, arg) {
@@ -270,7 +272,7 @@ var MODIFIERS = {
 
     if (!(arg && arg.$each)) {
       // Simple mode: not $each
-      hasValidFieldNames(arg);
+      assertHasValidFieldNames(arg);
       target[field].push(arg);
       return;
     }
@@ -279,7 +281,7 @@ var MODIFIERS = {
     var toPush = arg.$each;
     if (!(toPush instanceof Array))
       throw MinimongoError("$each must be an array", { field });
-    hasValidFieldNames(toPush);
+    assertHasValidFieldNames(toPush);
 
     // Parse $position
     var position = undefined;
@@ -349,7 +351,7 @@ var MODIFIERS = {
   $pushAll: function (target, field, arg) {
     if (!(typeof arg === "object" && arg instanceof Array))
       throw MinimongoError("Modifier $pushAll/pullAll allowed for arrays only");
-    hasValidFieldNames(arg);
+    assertHasValidFieldNames(arg);
     var x = target[field];
     if (x === undefined)
       target[field] = arg;
@@ -371,7 +373,7 @@ var MODIFIERS = {
       }
     }
     var values = isEach ? arg["$each"] : [arg];
-    hasValidFieldNames(values);
+    assertHasValidFieldNames(values);
     var x = target[field];
     if (x === undefined)
       target[field] = values;

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -27,11 +27,7 @@ LocalCollection._modify = function (doc, mod, options) {
       throw MinimongoError("Cannot change the _id of a document");
 
     // replace the whole document
-    for (var k in mod) {
-      if (/\./.test(k))
-        throw MinimongoError(
-          "When replacing document, field name may not contain '.'");
-    }
+    hasValidFieldNames(mod);
     newDoc = mod;
   } else {
     // apply modifiers to the doc.
@@ -155,8 +151,7 @@ var findModTarget = function (doc, keyparts, options) {
                       "' of list value " + JSON.stringify(doc[keypart]));
       }
     } else {
-      if (keypart.length && keypart.substr(0, 1) === '$')
-        throw MinimongoError("can't set field named " + keypart);
+      isValidFieldName(keypart);
       if (!(keypart in doc)) {
         if (options.noCreate)
           return undefined;
@@ -251,11 +246,7 @@ var MODIFIERS = {
       e.setPropertyError = true;
       throw e;
     }
-    if (_.isString(field) && field.indexOf('\0') > -1) {
-      // Null bytes are not allowed in Mongo field names
-      // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
-      throw MinimongoError(`Key ${field} must not contain null bytes`);
-    }
+    hasValidFieldNames(arg);
     target[field] = arg;
   },
   $setOnInsert: function (target, field, arg) {
@@ -279,6 +270,7 @@ var MODIFIERS = {
 
     if (!(arg && arg.$each)) {
       // Simple mode: not $each
+      hasValidFieldNames(arg);
       target[field].push(arg);
       return;
     }
@@ -287,6 +279,7 @@ var MODIFIERS = {
     var toPush = arg.$each;
     if (!(toPush instanceof Array))
       throw MinimongoError("$each must be an array", { field });
+    hasValidFieldNames(toPush);
 
     // Parse $position
     var position = undefined;
@@ -356,6 +349,7 @@ var MODIFIERS = {
   $pushAll: function (target, field, arg) {
     if (!(typeof arg === "object" && arg instanceof Array))
       throw MinimongoError("Modifier $pushAll/pullAll allowed for arrays only");
+    hasValidFieldNames(arg);
     var x = target[field];
     if (x === undefined)
       target[field] = arg;
@@ -371,13 +365,13 @@ var MODIFIERS = {
     var isEach = false;
     if (typeof arg === "object") {
       //check if first key is '$each'
-      for (var k in arg) {
-        if (k === "$each")
-          isEach = true;
-        break;
+      const keys = Object.keys(arg);
+      if (keys[0] === "$each"){
+        isEach = true;
       }
     }
     var values = isEach ? arg["$each"] : [arg];
+    hasValidFieldNames(values);
     var x = target[field];
     if (x === undefined)
       target[field] = values;

--- a/packages/minimongo/validation.js
+++ b/packages/minimongo/validation.js
@@ -1,0 +1,24 @@
+// Make sure field names do not contain Mongo restricted
+// characters ('.', '$', '\0').
+// https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+const invalidCharMsg = {
+  '.': "contain '.'",
+  '$': "start with '$'",
+  '\0': "contain null bytes",
+};
+export function assertIsValidFieldName(key) {
+  let match;
+  if (_.isString(key) && (match = key.match(/^\$|\.|\0/))) {
+    throw MinimongoError(`Key ${key} must not ${invalidCharMsg[match[0]]}`);
+  }
+};
+
+// checks if all field names in an object are valid
+export function assertHasValidFieldNames(doc){
+  if (doc && typeof doc === "object") {
+    JSON.stringify(doc, (key, value) => {
+      assertIsValidFieldName(key);
+      return value;
+    });
+  }
+};


### PR DESCRIPTION
#5165 

This fixes issues with minimongo allowing updates with invalid field names. I started out by looking at $addToSet as per ticket, and then expanded to check on other modifiers. I also checked on insert which was handling this issue. 

I ran all the tests on server MongoDB to confirm consistent behavior.