### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2011 - 2017 Meteor Development Group, Inc.
+Copyright (c) 2011 - 2017 Petar Korponaić 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,10 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-
-====================================================================
-This license applies to all code in Meteor that is not an externally
-maintained library. Externally maintained libraries have their own
-licenses, included in the LICENSES directory.
-====================================================================


### PR DESCRIPTION
Followed license structure defined: https://en.wikipedia.org/wiki/MIT_License with formatting for copyright holder. Updated license to remove "Meteor Development Group" which had been copied over from Meteor License that was previously used as template, replaced with Petar Korponaic as author.

Format:
Copyright (c) <year> <copyright holders>

