### PR TITLE
Change `runInThisContext` to `Script.prototype.runInThisContext`.

### DIFF
--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -325,10 +325,14 @@ var loadServerBundles = Profile("Load server bundles", function () {
 
     var scriptPath =
       parsedSourceMaps[absoluteFilePath] ? absoluteFilePath : fileInfoOSPath;
-    // The final 'true' is an undocumented argument to runIn[Foo]Context that
-    // causes it to print out a descriptive error message on parse error. It's
-    // what require() uses to generate its errors.
-    var func = require('vm').runInThisContext(wrapped, scriptPath, true);
+
+    var script = new (require('vm').Script)(wrapped, {
+      filename: scriptPath,
+      displayErrors: true
+    });
+
+    var func = script.runInThisContext();
+
     var args = [Npm, Assets];
 
     specialKeys.forEach(function (key) {


### PR DESCRIPTION
`vm`'s `runInThisContext` used to have an undocumented parameter to display error messages in executed code but this was actually changed to an `options`-style argument ages ago, in Node.js 0.11, via https://github.com/nodejs/node/commit/fd3657610e49005dfc778c3f060dbba0a34f286a.  Due to this change, and our lack of notice this "descriptive error message" was not displayed and the actual location of the error was quietly swallowed.

This reimplements the descriptive error message, which was also brought up by @d-schiffner in https://github.com/meteor/meteor/issues/3200#issuecomment-289685677.