### PR TITLE
fix bug when initiating dict with non string values

### DIFF
--- a/packages/reactive-dict/reactive-dict-tests.js
+++ b/packages/reactive-dict/reactive-dict-tests.js
@@ -6,6 +6,16 @@ Tinytest.add('ReactiveDict - set to undefined', function (test) {
   test.equal(dict.get('foo'), undefined);
 });
 
+Tinytest.add('ReactiveDict - initialize with data', function (test) {
+  var now = new Date();
+  var dict = new ReactiveDict({
+    now: now
+  });
+  
+  var nowFromDict = dict.get('now');
+  test.equal(nowFromDict, now);
+});
+
 Tinytest.add('ReactiveDict - setDefault', function (test) {
   var dict = new ReactiveDict;
   dict.set('A', 'blah');

--- a/packages/reactive-dict/reactive-dict.js
+++ b/packages/reactive-dict/reactive-dict.js
@@ -27,7 +27,10 @@ ReactiveDict = function (dictName) {
       this.name = dictName;
     } else if (typeof dictName === 'object') {
       // back-compat case: dictName is actually migrationData
-      this.keys = dictName;
+      this.keys = {};
+      for (let [key, value] of Object.entries(dictName)) {
+        this.keys[key] = stringify(value);
+      }
     } else {
       throw new Error("Invalid ReactiveDict argument: " + dictName);
     }


### PR DESCRIPTION
```js
var b = new ReactiveDict({b: true});
b.get('b') //throw (Error: EJSON.parse argument should be a string)
```
This is because `dict.set` stringify the value before settings it, which is not done when u initiate the dict with initial data.
