### PR TITLE
Upgrade npm to version 5.0.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,13 @@
 
 * Node has been upgraded to version 8.1.2.
 
+* The `npm` npm package has been upgraded to version 5.0.3, a major
+  upgrade from 4.6.1, requiring internal updates to dependency management
+  logic for Meteor packages that use `Npm.depends`. While these changes
+  should be backwards-compatible for existing Meteor packages, if you are
+  the maintainer of any packages, you should pay close attention to your
+  `npm-shrinkwrap.json` files when first using this version of `npm`.
+
 * The `node-gyp` npm package has been upgraded to version 3.6.2.
 
 * The `node-pre-gyp` npm package has been updated to version 0.6.36.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.1.2
+BUNDLE_VERSION=8.1.3
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -1,750 +1,751 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "from": "acorn@>=5.0.0 <5.1.0"
+      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0="
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "from": "ansi-regex@>=2.0.0 <3.0.0"
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "from": "ansi-styles@>=2.2.1 <3.0.0"
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "from": "babel-code-frame@>=6.22.0 <7.0.0"
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
     },
     "babel-core": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "from": "babel-core@>=6.22.1 <7.0.0"
+      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk="
     },
     "babel-generator": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-      "from": "babel-generator@>=6.25.0 <7.0.0"
+      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw="
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
-      "from": "babel-helper-builder-react-jsx@>=6.24.1 <7.0.0"
+      "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw="
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0"
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "from": "babel-helper-define-map@>=6.24.1 <7.0.0"
+      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA="
     },
     "babel-helper-evaluate-path": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.0.3.tgz",
-      "from": "babel-helper-evaluate-path@>=0.0.3 <0.0.4"
+      "integrity": "sha1-HRA6ydSlnl1DGEIhLxUXhfesVHs="
     },
     "babel-helper-flip-expressions": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.0.2.tgz",
-      "from": "babel-helper-flip-expressions@>=0.0.2 <0.0.3"
+      "integrity": "sha1-e6ss9hFivJJwPpspjvUSvPd9Z4c="
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "from": "babel-helper-function-name@>=6.24.1 <7.0.0"
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0"
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0"
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-      "from": "babel-helper-is-nodes-equiv@>=0.0.1 <0.0.2"
+      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.0.1.tgz",
-      "from": "babel-helper-is-void-0@>=0.0.1 <0.0.2"
+      "integrity": "sha1-7XRVO4g+aCJq5F+YmpmwLBkPEFo="
     },
     "babel-helper-mark-eval-scopes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.1.1.tgz",
-      "from": "babel-helper-mark-eval-scopes@>=0.1.1 <0.2.0"
+      "integrity": "sha1-RVQ0Xt+fJUlCe9IJjlMCU/ivKZI="
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0"
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
     },
     "babel-helper-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "from": "babel-helper-regex@>=6.24.1 <7.0.0"
+      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg="
     },
     "babel-helper-remove-or-void": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.1.1.tgz",
-      "from": "babel-helper-remove-or-void@>=0.1.1 <0.2.0"
+      "integrity": "sha1-nX4YVtxvr8tBsoOkFnMNwYRPZtc="
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0"
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
     },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.0.3.tgz",
-      "from": "babel-helper-to-multiple-sequence-expressions@>=0.0.3 <0.0.4"
+      "integrity": "sha1-x4mg+szSZpxRI0vizqej5aBXPCU="
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "from": "babel-helpers@>=6.24.1 <7.0.0"
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "from": "babel-messages@>=6.23.0 <7.0.0"
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0"
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
     },
     "babel-plugin-minify-constant-folding": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.0.4.tgz",
-      "from": "babel-plugin-minify-constant-folding@>=0.0.4 <0.0.5",
+      "integrity": "sha1-tuIxAmpgNeiM6t0gYSjX2ytcFeY=",
       "dependencies": {
         "jsesc": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "from": "jsesc@>=2.4.0 <3.0.0"
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
         }
       }
     },
     "babel-plugin-minify-dead-code-elimination": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.1.7.tgz",
