### PR TITLE
added command make clean for linux

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1286,7 +1286,6 @@ main.registerCommand({
   allowUnrecognizedOptions: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
-  Console.info(options);
   if (options.global) {   
     try {
       files.rm_recursive(path.join(process.env.HOME, '.meteor'));

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1,4 +1,5 @@
 var main = require('./main.js');
+var path = require('path');
 var _ = require('underscore');
 var files = require('../fs/files.js');
 var deploy = require('../meteor-services/deploy.js');
@@ -1269,6 +1270,45 @@ main.registerCommand({
   files.rm_recursive(localDir);
 
   Console.info("Project reset.");
+});
+
+///////////////////////////////////////////////////////////////////////////////
+// clean
+///////////////////////////////////////////////////////////////////////////////
+
+main.registerCommand({
+  name: 'clean',
+  maxArgs: 1,
+  requiresApp: false,
+  options: {
+    'global': { type: Boolean, short: 'g' }
+  },
+  allowUnrecognizedOptions: true,
+  catalogRefresh: new catalog.Refresh.Never()
+}, function (options) {
+  Console.info(options);
+  if (options.global) {   
+    try {
+      files.rm_recursive(path.join(process.env.HOME, '.meteor'));
+      Console.info("Global meteor folder cleaned.");
+    } catch (err) {
+      // Don't crash and print a stack trace because we failed to delete a .meteor
+      // directory. This happens sometimes on Windows and seems to be
+      // unavoidable.
+      console.log(err);
+    }
+  } else {
+    try {
+      // clean the project
+      files.rm_recursive(path.join(__dirname,'..','..','.meteor'));
+      Console.info("Meteor folder cleaned.");
+    } catch (err) {
+      // Don't crash and print a stack trace because we failed to delete a .meteor
+      // directory. This happens sometimes on Windows and seems to be
+      // unavoidable.
+      console.log(err);
+    }
+  }    
 });
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
in response for feature request [#77](https://github.com/meteor/meteor-feature-requests/issues/77) 
where would the ```.meteor``` normally be on windows so I can add its support.
I'll add a test once I know what would we with windows.