### PR TITLE
Inline process.env.NODE_ENV when minifying.

### DIFF
--- a/History.md
+++ b/History.md
@@ -31,6 +31,9 @@
   context and with its `EnvironmentVariable`s bound.
   [PR #8629](https://github.com/meteor/meteor/pull/8629)
 
+* The `minifier-js` package will now replace `process.env.NODE_ENV` with
+  its string value (or `"development"` if unspecified).
+
 * The `meteor-babel` npm package has been upgraded to version 0.21.5.
 
 * The `reify` npm package has been upgraded to version 0.11.22.

--- a/History.md
+++ b/History.md
@@ -31,6 +31,8 @@
   context and with its `EnvironmentVariable`s bound.
   [PR #8629](https://github.com/meteor/meteor/pull/8629)
 
+* The `meteor-babel` npm package has been upgraded to version 0.21.5.
+
 * The `reify` npm package has been upgraded to version 0.11.22.
 
 * Illegal characters in paths written in build output directories will now

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -21,14 +21,14 @@
       "from": "babel-code-frame@>=6.22.0 <7.0.0"
     },
     "babel-core": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
       "from": "babel-core@>=6.22.1 <7.0.0"
     },
     "babel-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-      "from": "babel-generator@>=6.24.1 <7.0.0"
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+      "from": "babel-generator@>=6.25.0 <7.0.0"
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.24.1",
@@ -280,8 +280,8 @@
       "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.22.0 <7.0.0"
     },
     "babel-plugin-transform-es2015-modules-reify": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-reify/-/babel-plugin-transform-es2015-modules-reify-0.11.0.tgz",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-reify/-/babel-plugin-transform-es2015-modules-reify-0.11.1.tgz",
       "from": "babel-plugin-transform-es2015-modules-reify@>=0.11.0 <0.12.0"
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -365,8 +365,8 @@
       "from": "babel-plugin-transform-property-literals@>=6.8.1 <7.0.0"
     },
     "babel-plugin-transform-react-display-name": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "from": "babel-plugin-transform-react-display-name@>=6.23.0 <7.0.0"
     },
     "babel-plugin-transform-react-jsx": {
@@ -460,33 +460,33 @@
       "from": "babel-runtime@>=6.22.0 <7.0.0"
     },
     "babel-template": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "from": "babel-template@>=6.22.0 <7.0.0"
     },
     "babel-traverse": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "from": "babel-traverse@>=6.22.1 <7.0.0"
     },
     "babel-types": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "from": "babel-types@>=6.22.0 <7.0.0"
     },
     "babylon": {
-      "version": "6.17.2",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
+      "version": "6.17.3",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
       "from": "babylon@>=6.15.0 <7.0.0"
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "from": "balanced-match@>=0.4.1 <0.5.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "from": "balanced-match@>=1.0.0 <2.0.0"
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "from": "brace-expansion@>=1.1.7 <2.0.0"
     },
     "chalk": {
@@ -530,8 +530,8 @@
       "from": "esutils@>=2.0.2 <3.0.0"
     },
     "globals": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "from": "globals@>=9.0.0 <10.0.0"
     },
     "has-ansi": {
@@ -590,9 +590,9 @@
       "from": "loose-envify@>=1.0.0 <2.0.0"
     },
     "meteor-babel": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.21.4.tgz",
-      "from": "meteor-babel@0.21.4"
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.21.5.tgz",
+      "from": "meteor-babel@0.21.5"
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",