-      "from": "babel-plugin-minify-dead-code-elimination@>=0.1.3 <0.2.0"
+      "integrity": "sha1-d09TbzR7mDk6J7qnF4cpaIE8NCw="
     },
     "babel-plugin-minify-flip-comparisons": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.0.2.tgz",
-      "from": "babel-plugin-minify-flip-comparisons@>=0.0.2 <0.0.3"
+      "integrity": "sha1-fQlTqlh27eYRiWa9qe3sxjvzRqs="
     },
     "babel-plugin-minify-guarded-expressions": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.0.4.tgz",
-      "from": "babel-plugin-minify-guarded-expressions@>=0.0.4 <0.0.5"
+      "integrity": "sha1-lXEEp2Dmp//ZZwBaehFiG7Qv0Rw="
     },
     "babel-plugin-minify-infinity": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.0.3.tgz",
-      "from": "babel-plugin-minify-infinity@>=0.0.3 <0.0.4"
+      "integrity": "sha1-TMmbYdErQ0zoCtZ1EDM1xYnLqaE="
     },
     "babel-plugin-minify-mangle-names": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.0.7.tgz",
-      "from": "babel-plugin-minify-mangle-names@>=0.0.7 <0.0.8",
+      "integrity": "sha1-/MX5pMTJwHMec6Sk49AC/LgA70E=",
       "dependencies": {
         "babel-helper-mark-eval-scopes": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.0.2.tgz",
-          "from": "babel-helper-mark-eval-scopes@>=0.0.2 <0.0.3"
+          "integrity": "sha1-kJ/R8jhFcM0wAyg3c4UtnWOSKjc="
         }
       }
     },
     "babel-plugin-minify-numeric-literals": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.0.1.tgz",
-      "from": "babel-plugin-minify-numeric-literals@>=0.0.1 <0.0.2"
+      "integrity": "sha1-lZfmwxFU19rzdE0L1BfBRLJ1vVM="
     },
     "babel-plugin-minify-replace": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.0.1.tgz",
-      "from": "babel-plugin-minify-replace@>=0.0.1 <0.0.2"
+      "integrity": "sha1-XVrqfLmJkkUkjR7pznov5Vao+sw="
     },
     "babel-plugin-minify-simplify": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.0.7.tgz",
-      "from": "babel-plugin-minify-simplify@>=0.0.7 <0.0.8"
+      "integrity": "sha1-QZjVieoQtLxb+TECBmGadDwNBmQ="
     },
     "babel-plugin-minify-type-constructors": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.0.3.tgz",
-      "from": "babel-plugin-minify-type-constructors@>=0.0.3 <0.0.4"
+      "integrity": "sha1-q1nBrYNba26OkyuHXU303Dk9nSY="
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "from": "babel-plugin-syntax-async-functions@>=6.13.0 <7.0.0"
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-      "from": "babel-plugin-syntax-async-generators@>=6.13.0 <7.0.0"
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0"
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "from": "babel-plugin-syntax-dynamic-import@>=6.18.0 <7.0.0"
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-      "from": "babel-plugin-syntax-flow@>=6.18.0 <7.0.0"
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0"
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "from": "babel-plugin-syntax-object-rest-spread@>=6.13.0 <7.0.0"
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "from": "babel-plugin-syntax-trailing-function-commas@>=6.22.0 <7.0.0"
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "from": "babel-plugin-transform-class-properties@>=6.24.1 <7.0.0"
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw="
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0"
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0"
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.22.0 <7.0.0"
+      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY="
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-classes@>=6.22.0 <7.0.0"
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.22.0 <7.0.0"
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM="
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0"
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0"
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0"
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.22.0 <7.0.0"
+      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4="
     },
     "babel-plugin-transform-es2015-modules-reify": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-reify/-/babel-plugin-transform-es2015-modules-reify-0.11.2.tgz",
-      "from": "babel-plugin-transform-es2015-modules-reify@>=0.11.0 <0.12.0"
+      "integrity": "sha1-T5Di58sfqVh/pDXyM74DMfCIs5o="
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-object-super@>=6.22.0 <7.0.0"
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40="
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.22.0 <7.0.0"
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.22.0 <7.0.0"
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA="
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0"
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.22.0 <7.0.0"
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw="
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0"
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0"
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.22.0 <7.0.0"
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek="
     },
     "babel-plugin-transform-es3-property-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
