### PR TITLE
Server-side rendering revamp

### DIFF
--- a/packages/boilerplate-generator/boilerplate-generator.js
+++ b/packages/boilerplate-generator/boilerplate-generator.js
@@ -31,7 +31,7 @@ Boilerplate.prototype.toHTML = function (extraData) {
     throw new Error('Boilerplate did not instantiate correctly.');
 
   return  "<!DOCTYPE html>\n" +
-    Blaze.toHTML(Blaze.With(_.extend(self.baseData, extraData),
+    Blaze.toHTML(Blaze.With(_.extend({}, self.baseData, extraData),
                             self.func));
 };
 

--- a/packages/server-render/.npm/package/.gitignore
+++ b/packages/server-render/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/server-render/.npm/package/README
+++ b/packages/server-render/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/server-render/.npm/package/npm-shrinkwrap.json
+++ b/packages/server-render/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": {
+    "magic-string": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.21.3.tgz",
+      "from": "magic-string@0.21.3"
+    },
+    "parse5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
+      "from": "parse5@3.0.2"
+    },
+    "vlq": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
+      "from": "vlq@>=0.2.1 <0.3.0"
+    }
+  }
+}

--- a/packages/server-render/README.md
+++ b/packages/server-render/README.md
@@ -1,0 +1,37 @@
+# server-render
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/server-render) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/server-render)
+***
+
+This package implements generic support for server-side rendering in
+Meteor apps, by providing a mechanism for injecting strings of HTML into
+static HTML in the body of HTTP responses.
+
+### Usage
+
+This package exports a function named `renderIntoElementById` which takes
+an HTML `id` string and a callback function.
+
+The callback should return a string of HTML, or a `Promise<string>` if it
+needs to do any asynchronous rendering work.
+
+If an element with the given `id` exists in the initial HTTP response body,
+the final result of the callback will be injected into that element as
+part of the initial HTTP response.
+
+The callback receives the current `request` object as a parameter, so it can
+render according to per-request information like `request.url`.
+
+The final result of the callback will be ignored if it is anything other
+than a string, or if there is no element with the given `id` in the body of
+the current response.
+
+Registering multiple callbacks for the same `id` is not well defined, so
+this function just returns any previously registered callback, in case the
+new callback needs to do something with it.
+
+Because the `renderIntoElementById` function is not automatically imported
+into other packages, you must import it explicitly:
+
+```js
+import { renderIntoElementById } from "meteor/server-render";
+```

--- a/packages/server-render/package.js
+++ b/packages/server-render/package.js
@@ -1,0 +1,24 @@
+Package.describe({
+  name: "server-render",
+  version: "0.1.0",
+  summary: "Generic support for server-side rendering in Meteor apps",
+  documentation: "README.md"
+});
+
+Npm.depends({
+  "magic-string": "0.21.3",
+  "parse5": "3.0.2"
+});
+
+Package.onUse(function(api) {
+  api.use("ecmascript");
+  api.use("webapp@1.3.17");
+  api.mainModule("server-render.js", "server");
+});
+
+Package.onTest(function(api) {
+  api.use("ecmascript");
+  api.use("tinytest");
+  api.use("server-render");
+  api.mainModule("server-render-tests.js", "server");
+});

