### PR TITLE
Remove leading slash from paths in Babel options

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -86,8 +86,8 @@ BCp.processOneFileForTarget = function (inputFile, source) {
     babelOptions.sourceMap = true;
     babelOptions.filename =
       babelOptions.sourceFileName = packageName
-      ? "/packages/" + packageName + "/" + inputFilePath
-      : "/" + inputFilePath;
+      ? "packages/" + packageName + "/" + inputFilePath
+      : inputFilePath;
 
     babelOptions.sourceMapTarget = babelOptions.filename + ".map";
 


### PR DESCRIPTION
Removes the leading slash from the `filename` and `sourceFileName` Babel options so that Babel plugins can distinguish relative paths from absolute paths.

I couldn't find out if the `filename` property is used somewhere in the Meteor build process but the `sourceFileName` is used in [tools/isobuild/bundler.js](https://github.com/meteor/meteor/blob/6a9f8b904425efce112103f3846d7a153f8988ca/tools/isobuild/bundler.js#L1245) where the removed slash is handled correctly.

Fixes #8566