### PR TITLE
Upgrade npm to version 5.0.3 (take 2)

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@
 
 * Node has been upgraded to version 8.1.2.
 
-* The `npm` npm package has been upgraded to version 5.0.3, a major
+* The `npm` npm package has been upgraded to version 5.0.4, a major
   upgrade from 4.6.1, requiring internal updates to dependency management
   logic for Meteor packages that use `Npm.depends`. While these changes
   should be backwards-compatible for existing Meteor packages, if you are

--- a/History.md
+++ b/History.md
@@ -7,7 +7,10 @@
   logic for Meteor packages that use `Npm.depends`. While these changes
   should be backwards-compatible for existing Meteor packages, if you are
   the maintainer of any packages, you should pay close attention to your
-  `npm-shrinkwrap.json` files when first using this version of `npm`.
+  `npm-shrinkwrap.json` files when first using this version of `npm`. For
+  normal Meteor application development, this change primarily affects the
+  version of `npm` used by `meteor npm ...` commands.
+  [PR #8835](https://github.com/meteor/meteor/pull/8835)
 
 * The `node-gyp` npm package has been upgraded to version 3.6.2.
 

--- a/History.md
+++ b/History.md
@@ -2,6 +2,13 @@
 
 * Node has been upgraded to version 8.1.2.
 
+* The `npm` npm package has been upgraded to version 5.0.3, a major
+  upgrade from 4.6.1, requiring internal updates to dependency management
+  logic for Meteor packages that use `Npm.depends`. While these changes
+  should be backwards-compatible for existing Meteor packages, if you are
+  the maintainer of any packages, you should pay close attention to your
+  `npm-shrinkwrap.json` files when first using this version of `npm`.
+
 * The `node-gyp` npm package has been upgraded to version 3.6.2.
 
 * The `node-pre-gyp` npm package has been updated to version 0.6.36.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.1.3
+BUNDLE_VERSION=8.1.4
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.1.2
+BUNDLE_VERSION=8.1.3
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.1.4
+BUNDLE_VERSION=8.1.5
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -1,750 +1,751 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "from": "acorn@>=5.0.0 <5.1.0"
+      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0="
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "from": "ansi-regex@>=2.0.0 <3.0.0"
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "from": "ansi-styles@>=2.2.1 <3.0.0"
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "from": "babel-code-frame@>=6.22.0 <7.0.0"
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
     },
     "babel-core": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "from": "babel-core@>=6.22.1 <7.0.0"
+      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk="
     },
     "babel-generator": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-      "from": "babel-generator@>=6.25.0 <7.0.0"
+      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw="
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
-      "from": "babel-helper-builder-react-jsx@>=6.24.1 <7.0.0"
+      "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw="
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0"
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "from": "babel-helper-define-map@>=6.24.1 <7.0.0"
+      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA="
     },
     "babel-helper-evaluate-path": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.0.3.tgz",
-      "from": "babel-helper-evaluate-path@>=0.0.3 <0.0.4"
+      "integrity": "sha1-HRA6ydSlnl1DGEIhLxUXhfesVHs="
     },
     "babel-helper-flip-expressions": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.0.2.tgz",
-      "from": "babel-helper-flip-expressions@>=0.0.2 <0.0.3"
+      "integrity": "sha1-e6ss9hFivJJwPpspjvUSvPd9Z4c="
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "from": "babel-helper-function-name@>=6.24.1 <7.0.0"
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0"
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0"
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-      "from": "babel-helper-is-nodes-equiv@>=0.0.1 <0.0.2"
+      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.0.1.tgz",
-      "from": "babel-helper-is-void-0@>=0.0.1 <0.0.2"
+      "integrity": "sha1-7XRVO4g+aCJq5F+YmpmwLBkPEFo="
     },
     "babel-helper-mark-eval-scopes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.1.1.tgz",
-      "from": "babel-helper-mark-eval-scopes@>=0.1.1 <0.2.0"
+      "integrity": "sha1-RVQ0Xt+fJUlCe9IJjlMCU/ivKZI="
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0"
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
     },
     "babel-helper-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "from": "babel-helper-regex@>=6.24.1 <7.0.0"
+      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg="
     },
     "babel-helper-remove-or-void": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.1.1.tgz",
-      "from": "babel-helper-remove-or-void@>=0.1.1 <0.2.0"
+      "integrity": "sha1-nX4YVtxvr8tBsoOkFnMNwYRPZtc="
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0"
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
     },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.0.3.tgz",
-      "from": "babel-helper-to-multiple-sequence-expressions@>=0.0.3 <0.0.4"
+      "integrity": "sha1-x4mg+szSZpxRI0vizqej5aBXPCU="
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "from": "babel-helpers@>=6.24.1 <7.0.0"
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "from": "babel-messages@>=6.23.0 <7.0.0"
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0"
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
     },
     "babel-plugin-minify-constant-folding": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.0.4.tgz",
-      "from": "babel-plugin-minify-constant-folding@>=0.0.4 <0.0.5",
+      "integrity": "sha1-tuIxAmpgNeiM6t0gYSjX2ytcFeY=",
       "dependencies": {
         "jsesc": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "from": "jsesc@>=2.4.0 <3.0.0"
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
         }
       }
     },
     "babel-plugin-minify-dead-code-elimination": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.1.7.tgz",
-      "from": "babel-plugin-minify-dead-code-elimination@>=0.1.3 <0.2.0"
+      "integrity": "sha1-d09TbzR7mDk6J7qnF4cpaIE8NCw="
     },
     "babel-plugin-minify-flip-comparisons": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.0.2.tgz",
-      "from": "babel-plugin-minify-flip-comparisons@>=0.0.2 <0.0.3"
+      "integrity": "sha1-fQlTqlh27eYRiWa9qe3sxjvzRqs="
     },
     "babel-plugin-minify-guarded-expressions": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.0.4.tgz",
-      "from": "babel-plugin-minify-guarded-expressions@>=0.0.4 <0.0.5"
+      "integrity": "sha1-lXEEp2Dmp//ZZwBaehFiG7Qv0Rw="
     },
     "babel-plugin-minify-infinity": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.0.3.tgz",
-      "from": "babel-plugin-minify-infinity@>=0.0.3 <0.0.4"
+      "integrity": "sha1-TMmbYdErQ0zoCtZ1EDM1xYnLqaE="
     },
     "babel-plugin-minify-mangle-names": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.0.7.tgz",
-      "from": "babel-plugin-minify-mangle-names@>=0.0.7 <0.0.8",
+      "integrity": "sha1-/MX5pMTJwHMec6Sk49AC/LgA70E=",
       "dependencies": {
         "babel-helper-mark-eval-scopes": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.0.2.tgz",
-          "from": "babel-helper-mark-eval-scopes@>=0.0.2 <0.0.3"
+          "integrity": "sha1-kJ/R8jhFcM0wAyg3c4UtnWOSKjc="
         }
       }
     },
     "babel-plugin-minify-numeric-literals": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.0.1.tgz",
-      "from": "babel-plugin-minify-numeric-literals@>=0.0.1 <0.0.2"
+      "integrity": "sha1-lZfmwxFU19rzdE0L1BfBRLJ1vVM="
     },
     "babel-plugin-minify-replace": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.0.1.tgz",
-      "from": "babel-plugin-minify-replace@>=0.0.1 <0.0.2"
+      "integrity": "sha1-XVrqfLmJkkUkjR7pznov5Vao+sw="
     },
     "babel-plugin-minify-simplify": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.0.7.tgz",
-      "from": "babel-plugin-minify-simplify@>=0.0.7 <0.0.8"
+      "integrity": "sha1-QZjVieoQtLxb+TECBmGadDwNBmQ="
     },
     "babel-plugin-minify-type-constructors": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.0.3.tgz",
