### PR TITLE
Adjusted bundler-cache saved file approach to remove out of date cache files.

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -558,7 +558,7 @@ Mongo.Collection.prototype.update = function update(selector, modifier, ...optio
       if (!(typeof options.insertedId === 'string' || options.insertedId instanceof Mongo.ObjectID))
         throw new Error("insertedId must be string or ObjectID");
       insertedId = options.insertedId;
-    } else if (! selector._id) {
+    } else if (!selector || !selector._id) {
       insertedId = this._makeNewID();
       options.insertedId = insertedId;
     }

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -1301,6 +1301,29 @@ testAsyncMulti('mongo-livedata - upsert without callback, ' + idGeneration, [
   }
 ]);
 
+// Regression test for https://github.com/meteor/meteor/issues/8666.
+testAsyncMulti('mongo-livedata - upsert with an undefined selector, ' + idGeneration, [
+  function (test, expect) {
+    this.collectionName = Random.id();
+    if (Meteor.isClient) {
+      Meteor.call('createInsecureCollection', this.collectionName);
+      Meteor.subscribe('c-' + this.collectionName, expect());
+    }
+  }, function (test, expect) {
+    var coll = new Mongo.Collection(this.collectionName, collectionOptions);
+    var testWidget = {
+      name: 'Widget name'
+    };
+    coll.upsert(testWidget._id, testWidget, expect(function (error, insertDetails) {
+      test.isFalse(error);
+      test.equal(
+        coll.findOne(insertDetails.insertedId),
+        Object.assign({ _id: insertDetails.insertedId }, testWidget)
+      );
+    }));
+  }
+]);
+
 // See https://github.com/meteor/meteor/issues/594.
 testAsyncMulti('mongo-livedata - document with length, ' + idGeneration, [
   function (test, expect) {

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -1294,7 +1294,6 @@ export class PackageSourceBatch {
 
     const fileHashes = [];
     const cacheKeyPrefix = sha1(JSON.stringify({
-      LINKER_CACHE_SALT,
       linkerOptions,
       files: jsResources.map((inputFile) => {
         fileHashes.push(inputFile.hash);
@@ -1308,7 +1307,10 @@ export class PackageSourceBatch {
         };
       })
     }));
-    const cacheKeySuffix = sha1(JSON.stringify(fileHashes));
+    const cacheKeySuffix = sha1(JSON.stringify({
+      LINKER_CACHE_SALT,
+      fileHashes
+    }));
     const cacheKey = `${cacheKeyPrefix}_${cacheKeySuffix}`;
 
     {


### PR DESCRIPTION
Hi all - this PR is intended to help fix longstanding issue #5818. My [comment here](https://github.com/meteor/meteor/issues/5818#issuecomment-226948656) explains the issue in detail, but here's a quick synopsis of the problem:

- In `tools/isobuild/compiler-plugin.js`, the `_linkJS` function is creating and storing linker cache files in an apps `.meteor/local/bundler-cache/linker` directory. The filename used for these cache files comes from hashing the contents of the JS files being compiled (along with several other properties). The hashing algorithm can be seen [here](https://github.com/meteor/meteor/blob/f0dd494c82244df79b544bdbf590ebecc0412189/tools/isobuild/compiler-plugin.js#L1295-L1309).
- Since the hash used for the cache filename is generated using the incoming file's  contents (among other things), this means that the bundler cache is keeping a copy of every single source file change ever made. For example, if I update one of my source .js files to have `console.log('Hello');` and save, a new bundler cache file is generated for this file. If I then update that same file to say `console.log('Hello world!');` and save, a new and separate bundler cache file is generated (since the contents of the source file differ, and the cache filename is built using a hash of the file contents).
- In theory I guess keeping a cached copy of every single file change ever made could be helpful, if people are jumping back and forth between common file changes in specific files. In practice however, this rarely happens - previous changes made are quickly outdated and rendered irrelevant as new changes come in; developers rarely go back in time to exact source file changes (within the context of using the Meteor build tool).
- Given that people are reporting `bundler-cache/linker` directory sizes in the 10's (and sometimes 100's) of GB's for single projects, I think we should consider a new approach that doesn't involve keeping around a cache file for every single JS file change.

This PR includes the fix I referred to in https://github.com/meteor/meteor/issues/5818#issuecomment-226948656. I've adjusted the cache file name hashing algorithm a bit, so filenames are now created with 2 parts - a hash that represents the file itself with all associated internal metadata, and a hash that represents the file contents. With this approach whenever a JS file change is made, a new 2 part hash is generated, and the `bundler-cache/linker` directory is purged of any existing files that match the first part of the hash. A new cache file is then written with all incoming changes, using a filename that is built using the 2 part hash.

Long story short, let me know what you guys think. This change is pretty easy to test - take any Meteor app you have and remove all files in `.meteor/local/bundler-cache/linker`. Start that app using a developer checkout (with this PR), then when running get a count of the number of `bundler-cache/linker/*` files that were created. Update one of the existing source files in your app, and get a new `bundler-cache/linker/*` file count - the counts will be the same (whereas before the file count would have gone up by 1).

2 more quick things to mention:

1. I have no idea how to build `self-test`s for this (since it involves running the build tool). I couldn't find anything related so any pointers here would be greatly appreciated.

2. If this change (or some variation of this change) gets accepted, it's important to note that since the new caching filename approach outlined in this PR differs from the previous approach, old cache files will be left intact. That means people should consider either `meteor reset`ing or removing all `bundler-cache/linker` files, to clean up the old (and no longer used) cache files.

Thanks!