### PR TITLE
Fix #8761 in three different ways.

### DIFF
--- a/History.md
+++ b/History.md
@@ -33,6 +33,11 @@
 
 * The `reify` npm package has been upgraded to version 0.11.22.
 
+* Illegal characters in paths written in build output directories will now
+  be replaced with `_`s rather than removed, so that file and directory
+  names consisting of only illegal characters do not become empty
+  strings. [PR #8765](https://github.com/meteor/meteor/pull/8765).
+
 ## v1.5, 2017-05-30
 
 * The `meteor-base` package implies a new `dynamic-import` package, which

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -143,7 +143,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
 
         if (needToMkdir) {
           // It's new -- create it
-          files.mkdir(files.pathJoin(this.buildPath, partial), 0o755);
+          files.mkdir_p(files.pathJoin(this.buildPath, partial), 0o755);
         }
         this.usedAsFile[partial] = false;
       } else if (this.usedAsFile[partial]) {
@@ -169,7 +169,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
         throw new Error(`Path contains forbidden segment '${part}'`);
       }
 
-      part = part.replace(/[^a-zA-Z0-9._\:\-@]/g, '');
+      part = part.replace(/[^a-zA-Z0-9._\:\-@#]/g, '_');
 
       // If at last component, pull extension (if any) off of part
       let ext = '';
@@ -345,7 +345,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
             }
           }
           if (needToMkdir) {
-            files.mkdir(files.pathJoin(this.buildPath, soFar), 0o755);
+            files.mkdir_p(files.pathJoin(this.buildPath, soFar), 0o755);
           }
           this.usedAsFile[soFar] = false;
         }

--- a/tools/tests/assets.js
+++ b/tools/tests/assets.js
@@ -23,9 +23,9 @@ selftest.define("assets - unicode asset names are allowed", () => {
   run.match('1 - getText: Hello world!');
   run.match('2 - getText: Hello world!');
   run.match('3 - getText: Hello world!');
-  run.match(/1 - absoluteFilePath:(.*)maaverde.txt/);
-  run.match(/2 - absoluteFilePath:(.*)maaverde.txt/);
-  run.match(/3 - absoluteFilePath:(.*)maaverde.txt/);
+  run.match(/1 - absoluteFilePath:(.*)ma_a_verde.txt/);
+  run.match(/2 - absoluteFilePath:(.*)ma_a_verde.txt/);
+  run.match(/3 - absoluteFilePath:(.*)ma_a_verde.txt/);
   run.stop();
 });
 


### PR DESCRIPTION
The root of the problem was that the `es5-ext` npm package contains directories called `#`, e.g.
https://github.com/medikoo/es5-ext/tree/master/array/%23

These directory names were being sanitized to `''` and thus ignored when reserving paths in the `Builder`, which led to reservation conflicts later.

This commit fixes the problem in three different and independently sufficient ways:

* Use `files.mkdir_p` instead of `files.mkdir` when creating parent directories of written files.
* Replace illegal characters in sanitized paths with `_` instead of `''`.
* Allow `#` in sanitized paths (only needs to be escaped in the shell, not actually forbidden in paths).

Fixes #8761.