### PR TITLE
Update to MongoDB  v3.2.15

### DIFF
--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -5,7 +5,7 @@ set -u
 
 UNAME=$(uname)
 ARCH=$(uname -m)
-MONGO_VERSION=3.2.12
+MONGO_VERSION=3.2.15
 NODE_VERSION=4.8.4
 NPM_VERSION=4.6.1
 


### PR DESCRIPTION
This is a re-open of @skirunman's #8911 which wasn't on a branch and thus I wasn't unable to make changes to the PR at all (to build a dev bundle).

---

Install latest version of MongoDB 3.2.x by default.