### PR TITLE
isClientSafe DDP errors

### DIFF
--- a/packages/meteor/errors.js
+++ b/packages/meteor/errors.js
@@ -47,7 +47,7 @@ Meteor.makeErrorType = function (name, constructor) {
  * ```
  * // on the server, pick a code unique to this error
  * // the reason field should be a useful debug message
- * throw new Meteor.Error("logged-out", 
+ * throw new Meteor.Error("logged-out",
  *   "The user must be logged in to post a comment.");
  *
  * // on the client
@@ -59,10 +59,10 @@ Meteor.makeErrorType = function (name, constructor) {
  *   }
  * });
  * ```
- * 
+ *
  * For legacy reasons, some built-in Meteor functions such as `check` throw
  * errors with a number in this field.
- * 
+ *
  * @param {String} [reason] Optional.  A short human-readable summary of the
  * error, like 'Not Found'.
  * @param {String} [details] Optional.  Additional information about the error,
@@ -72,6 +72,10 @@ Meteor.Error = Meteor.makeErrorType(
   "Meteor.Error",
   function (error, reason, details) {
     var self = this;
+
+    // Newer versions of DDP use this property to signify that an error
+    // can be sent back and reconstructed on the calling client.
+    self.isClientSafe = true;
 
     // String code uniquely identifying this kind of error.
     self.error = error;

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.6.1'
+  version: '1.7.0'
 });
 
 Package.registerBuildPlugin({


### PR DESCRIPTION
This is a possible implementation of something we discussed about a year ago here: https://forums.meteor.com/t/meteor-guide-methods/19662/34?u=aldeed

If any thrown error has `isClientSafe` set to `true`, it is cast into a `Meteor.Error` to be sent back to the client. I think an ideal implementation would not even reference `Meteor.Error` anywhere in the DDP code, but this is a simple, safe, backwards compatible solution for now.

The goal here is for NPM packages like [simpl-schema](https://github.com/aldeed/node-simple-schema) to be able to throw validation or other errors and have them sent back to the client call.

One question: Should it do the same thing for any sanitizedError that has `isClientSafe` set?

Closes https://github.com/meteor/meteor/issues/7305