### PR TITLE
Make minimongo upsert compliant with mongo behavior

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## v.NEXT
 
+* The `minimongo` and `mongo` packages are now compliant with the upsert behavior
+  of MongoDB 2.6 and higher. **As a result support for MongoDB 2.4 has been dropped.**
+  This mainly changes the effect of the selector on newly inserted documents.
+  [PR #8815](https://github.com/meteor/meteor/pull/8815)
+
 * The `accounts-facebook` and `facebook-oauth` packages have been updated to
   use the v2.9 of the Facebook Graph API for the Login Dialog since the v2.2
   version will be deprecated by Facebook in July.  There shouldn't be a problem

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -1148,20 +1148,17 @@ LocalCollection._createUpsertDocument = function (selector, modifier) {
   }
 
   // This double _modify call is made to help with nested properties (see issue #8631).
+  // We do this even if it's a replacement for validation purposes (e.g. ambiguous id's)
   LocalCollection._modify(newDoc, { $set: selectorDocument })
   LocalCollection._modify(newDoc, modifier, { isInsert: true })
-
-  if (selectorDocument._id && newDoc._id !== selectorDocument._id) {
-    if (isModify) {
-      throw new Error(`After applying the update to the document {_id: "${selectorDocument._id}" , ...}, the (immutable) field '_id' was found to have been altered to _id: "${newDoc._id}"`)
-    }else {
-      throw new Error(`The _id field cannot be changed from {_id: "${selectorDocument._id}"} to {_id: "${newDoc._id}"}`)
-    }
-  }
 
   if (isModify) {
     return newDoc
   } else {
+    // Replacement can take _id from query document
+    if (newDoc._id) {
+      modifier._id = newDoc._id;
+    }
     return modifier
   }
 }

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -1156,6 +1156,7 @@ LocalCollection._createUpsertDocument = function (selector, modifier) {
     return newDoc
   } else {
     // Replacement can take _id from query document
+    modifier = EJSON.clone(modifier);
     if (newDoc._id) {
       modifier._id = newDoc._id;
     }

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -1156,10 +1156,10 @@ LocalCollection._createUpsertDocument = function (selector, modifier) {
     return newDoc
   } else {
     // Replacement can take _id from query document
-    modifier = EJSON.clone(modifier);
+    const replacement = Object.assign({}, modifier);
     if (newDoc._id) {
-      modifier._id = newDoc._id;
+      replacement._id = newDoc._id;
     }
-    return modifier
+    return replacement
   }
 }

--- a/packages/minimongo/minimongo.js
+++ b/packages/minimongo/minimongo.js
@@ -1,4 +1,5 @@
 import { assertHasValidFieldNames } from './validation.js';