-      "from": "babel-plugin-minify-type-constructors@>=0.0.3 <0.0.4"
+      "integrity": "sha1-q1nBrYNba26OkyuHXU303Dk9nSY="
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "from": "babel-plugin-syntax-async-functions@>=6.13.0 <7.0.0"
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-      "from": "babel-plugin-syntax-async-generators@>=6.13.0 <7.0.0"
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0"
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "from": "babel-plugin-syntax-dynamic-import@>=6.18.0 <7.0.0"
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-      "from": "babel-plugin-syntax-flow@>=6.18.0 <7.0.0"
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0"
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "from": "babel-plugin-syntax-object-rest-spread@>=6.13.0 <7.0.0"
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "from": "babel-plugin-syntax-trailing-function-commas@>=6.22.0 <7.0.0"
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "from": "babel-plugin-transform-class-properties@>=6.24.1 <7.0.0"
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw="
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0"
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0"
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.22.0 <7.0.0"
+      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY="
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-classes@>=6.22.0 <7.0.0"
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.22.0 <7.0.0"
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM="
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0"
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0"
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0"
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.22.0 <7.0.0"
+      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4="
     },
     "babel-plugin-transform-es2015-modules-reify": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-reify/-/babel-plugin-transform-es2015-modules-reify-0.11.2.tgz",
-      "from": "babel-plugin-transform-es2015-modules-reify@>=0.11.0 <0.12.0"
+      "integrity": "sha1-T5Di58sfqVh/pDXyM74DMfCIs5o="
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-object-super@>=6.22.0 <7.0.0"
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40="
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.22.0 <7.0.0"
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.22.0 <7.0.0"
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA="
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0"
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.22.0 <7.0.0"
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw="
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0"
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0"
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.22.0 <7.0.0"
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek="
     },
     "babel-plugin-transform-es3-property-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
-      "from": "babel-plugin-transform-es3-property-literals@>=6.22.0 <7.0.0"
+      "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g="
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "from": "babel-plugin-transform-flow-strip-types@>=6.22.0 <7.0.0"
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988="
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.0.2.tgz",
-      "from": "babel-plugin-transform-inline-consecutive-adds@>=0.0.2 <0.0.3"
+      "integrity": "sha1-pY/Oz8CcCPv5NzpaPnB0bAPQH8E="
     },
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.8.4.tgz",
-      "from": "babel-plugin-transform-member-expression-literals@>=6.8.1 <7.0.0"
+      "integrity": "sha1-BWebxAWWuRKTQBlZqhYgqxsr5Dc="
     },
     "babel-plugin-transform-merge-sibling-variables": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.8.5.tgz",
-      "from": "babel-plugin-transform-merge-sibling-variables@>=6.8.2 <7.0.0"
+      "integrity": "sha1-A6vfEHxhJBkT6yaN3t5tW8VBhiw="
     },
     "babel-plugin-transform-minify-booleans": {
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.2.tgz",
-      "from": "babel-plugin-transform-minify-booleans@>=6.8.0 <7.0.0"
+      "integrity": "sha1-hFFXn3BucCweGrJ1beXI6jac8Hw="
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "from": "babel-plugin-transform-object-rest-spread@>=6.22.0 <7.0.0"
+      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE="
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.8.4.tgz",
-      "from": "babel-plugin-transform-property-literals@>=6.8.1 <7.0.0"
+      "integrity": "sha1-atMREQuAoZKlbvtd30/jym96Ydo="
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-      "from": "babel-plugin-transform-react-display-name@>=6.23.0 <7.0.0"
+      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE="
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-      "from": "babel-plugin-transform-react-jsx@>=6.24.1 <7.0.0"
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM="
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-      "from": "babel-plugin-transform-react-jsx-self@>=6.22.0 <7.0.0"
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24="
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-      "from": "babel-plugin-transform-react-jsx-source@>=6.22.0 <7.0.0"
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY="
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "from": "babel-plugin-transform-regenerator@>=6.22.0 <7.0.0"
+      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg="
     },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.0.5.tgz",
-      "from": "babel-plugin-transform-regexp-constructors@>=0.0.5 <0.0.6"
+      "integrity": "sha1-dNleDFZ+b8HZxpmghIlNQN6OWB0="
     },
     "babel-plugin-transform-remove-console": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.4.tgz",
-      "from": "babel-plugin-transform-remove-console@>=6.8.0 <7.0.0"
+      "integrity": "sha1-Qf3awZpymkw91+8pZOrAewlvmo8="
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.8.4.tgz",
-      "from": "babel-plugin-transform-remove-debugger@>=6.8.0 <7.0.0"
+      "integrity": "sha1-+FcEoIrapxtV13AFtblOm53yH24="
     },
     "babel-plugin-transform-remove-undefined": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.0.5.tgz",
-      "from": "babel-plugin-transform-remove-undefined@>=0.0.5 <0.0.6"
+      "integrity": "sha1-Eu8RgF4G6GHdLrDHzAQdIYS49BA="
     },
     "babel-plugin-transform-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-      "from": "babel-plugin-transform-runtime@>=6.22.0 <7.0.0"
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4="
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.8.4.tgz",
-      "from": "babel-plugin-transform-simplify-comparison-operators@>=6.8.1 <7.0.0"
+      "integrity": "sha1-KqJKJi1mTIyz4SWjBseY16LeCNU="
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0"
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
     },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.2.tgz",
-      "from": "babel-plugin-transform-undefined-to-void@>=6.8.0 <7.0.0"
+      "integrity": "sha1-/isdKU6wXodSTrk3JN6m4sPWb6E="
     },
     "babel-preset-babili": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/babel-preset-babili/-/babel-preset-babili-0.0.11.tgz",
-      "from": "babel-preset-babili@>=0.0.11 <0.0.12"
+      "integrity": "sha1-lGH9kC1qPIvAMrjwbC9pFnTBKh8="
     },
     "babel-preset-flow": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-      "from": "babel-preset-flow@>=6.23.0 <7.0.0"
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0="
     },
     "babel-preset-meteor": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-preset-meteor/-/babel-preset-meteor-6.26.0.tgz",
-      "from": "babel-preset-meteor@6.26.0"
+      "integrity": "sha1-v+/KEPMGfNPlYxsM1dpQKZb184s="
     },
     "babel-preset-react": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-      "from": "babel-preset-react@>=6.22.0 <7.0.0"
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A="
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "from": "babel-register@>=6.24.1 <7.0.0"
+      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118="
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "from": "babel-runtime@>=6.22.0 <7.0.0"
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
     },
     "babel-template": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-      "from": "babel-template@>=6.22.0 <7.0.0"
