### PR TITLE
Auto-install `meteor self-test` dependencies upon use.

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -136,14 +136,6 @@ For more fine-grained control, if you're interested in running only the specific
 
 While TinyTest and the `test-packages` command can be used to test internal Meteor packages, they cannot be used to test the Meteor Tool itself. The Meteor Tool is a node app that uses a home-grown "self test" system.
 
-#### Prerequisites
-
-To reduce the size of the Meteor distribution, some parts of the self-test system must be installed separately, including `phantomjs-prebuilt` and `browserstack-webdriver`.
-
-A notification will be displayed when attempting to use the `self-test` commands if these dependencies are not installed.  Make sure to install them into your checkout when prompted:
-
-    ./meteor npm install -g phantomjs-prebuilt browserstack-webdriver
-
 #### Listing available tests
 
 To see a list of the tests which are included in the self-test system, list them with the `--list` option:

--- a/History.md
+++ b/History.md
@@ -30,6 +30,11 @@
 
 * The `semver` npm package has been upgraded to version 5.4.1.
 
+* When running Meteor tool (i.e. `./meteor self-test`) tests during the course of
+  developing Meteor itself, it is no longer necessary to
+  `./meteor npm install -g phantomjs-prebuilt browserstack-webdriver`.  These
+  will now be installed automatically upon their use.
+
 ## v1.5.2, TBD
 
 * The `meteor-babel` package has been upgraded to version 0.23.1.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -35,10 +35,6 @@ if [ -z "$CIRCLE_NODE_TOTAL" ] || [ -z "$CIRCLE_NODE_INDEX" ]; then
   echo "Running all tests!"
 fi
 
-# Since PhantomJS has been removed from dev_bundle/lib/node_modules
-# (#6905), but self-test still needs it, install it now.
-./meteor npm install -g phantomjs-prebuilt browserstack-webdriver
-
 # Make sure we have initialized and updated submodules such as
 # packages/non-core/blaze.
 git submodule update --init --recursive

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -27,27 +27,14 @@ var release = require('../packaging/release.js');
 var projectContextModule = require('../project-context.js');
 var upgraders = require('../upgraders.js');
 
+import { ensureDependencies } from '../cli/dev-bundle-helpers.js';
+
+const DEV_DEPENDENCY_VERSIONS = {
+  'phantomjs-prebuilt': '2.1.14',
+  'browserstack-webdriver': '2.41.1',
+};
+
 require("../tool-env/install-runtime.js");
-
-function checkTestOnlyDependency(name) {
-  try {
-    var absPath = require.resolve(name);
-  } catch (e) {
-    throw new Error([
-      "Please install " + name + " by running the following command:",
-      "",
-      "  /path/to/meteor npm install -g " + name,
-      "",
-      "Where `/path/to/meteor` is the executable you used to run this self-test.",
-      ""
-    ].join("\n"));
-  }
-
-  return require(absPath);
-}
-
-var phantomjs = checkTestOnlyDependency("phantomjs-prebuilt");
-var webdriver = checkTestOnlyDependency('browserstack-webdriver');
 
 // To allow long stack traces that cross async boundaries
 require('longjohn');
@@ -1025,6 +1012,19 @@ var PhantomClient = function (options) {
   var self = this;
   Client.apply(this, arguments);
 
+  buildmessage.enterJob(
+    {
+      title: 'Installing PhantomJS in Meteor tool',
+    },
+    () => {
+      ensureDependencies({
+        'phantomjs-prebuilt': DEV_DEPENDENCY_VERSIONS['phantomjs-prebuilt'],
+      });
+    }
+  );
+
+  self.npm = require("phantomjs-prebuilt");
+
   self.name = "phantomjs";
   self.process = null;
 
@@ -1037,7 +1037,7 @@ _.extend(PhantomClient.prototype, {
   connect: function () {
     var self = this;
 
-    var phantomPath = phantomjs.path;
+    var phantomPath = self.npm.path;
 
     var scriptPath = files.pathJoin(files.getCurrentToolsDir(), "tools",
       "tool-testing", "phantom", "open-url.js");
@@ -1071,6 +1071,19 @@ var browserStackKey = null;
 var BrowserStackClient = function (options) {
   var self = this;
   Client.apply(this, arguments);
+
+  buildmessage.enterJob(
+    {
+      title: 'Installing BrowserStack WebDriver in Meteor tool',
+    },
+    () => {
+      ensureDependencies({
+        'browserstack-webdriver': DEV_DEPENDENCY_VERSIONS['browserstack-webdriver'],
+      });
+    }
+  );
+
+  self.npm = require('browserstack-webdriver');
 
   self.tunnelProcess = null;
   self.driver = null;
@@ -1115,7 +1128,7 @@ _.extend(BrowserStackClient.prototype, {
         throw error;
       }
 
-      self.driver = new webdriver.Builder().
+      self.driver = new self.npm.Builder().
         usingServer('http://hub.browserstack.com/wd/hub').
         withCapabilities(capabilities).
         build();

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -1023,7 +1023,7 @@ var PhantomClient = function (options) {
     }
   );
 
-  self.npm = require("phantomjs-prebuilt");
+  self.npmPackageExports = require("phantomjs-prebuilt");
 
   self.name = "phantomjs";
   self.process = null;
@@ -1037,7 +1037,7 @@ _.extend(PhantomClient.prototype, {
   connect: function () {
     var self = this;
 
-    var phantomPath = self.npm.path;
+    var phantomPath = self.npmPackageExports.path;
 
     var scriptPath = files.pathJoin(files.getCurrentToolsDir(), "tools",
       "tool-testing", "phantom", "open-url.js");
@@ -1083,7 +1083,7 @@ var BrowserStackClient = function (options) {
     }
   );
 
-  self.npm = require('browserstack-webdriver');
+  self.npmPackageExports = require('browserstack-webdriver');
 
   self.tunnelProcess = null;
   self.driver = null;
@@ -1128,7 +1128,7 @@ _.extend(BrowserStackClient.prototype, {
         throw error;
       }
 
-      self.driver = new self.npm.Builder().
+      self.driver = new self.npmPackageExports.Builder().
         usingServer('http://hub.browserstack.com/wd/hub').
         withCapabilities(capabilities).
         build();


### PR DESCRIPTION
**Note:** Targeted for `release-1.6`, because of the dependency on #8976.

---

This uses the same new facilities which were created for auto-installing Cordova (#8976) to also auto-install PhantomJS and BrowserStack WebDriver npms into their appropriate home in the dev bundle when they're needed for running self-tests.

Gloriously, this means if you're constantly changing between dev bundles, you'll no longer need to take the extra step of doing so each time. 🙌 