-      "from": "babel-plugin-transform-es3-property-literals@>=6.22.0 <7.0.0"
+      "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g="
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "from": "babel-plugin-transform-flow-strip-types@>=6.22.0 <7.0.0"
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988="
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.0.2.tgz",
-      "from": "babel-plugin-transform-inline-consecutive-adds@>=0.0.2 <0.0.3"
+      "integrity": "sha1-pY/Oz8CcCPv5NzpaPnB0bAPQH8E="
     },
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.8.4.tgz",
-      "from": "babel-plugin-transform-member-expression-literals@>=6.8.1 <7.0.0"
+      "integrity": "sha1-BWebxAWWuRKTQBlZqhYgqxsr5Dc="
     },
     "babel-plugin-transform-merge-sibling-variables": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.8.5.tgz",
-      "from": "babel-plugin-transform-merge-sibling-variables@>=6.8.2 <7.0.0"
+      "integrity": "sha1-A6vfEHxhJBkT6yaN3t5tW8VBhiw="
     },
     "babel-plugin-transform-minify-booleans": {
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.2.tgz",
-      "from": "babel-plugin-transform-minify-booleans@>=6.8.0 <7.0.0"
+      "integrity": "sha1-hFFXn3BucCweGrJ1beXI6jac8Hw="
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "from": "babel-plugin-transform-object-rest-spread@>=6.22.0 <7.0.0"
+      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE="
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.8.4.tgz",
-      "from": "babel-plugin-transform-property-literals@>=6.8.1 <7.0.0"
+      "integrity": "sha1-atMREQuAoZKlbvtd30/jym96Ydo="
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-      "from": "babel-plugin-transform-react-display-name@>=6.23.0 <7.0.0"
+      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE="
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-      "from": "babel-plugin-transform-react-jsx@>=6.24.1 <7.0.0"
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM="
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-      "from": "babel-plugin-transform-react-jsx-self@>=6.22.0 <7.0.0"
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24="
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-      "from": "babel-plugin-transform-react-jsx-source@>=6.22.0 <7.0.0"
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY="
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "from": "babel-plugin-transform-regenerator@>=6.22.0 <7.0.0"
+      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg="
     },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.0.5.tgz",
-      "from": "babel-plugin-transform-regexp-constructors@>=0.0.5 <0.0.6"
+      "integrity": "sha1-dNleDFZ+b8HZxpmghIlNQN6OWB0="
     },
     "babel-plugin-transform-remove-console": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.4.tgz",
-      "from": "babel-plugin-transform-remove-console@>=6.8.0 <7.0.0"
+      "integrity": "sha1-Qf3awZpymkw91+8pZOrAewlvmo8="
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.8.4.tgz",
-      "from": "babel-plugin-transform-remove-debugger@>=6.8.0 <7.0.0"
+      "integrity": "sha1-+FcEoIrapxtV13AFtblOm53yH24="
     },
     "babel-plugin-transform-remove-undefined": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.0.5.tgz",
-      "from": "babel-plugin-transform-remove-undefined@>=0.0.5 <0.0.6"
+      "integrity": "sha1-Eu8RgF4G6GHdLrDHzAQdIYS49BA="
     },
     "babel-plugin-transform-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-      "from": "babel-plugin-transform-runtime@>=6.22.0 <7.0.0"
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4="
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.8.4.tgz",
-      "from": "babel-plugin-transform-simplify-comparison-operators@>=6.8.1 <7.0.0"
+      "integrity": "sha1-KqJKJi1mTIyz4SWjBseY16LeCNU="
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0"
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
     },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.2.tgz",
-      "from": "babel-plugin-transform-undefined-to-void@>=6.8.0 <7.0.0"
+      "integrity": "sha1-/isdKU6wXodSTrk3JN6m4sPWb6E="
     },
     "babel-preset-babili": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/babel-preset-babili/-/babel-preset-babili-0.0.11.tgz",