--- a/packages/server-render/server-render-tests.js
+++ b/packages/server-render/server-render-tests.js
@@ -1,0 +1,101 @@
+import { Tinytest } from "meteor/tinytest";
+import { WebAppInternals } from "meteor/webapp";
+import { renderIntoElementById } from "meteor/server-render";
+import { parse } from "parse5";
+
+const skeleton = `
+  <h1>Look, Ma... static HTML!</h1>
+  <div id="container-2"></div>
+  <p>
+    <div id="container-1">
+    </div>
+  </p>`;
+
+Tinytest.add('server-render - boilerplate', function (test) {
+  // This test is not a very good demonstration of the server-render
+  // abstraction. In normal usage, you would call renderIntoElementById
+  // and not think about the rest of this stuff. The extra complexity owes
+  // to the trickiness of testing this package without using a real
+  // browser to parse the resulting HTTP response.
+
+  const realCallback =
+    // Use the underlying abstraction to set the static HTML skeleton.
+    WebAppInternals.registerBoilerplateDataCallback(
+      "meteor/server-render",
+      (data, request, arch) => {
+        if (request.isServerRenderTest) {
+          test.equal(arch, "web.browser");
+          test.equal(request.url, "/server-render/test");
+          data.body = skeleton;
+        }
+        return realCallback.call(this, data, request, arch);
+      }
+    );
+
+  renderIntoElementById("container-1", request => {
+    return "<oyez/>";
+  });
+
+  // This callback is async, and that's fine because
+  // WebAppInternals.getBoilerplate is able to yield. Internally the
+  // webapp package uses a function called getBoilerplateAsync, so the
+  // Fiber power-tools need not be involved in typical requests.
+  renderIntoElementById("container-2", async request => {
+    return (await "oy") + (await "ez");
+  });
+
+  try {
+    const boilerplate = WebAppInternals.getBoilerplate({
+      isServerRenderTest: true,
+      browser: { name: "fake" },
+      url: "/server-render/test"
+    }, "web.browser");
+
+    const ids = [];
+    const seen = new Set;
+
+    function walk(node) {
+      if (node && ! seen.has(node)) {
+        seen.add(node);
+
+        if (node.nodeName === "div" && node.attrs) {
+          node.attrs.some(attr => {
+            if (attr.name === "id") {
+              const id = attr.value;
+
+              if (id === "container-1") {
+                test.equal(node.childNodes[0].nodeName, "oyez");
+                ids.push(id);
+              } else if (id === "container-2") {
+                const child = node.childNodes[0];
+                test.equal(child.nodeName, "#text");
+                test.equal(child.value.trim(), "oyez");
+                ids.push(id);
+              }
+
+              return true;
+            }
+          });
+        }
+
+        if (node.childNodes) {
+          node.childNodes.forEach(walk)
+        }
+      }
+    }
+
+    walk(parse(boilerplate));
+
+    test.equal(ids, ["container-2", "container-1"]);
+
+  } finally {
+    // Cleanup to minimize interference with other tests:
+    WebAppInternals.registerBoilerplateDataCallback(
+      "meteor/server-render",
+      realCallback
+    );
+
+    renderIntoElementById("container-1", null);
+    renderIntoElementById("container-2", null);
+  }
+});

