### PR TITLE
filePath is relative to appPath

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -661,7 +661,7 @@ main.registerCommand({
       // We do mind if there are non-hidden directories, because we don't want
       // to recursively check everything to do some crazy heuristic to see if
       // we should try to creat an app.
-      var stats = files.stat(filePath);
+      var stats = files.stat(files.pathJoin(appPath, filePath));
       if (stats.isDirectory()) {
         // Could contain code
         return true;

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -660,7 +660,7 @@ main.registerCommand({
 
       // We do mind if there are non-hidden directories, because we don't want
       // to recursively check everything to do some crazy heuristic to see if
-      // we should try to creat an app.
+      // we should try to create an app.
       var stats = files.stat(files.pathJoin(appPath, filePath));
       if (stats.isDirectory()) {
         // Could contain code


### PR DESCRIPTION
If I have a directory `test-app` with `packages` subdirectory, and I run outside `test-app` directory `meteor create --bare test-app` it fails on `files.stat` because `files.stat('packages')` is run outside `test-app`, and it does not exist there.