### PR TITLE
Fixed broken upserts with undefined selectors (fixes regression in #8666).

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -558,7 +558,7 @@ Mongo.Collection.prototype.update = function update(selector, modifier, ...optio
       if (!(typeof options.insertedId === 'string' || options.insertedId instanceof Mongo.ObjectID))
         throw new Error("insertedId must be string or ObjectID");
       insertedId = options.insertedId;
-    } else if (! selector._id) {
+    } else if (!selector || !selector._id) {
       insertedId = this._makeNewID();
       options.insertedId = insertedId;
     }

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -1301,6 +1301,29 @@ testAsyncMulti('mongo-livedata - upsert without callback, ' + idGeneration, [
   }
 ]);
 
+// Regression test for https://github.com/meteor/meteor/issues/8666.
+testAsyncMulti('mongo-livedata - upsert with an undefined selector, ' + idGeneration, [
+  function (test, expect) {
+    this.collectionName = Random.id();
+    if (Meteor.isClient) {
+      Meteor.call('createInsecureCollection', this.collectionName);
+      Meteor.subscribe('c-' + this.collectionName, expect());
+    }
+  }, function (test, expect) {
+    var coll = new Mongo.Collection(this.collectionName, collectionOptions);
+    var testWidget = {
+      name: 'Widget name'
+    };
+    coll.upsert(testWidget._id, testWidget, expect(function (error, insertDetails) {
+      test.isFalse(error);
+      test.equal(
+        coll.findOne(insertDetails.insertedId),
+        Object.assign({ _id: insertDetails.insertedId }, testWidget)
+      );
+    }));
+  }
+]);
+
 // See https://github.com/meteor/meteor/issues/594.
 testAsyncMulti('mongo-livedata - document with length, ' + idGeneration, [
   function (test, expect) {


### PR DESCRIPTION
Hi guys - this PR fixes the issue identified in #8666. Mongo upserts are failing when an `undefined` selector is used. This functionality was allowed in previous versions of Meteor, but was changed (indirectly) in https://github.com/meteor/meteor/commit/f4e41cbf1bcb871d1a8e9a63d496bcb57233a8db. This change wasn't previously caught as the Mongo test suite doesn't have any tests for `undefined` selector upserts. I've included a new test to help prevent this from happening in the future. Thanks!