### PR TITLE
`meteor deploy` cleanup and partial modernization

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1310,8 +1310,7 @@ main.registerCommand({
       "Setting passwords on apps is no longer supported. Now there are " +
         "user accounts and your apps are associated with your account so " +
         "that only you (and people you designate) can access them. See the " +
-        Console.command("'meteor claim'") + " and " +
-        Console.command("'meteor authorized'") + " commands.");
+        Console.command("'meteor authorized'") + " command.");
     return 1;
   }
 
@@ -1436,33 +1435,6 @@ main.registerCommand({
   } else {
     return deploy.listAuthorized(site);
   }
-});
-
-///////////////////////////////////////////////////////////////////////////////
-// claim
-///////////////////////////////////////////////////////////////////////////////
-
-main.registerCommand({
-  name: 'claim',
-  minArgs: 1,
-  maxArgs: 1,
-  catalogRefresh: new catalog.Refresh.Never()
-}, function (options) {
-  auth.pollForRegistrationCompletion();
-  var site = qualifySitename(options.args[0]);
-
-  if (! auth.isLoggedIn()) {
-    Console.error(
-      "You must be logged in to claim sites. Use " +
-      Console.command("'meteor login'") + " to log in. If you don't have a " +
-      "Meteor developer account yet, create one by clicking " +
-      Console.command("'Sign in'") + " and then " +
-      Console.command("'Create account'") + " at www.meteor.com.");
-    Console.error();
-    return 1;
-  }
-
-  return deploy.claim(site);
 });
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -506,16 +506,6 @@ Options:
   --list        list authorized users and organizations (the default)
 
 
->>> claim
-Claim a site deployed with an old Meteor version.
-Usage: meteor claim <site>
-
-If you deployed a site with an old version of Meteor that did not have
-support for developer accounts, you can use this command to claim that
-site into your account. If you had set a password on the site you will
-be prompted for it one last time.
-
-
 >>> login
 Log in to your Meteor developer account.
 Usage: meteor login [--email]

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -205,36 +205,6 @@ var authedRpc = function (options) {
     return preflight ? { } : deployRpc(rpcOptions);
   }
 
