### PR TITLE
Remove check for standard-minifier-js@2.1.x from `bundle-visualizer`.

### DIFF
--- a/packages/non-core/bundle-visualizer/package.js
+++ b/packages/non-core/bundle-visualizer/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.2',
+  version: '1.0.3',
   summary: 'Meteor bundle analysis and visualization.',
   documentation: 'README.md',
 });

--- a/packages/non-core/bundle-visualizer/server.js
+++ b/packages/non-core/bundle-visualizer/server.js
@@ -114,24 +114,9 @@ Meteor.methods({
       throw new Meteor.Error("no-stats-bundles", "Unable to retrieve stats");
     }
 
-    const validStatBundles = statBundles.filter(statBundle => {
-      if (statBundle &&
-        statBundle.stats &&
-        statBundle.stats.minifier &&
-        statBundle.stats.minifier.name === "standard-minifier-js" &&
-        statBundle.stats.minifier.version.startsWith("2.1.")
-      ) {
-        return true;
-      }
-    });
-
-    if (! validStatBundles.length) {
-      throw new Meteor.Error("no-valid-stats", "No valid stats bundles")
-    }
-
     return {
       name: "main",
-      children: validStatBundles.map((statBundle, index, array) => ({
+      children: statBundles.map((statBundle, index, array) => ({
         // TODO: If multiple bundles, could
         // show abbr. bundle names with:
         //   `...${bundle.name.substr(-3)}`,


### PR DESCRIPTION
While this was helpful in one of the incarnations of the `bundle-visualizer` during development it isn't relevant anymore since the `.stats.json` will not be present in the bundle unless it was created by a recent version of `standard-minifier-js` which passed in `stats` (no older versions did this).

Removing this check will also make it possible for other minifiers to be used with `bundle-visualizer` without them also needing to fork make their own version.

Thusly, this makes the `bundle-visualizer` work with Meteor 1.6, which comes with `standard-minifier-js@2.2.x`.