+      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE="
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-      "from": "babel-traverse@>=6.22.1 <7.0.0"
+      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE="
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-      "from": "babel-types@>=6.22.0 <7.0.0"
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
     },
     "babylon": {
       "version": "6.17.3",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
-      "from": "babylon@>=6.15.0 <7.0.0"
+      "integrity": "sha1-EyfXCZULVY8gTlNSWH/QKQ+Njkg="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "from": "balanced-match@>=1.0.0 <2.0.0"
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "from": "brace-expansion@>=1.1.7 <2.0.0"
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "from": "chalk@>=1.1.0 <2.0.0"
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "from": "concat-map@0.0.1"
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "from": "convert-source-map@>=1.3.0 <2.0.0"
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
     },
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "from": "core-js@>=2.4.0 <3.0.0"
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "from": "debug@>=2.1.1 <3.0.0"
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "from": "detect-indent@>=4.0.0 <5.0.0"
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "from": "esutils@>=2.0.2 <3.0.0"
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "from": "globals@>=9.0.0 <10.0.0"
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "from": "has-ansi@>=2.0.0 <3.0.0"
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "from": "home-or-tmp@>=2.0.0 <3.0.0"
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "from": "invariant@>=2.2.0 <3.0.0"
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "from": "is-finite@>=1.0.0 <2.0.0"
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
     },
     "js-tokens": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "from": "js-tokens@>=3.0.0 <4.0.0"
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
     },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "from": "jsesc@>=1.3.0 <2.0.0"
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "from": "json5@>=0.5.0 <0.6.0"
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "from": "lodash@>=4.17.4 <5.0.0"
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "from": "lodash.isplainobject@>=4.0.6 <5.0.0"
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.some": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "from": "lodash.some@>=4.6.0 <5.0.0"
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "from": "loose-envify@>=1.0.0 <2.0.0"
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "meteor-babel": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.21.5.tgz",
-      "from": "meteor-babel@0.21.5"
+      "integrity": "sha1-ZS+G31V5QJMoDa4hgzGxO0/y2dE="
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/meteor-babel-helpers/-/meteor-babel-helpers-0.0.3.tgz",
-      "from": "meteor-babel-helpers@0.0.3"
+      "integrity": "sha1-8uXZ+HlvvS6JAQI9dpnlsgLqn7A="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "from": "minimatch@>=3.0.2 <4.0.0"
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM="
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "from": "minimist@0.0.8"
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.0.2.tgz",
-      "from": "minipass@>=2.0.0 <3.0.0"
+      "integrity": "sha1-+uXHgSQFH1b9IAffABLg2senUs4="
     },
     "minizlib": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz",
-      "from": "minizlib@>=1.0.3 <2.0.0"
+      "integrity": "sha1-1cGr93vhVGGZUuJTM27Mq5sqMvU="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "from": "mkdirp@>=0.5.1 <0.6.0"
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "from": "ms@2.0.0"
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "from": "number-is-nan@>=1.0.0 <2.0.0"
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "from": "os-homedir@>=1.0.0 <2.0.0"
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "from": "os-tmpdir@>=1.0.1 <2.0.0"
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "private": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "from": "private@>=0.1.6 <0.2.0"
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
     },
     "regenerate": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "from": "regenerate@>=1.2.1 <2.0.0"
+      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
     },
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "from": "regenerator-runtime@>=0.10.0 <0.11.0"
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "from": "regenerator-transform@0.9.11"
+      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM="
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "from": "regexpu-core@>=2.0.0 <3.0.0"
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
     },
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "from": "regjsgen@>=0.2.0 <0.3.0"
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "from": "jsesc@>=0.5.0 <0.6.0"
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
     "reify": {
       "version": "0.11.24",
       "resolved": "https://registry.npmjs.org/reify/-/reify-0.11.24.tgz",
-      "from": "reify@>=0.11.18 <0.12.0"
+      "integrity": "sha1-QR+5C99Vxfobx9l2vrCdyVQBif4="
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "from": "repeating@>=2.0.0 <3.0.0"
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
     },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "from": "semver@>=5.3.0 <6.0.0"
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "from": "slash@>=1.0.0 <2.0.0"
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "from": "source-map@>=0.5.0 <0.6.0"
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
     },
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "from": "source-map-support@>=0.4.2 <0.5.0"
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "from": "strip-ansi@>=3.0.0 <4.0.0"
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "from": "supports-color@>=2.0.0 <3.0.0"
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "from": "to-fast-properties@>=1.0.1 <2.0.0"
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "from": "trim-right@>=1.0.1 <2.0.0"
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "yallist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "from": "yallist@>=3.0.0 <4.0.0"
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
     }
   }
 }

--- a/packages/http/.npm/package/npm-shrinkwrap.json
+++ b/packages/http/.npm/package/npm-shrinkwrap.json
@@ -1,355 +1,368 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "ansi-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-      "from": "ansi-regex@>=2.0.0 <3.0.0"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "from": "ansi-styles@>=2.2.1 <3.0.0"
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "from": "asn1@>=0.2.3 <0.3.0"
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "from": "assert-plus@>=0.2.0 <0.3.0"
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "from": "async@>=1.5.2 <2.0.0"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw=="
     },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "from": "aws-sign2@>=0.6.0 <0.7.0"
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-      "from": "aws4@>=1.2.1 <2.0.0"
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40="
     },
     "bl": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "from": "bl@>=1.1.2 <1.2.0"
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g="
     },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "from": "boom@>=2.0.0 <3.0.0"
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
     },
     "caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "from": "caseless@>=0.11.0 <0.12.0"
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "from": "chalk@>=1.1.1 <2.0.0"
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "from": "combined-stream@>=1.0.5 <1.1.0"
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "from": "commander@>=2.9.0 <3.0.0"
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
+      "integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA=="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "from": "core-util-is@>=1.0.0 <1.1.0"
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "from": "cryptiles@>=2.0.0 <3.0.0"
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
     },
     "dashdash": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-      "from": "dashdash@>=1.12.0 <2.0.0",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "from": "assert-plus@>=1.0.0 <2.0.0"
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "from": "delayed-stream@>=1.0.0 <1.1.0"
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0"
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "extend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "from": "extend@>=3.0.0 <3.1.0"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "from": "extsprintf@1.0.2"
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
     },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "from": "forever-agent@>=0.6.1 <0.7.0"
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "1.0.0-rc4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-      "from": "form-data@>=1.0.0-rc3 <1.1.0"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w="
     },
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "from": "generate-function@>=2.0.0 <3.0.0"
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
     },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "from": "generate-object-property@>=1.1.0 <2.0.0"
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
     },
     "getpass": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-      "from": "getpass@>=0.1.1 <0.2.0",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "from": "assert-plus@>=1.0.0 <2.0.0"
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "from": "graceful-readlink@>=1.0.0"
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "har-validator": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "from": "har-validator@>=2.0.6 <2.1.0"
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "from": "has-ansi@>=2.0.0 <3.0.0"
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "from": "hawk@>=3.1.3 <3.2.0"
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
     },
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "from": "hoek@>=2.0.0 <3.0.0"
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "from": "http-signature@>=1.1.0 <1.2.0"
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
     },
     "inherits": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "from": "inherits@>=2.0.1 <2.1.0"
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-my-json-valid": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-      "from": "is-my-json-valid@>=2.12.4 <3.0.0"
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM="
     },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "from": "is-property@>=1.0.0 <2.0.0"
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "from": "is-typedarray@>=1.0.0 <1.1.0"
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "from": "isarray@>=1.0.0 <1.1.0"
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "from": "isstream@>=0.1.2 <0.2.0"
-    },
-    "jodid25519": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "from": "jodid25519@>=1.0.0 <2.0.0"
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jsbn": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-      "from": "jsbn@>=0.1.0 <0.2.0"
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-      "from": "json-schema@0.2.2"
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0"
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonpointer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-      "from": "jsonpointer@2.0.0"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-      "from": "jsprim@>=1.2.2 <2.0.0"
-    },
-    "mime-db": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-      "from": "mime-db@>=1.23.0 <1.24.0"
-    },
-    "mime-types": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-      "from": "mime-types@>=2.1.7 <2.2.0"
-    },
-    "node-uuid": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-      "from": "node-uuid@>=1.4.7 <1.5.0"
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "from": "oauth-sign@>=0.8.1 <0.9.0"
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "from": "pinkie@>=2.0.0 <3.0.0"
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0"
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0"
-    },
-    "qs": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
-      "from": "qs@>=6.1.0 <6.2.0"
-    },
-    "readable-stream": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "from": "readable-stream@>=2.0.5 <2.1.0"
-    },
-    "request": {
-      "version": "2.72.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
-      "from": "request@2.72.0"
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "from": "sntp@>=1.0.0 <2.0.0"
-    },
-    "sshpk": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-      "from": "sshpk@>=1.7.0 <2.0.0",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "from": "assert-plus@>=1.0.0 <2.0.0"
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "qs": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.2.tgz",
+      "integrity": "sha1-tZ2JJdDJme9tY6z0rFq7CtqiS1Q="
+    },
+    "readable-stream": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
+    },
+    "request": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
+      "integrity": "sha1-DOOheVEmILEEQfFMguIcEsDdtOE="
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "from": "string_decoder@>=0.10.0 <0.11.0"
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "from": "stringstream@>=0.0.4 <0.1.0"
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "from": "strip-ansi@>=3.0.0 <4.0.0"
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "from": "supports-color@>=2.0.0 <3.0.0"
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tough-cookie": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-      "from": "tough-cookie@>=2.2.0 <2.3.0"
+      "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc="
     },
     "tunnel-agent": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "from": "tunnel-agent@>=0.4.1 <0.5.0"
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-      "from": "tweetnacl@>=0.13.0 <0.14.0"
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "from": "util-deprecate@>=1.0.1 <1.1.0"
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "from": "verror@1.3.6"
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "from": "xtend@>=4.0.0 <5.0.0"
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     }
   }
 }

