### PR TITLE
Partial fix for #8775.

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2857,6 +2857,13 @@ Tinytest.add("minimongo - modify", function (test) {
   upsertException({a: 0}, {$setOnInsert: {b: {'a.b':1}}});
   upsertException({a: 0}, {$setOnInsert: {b: {'\0a':1}}});
 
+  // Test for https://github.com/meteor/meteor/issues/8775.
+  upsert(
+    { a: { $exists: true }},
+    { $setOnInsert: { a: 123 }},
+    { a: 123 }
+  );
+
   exception({}, {$set: {_id: 'bad'}});
 
   // $bit

--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -1253,9 +1253,9 @@ LocalCollection._f = {
 
 // Oddball function used by upsert.
 LocalCollection._removeDollarOperators = function (selector) {
-  var selectorDoc = {};
-  for (var k in selector)
-    if (k.substr(0, 1) !== '$')
-      selectorDoc[k] = selector[k];
-  return selectorDoc;
+  return JSON.parse(JSON.stringify(selector, (key, value) => {
+    if (! key.startsWith("$")) {
+      return value;
+    }
+  }));
 };


### PR DESCRIPTION
This may not be a complete fix for issue #8775, but I noticed while debugging the issue that `LocalCollection._removeDollarOperators` isn't removing nested `$`-operators (as it seems like it should be): https://github.com/meteor/meteor/blob/d6c4281eebe8fffcdeb415ccc361784f854126f4/packages/minimongo/minimongo.js#L790