### PR TITLE
localStorage: bring back proxy methods to window.localStorage. (Fix IE11 issue)

### DIFF
--- a/packages/localstorage/localstorage.js
+++ b/packages/localstorage/localstorage.js
@@ -24,17 +24,11 @@ if (key === retrieved) {
   if (Meteor.isServer) {
     Meteor._localStorage = storage;
   } else {
-    // IE11 doesn't handle properly attempts to change methods of the
-    // window.localStorage, attempts to do so will result in the complete
-    // break of the localStorage system for the domain in which it is
-    // done - until the user clean the browser/domain cache.
-    //
-    // Therefore, in the web, we don't set Meteor._localStorage to be a
-    // reference to window.localStorage . Instead, we set proxy methods.
-    //
-    // This will allow package developers that will find a need to change
-    // the behavior of Meteor._localStorage methods to do so without breaking
-    // the localStorage system on IE11. (e.g. meteorhacks:fast-render)
+    // Some browsers (e.g. IE11) don't properly handle attempts to change 
+    // window.localStorage methods. By using proxy methods to expose 
+    // window.localStorage functionality, developers can change 
+    // the behavior of Meteor._localStorage methods without breaking 
+    // window.localStorage.
 
     Meteor._localStorage = {
       getItem: function (key) {

--- a/packages/localstorage/localstorage.js
+++ b/packages/localstorage/localstorage.js
@@ -21,7 +21,33 @@ try {
 } catch (ignored) {}
 
 if (key === retrieved) {
-  Meteor._localStorage = storage;
+  if (Meteor.isServer) {
+    Meteor._localStorage = storage;
+  } else {
+    // IE11 doesn't handle properly attempts to change methods of the
+    // window.localStorage, attempts to do so will result in the complete
+    // break of the localStorage system for the domain in which it is
+    // done - until the user clean the browser/domain cache.
+    //
+    // Therefore, in the web, we don't set Meteor._localStorage to be a
+    // reference to window.localStorage . Instead, we set proxy methods.
+    //
+    // This will allow package developers that will find a need to change
+    // the behavior of Meteor._localStorage methods to do so without breaking
+    // the localStorage system on IE11. (e.g. meteorhacks:fast-render)
+
+    Meteor._localStorage = {
+      getItem: function (key) {
+        return window.localStorage.getItem(key);
+      },
+      setItem: function (key, value) {
+        window.localStorage.setItem(key, value);
+      },
+      removeItem: function (key) {
+        window.localStorage.removeItem(key);
+      }
+    };
+  }
 }
 
 if (! Meteor._localStorage) {


### PR DESCRIPTION
IE11 doesn't handle properly attempts to change methods of the
window.localStorage, attempts to do so will result in the complete break of the
localStorage system for the domain in which it is done - until the user clean
the browser/domain cache.

Therefore, in the web, we don't set Meteor._localStorage to be a reference to
window.localStorage . Instead, we set proxy methods.

This will allow package developers that will find a need to change the behavior
of Meteor._localStorage methods to do so without breaking the localStorage
system on IE11. (e.g. meteorhacks:fast-render)

IE11 (earlier IE versions weren't checked) doesn't handle attempts to replace
methods of window.localStorage with different functions properly.  Such attempt
will result in the String of the function we try to set saved as the function,
destroying the ability to use this function.

I couldn't find a way to tell in advance whether an attempt to set
window.localStorage will result in correct function write or not (I
intentionally avoid browser version detection, which is considered a bad
practice). If such attempt will fail we won't have a way to restore the
original function.

The situation is even worse than that. If for example we'll try to set
window.localStorage.setItem = function () {} the String value 'function () {}'
will be saved instead of the function - not only for the current session, but
as part of the localStorage (!) meaning that we'll have to ask users affected
by this bug to clear the cache to fix the situation.

The following won't work:

```javascript
Meteor._localStorage = window.localStorage // Just to make the example clear.
originalSetItem = Meteor._localStorage.setItem
Meteor._localStorage.setItem = function () {}
Meteor._localStorage.setItem = originalSetItem

typeof Meteor._localStorage.setItem -> string
```

-----------

### Potential related issues:

* https://forums.meteor.com/t/entire-meteor-app-non-working-in-ie11-since-meteor-1-5/37139
* https://github.com/meteor/meteor/pull/8782

See also discussion on this commit: https://github.com/jamiter/meteor/commit/a01cd04cfe2f1c9c1955aa22d6733e0d6eb33ef3

Related PR pushed to [meteorspark:fast-render](https://atmospherejs.com/meteorspark/fast-render) to workaround the issue this PR fix: https://github.com/kadirahq/fast-render/pull/191