### PR TITLE
Added a small note explaining how to get dev_bundle changes published.

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -90,9 +90,9 @@ This will generate a new tarball (`dev_bundle_<Platform>_<arch>_<version>.tar.gz
 
 ### Submitting "Dev Bundle" Pull Requests
 
-It's important to note that while `dev_bundle` pull requests are accepted/reviewed, new `dev_bundle`'s can only be published to MDG's Meteor infrastructure by an MDG staff member. This means that the build tool and package tests of submitted `dev_bundle` PR's will always initially fail (since the new `dev_bundle` hasn't yet been built/published by MDG, which means it can't be downloaded by Meteor's continuous integration environment). 
+It's important to note that while `dev_bundle` pull requests are accepted/reviewed, a new `dev_bundle` can only be published to MDG's Meteor infrastructure by an MDG staff member. This means that the build tool and package tests of submitted `dev_bundle` pull requests will always initially fail (since the new `dev_bundle` hasn't yet been built/published by MDG, which means it can't be downloaded by Meteor's continuous integration environment). 
 
-When submitting a `dev_bundle` PR, please mention @platform in the PR, requesting to have a new `dev_bundle` built/published.
+When submitting a `dev_bundle` PR, please mention @meteor/platform in the PR, requesting to have a new `dev_bundle` built/published.
 
 ## Additional documentation
 

--- a/Development.md
+++ b/Development.md
@@ -92,7 +92,7 @@ This will generate a new tarball (`dev_bundle_<Platform>_<arch>_<version>.tar.gz
 
 It's important to note that while `dev_bundle` pull requests are accepted/reviewed, a new `dev_bundle` can only be published to MDG's Meteor infrastructure by an MDG staff member. This means that the build tool and package tests of submitted `dev_bundle` pull requests will always initially fail (since the new `dev_bundle` hasn't yet been built/published by MDG, which means it can't be downloaded by Meteor's continuous integration environment). 
 
-When submitting a `dev_bundle` PR, please mention @meteor/platform in the PR, requesting to have a new `dev_bundle` built/published.
+Pull requests that contain `dev_bundle` changes will be noted by repo collaborators, and a request to have a new `dev_bundle` built/published will be forwarded to MDG.
 
 ## Additional documentation
 

--- a/Development.md
+++ b/Development.md
@@ -88,6 +88,12 @@ $ ./scripts/generate-dev-bundle.sh
 
 This will generate a new tarball (`dev_bundle_<Platform>_<arch>_<version>.tar.gz`) in the root of the checkout.  Assuming you bumped the `BUNDLE_VERSION`, the new version will be extracted automatically when you run `./meteor`.  If you are rebuilding the same version (or didn't bump the version number), you should delete the existing `dev_bundle` directory to ensure the new tarball is extracted when you run `./meteor`.
 
+### Submitting "Dev Bundle" Pull Requests
+
+It's important to note that while `dev_bundle` pull requests are accepted/reviewed, new `dev_bundle`'s can only be published to MDG's Meteor infrastructure by an MDG staff member. This means that the build tool and package tests of submitted `dev_bundle` PR's will always initially fail (since the new `dev_bundle` hasn't yet been built/published by MDG, which means it can't be downloaded by Meteor's continuous integration environment). 
+
+When submitting a `dev_bundle` PR, please mention @platform in the PR, requesting to have a new `dev_bundle` built/published.
+
 ## Additional documentation
 
 The Meteor core is best documented within the code itself, however, many components also have a `README.md` in their respective directories.


### PR DESCRIPTION
Hi all - I've updated the `Development.md` doc with a small note explaining why `dev_bundle` PR tests initially fail, and how to request a new `dev_bundle` be built/published. Thanks!