### PR TITLE
.meteorignore specifies intentionally untracked files and directories…

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -56,6 +56,7 @@ var packageJson = {
     optimism: "0.3.3",
     'lru-cache': '4.0.1',
     'cordova-lib': "6.4.0",
+    ignore: "3.3.3",
     longjohn: '0.2.11'
   }
 };


### PR DESCRIPTION
https://github.com/meteor/meteor/pull/8921
- use of `ignore` module instead of `glob-to-regexp`.
- be located before `files.js` `include`, `exclude` regexp filter instead of using it.
- allow multiple `.meteorignore` files in different directories, each governing the files contained by its own directory tree.
- use cache to faster load, but the cache should check updated time of `.meteorignore` to support live-update in production environment. (to be updated) 