### PR TITLE
Auto-install Cordova upon use rather than building into the dev bundle.

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.2.5
+BUNDLE_VERSION=9999.8976.0
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -52,7 +52,6 @@ var packageJson = {
     pathwatcher: "7.1.0",
     optimism: "0.3.3",
     'lru-cache': '4.0.1',
-    'cordova-lib': "7.0.1",
     longjohn: '0.2.11'
   }
 };

--- a/tools/cli/commands-cordova.js
+++ b/tools/cli/commands-cordova.js
@@ -68,29 +68,7 @@ function doAddPlatform(options) {
   });
 }
 
-// Add one or more Cordova platforms
-main.registerCommand({
-  name: 'add-platform',
-  options: {
-    verbose: { type: Boolean, short: "v" }
-  },
-  minArgs: 1,
-  maxArgs: Infinity,
-  requiresApp: true,
-  catalogRefresh: new catalog.Refresh.Never(),
-  notOnWindows: false
-}, function (options) {
-  doAddPlatform(options);
-});
-
-// Remove one or more Cordova platforms
-main.registerCommand({
-  name: 'remove-platform',
-  minArgs: 1,
-  maxArgs: Infinity,
-  requiresApp: true,
-  catalogRefresh: new catalog.Refresh.Never()
-}, function (options) {
+function doRemovePlatform(options) {
   import { CordovaProject } from '../cordova/project.js';
   import { PlatformList } from '../project-context.js';
 
@@ -128,6 +106,32 @@ version of Meteor`);
       cordovaProject.ensurePlatformsAreSynchronized(cordovaPlatforms);
     }
   });
+}
+
+// Add one or more Cordova platforms
+main.registerCommand({
+  name: 'add-platform',
+  options: {
+    verbose: { type: Boolean, short: "v" }
+  },
+  minArgs: 1,
+  maxArgs: Infinity,
+  requiresApp: true,
+  catalogRefresh: new catalog.Refresh.Never(),
+  notOnWindows: false
+}, function (options) {
+  doAddPlatform(options);
+});
+
+// Remove one or more Cordova platforms
+main.registerCommand({
+  name: 'remove-platform',
+  minArgs: 1,
+  maxArgs: Infinity,
+  requiresApp: true,
+  catalogRefresh: new catalog.Refresh.Never()
+}, function (options) {
+  doRemovePlatform(options);
 });
 
 main.registerCommand({

--- a/tools/cli/commands-cordova.js
+++ b/tools/cli/commands-cordova.js
@@ -22,18 +22,7 @@ function createProjectContext(appDir) {
   return projectContext;
 }
 
-// Add one or more Cordova platforms
-main.registerCommand({
-  name: 'add-platform',
-  options: {
-    verbose: { type: Boolean, short: "v" }
-  },
-  minArgs: 1,
-  maxArgs: Infinity,
-  requiresApp: true,
-  catalogRefresh: new catalog.Refresh.Never(),
-  notOnWindows: false
-}, function (options) {
+function doAddPlatform(options) {
   import { CordovaProject } from '../cordova/project.js';
 
   Console.setVerbose(!!options.verbose);
@@ -77,6 +66,21 @@ main.registerCommand({
       }
     }
   });
+}
+
+// Add one or more Cordova platforms
+main.registerCommand({
+  name: 'add-platform',
+  options: {
+    verbose: { type: Boolean, short: "v" }
+  },
+  minArgs: 1,
+  maxArgs: Infinity,
+  requiresApp: true,
+  catalogRefresh: new catalog.Refresh.Never(),
+  notOnWindows: false
+}, function (options) {
+  doAddPlatform(options);
 });
 
 // Remove one or more Cordova platforms

--- a/tools/cli/commands-cordova.js
+++ b/tools/cli/commands-cordova.js
@@ -6,6 +6,7 @@ import buildmessage from '../utils/buildmessage.js';
 import files from '../fs/files.js';
 import {
   CORDOVA_PLATFORMS,
+  ensureDevBundleDependencies,
   filterPlatforms,
 } from '../cordova';
 
@@ -120,6 +121,7 @@ main.registerCommand({
   catalogRefresh: new catalog.Refresh.Never(),
   notOnWindows: false
 }, function (options) {
+  ensureDevBundleDependencies();
   doAddPlatform(options);
 });
 
@@ -131,6 +133,7 @@ main.registerCommand({
   requiresApp: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
+  ensureDevBundleDependencies();
   doRemovePlatform(options);
 });
 

--- a/tools/cli/commands-cordova.js
+++ b/tools/cli/commands-cordova.js
@@ -2,14 +2,16 @@ import _ from 'underscore';
 import main from './main.js';
 import { Console } from '../console/console.js';
 import catalog from '../packaging/catalog/catalog.js';
-import { ProjectContext, PlatformList } from '../project-context.js';
 import buildmessage from '../utils/buildmessage.js';
 import files from '../fs/files.js';
-
-import * as cordova from '../cordova';
-import { CordovaProject } from '../cordova/project.js';
+import {
+  CORDOVA_PLATFORMS,
+  filterPlatforms,
+} from '../cordova';
 
 function createProjectContext(appDir) {
+  import { ProjectContext } from '../project-context.js';
+
   const projectContext = new ProjectContext({
     projectDir: appDir
   });
@@ -32,6 +34,8 @@ main.registerCommand({
   catalogRefresh: new catalog.Refresh.Never(),
   notOnWindows: false
 }, function (options) {
+  import { CordovaProject } from '../cordova/project.js';
+
   Console.setVerbose(!!options.verbose);
 
   const projectContext = createProjectContext(options.appDir);
@@ -43,7 +47,7 @@ main.registerCommand({
     for (platform of platformsToAdd) {
       if (_.contains(installedPlatforms, platform)) {
         buildmessage.error(`${platform}: platform is already added`);
-      } else if (!_.contains(cordova.CORDOVA_PLATFORMS, platform)) {
+      } else if (!_.contains(CORDOVA_PLATFORMS, platform)) {
         buildmessage.error(`${platform}: no such platform`);
       }
     }
@@ -56,7 +60,7 @@ main.registerCommand({
     if (buildmessage.jobHasMessages()) return;
 
     installedPlatforms = installedPlatforms.concat(platformsToAdd)
-    const cordovaPlatforms = cordova.filterPlatforms(installedPlatforms);
+    const cordovaPlatforms = filterPlatforms(installedPlatforms);
     cordovaProject.ensurePlatformsAreSynchronized(cordovaPlatforms);
 
     if (buildmessage.jobHasMessages()) {
@@ -83,6 +87,9 @@ main.registerCommand({
   requiresApp: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
+  import { CordovaProject } from '../cordova/project.js';
+  import { PlatformList } from '../project-context.js';
+
   const projectContext = createProjectContext(options.appDir);
 
   const platformsToRemove = options.args;
@@ -113,7 +120,7 @@ version of Meteor`);
     if (process.platform !== 'win32') {
       const cordovaProject = new CordovaProject(projectContext);
       if (buildmessage.jobHasMessages()) return;
-      const cordovaPlatforms = cordova.filterPlatforms(installedPlatforms);
+      const cordovaPlatforms = filterPlatforms(installedPlatforms);
       cordovaProject.ensurePlatformsAreSynchronized(cordovaPlatforms);
     }
   });

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -365,6 +365,8 @@ function doRunCommand(options) {
       });
     }
 
