### PR TITLE
Add --bundle-visualizer param

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -270,7 +270,9 @@ var runCommandOptions = {
     'no-lint': { type: Boolean },
     // Allow the version solver to make breaking changes to the versions
     // of top-level dependencies.
-    'allow-incompatible-update': { type: Boolean }
+    'allow-incompatible-update': { type: Boolean },
+    // Run with bundle-visualizer package
+    'bundle-visualizer': { type: Boolean }
   },
   catalogRefresh: new catalog.Refresh.Never()
 };
@@ -289,10 +291,16 @@ function doRunCommand(options) {
   const { parsedServerUrl, parsedMobileServerUrl } =
     parseServerOptionsForRunCommand(options, runTargets);
 
+  var includePackages = [];
+  if (options['bundle-visualizer']) {
+    includePackages.push('bundle-visualizer');
+  }
+
   var projectContext = new projectContextModule.ProjectContext({
     projectDir: options.appDir,
     allowIncompatibleUpdate: options['allow-incompatible-update'],
-    lintAppAndLocalPackages: !options['no-lint']
+    lintAppAndLocalPackages: !options['no-lint'],
+    includePackages: includePackages
   });
 
   main.captureAndExit("=> Errors while initializing project:", function () {

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -86,6 +86,7 @@ Options:
                    downgraded to versions that are potentially incompatible with
                    the current versions, if required to satisfy all package
                    version constraints.
+  --bundle-visualizer           Run with bundle-visualizer package.
 
 >>> debug
 Run the project, but suspend the server process for debugging.


### PR DESCRIPTION
This let's you run meteor app with bundle-visualizer package without touching `.meteor/packages`. 
Example usage: `meteor --production --bundle-visualizer`.