### PR TITLE
Adjust the previous watcher check to handle moved files

### DIFF
--- a/tools/fs/safe-watcher.js
+++ b/tools/fs/safe-watcher.js
@@ -78,7 +78,10 @@ function startNewWatcher(absPath) {
   const stat = statOrNull(absPath);
   const ino = stat && stat.ino;
   if (ino > 0 && entriesByIno.has(ino)) {
-    return entriesByIno.get(ino);
+    const entry = entriesByIno.get(ino);
+    if (entries[absPath] === entry) {
+      return entry;
+    }
   }
 
   function safeUnwatch() {


### PR DESCRIPTION
Hi all - this PR fixes issue #8942. If the following scenario happens in an app

1. `test1.html` is created.
2. `test1.html` is copied to `test2.html`.
2. `test2.html` is moved/renamed to `test3.html`.

further changes made to `test3.html` will not be picked up by the Meteor Tool, as there is no file watcher created to watch for `test3.html` changes. The reason for this is:

- When `test1.html` is copied into `test2.html`, a new watcher is created and stored in [`entriesByIno`](https://github.com/meteor/meteor/blob/devel/tools/fs/safe-watcher.js#L235) with the inode of `test2.html` serving as the key.
- When `test2.html` is moved/renamed to `test3.html`, the `entriesByIno` Map is first checked ([here](https://github.com/meteor/meteor/blob/devel/tools/fs/safe-watcher.js#L80)) to see if an `entry` exists with the same inode. Since renaming `test2.html` to `test3.html` keeps the same inode, an existing `entry` is found and returned.
- The problem is that the `entry` that is returned represents a file watcher for `test2.html` (which no longer exists) instead of `test3.html`, which means the returned file watcher is watching the wrong path for changes.

When checking the `entriesByIno` Map to see if an `entry` already exists for the specified inode, I've added an extra check to make sure the found `entry` is only re-used if the current file watcher path matches the returned path. So when checking to see if `test3.html` already has an `entry` in `entriesByIno`, when the `test2.html` `entry` is found (since it matches the inode check), the `test2.html` `entry` will not have a matching `*/test3.html` path, so the `test2.html` file watcher will not be re-used (and a new one will be created for `*/test3.html`).
