### PR TITLE
support env in babelrc

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -300,6 +300,16 @@ BCp._inferHelper = function (
   merge(babelOptions, babelrc, "presets");
   merge(babelOptions, babelrc, "plugins");
 
+  const babelEnv = (process.env.BABEL_ENV ||
+                    process.env_NODE_ENV ||
+                    "development");
+  if (babelrc && babelrc.env && babelrc.env[babelEnv]) {
+    const env = babelrc.env[babelEnv];
+    walkBabelRC(env);
+    merge(babelOptions, env, "presets");
+    merge(babelOptions, env, "plugins");
+  }
+
   return !! (babelrc.presets ||
              babelrc.plugins);
 };

--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -301,7 +301,7 @@ BCp._inferHelper = function (
   merge(babelOptions, babelrc, "plugins");
 
   const babelEnv = (process.env.BABEL_ENV ||
-                    process.env_NODE_ENV ||
+                    process.env.NODE_ENV ||
                     "development");
   if (babelrc && babelrc.env && babelrc.env[babelEnv]) {
     const env = babelrc.env[babelEnv];

--- a/tools/tests/apps/modules/.babelrc
+++ b/tools/tests/apps/modules/.babelrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "development": {
+      "plugins": ["transform-do-expressions"]
+    }
+  }
+}

--- a/tools/tests/apps/modules/babel-env.js
+++ b/tools/tests/apps/modules/babel-env.js
@@ -1,0 +1,18 @@
+function babeltest() {
+  // use transform-do-expressions plugin to prove babel `env` subkey was loaded
+  let x = do {
+      1;
+  };
+  console.log(x)
+}
+
+/*
+  If the plugin is loaded correctly there will be no errors during the compilation of this file.
+  Without this plugin you will get the error:
+
+  W20170803-17:58:17.054(-7)? (STDERR)   var x = do {
+   W20170803-17:58:17.055(-7)? (STDERR)           ^^
+   W20170803-17:58:17.055(-7)? (STDERR) 
+   W20170803-17:58:17.055(-7)? (STDERR) SyntaxError: Unexpected token do
+*/
+

--- a/tools/tests/apps/modules/package.json
+++ b/tools/tests/apps/modules/package.json
@@ -19,5 +19,8 @@
     "test": "METEOR_PROFILE=100 ../../../../meteor test --full-app --driver-package dispatch:mocha-phantomjs",
     "browser": "METEOR_PROFILE=100 ../../../../meteor test --full-app --driver-package dispatch:mocha-browser",
     "test-packages": "../../../../meteor test-packages --driver-package dispatch:mocha-phantomjs packages/modules-test-package"
+  },
+  "devDependencies": {
+    "babel-plugin-transform-do-expressions": "^6.22.0"
   }
 }


### PR DESCRIPTION
This PR implements support for the env key in `.babelrc` files.

It looks first for `BABEL_ENV` then `NODE_ENV` then finally defaults to `development` per the Babel documented behavior.

Rationale: be able to add additional babel plugins/presets for testing environment for example (eg. `babel-plugin-istanbul`)

I wasn't sure where to add tests as I did not see any existing tests for the functionality.  Please let me know your feedback.