+    import { ensureDevBundleDependencies } from '../cordova';
+    ensureDevBundleDependencies();
     prepareCordovaProject();
   }
 
@@ -1800,6 +1802,8 @@ function doTestCommand(options) {
       });
     }
 
+    import { ensureDevBundleDependencies } from '../cordova';
+    ensureDevBundleDependencies();
     prepareCordovaProject();
   }
 

--- a/tools/cli/dev-bundle-helpers.js
+++ b/tools/cli/dev-bundle-helpers.js
@@ -1,0 +1,20 @@
+import { pathJoin, getDevBundle } from '../fs/files.js';
+import { installNpmModule, moduleDoesResolve } from '../isobuild/meteor-npm.js';
+
+export function ensureDependencies(deps) {
+  // Check if each of the requested dependencies resolves, if not
+  // mark them for installation.
+  const needToInstall = Object.create(null);
+  Object.keys(deps).forEach(dep => {
+    if (!moduleDoesResolve(dep)) {
+      const versionToInstall = deps[dep];
+      needToInstall[dep] = versionToInstall;
+    }
+  });
+
+  const devBundleLib = pathJoin(getDevBundle(), 'lib');
+
+  // Install each of the requested modules.
+  Object.keys(needToInstall)
+    .forEach(dep => installNpmModule(dep, needToInstall[dep], devBundleLib));
+}

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -3,8 +3,6 @@ import assert from 'assert';
 import utils from '../utils/utils.js';
 import buildmessage from '../utils/buildmessage.js';
 
