### PR TITLE
npm-mongo: Upgrade to npm mongo@2.2.30 to fix arbiter login attempts

### DIFF
--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
     "buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "from": "buffer-shims@>=1.0.0 <2.0.0"
+      "from": "buffer-shims@>=1.0.0 <1.1.0"
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -31,14 +31,14 @@
       "from": "isarray@>=1.0.0 <1.1.0"
     },
     "mongodb": {
-      "version": "2.2.24",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.24.tgz",
-      "from": "mongodb@2.2.24"
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.29.tgz",
+      "from": "mongodb@2.2.29"
     },
     "mongodb-core": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.8.tgz",
-      "from": "mongodb-core@2.1.8"
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.13.tgz",
+      "from": "mongodb-core@2.1.13"
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -46,13 +46,13 @@
       "from": "process-nextick-args@>=1.0.6 <1.1.0"
     },
     "readable-stream": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-      "from": "readable-stream@2.1.5"
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+      "from": "readable-stream@2.2.7"
     },
     "require_optional": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "from": "require_optional@>=1.0.0 <1.1.0"
     },
     "resolve-from": {
@@ -60,15 +60,20 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "from": "resolve-from@>=2.0.0 <3.0.0"
     },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "from": "safe-buffer@>=5.1.0 <5.2.0"
+    },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "from": "semver@>=5.1.0 <6.0.0"
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "from": "string_decoder@>=0.10.0 <0.11.0"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "from": "string_decoder@>=1.0.0 <1.1.0"
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -31,14 +31,14 @@
       "from": "isarray@>=1.0.0 <1.1.0"
     },
     "mongodb": {
-      "version": "2.2.29",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.29.tgz",
-      "from": "mongodb@2.2.29"
+      "version": "2.2.30",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.30.tgz",
+      "from": "mongodb@2.2.30"
     },
     "mongodb-core": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.13.tgz",
-      "from": "mongodb-core@2.1.13"
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.14.tgz",
+      "from": "mongodb-core@2.1.14"
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '2.2.29',
+  version: '2.2.30',
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "2.2.29"
+  mongodb: "2.2.30"
 });
 
 Package.onUse(function (api) {

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '2.2.24',
+  version: '2.2.29',
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "2.2.24"
+  mongodb: "2.2.29"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Meteor 1.4.3.2 upgraded npm mongo to 2.2.24 in order to fix an issue
with MongoDB arbiter login attempts, see Meteor issue 8449 and Meteor
1.4.3.2 changelog.

But the MongoDB upstream fix was incomplete.

This commits upgrades npm mongo further to 2.2.29 in order to get the
fix for the related arbiter login issue NODE-981 on the MongoDB Jira,
which requires `mongo-core@>=2.1.10`, which requires `mongodb@>=2.2.26`;
see references below.

References:

 - Meteor issue 8449: <https://github.com/meteor/meteor/issues/8449>.
 - Meteor 1.4.3.2: <https://github.com/meteor/meteor/blob/devel/History.md#v1432-2017-03-14>
 - NODE-981 in MongoDB Jira: <https://jira.mongodb.org/browse/NODE-981>
 - mongodb-core 2.1.10 changelog: <https://github.com/christkv/mongodb-core/blob/2.0/HISTORY.md#2110-2017-04-18>,
 - mongodb 2.2.26 changelog: <https://github.com/mongodb/node-mongodb-native/blob/2.2/HISTORY.md#2226-2017-04-18>.

Signed-off-by: Steffen Prohaska <prohaska@zib.de>