--- a/packages/jshint/plugin/lint-jshint.js
+++ b/packages/jshint/plugin/lint-jshint.js
@@ -1,5 +1,5 @@
-var util = Npm.require('util');
-var Future = Npm.require('fibers/future');
+/* globals Npm, Plugin */
+
 var jshint = Npm.require('jshint').JSHINT;
 
 Plugin.registerLinter({
@@ -14,7 +14,7 @@ function JsHintLinter () {
   // packageName -> { config (json),
   //                  files: { [pathInPackage,arch] -> { hash, errors }}}
   this._cacheByPackage = {};
-};
+}
 
 var DEFAULT_CONFIG = JSON.stringify({
   undef: true,
@@ -114,4 +114,3 @@ JsHintLinter.prototype.processFilesForPackage = function (files, options) {
     });
   }
 };
-

--- a/packages/less/.npm/plugin/compileLessBatch/npm-shrinkwrap.json
+++ b/packages/less/.npm/plugin/compileLessBatch/npm-shrinkwrap.json
@@ -1,376 +1,342 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
-    "less": {
-      "version": "2.5.0",
-      "resolved": "https://github.com/meteor/less.js/tarball/8130849eb3d7f0ecf0ca8d0af7c4207b0442e3f6",
-      "from": "https://github.com/meteor/less.js/tarball/8130849eb3d7f0ecf0ca8d0af7c4207b0442e3f6",
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "asap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+      "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40="
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dependencies": {
-        "errno": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.3.tgz",
-          "from": "https://registry.npmjs.org/errno/-/errno-0.1.3.tgz",
-          "dependencies": {
-            "prr": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        },
-        "image-size": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
-          "from": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "promise": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-          "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-          "dependencies": {
-            "asap": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-              "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
-            }
-          }
-        },
-        "request": {
-          "version": "2.58.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
-          "from": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "bl": {
-              "version": "0.9.4",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "extend": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-              "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "1.0.0-rc1",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.3.0.tgz",
-                  "from": "https://registry.npmjs.org/async/-/async-1.3.0.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.3",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.3.tgz",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.3.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.15.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.15.0.tgz",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.15.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "har-validator": {
-              "version": "1.8.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-              "dependencies": {
-                "bluebird": {
-                  "version": "2.9.33",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.33.tgz",
-                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.33.tgz"
-                },
-                "chalk": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.8.1",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.12.0",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
-                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
-                    },
-                    "xtend": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dependencies": {
-                "boom": {
-                  "version": "2.8.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
-                },
-                "hoek": {
-                  "version": "2.14.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "dependencies": {
-                "asn1": {
-                  "version": "0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.3",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "qs": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-              "from": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-            }
-          }
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU="
+    },
+    "errno": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0="
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+      "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg="
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+    },
+    "image-size": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
+      "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "less": {
+      "version": "https://github.com/meteor/less.js/tarball/8130849eb3d7f0ecf0ca8d0af7c4207b0442e3f6",
+      "integrity": "sha1-dD95WEi4QkZPVjcydtAMY6WS/qM="
+    },
+    "mime": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+    },
+    "natives": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "promise": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+      "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY="
+    },
+    "prr": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+    },
+    "request": {
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "verror": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
     }
   }
 }

--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.7.9',
+  version: '2.7.10',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/modules-runtime/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules-runtime/.npm/package/npm-shrinkwrap.json
@@ -1,9 +1,10 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "install": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/install/-/install-0.10.1.tgz",
-      "from": "install@0.10.1"
+      "integrity": "sha1-HHtTyN1zNe9TTCZI3ij1md8b3Zc="
     }
   }
 }

--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -1,34 +1,35 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "from": "acorn@>=5.0.0 <5.1.0"
+      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0="
     },
     "minipass": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.0.2.tgz",
-      "from": "minipass@>=2.0.0 <3.0.0"
+      "integrity": "sha1-+uXHgSQFH1b9IAffABLg2senUs4="
     },
     "minizlib": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz",
-      "from": "minizlib@>=1.0.3 <2.0.0"
+      "integrity": "sha1-1cGr93vhVGGZUuJTM27Mq5sqMvU="
     },
     "reify": {
       "version": "0.11.24",
       "resolved": "https://registry.npmjs.org/reify/-/reify-0.11.24.tgz",
-      "from": "reify@0.11.24"
+      "integrity": "sha1-QR+5C99Vxfobx9l2vrCdyVQBif4="
     },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "from": "semver@>=5.3.0 <6.0.0"
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "yallist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "from": "yallist@>=3.0.0 <4.0.0"
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
     }
   }
 }

--- a/packages/stylus/.npm/plugin/compileStylusBatch/npm-shrinkwrap.json
+++ b/packages/stylus/.npm/plugin/compileStylusBatch/npm-shrinkwrap.json
@@ -1,176 +1,176 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "from": "amdefine@>=0.0.4"
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "autoprefixer": {
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.7.tgz",
-      "from": "autoprefixer@6.3.7"
+      "integrity": "sha1-jt8xZt2f1hFlM2Ysi7NqA8DvyHQ="
     },
     "autoprefixer-stylus": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/autoprefixer-stylus/-/autoprefixer-stylus-0.9.4.tgz",
-      "from": "autoprefixer-stylus@0.9.4"
+      "integrity": "sha1-dgkUaV3OMhyZgLSQ2BpDhcCNkU0="
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "from": "balanced-match@>=0.4.1 <0.5.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "from": "brace-expansion@>=1.0.0 <2.0.0"
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
     },
     "browserslist": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.6.tgz",
-      "from": "browserslist@>=1.3.4 <1.4.0"
+      "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM="
     },
     "caniuse-db": {
-      "version": "1.0.30000585",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000585.tgz",
-      "from": "caniuse-db@>=1.0.30000488 <2.0.0"
+      "version": "1.0.30000693",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000693.tgz",
+      "integrity": "sha1-hRDnqasErcyiOl3O+jTfnSjBziA="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "from": "concat-map@0.0.1"
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "css-parse": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
-      "from": "css-parse@>=1.7.0 <1.8.0"
+      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs="
     },
     "debug": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "from": "debug@*"
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "from": "fs.realpath@>=1.0.0 <2.0.0"
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "glob": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-      "from": "glob@>=7.0.0 <7.1.0"
+      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo="
     },
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "from": "has-flag@>=1.0.0 <2.0.0"
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "from": "inflight@>=1.0.4 <2.0.0"
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "from": "inherits@>=2.0.0 <3.0.0"
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "js-base64": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "from": "js-base64@>=2.1.9 <3.0.0"
+      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
     },
     "minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-      "from": "minimatch@>=3.0.2 <4.0.0"
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "from": "minimist@0.0.8"
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "from": "mkdirp@>=0.5.0 <0.6.0"
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
     },
     "ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "from": "ms@0.7.2"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multi-stage-sourcemap": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.2.1.tgz",
