### PR TITLE
Adjusted to add references to the new meteor/meteor-feature-requests repo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+**NOTE:** Issues in this repository are reserved for bugs only. To submit a feature request, please open a new issue in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests) repository.
+
 Remember, an issue is not the place to ask questions. You can use [Stack Overflow](http://stackoverflow.com/questions/tagged/meteor) for that, or you may want to start a discussion on the [Meteor forum](https://forums.meteor.com/).
 
 Before you open an issue, please check if a similar issue already exists or has been closed before.
@@ -10,14 +12,6 @@ Before you open an issue, please check if a similar issue already exists or has 
 - [ ] An *isolated* way to reproduce the behavior (example: GitHub repository with code isolated to the issue that anyone can clone to observe the problem)
 
 See [here](https://github.com/meteor/meteor/blob/devel/Contributing.md#reporting-a-bug-in-meteor) for more detail on what is expected of a bug report.
-
-### When you open an issue for a feature request, please add as much detail as possible:
-- [ ] A descriptive title
-- [ ] A description of the problem you're trying to solve, including *why* you think this is a problem
-- [ ] An overview of the suggested solution
-- [ ] If the feature changes current behavior, reasons why your solution is better
-
-See [here](https://github.com/meteor/meteor/blob/devel/Contributing.md#feature-requests) for more detail on what is expected of a feature request.
 
 ### Independent core packages
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
 
-Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
+Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first (in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests/issues) repository) and discuss your ideas there before implementing them.
 
 Always follow the [contribution guidelines](https://github.com/meteor/meteor/blob/devel/Contributing.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

--- a/Contributing.md
+++ b/Contributing.md
@@ -23,9 +23,9 @@ If you can think of any changes to the project, [documentation](https://github.c
 
 ### Finding work
 
-We curate specific issues that would make great pull requests for community contributors by applying the [`pull-requests-encouraged` label](https://github.com/meteor/meteor/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged).
+We curate specific issues that would make great pull requests for community contributors by applying the [`pull-requests-encouraged` label](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged).
 
-Issues which *also* have the [`confirmed` label](https://github.com/meteor/meteor/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) are considered to have their details clear enough to begin working on.
+Issues which *also* have the [`confirmed` label](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) are considered to have their details clear enough to begin working on.
 
 Any issue which does not have the `confirmed` label still requires discussion on implementation details but input and positive commentary is welcome!  Any pull request opened on an issue which is not `confirmed` is still welcome, however the pull-request is more likely to be sent back for reworking than a `confirmed` issue.  If in doubt about the best way to implement something, please create additional conversation on the issue.
 
@@ -142,8 +142,7 @@ for more details on proposing changes to core code.
 
 ## Feature requests
 
-We use GitHub to track feature requests. Feature request issues get the `feature` label, as well as a label
-corresponding to the Meteor subproject that they are a part of.
+Feature requests are tracked in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests) repository, and include a label that corresponds to the Meteor subproject that they are a part of.
 
 Meteor is a big project with [many sub-projects](https://github.com/meteor/meteor/tree/devel/packages). 
 There aren't as many [core developers (we're hiring!)](https://www.meteor.io/jobs/)
@@ -219,7 +218,7 @@ For more information about how to work with Meteor core, take a look at the [Dev
 
 ### Proposing your change
 
-You'll have the best chance of getting a change into core if you can build consensus in the community for it. Start by creating a well specified feature request as a Github issue.
+You'll have the best chance of getting a change into core if you can build consensus in the community for it. Start by creating a well specified feature request as a Github issue, in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests) repository.
 
 Help drive discussion and advocate for your feature on the Github ticket (and perhaps the forums). The higher the demand for the feature and the greater the clarity of it's specification will determine the likelihood of a core contributor prioritizing your feature by flagging it with the `pull-requests-encouraged` label.
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -23,9 +23,9 @@ If you can think of any changes to the project, [documentation](https://github.c
 
 ### Finding work
 
-We curate specific issues that would make great pull requests for community contributors by applying the [`pull-requests-encouraged` label](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged).
+We curate specific issues that would make great pull requests for community contributors by applying the `pull-requests-encouraged` label ([bugs](https://github.com/meteor/meteor/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged) / [feature requests](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged)).
 
-Issues which *also* have the [`confirmed` label](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) are considered to have their details clear enough to begin working on.
+Issues which *also* have the `confirmed` label ([bugs](https://github.com/meteor/meteor/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) / [feature requests](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed)) are considered to have their details clear enough to begin working on.
 
 Any issue which does not have the `confirmed` label still requires discussion on implementation details but input and positive commentary is welcome!  Any pull request opened on an issue which is not `confirmed` is still welcome, however the pull-request is more likely to be sent back for reworking than a `confirmed` issue.  If in doubt about the best way to implement something, please create additional conversation on the issue.
 

--- a/IssueTriage.md
+++ b/IssueTriage.md
@@ -1,6 +1,6 @@
 # Issue Triage
 
-This document describes the process Meteor contributors use to organize issues. We use Github [issues](https://github.com/meteor/meteor/issues) to track bugs and feature requests. Our goal is to maintain a list of issues that are relevant and well-defined (and [labeled](https://github.com/meteor/meteor/labels)) such that a contributor can immediately begin working on the code for a fix or feature request. Contributors who want to dive in and write code aren't likely to prioritize working on issues that are ambiguous and have low impact.
+This document describes the process Meteor contributors use to organize issues. We use Github [issues](https://github.com/meteor/meteor/issues) in this repository to track bugs, and [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests) to track feature requests. Our goal is to maintain a list of issues that are relevant and well-defined (and [labeled](https://github.com/meteor/meteor/labels)) such that a contributor can immediately begin working on the code for a fix or feature request. Contributors who want to dive in and write code aren't likely to prioritize working on issues that are ambiguous and have low impact.
 
 We would love to have more contributors who are willing to help out with triaging issues. You can begin by helping issue requesters create good reproductions and by confirming those reproductions on your own machine. It won't be long before the core maintainers notice your work and ask whether you'd like to be promoted to an issue maintainer.
 
@@ -38,7 +38,7 @@ The first step is in determining whether the issue is a bug, help question or fe
 1. For reasons described [here](Contributing.md#feature-requests), we would prefer features to be built as separate packages. If the feature can clearly be built as a package, explain this to the requester and close the issue.
 > - If the feature could be built as a package and serves a particular need, encourage the user to contribute it themselves.
 >- If the underlying issue could be better solved by existing technology, encourage them to seek help in the [forums](https://forums.meteor.com/c/help) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/meteor).
-2. If you haven't closed the issue, add the `feature` label and `Project:*` labels that apply (a best guess on the `Project:` is fine, sometimes it's hard to tell exactly which project the issue falls under).
+2. If you haven't closed the issue, add `Project:*` labels that apply (a best guess on the `Project:` is fine, sometimes it's hard to tell exactly which project the issue falls under).
 3. If it's not possible to build the feature as a package (as you identified in step 1), explore whether creating hooks in core would make it possible to do so. If it would, redefine the issue as a request to create those hooks.
 4. Work with the requester and others in the community to build a clear specification for the feature and update the issue description accordingly.
 5. Finally, add the `confirmed` label and [classify](#classification) the issue.
@@ -68,7 +68,7 @@ This is a somewhat subjective label and is interpreted in conjunction with Githu
 ## Issues ready to claim
 
 This state indicates that bugs/feature requests have reached the level of quality
-required for a contributor to begin writing code against (you can easily [filter for this list](https://github.com/meteor/meteor/labels/confirmed) by using the `confirmed` label).
+required for a contributor to begin writing code against (you can easily filter for [bugs](https://github.com/meteor/meteor/labels/confirmed) or [feature requests](https://github.com/meteor/meteor-feature-requests/labels/confirmed) that are ready to claim, by using the `confirmed` label).
 
 Although this should have already been done by this stage, ensure the issue is
 correctly labeled and the title/description have been updated to reflect an


### PR DESCRIPTION
Hi guys - I've updated the repo templates and supporting docs to reference [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests). Once we flip that repo to be public, we should be all set to merge these in. Let me know if you notice anything that should be changed. Thanks!