### PR TITLE
Ensure visualizer displays on top of other UI

### DIFF
--- a/packages/non-core/bundle-visualizer/style.css
+++ b/packages/non-core/bundle-visualizer/style.css
@@ -10,6 +10,7 @@
 
 .meteorBundleVisualizer.meteorBundleVisualizerRootContainer {
   position: absolute;
+  z-index: 99999;
   top: 0;
   font-family: 'Open Sans', sans-serif;
   font-size: 12px;


### PR DESCRIPTION
There was an issue where most of the visualizer was visible but the module size details displayed when hovering over a segment were hidden behind some UI elements. Setting a high z-index fixes it.