### PR TITLE
Clarify 'meteor update' message for indirect dependencies

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1787,10 +1787,10 @@ main.registerCommand({
       Console.info("\nNewer versions of the following indirect dependencies" +
                    " are available:");
       _.each(nonlatestIndirectDeps, printItem);
-      Console.info([
-        "To update one or more of these packages, pass their names to ",
-        "`meteor update`, or just run `meteor update --all-packages`."
-      ].join("\n"));
+      Console.info(`These versions may not be compatible with your project.
+To update one or more of these packages to their latest compatible versions, 
+pass their names to \`meteor update\`, or just run \`meteor update ` +
+        `--all-packages\`.`);
     }
   }
 });

--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1787,10 +1787,11 @@ main.registerCommand({
       Console.info("\nNewer versions of the following indirect dependencies" +
                    " are available:");
       _.each(nonlatestIndirectDeps, printItem);
-      Console.info(`These versions may not be compatible with your project.
-To update one or more of these packages to their latest compatible versions, 
-pass their names to \`meteor update\`, or just run \`meteor update ` +
-        `--all-packages\`.`);
+      Console.info(["These versions may not be compatible with your project.",
+        "To update one or more of these packages to their latest",
+        "compatible versions, pass their names to `meteor update`,",
+        "or just run `meteor update --all-packages`.",
+      ].join("\n"));
     }
   }
 });


### PR DESCRIPTION
* Adjust string style to be in line with meteor style guide 6.2

* Partially addresses #8721 and #8488

After running 'meteor update', if there are newer, incompatible versions of indirect dependencies available, the console output seems to imply that these versions are compatible and can be updated using 'meteor update', when they cannot be. This leads the user to wonder if the 'meteor update' command is working properly or not, as the suggested solution does not eliminate what looks like a warning message.

In this PR I am trying to clarify that there is a possibility that the newer versions may not be compatible and to be more precise about what 'meteor update' actually does.

A better solution would be to proactively identify whether the newer versions are incompatible and tell the user, so that they don't have to run additional commands to find out that information. If it seems like a good idea, I could try to implement it in a subsequent PR.

I was not sure how exactly to follow the meteor code style guide for strings (section 6.2). My string is both multi-line (use template literals) and longer than 80 characters (use string concatenation), so I've used template literals and then concatenated them to respect the character limit.

This is my first ever open source PR. Please let me know if I have missed anything!