-      "from": "multi-stage-sourcemap@0.2.1"
+      "integrity": "sha1-sJ/IWG6qF/gdV1xK0C4Pej9rEQU="
     },
     "nib": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/nib/-/nib-1.1.2.tgz",
-      "from": "nib@1.1.2"
+      "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc="
     },
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "from": "normalize-range@>=0.1.2 <0.2.0"
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "num2fraction": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "from": "num2fraction@>=1.2.2 <2.0.0"
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "from": "once@>=1.3.0 <2.0.0"
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "postcss": {
       "version": "5.0.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.21.tgz",
-      "from": "postcss@5.0.21",
+      "integrity": "sha1-1M9vGXdGSMSSrFfCmPavs8BMrv4=",
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "from": "source-map@>=0.5.5 <0.6.0"
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
         }
       }
     },
     "postcss-value-parser": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-      "from": "postcss-value-parser@>=3.2.3 <4.0.0"
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
     },
     "sax": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-      "from": "sax@>=0.5.0 <0.6.0"
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
     },
     "source-map": {
       "version": "0.1.43",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "from": "source-map@>=0.1.0 <0.2.0"
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y="
     },
     "stylus": {
-      "version": "0.54.5",
-      "resolved": "https://github.com/meteor/stylus/tarball/bb47a357d132ca843718c63998eb37b90013a449",
-      "from": "https://github.com/meteor/stylus/tarball/bb47a357d132ca843718c63998eb37b90013a449"
+      "version": "https://github.com/meteor/stylus/tarball/bb47a357d132ca843718c63998eb37b90013a449",
+      "integrity": "sha1-X7DTXdx6DgWUHDyZ5wgPUSFBLi8="
     },
     "supports-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "from": "supports-color@>=3.1.2 <4.0.0"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY="
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "from": "wrappy@>=1.0.0 <2.0.0"
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/packages/stylus/package.js
+++ b/packages/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.513.9"
+  version: "2.513.10"
 });
 
 Package.registerBuildPlugin({

--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -4,9 +4,6 @@ cd "`dirname "$0"`"
 cd ../..
 export METEOR_HOME=`pwd`
 
-# Clear dev_bundle/.npm to ensure consistent test runs.
-./meteor npm cache clear
-
 # Just in case these packages haven't been installed elsewhere.
 ./meteor npm install -g phantomjs-prebuilt browserstack-webdriver
 

--- a/scripts/admin/eslint/npm-shrinkwrap.json
+++ b/scripts/admin/eslint/npm-shrinkwrap.json
@@ -1,0 +1,822 @@
+{
+  "name": "meteor-jsdoc",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "babel-eslint": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.7.tgz",
+      "integrity": "sha1-eSv6d/JwmvbyCtT3lswtzwtxMWU=",
+      "dependencies": {
+        "acorn-to-esprima": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-2.0.8.tgz",
+          "integrity": "sha1-AD8MZC65ITL0F9NwjxStqCrfLrE="
+        },
+        "babel-traverse": {
+          "version": "6.10.4",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.10.4.tgz",
+          "integrity": "sha1-289B/x8y62FIWc6tSHEWDx8SDXg=",
+          "dependencies": {
+            "babel-code-frame": {
+              "version": "6.11.0",
+              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz",
+              "integrity": "sha1-kHLdI1P7D4W2tX0sl/DRNNGIrtg=",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                },
+                "js-tokens": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
+                  "integrity": "sha1-eZA/VWPud4zBFi5tzxoAJ8l/nLU="
+                }
+              }
+            },
+            "babel-messages": {
+              "version": "6.8.0",
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+              "integrity": "sha1-v1BHNsqWfm1l7wrbWipflHyODrk="
+            },
+            "babel-runtime": {
+              "version": "6.9.2",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
+              "integrity": "sha1-1/45G8LMKbgIfB2bOYeJEun8/Vk=",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
+                  "integrity": "sha1-30CKtG0Br/kcAcPnlxk11CLFT4E="
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "integrity": "sha1-QD1tQKS9/5wzDdk5Lcuy2ai7ofw="
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                }
+              }
+            },
+            "globals": {
+              "version": "8.18.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+              "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ="
+            },
+            "invariant": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
+              "integrity": "sha1-sJcBBUdmjH4zcCjr6Bbr42yKjVQ=",
+              "dependencies": {
+                "loose-envify": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
+                  "integrity": "sha1-aaZarT3lQs9O4PT+dOjjPHCcyw8=",
+                  "dependencies": {
+                    "js-tokens": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
+                      "integrity": "sha1-FOVutoyPGpLEPVn1AU7CncIPKuE="
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.13.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+              "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz",
+          "integrity": "sha1-o981W6uQ3c9mMYZAcXzywVTmZIo=",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.9.2",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
+              "integrity": "sha1-1/45G8LMKbgIfB2bOYeJEun8/Vk=",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
+                  "integrity": "sha1-30CKtG0Br/kcAcPnlxk11CLFT4E="
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "integrity": "sha1-QD1tQKS9/5wzDdk5Lcuy2ai7ofw="
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+            },
+            "lodash": {
+              "version": "4.13.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+              "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
+            },
+            "to-fast-properties": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+              "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA="
+            }
+          }
+        },
+        "babylon": {
+          "version": "6.8.4",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
+          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.9.2",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
+              "integrity": "sha1-1/45G8LMKbgIfB2bOYeJEun8/Vk=",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
+                  "integrity": "sha1-30CKtG0Br/kcAcPnlxk11CLFT4E="
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "integrity": "sha1-QD1tQKS9/5wzDdk5Lcuy2ai7ofw="
+                }
+              }
+            }
+          }
+        },
+        "lodash.assign": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+          "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+                }
+              }
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+                }
+              }
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.8",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                  "integrity": "sha1-W/jaiH8B8qnknAoXXNrrMYoOQ9w="
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+                }
+              }
+            }
+          }
+        },
+        "lodash.pick": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
+          "integrity": "sha1-8lKoVbIEa2G805BLJvdr0u/GVVA=",
+          "dependencies": {
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.8",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                  "integrity": "sha1-W/jaiH8B8qnknAoXXNrrMYoOQ9w="
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+              "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU="
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.8",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                      "integrity": "sha1-W/jaiH8B8qnknAoXXNrrMYoOQ9w="
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+            }
+          }
+        }
+      }
+    },
+    "eslint": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.22.1.tgz",
+      "integrity": "sha1-VbrAiUWwrNoXRWINIKUqK6mH1m4=",
+      "dependencies": {
+        "chalk": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+              "integrity": "sha1-sDP1f5Pi0oreuLwRE4+hPaD9IKM="
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+              "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0="
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "readable-stream": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+              "integrity": "sha1-YzR5t70vvnoehpgltAoLMzufK/w=",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg="
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "process-nextick-args": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz",
+                  "integrity": "sha1-kYpatKd0Q0C4P/QWEBulPFxTGHk="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "util-deprecate": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE="
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+            }
+          }
+        },
+        "doctrine": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+          "integrity": "sha1-gUKEkalC7xiwSSBW7aOADu5X1h0=",
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U="
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+        },
+        "escope": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.1.0.tgz",
+          "integrity": "sha1-kspI9ihrOA5DiOCRiKkEsPodm34=",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+              "integrity": "sha1-uHkjnteBngsIxAum4Z+gR8p8jR0=",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "integrity": "sha1-366lByEwEELi2JwXGdQ0k/qCFlY=",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M="
+                    }
+                  }
+                },
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M="
+                    }
+                  }
+                },
+                "es6-set": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                  "integrity": "sha1-SXzSNcmiaR9Mqg4z3XPvhr3nOKw="
+                },
+                "es6-symbol": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
+                  "integrity": "sha1-nPf6su2v8bHaj+jmi/4/Wspsohg="
+                },
+                "event-emitter": {
+                  "version": "0.3.3",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                  "integrity": "sha1-346AZUHGirj/IKeaGEG5GrqhvuQ="
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+              "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "integrity": "sha1-366lByEwEELi2JwXGdQ0k/qCFlY="
+                },
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4="
+                },
+                "es6-symbol": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                  "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M="
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+              "integrity": "sha1-j+uWNpnU0bLWWlds1LEpZnKg8Ok="
+            },
+            "estraverse": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
+              "integrity": "sha1-FeKKRGuLgrxwDMyLlseK9NoNbLo="
+            }
+          }
+        },
+        "espree": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.0.3.tgz",
+          "integrity": "sha1-H73/YKQQvQ1Baxqz1iMNNLekUOE="
+        },
+        "estraverse": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
+          "integrity": "sha1-WuRpYyQ2ACBmdMyySgnhZnT83KE="
+        },
+        "estraverse-fb": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+          "integrity": "sha1-Fg51qA5gWwjOiUvM4v4+Qpq/kr8="
+        },
+        "globals": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+        },
+        "inquirer": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+          "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+            },
+            "cli-width": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
+              "integrity": "sha1-FNT2hwI02R6X992B52voJxQQoe8="
+            },
+            "figures": {
+              "version": "1.3.5",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
+              "integrity": "sha1-0aMfTh0sKTjs3lwGqhYTTPKfR3E="
+            },
+            "lodash": {
+              "version": "3.9.3",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+              "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI="
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                  "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34="
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4="
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.3",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
+              "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY="
+            },
+            "through": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
+              "integrity": "sha1-X8w2kP7S/fmMb8iLTSB6RiSsO4c="
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+          "integrity": "sha1-j6bECLJr6VtFoj6PjEtGSlOHTSs=",
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+              "integrity": "sha1-w8cu+u07lxVBY9wB3TSeHP4PgPw="
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "integrity": "sha1-i8Nv+Hrtvnzp6vC8o2sjVKdDhA8="
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+          "integrity": "sha1-yhrNNCPsJ10SFAp7q1HbAVugs8A=",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+              "integrity": "sha1-vPrjkFllbRlz0LnmoadBVLWpoTY=",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.9.3",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+                  "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI="
+                },
+                "sprintf-js": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
+                  "integrity": "sha1-EeTYT/MhRONbC/Omb4WH842PmXg="
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+              "integrity": "sha1-QpLB1o5Bc9gV+iKQ3Hr8ltgfzYM="
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "integrity": "sha1-C8IPa/NXCmmO8N3/kCBjxsq9pr8=",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "integrity": "sha1-ybfQPAPze8cEvhAOUitA249s/Nk=",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                  "integrity": "sha1-OPZzDAOqttXtu1K9k0iF51bXFnQ="
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        },
+        "optionator": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+          "dependencies": {
+            "deep-is": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+            },
+            "fast-levenshtein": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+              "integrity": "sha1-O+2xhOOflcsNiJKGiOax7jJzRGo="
+            },
+            "levn": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+              "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ="
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+            },
+            "type-check": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+              "integrity": "sha1-kjOSPE2hdNCsVIDs/W74TDSetY0="
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+          "integrity": "sha1-WkirlgI9usG3uND/q/b2PxZ3vp8="
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+          "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI="
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.5.0.tgz",
+      "integrity": "sha1-b2DLrW/6HcTl2TkZtaHtZ1IubLc="
+    }
+  }
+}

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -7,7 +7,7 @@ UNAME=$(uname)
 ARCH=$(uname -m)
 MONGO_VERSION=3.2.12
 NODE_VERSION=8.1.2
