### PR TITLE
Cut of regex flags in ejson parser to avoid abuse

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -105,8 +105,11 @@ var builtinConverters = [
       return { $regexp: regexp.source, $flags: regexp.flags };
     },
     fromJSONValue: function (obj) {
-      //replaces duplicate / invalid flags
-      return new RegExp(obj.$regexp, obj.$flags.replace(/[^gimuy]/g,'').replace(/(.)(?=.*\1)/g, ''));
+      // replaces duplicate / invalid flags
+      // cut of flags to 50 chars to avoid abusing regex for DOS
+      return new RegExp(obj.$regexp, obj.$flags.substr(0, 50)
+                                               .replace(/[^gimuy]/g,'')
+                                               .replace(/(.)(?=.*\1)/g, ''));
     }
   },
   { // NaN, Inf, -Inf. (These are the only objects with typeof !== 'object'


### PR DESCRIPTION
Little follow-up PR for https://github.com/meteor/meteor/pull/8821 to avoid the potential DOS-abuse spotted by @abernix https://github.com/meteor/meteor/commit/5e2aa5c6590431e19cabdc33ad312dcfd28f1835#commitcomment-23313310