-      "from": "babel-preset-babili@>=0.0.11 <0.0.12"
+      "integrity": "sha1-lGH9kC1qPIvAMrjwbC9pFnTBKh8="
     },
     "babel-preset-flow": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-      "from": "babel-preset-flow@>=6.23.0 <7.0.0"
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0="
     },
     "babel-preset-meteor": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-preset-meteor/-/babel-preset-meteor-6.26.0.tgz",
-      "from": "babel-preset-meteor@6.26.0"
+      "integrity": "sha1-v+/KEPMGfNPlYxsM1dpQKZb184s="
     },
     "babel-preset-react": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-      "from": "babel-preset-react@>=6.22.0 <7.0.0"
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A="
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "from": "babel-register@>=6.24.1 <7.0.0"
+      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118="
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "from": "babel-runtime@>=6.22.0 <7.0.0"
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
     },
     "babel-template": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-      "from": "babel-template@>=6.22.0 <7.0.0"
+      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE="
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-      "from": "babel-traverse@>=6.22.1 <7.0.0"
+      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE="
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-      "from": "babel-types@>=6.22.0 <7.0.0"
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
     },
     "babylon": {
       "version": "6.17.3",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
-      "from": "babylon@>=6.15.0 <7.0.0"
+      "integrity": "sha1-EyfXCZULVY8gTlNSWH/QKQ+Njkg="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "from": "balanced-match@>=1.0.0 <2.0.0"
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "from": "brace-expansion@>=1.1.7 <2.0.0"
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "from": "chalk@>=1.1.0 <2.0.0"
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "from": "concat-map@0.0.1"
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "from": "convert-source-map@>=1.3.0 <2.0.0"
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
     },
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "from": "core-js@>=2.4.0 <3.0.0"
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "from": "debug@>=2.1.1 <3.0.0"
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "from": "detect-indent@>=4.0.0 <5.0.0"
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "from": "esutils@>=2.0.2 <3.0.0"
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "from": "globals@>=9.0.0 <10.0.0"
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "from": "has-ansi@>=2.0.0 <3.0.0"
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "from": "home-or-tmp@>=2.0.0 <3.0.0"
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "from": "invariant@>=2.2.0 <3.0.0"
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "from": "is-finite@>=1.0.0 <2.0.0"
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
     },
     "js-tokens": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "from": "js-tokens@>=3.0.0 <4.0.0"
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
     },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "from": "jsesc@>=1.3.0 <2.0.0"
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "from": "json5@>=0.5.0 <0.6.0"
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "from": "lodash@>=4.17.4 <5.0.0"
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "from": "lodash.isplainobject@>=4.0.6 <5.0.0"
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.some": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "from": "lodash.some@>=4.6.0 <5.0.0"
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "from": "loose-envify@>=1.0.0 <2.0.0"
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "meteor-babel": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.21.5.tgz",
-      "from": "meteor-babel@0.21.5"
+      "integrity": "sha1-ZS+G31V5QJMoDa4hgzGxO0/y2dE="
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/meteor-babel-helpers/-/meteor-babel-helpers-0.0.3.tgz",
-      "from": "meteor-babel-helpers@0.0.3"
+      "integrity": "sha1-8uXZ+HlvvS6JAQI9dpnlsgLqn7A="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "from": "minimatch@>=3.0.2 <4.0.0"
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM="
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "from": "minimist@0.0.8"
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.0.2.tgz",
-      "from": "minipass@>=2.0.0 <3.0.0"
+      "integrity": "sha1-+uXHgSQFH1b9IAffABLg2senUs4="
     },
     "minizlib": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz",
-      "from": "minizlib@>=1.0.3 <2.0.0"
+      "integrity": "sha1-1cGr93vhVGGZUuJTM27Mq5sqMvU="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "from": "mkdirp@>=0.5.1 <0.6.0"
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "from": "ms@2.0.0"
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "from": "number-is-nan@>=1.0.0 <2.0.0"
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "from": "os-homedir@>=1.0.0 <2.0.0"
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "from": "os-tmpdir@>=1.0.1 <2.0.0"
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "private": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "from": "private@>=0.1.6 <0.2.0"
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
     },
     "regenerate": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "from": "regenerate@>=1.2.1 <2.0.0"
