### PR TITLE
Increase mongo connection timeout to reduce self-test mongo errors

### DIFF
--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -593,7 +593,7 @@ var launchMongo = function (options) {
         'meteor',
         new mongoNpmModule.Server('127.0.0.1', options.port, {
           poolSize: 1,
-          socketOptions: {connectTimeoutMS: 30000},
+          socketOptions: {connectTimeoutMS: 60000},
         }),
         {safe: true});
 

--- a/tools/tests/modules.js
+++ b/tools/tests/modules.js
@@ -24,7 +24,7 @@ selftest.define("modules - test app", function () {
       "--driver-package", "dispatch:mocha-phantomjs"
     );
 
-    run.waitSecs(180);
+    run.waitSecs(60);
     run.match("App running at");
     run.match("SERVER FAILURES: 0");
     run.match("CLIENT FAILURES: 0");


### PR DESCRIPTION
Hi all - this PR should fix the `modules - test app` self-test timeout issues that were originally uncovered by https://github.com/meteor/meteor/commit/4d37a05fb33576b8f167168f4bc1b12821354615 (and reverted by https://github.com/meteor/meteor/pull/8913/commits/565281e765cb9e5f5c10ac37c8ee03f42ecc1874). With 4d37a05fb33576b8f167168f4bc1b12821354615 in place, the `modules - test app` self-test times out on most runs, due to not being able to connect to Mongo within the [`tools/runners/run-mongo.js`](https://github.com/meteor/meteor/blob/2ebd647e1a16c41344bc13533bd852bfd843620f/tools/runners/run-mongo.js#L596) specified mongo connection timeout of 30 seconds. Increasing this timeout to 60 seconds allows the test to pass properly and shouldn't impact any other parts of the codebase (or normal non-test Mongo usage). 

While these changes will help address the `modules - test app` self-test mongo timeout errors, there is still something else happening here that needs to be investigated further. When running in test mode, the initial node mongo `open` connection call ([here](https://github.com/meteor/meteor/blob/3b2e0b6dbcd32ab8adebf1fb3ead69fe236da944/tools/runners/run-mongo.js#L600)) takes quite a while to complete (on Linux, usually between 30 - 40 seconds). This is the main source of the mongo connection timeout being hit. I'm not sure why the initial `open` call is taking so long, but even more bizarre is that if I switch the mongo `Server` host used to `localhost` instead of `127.0.0.1` ([here](https://github.com/meteor/meteor/blob/3b2e0b6dbcd32ab8adebf1fb3ead69fe236da944/tools/runners/run-mongo.js#L594)), the `open` call completes within milliseconds. Again, this is only happening when using test mode, so that narrows the problem area a bit.

Long story short, the changes in this PR should help us get the work in https://github.com/meteor/meteor/pull/8913/commits/565281e765cb9e5f5c10ac37c8ee03f42ecc1874 back into `1.5.2` (if it's not too late), but this problem should be looked into further at some point.

One last thing - this PR also includes a change to lower the timeouts we put in `modules - test app` that are no longer needed, due to the increased mongo connection timeout.

Thanks!
