### PR TITLE
Fix disabling of token expiration

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
 ## v.NEXT
 
-* `accounts-base` no longer mistakenly expires tokens when the
-  `loginExpirationInDays` option is set to `null`.
+* `Accounts.config` no longer mistakenly allows token to expire when
+  the `loginExpirationInDays` option is set to `null`.
   [Issue #5121](https://github.com/meteor/meteor/issues/5121)
   [PR #8917](https://github.com/meteor/meteor/pull/8917)
 

--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## v.NEXT
 
+* `accounts-base` no longer mistakenly expires tokens when the
+  `loginExpirationInDays` option is set to `null`.
+  [Issue #5121](https://github.com/meteor/meteor/issues/5121)
+  [PR #8917](https://github.com/meteor/meteor/pull/8917)
+
 ## v1.5.1, 2017-07-12
 
 * Node has been upgraded to version 4.8.4.

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -213,8 +213,14 @@ export class AccountsCommon {
     }
   }
 
-  _getTokenLifetimeMs() {
-    return (this._options.loginExpirationInDays ||
+  // The options argument is only used by tests.
+  _getTokenLifetimeMs(options) {
+    options = options || this._options;
+    if (options.loginExpirationInDays === null) {
+      // We disable login expiration by returning Infinity
+      return Infinity;
+    }
+    return (options.loginExpirationInDays ||
             DEFAULT_LOGIN_EXPIRATION_DAYS) * 24 * 60 * 60 * 1000;
   }
 

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -13,6 +13,24 @@ Tinytest.add('accounts - config validates keys', function (test) {
   });
 });
 
+// test the loginExpirationInDays config
+
+Tinytest.add( 'accounts - config - token limetime', function (test) {
+  var config = { loginExpirationInDays: 2 };
+  test.equal(Accounts._getTokenLifetimeMs(config), 2 * 24 * 60 * 60 * 1000);
+});
+
+Tinytest.add( 'accounts - config - unexpiring tokens', function (test) {
+  var config = { loginExpirationInDays: null };
+  test.equal(Accounts._getTokenLifetimeMs(config), Infinity);
+});
+
+Tinytest.add( 'accounts - config - default token limetime', function(test) {
+  var DEFAULT_LOGIN_EXPIRATION_DAYS = 90; // copied from accounts_common.js
+  var config1 = {};
+  var config2 = { loginExpirationInDays: DEFAULT_LOGIN_EXPIRATION_DAYS };
+  test.equal(Accounts._getTokenLifetimeMs(config1), Accounts._getTokenLifetimeMs(config2));
+});
 
 var idsInValidateNewUser = {};
 Accounts.validateNewUser(function (user) {

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "A user account system",
-  version: "1.3.1"
+  version: "1.3.2"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
This pull request fixes #5121.

I also add a test for this fix, and a few other tests for related functionality. These tests didn't already exist because it was difficult to test Accounts configuration as the `Accounts.config` method modified global state.