### PR TITLE
Attempt to fix "ENOTEMPTY" by updating rimraf dependency.

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.8.17
+BUNDLE_VERSION=4.8.18
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -42,7 +42,7 @@ var packageJson = {
     "http-proxy": "1.11.1",
     "wordwrap": "0.0.2",
     "moment": "2.8.4",
-    "rimraf": "2.4.3",
+    "rimraf": "2.6.1",
     "glob": "7.0.6",
     // XXX: When we update this, see if it fixes this Github issue:
     // https://github.com/jgm/CommonMark/issues/276 . If it does, remove the


### PR DESCRIPTION
There have been a number of commits in [the history for `rimraf`](https://github.com/isaacs/rimraf/commits/master) which indicate other projects have also been struggling with ENOTEMPTY, specifically on Windows.

[This commit on `rimraf`](https://github.com/isaacs/rimraf/commit/d53235de863cfb00f691456288fcf3abbced7f6c), included in 2.6.1, takes a relatively aggressive approach but the absence of follow-up commits in a while leads me to believe that approach may have helped.

Of course, if Windows wants to cache a file handle after a process has stopped using it, that is its prerogative but the result is that tools (like Meteor) need to guess when it's safe to delete directories, which may still have cached file handles open on the OS, or try excessively (in the way this update to `rimraf` does) until its permitted in order to properly cleanup any mess which may have been made.

In triaging this issue (on a non-GitHub issue), I was able (on Windows) to reproduce only a single `ENOTEMPTY` error out of 14 attempts by continually running `./meteor --get-ready` (a development command which builds Meteor core packages) on fresh versions of a Meteor checkout.  This process triggers a lot of the same processes which take place building developer applications, so is a helpful way of trying to throw the error.  After applying this fix, I then ran the process an additional 30 times, and was no longer able to reproduce it.

I'm hoping this means the issue will be substantially lessened.

Attempts to help with meteor/meteor#8485.

(`dev-bundle-4.8.18` has been rebuilt and published for this PR)