-NPM_VERSION=4.6.1
+NPM_VERSION=5.0.3
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -7,7 +7,7 @@ UNAME=$(uname)
 ARCH=$(uname -m)
 MONGO_VERSION=3.2.12
 NODE_VERSION=8.1.2
-NPM_VERSION=5.0.3
+NPM_VERSION=5.0.4
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -35,9 +35,6 @@ if [ -z "$CIRCLE_NODE_TOTAL" ] || [ -z "$CIRCLE_NODE_INDEX" ]; then
   echo "Running all tests!"
 fi
 
-# Clear dev_bundle/.npm to ensure consistent test runs.
-./meteor npm cache clear
-
 # Since PhantomJS has been removed from dev_bundle/lib/node_modules
 # (#6905), but self-test still needs it, install it now.
 ./meteor npm install -g phantomjs-prebuilt browserstack-webdriver

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -11,7 +11,7 @@ var packageJson = {
   dependencies: {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version
-    npm: "5.0.3",
+    npm: "5.0.4",
     "node-gyp": "3.6.2",
     "node-pre-gyp": "0.6.36",
     "meteor-babel": "0.21.5",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -11,7 +11,7 @@ var packageJson = {
   dependencies: {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version
-    npm: "4.6.1",
+    npm: "5.0.3",
     "node-gyp": "3.6.2",
     "node-pre-gyp": "0.6.36",
     "meteor-babel": "0.21.5",

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -97,9 +97,6 @@ rm -Recurse -Force "${DIR}\bin\node_modules"
 copy "${CHECKOUT_DIR}\scripts\npm.cmd" "${DIR}\bin\npm.cmd"
 npm version
 
-# npm depends on a hardcoded file path to node-gyp, so we need this to be
-# un-flattened
-cd node_modules\npm
 npm install node-gyp
 
 # Make sure node-gyp knows how to find its build tools.

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -994,10 +994,10 @@ const installNpmModule = meteorNpm.installNpmModule = (name, version, dir) => {
 
   if (! result.success) {
     const pkgNotFound =
-      `404  '${utils.quotemeta(name)}' is not in the npm registry`;
+      `404 Not Found: ${utils.quotemeta(name)}@${utils.quotemeta(version)}`;
 
     const versionNotFound =
-      "No compatible version found: " +
+      "No matching version found for " +
       `${utils.quotemeta(name)}@${utils.quotemeta(version)}`;
 
     if (result.stderr.match(new RegExp(pkgNotFound))) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -914,8 +914,15 @@ function getInstalledDependenciesTree(dir) {
         version: pkg.version
       };
 
+      const from = pkg._from || pkg.from;
+      if (from &&
+          utils.isNpmUrl(from) &&
+          ! utils.isNpmUrl(info.version)) {
+        info.version = from;
+      }
+
       const resolved = pkg._resolved || pkg.resolved;
-      if (resolved) {
+      if (resolved && resolved !== info.version) {
         info.resolved = resolved;
       }
 

--- a/tools/tests/apps/modules/node_modules/repl/index.js
+++ b/tools/tests/apps/modules/node_modules/repl/index.js
@@ -1,3 +1,0 @@
-// This module provides a very incomplete client-side stub implementation
-// of the native 'repl' module.
-exports.notEmpty = true;

--- a/tools/tests/apps/modules/package-lock.json
+++ b/tools/tests/apps/modules/package-lock.json
@@ -1,0 +1,652 @@
+{
+  "name": "modules-test-app",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "asap": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+    },
+    "async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+    },
+    "aws-sdk": {
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.77.0.tgz",
+      "integrity": "sha1-gJCQu4dNj0//ysUxZilYdjjnhlw="
+    },
+    "babel-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+    },
+    "big-number": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/big-number/-/big-number-0.3.1.tgz",
+      "integrity": "sha1-rHMCDApZu3nrF8LOLbd/d9l04BM="
+    },
+    "bl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4="
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "buffer": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
+      "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg="
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "core-js": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crypto-browserify": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "generic-pool": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.5.4.tgz",
+      "integrity": "sha1-OMYYhRPhQDCUjsblz2VSPZd5KZs="
+    },
+    "github": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+      "integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s="
+    },
+    "iconv-lite": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+    },
+    "idle-gc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/idle-gc/-/idle-gc-1.0.1.tgz",
+      "integrity": "sha1-5BgKGF/MkYULlGe4xZ5xYMX0uB0="
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "meteor-node-stubs": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-0.2.11.tgz",
+      "integrity": "sha1-cV5Owc6IgkiylgThbQkiVrDLfjQ=",
+      "dependencies": {
+        "asn1.js": {
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.0.tgz",
+          "integrity": "sha1-9xoSQ/PnnUbXsH1/v0gk7nOvBUo="
+        },
+        "assert": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+          "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE="
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "Base64": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+          "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
+        },
+        "base64-js": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
+        },
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+        },
+        "brorand": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz",
+          "integrity": "sha1-QChwa5FfkfezSaLgvzw3YDnSFuU="
+        },
+        "browserify-aes": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+          "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo="
+        },
+        "browserify-cipher": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+          "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo="
+        },
+        "browserify-des": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+          "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0="
+        },
+        "browserify-rsa": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+          "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ="
+        },
+        "browserify-sign": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
+          "integrity": "sha1-EHc5EMPCBtVCCkaq2GlPgguFlo8="
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0="
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg="
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+        },
+        "cipher-base": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+          "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc="
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA="
+        },
+        "constants-browserify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+          "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+        },
+        "create-ecdh": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+          "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30="
+        },
+        "create-hash": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+          "integrity": "sha1-USEAYte7dHn2xlu0GpIgix1hq60="
+        },
+        "create-hmac": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+          "integrity": "sha1-0/tLolPriz9W456i+8uK90e9MXA="
+        },
+        "crypto-browserify": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+          "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI="
+        },
+        "date-now": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+          "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+        },
+        "des.js": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+          "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw="
+        },
+        "diffie-hellman": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+          "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4="
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+          "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+        },
+        "elliptic": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
+          "integrity": "sha1-5MgeCCnPCmWrcOmYuCMnI7XBvEg="
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "evp_bytestokey": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+          "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM="
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        },
+        "hash.js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+          "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM="
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA="
+        },
+        "https-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+          "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+        },
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+          "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "miller-rabin": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+          "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0="
+        },
+        "minimalistic-assert": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+          "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+        },
+        "os-browserify": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+          "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+        },
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+        },
+        "parse-asn1": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+          "integrity": "sha1-NQYPbVAV03Yox3D04JGgtaJ4vCM="
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+          "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "pbkdf2": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
+          "integrity": "sha1-8sSyWmAAWLPDdzwIbDfbvuH/5pM="
+        },
+        "process": {
+          "version": "0.11.9",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+          "integrity": "sha1-e9WtIapiU+fahoImTx4R0RwDGME="
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "public-encrypt": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+          "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+          "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+        },
+        "randombytes": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
+          "integrity": "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew="
+        },
+        "readable-stream": {
+          "version": "git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694"
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+        },
+        "ripemd160": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+          "integrity": "sha1-k6S71JQrxXS2mo+lfHHeEOzKfW4="
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+        },
+        "sha.js": {
+          "version": "2.4.8",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+          "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08="
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+          "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds="
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+          "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0="
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+          "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+        },
+        "url": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk="
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM="
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        }
+      }
+    },
+    "mime": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+    },
+    "moment": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.1.tgz",
+      "integrity": "sha1-v0AmQTZA0bgCRnzzU2B/hGTWr0c="
+    },
+    "mssql": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mssql/-/mssql-3.3.0.tgz",
+      "integrity": "sha1-tuYzf/Ej6Hv4ruHmyDRLU8pdqFY="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "qs": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.4.tgz",
+      "integrity": "sha1-UQGdhHIMk5uCc36EVWp4Izjs6ns="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "readable-stream": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00="
+    },
+    "regenerator-runtime": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+      "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "sprintf": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+      "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8="
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+    },
+    "stripe": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-4.23.1.tgz",
+      "integrity": "sha1-31KXcyPT7oh6B6xZBXA/zcBF0u4="
+    },
+    "tedious": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-1.14.0.tgz",
+      "integrity": "sha1-wFwwO4Zoz5HlWmSTt0SGavYZh94=",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk="
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
+      }
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+    },
+    "winston": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk="
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
+    }
+  }
+}

