### PR TITLE
Handle regular expressions in EJSON

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -94,6 +94,21 @@ var builtinConverters = [
       return new Date(obj.$date);
     }
   },
+  { // RegExp
+    matchJSONValue: function (obj) {
+      return _.has(obj, '$regexp') && _.has(obj, '$flags') && _.size(obj) === 2;
+    },
+    matchObject: function (obj) {
+      return obj instanceof RegExp;
+    },
+    toJSONValue: function (regexp) {
+      return { $regexp: regexp.source, $flags: regexp.flags };
+    },
+    fromJSONValue: function (obj) {
+      //replaces duplicate / invalid flags
+      return new RegExp(obj.$regexp, obj.$flags.replace(/[^gimuy]/g,'').replace(/(.)(?=.*\1)/g, ''));
+    }
+  },
   { // NaN, Inf, -Inf. (These are the only objects with typeof !== 'object'
     // which we match.)
     matchJSONValue: function (obj) {

--- a/packages/ejson/ejson_test.js
+++ b/packages/ejson/ejson_test.js
@@ -185,6 +185,16 @@ Tinytest.add("ejson - parse", function (test) {
   );
 });
 
+Tinytest.add("ejson - regexp", function (test) {
+  test.equal(EJSON.stringify(/foo/gi), "{\"$regexp\":\"foo\",\"$flags\":\"gi\"}");
+  var d = new RegExp("foo", "gi");
+  var obj = { $regexp: "foo", $flags: "gi" };
+
+  var eObj = EJSON.toJSONValue(obj);
+  var roundTrip = EJSON.fromJSONValue(eObj);
+  test.equal(obj, roundTrip);
+});
+
 Tinytest.add("ejson - custom types", function (test) {
   var testSameConstructors = function (obj, compareWith) {
     test.equal(obj.constructor, compareWith.constructor);

--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -775,8 +775,7 @@ ELEMENT_OPERATORS = {
       var regexp;
       if (valueSelector.$options !== undefined) {
         // Options passed in $options (even the empty string) always overrides
-        // options in the RegExp object itself. (See also
-        // Mongo.Collection._rewriteSelector.)
+        // options in the RegExp object itself. 
 
         // Be clear that we only support the JS-supported options, not extended
         // ones (eg, Mongo supports x and s). Ideally we would implement x and s

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1183,7 +1183,7 @@ MongoConnection.prototype._observeChanges = function (
     throw Error("You may not observe a cursor with {fields: {_id: 0}}");
   }
 
-  var observeKey = JSON.stringify(
+  var observeKey = EJSON.stringify(
     _.extend({ordered: ordered}, cursorDescription));
 
   var multiplexer, observeDriver;

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -2152,87 +2152,14 @@ _.each(Meteor.isServer ? [true, false] : [true], function (minimongo) {
 });  // end idGeneration parametrization
 
 Tinytest.add('mongo-livedata - rewrite selector', function (test) {
-  test.equal(Mongo.Collection._rewriteSelector({x: /^o+B/im}),
-             {x: {$regex: '^o+B', $options: 'im'}});
-  test.equal(Mongo.Collection._rewriteSelector({x: {$regex: /^o+B/im}}),
-             {x: {$regex: '^o+B', $options: 'im'}});
-  test.equal(Mongo.Collection._rewriteSelector({x: /^o+B/}),
-             {x: {$regex: '^o+B'}});
-  test.equal(Mongo.Collection._rewriteSelector({x: {$regex: /^o+B/}}),
-             {x: {$regex: '^o+B'}});
+ 
   test.equal(Mongo.Collection._rewriteSelector('foo'),
              {_id: 'foo'});
 
-  test.equal(
-    Mongo.Collection._rewriteSelector(
-      {'$or': [
-        {x: /^o/},
-        {y: /^p/},
-        {z: 'q'},
-        {w: {$regex: /^r/}}
-      ]}
-    ),
-    {'$or': [
-      {x: {$regex: '^o'}},
-      {y: {$regex: '^p'}},
-      {z: 'q'},
-      {w: {$regex: '^r'}}
-    ]}
-  );
-
-  test.equal(
-    Mongo.Collection._rewriteSelector(
-      {'$or': [
-        {'$and': [
-          {x: /^a/i},
-          {y: /^b/},
-          {z: {$regex: /^c/i}},
-          {w: {$regex: '^[abc]', $options: 'i'}}, // make sure we don't break vanilla selectors
-          {v: {$regex: /O/, $options: 'i'}}, // $options should override the ones on the RegExp object
-          {u: {$regex: /O/m, $options: 'i'}} // $options should override the ones on the RegExp object
-        ]},
-        {'$nor': [
-          {s: /^d/},
-          {t: /^e/i},
-          {u: {$regex: /^f/i}},
-          // even empty string overrides built-in flags
-          {v: {$regex: /^g/i, $options: ''}}
-        ]}
-      ]}
-    ),
-    {'$or': [
-      {'$and': [
-        {x: {$regex: '^a', $options: 'i'}},
-        {y: {$regex: '^b'}},
-        {z: {$regex: '^c', $options: 'i'}},
-        {w: {$regex: '^[abc]', $options: 'i'}},
-        {v: {$regex: 'O', $options: 'i'}},
-        {u: {$regex: 'O', $options: 'i'}}
-      ]},
-      {'$nor': [
-        {s: {$regex: '^d'}},
-        {t: {$regex: '^e', $options: 'i'}},
-        {u: {$regex: '^f', $options: 'i'}},
-        {v: {$regex: '^g', $options: ''}}
-      ]}
-    ]}
-  );
 
   var oid = new Mongo.ObjectID();
   test.equal(Mongo.Collection._rewriteSelector(oid),
              {_id: oid});
-
-  // Make sure selectors with "length" properties are handled properly
-  // (verifies issue #8329 has been resolved).
-  const SomeSelector = function (length) {
-    this.length = length;
-  };
-  const length = 2;
-  const testSelector = new SomeSelector(length);
-  test.equal(
-    Mongo.Collection._rewriteSelector(testSelector),
-    { length }
-  );
 
   test.matches(
     Mongo.Collection._rewriteSelector({ _id: null })._id,

--- a/tools/tests/command-line.js
+++ b/tools/tests/command-line.js
@@ -315,6 +315,7 @@ selftest.define("argument parsing", function () {
   s.createApp('myapp', 'standard-app');
   s.cd('myapp', function () {
     run = s.run("list");
+    run.waitSecs(30);
     run.expectExit(0);
   });
 

--- a/tools/tests/releases.js
+++ b/tools/tests/releases.js
@@ -189,10 +189,10 @@ selftest.define("checkout", ['checkout'], function () {
   s.cd('myapp', function () {
     s.write(".meteor/release", "something");
     run = s.run("list");
-    run.waitSecs(10);
     run.readErr("=> Running Meteor from a checkout");
     run.matchErr("project version");
     run.matchErr("(Meteor something)\n");
+    run.waitSecs(30);
     run.expectExit(0);
   });
 });

--- a/tools/tests/releases.js
+++ b/tools/tests/releases.js
@@ -189,6 +189,7 @@ selftest.define("checkout", ['checkout'], function () {
   s.cd('myapp', function () {
     s.write(".meteor/release", "something");
     run = s.run("list");
+    run.waitSecs(10);
     run.readErr("=> Running Meteor from a checkout");
     run.matchErr("project version");
     run.matchErr("(Meteor something)\n");


### PR DESCRIPTION
Fixes: https://github.com/meteor/meteor/issues/5652

Background (kudos to: https://github.com/meteor/meteor/issues/5652#issuecomment-157544912 for pointing in the right direction):
Meteor multiplexes/re-uses duplicate observers. For fast look-up of duplicate observers it creates a hash with some properties of the cursor (e.g. selector, projection, ...).
However, for this hash it simply uses `JSON.stringify` ( https://github.com/meteor/meteor/blob/a4de554a95455e91b5d7e71c4c611c2e78725d5e/packages/mongo/mongo_driver.js#L1221 ) , which can not stringify regular expressions. This leads to a problem where different queries would re-use the same (wrong) observer.

However, this selector has already passed the `Mongo.Collection._rewriteSelector` (https://github.com/meteor/meteor/blob/906aab4447ace6cedf873abe0f3c99ad5539cadc/packages/mongo/collection.js#L369) method, which should replace regular expression objects with the alternative `{ $regex: '', $options: '' }` syntax. The problem is that `Mongo.Collection._rewriteSelector` doesn't do its work thoroughly and misses regular expressions inside `$elemMatch` amongst others.

Btw, since order of JSON doesn't guarantee the order of keys in an object, this is probably not the best way to 'hash' the selector, but that's another issue.

Approaches considered:

1. Fix `_rewriteSelector`. This would mean replace every occurence of a regular expression, even deeply nested once in `$elemMatch` and `$in` (amongst others?)

This poses 2 problems:
- The `$in`-array does not support  `{ $regex: '', $options: '' }` syntax
- `_rewriteSelector` is called multiple times for each query, and `$in` can sometimes contain long lists (at least in my apps) which would be a potential serious performance hit.

2. Just use a replacer function in the `JSON.stringify` method here: https://github.com/meteor/meteor/blob/a4de554a95455e91b5d7e71c4c611c2e78725d5e/packages/mongo/mongo_driver.js#L1221
This could check if a value is a RegExp instance and replace it with something serializable

This is the least obtrusive way (like 1 line of code) to fix the specific problem mentioned in: https://github.com/meteor/meteor/issues/5652
However, that still leaves a buggy `_rewriteSelector`. And my mom always thought me I shouldn't do half-assed work, which is why I went for option 3

3. Add support to EJSON for RegExp stringify/parsing. This solves the problem with both `_rewriteSelector` and with `observeKey`-hash.

This is IMO the most elegant solution, but it's also the most obtrusive. From what I can make out from the comments in the code the only reason `_rewriteSelector` replaced regular expressions is to make them DDP-serializable (although it's not clear why it should be DDP-serializable), which this approach achieves. 
But there might be something crucial I'm missing here. Please review