### PR TITLE
Adjusted the jshint package to meet its own linting requirements.

### DIFF
--- a/packages/jshint/plugin/lint-jshint.js
+++ b/packages/jshint/plugin/lint-jshint.js
@@ -1,5 +1,5 @@
-var util = Npm.require('util');
-var Future = Npm.require('fibers/future');
+/* globals Npm, Plugin */
+
 var jshint = Npm.require('jshint').JSHINT;
 
 Plugin.registerLinter({
@@ -14,7 +14,7 @@ function JsHintLinter () {
   // packageName -> { config (json),
   //                  files: { [pathInPackage,arch] -> { hash, errors }}}
   this._cacheByPackage = {};
-};
+}
 
 var DEFAULT_CONFIG = JSON.stringify({
   undef: true,
@@ -114,4 +114,3 @@ JsHintLinter.prototype.processFilesForPackage = function (files, options) {
     });
   }
 };
-


### PR DESCRIPTION
Hi all - sorry, there isn't an associated issue # with this PR, but I thought I'd fire it in regardless. This PR fixes the `jshint` linting errors that show up in the logs on every Travis run (or when running `./packages/test-in-console/run.sh` locally). For example, see the output of https://travis-ci.org/meteor/meteor/builds/244730834 starting on line 562:

![screenshot 2017-06-21 10 02 59](https://user-images.githubusercontent.com/137740/27388895-d33c45ec-566a-11e7-9ebc-a06a80b4cc4c.png)

These errors are coming from linting the `jshint` wrapper package itself. This PR adjusts the wrapper package to meet the configured linter requirements. Thanks!
