### PR TITLE
Run all "bare" package files before requiring eager entry point modules.

### DIFF
--- a/History.md
+++ b/History.md
@@ -24,6 +24,12 @@
   [Issue #5121](https://github.com/meteor/meteor/issues/5121)
   [PR #8917](https://github.com/meteor/meteor/pull/8917)
 
+* Files contained by `client/compatibility/` directories or added with
+  `api.addFiles(files, ..., { bare: true })` are now evaluated before
+  importing modules with `require`, which may be a breaking change if you
+  depend on the interleaving of `bare` files with eager module evaluation.
+  [PR #8972](https://github.com/meteor/meteor/pull/8972)
+
 ## v1.5.1, 2017-07-12
 
 * Node has been upgraded to version 4.8.4.

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -398,6 +398,9 @@ _.extend(Module.prototype, {
     // Now that we have installed everything in this package or
     // application, immediately require the non-lazy modules and
     // evaluate the bare files.
+
+    const eagerModuleFiles = [];
+
     _.each(this.files, file => {
       if (file.bare) {
         chunks.push("\n", file.getPrelinkedOutput({
@@ -405,6 +408,12 @@ _.extend(Module.prototype, {
           noLineNumbers: this.noLineNumbers
         }));
       } else if (moduleCount > 0 && ! file.lazy) {
+        eagerModuleFiles.push(file);
+      }
+    });
+
+    if (eagerModuleFiles.length > 0) {
+      _.each(eagerModuleFiles, file => {
         if (file.mainModule) {
           exportsName = "exports";
         }
@@ -415,8 +424,8 @@ _.extend(Module.prototype, {
           JSON.stringify("./" + file.installPath),
           ");"
         );
-      }
-    });
+      });
+    }
 
     return exportsName;
   }

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -233,8 +233,8 @@ _.extend(Module.prototype, {
 
     _.each(this.files, file => {
       if (file.bare) {
-        // Bare files will be added in between the synchronous require
-        // calls in _chunkifyEagerRequires.
+        // Bare files will be added before the synchronous require calls
+        // in _chunkifyEagerRequires.
         return;
       }
 
@@ -384,10 +384,9 @@ _.extend(Module.prototype, {
   },
 
   // Adds require calls to the chunks array for all modules that should be
-  // eagerly evaluated, and also includes bare files in the appropriate
-  // order with respect to the require calls. Returns the name of the
-  // variable that holds the main exports object, if api.mainModule was
-  // used to define a main module.
+  // eagerly evaluated, and also includes any bare files before the
+  // require calls. Returns the name of the variable that holds the main
+  // exports object, if api.mainModule was used to define a main module.
   _chunkifyEagerRequires(chunks, moduleCount, sourceWidth) {
     assert.ok(_.isArray(chunks));
     assert.ok(_.isNumber(moduleCount));
@@ -396,8 +395,8 @@ _.extend(Module.prototype, {
     let exportsName;
 
     // Now that we have installed everything in this package or
-    // application, immediately require the non-lazy modules and
-    // evaluate the bare files.
+    // application, first evaluate the bare files, then require the
+    // non-lazy (eager) modules.
 
     const eagerModuleFiles = [];
 


### PR DESCRIPTION
Immediately after each Meteor package is evaluated, we synchronously `require` its eager entry point modules (typically those identified by `api.mainModule`), before loading other packages. This behavior makes the load order of packages more important than it should be, leading to bugs like #8969, where one package synchronously imports another package that hasn't loaded yet, and gets weird/`undefined` results.

The natural solution here is to run all eager `require` calls after loading all package code. However, we have avoided making that change because of an obscure feature that allows package files to be `bare`, which means they are not wrapped as modules, and thus may declare variables directly in the package scope. Historically, `bare` code could run in between eager `require` calls, according to the order of `api.addFiles` calls in the `package.js` file.

If we care about the intentional interleaving of `bare` code with `require` calls, then calling `require` later is not possible without breaking backwards compatibility, since we can't defer the `bare` code without putting it a different scope. However, it appears that no Meteor core packages depend on `bare`/`require` interleaving, and I suspect very few existing Meteor packages will be broken by this change.

Specifically, this PR just runs all `bare` code in a given package before calling `require` to evaluate the package's eager entry point module(s). If this works, then we're one step closer to deferring all `require` calls until every package has finished evaluating, which will fix bugs like #8969, as well as making it unnecessary to move files from `node_modules` into the `modules` package, which has been a source of some confusion ever since Meteor 1.3.