### PR TITLE
Provide support for setting Mongo SSL settings in the Environment

### DIFF
--- a/packages/mongo/remote_collection_driver.js
+++ b/packages/mongo/remote_collection_driver.js
@@ -1,3 +1,5 @@
+var fs = require('fs');
+
 MongoInternals.RemoteCollectionDriver = function (
   mongo_url, options) {
   var self = this;
@@ -30,6 +32,22 @@ MongoInternals.defaultRemoteCollectionDriver = _.once(function () {
 
   if (process.env.MONGO_OPLOG_URL) {
     connectionOptions.oplogUrl = process.env.MONGO_OPLOG_URL;
+  }
+
+  if (process.env.MONGO_SSL_VALIDATE) {
+    connectionOptions.sslValidate = process.env.MONGO_SSL_VALIDATE;
+  }
+
+  if (process.env.MONGO_SSL_KEY_PATH) {
+    connectionOptions.sslKey = fs.readFileSync(process.env.MONGO_SSL_KEY_PATH);
+  }
+
+  if (process.env.MONGO_SSL_CERT_PATH) {
+    connectionOptions.sslCert = fs.readFileSync(process.env.MONGO_SSL_CERT_PATH);
+  }
+
+  if (process.env.MONGO_SSL_CA_PATH) {
+    connectionOptions.sslCa = fs.readFileSync(process.env.MONGO_SSL_CA_PATH);
   }
 
   if (! mongoUrl)


### PR DESCRIPTION
In some environments it can be beneficial to support SSL connections to MongoDB using a self-signed certificate or a private certificate authority. Meteor does not currently provide good mechanism to allow a developer to specify these SSL settings for the MongoDB connection.

References https://github.com/meteor/meteor/issues/6958 where a method for configuring Mongo is desired.
