### PR TITLE
Change default `from` email for `accounts-password` to an "example".

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,14 @@
   this is to prevent duplicate name error on reloads. Initial data is now
   properly serialized.
 
+* `accounts-password` now uses `example.com` as a default "from" address instead
+  of `meteor.com`. This change could break account-related e-mail notifications
+  (forgot password, activation, etc.) for applications which do not properly
+  configure a "from" domain since e-mail providers will often reject mail sent
+  from `example.com`. Ensure that `Accounts.emailTemplates.from` is set to a
+  proper domain in all applications.
+  [PR #8760](https://github.com/meteor/meteor/issues/8760)
+
 * Add `DDP._CurrentPublicationInvocation` and `DDP._CurrentMethodInvocation`.
   `DDP._CurrentInvocation` remains for backwards-compatibility. This change
   allows method calls from publications to inherit the `connection` from the

--- a/packages/accounts-password/email_templates.js
+++ b/packages/accounts-password/email_templates.js
@@ -19,7 +19,7 @@ Thanks.
  * @importFromPackage accounts-base
  */
 Accounts.emailTemplates = {
-  from: "Meteor Accounts <no-reply@meteor.com>",
+  from: "Accounts Example <no-reply@example.com>",
   siteName: Meteor.absoluteUrl().replace(/^https?:\/\//, '').replace(/\/$/, ''),
 
   resetPassword: {

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.3.6"
+  version: "2.0.0"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Currently, the default "from" address for `meteor-accounts` is
"no-reply@meteor.com".  While this works for many users, and granted it
is a "no reply" address and there should be no expectation of the
address working, it contributes to a negative spam rating for the
"meteor.com" domain and a surplus of extra e-mail.

The correct way to set the default "from" address is by setting:

```js
Accounts.emailTemplates.from = "Name <email@domain.com>";
```

As per the documentation here:

* https://docs.meteor.com/api/passwords.html#Accounts-emailTemplates

By changing it to "example.com", and making a more obvious "example"
out of the name ("Accounts Example"), it should encourage users to
actually change the address to something more reasonable especially
since many e-mail providers will also reject mail coming from
"example.com", which should provide a clear warning to those who have
their e-mail misconfigured.

/cc @n1mmy 