### PR TITLE
Eliminate underscore usage from the `meteor` package.

### DIFF
--- a/packages/meteor/dynamics_browser.js
+++ b/packages/meteor/dynamics_browser.js
@@ -7,32 +7,32 @@ Meteor.EnvironmentVariable = function () {
   this.slot = nextSlot++;
 };
 
-_.extend(Meteor.EnvironmentVariable.prototype, {
-  get: function () {
-    return currentValues[this.slot];
-  },
+var EVp = Meteor.EnvironmentVariable.prototype;
 
-  getOrNullIfOutsideFiber: function () {
-    return this.get();
-  },
+EVp.get = function () {
+  return currentValues[this.slot];
+};
 
-  withValue: function (value, func) {
-    var saved = currentValues[this.slot];
-    try {
-      currentValues[this.slot] = value;
-      var ret = func();
-    } finally {
-      currentValues[this.slot] = saved;
-    }
-    return ret;
+EVp.getOrNullIfOutsideFiber = function () {
+  return this.get();
+};
+
+EVp.withValue = function (value, func) {
+  var saved = currentValues[this.slot];
+  try {
+    currentValues[this.slot] = value;
+    var ret = func();
+  } finally {
+    currentValues[this.slot] = saved;
   }
-});
+  return ret;
+};
 
 Meteor.bindEnvironment = function (func, onException, _this) {
   // needed in order to be able to create closures inside func and
   // have the closed variables not change back to their original
   // values
-  var boundValues = _.clone(currentValues);
+  var boundValues = currentValues.slice();
 
   if (!onException || typeof(onException) === 'string') {
     var description = onException || "callback of async function";
@@ -48,7 +48,7 @@ Meteor.bindEnvironment = function (func, onException, _this) {
     var savedValues = currentValues;
     try {
       currentValues = boundValues;
-      var ret = func.apply(_this, _.toArray(arguments));
+      var ret = func.apply(_this, arguments);
     } catch (e) {
       // note: callback-hook currently relies on the fact that if onException
       // throws in the browser, the wrapped call throws.

--- a/packages/meteor/fiber_helpers.js
+++ b/packages/meteor/fiber_helpers.js
@@ -54,121 +54,123 @@ Meteor._SynchronousQueue = function () {
   self._draining = false;
 };
 
-_.extend(Meteor._SynchronousQueue.prototype, {
-  runTask: function (task) {
-    var self = this;
+var SQp = Meteor._SynchronousQueue.prototype;
 
-    if (!self.safeToRunTask()) {
-      if (Fiber.current)
-        throw new Error("Can't runTask from another task in the same fiber");
-      else
-        throw new Error("Can only call runTask in a Fiber");
-    }
+SQp.runTask = function (task) {
+  var self = this;
 
-    var fut = new Future;
-    var handle = {
-      task: Meteor.bindEnvironment(task, function (e) {
-        Meteor._debug("Exception from task:", e && e.stack || e);
-        throw e;
-      }),
-      future: fut,
-      name: task.name
-    };
-    self._taskHandles.push(handle);
-    self._scheduleRun();
-    // Yield. We'll get back here after the task is run (and will throw if the
-    // task throws).
-    fut.wait();
-  },
-  queueTask: function (task) {
-    var self = this;
-    self._taskHandles.push({
-      task: task,
-      name: task.name
-    });
-    self._scheduleRun();
-    // No need to block.
-  },
+  if (!self.safeToRunTask()) {
+    if (Fiber.current)
+      throw new Error("Can't runTask from another task in the same fiber");
+    else
+      throw new Error("Can only call runTask in a Fiber");
+  }
 
-  flush: function () {
-    var self = this;
-    self.runTask(function () {});
-  },
+  var fut = new Future;
+  var handle = {
+    task: Meteor.bindEnvironment(task, function (e) {
+      Meteor._debug("Exception from task:", e && e.stack || e);
+      throw e;
+    }),
+    future: fut,
+    name: task.name
+  };
+  self._taskHandles.push(handle);
+  self._scheduleRun();
+  // Yield. We'll get back here after the task is run (and will throw if the
+  // task throws).
+  fut.wait();
+};
 
-  safeToRunTask: function () {
-    var self = this;
-    return Fiber.current && self._currentTaskFiber !== Fiber.current;
-  },
+SQp.queueTask = function (task) {
+  var self = this;
+  self._taskHandles.push({
+    task: task,
+    name: task.name
+  });
+  self._scheduleRun();
+  // No need to block.
+};
 
-  drain: function () {
-    var self = this;
-    if (self._draining)
-      return;
-    if (!self.safeToRunTask())
-      return;
-    self._draining = true;
-    while (! self._taskHandles.isEmpty()) {
-      self.flush();
-    }
-    self._draining = false;
-  },
+SQp.flush = function () {
+  var self = this;
+  self.runTask(function () {});
+};
 
-  _scheduleRun: function () {
-    var self = this;
-    // Already running or scheduled? Do nothing.
-    if (self._runningOrRunScheduled)
-      return;
+SQp.safeToRunTask = function () {
+  var self = this;
+  return Fiber.current && self._currentTaskFiber !== Fiber.current;
+};
 
-    self._runningOrRunScheduled = true;
-    setImmediate(function () {
-      Fiber(function () {
-        self._run();
-      }).run();
-    });
-  },
-  _run: function () {
-    var self = this;
+SQp.drain = function () {
+  var self = this;
+  if (self._draining)
+    return;
+  if (!self.safeToRunTask())
+    return;
+  self._draining = true;
+  while (! self._taskHandles.isEmpty()) {
+    self.flush();
+  }
+  self._draining = false;
+};
 
-    if (!self._runningOrRunScheduled)
-      throw new Error("expected to be _runningOrRunScheduled");
+SQp._scheduleRun = function () {
+  var self = this;
+  // Already running or scheduled? Do nothing.
+  if (self._runningOrRunScheduled)
+    return;
 
-    if (self._taskHandles.isEmpty()) {
-      // Done running tasks! Don't immediately schedule another run, but
-      // allow future tasks to do so.
-      self._runningOrRunScheduled = false;
-      return;
-    }
-    var taskHandle = self._taskHandles.shift();
+  self._runningOrRunScheduled = true;
+  setImmediate(function () {
+    Fiber(function () {
+      self._run();
+    }).run();
+  });
+};
 
-    // Run the task.
-    self._currentTaskFiber = Fiber.current;
-    var exception = undefined;
-    try {
-      taskHandle.task();
-    } catch (err) {
-      if (taskHandle.future) {
-        // We'll throw this exception through runTask.
-        exception = err;
-      } else {
-        Meteor._debug("Exception in queued task: " + (err.stack || err));
-      }
-    }
-    self._currentTaskFiber = undefined;
+SQp._run = function () {
+  var self = this;
 
-    // Soon, run the next task, if there is any.
+  if (!self._runningOrRunScheduled)
+    throw new Error("expected to be _runningOrRunScheduled");
+
+  if (self._taskHandles.isEmpty()) {
+    // Done running tasks! Don't immediately schedule another run, but
+    // allow future tasks to do so.
     self._runningOrRunScheduled = false;
-    self._scheduleRun();
+    return;
+  }
+  var taskHandle = self._taskHandles.shift();
 
-    // If this was queued with runTask, let the runTask call return (throwing if
-    // the task threw).
+  // Run the task.
+  self._currentTaskFiber = Fiber.current;
+  var exception = undefined;
+  try {
+    taskHandle.task();
+  } catch (err) {
     if (taskHandle.future) {
-      if (exception)
-        taskHandle.future['throw'](exception);
-      else
-        taskHandle.future['return']();
+      // We'll throw this exception through runTask.
+      exception = err;
+    } else {
+      Meteor._debug("Exception in queued task: " + (err.stack || err));
     }
   }
-});
+  self._currentTaskFiber = undefined;
+
+  // Soon, run the next task, if there is any.
+  self._runningOrRunScheduled = false;
+  self._scheduleRun();
+
+  // If this was queued with runTask, let the runTask call return (throwing if
+  // the task threw).
+  if (taskHandle.future) {
+    if (exception)
+      taskHandle.future['throw'](exception);
+    else
+      taskHandle.future['return']();
+  }
+};
 
 // Sleep. Mostly used for debugging (eg, inserting latency into server
 // methods).

--- a/packages/meteor/fiber_helpers_test.js
+++ b/packages/meteor/fiber_helpers_test.js
@@ -9,7 +9,11 @@ Tinytest.add("fibers - synchronous queue", function (test) {
     };
   };
   var outputIsUpTo = function (n) {
-    test.equal(output, _.range(1, n+1));
+    var range = [];
+    for (var i = 1; i <= n; ++i) {
+      range.push(i);
+    }
+    test.equal(output, range);
   };
 
   // Queue a task. It cannot run until we yield.

--- a/packages/meteor/fiber_stubs_client.js
+++ b/packages/meteor/fiber_stubs_client.js
@@ -17,70 +17,72 @@ Meteor._SynchronousQueue = function () {
   self._runTimeout = null;
 };
 
-_.extend(Meteor._SynchronousQueue.prototype, {
-  runTask: function (task) {
-    var self = this;
-    if (!self.safeToRunTask())
-      throw new Error("Could not synchronously run a task from a running task");
-    self._tasks.push(task);
-    var tasks = self._tasks;
-    self._tasks = [];
-    self._running = true;
+var SQp = Meteor._SynchronousQueue.prototype;
 
-    if (self._runTimeout) {
-      // Since we're going to drain the queue, we can forget about the timeout
-      // which tries to run it.  (But if one of our tasks queues something else,
-      // the timeout will be correctly re-created.)
-      clearTimeout(self._runTimeout);
-      self._runTimeout = null;
-    }
+SQp.runTask = function (task) {
+  var self = this;
+  if (!self.safeToRunTask())
+    throw new Error("Could not synchronously run a task from a running task");
+  self._tasks.push(task);
+  var tasks = self._tasks;
+  self._tasks = [];
+  self._running = true;
 
-    try {
-      while (!_.isEmpty(tasks)) {
-        var t = tasks.shift();
-        try {
-          t();
-        } catch (e) {
-          if (_.isEmpty(tasks)) {
-            // this was the last task, that is, the one we're calling runTask
-            // for.
-            throw e;
-          } else {
-            Meteor._debug("Exception in queued task: " + (e.stack || e));
-          }
-        }
-      }
-    } finally {
-      self._running = false;
-    }
-  },
-
-  queueTask: function (task) {
-    var self = this;
-    self._tasks.push(task);
-    // Intentionally not using Meteor.setTimeout, because it doesn't like runing
-    // in stubs for now.
-    if (!self._runTimeout) {
-      self._runTimeout = setTimeout(_.bind(self.flush, self), 0);
-    }
-  },
-
-  flush: function () {
-    var self = this;
-    self.runTask(function () {});
-  },
-
-  drain: function () {
-    var self = this;
-    if (!self.safeToRunTask())
-      return;
-    while (!_.isEmpty(self._tasks)) {
-      self.flush();
-    }
-  },
-
-  safeToRunTask: function () {
-    var self = this;
-    return !self._running;
+  if (self._runTimeout) {
+    // Since we're going to drain the queue, we can forget about the timeout
+    // which tries to run it.  (But if one of our tasks queues something else,
+    // the timeout will be correctly re-created.)
+    clearTimeout(self._runTimeout);
+    self._runTimeout = null;
   }
-});
+
+  try {
+    while (tasks.length > 0) {
+      var t = tasks.shift();
+      try {
+        t();
+      } catch (e) {
+        if (tasks.length === 0) {
+          // this was the last task, that is, the one we're calling runTask
+          // for.
+          throw e;
+        }
+        Meteor._debug("Exception in queued task: " + (e.stack || e));
+      }
+    }
+  } finally {
+    self._running = false;
+  }
+};
+
+SQp.queueTask = function (task) {
+  var self = this;
+  self._tasks.push(task);
+  // Intentionally not using Meteor.setTimeout, because it doesn't like runing
+  // in stubs for now.
+  if (!self._runTimeout) {
+    self._runTimeout = setTimeout(function () {
+      return self.flush.apply(self, arguments);
+    }, 0);
+  }
+};
+
+SQp.flush = function () {
+  var self = this;
+  self.runTask(function () {});
+};
+
+SQp.drain = function () {
+  var self = this;
+  if (!self.safeToRunTask()) {
+    return;
+  }
+  while (self._tasks.length > 0) {
+    self.flush();
+  }
+};
+
+SQp.safeToRunTask = function () {
+  var self = this;
+  return !self._running;
+};

--- a/packages/meteor/helpers.js
+++ b/packages/meteor/helpers.js
@@ -14,136 +14,136 @@ if (typeof __meteor_runtime_config__ === 'object' &&
 // XXX find a better home for these? Ideally they would be _.get,
 // _.ensure, _.delete..
 
-_.extend(Meteor, {
-  // _get(a,b,c,d) returns a[b][c][d], or else undefined if a[b] or
-  // a[b][c] doesn't exist.
-  //
-  _get: function (obj /*, arguments */) {
-    for (var i = 1; i < arguments.length; i++) {
-      if (!(arguments[i] in obj))
-        return undefined;
-      obj = obj[arguments[i]];
-    }
-    return obj;
-  },
-
-  // _ensure(a,b,c,d) ensures that a[b][c][d] exists. If it does not,
-  // it is created and set to {}. Either way, it is returned.
-  //
-  _ensure: function (obj /*, arguments */) {
-    for (var i = 1; i < arguments.length; i++) {
-      var key = arguments[i];
-      if (!(key in obj))
-        obj[key] = {};
-      obj = obj[key];
-    }
-
-    return obj;
-  },
-
-  // _delete(a, b, c, d) deletes a[b][c][d], then a[b][c] unless it
-  // isn't empty, then a[b] unless it isn't empty.
-  //
-  _delete: function (obj /*, arguments */) {
-    var stack = [obj];
-    var leaf = true;
-    for (var i = 1; i < arguments.length - 1; i++) {
-      var key = arguments[i];
-      if (!(key in obj)) {
-        leaf = false;
-        break;
-      }
-      obj = obj[key];
-      if (typeof obj !== "object")
-        break;
-      stack.push(obj);
-    }
-
-    for (var i = stack.length - 1; i >= 0; i--) {
-      var key = arguments[i+1];
-
-      if (leaf)
-        leaf = false;
-      else
-        for (var other in stack[i][key])
-          return; // not empty -- we're done
-
-      delete stack[i][key];
-    }
-  },
-
-  // wrapAsync can wrap any function that takes some number of arguments that
-  // can't be undefined, followed by some optional arguments, where the callback
-  // is the last optional argument.
-  // e.g. fs.readFile(pathname, [callback]),
-  // fs.open(pathname, flags, [mode], [callback])
-  // For maximum effectiveness and least confusion, wrapAsync should be used on
-  // functions where the callback is the only argument of type Function.
-
-  /**
-   * @memberOf Meteor
-   * @summary Wrap a function that takes a callback function as its final parameter. The signature of the callback of the wrapped function should be `function(error, result){}`. On the server, the wrapped function can be used either synchronously (without passing a callback) or asynchronously (when a callback is passed). On the client, a callback is always required; errors will be logged if there is no callback. If a callback is provided, the environment captured when the original function was called will be restored in the callback.
-   * @locus Anywhere
-   * @param {Function} func A function that takes a callback as its final parameter
-   * @param {Object} [context] Optional `this` object against which the original function will be invoked
-   */
-  wrapAsync: function (fn, context) {
-    return function (/* arguments */) {
-      var self = context || this;
-      var newArgs = _.toArray(arguments);
-      var callback;
-
-      for (var i = newArgs.length - 1; i >= 0; --i) {
-        var arg = newArgs[i];
-        var type = typeof arg;
-        if (type !== "undefined") {
-          if (type === "function") {
-            callback = arg;
-          }
-          break;
-        }
-      }
-
-      if (! callback) {
-        if (Meteor.isClient) {
-          callback = logErr;
-        } else {
-          var fut = new Future();
-          callback = fut.resolver();
-        }
-        ++i; // Insert the callback just after arg.
-      }
-
-      newArgs[i] = Meteor.bindEnvironment(callback);
-      var result = fn.apply(self, newArgs);
-      return fut ? fut.wait() : result;
-    };
-  },
-
-  // Sets child's prototype to a new object whose prototype is parent's
-  // prototype. Used as:
-  //   Meteor._inherits(ClassB, ClassA).
-  //   _.extend(ClassB.prototype, { ... })
-  // Inspired by CoffeeScript's `extend` and Google Closure's `goog.inherits`.
-  _inherits: function (Child, Parent) {
-    // copy Parent static properties
-    for (var key in Parent) {
-      // make sure we only copy hasOwnProperty properties vs. prototype
-      // properties
-      if (_.has(Parent, key))
-        Child[key] = Parent[key];
-    }
-
-    // a middle member of prototype chain: takes the prototype from the Parent
-    var Middle = function () {
-      this.constructor = Child;
-    };
-    Middle.prototype = Parent.prototype;
-    Child.prototype = new Middle();
-    Child.__super__ = Parent.prototype;
-    return Child;
+// _get(a,b,c,d) returns a[b][c][d], or else undefined if a[b] or
+// a[b][c] doesn't exist.
+//
+Meteor._get = function (obj /*, arguments */) {
+  for (var i = 1; i < arguments.length; i++) {
+    if (!(arguments[i] in obj))
+      return undefined;
+    obj = obj[arguments[i]];
   }
-});
+  return obj;
+};
+
+// _ensure(a,b,c,d) ensures that a[b][c][d] exists. If it does not,
+// it is created and set to {}. Either way, it is returned.
+//
+Meteor._ensure = function (obj /*, arguments */) {
+  for (var i = 1; i < arguments.length; i++) {
+    var key = arguments[i];
+    if (!(key in obj))
+      obj[key] = {};
+    obj = obj[key];
+  }
+
+  return obj;
+};
+
+// _delete(a, b, c, d) deletes a[b][c][d], then a[b][c] unless it
+// isn't empty, then a[b] unless it isn't empty.
+//
+Meteor._delete = function (obj /*, arguments */) {
+  var stack = [obj];
+  var leaf = true;
+  for (var i = 1; i < arguments.length - 1; i++) {
+    var key = arguments[i];
+    if (!(key in obj)) {
+      leaf = false;
+      break;
+    }
+    obj = obj[key];
+    if (typeof obj !== "object")
+      break;
+    stack.push(obj);
+  }
+
+  for (var i = stack.length - 1; i >= 0; i--) {
+    var key = arguments[i+1];
+
+    if (leaf)
+      leaf = false;
+    else
+      for (var other in stack[i][key])
+        return; // not empty -- we're done
+
+    delete stack[i][key];
+  }
+};
+
+// wrapAsync can wrap any function that takes some number of arguments that
+// can't be undefined, followed by some optional arguments, where the callback
+// is the last optional argument.
+// e.g. fs.readFile(pathname, [callback]),
+// fs.open(pathname, flags, [mode], [callback])
+// For maximum effectiveness and least confusion, wrapAsync should be used on
+// functions where the callback is the only argument of type Function.
+
+/**
+ * @memberOf Meteor
+ * @summary Wrap a function that takes a callback function as its final parameter. The signature of the callback of the wrapped function should be `function(error, result){}`. On the server, the wrapped function can be used either synchronously (without passing a callback) or asynchronously (when a callback is passed). On the client, a callback is always required; errors will be logged if there is no callback. If a callback is provided, the environment captured when the original function was called will be restored in the callback.
+ * @locus Anywhere
+ * @param {Function} func A function that takes a callback as its final parameter
+ * @param {Object} [context] Optional `this` object against which the original function will be invoked
+ */
+Meteor.wrapAsync = function (fn, context) {
+  return function (/* arguments */) {
+    var self = context || this;
+    var newArgs = Array.prototype.slice.call(arguments);
+    var callback;
+
+    for (var i = newArgs.length - 1; i >= 0; --i) {
+      var arg = newArgs[i];
+      var type = typeof arg;
+      if (type !== "undefined") {
+        if (type === "function") {
+          callback = arg;
+        }
+        break;
+      }
+    }
+
+    if (! callback) {
+      if (Meteor.isClient) {
+        callback = logErr;
+      } else {
+        var fut = new Future();
+        callback = fut.resolver();
+      }
+      ++i; // Insert the callback just after arg.
+    }
+
+    newArgs[i] = Meteor.bindEnvironment(callback);
+    var result = fn.apply(self, newArgs);
+    return fut ? fut.wait() : result;
+  };
+};
+
+// Sets child's prototype to a new object whose prototype is parent's
+// prototype. Used as:
+//   Meteor._inherits(ClassB, ClassA).
+//   _.extend(ClassB.prototype, { ... })
+// Inspired by CoffeeScript's `extend` and Google Closure's `goog.inherits`.
+var hasOwn = Object.prototype.hasOwnProperty;
+Meteor._inherits = function (Child, Parent) {
+  // copy Parent static properties
+  for (var key in Parent) {
+    // make sure we only copy hasOwnProperty properties vs. prototype
+    // properties
+    if (hasOwn.call(Parent, key)) {
+      Child[key] = Parent[key];
+    }
+  }
+
+  // a middle member of prototype chain: takes the prototype from the Parent
+  var Middle = function () {
+    this.constructor = Child;
+  };
+  Middle.prototype = Parent.prototype;
+  Child.prototype = new Middle();
+  Child.__super__ = Parent.prototype;
+  return Child;
+};
 
 var warnedAboutWrapAsync = false;
 

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -15,8 +15,6 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.use('underscore', ['client', 'server']);
-
   api.use('isobuild:compiler-plugin@1.0.0');
 
   api.export('Meteor');

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.7.0'
+  version: '1.8.0'
 });
 
 Package.registerBuildPlugin({

--- a/packages/meteor/timers.js
+++ b/packages/meteor/timers.js
@@ -13,65 +13,63 @@ var bindAndCatch = function (context, f) {
   return Meteor.bindEnvironment(withoutInvocation(f), context);
 };
 
-_.extend(Meteor, {
-  // Meteor.setTimeout and Meteor.setInterval callbacks scheduled
-  // inside a server method are not part of the method invocation and
-  // should clear out the CurrentMethodInvocation environment variable.
+// Meteor.setTimeout and Meteor.setInterval callbacks scheduled
+// inside a server method are not part of the method invocation and
+// should clear out the CurrentMethodInvocation environment variable.
 
-  /**
-   * @memberOf Meteor
-   * @summary Call a function in the future after waiting for a specified delay.
-   * @locus Anywhere
-   * @param {Function} func The function to run
-   * @param {Number} delay Number of milliseconds to wait before calling function
-   */
-  setTimeout: function (f, duration) {
-    return setTimeout(bindAndCatch("setTimeout callback", f), duration);
-  },
+/**
+ * @memberOf Meteor
+ * @summary Call a function in the future after waiting for a specified delay.
+ * @locus Anywhere
+ * @param {Function} func The function to run
+ * @param {Number} delay Number of milliseconds to wait before calling function
+ */
+Meteor.setTimeout = function (f, duration) {
+  return setTimeout(bindAndCatch("setTimeout callback", f), duration);
+};
 
-  /**
-   * @memberOf Meteor
-   * @summary Call a function repeatedly, with a time delay between calls.
-   * @locus Anywhere
-   * @param {Function} func The function to run
-   * @param {Number} delay Number of milliseconds to wait between each function call.
-   */
-  setInterval: function (f, duration) {
-    return setInterval(bindAndCatch("setInterval callback", f), duration);
-  },
+/**
+ * @memberOf Meteor
+ * @summary Call a function repeatedly, with a time delay between calls.
+ * @locus Anywhere
+ * @param {Function} func The function to run
+ * @param {Number} delay Number of milliseconds to wait between each function call.
+ */
+Meteor.setInterval = function (f, duration) {
+  return setInterval(bindAndCatch("setInterval callback", f), duration);
+};
 
-  /**
-   * @memberOf Meteor
-   * @summary Cancel a repeating function call scheduled by `Meteor.setInterval`.
-   * @locus Anywhere
-   * @param {Object} id The handle returned by `Meteor.setInterval`
-   */
-  clearInterval: function(x) {
-    return clearInterval(x);
-  },
+/**
+ * @memberOf Meteor
+ * @summary Cancel a repeating function call scheduled by `Meteor.setInterval`.
+ * @locus Anywhere
+ * @param {Object} id The handle returned by `Meteor.setInterval`
+ */
+Meteor.clearInterval = function(x) {
+  return clearInterval(x);
+};
 
-  /**
-   * @memberOf Meteor
-   * @summary Cancel a function call scheduled by `Meteor.setTimeout`.
-   * @locus Anywhere
-   * @param {Object} id The handle returned by `Meteor.setTimeout`
-   */
-  clearTimeout: function(x) {
-    return clearTimeout(x);
-  },
+/**
+ * @memberOf Meteor
+ * @summary Cancel a function call scheduled by `Meteor.setTimeout`.
+ * @locus Anywhere
+ * @param {Object} id The handle returned by `Meteor.setTimeout`
+ */
+Meteor.clearTimeout = function(x) {
+  return clearTimeout(x);
+};
 
-  // XXX consider making this guarantee ordering of defer'd callbacks, like
-  // Tracker.afterFlush or Node's nextTick (in practice). Then tests can do:
-  //    callSomethingThatDefersSomeWork();
-  //    Meteor.defer(expect(somethingThatValidatesThatTheWorkHappened));
+// XXX consider making this guarantee ordering of defer'd callbacks, like
+// Tracker.afterFlush or Node's nextTick (in practice). Then tests can do:
+//    callSomethingThatDefersSomeWork();
+//    Meteor.defer(expect(somethingThatValidatesThatTheWorkHappened));
 
-  /**
-   * @memberOf Meteor
-   * @summary Defer execution of a function to run asynchronously in the background (similar to `Meteor.setTimeout(func, 0)`.
-   * @locus Anywhere
-   * @param {Function} func The function to run
-   */
-  defer: function (f) {
-    Meteor._setImmediate(bindAndCatch("defer callback", f));
-  }
-});
+/**
+ * @memberOf Meteor
+ * @summary Defer execution of a function to run asynchronously in the background (similar to `Meteor.setTimeout(func, 0)`.
+ * @locus Anywhere
+ * @param {Function} func The function to run
+ */
+Meteor.defer = function (f) {
+  Meteor._setImmediate(bindAndCatch("defer callback", f));
+};

--- a/packages/meteor/url_common.js
+++ b/packages/meteor/url_common.js
@@ -14,7 +14,7 @@ Meteor.absoluteUrl = function (path, options) {
     path = undefined;
   }
   // merge options with defaults
-  options = _.extend({}, Meteor.absoluteUrl.defaultOptions, options || {});
+  options = Object.assign({}, Meteor.absoluteUrl.defaultOptions, options || {});
 
   var url = options.rootUrl;
   if (!url)

--- a/packages/meteor/url_tests.js
+++ b/packages/meteor/url_tests.js
@@ -1,6 +1,5 @@
 Tinytest.add("absolute-url - basics", function(test) {
-
-  _.each(['', 'http://'], function (prefix) {
+  ['', 'http://'].forEach(function (prefix) {
 
     test.equal(Meteor.absoluteUrl({rootUrl: prefix + 'asdf.com'}),
                'http://asdf.com/');

--- a/packages/underscore/package.js
+++ b/packages/underscore/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Collection of small helpers: _.map, _.each, ...",
-  version: '1.0.10'
+  version: '1.1.0'
 });
 
 Package.onUse(function (api) {

--- a/packages/underscore/package.js
+++ b/packages/underscore/package.js
@@ -4,33 +4,11 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  // Like all packages, we have an implicit depedency on the 'meteor'
-  // package, which provides such things as the *.js file handler. Use
-  // an undocumented API to allow 'meteor' to alter us even though we
-  // depend on it. This is necessary since 'meteor' depends on us. One
-  // day we will avoid this problem by refactor, but for now this is a
-  // practical and expedient solution.
-  //
-  // XXX Now the *.js handler is intrinsic rather than coming from the
-  // 'meteor' package and we could remove this (if we provided a way
-  // to let the package opt to not depend on 'meteor'.) We could even
-  // remove unordered dependency support, though I think it's worth keeping
-  // around for now to keep the possibility of dependency
-  // configuration alive in the codebase.
-  api.use('meteor', {unordered: true});
-
-  api.export('_');
-
   // NOTE: we patch _.each and various other functions that polymorphically take
   // objects, arrays, and array-like objects (such as the querySelectorAll
   // return value, document.images, and 'arguments') such that objects with a
   // numeric length field whose constructor === Object are still treated as
   // objects, not as arrays.  Search for looksLikeArray.
   api.addFiles(['pre.js', 'underscore.js', 'post.js']);
-});
-
-
-Package.onTest(function (api) {
-  // Also turn off the strong 'meteor' dependency in the test slice
-  api.use('meteor', {unordered: true});
+  api.export('_');
 });


### PR DESCRIPTION
Because the `meteor` package [depends on `underscore`](https://github.com/meteor/meteor/blob/96db56b0bae5168fa852eead7cbf0131a12c0ec8/packages/meteor/package.js#L18), and every package implicitly depends on the `meteor` package, the `underscore` package (in its entirety) is typically the first package to load in any Meteor application. This PR removes that dependency, so packages that do not depend on `underscore` can load a little sooner, and the Meteor core will be that much closer to not depending on `underscore` at all.

This PR is best viewed with `?w=1` to ignore whitespace-only changes: https://github.com/meteor/meteor/pull/8971/files?w=1