-import { oldToNew as oldToNewPluginIds } from 'cordova-registry-mapper';
-
 export const CORDOVA_ARCH = "web.cordova";
 
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
@@ -61,6 +59,7 @@ export function pluginVersionsFromStarManifest(star) {
 }
 
 export function newPluginId(id) {
+  import { oldToNew as oldToNewPluginIds } from 'cordova-registry-mapper';
   return oldToNewPluginIds[id];
 }
 

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -3,8 +3,7 @@ import assert from 'assert';
 import utils from '../utils/utils.js';
 import buildmessage from '../utils/buildmessage.js';
 
-import { oldToNew as oldToNewPluginIds, newToOld as newToOldPluginIds }
-  from 'cordova-registry-mapper';
+import { oldToNew as oldToNewPluginIds } from 'cordova-registry-mapper';
 
 export const CORDOVA_ARCH = "web.cordova";
 

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -7,6 +7,12 @@ export const CORDOVA_ARCH = "web.cordova";
 
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
+export const CORDOVA_DEV_BUNDLE_VERSIONS = {
+  'cordova-lib': '7.0.1',
+  'cordova-common': '1.5.1',
+  'cordova-registry-mapper': '1.1.15',
+};
+
 export const CORDOVA_PLATFORM_VERSIONS = {
   'android': '6.2.3',
   'ios': '4.4.0'
@@ -16,6 +22,18 @@ const PLATFORM_TO_DISPLAY_NAME_MAP = {
   'ios': 'iOS',
   'android': 'Android'
 };
+
+export function ensureDevBundleDependencies() {
+  buildmessage.enterJob(
+    {
+      title: 'Installing Cordova in Meteor tool',
+    },
+    () => {
+      require("../cli/dev-bundle-helpers.js")
+        .ensureDependencies(CORDOVA_DEV_BUNDLE_VERSIONS);
+    }
+  );
+}
 
 export function displayNameForPlatform(platform) {
   return PLATFORM_TO_DISPLAY_NAME_MAP[platform] || platform;

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -191,7 +191,7 @@ outdated platforms`);
       this.projectContext,
       this.projectRoot,
       { mobileServerUrl: this.options.mobileServerUrl,
-        settingsFile: this.topsion.settingsFile }
+        settingsFile: this.options.settingsFile }
     );
 
     builder.processControlFile();

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -631,6 +631,8 @@ mobile-config.js accordingly.`);
 
         this.removePlugins(pluginsToRemove);
 
+        let pluginVersionsToInstall;
+
         // Now install the necessary plugins.
         if (shouldReinstallAllPlugins) {
           pluginVersionsToInstall = pluginVersions;

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -403,7 +403,7 @@ from Cordova project`, async () => {
 
     const installedPlatforms = this.listInstalledPlatforms();
 
-    for (platform of platforms) {
+    for (let platform of platforms) {
       if (_.contains(installedPlatforms, platform)) {
         continue;
       }
@@ -411,7 +411,7 @@ from Cordova project`, async () => {
       this.addPlatform(platform);
     }
 
-    for (platform of installedPlatforms) {
+    for (let platform of installedPlatforms) {
       if (!_.contains(platforms, platform) &&
         _.contains(CORDOVA_PLATFORMS, platform)) {
         this.removePlatform(platform);

--- a/tools/cordova/runner.js
+++ b/tools/cordova/runner.js
@@ -93,7 +93,7 @@ export class CordovaRunner {
   startRunTargets() {
     this.started = false;
 
-    for (runTarget of this.runTargets) {
+    for (let runTarget of this.runTargets) {
       const messages = buildmessage.capture({ title: `starting ${runTarget.title}` }, () => {
         Promise.await(runTarget.start(this.cordovaProject));
       });

--- a/tools/cordova/runner.js
+++ b/tools/cordova/runner.js
@@ -82,7 +82,7 @@ export class CordovaRunner {
         return;
       }
 
-      for (platform of this.platformsForRunTargets) {
+      for (let platform of this.platformsForRunTargets) {
         this.cordovaProject.prepareForPlatform(platform);
       }
     });

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -170,7 +170,6 @@ var Profile = require('../tool-env/profile.js').Profile;
 var packageVersionParser = require('../packaging/package-version-parser.js');
 var release = require('../packaging/release.js');
 import { load as loadIsopacket } from '../tool-env/isopackets.js';
-import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 import { gzipSync } from "zlib";
 
 // files to ignore when bundling. node has no globs, so use regexps
@@ -1670,6 +1669,8 @@ class ClientTarget extends Target {
     if (this.arch === 'web.cordova') {
       const { WebAppHashing } =
         loadIsopacket('cordova-support')['webapp-hashing'];
+
+      import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 
       const cordovaCompatibilityVersions =
         _.object(_.map(CORDOVA_PLATFORM_VERSIONS, (version, platform) => {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -988,8 +988,21 @@ var getShrinkwrappedDependencies = function (dir) {
   return treeToDependencies(getShrinkwrappedDependenciesTree(dir));
 };
 
-const installNpmModule = meteorNpm.installNpmModule = (name, version, dir) => {
+const moduleDoesResolve = meteorNpm.moduleDoesResolve = (dep) => {
+  try {
+    require.resolve(dep);
+  } catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') {
+      throw e;
+    }
 
+    return false;
+  }
+
+  return true;
+};
+
+const installNpmModule = meteorNpm.installNpmModule = (name, version, dir) => {
   const installArg = utils.isNpmUrl(version)
     ? version
     : `${name}@${version}`;


### PR DESCRIPTION
**Note:** This is targeting `release-1.6`, though it's reasonable to believe this could go into a `release-1.5.x` branch (currently, `release-1.5.2`).

---

This changes `cordova-lib` (and its rather large dependency tree) to no longer be built into the initially downloaded dev bundle by `generate-dev-bundle.sh`, but rather to be downloaded and installed automatically upon execution of commands which utilize Cordova functionality, namely `meteor add-platform <target>`, `meteor remove-platform <target>` and `meteor run <target>`.

This falls short of completely decoupling Cordova from Meteor (as https://github.com/meteor/meteor-feature-requests/issues/112 is requesting), but by removing it from the initial dev bundle we reduce the download size of the installation tarball by about 35MB (a ~38% decrease).

This PR also includes [this fix](https://github.com/meteor/meteor/commit/043e2922f6ef8ee49e32ef37a81704b2d08730fc) for a misspelled parameter which was breaking Cordova on the `release-1.6` branch (which I was testing on).

This might still be "work-in-progress", but I submit it for consideration. 😉 