### PR TITLE
[#3599] match $near behavior in minimongo to mongo

### DIFF
--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -699,7 +699,7 @@ LocalCollection.prototype.update = function (selector, mod, options, callback) {
   }
   if (!options) options = {};
 
-  var matcher = new Minimongo.Matcher(selector);
+  var matcher = new Minimongo.Matcher(selector, true);
 
   // Save the original results of any query that we might need to
   // _recomputeResults on, because _modifyAndNotify will mutate the objects in

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2301,7 +2301,6 @@ Tinytest.add("minimongo - modify", function (test) {
                   {'a.x': 1, 'a.y': 3},
                   {$set: {'a.$.z': 5}},
                   {a: [{x: 1}, {y: 3, z: 5}]});
-  // with $near, make sure it does not find the closest one (#3599)
   modifyWithQuery({a: [{x: 1}, {y: 1}, {x: 1, y: 1}]},
                   {a: {$elemMatch: {x: 1, y: 1}}},
                   {$set: {'a.$.x': 2}},
@@ -2310,6 +2309,7 @@ Tinytest.add("minimongo - modify", function (test) {
                   {'a.b': {$elemMatch: {x: 1, y: 1}}},
                   {$set: {'a.$.b': 3}},
                   {a: [{b: 3}]});
+  // with $near, make sure it does not find the closest one (#3599)
   modifyWithQuery({a: []},
                   {'a.b': {$near: [5, 5]}},
                   {$set: {'a.$.b': 'k'}},
@@ -2323,7 +2323,13 @@ Tinytest.add("minimongo - modify", function (test) {
                        {b: [9,9]}]},
                   {'a.b': {$near: [5, 5]}},
                   {$set: {'a.$.b': 'k'}},
-                  {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[9,9]}]});  
+                  {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[9,9]}]}); 
+  modifyWithQuery({a: [{b: [1,1]},
+                       {b: [ [3,3], [4,4] ]},
+                       {b: [9,9]}]},
+                  {'a.b': {$near: [9, 9], $maxDistance: 1}},
+                  {$set: {'a.$.b': 'k'}},
+                  {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[9,9]}]}); 
   modifyWithQuery({a: [{b: [1,1]},
                        {b: [ [3,3], [4,4] ]},
                        {b: [9,9]}]},
@@ -2336,12 +2342,23 @@ Tinytest.add("minimongo - modify", function (test) {
                   {'a.b': {$near: [9, 9]}},
                   {$set: {'a.$.b': 'k'}},
                   {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[9,9]}]});
