### PR TITLE
tools: fix Galaxy discovery

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,9 +13,9 @@ dependencies:
     - ".meteor"
     - ".babel-cache"
   override:
-    # shouldn't take longer than 10 minutes
-    - ./meteor --get-ready:
-        timeout: 600
+    # shouldn't take longer than 5 minutes
+    - ./meteor --help:
+        timeout: 300
         environment:
           METEOR_PRETTY_OUTPUT: 0
           METEOR_DISABLE_OPTIMISTIC_CACHING: 1

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -383,6 +383,8 @@ export class IsopackCache {
               });
             }
           }
+
+          requestGarbageCollection();
         }
       }
 

--- a/tools/isobuild/isopack.js
+++ b/tools/isobuild/isopack.js
@@ -14,6 +14,7 @@ var utils = require('../utils/utils.js');
 var buildPluginModule = require('./build-plugin.js');
 var Console = require('../console/console.js').Console;
 var Profile = require('../tool-env/profile.js').Profile;
+import { requestGarbageCollection } from "../utils/gc.js";
 
 var rejectBadPath = function (p) {
   if (p.match(/\.\./)) {
@@ -1802,6 +1803,8 @@ _.extend(Isopack.prototype, {
       symlink: false
     });
 
+    requestGarbageCollection();
+
     // Build all of the isopackets now, so that no build step is required when
     // you're actually running meteor from a release in order to load packages.
     var isopacketBuildContext = isopackets.makeIsopacketBuildContext();
@@ -1812,6 +1815,8 @@ _.extend(Isopack.prototype, {
       // process are going to be the current tool's isopackets, not the
       // isopackets that we're writing out.
       _.each(isopackets.ISOPACKETS, function (packages, isopacketName) {
+        requestGarbageCollection();
+
         buildmessage.enterJob({
           title: "compiling " + isopacketName + " packages for the tool"
         }, function () {
@@ -1829,6 +1834,8 @@ _.extend(Isopack.prototype, {
           if (buildmessage.jobHasMessages()) {
             return;
           }
+
+          requestGarbageCollection();
 
           image.write(
             builder.enter(files.pathJoin('isopackets', isopacketName)));

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -1999,7 +1999,10 @@ var runTests = function (options) {
   _.each(testList.filteredTests, function (test) {
     totalRun++;
     Console.error(test.file + ": " + test.name + " ... ");
+    runTest(test);
+  });
 
+  function runTest(test, tries = 3) {
     var failure = null;
     try {
       runningTest = test;
@@ -2017,6 +2020,16 @@ var runTests = function (options) {
 
     if (failure) {
       Console.error("... fail!", Console.options({ indent: 2 }));
+
+      if (--tries > 0) {
+        Console.error(
+          "... retrying (" + tries + (tries === 1 ? " try" : " tries") + " remaining) ...",
+          Console.options({ indent: 2 })
+        );
+
+        return runTest(test, tries);
+      }
+
       failedTests.push(test);
       testList.notifyFailed(test);
 
@@ -2078,7 +2091,7 @@ var runTests = function (options) {
         "... ok (" + durationMs + " ms)",
         Console.options({ indent: 2 }));
     }
-  });
+  }
 
   testList.saveTestState();
 

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -308,8 +308,10 @@ _.extend(exports, {
     Console.debug("Doing HTTP request: ", options.method || 'GET', options.url);
     var request = require('request');
     var req = request(options, function (error, response, body) {
-      if (! error && response && body
-          && (typeof(body) == "string" || Buffer.isBuffer(body))) {
+      if (! error &&
+          response &&
+          (typeof body === "string" ||
+           Buffer.isBuffer(body))) {
         const contentLength = Number(response.headers["content-length"]);
         const actualLength = Buffer.byteLength(body);
 

--- a/tools/utils/http-helpers.js
+++ b/tools/utils/http-helpers.js
@@ -308,7 +308,8 @@ _.extend(exports, {
     Console.debug("Doing HTTP request: ", options.method || 'GET', options.url);
     var request = require('request');
     var req = request(options, function (error, response, body) {
-      if (! error && response && body) {
+      if (! error && response && body
+          && (typeof(body) == "string" || Buffer.isBuffer(body))) {
         const contentLength = Number(response.headers["content-length"]);
         const actualLength = Buffer.byteLength(body);
 


### PR DESCRIPTION
1a036553 in 1.4.4.2 expanded on the HTTP error checking added by 30aec9f in
1.4.2. Neither of these changes were aware that discoverGalaxy invokes
httpHelpers.request with json:true, resulting in a `body` that is a parsed JSON
object rather than a string or Buffer.  Before 1.4.4.2, this had no consequences
because body.length is undefined and `undefined < 90` is false, but the change
to Buffer.byteLength actually made the condition true.

It's safe to not check length in the JSON case because a truncated JSON object
is not legal JSON (unless the truncation just drops trailing whitespace, in
white case that's OK).

I check for both string and Buffer because some calls to this function pass in
an encoding option.  Buffer.byteLength works with both types.
