### PR TITLE
Update Facebook api version in loginUrl

### DIFF
--- a/packages/accounts-facebook/package.js
+++ b/packages/accounts-facebook/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Login service for Facebook accounts",
-  version: "1.2.0"
+  version: "1.2.1"
 });
 
 Package.onUse(function(api) {

--- a/packages/facebook-oauth/facebook_client.js
+++ b/packages/facebook-oauth/facebook_client.js
@@ -31,7 +31,7 @@ Facebook.requestCredential = function (options, credentialRequestCompleteCallbac
   var loginStyle = OAuth._loginStyle('facebook', config, options);
 
   var loginUrl =
-        'https://www.facebook.com/v2.2/dialog/oauth?client_id=' + config.appId +
+        'https://www.facebook.com/v2.9/dialog/oauth?client_id=' + config.appId +
         '&redirect_uri=' + OAuth._redirectUri('facebook', config) +
         '&display=' + display + '&scope=' + scope +
         '&state=' + OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl);

--- a/packages/facebook-oauth/package.js
+++ b/packages/facebook-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Facebook OAuth flow",
-  version: "1.3.1"
+  version: "1.3.2"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
The most recent version of the API is Version 2.9, which was introduced on April 18th, 2017 https://developers.facebook.com/docs/apps/changelog

The url parameters are not changed with the new version https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow

Fixes https://github.com/meteor/meteor/issues/8856