--- a/tools/tests/apps/modules/packages/modules-test-package/.npm/package/npm-shrinkwrap.json
+++ b/tools/tests/apps/modules/packages/modules-test-package/.npm/package/npm-shrinkwrap.json
@@ -1,181 +1,189 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "assert": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
-      "from": "assert@1.3.0"
+      "integrity": "sha1-A5OaYiWCqBLMICMgoLmlbJuBWEk="
     },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "from": "boolbase@>=1.0.0 <1.1.0"
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "from": "buffer-shims@>=1.0.0 <2.0.0"
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "cheerio": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-      "from": "cheerio@0.22.0"
+      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "from": "core-util-is@>=1.0.0 <1.1.0"
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "from": "css-select@>=1.2.0 <1.3.0"
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg="
     },
     "css-what": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "from": "css-what@>=2.1.0 <2.2.0"
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
     },
     "dom-serializer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "from": "dom-serializer@>=0.1.0 <0.2.0",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "from": "domelementtype@>=1.1.1 <1.2.0"
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
     "domelementtype": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "from": "domelementtype@>=1.0.0 <2.0.0"
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domhandler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "from": "domhandler@>=2.3.0 <3.0.0"
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk="
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "from": "domutils@1.5.1"
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8="
     },
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "from": "entities@>=1.1.1 <1.2.0"
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "htmlparser2": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "from": "htmlparser2@>=3.9.1 <4.0.0"
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg="
     },
     "inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "from": "inherits@2.0.1"
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "from": "isarray@>=1.0.0 <1.1.0"
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-      "from": "lodash.assignin@>=4.0.9 <5.0.0"
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
     "lodash.bind": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "from": "lodash.bind@>=4.1.4 <5.0.0"
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
     },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "from": "lodash.defaults@>=4.0.1 <5.0.0"
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.filter": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "from": "lodash.filter@>=4.4.0 <5.0.0"
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "from": "lodash.flatten@>=4.2.0 <5.0.0"
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.foreach": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "from": "lodash.foreach@>=4.3.0 <5.0.0"
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "from": "lodash.map@>=4.4.0 <5.0.0"
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
     "lodash.merge": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "from": "lodash.merge@>=4.4.0 <5.0.0"
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
     },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "from": "lodash.pick@>=4.2.1 <5.0.0"
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.reduce": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-      "from": "lodash.reduce@>=4.4.0 <5.0.0"
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
     },
     "lodash.reject": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-      "from": "lodash.reject@>=4.4.0 <5.0.0"
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
     },
     "lodash.some": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "from": "lodash.some@>=4.4.0 <5.0.0"
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "nth-check": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-      "from": "nth-check@>=1.0.1 <1.1.0"
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ="
     },
     "os-browserify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.0.tgz",
-      "from": "os-browserify@0.2.0"
+      "integrity": "sha1-SRfR6su/0qoaLuQ5tD1EsPnTx5A="
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0"
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "readable-stream": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-      "from": "readable-stream@>=2.0.2 <3.0.0"
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "from": "string_decoder@>=0.10.0 <0.11.0"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
     },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "from": "util@0.10.3"
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "from": "util-deprecate@>=1.0.1 <1.1.0"
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     }
   }
 }

