### PR TITLE
Upgraded to Mongo 3.4.5.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 ## v.NEXT
 
+* Meteor has been upgraded to support Mongo 3.4.5 by default (the bundled
+  version used by `meteor run` has been upgraded). Internally it now uses the
+  2.2.29 version of the `mongodb` npm driver, and has been tested against
+  Mongo databases ranging from versions 2.6.10 to 3.4.5.
+  [FR #129](https://github.com/meteor/meteor-feature-requests/issues/129)
+
 * `observe`/`observeChanges` callbacks are now bound using `Meteor.bindEnvironment`.
   The same `EnvironmentVariable`s that were present when `observe`/`observeChanges`
   was called are now available inside the callbacks.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.8.19
+BUNDLE_VERSION=9999.8864.0
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.8.18
+BUNDLE_VERSION=4.8.19
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
     "buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "from": "buffer-shims@>=1.0.0 <2.0.0"
+      "from": "buffer-shims@>=1.0.0 <1.1.0"
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -31,14 +31,14 @@
       "from": "isarray@>=1.0.0 <1.1.0"
     },
     "mongodb": {
-      "version": "2.2.24",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.24.tgz",
-      "from": "mongodb@2.2.24"
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.29.tgz",
+      "from": "mongodb@2.2.29"
     },
     "mongodb-core": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.8.tgz",
-      "from": "mongodb-core@2.1.8"
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.13.tgz",
+      "from": "mongodb-core@2.1.13"
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -46,13 +46,13 @@
       "from": "process-nextick-args@>=1.0.6 <1.1.0"
     },
     "readable-stream": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-      "from": "readable-stream@2.1.5"
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+      "from": "readable-stream@2.2.7"
     },
     "require_optional": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "from": "require_optional@>=1.0.0 <1.1.0"
     },
     "resolve-from": {
@@ -60,15 +60,20 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "from": "resolve-from@>=2.0.0 <3.0.0"
     },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "from": "safe-buffer@>=5.1.0 <5.2.0"
+    },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "from": "semver@>=5.1.0 <6.0.0"
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "from": "string_decoder@>=0.10.0 <0.11.0"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "from": "string_decoder@>=1.0.0 <1.1.0"
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '2.2.24',
+  version: '2.2.29',
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "2.2.24"
+  mongodb: "2.2.29"
 });
 
 Package.onUse(function (api) {

--- a/scripts/admin/test-packages-with-mongo-versions.rb
+++ b/scripts/admin/test-packages-with-mongo-versions.rb
@@ -7,10 +7,10 @@
 require 'tmpdir'
 
 mongo_install_urls = {
+  "3.4.5" => "https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.4.5.tgz",
   "3.2.6" => "https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.2.6.tgz",
   "3.0.5" => "https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.0.5.tgz",
-  "2.6.10" => "http://downloads.mongodb.org/osx/mongodb-osx-x86_64-2.6.10.tgz",
-  "2.4.14" => "http://downloads.mongodb.org/osx/mongodb-osx-x86_64-2.4.14.tgz"
+  "2.6.10" => "http://downloads.mongodb.org/osx/mongodb-osx-x86_64-2.6.10.tgz"
 }
 
 mongo_port = "12345"
@@ -29,7 +29,7 @@ puts "Putting output in: #{path_to_output}/"
 
 test_env = "TEST_PACKAGES_EXCLUDE=\"less\""
 
-["3.2.6", "3.0.5", "2.6.10", "2.4.14"].each do |mongo_version|
+["3.4.5", "3.2.6", "3.0.5", "2.6.10"].each do |mongo_version|
   puts "Installing and testing with Mongo #{mongo_version}..."
 
   Dir.mktmpdir "mongo_install" do |mongo_install_dir|

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -5,7 +5,7 @@ set -u
 
 UNAME=$(uname)
 ARCH=$(uname -m)
-MONGO_VERSION=3.2.12
+MONGO_VERSION=3.4.5
 NODE_VERSION=4.8.3
 NPM_VERSION=4.6.1
 

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -52,7 +52,8 @@ function spawnMongod(mongodPath, port, dbPath, replSetName) {
     // Use an 8MB oplog rather than 256MB. Uses less space on disk and
     // initializes faster. (Not recommended for production!)
     '--oplogSize', '8',
-    '--replSet', replSetName
+    '--replSet', replSetName,
+    '--noauth'
   ];
 
   // Use mmapv1 on 32bit platforms, as our binary doesn't support WT
@@ -533,12 +534,12 @@ var launchMongo = function (options) {
       // note: don't use "else ifs" in this, because 'data' can have multiple
       // lines
       if (/\[initandlisten\] Did not find local replica set configuration document at startup/.test(data) ||
-          /\[ReplicationExecutor\] Locally stored replica set configuration does not have a valid entry for the current node/.test(data)) {
+          /\[.*\] Locally stored replica set configuration does not have a valid entry for the current node/.test(data)) {
         replSetReadyToBeInitiated = true;
         maybeReadyToTalk();
       }
 
-      if (/ \[initandlisten\] waiting for connections on port/.test(data)) {
+      if (/ \[.*\] waiting for connections on port/.test(data)) {
         listening = true;
         maybeReadyToTalk();
       }
@@ -593,7 +594,7 @@ var launchMongo = function (options) {
         'meteor',
         new mongoNpmModule.Server('127.0.0.1', options.port, {
           poolSize: 1,
-          socketOptions: {connectTimeoutMS: 30000},
+          socketOptions: {connectTimeoutMS: 60000},
         }),
         {safe: true});
 

--- a/tools/tests/mongo.js
+++ b/tools/tests/mongo.js
@@ -33,10 +33,10 @@ var testMeteorMongo = function (appDir) {
 
   var mongoRun = s.run('mongo');
   mongoRun.match('MongoDB shell');
-  mongoRun.match('connecting to: 127.0.0.1');
+  mongoRun.match('connecting to: mongodb://127.0.0.1');
   // Note: when mongo shell's input is not a tty, there is no prompt.
   mongoRun.write('db.version()\n');
-  mongoRun.match(/3\.2\.\d+/);
+  mongoRun.match(/3\.4\.\d+/);
   mongoRun.stop();
 
   run.stop();


### PR DESCRIPTION
Hi all - this PR is intended to address feature request https://github.com/meteor/meteor-feature-requests/issues/129. The Meteor tool has been updated to use Mongo 3.4.5 (the latest stable version as of today). For the most part, this has been a pretty painless upgrade. There have been quite a few changes since 3.2 (see the 3.4 changelog [here](https://docs.mongodb.com/manual/release-notes/3.4-changelog/)), but most of those changes have been internal to the Mongo core itself). All existing `self-test`'s and `package-test`'s are passing (after a few small tweaks), and I've been manually testing these changes against older databases without any issues.

Since these changes require a new version of the dev bundle, CircleCI's `self-tests`'s will fail until a new version is published by MDG. Given the other changes that are happening currently, I wasn't sure what would be an appropriate `BUNDLE_VERSION`, so for now I've just bumped the minor by 1 (let me know if that should change).

Thanks all - standing by for feedback!