+import populateDocumentWithQueryFields from './upsert_document.js';
 
 // XXX type checking on selectors (graceful error if malformed)
 

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2944,6 +2944,9 @@ Tinytest.add("minimongo - modify", function (test) {
   // But leave actual empty objects
   upsert({"a": {}}, {"$set": {"c": "foo"}}, {"a": {}, "c": "foo"})
 
+   // Also filter out shorthand regexp notation
+  upsert({"a": /a/}, {"$set": {"c": "foo"}}, {"c": "foo"})
+
   // Test nested fields
   upsert({"$and": [{"a.a": "foo"}, {"$or": [{"a.b": "baz"}]}]}, {"$set": {"c": "foo"}}, {"a": {"a": "foo", "b": "baz"}, "c": "foo"})
 
@@ -2969,8 +2972,14 @@ Tinytest.add("minimongo - modify", function (test) {
   upsertException({"a": {"$eq": "bar", "b": "foo"}}, {})
   upsertException({"a": {"b": "foo", "$eq": "bar"}}, {})
 
-  var mongoIdForUpsert = new MongoID.ObjectID();
+  var mongoIdForUpsert = new MongoID.ObjectID('44915733af80844fa1cef07a');
   upsert({_id: mongoIdForUpsert},{$setOnInsert: {a: 123}},{a: 123})
+
+  // Test for https://github.com/meteor/meteor/issues/7758
+  upsert({n_id: mongoIdForUpsert, c_n: "bar"},
+    {$set: { t_t_o: "foo"}},
+    {n_id: mongoIdForUpsert, t_t_o: "foo", c_n: "bar"});
+
 
   exception({}, {$set: {_id: 'bad'}});
 

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2947,6 +2947,9 @@ Tinytest.add("minimongo - modify", function (test) {
   // Test nested fields
   upsert({"$and": [{"a.a": "foo"}, {"$or": [{"a.b": "baz"}]}]}, {"$set": {"c": "foo"}}, {"a": {"a": "foo", "b": "baz"}, "c": "foo"})
 
+  // Test for https://github.com/meteor/meteor/issues/5294
+  upsert({"a": {"$ne": 444}},{"$push": {"a": 123}}, {"a": [123]})
+
   // Nested fields don't work with literal objects
   upsertException({"a": {}, "a.b": "foo"}, {});
 
@@ -2967,7 +2970,7 @@ Tinytest.add("minimongo - modify", function (test) {
   upsertException({"a": {"b": "foo", "$eq": "bar"}}, {})
 
   var mongoIdForUpsert = new MongoID.ObjectID();
-  upsert({_id: mongoIdForUpsert},{$setOnInsert:{a:123}},{a:123})
+  upsert({_id: mongoIdForUpsert},{$setOnInsert: {a: 123}},{a: 123})
 
   exception({}, {$set: {_id: 'bad'}});
 

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2341,7 +2341,7 @@ Tinytest.add("minimongo - modify", function (test) {
     coll.update(query, mod);
     var actual = coll.findOne();
 
-    if(!expected._id){
+    if (!expected._id) {
       delete actual._id;  // added by insert
     }
 
@@ -2982,6 +2982,9 @@ Tinytest.add("minimongo - modify", function (test) {
   // Replacement can take _id from query
   upsert({"_id": "foo", "foo": "bar"}, {"bar": "foo"}, {"_id": "foo", "bar": "foo"})
 
+  // Replacement update keeps _id
+  upsertUpdate({"_id": "foo", "bar": "baz"}, {"_id":"foo"}, {"bar": "crow"}, {"_id": "foo", "bar": "crow"});
+  
   // Nested fields don't work with literal objects
   upsertException({"a": {}, "a.b": "foo"}, {});
 

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -2951,10 +2951,19 @@ Tinytest.add("minimongo - modify", function (test) {
   upsert({"$and": [{"a.a": "foo"}, {"$or": [{"a.b": "baz"}]}]}, {"$set": {"c": "foo"}}, {"a": {"a": "foo", "b": "baz"}, "c": "foo"})
 
   // Test for https://github.com/meteor/meteor/issues/5294
+  //
   upsert({"a": {"$ne": 444}},{"$push": {"a": 123}}, {"a": [123]})
+
+  // Mod takes precedence over query
+  upsert({"a": "foo"},{"a": "bar"}, {"a": "bar"})
+  upsert({"a": "foo"},{"$set":{"a": "bar"}}, {"a": "bar"})
 
   // Nested fields don't work with literal objects
   upsertException({"a": {}, "a.b": "foo"}, {});
+
+  // You can't have an ambiguious ID
+  upsertException({"_id":"foo"}, {"_id":"bar"});
+  upsertException({"_id":"foo"}, {"$set":{"_id":"bar"}});
 
   // You can't set the same field twice
   upsertException({"$and": [{"a": "foo"}, {"a": "foo"}]}, {}); //not even with same value

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -25,9 +25,10 @@ LocalCollection._modify = function (doc, mod, options) {
   var newDoc;
 
   if (!isModifier) {
-    if (mod._id && !EJSON.equals(doc._id, mod._id))
-      throw MinimongoError("Cannot change the _id of a document");
-
+    if (mod._id && doc._id && !EJSON.equals(doc._id, mod._id)) {
+      throw MinimongoError(`The _id field cannot be changed from {_id: "${doc._id}"} to {_id: "${mod._id}"}`);
+    }
+    
     // replace the whole document
     assertHasValidFieldNames(mod);
     newDoc = mod;
@@ -45,10 +46,6 @@ LocalCollection._modify = function (doc, mod, options) {
       _.each(operand, function (arg, keypath) {
         if (keypath === '') {
           throw MinimongoError("An empty update path is not valid.");
-        }
-
-        if (keypath === '_id' && op !== '$setOnInsert') {
-          throw MinimongoError("Mod on _id not allowed");
         }
 
         var keyparts = keypath.split('.');
@@ -70,6 +67,10 @@ LocalCollection._modify = function (doc, mod, options) {
         modFunc(target, field, arg, keypath, newDoc);
       });
     });
+
+    if (doc._id && !EJSON.equals(doc._id, newDoc._id)) {
+      throw MinimongoError(`After applying the update to the document {_id: "${doc._id}" , ...}, the (immutable) field '_id' was found to have been altered to _id: "${newDoc._id}"`);
+    }
   }
 
   // move new document into place.

--- a/packages/minimongo/modify.js
+++ b/packages/minimongo/modify.js
@@ -69,7 +69,9 @@ LocalCollection._modify = function (doc, mod, options) {
     });
 
     if (doc._id && !EJSON.equals(doc._id, newDoc._id)) {
-      throw MinimongoError(`After applying the update to the document {_id: "${doc._id}" , ...}, the (immutable) field '_id' was found to have been altered to _id: "${newDoc._id}"`);
+      throw MinimongoError('After applying the update to the document {_id: ' +
+      `"${doc._id}" , ...}, the (immutable) field '_id' was found to have` +
+      ` been altered to _id: "${newDoc._id}"`);
     }
   }
 

--- a/packages/minimongo/package.js
+++ b/packages/minimongo/package.js
@@ -28,6 +28,7 @@ Package.onUse(function (api) {
     'minimongo.js',
     'wrap_transform.js',
     'helpers.js',
+    'upsert_document.js',
     'selector.js',
     'sort.js',
     'projection.js',

--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -1250,33 +1250,3 @@ LocalCollection._f = {
     throw Error("Unknown type to sort");
   }
 };
-
-const objectOnlyHasDollarKeys = (object) => {
-  const keys = Object.keys(object);
-  return keys.length > 0 && keys.every(key => key.charAt(0) === '$');
-};
-
-// When performing an upsert, the incoming selector object can be re-used as
-// the upsert modifier object, as long as Mongo query and projection
-// operators (prefixed with a $ character) are removed from the newly
-// created modifier object. This function attempts to strip all $ based Mongo
-// operators when creating the upsert modifier object.
-// NOTE: There is a known issue here in that some Mongo $ based opeartors
-// should not actually be stripped.
-// See https://github.com/meteor/meteor/issues/8806.
-LocalCollection._removeDollarOperators = (selector) => {
-  let cleansed = {};
-  Object.keys(selector).forEach((key) => {
-    const value = selector[key];
-    if (key.charAt(0) !== '$' && !objectOnlyHasDollarKeys(value)) {
-      if (value !== null
-          && value.constructor
-          && Object.getPrototypeOf(value) === Object.prototype) {
-        cleansed[key] = LocalCollection._removeDollarOperators(value);
-      } else {
-        cleansed[key] = value;
-      }
-    }
-  });
-  return cleansed;
-};

--- a/packages/minimongo/upsert_document.js
+++ b/packages/minimongo/upsert_document.js
@@ -15,109 +15,111 @@
 // - you can not have '$'-prefixed keys more than one-level deep in an object
 
 // Fills a document with certain fields from an upsert selector
-populateDocumentWithQueryFields = function (query, document = {}) {
-
-    if (Object.getPrototypeOf(query) === Object.prototype) {
-        // handle implicit $and
-        for (let [key, value] of Object.entries(query)) {
-            // handle explicit $and
-            if (key === "$and") {
-                value.forEach(sq => populateDocumentWithQueryFields(sq, document))
-            }
-            // handle $or nodes with exactly 1 child
-            else if (key === "$or") {
-                if (value.length === 1) {
-                    populateDocumentWithQueryFields(value[0], document)
-                }
-            }
-            //Ignore other '$'-prefixed logical selectors
-            else if (key[0] !== "$") {
-                populateDocumentWithKeyValue(document, key, value);
-            }
+export default function populateDocumentWithQueryFields (query, document = {}) {
+  if (Object.getPrototypeOf(query) === Object.prototype) {
+    // handle implicit $and
+    Object.keys(query).forEach(function (key) {
+      const value = query[key];
+      if (key === '$and') {
+        // handle explicit $and
+        value.forEach(sq => populateDocumentWithQueryFields(sq, document));
+      } else if (key === '$or') {
+        // handle $or nodes with exactly 1 child
+        if (value.length === 1) {
+          populateDocumentWithQueryFields(value[0], document);
         }
-    } else {
-        // Handle meteor-specific shortcut for selecting _id
-        if (LocalCollection._selectorIsId(query)) {
-            insertIntoDocument(document, "_id", query);
-        }
+      } else if (key[0] !== '$') {
+        // Ignore other '$'-prefixed logical selectors
+        populateDocumentWithKeyValue(document, key, value);
+      }
+    })
+  } else {
+    // Handle meteor-specific shortcut for selecting _id
+    if (LocalCollection._selectorIsId(query)) {
+      insertIntoDocument(document, '_id', query);
     }
+  }
 
-    return document;
-
+  return document;
 }
 
 // Handles one key/value pair to put in the selector document
-function populateDocumentWithKeyValue(document, key, value) {
-    if (value && Object.getPrototypeOf(value) === Object.prototype) {
-        populateDocumentWithObject(document, key, value);
-    } else if (!(value instanceof RegExp)) {
-        insertIntoDocument(document, key, value);
-    }
+function populateDocumentWithKeyValue (document, key, value) {
+  if (value && Object.getPrototypeOf(value) === Object.prototype) {
+    populateDocumentWithObject(document, key, value);
+  } else if (!(value instanceof RegExp)) {
+    insertIntoDocument(document, key, value);
+  }
 }
 
+// Handles a key, value pair to put in the selector document 
+// if the value is an object
+function populateDocumentWithObject (document, key, value) {
+  const keys = Object.keys(value);
+  const unprefixedKeys = keys.filter(k => k[0] !== '$');
 
-// Handles a key, value to put in the selector document if the value is an object
-function populateDocumentWithObject(document, key, value) {
-    const keys = Object.keys(value);
-    const unprefixedKeys = keys.filter(k => k[0] !== "$");
-
-    if (unprefixedKeys.length > 0 || !keys.length) {
-        //Literal (possibly empty) object ( or empty object ) 
-        //Don't allow mixing '$'-prefixed with non-'$'-prefixed fields
-        if (keys.length !== unprefixedKeys.length) {
-            throw new Error(`unknown operator: ${unprefixedKeys[0]}`)
-        } else {
-            validateObject(value, key);
-            insertIntoDocument(document, key, value);
-        }
+  if (unprefixedKeys.length > 0 || !keys.length) {
+    // Literal (possibly empty) object ( or empty object ) 
+    // Don't allow mixing '$'-prefixed with non-'$'-prefixed fields
+    if (keys.length !== unprefixedKeys.length) {
+      throw new Error(`unknown operator: ${unprefixedKeys[0]}`);
     } else {
-        for (let [k, v] of Object.entries(value)) {
-            if (k === "$eq") {
-                populateDocumentWithKeyValue(document, key, v);
-            }
-            //every value for $all should be dealt with as separate $eq-s
-            else if (k === "$all") {
-                v.forEach(vx => populateDocumentWithKeyValue(document, key, vx))
-            }
-        }
+      validateObject(value, key);
+      insertIntoDocument(document, key, value);
     }
+  } else {
+    Object.keys(value).forEach(function (k) {
+      const v = value[k];
+      if (k === '$eq') {
+        populateDocumentWithKeyValue(document, key, v);
+      } else if (k === '$all') {
+        // every value for $all should be dealt with as separate $eq-s
+        v.forEach(vx => populateDocumentWithKeyValue(document, key, vx));
+      }
+    })
+  }
 }
 
 // Actually inserts a key value into the selector document
-// However, this checks there is no ambiguity in setting the value for the given key, throws otherwise
-function insertIntoDocument(document, key, value) {
+// However, this checks there is no ambiguity in setting 
+// the value for the given key, throws otherwise
+function insertIntoDocument (document, key, value) {
+  Object.keys(document).forEach(existingKey => {
+    if (
+      (existingKey.length > key.length && existingKey.indexOf(key) === 0)
+      || (key.length > existingKey.length && key.indexOf(existingKey) === 0)
+    ) {
+      throw new Error('cannot infer query fields to set, both paths ' +
+        `${existingKey}' and '${key}' are matched`);
+    } else if (existingKey === key) {
+      throw new Error(`cannot infer query fields to set, path ${key} ` +
+        'is matched twice');
+    }
+  })
 
-    Object.keys(document).forEach(existingKey => {
-        if (
-            (existingKey.length > key.length && existingKey.indexOf(key) === 0)
-            || (key.length > existingKey.length && key.indexOf(existingKey) === 0)
-        ) {
-            throw new Error(`cannot infer query fields to set, both paths '${existingKey}' and '${key}' are matched`)
-        }
-        else if (existingKey === key) {
-            throw new Error(`cannot infer query fields to set, path ${key} is matched twice`)
-        }
-    })
-
-    document[key] = value;
+  document[key] = value;
 }
 
 // Recursively validates an object that is nested more than one level deep
-function validateObject(obj, path) {
-    if (obj && Object.getPrototypeOf(obj) === Object.prototype) {
-        for (let [key, value] of Object.entries(obj)) {
-            validateKeyInPath(key, path);
-            validateObject(value, path + "." + key);
-        }
-    }
+function validateObject (obj, path) {
+  if (obj && Object.getPrototypeOf(obj) === Object.prototype) {
+    Object.keys(obj).forEach(function (key) {
+      validateKeyInPath(key, path);
+      validateObject(obj[key], path + '.' + key);
+    })
+  }
 }
 
-// Validates the key in a path. Objects that are nested more then 1 level cannot have dotted fields or fields starting with '$'
-function validateKeyInPath(key, path) {
-    if (key.includes(".")) {
-        throw new Error(`The dotted field '${key}' in '${path}.${key}' is not valid for storage.`)
-    }
-    if (key[0] === "$") {
-        throw new Error(`The dollar ($) prefixed field  '${path}.${key}' is not valid for storage.`)
-    }
+// Validates the key in a path. 
+// Objects that are nested more then 1 level cannot have dotted fields 
+// or fields starting with '$'
+function validateKeyInPath (key, path) {
+  if (key.includes('.')) {
+    throw new Error(`The dotted field '${key}' in '${path}.${key}' ` +
+      'is not valid for storage.');
+  }
+  if (key[0] === '$') {
+    throw new Error(`The dollar ($) prefixed field  '${path}.${key}' ` +
+      'is not valid for storage.');
+  }
 }

--- a/packages/minimongo/upsert_document.js
+++ b/packages/minimongo/upsert_document.js
@@ -1,0 +1,123 @@
+// Creating a document from an upsert is quite tricky.
+// E.g. this selector: {"$or": [{"b.foo": {"$all": ["bar"]}}]}, should result in: {"b.foo": "bar"}
+// But this selector: {"$or": [{"b": {"foo": {"$all": ["bar"]}}}]} should throw an error
+
+// Some rules (found mainly with trial & error, so there might be more):
+// - handle all childs of $and (or implicit $and)
+// - handle $or nodes with exactly 1 child
+// - ignore $or nodes with more than 1 child
+// - ignore $nor and $not nodes
+// - throw when a value can not be set unambiguously
+// - every value for $all should be dealt with as separate $eq-s
+// - threat all children of $all as $eq setters (=> set if $all.length === 1, otherwise throw error)
+// - you can not mix '$'-prefixed keys and non-'$'-prefixed keys
+// - you can only have dotted keys on a root-level
+// - you can not have '$'-prefixed keys more than one-level deep in an object
+
+// Fills a document with certain fields from an upsert selector
+populateDocumentWithQueryFields = function (query, document = {}) {
+
+    if (Object.getPrototypeOf(query) === Object.prototype) {
+        // handle implicit $and
+        for (let [key, value] of Object.entries(query)) {
+            // handle explicit $and
+            if (key === "$and") {
+                value.forEach(sq => populateDocumentWithQueryFields(sq, document))
+            }
+            // handle $or nodes with exactly 1 child
+            else if (key === "$or") {
+                if (value.length === 1) {
+                    populateDocumentWithQueryFields(value[0], document)
+                }
+            }
+            //Ignore other '$'-prefixed logical selectors
+            else if (key[0] !== "$") {
+                populateDocumentWithKeyValue(document, key, value);
+            }
+        }
+    } else {
+        // Handle meteor-specific shortcut for selecting _id
+        if (LocalCollection._selectorIsId(query)) {
+            insertIntoDocument(document, "_id", query);
+        }
+    }
+
+    return document;
+
+}
+
+// Handles one key/value pair to put in the selector document
+function populateDocumentWithKeyValue(document, key, value) {
+    if (value && Object.getPrototypeOf(value) === Object.prototype) {
+        populateDocumentWithObject(document, key, value);
+    } else {
+        insertIntoDocument(document, key, value);
+    }
+}
+
+
+// Handles a key, value to put in the selector document if the value is an object
+function populateDocumentWithObject(document, key, value) {
+    const keys = Object.keys(value);
+    const unprefixedKeys = keys.filter(k => k[0] !== "$");
+
+    if (unprefixedKeys.length > 0 || !keys.length) {
+        //Literal (possibly empty) object ( or empty object ) 
+        //Don't allow mixing '$'-prefixed with non-'$'-prefixed fields
+        if (keys.length !== unprefixedKeys.length) {
+            throw new Error(`unknown operator: ${unprefixedKeys[0]}`)
+        } else {
+            validateObject(value, key);
+            insertIntoDocument(document, key, value);
+        }
+    } else {
+        for (let [k, v] of Object.entries(value)) {
+            if (k === "$eq") {
+                populateDocumentWithKeyValue(document, key, v);
+            }
+            //every value for $all should be dealt with as separate $eq-s
+            else if (k === "$all") {
+                v.forEach(vx => populateDocumentWithKeyValue(document, key, vx))
+            }
+        }
+    }
+}
+
+// Actually inserts a key value into the selector document
+// However, this checks there is no ambiguity in setting the value for the given key, throws otherwise
+function insertIntoDocument(document, key, value) {
+
+    Object.keys(document).forEach(existingKey => {
+        if (
+            (existingKey.length > key.length && existingKey.indexOf(key) === 0)
+            || (key.length > existingKey.length && key.indexOf(existingKey) === 0)
+        ) {
+            throw new Error(`cannot infer query fields to set, both paths '${existingKey}' and '${key}' are matched`)
+        }
+        else if (existingKey === key) {
+            throw new Error(`cannot infer query fields to set, path ${key} is matched twice`)
+        }
+    })
+
+    document[key] = value;
+}
+
+// Recursively validates an object that is nested more than one level deep
+function validateObject(obj, path) {
+    if (obj && Object.getPrototypeOf(obj) === Object.prototype) {
+        for (let [key, value] of Object.entries(obj)) {
+            validateKeyInPath(key, path);
+            validateObject(value, path + "." + key);
+        }
+    }
+}
+
+// Validates the key in a path. Objects that are nested more then 1 level cannot have dotted fields or fields starting with '$'
+function validateKeyInPath(key, path) {
+    if (key.includes(".")) {
+        throw new Error(`The dotted field '${key}' in '${path}.${key}' is not valid for storage.`)
+    }
+    if (key[0] === "$") {
+        throw new Error(`The dollar ($) prefixed field  '${path}.${key}' is not valid for storage.`)
+    }
+}

--- a/packages/minimongo/upsert_document.js
+++ b/packages/minimongo/upsert_document.js
@@ -50,7 +50,7 @@ populateDocumentWithQueryFields = function (query, document = {}) {
 function populateDocumentWithKeyValue(document, key, value) {
     if (value && Object.getPrototypeOf(value) === Object.prototype) {
         populateDocumentWithObject(document, key, value);
-    } else {
+    } else if (!(value instanceof RegExp)) {
         insertIntoDocument(document, key, value);
     }
 }

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -562,6 +562,7 @@ Mongo.Collection.prototype.update = function update(selector, modifier, ...optio
       insertedId = options.insertedId;
     } else if (!selector || !selector._id) {
       insertedId = this._makeNewID();
+      options.generatedId = true;
       options.insertedId = insertedId;
     }
   }

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -574,7 +574,7 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
       );
     } else {
       
-      if (options.upsert && !knownId && isModify) {
+      if (options.upsert && !knownId && options.insertedId && isModify) {
         if (!mongoMod.hasOwnProperty('$setOnInsert')) {
           mongoMod.$setOnInsert = {};
         }
@@ -591,10 +591,14 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
               // If this was an upsert() call, and we ended up
               // inserting a new doc and we know its id, then
               // return that id as well.
-
-              if (options.upsert && meteorResult.insertedId && knownId) {
-                meteorResult.insertedId = knownId;
+              if (options.upsert && meteorResult.insertedId) {
+                if (knownId) {
+                  meteorResult.insertedId = knownId;
+                } else if (meteorResult.insertedId instanceof MongoDB.ObjectID) {
+                  meteorResult.insertedId = new Mongo.ObjectID(meteorResult.insertedId.toHexString());
+                }
               }
+
               callback(err, meteorResult);
             } else {
               callback(err, meteorResult.numberAffected);

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -696,39 +696,39 @@ var simulateUpsertWithInsertedId = function (collection, selector, mod,
       callback(new Error("Upsert failed after " + NUM_OPTIMISTIC_TRIES + " tries."));
     } else {
       collection.update(selector, mod, mongoOptsForUpdate,
-                      bindEnvironmentForWrite(function (err, result) {
-                        if (err) {
-                          callback(err);
-                        } else if (result && result.result.n != 0) {
-                          callback(null, {
-                            numberAffected: result.result.n
-                          });
-                        } else {
-                          doConditionalInsert();
-                        }
-                      }));
+                        bindEnvironmentForWrite(function (err, result) {
+                          if (err) {
+                            callback(err);
+                          } else if (result && result.result.n != 0) {
+                            callback(null, {
+                              numberAffected: result.result.n
+                            });
+                          } else {
+                            doConditionalInsert();
+                          }
+                        }));
     }
   };
 
   var doConditionalInsert = function () {
     collection.update(selector, replacementWithId, mongoOptsForInsert,
-                    bindEnvironmentForWrite(function (err, result) {
-                      if (err) {
-                        // figure out if this is a
-                        // "cannot change _id of document" error, and
-                        // if so, try doUpdate() again, up to 3 times.
-                        if (MongoConnection._isCannotChangeIdError(err)) {
-                          doUpdate();
+                      bindEnvironmentForWrite(function (err, result) {
+                        if (err) {
+                          // figure out if this is a
+                          // "cannot change _id of document" error, and
+                          // if so, try doUpdate() again, up to 3 times.
+                          if (MongoConnection._isCannotChangeIdError(err)) {
+                            doUpdate();
+                          } else {
+                            callback(err);
+                          }
                         } else {
-                          callback(err);
+                          callback(null, {
+                            numberAffected: result.result.upserted.length,
+                            insertedId: insertedId,
+                          });
                         }
-                      } else {
-                        callback(null, {
-                          numberAffected: result.result.upserted.length,
-                          insertedId: insertedId,
-                        });
-                      }
-                    }));
+                      }));
   };
 
   doUpdate();

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -620,24 +620,15 @@ var NUM_OPTIMISTIC_TRIES = 3;
 
 // exposed for testing
 MongoConnection._isCannotChangeIdError = function (err) {
-  // First check for what this error looked like in Mongo 2.4.  Either of these
-  // checks should work, but just to be safe...
-  if (err.code === 13596) {
-    return true;
-  }
 
   // Mongo 3.2.* returns error as next Object:
-  // {name: String, code: Number, err: String}
-  // Older Mongo returns:
   // {name: String, code: Number, errmsg: String}
+  // Older Mongo returns:
+  // {name: String, code: Number, err: String}
   var error = err.errmsg || err.err;
 
-  if (error.indexOf('cannot change _id of a document') === 0) {
-    return true;
-  }
-
-  // Now look for what it looks like in Mongo 2.6.  We don't use the error code
-  // here, because the error code we observed it producing (16837) appears to be
+  // We don't use the error code here
+  // because the error code we observed it producing (16837) appears to be
   // a far more generic error code based on examining the source.
   if (error.indexOf('The _id field cannot be changed') === 0) {
     return true;

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -513,6 +513,15 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
 
     var isModify = LocalCollection._isModificationMod(mongoMod);
 
+    if (options._forbidReplace && !isModify) {
+      var err = new Error("Invalid modifier. Replacements are forbidden.");
+      if (callback) {
+        return callback(err);
+      } else {
+        throw err;
+      }
+    }
+
     // We've already run replaceTypes/replaceMeteorAtomWithMongo on
     // selector and mod.  We assume it doesn't matter, as far as
     // the behavior of modifiers is concerned, whether `_modify`
@@ -531,15 +540,6 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
         } else {
           throw err;
         }
-      }
-    }
-
-    if (options._forbidReplace && !isModify) {
-      var err = new Error("Invalid modifier. Replacements are forbidden.");
-      if (callback) {
-        return callback(err);
-      } else {
-        throw err;
       }
     }
 
@@ -581,7 +581,7 @@ MongoConnection.prototype._update = function (collection_name, selector, mod,
         knownId = options.insertedId;
         Object.assign(mongoMod.$setOnInsert, replaceTypes({_id: options.insertedId}, replaceMeteorAtomWithMongo));
       }
-
+      
       collection.update(
         mongoSelector, mongoMod, mongoOpts,
         bindEnvironmentForWrite(function (err, result) {

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -1646,14 +1646,15 @@ if (Meteor.isServer) {
     var run = test.runId();
     var coll = new Mongo.Collection("livedata_upsert_errorparse_collection_"+run, collectionOptions);
 
-    coll.insert({_id: 'foobar'});
+    coll.insert({_id:'foobar', foo: 'bar'});
     var err;
     try {
-      coll.update({_id: 'foobar'}, {_id: 'cowbar'});
+      coll.update({foo: 'bar'}, {_id: 'cowbar'});
     } catch (e) {
       err = e;
     }
     test.isTrue(err);
+    console.log("WUUUK");
     test.isTrue(MongoInternals.Connection._isCannotChangeIdError(err));
 
     try {

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -1654,7 +1654,6 @@ if (Meteor.isServer) {
       err = e;
     }
     test.isTrue(err);
-    console.log("WUUUK");
     test.isTrue(MongoInternals.Connection._isCannotChangeIdError(err));
 
     try {


### PR DESCRIPTION
Attempt to fix: https://github.com/meteor/meteor/issues/8806, https://github.com/meteor/meteor/issues/5611, https://github.com/meteor/meteor/issues/8794, https://github.com/meteor/meteor/issues/5294 and https://github.com/meteor/meteor/issues/8775

This turned out to be quite painful. Following https://github.com/mongodb/mongo/blob/master/src/mongo/db/update/update_driver.cpp#L176 takes you to a big journey of mongo's source code. So a direct port is not really viable. I tried to infer what I could and also discovered a lot of rules with trial & error. It's possible there are more things I've missed.

However, this PR works with all old tests and makes the upsert behavior compliant with a big range of more complex upserts for every rule I could infer.

**But there's a catch**: This is possibly a BC break, since the behavior for these more complex selectors is, albeit compliant with mongo, different then what Meteor would have entered in the database before. 
E.g. this upsert: `{$and: [{foo: "bar"}]}, {$set: {a: 123}}` would now correctly result in `{foo: 'bar', a: 123}`, while in old versions it would be just `{a: 123}`
To make matters worse, it is not just for minimongo, but because Meteor simulates upserts for Mongo 2.4 compatibility (see: https://github.com/meteor/meteor/blob/devel/packages/mongo/mongo_driver.js#L527) it's also for what ends up in the actual database in some situations.
Now wouldn't be a bad time to remove that simulated upsert stuff (if 2.4 support is no longer a requirement), otherwise behavior might break again in the future.

So this needs a decent review and some warnings in changelogs here and there.