--- a/tools/tests/apps/modules/packages/modules-test-package/client.js
+++ b/tools/tests/apps/modules/packages/modules-test-package/client.js
@@ -1,12 +1,5 @@
 import assert from "assert";
-
 import {checkPackageVars} from "./common";
-
-// This verifies that Meteor packages can import native Node modules on
-// the client that are not implemented by meteor-node-stubs, in case the
-// app has a custom stub installed that takes precedence.
-import {notEmpty} from "repl";
-assert.strictEqual(notEmpty, true);
 
 export const where = "client";
 export * from "./common";

--- a/tools/tests/apps/modules/packages/modules-test-plugin/.npm/package/npm-shrinkwrap.json
+++ b/tools/tests/apps/modules/packages/modules-test-plugin/.npm/package/npm-shrinkwrap.json
@@ -1,59 +1,60 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "arson": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/arson/-/arson-0.2.3.tgz",
-      "from": "arson@0.2.3"
+      "integrity": "sha1-o9jAuQk0DQSDFGFwA+xuASzzi5U="
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0"
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.0.tgz",
-      "from": "babel-plugin-transform-class-properties@6.9.0"
+      "integrity": "sha1-DxgxuPeNcuT4FqC4vVk0Yj5RJms="
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz",
-      "from": "babel-plugin-transform-strict-mode@6.8.0"
+      "integrity": "sha1-wM5mIMtfLB+xArIPZXQRVcq8REo="
     },
     "babel-runtime": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-      "from": "babel-runtime@>=6.9.0 <7.0.0"
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
     },
     "babel-types": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
-      "from": "babel-types@>=6.8.0 <7.0.0"
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
     },
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "from": "core-js@>=2.4.0 <3.0.0"
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "from": "esutils@>=2.0.2 <3.0.0"
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "from": "lodash@>=4.2.0 <5.0.0"
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "regenerator-runtime": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
-      "from": "regenerator-runtime@>=0.10.0 <0.11.0"
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "to-fast-properties": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-      "from": "to-fast-properties@>=1.0.1 <2.0.0"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     }
   }
 }

--- a/tools/tests/apps/modules/packages/modules-test-plugin/.npm/plugin/compile-arson/npm-shrinkwrap.json
+++ b/tools/tests/apps/modules/packages/modules-test-plugin/.npm/plugin/compile-arson/npm-shrinkwrap.json
@@ -1,54 +1,55 @@
 {
+  "lockfileVersion": 1,
   "dependencies": {
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0"
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.0.tgz",
-      "from": "babel-plugin-transform-class-properties@6.9.0"
+      "integrity": "sha1-DxgxuPeNcuT4FqC4vVk0Yj5RJms="
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz",
-      "from": "babel-plugin-transform-strict-mode@6.8.0"
+      "integrity": "sha1-wM5mIMtfLB+xArIPZXQRVcq8REo="
     },
     "babel-runtime": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-      "from": "babel-runtime@>=6.9.0 <7.0.0"
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
     },
     "babel-types": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
-      "from": "babel-types@>=6.8.0 <7.0.0"
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
     },
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "from": "core-js@>=2.4.0 <3.0.0"
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "from": "esutils@>=2.0.2 <3.0.0"
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "from": "lodash@>=4.2.0 <5.0.0"
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "regenerator-runtime": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
-      "from": "regenerator-runtime@>=0.10.0 <0.11.0"
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "to-fast-properties": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-      "from": "to-fast-properties@>=1.0.1 <2.0.0"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     }
   }
 }

--- a/tools/tests/apps/modules/tests.js
+++ b/tools/tests/apps/modules/tests.js
@@ -207,11 +207,6 @@ describe("native node_modules", () => {
     assert.strictEqual(typeof require("repl").start, "function");
   });
 
-  Meteor.isClient &&
-  it("can be overridden on the client", () => {
-    assert.strictEqual(require("repl").notEmpty, true);
-  });
-
   it("can be implemented by wrapper npm packages", () => {
     const Stream = require("stream");
     assert.strictEqual(typeof Stream, "function");

--- a/tools/tests/compiler-plugins.js
+++ b/tools/tests/compiler-plugins.js
@@ -101,6 +101,7 @@ selftest.define("compiler plugin caching - coffee", () => {
 
     const cacheMatch = selftest.markStack((message) => {
       run.match(`CACHE(${ packageName }): ${ message }`);
+      run.waitSecs(30);
     });
 
     // First program built (web.browser) compiles everything.

--- a/tools/tests/hot-code-push.js
+++ b/tools/tests/hot-code-push.js
@@ -55,6 +55,7 @@ jquery
 my-package`);
     run.match(/my-package.*added,/);
     run.match("client connected");
+    run.waitSecs(45);
     run.match("numCssChanges: 0");
 
     s.write("packages/my-package/foo.css", "body { background-color: blue; }");
@@ -70,11 +71,13 @@ appcache`);
     run.match("server restarted");
     run.match("numCssChanges: 0");
     run.match(/background-color: (blue|rgb\(0, 0, 255\))/);
+    run.waitSecs(30);
 
     s.write("packages/my-package/foo.css", "body { background-color: red; }");
     run.match("Client modified -- refreshing");
     run.match("numCssChanges: 1");
     run.match(/background-color: (red|rgb\(255, 0, 0\))/);
+    run.waitSecs(20);
 
     // XXX: Remove me.  This shouldn't be needed, but sometimes
     // if we run too quickly on fast (or Linux?) machines, it looks
@@ -86,6 +89,7 @@ jquery`);
     run.match(/my-package.*removed from your project/);
     run.match("numCssChanges: 0");
     run.match(/background-color: (transparent|rgba\(0, 0, 0, 0\))/);
+    run.waitSecs(30);
 
     run.stop();
   });

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -1045,7 +1045,13 @@ _.extend(PhantomClient.prototype, {
       files.convertToOSPath(scriptPath), self.url],
       {}, function (error, stdout, stderr) {
         if (self._logError && error) {
-          console.log("PhantomJS exited with error ", error, "\nstdout:\n", stdout, "\nstderr:\n", stderr);
+          console.log(
+            "PhantomJS exited with error ", error,
+            "\nstdout:\n", stdout,
+            "\nstderr:\n", stderr
+          );
+        } else if (stderr) {
+          console.log("PhantomJS stderr:\n", stderr);
         }
       });
   },


### PR DESCRIPTION
This PR takes the place of https://github.com/meteor/meteor/pull/8831, which was prematurely merged and closed by @benjamn.

This is a major update from npm 4.6.1, and should bring significant benefits in terms of speed and reproducibility of `npm install`s. Read the [blog post](http://blog.npmjs.org/post/161081169345/v500) for an introduction to those benefits.

To understand npm's new `package-lock.json` file format, I would highly recommend reading [this documentation](https://docs.npmjs.com/files/package-lock.json). Note especially that `npm-shrinkwrap.json` files are exactly the same as `package-lock.json` files, except that `package-lock.json` files cannot be published to npm.

For backwards compatibility, Meteor still works with `npm-shrinkwrap.json` files internally (for example, to manage `Npm.depends`-style dependencies), but that's perfectly fine because `npm-shrinkwrap.json` files have the same meaning as `package-lock.json` files. The distinction about publishing is moot because Meteor packages are not published to npm.

For application developers using `meteor npm` in their own apps, this update is a great opportunity to revisit your workflows to see if you can make better use of the new `npm` version. In particular, if you've been using `yarn` (or `meteor yarn`), you might consider switching back to `meteor npm`, since `package-lock.json` files are directly inspired by `yarn.lock` files.

Meteor remains completely agnostic about how you populate the `node_modules` directory in your application, so you shouldn't have to change your workflows at all if you don't want to. However, this new version of `npm` is a pretty big leap forward, so with any luck it will make your dependency management a little bit faster and more reliable.