### PR TITLE
Include the Node.js and npm version in the `star.json` manifest.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,12 @@
 ## v.NEXT
 
+* The `star.json` manifest created within the root of a `meteor build` bundle
+  will now contain `nodeVersion` and `npmVersion` which will specify the exact
+  versions of Node.js and npm (respectively) which the Meteor release was
+  bundled with.  The `.node_version.txt` file will still be written into the
+  root of the bundle, but it may be deprecated in a future version of Meteor.
+  [PR #8956](https://github.com/meteor/meteor/pull/8956)
+
 * A new package called `mongo-dev-server` has been created and wired into
   `mongo` as a dependency. As long as this package is included in a Meteor
   application (which it is by default since all new Meteor apps have `mongo`

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2628,7 +2628,9 @@ var writeSiteArchive = Profile("bundler writeSiteArchive", function (
       format: "site-archive-pre1",
       builtBy,
       programs: [],
-      meteorRelease: releaseName
+      meteorRelease: releaseName,
+      nodeVersion: process.versions.node,
+      npmVersion: meteorNpm.npmVersion,
     };
     var nodePath = [];
 

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -14,6 +14,7 @@ var buildmessage = require('../utils/buildmessage.js');
 var utils = require('../utils/utils.js');
 var runLog = require('../runners/run-log.js');
 var Profile = require('../tool-env/profile.js').Profile;
+import { version as npmVersion } from 'npm';
 import { execFileAsync } from "../utils/processes.js";
 import {
   get as getRebuildArgs
@@ -32,6 +33,9 @@ import {
 } from "../fs/optimistic.js";
 
 var meteorNpm = exports;
+
+// Expose the version of npm in use from the dev bundle.
+meteorNpm.npmVersion = npmVersion;
 
 // if a user exits meteor while we're trying to create a .npm
 // directory, we will have temporary directories that we clean up


### PR DESCRIPTION
This makes it possible to know exactly which version of Node.js and npm were used by the `meteor` tool which the bundle was built from by making new values available alongside the existing `meteorRelease` value in `star.json`: `nodeVersion` and `npmVersion`.  The version of the `star.json` has remained the same since this is only adding new properties, not removing any existing.  This preserves the existing `.node_version.txt` for compatibility reasons, but it's reasonable to believe that may be deprecated in a future version.

Those using `.node_version.txt` should consider using the `nodeVersion` value in `star.json`, though it should be noted that it does not include the `v`(ersion) prefix as the `.node_version.txt` file did.