### PR TITLE
Move localStorage access back into try statement

### DIFF
--- a/packages/localstorage/localstorage.js
+++ b/packages/localstorage/localstorage.js
@@ -6,11 +6,13 @@
 // Accessing window.localStorage can also immediately throw an error in IE (#1291).
 
 var hasOwn = Object.prototype.hasOwnProperty;
-var storage = global.localStorage;
 var key = '_localstorage_test_' + Random.id();
 var retrieved;
+var storage;
 
 try {
+  storage = global.localStorage;
+  
   if (storage) {
     storage.setItem(key, key);
     retrieved = storage.getItem(key);


### PR DESCRIPTION
@benjamn, here you go. Maybe move the comment also inside the try/catch block?

This fixes #1291 again after it got reverted in the 1.5 branch by accident.

Accessing window.localStorage can immediately throw an error in IE and other/older webkit versions.

See https://github.com/meteor/meteor/pull/8327#issuecomment-302176415