### PR TITLE
Make minified code run on older WebKit platforms

### DIFF
--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -12,6 +12,7 @@ meteorJsMinify = function (source) {
         drop_debugger: false,
         unused: false,
         dead_code: false,
+        collapse_vars: false,
         global_defs: {
           "process.env.NODE_ENV": NODE_ENV
         }


### PR DESCRIPTION
Resolves #8928

Minifying sockjs.js without this flag results in all Meteor apps being broken on older platforms such as iPad 1G. There's a thorough investigation report within the link to the corresponding issue that I had to do to find out the reason for my apps being unusable on certain devices after being bundled.

This is a very important bug fix, please do not close it without reading the issue that I've provided as a reference.
