### PR TITLE
Update CoffeeScript to 1.12.6

### DIFF
--- a/History.md
+++ b/History.md
@@ -39,7 +39,7 @@
   strings. [PR #8765](https://github.com/meteor/meteor/pull/8765).
 
 * The `coffeescript` package has been updated to use CoffeeScript version
-  1.12.6.
+  1.12.6. [PR #8777](https://github.com/meteor/meteor/pull/8777)
 
 ## v1.5, 2017-05-30
 

--- a/History.md
+++ b/History.md
@@ -38,6 +38,9 @@
   names consisting of only illegal characters do not become empty
   strings. [PR #8765](https://github.com/meteor/meteor/pull/8765).
 
+* The `coffeescript` package has been updated to use CoffeeScript version
+  1.12.6.
+
 ## v1.5, 2017-05-30
 
 * The `meteor-base` package implies a new `dynamic-import` package, which

--- a/packages/non-core/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
+++ b/packages/non-core/coffeescript/.npm/plugin/compileCoffeescript/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "coffee-script": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.3.tgz",
-      "from": "coffee-script@1.12.3"
+    "coffeescript": {
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.6.tgz",
+      "from": "coffeescript@1.12.6"
     },
     "source-map": {
       "version": "0.5.6",

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.12.3_1"
+  version: "1.12.6_1"
 });
 
 Package.registerBuildPlugin({
@@ -8,7 +8,7 @@ Package.registerBuildPlugin({
   use: ['caching-compiler', 'ecmascript'],
   sources: ['plugin/compile-coffeescript.js'],
   npmDependencies: {
-    "coffee-script": "1.12.3",
+    "coffeescript": "1.12.6",
     "source-map": "0.5.6"
   }
 });

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Javascript dialect with fewer braces and semicolons",
-  version: "1.12.6_1"
+  version: "1.12.6"
 });
 
 Package.registerBuildPlugin({

--- a/packages/non-core/coffeescript/plugin/compile-coffeescript.js
+++ b/packages/non-core/coffeescript/plugin/compile-coffeescript.js
@@ -2,13 +2,13 @@ import {
   SourceMapConsumer,
   SourceMapGenerator,
 } from 'source-map';
-import coffee from 'coffee-script';
+import coffee from 'coffeescript';
 import { BabelCompiler } from 'meteor/babel-compiler';
 
-// The coffee-script compiler overrides Error.prepareStackTrace, mostly for the
+// The CoffeeScript compiler overrides Error.prepareStackTrace, mostly for the
 // use of coffee.run which we don't use.  This conflicts with the tool's use of
 // Error.prepareStackTrace to properly show error messages in linked code.
-// Restore the tool's one after coffee-script clobbers it at import time.
+// Restore the tool's one after CoffeeScript clobbers it at import time.
 if (Error.METEOR_prepareStackTrace) {
   Error.prepareStackTrace = Error.METEOR_prepareStackTrace;
 }


### PR DESCRIPTION
Bumps the CoffeeScript version, and uses the new primary repo, `coffeescript`.