+      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
     },
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "from": "regenerator-runtime@>=0.10.0 <0.11.0"
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "from": "regenerator-transform@0.9.11"
+      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM="
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "from": "regexpu-core@>=2.0.0 <3.0.0"
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
     },
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "from": "regjsgen@>=0.2.0 <0.3.0"
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "from": "jsesc@>=0.5.0 <0.6.0"
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
     "reify": {
       "version": "0.11.24",
       "resolved": "https://registry.npmjs.org/reify/-/reify-0.11.24.tgz",
-      "from": "reify@>=0.11.18 <0.12.0"
+      "integrity": "sha1-QR+5C99Vxfobx9l2vrCdyVQBif4="
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "from": "repeating@>=2.0.0 <3.0.0"
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
     },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "from": "semver@>=5.3.0 <6.0.0"
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "from": "slash@>=1.0.0 <2.0.0"
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "from": "source-map@>=0.5.0 <0.6.0"
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
     },
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "from": "source-map-support@>=0.4.2 <0.5.0"
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "from": "strip-ansi@>=3.0.0 <4.0.0"
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "from": "supports-color@>=2.0.0 <3.0.0"
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "from": "to-fast-properties@>=1.0.1 <2.0.0"
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "from": "trim-right@>=1.0.1 <2.0.0"
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "yallist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "from": "yallist@>=3.0.0 <4.0.0"
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
     }
   }
 }

--- a/packages/jshint/plugin/lint-jshint.js
+++ b/packages/jshint/plugin/lint-jshint.js
@@ -1,5 +1,5 @@
-var util = Npm.require('util');
-var Future = Npm.require('fibers/future');
+/* globals Npm, Plugin */
+
 var jshint = Npm.require('jshint').JSHINT;
 
 Plugin.registerLinter({
@@ -14,7 +14,7 @@ function JsHintLinter () {
   // packageName -> { config (json),
   //                  files: { [pathInPackage,arch] -> { hash, errors }}}
   this._cacheByPackage = {};
-};
+}
 
 var DEFAULT_CONFIG = JSON.stringify({
   undef: true,
@@ -114,4 +114,3 @@ JsHintLinter.prototype.processFilesForPackage = function (files, options) {
     });
   }
 };
-

--- a/packages/modules-runtime/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules-runtime/.npm/package/npm-shrinkwrap.json
@@ -1,9 +1,10 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "install": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/install/-/install-0.10.1.tgz",
-      "from": "install@0.10.1"
+      "integrity": "sha1-HHtTyN1zNe9TTCZI3ij1md8b3Zc="
     }
   }
 }

--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -1,34 +1,35 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "from": "acorn@>=5.0.0 <5.1.0"
+      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0="
     },
     "minipass": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.0.2.tgz",
-      "from": "minipass@>=2.0.0 <3.0.0"
+      "integrity": "sha1-+uXHgSQFH1b9IAffABLg2senUs4="
     },
     "minizlib": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz",
-      "from": "minizlib@>=1.0.3 <2.0.0"
+      "integrity": "sha1-1cGr93vhVGGZUuJTM27Mq5sqMvU="
     },
     "reify": {
       "version": "0.11.24",
       "resolved": "https://registry.npmjs.org/reify/-/reify-0.11.24.tgz",
-      "from": "reify@0.11.24"
+      "integrity": "sha1-QR+5C99Vxfobx9l2vrCdyVQBif4="
     },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "from": "semver@>=5.3.0 <6.0.0"
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "yallist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "from": "yallist@>=3.0.0 <4.0.0"
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
     }
   }
 }

--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -4,9 +4,6 @@ cd "`dirname "$0"`"
 cd ../..
 export METEOR_HOME=`pwd`
 
-# Clear dev_bundle/.npm to ensure consistent test runs.
-./meteor npm cache clear
-
 # Just in case these packages haven't been installed elsewhere.
 ./meteor npm install -g phantomjs-prebuilt browserstack-webdriver
 