-  if (info.protection === "password") {
-    if (preflight) {
-      return { protection: info.protection };
-    }
-    // Password protected. Read a password, hash it, and include the
-    // hashed password as a query parameter when doing the RPC.
-    var password;
-    password = Console.readLine({
-      echo: false,
-      prompt: "Password: ",
-      stream: process.stderr
-    });
-
-    // Hash the password so we never send plaintext over the
-    // wire. Doesn't actually make us more secure, but it means we
-    // won't leak a user's password, which they might use on other
-    // sites too.
-    var crypto = require('crypto');
-    var hash = crypto.createHash('sha1');
-    hash.update('S3krit Salt!');
-    hash.update(password);
-    password = hash.digest('hex');
-
-    rpcOptions = _.clone(rpcOptions);
-    rpcOptions.qs = _.clone(rpcOptions.qs || {});
-    rpcOptions.qs.password = password;
-
-    return deployRpc(rpcOptions);
-  }
-
   if (info.protection === "account") {
     if (! _.has(info, 'authorized')) {
       // Absence of this implies that we are not an authorized user on
@@ -399,12 +369,7 @@ var bundleAndDeploy = function (options) {
     return 1;
   }
 
-  if (preflight.protection === "password") {
-    printLegacyPasswordMessage(site);
-    Console.error("If it's not your site, please try a different name!");
-    return 1;
-
-  } else if (preflight.protection === "account" &&
+  if (preflight.protection === "account" &&
              ! preflight.authorized) {
     printUnauthorizedMessage();
     return 1;
@@ -547,10 +512,7 @@ var checkAuthThenSendRpc = function (site, operation, what) {
     return null;
   }
 
-  if (preflight.protection === "password") {
-    printLegacyPasswordMessage(site);
-    return null;
-  } else if (preflight.protection === "account" &&
+  if (preflight.protection === "account" &&
              ! preflight.authorized) {
     if (! auth.isLoggedIn()) {
       // Maybe the user is authorized for this app but not logged in
@@ -656,11 +618,6 @@ var listAuthorized = function (site) {
 
   if (! _.has(info, 'protection')) {
     Console.info("<anyone>");
-    return 0;
-  }
-
-  if (info.protection === "password") {
-    Console.info("<password>");
     return 0;
   }
 

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -19,7 +19,7 @@ import {
   isLoggedIn,
   maybePrintRegistrationLink,
 } from './auth.js';
-import _ from 'underscore';
+import { clone } from 'underscore';
 import { recordPackages } from './stats.js';
 import { Console } from '../console/console.js';
 
@@ -71,8 +71,8 @@ const CAPABILITIES = ['showDeployMessages', 'canTransferAuthorization'];
 //   body, or a generic 'try again later' message, as appropriate
 
 function deployRpc(options) {
-  options = _.clone(options);
-  options.headers = _.clone(options.headers || {});
+  options = clone(options);
+  options.headers = clone(options.headers || {});
   if (options.headers.cookie) {
     throw new Error("sorry, can't combine cookie headers yet");
   }
@@ -165,7 +165,7 @@ function deployRpc(options) {
 //   the user to log in with a username and password and then resend the
 //   RPC.
 function authedRpc(options) {
-  var rpcOptions = _.clone(options);
+  var rpcOptions = clone(options);
   var preflight = rpcOptions.preflight;
   delete rpcOptions.preflight;
 

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -13,6 +13,8 @@ var _ = require('underscore');
 var stats = require('./stats.js');
 var Console = require('../console/console.js').Console;
 
+const hasOwn = Object.prototype.hasOwnProperty;
+
 const CAPABILITIES = ['showDeployMessages', 'canTransferAuthorization'];
 
 // Make a synchronous RPC to the "classic" MDG deploy API. The deploy
@@ -119,11 +121,11 @@ function deployRpc(options) {
 
   var hasAllExpectedKeys = _.all(_.map(
     options.expectPayload || [], function (key) {
-      return ret.payload && _.has(ret.payload, key);
+      return ret.payload && hasOwn.call(ret.payload, key);
     }));
 
-  if ((options.expectPayload && ! _.has(ret, 'payload')) ||
-      (options.expectMessage && ! _.has(ret, 'message')) ||
+  if ((options.expectPayload && ! hasOwn.call(ret, 'payload')) ||
+      (options.expectMessage && ! hasOwn.call(ret, 'message')) ||
       ! hasAllExpectedKeys) {
     delete ret.payload;
     delete ret.message;
@@ -198,7 +200,7 @@ function authedRpc(options) {
   }
   var info = infoResult.payload;
 
-  if (! _.has(info, 'protection')) {
+  if (! hasOwn.call(info, 'protection')) {
     // Not protected.
     //
     // XXX should prompt the user to claim the app (only if deploying?)
@@ -206,7 +208,7 @@ function authedRpc(options) {
   }
 
   if (info.protection === "account") {
-    if (! _.has(info, 'authorized')) {
+    if (! hasOwn.call(info, 'authorized')) {
       // Absence of this implies that we are not an authorized user on
       // this app
       if (preflight) {
@@ -601,13 +603,13 @@ export function listAuthorized(site) {
   }
   var info = result.payload;
 
-  if (! _.has(info, 'protection')) {
+  if (! hasOwn.call(info, 'protection')) {
     Console.info("<anyone>");
     return 0;
   }
 
   if (info.protection === "account") {
-    if (! _.has(info, 'authorized')) {
+    if (! hasOwn.call(info, 'authorized')) {
       Console.error("Couldn't get authorized users list: " +
                     "You are not authorized");
       return 1;
@@ -754,7 +756,7 @@ async function discoverGalaxy(site, scheme) {
     throw new Error(
       "unexpected galaxyDiscoveryVersion: " + body.galaxyDiscoveryVersion);
   }
-  if (!_.has(body, "deployURL")) {
+  if (! hasOwn.call(body, "deployURL")) {
     throw new Error("no deployURL");
   }
   return body.deployURL;

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -19,7 +19,6 @@ import {
   isLoggedIn,
   maybePrintRegistrationLink,
 } from './auth.js';
-import { clone } from 'underscore';
 import { recordPackages } from './stats.js';
 import { Console } from '../console/console.js';
 
@@ -71,8 +70,8 @@ const CAPABILITIES = ['showDeployMessages', 'canTransferAuthorization'];
 //   body, or a generic 'try again later' message, as appropriate
 
 function deployRpc(options) {
-  options = clone(options);
-  options.headers = clone(options.headers || {});
+  options = Object.assign({}, options);
+  options.headers = Object.assign({}, options.headers || {});
   if (options.headers.cookie) {
     throw new Error("sorry, can't combine cookie headers yet");
   }
@@ -165,7 +164,7 @@ function deployRpc(options) {
 //   the user to log in with a username and password and then resend the
 //   RPC.
 function authedRpc(options) {
-  var rpcOptions = clone(options);
+  var rpcOptions = Object.assign({}, options);
   var preflight = rpcOptions.preflight;
   delete rpcOptions.preflight;
 

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -58,7 +58,7 @@ const CAPABILITIES = ['showDeployMessages', 'canTransferAuthorization'];
 //   derived from either a transport-level exception, the response
 //   body, or a generic 'try again later' message, as appropriate
 
-var deployRpc = function (options) {
+function deployRpc(options) {
   options = _.clone(options);
   options.headers = _.clone(options.headers || {});
   if (options.headers.cookie) {
@@ -152,7 +152,7 @@ var deployRpc = function (options) {
 //   accounts server but our authentication actually fails, then prompt
 //   the user to log in with a username and password and then resend the
 //   RPC.
-var authedRpc = function (options) {
+function authedRpc(options) {
   var rpcOptions = _.clone(options);
   var preflight = rpcOptions.preflight;
   delete rpcOptions.preflight;
@@ -243,7 +243,7 @@ var authedRpc = function (options) {
 // When the user is trying to do something with an app that they are not
 // authorized for, instruct them to get added via 'meteor authorized
 // --add' or switch accounts.
-var printUnauthorizedMessage = function () {
+function printUnauthorizedMessage() {
   var username = auth.loggedInUsername();
   Console.error("Sorry, that site belongs to a different user.");
   if (username) {
@@ -261,7 +261,7 @@ var printUnauthorizedMessage = function () {
 // syntactically good, canonicalize it (this essentially means
 // stripping 'http://' or a trailing '/' if present) and return it. If
 // not, print an error message to stderr and return null.
-var canonicalizeSite = function (site) {
+function canonicalizeSite(site) {
   // There are actually two different bugs here. One is that the meteor deploy
   // server does not support apps whose total site length is greater than 63
   // (because of how it generates Mongo database names); that can be fixed on
@@ -314,7 +314,7 @@ var canonicalizeSite = function (site) {
 //   stats server.
 // - buildOptions: the 'buildOptions' argument to the bundler
 // - rawOptions: any unknown options that were passed to the command line tool
-var bundleAndDeploy = function (options) {
+export function bundleAndDeploy(options) {
   if (options.recordPackageUsage === undefined) {
     options.recordPackageUsage = true;
   }
@@ -452,7 +452,7 @@ var bundleAndDeploy = function (options) {
   return 0;
 };
 
-var deleteApp = function (site) {
+export function deleteApp(site) {
   site = canonicalizeSite(site);
   if (! site) {
     return 1;
@@ -483,7 +483,7 @@ var deleteApp = function (site) {
 // messages.  Returns the result of the RPC if successful, or null
 // otherwise (including if auth failed or if the user is not authorized
 // for this site).
-var checkAuthThenSendRpc = function (site, operation, what) {
+function checkAuthThenSendRpc(site, operation, what) {
   var preflight = authedRpc({
     operation: operation,
     site: site,
@@ -550,7 +550,7 @@ var checkAuthThenSendRpc = function (site, operation, what) {
 // On failure, prints a message to stderr and returns null. Otherwise,
 // returns a temporary authenticated Mongo URL allowing access to this
 // site's database.
-var temporaryMongoUrl = function (site) {
+export function temporaryMongoUrl(site) {
   site = canonicalizeSite(site);
   if (! site) {
     // canonicalizeSite printed an error
@@ -566,7 +566,7 @@ var temporaryMongoUrl = function (site) {
   }
 };
 
-var logs = function (site) {
+export function logs(site) {
   site = canonicalizeSite(site);
   if (! site) {
     return 1;
@@ -583,7 +583,7 @@ var logs = function (site) {
   }
 };
 
-var listAuthorized = function (site) {
+export function listAuthorized(site) {
   site = canonicalizeSite(site);
   if (! site) {
     return 1;
@@ -627,7 +627,7 @@ var listAuthorized = function (site) {
 };
 
 // action is "add", "transfer" or "remove"
-var changeAuthorized = function (site, action, username) {
+export function changeAuthorized(site, action, username) {
   site = canonicalizeSite(site);
   if (! site) {
     // canonicalizeSite will have already printed an error
@@ -657,7 +657,7 @@ var changeAuthorized = function (site, action, username) {
   return 0;
 };
 
-var listSites = function () {
+export function listSites() {
   var result = deployRpc({
     method: "GET",
     operation: "authorized-apps",
@@ -759,11 +759,3 @@ async function discoverGalaxy(site, scheme) {
   }
   return body.deployURL;
 }
-
-exports.bundleAndDeploy = bundleAndDeploy;
-exports.deleteApp = deleteApp;
-exports.temporaryMongoUrl = temporaryMongoUrl;
-exports.logs = logs;
-exports.listAuthorized = listAuthorized;
-exports.changeAuthorized = changeAuthorized;
-exports.listSites = listSites;

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -129,10 +129,10 @@ function deployRpc(options) {
     ret.message = body;
   }
 
-  var hasAllExpectedKeys = _.all(_.map(
-    options.expectPayload || [], function (key) {
-      return ret.payload && hasOwn.call(ret.payload, key);
-    }));
+  const hasAllExpectedKeys =
+    (options.expectPayload || [])
+      .map(key => ret.payload && hasOwn.call(ret.payload, key))
+      .every(x => x);
 
   if ((options.expectPayload && ! hasOwn.call(ret, 'payload')) ||
       (options.expectMessage && ! hasOwn.call(ret, 'message')) ||
@@ -626,7 +626,7 @@ export function listAuthorized(site) {
     }
 
     Console.info((loggedInUsername() || "<you>"));
-    _.each(info.authorized, function (username) {
+    info.authorized.forEach(username => {
       if (username) {
         // Current username rules don't let you register anything that we might
         // want to split over multiple lines (ex: containing a space), but we
@@ -687,10 +687,9 @@ export function listSites() {
       ! result.payload.sites.length) {
     Console.info("You don't have any sites yet.");
   } else {
-    result.payload.sites.sort();
-    _.each(result.payload.sites, function (site) {
-      Console.info(site);
-    });
+    result.payload.sites
+      .sort()
+      .forEach(site => Console.info(site));
   }
   return 0;
 };

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -66,7 +66,7 @@ function deployRpc(options) {
   if (options.headers.cookie) {
     throw new Error("sorry, can't combine cookie headers yet");
   }
-  options.qs = _.extend({}, options.qs, {capabilities: CAPABILITIES});
+  options.qs = Object.assign({}, options.qs, {capabilities: CAPABILITIES});
 
   const deployURLBase = getDeployURL(options.site).await();
 
@@ -410,7 +410,7 @@ export function bundleAndDeploy(options) {
       method: 'POST',
       operation: 'deploy',
       site: site,
-      qs: _.extend({}, options.rawOptions, settings !== null ? {settings: settings} : {}),
+      qs: Object.assign({}, options.rawOptions, settings !== null ? {settings: settings} : {}),
       bodyStream: files.createTarGzStream(files.pathJoin(buildDir, 'bundle')),
       expectPayload: ['url'],
       preflightPassword: preflight.preflightPassword,


### PR DESCRIPTION
In the course of looking at another issue I:

* Removed `meteor claim` which is no longer a supported command.
* Removed checks for `protection` of type `password` which @glasser confirmed (verbally) was no longer supported by the Galaxy API.
* Updates to newer ECMAScript language `import` and `export`s.
* ~_Mostly_ r~Removes `underscore` in lieu of native ECMAScript

May be be best reviewed commit by commit and I recommend **not**-squashing for posterity.