### PR TITLE
Adjust self-test match / timeout settings to help reduce Circle test failures

### DIFF
--- a/tools/tests/colon-converter-tests.js
+++ b/tools/tests/colon-converter-tests.js
@@ -74,7 +74,7 @@ if (process.platform !== "win32") {
       });
 
       var run = s.run("add", packageName);
-      run.matchErr("colons");
+      run.matchErrBeforeExit("colons");
     });
   });
 }

--- a/tools/tests/linter-plugins.js
+++ b/tools/tests/linter-plugins.js
@@ -109,6 +109,7 @@ selftest.define('linter plugins - linting package with `meteor lint`', () => {
   s.cd('myapp/packages/my-package');
 
   const run = s.run('lint');
+  run.waitSecs(10);
 
   const messages = [
     /While linting files .* my-package .*Server/,

--- a/tools/tests/linter-plugins.js
+++ b/tools/tests/linter-plugins.js
@@ -109,7 +109,7 @@ selftest.define('linter plugins - linting package with `meteor lint`', () => {
   s.cd('myapp/packages/my-package');
 
   const run = s.run('lint');
-  run.waitSecs(10);
+  run.waitSecs(15);
 
   const messages = [
     /While linting files .* my-package .*Server/,

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -109,6 +109,7 @@ selftest.define("change packages during hot code push", [], function () {
   run.waitSecs(5);
   run.match("myapp");
   run.match("proxy");
+  run.waitSecs(5);
   run.match("MongoDB");
   run.waitSecs(5);
   run.match("your app");


### PR DESCRIPTION
These changes should help with the recent (common) increase in the number of Circle build failures. With these adjustments I'm now seeing successful builds (with Ubuntu 14.04) in my own Circle environment, and very few failure retries. I'm sure we'll need to tweak further, but these changes should help get the tests working for the pending PR's. Thanks!