### PR TITLE
Don't skip reinstalling unchanged Npm.depends-style dependencies.

### DIFF
--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -646,10 +646,7 @@ var updateExistingNpmDirectory = function (packageName, newPackageNpmDir,
     // Otherwise install npmTree.dependencies as if we were creating a new
     // .npm/package directory, and leave preservedShrinkwrap empty.
     _.each(npmTree.dependencies, (info, name) => {
-      const installed = minInstalledTree.dependencies[name];
-      if (! installed || installed.version !== info.version) {
-        installNpmModule(name, info.version, newPackageNpmDir);
-      }
+      installNpmModule(name, info.version, newPackageNpmDir);
     });
 
     // Note: as of npm@4.0.0, npm-shrinkwrap.json files are regarded as


### PR DESCRIPTION
If the comment just above the changed code is to be taken seriously, it was definitely a mistake to skip reinstalling any packages, even if their required versions have not changed, since we're populating a brand-new `node_modules` directory whose contents will dictate the new `npm-shrinkwrap.json` file.

Fixes #8732.
Should also fix #8747.