### PR TITLE
Make METEOR_WATCH_PRIORITIZE_CHANGED opt-out instead of opt-in.

### DIFF
--- a/tools/fs/safe-watcher.js
+++ b/tools/fs/safe-watcher.js
@@ -17,9 +17,14 @@ if (process.platform === "win32") {
   WATCHER_ENABLED = false;
 }
 
-var PRIORITIZE_CHANGED =
-  process.env.METEOR_WATCH_PRIORITIZE_CHANGED &&
-  JSON.parse(process.env.METEOR_WATCH_PRIORITIZE_CHANGED);
+// Default to prioritizing changed files, but disable that behavior (and
+// thus prioritize all files equally) if METEOR_WATCH_PRIORITIZE_CHANGED
+// is explicitly set to a string that parses to a falsy value.
+var PRIORITIZE_CHANGED = true;
+if (process.env.METEOR_WATCH_PRIORITIZE_CHANGED &&
+    ! JSON.parse(process.env.METEOR_WATCH_PRIORITIZE_CHANGED)) {
+  PRIORITIZE_CHANGED = false;
+}
 
 var DEFAULT_POLLING_INTERVAL =
   ~~process.env.METEOR_WATCH_POLLING_INTERVAL_MS || 5000;

--- a/tools/tests/compiler-plugins.js
+++ b/tools/tests/compiler-plugins.js
@@ -22,6 +22,7 @@ function startRun(sandbox) {
 // Tests the actual cache logic used by coffeescript.
 selftest.define("compiler plugin caching - coffee", () => {
   var s = new Sandbox({ fakeMongo: true });
+  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
 
   s.createApp("myapp", "caching-coffee");
   s.cd("myapp");
@@ -91,6 +92,7 @@ selftest.define("compiler plugin caching - coffee", () => {
 
   selftest.define("compiler plugin caching - " + packageName, () => {
     var s = new Sandbox({ fakeMongo: true });
+    s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
 
     s.createApp("myapp", "caching-" + packageName);
     s.cd("myapp");
@@ -278,6 +280,7 @@ selftest.define("compiler plugin caching - local plugin", function () {
 // Test error on duplicate compiler plugins.
 selftest.define("compiler plugins - duplicate extension", () => {
   const s = new Sandbox({ fakeMongo: true });
+  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
 
   s.createApp("myapp", "duplicate-compiler-extensions");
   s.cd("myapp");

--- a/tools/tests/cordova-plugins.js
+++ b/tools/tests/cordova-plugins.js
@@ -135,6 +135,8 @@ selftest.define("change cordova plugins", ["cordova"], function () {
   var s = new Sandbox();
   var run;
 
+  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
+
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");

--- a/tools/tests/hot-code-push.js
+++ b/tools/tests/hot-code-push.js
@@ -7,6 +7,8 @@ selftest.define("css hot code push", function (options) {
     clients: options.clients
   });
 
+  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
+
   s.createApp("myapp", "css-injection-test");
   s.cd("myapp");
   s.testWithAllClients(function (run) {

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -100,6 +100,8 @@ selftest.define("change packages during hot code push", [], function () {
   var s = new Sandbox();
   var run;
 
+  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
+
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -22,6 +22,8 @@ selftest.define("run", function () {
   var s = new Sandbox({ fakeMongo: true });
   var run;
 
+  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
+
   // Starting a run
   s.createApp("myapp", "standard-app");
   s.cd("myapp");
@@ -287,6 +289,7 @@ selftest.define("update during run", ["checkout", 'custom-warehouse'], function 
   run.tellMongo(MONGO_LISTENING);
   run.waitSecs(2);
   run.match('localhost:3000');
+  run.waitSecs(10);
   s.write('.meteor/release', DEFAULT_RELEASE_TRACK + '@v2');
   s.write('empty.js', '');
   run.waitSecs(2);


### PR DESCRIPTION
This restores the behavior of 8c70716954f8fcdd02fc0c673a39da2b7186ce2b by default, with the option of disabling the prioritized file watching system by setting `METEOR_WATCH_PRIORITIZE_CHANGED` explicitly to `"false"`.

The self-tests where the environment variable is explicitly set form a nice to-do list of tests that should be improved to be more robust to cope with differences in file watcher timing.

Helps with #8648 and similar issues.