### PR TITLE
Add 'meteor list --tree' to show a tree of package dependencies.

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1138,6 +1138,8 @@ main.registerCommand({
   name: 'list',
   requiresApp: true,
   options: {
+    'tree': { type: Boolean },
+    'weak': { type: Boolean },
     'allow-incompatible-update': { type: Boolean }
   },
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: true })
@@ -1152,6 +1154,86 @@ main.registerCommand({
   // No need to display the PackageMapDelta here, since we're about to list all
   // of the packages anyway!
 
+  if (options['tree']) {
+    const showWeak = !!options['weak'];
+    // Load package details of all used packages (inc. dependencies)
+    const packageDetails = new Map;
+    projectContext.packageMap.eachPackage(function (name, info) {
+      packageDetails.set(name, projectContext.projectCatalog.getVersion(name, info.version));
+    });
+
+    // Build a set of top level package names
+    const topLevelSet = new Set;
+    projectContext.projectConstraintsFile.eachConstraint(function (constraint) {
+      topLevelSet.add(constraint.package);
+    });
+
+    // Package that should not be expanded (top level or expanded already)
+    const dontExpand = new Set(topLevelSet.values());
+
+    // Recursive function that outputs each package
+    const printPackage = function (package, isWeak, indent1, indent2) {
+      const packageName = package.packageName;
+      const depsObj = package.dependencies || {};
+      let deps = Object.keys(depsObj).sort();
+      // Ignore references to a meteor version or isobuild marker packages
+      deps = deps.filter(dep => {
+        return dep !== 'meteor' && !compiler.isIsobuildFeaturePackage(dep);
+      });
+
+      if (!showWeak) {
+        // Filter out any weakly referenced dependencies
+        deps = deps.filter(dep => {
+          let references = depsObj[dep].references || [];
+          let weakRef = references.length > 0 && references.every(r => r.weak);
+          return !weakRef;
+        });
+      }
+
+      const expandedAlready = (deps.length > 0 && dontExpand.has(packageName));
+      const shouldExpand = (deps.length > 0 && !expandedAlready && !isWeak);
+      if (indent1 !== '') {
+        indent1 += (shouldExpand ? '┬' : '─') + ' ';
+      }
+
+      let suffix = (isWeak ? '[weak]' : '');
+      if (expandedAlready) {
+        suffix += topLevelSet.has(packageName) ? ' (top level)' : ' (expanded above)';
+      }
+
+      Console.info(indent1 + packageName + '@' + package.version + suffix);
+      if (shouldExpand) {
+        dontExpand.add(packageName);
+        deps.forEach((dep, index) => {
+          const references = depsObj[dep].references || [];
+          const weakRef = references.length > 0 && references.every(r => r.weak);
+          const last = ((index + 1) === deps.length);
+          const child = packageDetails.get(dep);
+          const newIndent1 = indent2 + (last ? '└─' : '├─');
+          const newIndent2 = indent2 + (last ? '  ' : '│ ');
+          if (child) {
+            printPackage(child, weakRef, newIndent1, newIndent2);
+          } else if (weakRef) {
+            Console.info(newIndent1 + '─ ' + dep + '[weak] package skipped');
+          } else {
+            Console.info(newIndent1 + '─ ' + dep + ' missing?');
+          }
+        });
+      }
+    };
+
+    const topLevelNames = Array.from(topLevelSet.values()).sort();
+    topLevelNames.forEach((dep, index) => {
+      const package = packageDetails.get(dep);
+      if (package) {
+        // Force top level packages to be expanded
+        dontExpand.delete(package.packageName);
+        printPackage(package, false, '', '');
+      }
+    });
+
+    return 0;
+  }
 
   var items = [];
   var newVersionsAvailable = false;

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -248,9 +248,14 @@ Options:
 >>> list
 List the packages explicitly used by your project.
 Usage: meteor list
+       meteor list --tree [--weak]
 
 Lists the packages that you have explicitly added to your project.
-This will not list transitive dependencies.
+Transitive dependencies are not listed unless you use the --tree option,
+which outputs a tree showing how packages are referenced.
+
+Options:
+  --weak           Show weakly referenced dependencies in the tree.
 
 >>> add-platform
 Add a platform to this project.


### PR DESCRIPTION
Add 'meteor list --tree' to show a tree of package dependencies.
There's also a --weak command line option which when specified shows weak dependencies.

See feature request: https://github.com/meteor/meteor-feature-requests/issues/143

With the basic `meteor list --tree` it gives output very much like `npm list` (example below).

At the top level are the constraints from the .meteor/packages, and then for each of those it outputs the (strong) dependencies of each, expanding recursively.
Subsequent references of a package do not get expanded again. This avoids infinite recursion and an excessive amount of repetitive output.
Weak references can be show by also specifying the `--weak` option, but this never follows weak references. As any weakly referenced package which is present must also have a strong reference - so it gets expanded at the first strong reference.
Top level references are only every expanded at the top level rather than on first encounter, which I think makes the output more sensible.

Note that the version included in each line is version selected NOT the constraint. When expanding one level down the constraint would be better, but when you have cross references, and deeper nesting it seemed better to display the actual version selected by the constraint solver.

Here's a truncated example with --weak specified:
```
accounts-base@1.3.2                           
├── autopublish[weak] package skipped         
├── blaze[weak] package skipped               
├─┬ callback-hook@1.0.10                      
│ └── underscore@1.0.10                       
├─┬ check@1.2.5                               
│ ├─┬ ejson@1.0.13                            
│ │ ├── base64@1.0.10                         
│ │ └── underscore@1.0.10                     
│ ├─┬ modules@0.9.2                           
│ │ └── modules-runtime@0.8.0                 
│ └── underscore@1.0.10                       
├─┬ ddp@1.3.0                                 
│ ├─┬ ddp-client@2.0.0                        
│ │ ├── check@1.2.5 (expanded above)          
│ │ ├─┬ ddp-common@1.2.9                      
│ │ │ ├── check@1.2.5 (expanded above)        
│ │ │ ├── ejson@1.0.13 (expanded above)       
│ │ │ ├─┬ random@1.0.10                       
│ │ │ │ ├── ecmascript@0.8.2 (top level)      
│ │ │ │ └── underscore@1.0.10  
 ...
```

Thoughts for improvements:
Personally, the output with package names, versions and suffix text (e.g. 'expanded above') feels a bit cluttered. So I'm open to suggestions for making it easier to read.  I did consider color or some other console highlighting but the `Console` class would probably need extending.
I also considered removing the versions, but you can't see them for indirectly referenced packages without delving into `.meteor/versions`, and if you want to dig deeper with a `meteor show xxx` you ideally want to specify the version.
Instead of 'expanded above' and 'top level' we could use unicode arrows or and asterisk etc., but we'd probably need to add a note at the bottom to explain otherwise people will get confused. Similarly, '[weak]' could be a ? or something, but in both cases I figured being explicit was better.

Finally, unlike the regular `meteor list`, I didn't add the plugin packages from `projectContext.cordovaPluginsFile` because I wasn't sure what they were for or how to test - are they included in the solver's answer set?
Rather than adding them to the root set, it may be best to note any packages in the 'answer' that weren't visited by walking down from the root, and just visit those explicitly at the end.

Oh, finally-finally, I used the new meteor coding style and Set/Map rather than sticking to the style of the surrounding file as it seemed separate enough, and Set/Map/Array.[map|filter|sort|every] seemed a better choice than underscore equivalents.