--- a/packages/babel-compiler/babel.js
+++ b/packages/babel-compiler/babel.js
@@ -1,12 +1,15 @@
+var meteorBabel = null;
+function getMeteorBabel() {
+  return meteorBabel || (meteorBabel = Npm.require("meteor-babel"));
+}
+
 /**
  * Returns a new object containing default options appropriate for
  */
 function getDefaultOptions(extraFeatures) {
-  var meteorBabel = Npm.require('meteor-babel');
-
   // See https://github.com/meteor/babel/blob/master/options.js for more
   // information about what the default options are.
-  var options = meteorBabel.getDefaultOptions(extraFeatures);
+  var options = getMeteorBabel().getDefaultOptions(extraFeatures);
 
   // The sourceMap option should probably be removed from the default
   // options returned by meteorBabel.getDefaultOptions.
@@ -22,22 +25,24 @@ Babel = {
   validateExtraFeatures: Function.prototype,
 
   parse: function (source) {
-    return Npm.require('meteor-babel').parse(source);
+    return getMeteorBabel().parse(source);
   },
 
   compile: function (source, options) {
-    var meteorBabel = Npm.require('meteor-babel');
     options = options || getDefaultOptions();
-    return meteorBabel.compile(source, options);
+    return getMeteorBabel().compile(source, options);
   },
 
   setCacheDir: function (cacheDir) {
-    Npm.require('meteor-babel').setCacheDir(cacheDir);
+    getMeteorBabel().setCacheDir(cacheDir);
   },
 
-  minify: function(source, options) {
-    var meteorBabel = Npm.require('meteor-babel');
-    var options = options || meteorBabel.getMinifierOptions();
-    return meteorBabel.minify(source, options);
+  minify: function (source, options) {
+    var options = options || getMeteorBabel().getMinifierOptions();
+    return getMeteorBabel().minify(source, options);
+  },
+
+  getMinifierOptions: function (extraFeatures) {
+    return getMeteorBabel().getMinifierOptions(extraFeatures);
   }
 };

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,11 +6,11 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.19.2'
+  version: '6.19.3'
 });
 
 Npm.depends({
-  'meteor-babel': '0.21.4'
+  'meteor-babel': '0.21.5'
 });
 
 Package.onUse(function (api) {

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -16,9 +16,9 @@
       "from": "source-map@>=0.5.1 <0.6.0"
     },
     "uglify-js": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.13.tgz",
-      "from": "uglify-js@3.0.13"
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.15.tgz",
+      "from": "uglify-js@3.0.15"
     }
   }
 }

--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -2,6 +2,8 @@ var uglify;
 
 meteorJsMinify = function (source) {
   var result = {};
+  var NODE_ENV = process.env.NODE_ENV || "development";
+
   uglify = uglify || Npm.require("uglify-js");
 
   try {
@@ -9,7 +11,10 @@ meteorJsMinify = function (source) {
       compress: {
         drop_debugger: false,
         unused: false,
-        dead_code: false
+        dead_code: false,
+        global_defs: {
+          "process.env.NODE_ENV": NODE_ENV
+        }
       }
     });
 
@@ -24,7 +29,14 @@ meteorJsMinify = function (source) {
     // Although Babel.minify can handle a wider variety of ECMAScript
     // 2015+ syntax, it is substantially slower than UglifyJS, so we use
     // it only as a fallback.
-    result.code = Babel.minify(source).code;
+    if (Babel.getMinifierOptions) {
+      var options = Babel.getMinifierOptions({
+        inlineNodeEnv: NODE_ENV
+      });
+      result.code = Babel.minify(source, options).code;
+    } else {
+      result.code = Babel.minify(source).code;
+    }
   }
 
   return result;

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "2.1.0"
+  version: "2.1.1"
 });
 
 Npm.depends({
-  "uglify-js": "3.0.13"
+  "uglify-js": "3.0.15"
 });
 
 Package.onUse(function (api) {

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,7 +14,7 @@ var packageJson = {
     npm: "4.6.1",
     "node-gyp": "3.6.0",
     "node-pre-gyp": "0.6.34",
-    "meteor-babel": "0.21.4",
+    "meteor-babel": "0.21.5",
     reify: "0.11.22",
     "meteor-promise": "0.8.4",
     fibers: "1.0.15",


### PR DESCRIPTION
Despite [my previous concerns](https://github.com/meteor/meteor/issues/6402#issuecomment-221042378), having `minifier-js` replace `process.env.NODE_ENV` with its string value seems to be the most direct way to guarantee production versions of React modules do not access `process.env.NODE_ENV` at runtime, and that any resulting dead code is removed.

Relevant [background](https://forums.meteor.com/t/new-react-devtools-check-if-your-production-build-is-really-in-production-mode/36199).

Fixes meteor/meteor#6402.
Fixes meteor/meteor-feature-requests#94.