### PR TITLE
Added userCollectionName option to Accounts

### DIFF
--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -20,7 +20,7 @@ export class AccountsCommon {
 
     // There is an allow call in accounts_server.js that restricts writes to
     // this collection.
-    this.users = new Mongo.Collection("users", {
+    this.users = new Mongo.Collection(options.userCollectionName || "users", {
       _preventAutopublish: true,
       connection: this.connection
     });
@@ -89,6 +89,9 @@ export class AccountsCommon {
   // - ambiguousErrorMessages {Boolean}
   //     Return ambiguous error messages from login failures to prevent
   //     user enumeration.
+  // - userCollectionName {Boolean}
+  //     Sets the name of the collection where users are stored.
+  //     Defaults to "users";
 
   /**
    * @summary Set global accounts options.
@@ -102,6 +105,7 @@ export class AccountsCommon {
    * @param {Number} options.passwordResetTokenExpirationInDays The number of days from when a link to reset password is sent until token expires and user can't reset password with the link anymore. Defaults to 3.
    * @param {Number} options.passwordEnrollTokenExpirationInDays The number of days from when a link to set inital password is sent until token expires and user can't set password with the link anymore. Defaults to 30.
    * @param {Boolean} options.ambiguousErrorMessages Return ambiguous error messages from login failures to prevent user enumeration. Defaults to false.
+   * @param {String} options.userCollectionName Sets the name of the collection where users are stored. Defaults to "users";
    */
   config(options) {
     var self = this;

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -20,7 +20,7 @@ export class AccountsCommon {
 
     // There is an allow call in accounts_server.js that restricts writes to
     // this collection.
-    this.users = new Mongo.Collection(options.userCollectionName || "users", {
+    this.users = new Mongo.Collection((options && options.userCollectionName) || "users", {
       _preventAutopublish: true,
       connection: this.connection
     });


### PR DESCRIPTION

I think that Meteor can be improved by adding a userCollectionName option to the accounts-base package. The reason I think this is because:

Meteor only allows connection to one database by default
There is a use case (I'm facing it!) where you are running multiple meteor apps from a single database where each app has a completely different type of user.
Currently these users are forced into the same collection by the constraints of Meteor, the solution would be to allow them to be stored in two separate collections.

Out use case comes from the need for a customer app, through which our customers interact with us, and a separate app (with completely different codebase/functionality) which our internal team use for various back-office functions. Because they use the same database we are currently forced to mix the two types of users, from the two separate apps, in a single collection. As they are separate entities, we believe this to be bad practice and would like Meteor to allow us to store them in separate collections by setting a userCollectionName package.

This option would set the name of the collection assigned to Accounts.users and Meteor.users. As it is configurable by app, it allows the different apps to have separate user collections in the same database.

https://github.com/meteor/meteor/issues/8757