### PR TITLE
Adjust minimongo behavior to match server when functions are in selectors

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -161,6 +161,14 @@ Tinytest.add("minimongo - basics", function (test) {
   test.equal(c.find({foo: {bam: 'baz'}}).count(), 0);
   test.equal(c.find({foo: {bar: 'baz'}}).count(), 1);
 
+  // Regression test for #5301
+  c.remove({});
+  c.insert({ a: 'a', b: 'b' });
+  const noop = () => null;
+  test.equal(c.find({ a: noop }).count(), 1);
+  test.equal(c.find({ a: 'a', b: noop }).count(), 1);
+  test.equal(c.find({ c: noop }).count(), 1);
+  test.equal(c.find({ a: noop, c: 'c' }).count(), 0);
 });
 
 Tinytest.add("minimongo - error - no options", function (test) {

--- a/packages/minimongo/selector.js
+++ b/packages/minimongo/selector.js
@@ -142,10 +142,15 @@ var compileDocumentSelector = function (docSelector, matcher, options) {
       var lookUpByIndex = makeLookupFunction(key);
       var valueMatcher =
         compileValueSelector(subSelector, matcher, options.isRoot);
-      docMatchers.push(function (doc) {
-        var branchValues = lookUpByIndex(doc);
-        return valueMatcher(branchValues);
-      });
+      // Don't add a matcher if subSelector is a function -- this is to match
+      // the behavior of Meteor on the server (inherited from the node mongodb
+      // driver), which is to ignore any part of a selector which is a function.
+      if (typeof subSelector !== 'function') {
+        docMatchers.push(function (doc) {
+          var branchValues = lookUpByIndex(doc);
+          return valueMatcher(branchValues);
+        });
+      }
     }
   });
 


### PR DESCRIPTION
Fixes #5301 

Currently when functions are (mistakenly?) passed as a part of a selector object in a minimongo query on the client, no results are matched.

However, the same query on the server ignores any part of the selector object which is a function and returns whatever matches the other parts of the selector. This behavior seems to come from the node mongodb driver.

As discussed in #5301, even though the client behavior might be more logical, the proposed solution is to change it to match the server for consistency.

I explored some of the relative behaviors on the server and client when functions are passed in this [repro](https://github.com/jamesmillerburgess/meteor-issue-5301), but I didn't find anything else. I certainly didn't explore every possible way functions could be passed, so I might have missed something.