### PR TITLE
Increase "modules - test app" self-test wait time to fix Circle

### DIFF
--- a/tools/tests/modules.js
+++ b/tools/tests/modules.js
@@ -24,7 +24,7 @@ selftest.define("modules - test app", function () {
       "--driver-package", "dispatch:mocha-phantomjs"
     );
 
-    run.waitSecs(60);
+    run.waitSecs(120);
     run.match("App running at");
     run.match("SERVER FAILURES: 0");
     run.match("CLIENT FAILURES: 0");

--- a/tools/tests/modules.js
+++ b/tools/tests/modules.js
@@ -24,7 +24,7 @@ selftest.define("modules - test app", function () {
       "--driver-package", "dispatch:mocha-phantomjs"
     );
 
-    run.waitSecs(120);
+    run.waitSecs(180);
     run.match("App running at");
     run.match("SERVER FAILURES: 0");
     run.match("CLIENT FAILURES: 0");


### PR DESCRIPTION
Circle builds on `devel` are currently failing (and have now many times in a row) because of `modules - test app` self-test failures (outside of the segfaults):

```
modules: modules - test app ... 
  ... fail!
  ... retrying (2 tries remaining) ...
  ... fail!
  ... retrying (1 try remaining) ...
  ... fail!
  => match-timeout at ../../../tools/tests/modules.js:28
  => Pattern: App running at
  => Last 100 lines:
  2| => Running Meteor from a checkout -- overrides project version (Meteor 1.5.1)
```

I SSH'd into Circle and ran some direct tests, incrementally increasing the `modules - test app` wait time until it passed. 120 seconds seems to work well, so I've added that here. Thanks!