### PR TITLE
Avoid adjusting line counts when removing source map comments.

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2540,7 +2540,7 @@ function addSourceMappingURL(data, url) {
     // If data is a Buffer, convert it to a string.
     .toString("utf8")
     // Remove any existing source map comments.
-    .replace(/\n\/\/# sourceMappingURL=[^\n]+/g, "");
+    .replace(/\n\/\/# sourceMappingURL=[^\n]+/g, '\n');
   // Append the new source map comment to the end of the code.
   return dataString + "\n//# sourceMappingURL=" + url + "\n";
 }


### PR DESCRIPTION
Fixes #8927 

The problem was introduced in 1.5-beta.3 and results in source maps being out by one line for each file containing source maps (e.g. produced by Typescript compiler).

The change keeps the line rather than removing it, but unlike the original change (before 1.5-beta.3) it doesn't add add the slash slash comment (//) as I can't see where that would be needed (other than in a multi-line back tick string - but that case is broken anyway).

It does retain tying the match to the start of a line (introduced in 1.5-beta.3), though I did consider whether the expression would be simpler using multi-line mode:  `/^\/\/# sourceMappingURL=.+/gm`