### PR TITLE
Fixes #8879 Build phase command line output jumps

### DIFF
--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -67,8 +67,10 @@ var wordwrap = require('wordwrap');
 
 var PROGRESS_DEBUG = !!process.env.METEOR_PROGRESS_DEBUG;
 var FORCE_PRETTY=undefined;
-var CARRIAGE_RETURN =
-  (process.platform === 'win32' && process.stdout.isTTY && process.title !== 'Windows PowerShell' ? new Array(249).join('\b') : '\r');
+// Set the default CR to \r unless we're running with cmd
+var CARRIAGE_RETURN = process.platform === 'win32' &&
+      process.stdout.isTTY &&
+      process.argv[1].toLowerCase().includes('cmd') ? new Array(249).join('\b') : '\r';
 
 if (process.env.METEOR_PRETTY_OUTPUT) {
   FORCE_PRETTY = process.env.METEOR_PRETTY_OUTPUT != '0';


### PR DESCRIPTION
Fixes #8879  (or refixes #6785).

The test for 'Windows Powershell' in the user's `window.title` property is "inverted" to instead test for "not executable name containing `cmd`".

This seems to be more reliable and in line with Microsoft's intention of removing `cmd.exe` from Windows 10 - i.e. that it will be more strategic to adopt non-`cmd.exe` ways of working.