-  modifyWithQuery({a: [{b: [9,9]},
+  modifyWithQuery({a: [{b:[4,3]},
+                       {c: [1,1]}]},
+                  {'a.c': {$near: [1, 1]}},
+                  {$set: {'a.$.c': 'k'}},
+                  {"a":[{"c": "k", "b":[4,3]},{"c":[1,1]}]});
+  modifyWithQuery({a: [{c: [9,9]},
                        {b: [ [3,3], [4,4] ]},
                        {b: [1,1]}]},
-                  {'a.b': {$near: [9, 9]}},
+                  {'a.b': {$near: [1, 1]}},
                   {$set: {'a.$.b': 'k'}},
-                  {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[1,1]}]});
+                  {"a":[{"c": [9,9], "b":"k"},{"b": [ [3,3], [4,4]]},{"b":[1,1]}]});  
+  modifyWithQuery({a: [{c: [9,9], b:[4,3]},
+                       {b: [ [3,3], [4,4] ]},
+                       {b: [1,1]}]},
+                  {'a.b': {$near: [1, 1]}},
+                  {$set: {'a.$.b': 'k'}},
+                  {"a":[{"c": [9,9], "b":"k"},{"b": [ [3,3], [4,4]]},{"b":[1,1]}]});
 
   // $inc
   modify({a: 1, b: 2}, {$inc: {a: 10}}, {a: 11, b: 2});

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2301,13 +2301,7 @@ Tinytest.add("minimongo - modify", function (test) {
                   {'a.x': 1, 'a.y': 3},
                   {$set: {'a.$.z': 5}},
                   {a: [{x: 1}, {y: 3, z: 5}]});
-  // with $near, make sure it finds the closest one
-  modifyWithQuery({a: [{b: [1,1]},
-                       {b: [ [3,3], [4,4] ]},
-                       {b: [9,9]}]},
-                  {'a.b': {$near: [5, 5]}},
-                  {$set: {'a.$.b': 'k'}},
-                  {a: [{b: [1,1]}, {b: 'k'}, {b: [9,9]}]});
+  // with $near, make sure it does not find the closest one (#3599)
   modifyWithQuery({a: [{x: 1}, {y: 1}, {x: 1, y: 1}]},
                   {a: {$elemMatch: {x: 1, y: 1}}},
                   {$set: {'a.$.x': 2}},
@@ -2316,6 +2310,38 @@ Tinytest.add("minimongo - modify", function (test) {
                   {'a.b': {$elemMatch: {x: 1, y: 1}}},
                   {$set: {'a.$.b': 3}},
                   {a: [{b: 3}]});
+  modifyWithQuery({a: []},
+                  {'a.b': {$near: [5, 5]}},
+                  {$set: {'a.$.b': 'k'}},
+                  {"a":[]});
+  modifyWithQuery({a: [{b: [ [3,3], [4,4] ]}]},
+                  {'a.b': {$near: [5, 5]}},
+                  {$set: {'a.$.b': 'k'}},
+                  {"a":[{"b":"k"}]});
+  modifyWithQuery({a: [{b: [1,1]},
+                       {b: [ [3,3], [4,4] ]},
+                       {b: [9,9]}]},
+                  {'a.b': {$near: [5, 5]}},
+                  {$set: {'a.$.b': 'k'}},
+                  {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[9,9]}]});  
+  modifyWithQuery({a: [{b: [1,1]},
+                       {b: [ [3,3], [4,4] ]},
+                       {b: [9,9]}]},
+                  {'a.b': {$near: [9, 9]}},
+                  {$set: {'a.$.b': 'k'}},
+                  {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[9,9]}]});
+  modifyWithQuery({a: [{b: [9,9]},
+                       {b: [ [3,3], [4,4] ]},
+                       {b: [9,9]}]},
+                  {'a.b': {$near: [9, 9]}},
+                  {$set: {'a.$.b': 'k'}},
+                  {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[9,9]}]});
+  modifyWithQuery({a: [{b: [9,9]},
+                       {b: [ [3,3], [4,4] ]},
+                       {b: [1,1]}]},
+                  {'a.b': {$near: [9, 9]}},
+                  {$set: {'a.$.b': 'k'}},
+                  {"a":[{"b":"k"},{"b":[[3,3],[4,4]]},{"b":[1,1]}]});
 
   // $inc
   modify({a: 1, b: 2}, {$inc: {a: 10}}, {a: 11, b: 2});

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -3251,7 +3251,7 @@ Tinytest.add("minimongo - $near operator tests", function (test) {
   testNear([2, 2], 1000, ['x', 'y']);
 
   // issue #3599
-  // Ensure that distance are not used as a tie-breaker for sort.
+  // Ensure that distance is not used as a tie-breaker for sort.
   test.equal(
     _.pluck(coll.find({'a.b': {$near: [1, 1]}}, {sort: {k: 1}}).fetch(), '_id'),
     ['x', 'y']);

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -3207,13 +3207,14 @@ Tinytest.add("minimongo - $near operator tests", function (test) {
   // 'y'.
   testNear([2, 2], 1000, ['x', 'y']);
 
-  // Ensure that distance is used as a tie-breaker for sort.
+  // issue #3599
+  // Ensure that distance are not used as a tie-breaker for sort.
   test.equal(
     _.pluck(coll.find({'a.b': {$near: [1, 1]}}, {sort: {k: 1}}).fetch(), '_id'),
     ['x', 'y']);
   test.equal(
     _.pluck(coll.find({'a.b': {$near: [5, 5]}}, {sort: {k: 1}}).fetch(), '_id'),
-    ['y', 'x']);
+    ['x', 'y']);
 
   var operations = [];
   var cbs = log_callbacks(operations);

--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -18,7 +18,7 @@
 // Main entry point.
 //   var matcher = new Minimongo.Matcher({a: {$gt: 5}});
 //   if (matcher.documentMatches({a: 7})) ...
-Minimongo.Matcher = function (selector) {
+Minimongo.Matcher = function (selector, isUpdate = false) {
   var self = this;
   // A set (object mapping string -> *) of all of the document paths looked
   // at by the selector. Also includes the empty string if it may look at any
@@ -41,6 +41,10 @@ Minimongo.Matcher = function (selector) {
   // Sorter._useWithMatcher.
   self._selector = null;
   self._docMatcher = self._compileSelector(selector);
+  // Set to true if selection is done for an update operation
+  // Default is false
+  // Used for $near array update (issue #3599)
+  self._isUpdate = isUpdate;
 };
 
 _.extend(Minimongo.Matcher.prototype, {
@@ -497,7 +501,9 @@ var VALUE_OPERATORS = {
           return;
         result.result = true;
         result.distance = curDistance;
-        if (!branch.arrayIndices)
+        if (matcher._isUpdate)
+          result.arrayIndices = [0,0];
+        else if (!branch.arrayIndices)
           delete result.arrayIndices;
         else
           result.arrayIndices = branch.arrayIndices;


### PR DESCRIPTION
#3599 
The goal was to match the behavior of $near in tests to Mongo as close as possible in tests. As such, all the tests I added or updated have been run on server Mongo before I started fixing the code. Here's the issues I discovered:
1. In Mongo, sort as an option [overrides $near sort completely](https://docs.mongodb.com/manual/reference/operator/query/near/#sort-operation) and does not use $near as a tie-breaker.
2. When using $near to query an array with an update, Mongo always uses the first matching index to update.
3. Mongo and MiniMongo differ in the behavior of observe and applying changes. This seemed out of scope and possibly not an issue for this ticket. 
4. Mongo does not throw an error on find with $near when it's not a top-level operator like "{$and:{$near". Instead, it throws an error on fetch(). As such, I thought the current behavior of MiniMongo (throwing an error on find) is acceptable. 