--- a/scripts/admin/eslint/npm-shrinkwrap.json
+++ b/scripts/admin/eslint/npm-shrinkwrap.json
@@ -1,0 +1,822 @@
+{
+  "name": "meteor-jsdoc",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "babel-eslint": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.7.tgz",
+      "integrity": "sha1-eSv6d/JwmvbyCtT3lswtzwtxMWU=",
+      "dependencies": {
+        "acorn-to-esprima": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-2.0.8.tgz",
+          "integrity": "sha1-AD8MZC65ITL0F9NwjxStqCrfLrE="
+        },
+        "babel-traverse": {
+          "version": "6.10.4",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.10.4.tgz",
+          "integrity": "sha1-289B/x8y62FIWc6tSHEWDx8SDXg=",
+          "dependencies": {
+            "babel-code-frame": {
+              "version": "6.11.0",
+              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz",
+              "integrity": "sha1-kHLdI1P7D4W2tX0sl/DRNNGIrtg=",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                },
+                "js-tokens": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
+                  "integrity": "sha1-eZA/VWPud4zBFi5tzxoAJ8l/nLU="
+                }
+              }
+            },
+            "babel-messages": {
+              "version": "6.8.0",
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+              "integrity": "sha1-v1BHNsqWfm1l7wrbWipflHyODrk="
+            },
+            "babel-runtime": {
+              "version": "6.9.2",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
+              "integrity": "sha1-1/45G8LMKbgIfB2bOYeJEun8/Vk=",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
+                  "integrity": "sha1-30CKtG0Br/kcAcPnlxk11CLFT4E="
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "integrity": "sha1-QD1tQKS9/5wzDdk5Lcuy2ai7ofw="
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                }
+              }
+            },
+            "globals": {
+              "version": "8.18.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+              "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ="
+            },
+            "invariant": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
+              "integrity": "sha1-sJcBBUdmjH4zcCjr6Bbr42yKjVQ=",
+              "dependencies": {
+                "loose-envify": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
+                  "integrity": "sha1-aaZarT3lQs9O4PT+dOjjPHCcyw8=",
+                  "dependencies": {
+                    "js-tokens": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
+                      "integrity": "sha1-FOVutoyPGpLEPVn1AU7CncIPKuE="
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.13.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+              "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz",
+          "integrity": "sha1-o981W6uQ3c9mMYZAcXzywVTmZIo=",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.9.2",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
+              "integrity": "sha1-1/45G8LMKbgIfB2bOYeJEun8/Vk=",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
+                  "integrity": "sha1-30CKtG0Br/kcAcPnlxk11CLFT4E="
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "integrity": "sha1-QD1tQKS9/5wzDdk5Lcuy2ai7ofw="
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+            },
+            "lodash": {
+              "version": "4.13.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+              "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
+            },
+            "to-fast-properties": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+              "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA="
+            }
+          }
+        },
+        "babylon": {
+          "version": "6.8.4",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
+          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.9.2",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
+              "integrity": "sha1-1/45G8LMKbgIfB2bOYeJEun8/Vk=",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
+                  "integrity": "sha1-30CKtG0Br/kcAcPnlxk11CLFT4E="
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "integrity": "sha1-QD1tQKS9/5wzDdk5Lcuy2ai7ofw="
+                }
+              }
+            }
+          }
+        },
+        "lodash.assign": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+          "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+                }
+              }
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+                }
+              }
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.8",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                  "integrity": "sha1-W/jaiH8B8qnknAoXXNrrMYoOQ9w="
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+                }
+              }
+            }
+          }
+        },
+        "lodash.pick": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
+          "integrity": "sha1-8lKoVbIEa2G805BLJvdr0u/GVVA=",
+          "dependencies": {
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.8",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                  "integrity": "sha1-W/jaiH8B8qnknAoXXNrrMYoOQ9w="
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+              "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU="
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.8",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                      "integrity": "sha1-W/jaiH8B8qnknAoXXNrrMYoOQ9w="
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+            }
+          }
+        }
+      }
+    },
+    "eslint": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.22.1.tgz",
+      "integrity": "sha1-VbrAiUWwrNoXRWINIKUqK6mH1m4=",
+      "dependencies": {
+        "chalk": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+              "integrity": "sha1-sDP1f5Pi0oreuLwRE4+hPaD9IKM="
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+              "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0="
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "readable-stream": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+              "integrity": "sha1-YzR5t70vvnoehpgltAoLMzufK/w=",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg="
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "process-nextick-args": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz",
+                  "integrity": "sha1-kYpatKd0Q0C4P/QWEBulPFxTGHk="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "util-deprecate": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE="
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+            }
+          }
+        },
+        "doctrine": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+          "integrity": "sha1-gUKEkalC7xiwSSBW7aOADu5X1h0=",
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U="
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+        },
+        "escope": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.1.0.tgz",
+          "integrity": "sha1-kspI9ihrOA5DiOCRiKkEsPodm34=",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+              "integrity": "sha1-uHkjnteBngsIxAum4Z+gR8p8jR0=",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "integrity": "sha1-366lByEwEELi2JwXGdQ0k/qCFlY=",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M="
+                    }
+                  }
+                },
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M="
+                    }
+                  }
+                },
+                "es6-set": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                  "integrity": "sha1-SXzSNcmiaR9Mqg4z3XPvhr3nOKw="
+                },
+                "es6-symbol": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
+                  "integrity": "sha1-nPf6su2v8bHaj+jmi/4/Wspsohg="
+                },
+                "event-emitter": {
+                  "version": "0.3.3",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                  "integrity": "sha1-346AZUHGirj/IKeaGEG5GrqhvuQ="
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+              "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "integrity": "sha1-366lByEwEELi2JwXGdQ0k/qCFlY="
+                },
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4="
+                },
+                "es6-symbol": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                  "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M="
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+              "integrity": "sha1-j+uWNpnU0bLWWlds1LEpZnKg8Ok="
+            },
+            "estraverse": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
+              "integrity": "sha1-FeKKRGuLgrxwDMyLlseK9NoNbLo="
+            }
+          }
+        },
+        "espree": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.0.3.tgz",
+          "integrity": "sha1-H73/YKQQvQ1Baxqz1iMNNLekUOE="
+        },
+        "estraverse": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
+          "integrity": "sha1-WuRpYyQ2ACBmdMyySgnhZnT83KE="
+        },
+        "estraverse-fb": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+          "integrity": "sha1-Fg51qA5gWwjOiUvM4v4+Qpq/kr8="
+        },
+        "globals": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+        },
+        "inquirer": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+          "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+            },
+            "cli-width": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
+              "integrity": "sha1-FNT2hwI02R6X992B52voJxQQoe8="
+            },
+            "figures": {
+              "version": "1.3.5",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
+              "integrity": "sha1-0aMfTh0sKTjs3lwGqhYTTPKfR3E="
+            },
+            "lodash": {
+              "version": "3.9.3",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+              "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI="
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                  "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34="
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4="
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.3",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
+              "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY="
+            },
+            "through": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
+              "integrity": "sha1-X8w2kP7S/fmMb8iLTSB6RiSsO4c="
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+          "integrity": "sha1-j6bECLJr6VtFoj6PjEtGSlOHTSs=",
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+              "integrity": "sha1-w8cu+u07lxVBY9wB3TSeHP4PgPw="
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "integrity": "sha1-i8Nv+Hrtvnzp6vC8o2sjVKdDhA8="
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+          "integrity": "sha1-yhrNNCPsJ10SFAp7q1HbAVugs8A=",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+              "integrity": "sha1-vPrjkFllbRlz0LnmoadBVLWpoTY=",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.9.3",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+                  "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI="
+                },
+                "sprintf-js": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
+                  "integrity": "sha1-EeTYT/MhRONbC/Omb4WH842PmXg="
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+              "integrity": "sha1-QpLB1o5Bc9gV+iKQ3Hr8ltgfzYM="
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "integrity": "sha1-C8IPa/NXCmmO8N3/kCBjxsq9pr8=",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "integrity": "sha1-ybfQPAPze8cEvhAOUitA249s/Nk=",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                  "integrity": "sha1-OPZzDAOqttXtu1K9k0iF51bXFnQ="
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        },
+        "optionator": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+          "dependencies": {
+            "deep-is": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+            },
+            "fast-levenshtein": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+              "integrity": "sha1-O+2xhOOflcsNiJKGiOax7jJzRGo="
+            },
+            "levn": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+              "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ="
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+            },
+            "type-check": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+              "integrity": "sha1-kjOSPE2hdNCsVIDs/W74TDSetY0="
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+          "integrity": "sha1-WkirlgI9usG3uND/q/b2PxZ3vp8="
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+          "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI="
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.5.0.tgz",
+      "integrity": "sha1-b2DLrW/6HcTl2TkZtaHtZ1IubLc="
+    }
+  }
+}

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -7,7 +7,7 @@ UNAME=$(uname)
 ARCH=$(uname -m)
 MONGO_VERSION=3.2.12
 NODE_VERSION=8.1.2
