### PR TITLE
updated dependency of semver to the latest version

### DIFF
--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -17,7 +17,7 @@ var packageJson = {
     // (and there are backwards-incompatible changes either way).
     underscore: "1.5.2",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
-    semver: "4.1.0"
+    semver: "4.3.2"
   },
   // These are only used in dev mode (by shell.js) so end-users can avoid
   // needing to install them if they use `npm install --production`.

--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -17,7 +17,7 @@ var packageJson = {
     // (and there are backwards-incompatible changes either way).
     underscore: "1.5.2",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
-    semver: "4.3.2"
+    semver: "5.3.0"
   },
   // These are only used in dev mode (by shell.js) so end-users can avoid
   // needing to install them if they use `npm install --production`.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -28,7 +28,7 @@ var packageJson = {
     // (and there are backwards-incompatible changes either way).
     underscore: "1.5.2",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
-    semver: "4.3.2",
+    semver: "5.3.0",
     request: "2.47.0",
     fstream: "https://github.com/meteor/fstream/tarball/cf4ea6c175355cec7bee38311e170d08c4078a5d",
     tar: "2.2.1",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -28,7 +28,7 @@ var packageJson = {
     // (and there are backwards-incompatible changes either way).
     underscore: "1.5.2",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
-    semver: "4.1.0",
+    semver: "4.3.2",
     request: "2.47.0",
     fstream: "https://github.com/meteor/fstream/tarball/cf4ea6c175355cec7bee38311e170d08c4078a5d",
     tar: "2.2.1",


### PR DESCRIPTION
The currently used version of semver does have a medium-level security issue. Therefore, the dependencies of `meteor-dev-bundle` had been updated.

|            | Regular Expression Denial of Service   |
| ---------- | -------------------------------------- |
| Name       | semver                                 |
| CVSS       | 5.3 (Medium)                           |
| Installed  | 4.1.0                                  |
| Vulnerable | <4.3.2                                 |
| Patched    | 4.3.2                                  |
| Path       | meteor-dev-bundle@0.0.0 > semver@4.1.0 |
| More Info  | https://nodesecurity.io/advisories/31  |