--- a/packages/server-render/server-render.js
+++ b/packages/server-render/server-render.js
@@ -1,0 +1,74 @@
+import { WebAppInternals } from "meteor/webapp";
+import { SAXParser } from "parse5";
+import MagicString from "magic-string";
+
+const callbacksById = Object.create(null);
+
+// Register a callback function that returns a string of HTML (or a
+// Promise<string> if asynchronous work needs to be done). If an element
+// with the given id exists in the initial HTTP response body, the result
+// of the callback will be injected into that element as part of the
+// initial response. The callback receives the current request object as a
+// parameter, so it can render according to per-request information like
+// request.url. The final result of the callback will be ignored if it is
+// anything other than a string, or if there is no element with the given
+// id in the body of the current response. Registering multiple callbacks
+// for the same id is not well defined, so this function just returns any
+// previously registered callback, in case the new callback needs to do
+// something with it.
+export function renderIntoElementById(id, callback) {
+  const previous = callbacksById[id];
+  callbacksById[id] = callback;
+  return previous;
+}
+
+WebAppInternals.registerBoilerplateDataCallback(
+  "meteor/server-render",
+  (data, request, arch) => {
+    let madeChanges = false;
+
+    function rewrite(property) {
+      const html = data[property];
+      if (typeof html !== "string") {
+        return;
+      }
+
+      let promise = Promise.resolve();
+      const magic = new MagicString(html);
+      const parser = new SAXParser({
+        locationInfo: true,
+      });
+
+      parser.on("startTag", (name, attrs, selfClosing, loc) => {
+        attrs.some(attr => {
+          if (attr.name === "id") {
+            // TODO Ignore this id if it appears later?
+            const callback = callbacksById[attr.value];
+            if (typeof callback === "function") {
+              promise = promise
+                .then(() => callback(request))
+                .then(rendered => {
+                  if (typeof rendered === "string") {
+                    magic.appendRight(loc.endOffset, rendered);
+                    madeChanges = true;
+                  }
+                });
+            }
+            return true;
+          }
+        });
+      });
+
+      parser.write(html);
+
+      return promise.then(
+        () => data[property] = magic.toString()
+      );
+    }
+
+    return Promise.all([
+      rewrite("body"),
+      rewrite("dynamicBody"),
+    ]).then(() => madeChanges);
+  }
+);

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.3.16'
+  version: '1.3.17'
 });
 
 Npm.depends({connect: "2.30.2",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -30,15 +30,19 @@ Package.onUse(function (api) {
   // (browser-policy depends on webapp). So we don't explicitly depend in any
   // way on browser-policy here, but we use it when it is loaded, and it can be
   // loaded after webapp.
-  api.export(['WebApp', 'main', 'WebAppInternals'], 'server');
-  api.export(['WebApp'], 'client');
-  api.addFiles('webapp_server.js', 'server');
-  api.addFiles('webapp_client.js', 'client');
-  api.addFiles('webapp_cordova.js', 'web.cordova');
+  api.mainModule('webapp_server.js', 'server');
+  api.export('WebApp', 'server');
+  api.export('WebAppInternals', 'server');
+  api.export('main', 'server');
+
+  api.mainModule('webapp_client.js', 'client');
+  api.export('WebApp', 'client');
+
+  api.mainModule('webapp_cordova.js', 'web.cordova');
 });
 
 Package.onTest(function (api) {
-  api.use(['tinytest', 'webapp', 'http', 'underscore']);
+  api.use(['tinytest', 'ecmascript', 'webapp', 'http', 'underscore']);
   api.addFiles('webapp_tests.js', 'server');
   api.addFiles('webapp_client_tests.js', 'client');
 });

--- a/packages/webapp/webapp_client.js
+++ b/packages/webapp/webapp_client.js
@@ -1,15 +1,18 @@
-WebApp = {
-
-  _isCssLoaded: function () {
-    if (document.styleSheets.length === 0)
+export const WebApp = {
+  _isCssLoaded() {
+    if (document.styleSheets.length === 0) {
       return true;
+    }
 
-    return _.find(document.styleSheets, function (sheet) {
-      if (sheet.cssText && !sheet.cssRules) // IE8
-        return !sheet.cssText.match(/meteor-css-not-found-error/);
-      return !_.find(sheet.cssRules, function (rule) {
-        return rule.selectorText === '.meteor-css-not-found-error';
-      });
+    return _.find(document.styleSheets, sheet => {
+      if (sheet.cssText && ! sheet.cssRules) { // IE8
+        return ! sheet.cssText.match(/meteor-css-not-found-error/);
+      }
+
+      return ! _.find(
+        sheet.cssRules,
+        rule => rule.selectorText === '.meteor-css-not-found-error'
+      );
     });
   }
 };

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -1,25 +1,21 @@
-////////// Requires //////////
-
-var fs = Npm.require("fs");
-var http = Npm.require("http");
-var os = Npm.require("os");
-var path = Npm.require("path");
-var url = Npm.require("url");
-var crypto = Npm.require("crypto");
-
-var connect = Npm.require('connect');
-var parseurl = Npm.require('parseurl');
-var useragent = Npm.require('useragent');
-var send = Npm.require('send');
-
-var Future = Npm.require('fibers/future');
-var Fiber = Npm.require('fibers');
+import { readFile } from "fs";
+import { createServer } from "http";
+import {
+  join as pathJoin,
+  dirname as pathDirname,
+} from "path";
+import { parse as parseUrl } from "url";
+import { createHash } from "crypto";
+import connect from "connect";
+import parseRequest from "parseurl";
+import { lookup as lookupUserAgent } from "useragent";
+import send from "send";
 
 var SHORT_SOCKET_TIMEOUT = 5*1000;
 var LONG_SOCKET_TIMEOUT = 120*1000;
 
-WebApp = {};
-WebAppInternals = {};
+export const WebApp = {};
+export const WebAppInternals = {};
 
 WebAppInternals.NpmModules = {
   connect: {
@@ -43,13 +39,13 @@ var bundledJsCssUrlRewriteHook = function (url) {
 };
 
 var sha1 = function (contents) {
-  var hash = crypto.createHash('sha1');
+  var hash = createHash('sha1');
   hash.update(contents);
   return hash.digest('hex');
 };
 
 var readUtf8FileSync = function (filename) {
-  return Meteor.wrapAsync(fs.readFile)(filename, 'utf8');
+  return Meteor.wrapAsync(readFile)(filename, 'utf8');
 };
 
 // #BrowserIdentification
@@ -98,7 +94,7 @@ var camelCase = function (name) {
 };
 
 var identifyBrowser = function (userAgentString) {
-  var userAgent = useragent.lookup(userAgentString);
+  var userAgent = lookupUserAgent(userAgentString);
   return {
     name: camelCase(userAgent.family),
     major: +userAgent.major,
@@ -113,7 +109,7 @@ WebAppInternals.identifyBrowser = identifyBrowser;
 WebApp.categorizeRequest = function (req) {
   return _.extend({
     browser: identifyBrowser(req.headers['user-agent']),
-    url: url.parse(req.url, true)
+    url: parseUrl(req.url, true)
   }, _.pick(req, 'dynamicHead', 'dynamicBody'));
 };
 
@@ -292,7 +288,7 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
   return new Boilerplate(arch, manifest,
     _.extend({
       pathMapper: function (itemPath) {
-        return path.join(archPath[arch], itemPath); },
+        return pathJoin(archPath[arch], itemPath); },
       baseDataExtension: {
         additionalStaticJs: _.map(
           additionalStaticJs || [],
@@ -338,7 +334,7 @@ WebAppInternals.staticFilesMiddleware = function (staticFiles, req, res, next) {
     next();
     return;
   }
-  var pathname = parseurl(req).pathname;
+  var pathname = parseRequest(req).pathname;
   try {
     pathname = decodeURIComponent(pathname);
   } catch (e) {
@@ -449,12 +445,12 @@ WebAppInternals.parsePort = function (port) {
   return parseInt(port);
 };
 
-var runWebAppServer = function () {
+function runWebAppServer() {
   var shuttingDown = false;
   var syncQueue = new Meteor._SynchronousQueue();
 
   var getItemPathname = function (itemUrl) {
-    return decodeURIComponent(url.parse(itemUrl).pathname);
+    return decodeURIComponent(parseUrl(itemUrl).pathname);
   };
 
   WebAppInternals.reloadClientPrograms = function () {
@@ -462,9 +458,9 @@ var runWebAppServer = function () {
       staticFiles = {};
       var generateClientProgram = function (clientPath, arch) {
         // read the control for the client we'll be serving up
-        var clientJsonPath = path.join(__meteor_bootstrap__.serverDir,
+        var clientJsonPath = pathJoin(__meteor_bootstrap__.serverDir,
                                    clientPath);
-        var clientDir = path.dirname(clientJsonPath);
+        var clientDir = pathDirname(clientJsonPath);
         var clientJson = JSON.parse(readUtf8FileSync(clientJsonPath));
         if (clientJson.format !== "web-program-pre1")
           throw new Error("Unsupported format for client assets: " +
@@ -479,7 +475,7 @@ var runWebAppServer = function () {
         _.each(manifest, function (item) {
           if (item.url && item.where === "client") {
             staticFiles[urlPrefix + getItemPathname(item.url)] = {
-              absolutePath: path.join(clientDir, item.path),
+              absolutePath: pathJoin(clientDir, item.path),
               cacheable: item.cacheable,
               hash: item.hash,
               // Link from source to its map
@@ -491,7 +487,7 @@ var runWebAppServer = function () {
               // Serve the source map too, under the specified URL. We assume all
               // source maps are cacheable.
               staticFiles[urlPrefix + getItemPathname(item.sourceMapUrl)] = {
-                absolutePath: path.join(clientDir, item.sourceMap),
+                absolutePath: pathJoin(clientDir, item.sourceMap),
                 cacheable: true
               };
             }
@@ -526,7 +522,7 @@ var runWebAppServer = function () {
       try {
         var clientPaths = __meteor_bootstrap__.configJson.clientPaths;
         _.each(clientPaths, function (clientPath, arch) {
-          archPath[arch] = path.dirname(clientPath);
+          archPath[arch] = pathDirname(clientPath);
           generateClientProgram(clientPath, arch);
         });
 
@@ -643,9 +639,9 @@ var runWebAppServer = function () {
   // Serve static files from the manifest.
   // This is inspired by the 'static' middleware.
   app.use(function (req, res, next) {
-    Fiber(function () {
-     WebAppInternals.staticFilesMiddleware(staticFiles, req, res, next);
-    }).run();
+    Promise.resolve().then(() => {
+      WebAppInternals.staticFilesMiddleware(staticFiles, req, res, next);
+    });
   });
 
   // Packages and apps can add handlers to this via WebApp.connectHandlers.
@@ -667,15 +663,18 @@ var runWebAppServer = function () {
   });
 
   app.use(function (req, res, next) {
-    Fiber(function () {
-      if (!appUrl(req.url))
+    Promise.resolve().then(() => {
+      if (! appUrl(req.url)) {
         return next();
+      }
 
       var headers = {
         'Content-Type': 'text/html; charset=utf-8'
       };
-      if (shuttingDown)
+
+      if (shuttingDown) {
         headers['Connection'] = 'Close';
+      }
 
       var request = WebApp.categorizeRequest(req);
 
@@ -692,7 +691,7 @@ var runWebAppServer = function () {
         res.writeHead(200, headers);
         res.write(".meteor-css-not-found-error { width: 0px;}");
         res.end();
-        return undefined;
+        return;
       }
 
       if (request.url.query && request.url.query['meteor_js_resource']) {
@@ -703,7 +702,7 @@ var runWebAppServer = function () {
         headers['Cache-Control'] = 'no-cache';
         res.writeHead(404, headers);
         res.end("404 Not Found");
-        return undefined;
+        return;
       }
 
       if (request.url.query && request.url.query['meteor_dont_serve_index']) {
@@ -714,11 +713,11 @@ var runWebAppServer = function () {
         headers['Cache-Control'] = 'no-cache';
         res.writeHead(404, headers);
         res.end("404 Not Found");
-        return undefined;
+        return;
       }
 
       // /packages/asdfsad ... /__cordova/dafsdf.js
-      var pathname = parseurl(req).pathname;
+      var pathname = parseRequest(req).pathname;
       var archKey = pathname.split('/')[1];
       var archKeyCleaned = 'web.' + archKey.replace(/^__/, '');
 
@@ -735,15 +734,16 @@ var runWebAppServer = function () {
         Log.error("Error running template: " + e.stack);
         res.writeHead(500, headers);
         res.end();
-        return undefined;
+        return;
       }
 
       var statusCode = res.statusCode ? res.statusCode : 200;
       res.writeHead(statusCode, headers);
       res.write(boilerplate);
       res.end();
-      return undefined;
-    }).run();
+
+      return;
+    });
   });
 
   // Return 404 by default, if no other handlers serve this URL.
@@ -753,7 +753,7 @@ var runWebAppServer = function () {
   });
 
 
-  var httpServer = http.createServer(app);
+  var httpServer = createServer(app);
   var onListeningCallbacks = [];
 
   // After 5 seconds w/o data on a socket, kill it.  On the other hand, if
@@ -805,37 +805,36 @@ var runWebAppServer = function () {
         f();
     }
   });
-
-  // Let the rest of the packages (and Meteor.startup hooks) insert connect
-  // middlewares and update __meteor_runtime_config__, then keep going to set up
-  // actually serving HTML.
-  main = function (argv) {
-    WebAppInternals.generateBoilerplate();
-
-    // only start listening after all the startup code has run.
-    var localPort = WebAppInternals.parsePort(process.env.PORT) || 0;
-    var host = process.env.BIND_IP;
-    var localIp = host || '0.0.0.0';
-    httpServer.listen(localPort, localIp, Meteor.bindEnvironment(function() {
-      if (process.env.METEOR_PRINT_ON_LISTEN)
-        console.log("LISTENING"); // must match run-app.js
-
-      var callbacks = onListeningCallbacks;
-      onListeningCallbacks = null;
-      _.each(callbacks, function (x) { x(); });
-
-    }, function (e) {
-      console.error("Error listening:", e);
-      console.error(e && e.stack);
-    }));
-
-    return 'DAEMON';
-  };
-};
-
+}
 
 runWebAppServer();
 
+// Let the rest of the packages (and Meteor.startup hooks) insert connect
+// middlewares and update __meteor_runtime_config__, then keep going to set up
+// actually serving HTML.
+export function main(argv) {
+  WebAppInternals.generateBoilerplate();
+
+  // Only start listening after all the startup code has run.
+  var localPort = WebAppInternals.parsePort(process.env.PORT) || 0;
+  var host = process.env.BIND_IP;
+  var localIp = host || '0.0.0.0';
+  WebApp.httpServer.listen(localPort, localIp, Meteor.bindEnvironment(function() {
+    if (process.env.METEOR_PRINT_ON_LISTEN) {
+      console.log("LISTENING"); // must match run-app.js
+    }
+
+    var callbacks = onListeningCallbacks;
+    onListeningCallbacks = null;
+    _.each(callbacks, function (x) { x(); });
+
+  }, function (e) {
+    console.error("Error listening:", e);
+    console.error(e && e.stack);
+  }));
+
+  return 'DAEMON';
+}
 
 var inlineScriptsAllowed = true;
 

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -163,6 +163,7 @@ Tinytest.add("webapp - WebAppInternals.registerBoilerplateDataCallback", functio
   function callback(data, request, arch) {
     test.equal(arch, "web.browser");
     test.equal(request.url, "http://example.com");
+    test.equal(data.dynamicHead, "so dynamic");
     test.equal(data.body, "");
     data.body = "<div>oyez</div>";
     ++callCount;
@@ -175,6 +176,7 @@ Tinytest.add("webapp - WebAppInternals.registerBoilerplateDataCallback", functio
   const req = new http.IncomingMessage();
   req.url = "http://example.com";
   req.browser = { name: "headless" };
+  req.dynamicHead = "so dynamic";
 
   const html = WebAppInternals.getBoilerplate(req, "web.browser");
 

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -78,7 +78,7 @@ Tinytest.add("webapp - additional static javascript", function (test) {
   // before settng it back to what it was originally.
   WebAppInternals.setInlineScriptsAllowed(true);
 
-  Meteor._noYieldsAllowed(function () {
+  (function () {
     var boilerplate = WebAppInternals.getBoilerplate({
       browser: "doesn't-matter",
       url: "also-doesnt-matter"
@@ -100,14 +100,14 @@ Tinytest.add("webapp - additional static javascript", function (test) {
         nextCalled = true;
       });
     test.isTrue(nextCalled);
-  });
+  })();
 
   // When inline scripts are disallowed, the script body should not be
   // inlined, and the script should be included in a <script src="..">
   // tag.
   WebAppInternals.setInlineScriptsAllowed(false);
 
-  Meteor._noYieldsAllowed(function () {
+  (function () {
     var boilerplate = WebAppInternals.getBoilerplate({
       browser: "doesn't-matter",
       url: "also-doesnt-matter"
@@ -129,7 +129,7 @@ Tinytest.add("webapp - additional static javascript", function (test) {
     var resBody = res.getBody();
     test.isTrue(resBody.indexOf(additionalScript) !== -1);
     test.equal(res.statusCode, 200);
-  });
+  })();
 
   WebAppInternals.setInlineScriptsAllowed(origInlineScriptsAllowed);
 });


### PR DESCRIPTION
To support server-side rendering of any kind, it would be ideal if there was a way for server code to inject rendered HTML into the boilerplate HTML generated by packages like `static-html`. Until now, that hasn't been possible, since the only mechanism for adding dynamic HTML to the initial HTTP response was to modify `request.dynamicHead` and/or `request.dynamicBody`.

With this new API, it should now be possible to register callbacks that (for example) parse `boilerplate.baseData.body`, find DOM nodes by `id`, render HTML fragments, inject the fragments into the DOM, and set `boilerplate.baseData.body` to the resulting HTML string.

I previously thought this would require changes to the `boilerplate-generator` package, and thus we had to wait for #8820 to be finished, but it turns out we can intercept `boilerplate.baseData` before calling `boilerplate.toHTML`, with only the changes in this PR.

I also took this opportunity to modernize the `webapp` package to use more ECMAScript 2015+ features, so it may be easier to review this PR commit-by-commit.