### PR TITLE
Adjust test-packages --test-app-path to create the directory if missing

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1579,8 +1579,31 @@ function doTestCommand(options) {
   // cleaned up on process exit. Using a temporary app dir means that we can
   // run multiple "test-packages" commands in parallel without them stomping
   // on each other.
-  var testRunnerAppDir =
-        options['test-app-path'] || files.mkdtemp('meteor-test-run');
+  let testRunnerAppDir;
+  const testAppPath = options['test-app-path'];
+  if (testAppPath) {
+    try {
+      if (files.mkdir_p(testAppPath, 0o700)) {
+        testRunnerAppDir = testAppPath;
+      } else {
+        Console.error(
+          'The specified --test-app-path directory could not be used, as ' +
+          `"${testAppPath}" already exists and it is not a directory.`
+        );
+        return 1;
+      }
+    } catch (error) {
+      Console.error(
+        'Unable to create the specified --test-app-path directory of ' +
+        `"${testAppPath}".`
+      );
+      throw error;
+    }
+  }
+
+  if (!testRunnerAppDir) {
+    testRunnerAppDir = files.mkdtemp('meteor-test-run')
+  }
 
   // Download packages for our architecture, and for the deploy server's
   // architecture if we're deploying.
@@ -1611,7 +1634,19 @@ function doTestCommand(options) {
     projectContextOptions.projectDir = testRunnerAppDir;
     projectContextOptions.projectDirForLocalPackages = options.appDir;
 
-    require("./default-npm-deps.js").install(testRunnerAppDir);
+    try {
+      require("./default-npm-deps.js").install(testRunnerAppDir);
+    } catch (error) {
+      if (error.code === 'EACCES' && options['test-app-path']) {
+        Console.error(
+          'The specified --test-app-path directory of ' +
+          `"${testRunnerAppDir}" exists, but the current user does not have ` +
+          `read/write permission in it.`
+        );
+      }
+      throw error;
+    }
+
     if (buildmessage.jobHasMessages()) {
       return;
     }

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1602,7 +1602,7 @@ function doTestCommand(options) {
   }
 
   if (!testRunnerAppDir) {
-    testRunnerAppDir = files.mkdtemp('meteor-test-run')
+    testRunnerAppDir = files.mkdtemp('meteor-test-run');
   }
 
   // Download packages for our architecture, and for the deploy server's

--- a/tools/tests/command-line.js
+++ b/tools/tests/command-line.js
@@ -561,3 +561,75 @@ selftest.define("old cli tests (converted)", function () {
   run.expectExit(0);
   files.unlink(files.pathJoin(s.cwd, 'settings.js'));
 });
+
+// Added to address https://github.com/meteor/meteor/issues/8897.
+selftest.define(
+  'meteor test-packages --test-app-path directory',
+  function () {
+    var s = new Sandbox();
+    var run;
+
+    // If test-app-path doesn't exist, it should be created.
+    var testAppPath = '/tmp/meteor_test_app_path';
+    files.rm_recursive(testAppPath);
+    selftest.expectFalse(files.exists(testAppPath));
+    s.createApp('test-app-path-app', 'package-tests', {
+      dontPrepareApp: true
+    });
+    s.cd('test-app-path-app/packages/say-something', function () {
+      run = s.run(
+        'test-packages',
+        '--once',
+        { 'test-app-path': testAppPath },
+        './'
+      );
+      run.match('Started');
+      selftest.expectTrue(files.exists(testAppPath));
+      run.stop();
+      files.rm_recursive(testAppPath);
+    });
+
+    // If test-app-path already exists, make sure that directory is used.
+    var testAppPath = '/tmp/meteor_test_app_path';
+    files.rm_recursive(testAppPath);
+    files.mkdir_p(testAppPath);
+    selftest.expectTrue(files.exists(testAppPath));
+    selftest.expectFalse(files.exists(testAppPath + '/.meteor'));
+    s.createApp('test-app-path-app', 'package-tests', {
+      dontPrepareApp: true
+    });
+    s.cd('test-app-path-app/packages/say-something', function () {
+      run = s.run(
+        'test-packages',
+        '--once',
+        { 'test-app-path': testAppPath },
+        './'
+      );
+      run.match('Started');
+      selftest.expectTrue(files.exists(testAppPath + '/.meteor'));
+      run.stop();
+      files.rm_recursive(testAppPath);
+    });
+
+    // If test-app-path already exists but is a file instead of a directory,
+    // show a console error message explaining this, and exit.
+    var testAppPath = '/tmp/meteor_test_app_path';
+    files.rm_recursive(testAppPath);
+    files.writeFile(testAppPath, '<3 meteor');
+    selftest.expectTrue(files.exists(testAppPath));
+    s.createApp('test-app-path-app', 'package-tests', {
+      dontPrepareApp: true
+    });
+    s.cd('test-app-path-app/packages/say-something', function () {
+      run = s.run(
+        'test-packages',
+        '--once',
+        { 'test-app-path': testAppPath },
+        './'
+      );
+      run.matchErr('is not a directory');
+      run.expectExit(1);
+      files.rm_recursive(testAppPath);
+    });
+  }
+);


### PR DESCRIPTION
Hi all - this PR is intended to fix https://github.com/meteor/meteor/issues/8897. The `test-packages` command `--test-app-path` parameter expects the specified directory to already exist. If it doesn't, an error is thrown. The changes in this PR create the specified directory if it doesn't already exist (and adds a few extra safeguards, like handling user permission errors, cases where the `test-app-path` already exists as a file instead of a directory, etc.). It also adds `self-test`'s for `--test-app-path` functionality. Thanks!

cc @mitar 