### PR TITLE
Bind environment of observeChanges callbacks

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## v.NEXT
 
+* `observe`/`observeChanges` callbacks are now bound.
+  The same `EnvironmentVariable`s that was present when
+  `observe`/`observeChanges` was called is now available inside the callbacks.
+  [PR #8734](https://github.com/meteor/meteor/pull/8734)
+
 * `reactive-dict` now supports setting initial data when defining a named
   `ReactiveDict`. No longer run migration logic when used on the server,
   this is to prevent duplicate name error on reloads. Initial data is now

--- a/History.md
+++ b/History.md
@@ -1,8 +1,8 @@
 ## v.NEXT
 
-* `observe`/`observeChanges` callbacks are now bound.
-  The same `EnvironmentVariable`s that was present when
-  `observe`/`observeChanges` was called is now available inside the callbacks.
+* `observe`/`observeChanges` callbacks are now bound using `Meteor.bindEnvironment`.
+  The same `EnvironmentVariable`s that were present when `observe`/`observeChanges`
+  was called are now available inside the callbacks.
   [PR #8734](https://github.com/meteor/meteor/pull/8734)
 
 * `reactive-dict` now supports setting initial data when defining a named

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -949,7 +949,23 @@ Cursor.prototype.observe = function (callbacks) {
 
 Cursor.prototype.observeChanges = function (callbacks) {
   var self = this;
+  var methods = [
+    'addedAt',
+    'added',
+    'changedAt',
+    'changed',
+    'removedAt',
+    'removed',
+    'movedTo'
+  ];
   var ordered = LocalCollection._observeChangesCallbacksAreOrdered(callbacks);
+
+  methods.forEach(function (method) {
+    if (callbacks[method] && typeof callbacks[method] == "function") {
+      callbacks[method] = Meteor.bindEnvironment(callbacks[method]);
+    }
+  });
+  
   return self._mongo._observeChanges(
     self._cursorDescription, ordered, callbacks);
 };

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -960,9 +960,11 @@ Cursor.prototype.observeChanges = function (callbacks) {
   ];
   var ordered = LocalCollection._observeChangesCallbacksAreOrdered(callbacks);
 
+  // XXX: Can we find out if callbacks are from observe?
+  var exceptionName = ' observe/observeChanges callback'; 
   methods.forEach(function (method) {
     if (callbacks[method] && typeof callbacks[method] == "function") {
-      callbacks[method] = Meteor.bindEnvironment(callbacks[method]);
+      callbacks[method] = Meteor.bindEnvironment(callbacks[method], method + exceptionName);
     }
   });
   

--- a/packages/mongo/observe_changes_tests.js
+++ b/packages/mongo/observe_changes_tests.js
@@ -394,3 +394,23 @@ testAsyncMulti("observeChanges - bad query", [
     f2.wait();
   }
 ]);
+
+if (Meteor.isServer) {
+  Tinytest.addAsync(
+    "observeChanges - EnvironmentVariable",
+    function (test, onComplete) {
+      var c = makeCollection();
+      var environmentVariable = new Meteor.EnvironmentVariable;
+      environmentVariable.withValue(true, function() {
+        var handle = c.find({}, { fields: { 'type.name': 1 }}).observeChanges({
+          added: function() {
+            test.isTrue(environmentVariable.get());
+            handle.stop();
+            onComplete();
+          }
+        });
+      });
+      c.insert({ type: { name: 'foobar' } });
+    }
+  );  
+}


### PR DESCRIPTION
This will use `bindEnvironment` on `observe` and `observeChanges` callbacks.
This will allow `Meteor.userId()` to be used within these callbacks.

See this conversation for background.
https://github.com/meteor/meteor/pull/8629#issuecomment-300084704

/cc @mitar 