### PR TITLE
Enable throttled garbage collection (borrowed from release-1.6).

### DIFF
--- a/meteor
+++ b/meteor
@@ -132,4 +132,7 @@ fi
 # the script take precedence over $NODE_PATH; it used to be that users would
 # screw up their meteor installs by have a ~/node_modules
 
-exec "$DEV_BUNDLE/bin/node" ${TOOL_NODE_FLAGS} "$METEOR" "$@"
+exec "$DEV_BUNDLE/bin/node" \
+     --expose-gc \
+     ${TOOL_NODE_FLAGS} \
+     "$METEOR" "$@"

--- a/tools/utils/gc.js
+++ b/tools/utils/gc.js
@@ -1,12 +1,10 @@
-// For this global function to be defined, the --expose-gc flag must have
-// been passed to node at the bottom of the ../../meteor script, probably
-// via the TOOL_NODE_FLAGS environment variable.
-const gc = global.gc;
+import { throttle } from "underscore";
 
-// In the future, this function may become smarter about how often it
-// actually calls the gc function, but that's an implementation detail.
-export function requestGarbageCollection() {
-  if (typeof gc === "function") {
-    gc();
-  }
-}
+export const requestGarbageCollection =
+  // For this global function to be defined, the --expose-gc flag must
+  // have been passed to node at the bottom of the ../../meteor script,
+  // probably via the TOOL_NODE_FLAGS environment variable.
+  typeof global.gc === "function"
+    // Restrict actual garbage collections to once per 500ms.
+    ? throttle(global.gc, 500)
+    : function () {};


### PR DESCRIPTION
Tests have been [failing](https://circleci.com/gh/meteor/meteor/4536#tests/containers/2) recently on the `master` branch because the `./meteor self-test create` test runs out of memory.

The `release-1.6` branch contains a few commits that successfully limit memory usage by forcing garbage collection periodically (throttled to once every 500ms).

This PR back-ports those commits to `master`, which I hope will fix the failing tests.