-NPM_VERSION=4.6.1
+NPM_VERSION=5.0.3
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -35,9 +35,6 @@ if [ -z "$CIRCLE_NODE_TOTAL" ] || [ -z "$CIRCLE_NODE_INDEX" ]; then
   echo "Running all tests!"
 fi
 
-# Clear dev_bundle/.npm to ensure consistent test runs.
-./meteor npm cache clear
-
 # Since PhantomJS has been removed from dev_bundle/lib/node_modules
 # (#6905), but self-test still needs it, install it now.
 ./meteor npm install -g phantomjs-prebuilt browserstack-webdriver

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -11,7 +11,7 @@ var packageJson = {
   dependencies: {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version
-    npm: "4.6.1",
+    npm: "5.0.3",
     "node-gyp": "3.6.2",
     "node-pre-gyp": "0.6.36",
     "meteor-babel": "0.21.5",

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -97,9 +97,6 @@ rm -Recurse -Force "${DIR}\bin\node_modules"
 copy "${CHECKOUT_DIR}\scripts\npm.cmd" "${DIR}\bin\npm.cmd"
 npm version
 
-# npm depends on a hardcoded file path to node-gyp, so we need this to be
-# un-flattened
-cd node_modules\npm
 npm install node-gyp
 
 # Make sure node-gyp knows how to find its build tools.

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -994,10 +994,10 @@ const installNpmModule = meteorNpm.installNpmModule = (name, version, dir) => {
 
   if (! result.success) {
     const pkgNotFound =
-      `404  '${utils.quotemeta(name)}' is not in the npm registry`;
+      `404 Not Found: ${utils.quotemeta(name)}@${utils.quotemeta(version)}`;
 
     const versionNotFound =
-      "No compatible version found: " +
+      "No matching version found for " +
       `${utils.quotemeta(name)}@${utils.quotemeta(version)}`;
 
     if (result.stderr.match(new RegExp(pkgNotFound))) {


### PR DESCRIPTION
This is a major update from npm 4.6.1, and should bring significant benefits in terms of speed and reproducibility of `npm install`s. Read the [blog post](http://blog.npmjs.org/post/161081169345/v500) for an introduction to those benefits.

To understand npm's new `package-lock.json` file format, I would highly recommend reading [this documentation](https://docs.npmjs.com/files/package-lock.json). Note especially that `npm-shrinkwrap.json` files are exactly the same as `package-lock.json` files, except that `package-lock.json` files cannot be published to npm.

For backwards compatibility, Meteor still works with `npm-shrinkwrap.json` files internally (for example, to manage `Npm.depends`-style dependencies), but that's perfectly fine because `npm-shrinkwrap.json` files have the same meaning as `package-lock.json` files. The distinction about publishing is moot because Meteor packages are not published to npm.

For application developers using `meteor npm` in their own apps, this update is a great opportunity to revisit your workflows to see if you can make better use of the new `npm` version. In particular, if you've been using `yarn` (or `meteor yarn`), you might consider switching back to `meteor npm`, since `package-lock.json` files are directly inspired by `yarn.lock` files.

Meteor remains completely agnostic about how you populate the `node_modules` directory in your application, so you shouldn't have to change your workflows at all if you don't want to. However, this new version of `npm` is a pretty big leap forward, so with any luck it will make your dependency management a little bit faster and more reliable.