### PR TITLE
Immediately dirty optimistic functions when relevant paths modified.

### DIFF
--- a/tools/fs/optimistic.js
+++ b/tools/fs/optimistic.js
@@ -10,6 +10,7 @@ import {
   lstat,
   readFile,
   readdir,
+  dependOnPath,
 } from "./files.js";
 
 // When in doubt, the optimistic caching system can be completely disabled
@@ -18,7 +19,7 @@ const ENABLED = ! process.env.METEOR_DISABLE_OPTIMISTIC_CACHING;
 
 function makeOptimistic(name, fn) {
   const wrapper = wrap(ENABLED ? function (...args) {
-    maybeDependOnNodeModules(args[0]);
+    maybeDependOnPath(args[0]);
     return fn.apply(this, args);
   } : fn, {
     makeCacheKey(...args) {
@@ -114,6 +115,13 @@ export const shouldWatch = wrap(path => {
   // node_modules directories might have changed.
   return false;
 });
+
+function maybeDependOnPath(path) {
+  if (typeof path === "string") {
+    dependOnPath(path);
+    maybeDependOnNodeModules(path);
+  }
+}
 
 function maybeDependOnNodeModules(path) {
   if (typeof path !== "string") {

--- a/tools/tests/compiler-plugins.js
+++ b/tools/tests/compiler-plugins.js
@@ -22,7 +22,6 @@ function startRun(sandbox) {
 // Tests the actual cache logic used by coffeescript.
 selftest.define("compiler plugin caching - coffee", () => {
   var s = new Sandbox({ fakeMongo: true });
-  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
 
   s.createApp("myapp", "caching-coffee");
   s.cd("myapp");
@@ -92,7 +91,6 @@ selftest.define("compiler plugin caching - coffee", () => {
 
   selftest.define("compiler plugin caching - " + packageName, () => {
     var s = new Sandbox({ fakeMongo: true });
-    s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
 
     s.createApp("myapp", "caching-" + packageName);
     s.cd("myapp");
@@ -280,7 +278,6 @@ selftest.define("compiler plugin caching - local plugin", function () {
 // Test error on duplicate compiler plugins.
 selftest.define("compiler plugins - duplicate extension", () => {
   const s = new Sandbox({ fakeMongo: true });
-  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
 
   s.createApp("myapp", "duplicate-compiler-extensions");
   s.cd("myapp");

--- a/tools/tests/cordova-plugins.js
+++ b/tools/tests/cordova-plugins.js
@@ -136,8 +136,6 @@ selftest.define("change cordova plugins", ["cordova"], function () {
   var s = new Sandbox();
   var run;
 
-  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
-
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");

--- a/tools/tests/hot-code-push.js
+++ b/tools/tests/hot-code-push.js
@@ -7,6 +7,8 @@ selftest.define("css hot code push", function (options) {
     clients: options.clients
   });
 
+  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
+
   s.createApp("myapp", "css-injection-test");
   s.cd("myapp");
   s.testWithAllClients(function (run) {

--- a/tools/tests/hot-code-push.js
+++ b/tools/tests/hot-code-push.js
@@ -7,8 +7,6 @@ selftest.define("css hot code push", function (options) {
     clients: options.clients
   });
 
-  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
-
   s.createApp("myapp", "css-injection-test");
   s.cd("myapp");
   s.testWithAllClients(function (run) {

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -100,8 +100,6 @@ selftest.define("change packages during hot code push", [], function () {
   var s = new Sandbox();
   var run;
 
-  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
-
   // Starting a run
   s.createApp("myapp", "package-tests");
   s.cd("myapp");

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -260,7 +260,7 @@ selftest.define("update during run", ["checkout", 'custom-warehouse'], function 
   run.match('localhost:3000');
   s.write('.meteor/release', DEFAULT_RELEASE_TRACK + '@v2');
   s.write('empty.js', '');
-  run.waitSecs(2);
+  run.waitSecs(10);
   run.match('restarted');
   run.waitSecs(10);
   run.stop();
@@ -270,11 +270,11 @@ selftest.define("update during run", ["checkout", 'custom-warehouse'], function 
   s.write('.meteor/release', DEFAULT_RELEASE_TRACK + '@v1');
   run = s.run("--release", DEFAULT_RELEASE_TRACK + "@v1");
   run.tellMongo(MONGO_LISTENING);
-  run.waitSecs(2);
+  run.waitSecs(10);
   run.match('localhost:3000');
   s.write('.meteor/release', DEFAULT_RELEASE_TRACK + '@v2');
   s.write('empty.js', '');
-  run.waitSecs(2);
+  run.waitSecs(10);
   run.match('restarted');
   run.waitSecs(10);
   run.stop();
@@ -288,12 +288,12 @@ selftest.define("update during run", ["checkout", 'custom-warehouse'], function 
   s.write('.meteor/release', DEFAULT_RELEASE_TRACK + '@v1');
   run = s.run();
   run.tellMongo(MONGO_LISTENING);
-  run.waitSecs(2);
+  run.waitSecs(10);
   run.match('localhost:3000');
   run.waitSecs(10);
   s.write('.meteor/release', DEFAULT_RELEASE_TRACK + '@v2');
   s.write('empty.js', '');
-  run.waitSecs(2);
+  run.waitSecs(10);
   run.match('restarted');
   run.waitSecs(10);
   run.stop();

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -239,6 +239,8 @@ selftest.define("update during run", ["checkout", 'custom-warehouse'], function 
   });
   var run;
 
+  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
+
   s.createApp("myapp", "packageless", { release: DEFAULT_RELEASE_TRACK + '@v1' });
   s.cd("myapp");
 

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -22,8 +22,6 @@ selftest.define("run", function () {
   var s = new Sandbox({ fakeMongo: true });
   var run;
 
-  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
-
   // Starting a run
   s.createApp("myapp", "standard-app");
   s.cd("myapp");
@@ -240,8 +238,6 @@ selftest.define("update during run", ["checkout", 'custom-warehouse'], function 
     fakeMongo: true
   });
   var run;
-
-  s.set("METEOR_WATCH_PRIORITIZE_CHANGED", "false");
 
   s.createApp("myapp", "packageless", { release: DEFAULT_RELEASE_TRACK + '@v1' });
   s.cd("myapp");


### PR DESCRIPTION
Should fix #8988 and #8942.

Now that #8866 is the default behavior, it can take up to 5000ms for changes to files modified during the build process to be noticed.

Before #8866, when we called e.g. `files.writeFile(path)`, a native file watcher would notice the change immediately, almost always before the build process read the file again. This was definitely racy, but we were getting away with it consistently... until #8866.

I was able to reproduce the problem in #8988 by running
```sh
echo some-local-package-name >> .meteor/packages
```
in an app with a local package of the given name. After debugging the endless rebuild cycle, I found that `.meteor/versions` was being rewritten by `files.writeFile` during the build process, but the file watching system was not noticing the change in time to prevent `watch.isUpToDate` from returning `true`. The change was finally detected when restarting the Watcher responsible for `.meteor/versions`, which of course triggered another rebuild, so the same problem kept happening again and again.