### PR TITLE
Update crosswalk cordova plugin to latest version

### DIFF
--- a/packages/crosswalk/package.js
+++ b/packages/crosswalk/package.js
@@ -6,5 +6,5 @@ instead of the System WebView on Android",
 });
 
 Cordova.depends({
-  'cordova-plugin-crosswalk-webview': '2.2.0'
+  'cordova-plugin-crosswalk-webview': '2.3.0'
 });


### PR DESCRIPTION
Upgrade crosswalk webview cordova plugin to latest (and last) supported version. See https://crosswalk-project.org/blog/crosswalk-final-release.html