### PR TITLE
Reinstate the mongo-dev-server package (#8853)

### DIFF
--- a/History.md
+++ b/History.md
@@ -36,6 +36,18 @@
   root of the bundle, but it may be deprecated in a future version of Meteor.
   [PR #8956](https://github.com/meteor/meteor/pull/8956)
 
+* A new package called `mongo-dev-server` has been created and wired into
+  `mongo` as a dependency. As long as this package is included in a Meteor
+  application (which it is by default since all new Meteor apps have `mongo`
+  as a dependency), a local development MongoDB server is started alongside
+  the application. This package was created to provide a way to disable the
+  local development Mongo server, when `mongo` isn't needed (e.g. when using
+  Meteor as a build system only). If an application has no dependency on
+  `mongo`, the `mongo-dev-server` package is not added, which means no local
+  development Mongo server is started.
+  [Feature Request #31](https://github.com/meteor/meteor-feature-requests/issues/31)
+  [PR #8853](https://github.com/meteor/meteor/pull/8853)
+
 * `Accounts.config` no longer mistakenly allows tokens to expire when
   the `loginExpirationInDays` option is set to `null`.
   [Issue #5121](https://github.com/meteor/meteor/issues/5121)

--- a/packages/mongo-dev-server/README.md
+++ b/packages/mongo-dev-server/README.md
@@ -1,0 +1,18 @@
+# mongo-dev-server
+
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/mongo-dev-server) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/mongo-dev-server)
+***
+
+When the `mongo-dev-server` package is included in a Meteor application, a
+local development MongoDB server is started alongside the application. This
+package is mostly used internally, as it is included by default with any
+application that has a dependency on `mongo` (which is most Meteor
+applications). In some cases however, people might be interested in
+using the Meteor Tool without having to start a local development Mongo
+instance (e.g. when using Meteor as a build system). If an application has no
+dependency on `mongo`, the `mongo-dev-server` package will be removed
+(since it is a direct dependency of the `mongo` package), and no local
+development Mongo server will be started.
+
+Note this is a `debugOnly` package, meaning it will not be included in any
+production bundles.

--- a/packages/mongo-dev-server/package.js
+++ b/packages/mongo-dev-server/package.js
@@ -1,0 +1,12 @@
+Package.describe({
+  debugOnly: true,
+  documentation: 'README.md',
+  name: 'mongo-dev-server',
+  summary: 'Start MongoDB alongside Meteor, in development mode.',
+  version: '1.0.1-beta152.7',
+});
+
+Package.onUse(function (api) {
+  api.use('modules');
+  api.mainModule('server.js', 'server');
+});

--- a/packages/mongo-dev-server/server.js
+++ b/packages/mongo-dev-server/server.js
@@ -1,0 +1,3 @@
+if (process.env.MONGO_URL === 'no-mongo-server') {
+  Meteor._debug('Note: Restart Meteor to start the MongoDB server.');
+}

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -34,7 +34,8 @@ Package.onUse(function (api) {
     'diff-sequence',
     'mongo-id',
     'check',
-    'ecmascript'
+    'ecmascript',
+    'mongo-dev-server',
   ]);
 
   // Binary Heap data structure is used to optimize oplog observe driver

--- a/tools/tests/static-html.js
+++ b/tools/tests/static-html.js
@@ -54,8 +54,7 @@ selftest.define("static-html - throws error", () => {
   s.cd('myapp');
 
   const run = startRun(s);
-  run.match("Attributes on <head> not supported");
-  run.waitSecs(90);
+  run.matchBeforeExit("Attributes on <head> not supported");
 
   run.stop();
 });


### PR DESCRIPTION
Only start the MongoDB server if this package is present in the project.

This reverts commit 565281e765cb9e5f5c10ac37c8ee03f42ecc1874.

In addition to re-instating the `mongo-dev-server` changes, this PR also includes adjustments to the `static-html - throws error` self-test, that are required as part of the `mongo-dev-server` work. These adjustments were orginally included in https://github.com/meteor/meteor/commit/4d37a05fb33576b8f167168f4bc1b12821354615, but when some of these changes were reverted by https://github.com/meteor/meteor/commit/565281e765cb9e5f5c10ac37c8ee03f42ecc1874, the `static-html - throws error` fix was left in 1.5.2. Without the rest of the `mongo-dev-server`  changes in place howerver, this self-test fix had to be changed, which was done in https://github.com/meteor/meteor/pull/8913/commits/22e86ce20866c26cbfe2d68f3119de83a036cd97. Long story short - now that we're adding the `mongo-dev-server` changes back into 1.5.2, we have to apply the `static-html - throws error` changes again.

Also - the `modules - test app` self-test failure here is related to the work done in https://github.com/meteor/meteor/pull/8963, and is still being investigated (https://github.com/meteor/meteor/pull/8913#commitcomment-23547728). It isn't caused by the changes in this PR.

Thanks!