### PR TITLE
Allow any `meteor <subcommand> ...` found in node_modules/.bin

### DIFF
--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -1,46 +1,48 @@
 // Note that this file is required before we install our Babel hooks in
 // ../tool-env/install-babel.js, so we can't use ES2015+ syntax here.
 
-var fs = require("fs");
-var path = require("path");
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
 
 // The dev_bundle/bin command has to come immediately after the meteor
 // command, as in `meteor npm` or `meteor node`, because we don't want to
 // require("./main.js") for these commands.
-var devBundleBinCommand = process.argv[2];
-var args = process.argv.slice(3);
+const devBundleBinCommand = process.argv[2];
+const args = process.argv.slice(3);
 
 // On Windows, try the .cmd and .exe extensions.
-var isWindows = process.platform === "win32";
-var extensions = isWindows ? [".cmd", ".exe"] : [""];
+const isWindows = process.platform === "win32";
+const extensions = isWindows ? [".cmd", ".exe"] : [""];
 
 function getChildProcess() {
   if (typeof devBundleBinCommand !== "string") {
     return Promise.resolve(null);
   }
 
-  var helpers = require("./dev-bundle-bin-helpers.js");
-  var getEnvOptions = {};
+  const helpers = require("./dev-bundle-bin-helpers.js");
+  const getEnvOptions = {};
 
   return Promise.all([
     helpers.getDevBundle(),
     helpers.getEnv(getEnvOptions)
   ]).then(function (devBundleAndEnv) {
-    var devBundleDir = devBundleAndEnv[0];
-    var env = devBundleAndEnv[1];
+    const devBundleDir = devBundleAndEnv[0];
+    const env = devBundleAndEnv[1];
 
     // Strip leading and/or trailing whitespace.
-    var name = devBundleBinCommand.replace(/^\s+|\s+$/g, "");
+    const name = devBundleBinCommand.replace(/^\s+|\s+$/g, "");
 
     if (! helpers.isValidCommand(name, devBundleDir)) {
       return null;
     }
 
-    var cmd = null;
+    let cmd = null;
 
     getEnvOptions.extraPaths.some(function (dir) {
       return extensions.some(function (ext) {
-        var candidate = path.join(dir, name + ext);
+        const candidate = path.join(dir, name + ext);
         try {
           if (fs.statSync(candidate).isFile()) {
             cmd = candidate;
@@ -56,7 +58,7 @@ function getChildProcess() {
       return null;
     }
 
-    var child = require("child_process").spawn(cmd, args, {
+    const child = require("child_process").spawn(cmd, args, {
       stdio: "inherit",
       env: env
     });

--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -1,8 +1,10 @@
-var fs = require("fs");
-var path = require("path");
-var files = require("../fs/mini-files.js");
-var finder = require("./file-finder.js");
-var hasOwn = Object.prototype.hasOwnProperty;
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const files = require("../fs/mini-files.js");
+const finder = require("./file-finder.js");
+const hasOwn = Object.prototype.hasOwnProperty;
 
 function getDevBundle() {
   return require("./dev-bundle.js");
@@ -20,7 +22,7 @@ exports.isValidCommand = function(name, devBundleDir) {
     return false;
   }
 
-  var meteorCommandsJsonPath =
+  const meteorCommandsJsonPath =
     path.join(devBundleDir, "bin", ".meteor-commands.json");
 
   try {
@@ -35,13 +37,13 @@ exports.isValidCommand = function(name, devBundleDir) {
 };
 
 exports.getEnv = function (options) {
-  var devBundle = options && options.devBundle;
-  var devBundlePromise = typeof devBundle === "string"
+  const devBundle = options && options.devBundle;
+  const devBundlePromise = typeof devBundle === "string"
     ? Promise.resolve(files.convertToOSPath(devBundle))
     : getDevBundle();
 
   return devBundlePromise.then(function (devBundleDir) {
-    var extraPaths = [
+    const extraPaths = [
       // When npm looks for node, it must find dev_bundle/bin/node.
       path.join(devBundleDir, "bin"),
     ];
@@ -58,7 +60,7 @@ exports.getEnv = function (options) {
       path.join(devBundleDir, "lib", "node_modules", ".bin")
     );
 
-    var env = Object.create(process.env);
+    const env = Object.create(process.env);
 
     // Make sure notifications to update npm aren't presented to the user.
     env.NPM_CONFIG_NO_UPDATE_NOTIFIER = true;
@@ -90,8 +92,8 @@ exports.getEnv = function (options) {
       options.extraPaths = extraPaths;
     }
 
-    var paths = extraPaths.slice(0);
-    var PATH = env.PATH || env.Path;
+    const paths = extraPaths.slice(0);
+    const PATH = env.PATH || env.Path;
     if (PATH) {
       paths.push(PATH);
     }
@@ -108,7 +110,7 @@ exports.getEnv = function (options) {
 
 // Caching env.GYP_MSVS_VERSION allows us to avoid invoking Python every
 // time Meteor runs an npm command. TODO Store this on disk?
-var cachedMSVSVersion;
+let cachedMSVSVersion;
 
 function addWindowsVariables(devBundleDir, env) {
   // On Windows we provide a reliable version of python.exe for use by
@@ -132,11 +134,11 @@ function addWindowsVariables(devBundleDir, env) {
   // If $GYP_MSVS_VERSION was not provided, use the gyp Python library to
   // infer it, or default to 2015 if that doesn't work.
   return new Promise(function (resolve) {
-    var nodeGypPylibDir = path.join(
+    const nodeGypPylibDir = path.join(
       devBundleDir, "lib", "node_modules", "node-gyp", "gyp", "pylib"
     );
 
-    var child = require("child_process").spawn(env.PYTHON, ["-c", [
+    const child = require("child_process").spawn(env.PYTHON, ["-c", [
       "from gyp.MSVSVersion import SelectVisualStudioVersion",
       "try:",
       "  print SelectVisualStudioVersion(allow_fallback=False).short_name",
@@ -147,7 +149,7 @@ function addWindowsVariables(devBundleDir, env) {
       stdio: "pipe"
     });
 
-    var chunks = [];
+    const chunks = [];
     child.stdout.on("data", function (chunk) {
       chunks.push(chunk);
     });

--- a/tools/cli/dev-bundle.js
+++ b/tools/cli/dev-bundle.js
@@ -5,12 +5,14 @@
 // but that's unavoidable if we don't want to install Babel and load all
 // the rest of the code every time we run `meteor npm` or `meteor node`.
 
-var fs = require("fs");
-var path = require("path");
-var links = require("./dev-bundle-links.js");
-var finder = require("./file-finder.js");
-var rootDir = path.resolve(__dirname, "..", "..");
-var defaultDevBundlePromise =
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const links = require("./dev-bundle-links.js");
+const finder = require("./file-finder.js");
+const rootDir = path.resolve(__dirname, "..", "..");
+const defaultDevBundlePromise =
   Promise.resolve(path.join(rootDir, "dev_bundle"));
 
 function getDevBundleDir() {
@@ -18,24 +20,24 @@ function getDevBundleDir() {
   // checkout, because it's always better to respect the .meteor/release
   // file of the current app, if possible.
 
-  var releaseFile = finder.findReleaseFile();
+  const releaseFile = finder.findReleaseFile();
   if (! releaseFile) {
     return defaultDevBundlePromise;
   }
 
-  var localDir = finder.findLocalDir(releaseFile);
+  const localDir = finder.findLocalDir(releaseFile);
   if (! localDir) {
     return defaultDevBundlePromise;
   }
 
-  var devBundleLink = path.join(localDir, "dev_bundle");
+  const devBundleLink = path.join(localDir, "dev_bundle");
   if (finder.statOrNull(devBundleLink)) {
     return new Promise(function (resolve) {
       resolve(links.readLink(devBundleLink));
     });
   }
 
-  var release = fs.readFileSync(
+  const release = fs.readFileSync(
     releaseFile, "utf8"
   ).replace(/^\s+|\s+$/g, "");
 
@@ -56,31 +58,31 @@ function getDevBundleDir() {
 }
 
 function getDevBundleForRelease(release) {
-  var parts = release.split("@");
+  const parts = release.split("@");
   if (parts.length < 2) {
     return null;
   }
 
-  var track = parts[0];
-  var version = parts.slice(1).join("@");
+  const track = parts[0];
+  const version = parts.slice(1).join("@");
 
-  var packageMetadataDir = finder.findPackageMetadataDir();
+  const packageMetadataDir = finder.findPackageMetadataDir();
   if (! packageMetadataDir) {
     return null;
   }
 
-  var meteorToolDir = finder.findMeteorToolDir(packageMetadataDir);
+  const meteorToolDir = finder.findMeteorToolDir(packageMetadataDir);
   if (! meteorToolDir) {
     return null;
   }
 
-  var dbPath = finder.findDbPath(packageMetadataDir);
+  const dbPath = finder.findDbPath(packageMetadataDir);
   if (! meteorToolDir) {
     return null;
   }
 
-  var sqlite3 = require("sqlite3");
-  var db = new sqlite3.Database(dbPath);
+  const sqlite3 = require("sqlite3");
+  const db = new sqlite3.Database(dbPath);
 
   return new Promise(function (resolve, reject) {
     db.get(
@@ -93,8 +95,8 @@ function getDevBundleForRelease(release) {
 
   }).then(function (data) {
     if (data) {
-      var tool = JSON.parse(data.content).tool;
-      var devBundleDir = path.join(
+      const tool = JSON.parse(data.content).tool;
+      const devBundleDir = path.join(
         meteorToolDir,
         tool.split("@").slice(1).join("@"),
         "mt-" + getHostArch(),

--- a/tools/cli/file-finder.js
+++ b/tools/cli/file-finder.js
@@ -85,6 +85,28 @@ exports.findDbPath = function (packageMetadataDir) {
   return dbPath;
 };
 
+exports.findNodeModulesDotBinDirs = function () {
+  const dirs = [];
+
+  const releaseFile = exports.findReleaseFile();
+  if (! releaseFile) {
+    return dirs;
+  }
+
+  const rootAppDir = path.resolve(releaseFile, "..", "..");
+
+  find(process.cwd(), dir => {
+    const dotBinDir = path.join(dir, "node_modules", ".bin");
+    if (statOrNull(dotBinDir, "isDirectory")) {
+      dirs.push(dotBinDir);
+    }
+
+    return dir === rootAppDir;
+  });
+
+  return dirs;
+};
+
 function statOrNull(path, statMethod) {
   let stat;
 

--- a/tools/cli/file-finder.js
+++ b/tools/cli/file-finder.js
@@ -1,0 +1,137 @@
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const rootDir = path.resolve(__dirname, "..", "..");
+
+exports.findReleaseFile = function () {
+  return find(
+    process.cwd(),
+    makeStatTest("isFile"),
+    ".meteor", "release"
+  );
+};
+
+exports.findLocalDir = function (releaseFile) {
+  if (typeof releaseFile === "undefined") {
+    releaseFile = exports.findReleaseFile();
+  }
+
+  if (! releaseFile) {
+    return null;
+  }
+
+  let localDir = path.join(path.dirname(releaseFile), "local");
+  if (! statOrNull(localDir, "isDirectory")) {
+    try {
+      fs.mkdirSync(localDir);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  return localDir;
+};
+
+exports.findPackageMetadataDir = function () {
+  return find(
+    rootDir,
+    makeStatTest("isDirectory"),
+    ".meteor", "package-metadata"
+  );
+};
+
+exports.findMeteorToolDir = function (packageMetadataDir) {
+  if (typeof packageMetadataDir === "undefined") {
+    packageMetadataDir = exports.findPackageMetadataDir();
+  }
+
+  if (! packageMetadataDir) {
+    return null;
+  }
+
+  const meteorToolDir = path.resolve(
+    packageMetadataDir,
+    "..", "packages", "meteor-tool"
+  );
+
+  const meteorToolStat = statOrNull(meteorToolDir, "isDirectory");
+  if (! meteorToolStat) {
+    return null;
+  }
+
+  return meteorToolDir;
+};
+
+exports.findDbPath = function (packageMetadataDir) {
+  if (typeof packageMetadataDir === "undefined") {
+    packageMetadataDir = exports.findPackageMetadataDir();
+  }
+
+  if (! packageMetadataDir) {
+    return null;
+  }
+
+  const dbPath = path.join(
+    packageMetadataDir,
+    "v2.0.1",
+    "packages.data.db"
+  );
+
+  if (! statOrNull(dbPath, "isFile")) {
+    return null;
+  }
+
+  return dbPath;
+};
+
+function statOrNull(path, statMethod) {
+  let stat;
+
+  try {
+    stat = fs.statSync(path);
+  } catch (e) {
+    if (e.code !== "ENOENT") {
+      throw e;
+    }
+  }
+
+  if (stat) {
+    if (typeof statMethod === "string") {
+      if (stat[statMethod]()) {
+        return stat;
+      }
+    } else {
+      return stat;
+    }
+  }
+
+  return null;
+}
+
+exports.statOrNull = statOrNull;
+
+function find(dir, predicate) {
+  const joinArgs = Array.prototype.slice.call(arguments, 2);
+  joinArgs.unshift(null);
+
+  while (true) {
+    joinArgs[0] = dir;
+    const joined = path.join.apply(path, joinArgs);
+    if (predicate(joined)) {
+      return joined;
+    }
+
+    const parentDir = path.dirname(dir);
+    if (parentDir === dir) break;
+    dir = parentDir;
+  }
+
+  return null;
+}
+
+function makeStatTest(method) {
+  return function (file) {
+    return statOrNull(file, method);
+  };
+}


### PR DESCRIPTION
A very handy new `npm` tool called [`npx`](https://www.npmjs.com/package/npx) is now [shipping](http://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) with `npm@5.2.0`, and it's gotten me thinking about how best to make it available to Meteor developers.

The `npx` command-line tool can be used to run any command that would normally be available to `npm` scripts, so you can (for example) install a tool like `cowsay` in your local `node_modules` directory and then execute it with `npx cowsay ...`:
```sh
% npm install --save-dev cowsay
% npx cowsay meteor
 ________
< meteor >
 --------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

[Meteor 1.6](https://github.com/meteor/meteor/pull/8728) will ship with `npm@5.2.0` (or later), so with the latest beta, `1.6-beta.6`, you can already use `npx` as a `meteor` subcommand:
```sh
meteor npx <command> ...
```
> In case you're not already familiar with subcommands like `meteor node` and `meteor npm`, running `npx` as a `meteor` subcommand conveniently determines the versions of Node and `npm`, and sets various environment variables, according to your Meteor version.

That's some pretty neat new functionality to get for free; however, it only works in Meteor 1.6 at the moment, and Meteor 1.6 is still in beta. So what about Meteor 1.5.x, which uses `npm@4.6.1`?

As I've been reading about `npx`, it occured to me that `meteor <command> ...` serves a very similar purpose to `npx`, and in some sense `meteor node ...` and `meteor npm ...` are just special cases of the same functionality that `npx` provides in the wider `npm` ecosystem.

In other words, there's nothing stopping us from giving `meteor` the power to execute arbitrary subcommands, beyond the ones installed the the `~/.meteor/path/to/release/dev_bundle/bin` directory. This pull request implements that behavior, giving the benefits of `npx <command> ...` with just `meteor <command> ...`:
```sh
% meteor npm install --save-dev cowsay
% meteor cowsay METEOR
 ________
< METEOR >
 --------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

Note that official commands like `meteor run` cannot be overridden, nor can important subcommands like `meteor node` and `meteor npm`. Any other commands you've installed in `node_modules/.bin` are fair game, however.

One advantage that `npx <command>` has over `meteor <command>` is that commands executed by `npx` can always be assumed to be Node scripts written in JavaScript, so `npx` is able to run the command in its own process, rather than spawning a new Node process. That's the trick touted by [this tweet](https://twitter.com/maybekatz/status/877444832494596096). By contrast, `meteor <command>` might refer to an arbitrary executable program, so spawning a new process is important. That said, Meteor [takes care](https://github.com/meteor/meteor/blob/f368ab0e05b67fe22dc00d3d3a5e77af37b6d926/tools/index.js#L9-L10) to avoid loading more of the codebase than necessary (for example, it avoids any Babel compilation) when executing a subcommand, so the overhead of `meteor <command> ...` is also fairly small.

Once Meteor 1.6 is out, I'm honestly not sure if `meteor npx <command> ...` or `meteor <command> ...` will be preferred… or if `meteor <unknown command> ...` will be transformed into `meteor npx <unknown command> ...` behind the scenes. Until then, I hope this PR fills the gap.