### PR TITLE
Add support for initial data alongside a name for ReactiveDict

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## v.NEXT
 
+* `reactive-dict` now supports setting initial data when defining a named
+  `ReactiveDict`. No longer run migration logic when used on the server,
+  this is to prevent duplicate name error on reloads. Initial data is now
+  properly serialized.
+
 ## v1.4.4.2, 2017-05-02
 
 * Node has been upgraded to version 4.8.2.

--- a/packages/reactive-dict/migration.js
+++ b/packages/reactive-dict/migration.js
@@ -1,3 +1,5 @@
+import { ReactiveDict } from './reactive-dict';
+
 ReactiveDict._migratedDictData = {}; // name -> data
 ReactiveDict._dictsToMigrate = {}; // name -> ReactiveDict
 
@@ -34,3 +36,5 @@ if (Meteor.isClient && Package.reload) {
     return [true, {dicts: dataToMigrate}];
   });
 }
+
+export { ReactiveDict };

--- a/packages/reactive-dict/package.js
+++ b/packages/reactive-dict/package.js
@@ -7,9 +7,8 @@ Package.onUse(function (api) {
   api.use(['underscore', 'tracker', 'ejson', 'ecmascript']);
   // If we are loading mongo-livedata, let you store ObjectIDs in it.
   api.use('mongo', {weak: true});
+  api.mainModule('migration.js');
   api.export('ReactiveDict');
-  api.addFiles('reactive-dict.js');
-  api.addFiles('migration.js');
 });
 
 Package.onTest(function (api) {

--- a/packages/reactive-dict/reactive-dict-tests.js
+++ b/packages/reactive-dict/reactive-dict-tests.js
@@ -11,8 +11,24 @@ Tinytest.add('ReactiveDict - initialize with data', function (test) {
   var dict = new ReactiveDict({
     now: now
   });
-  
+
   var nowFromDict = dict.get('now');
+  test.equal(nowFromDict, now);
+
+  // Test with static value here as a named dict could
+  // be migrated if code reload happens while testing
+  dict = new ReactiveDict('foo', {
+    foo: 'bar'
+  });
+
+  nowFromDict = dict.get('foo');
+  test.equal(nowFromDict, 'bar');
+
+  dict = new ReactiveDict(undefined, {
+    now: now
+  });
+
+  nowFromDict = dict.get('now');
   test.equal(nowFromDict, now);
 });
 


### PR DESCRIPTION
As per the discussion in #8643 I've changed the implementation of `ReactiveDict` to support setting initial data when creating a `ReactiveDict` with a name.
```js
const state = new ReactiveDict('applicationState', { currentRoute: 'home' });
```
This PR also fixes the issue brought up in #8643 by using `_setObject` which uses `set` to set the data and make sure it's stringified.

I also took the liberty to re-write `ReactiveDict` as an es2015 class.

/cc @hwillson, @abernix