### PR TITLE
Email package improvements

### DIFF
--- a/packages/email/.npm/package/npm-shrinkwrap.json
+++ b/packages/email/.npm/package/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "node4mailer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/node4mailer/-/node4mailer-4.0.2.tgz",
-      "from": "node4mailer@4.0.2"
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/node4mailer/-/node4mailer-4.0.3.tgz",
+      "from": "node4mailer@4.0.3"
     },
     "stream-buffers": {
       "version": "0.2.5",

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -28,6 +28,10 @@ var makeTransport = function (mailUrlString) {
                     mailUrlString + ") must be 'smtp' or 'smtps'");
   }
 
+  if (mailUrl.protocol === 'smtp:' && mailUrl.port === '465') {
+    Meteor._debug("$MAIL_URL is of the form smtp://...:465 -- did you mean smtps://...:465? (Note added 's' to enable SSL.)");
+  }
+
   // Allow overriding pool setting, but default to true.
   if (!mailUrl.query) {
     mailUrl.query = {};

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -29,7 +29,9 @@ var makeTransport = function (mailUrlString) {
   }
 
   if (mailUrl.protocol === 'smtp:' && mailUrl.port === '465') {
-    Meteor._debug("$MAIL_URL is of the form smtp://...:465 -- did you mean smtps://...:465? (Note added 's' to enable SSL.)");
+    Meteor._debug("The $MAIL_URL is 'smtp://...:465'.  " +
+                  "You probably want 'smtps://' (The 's' enables TLS/SSL) " +
+                  "since '465' is typically a secure port.");
   }
 
   // Allow overriding pool setting, but default to true.

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.2.2"
+  version: "1.2.3"
 });
 
 Npm.depends({

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.2.1"
+  version: "1.2.2"
 });
 
 Npm.depends({
-  node4mailer: "4.0.2",
+  node4mailer: "4.0.3",
   "stream-buffers": "0.2.5"
 });
 


### PR DESCRIPTION
I've made two changes to the Email package:
1. Using a MAIL_URL of the form `smtp://...:465` now warns that there's probably a bug (protocol should be `smtps:`). `email@1` used to automatically force `smtps:` protocol when port was 465, so this warning is useful for upgraders, without getting in the way of people who Know What They're Doing.  In response to #8696 and some later comments on #8591.
2. I tweaked `node4mailer` slightly to work on even older versions of Node 4. In response to https://github.com/chriswessels/meteor-tupperware/issues/32

I tested the warning in both activating and nonactivating cases, and tested that sending multiple messages only causes one warning.  (In fact, if `MAIL_URL` changes multiple times, each one may cause a warning.  But this seems good.)