### PR TITLE
Unpin `modules` from `npm-bcrypt`

### DIFF
--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.3.6"
+  version: "1.3.7"
 });
 
 Package.onUse(function(api) {

--- a/packages/npm-bcrypt/package.js
+++ b/packages/npm-bcrypt/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Wrapper around the bcrypt npm package",
-  version: "0.9.2",
+  version: "0.9.3",
   documentation: null
 });
 

--- a/packages/npm-bcrypt/package.js
+++ b/packages/npm-bcrypt/package.js
@@ -9,7 +9,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.use("modules@0.7.5", "server");
+  api.use("modules", "server");
   api.mainModule("wrapper.js", "server");
   api.export("NpmModuleBcrypt", "server");
 });


### PR DESCRIPTION
The `modules` package should not be pinned to the `0.7.5` release any longer.

These are published, but this PR will allow me to merge it to `master`.

/cc @benjamn 