### PR TITLE
Add sizes necessary for iOs legacy, notification icon support.

### DIFF
--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -25,6 +25,15 @@ const iconsIosSizes = {
   'ios_spotlight': '40x40',
   'ios_spotlight_2x': '80x80',
   'ios_spotlight_3x': '120x120',
+  'ios_notification': '20x20',
+  'ios_notification_2x': '40x40',
+  'ios_notification_3x': '60x60',
+  'iphone_legacy': '57x57',
+  'iphone_legacy_2x': '114x114',
+  'ipad_spotlight_legacy': '50x50',
+  'ipad_spotlight_legacy_2x': '100x100',
+  'ipad_app_legacy': '72x72',
+  'ipad_app_legacy_2x': '144x144',
 };
 
 const iconsAndroidSizes = {
@@ -537,6 +546,15 @@ Valid platforms are: ios, android.`);
      * - `ios_spotlight` (40x40)
      * - `ios_spotlight_2x` (80x80)
      * - `ios_spotlight_3x` (120x120)
+     * - 'ios_notification': '20x20',
+     * - 'ios_notification_2x': '40x40',
+     * - 'ios_notification_3x': '60x60',
+     * - 'iphone_legacy': '57x57',
+     * - 'iphone_legacy_2x': '114x114',
+     * - 'ipad_spotlight_legacy': '50x50',
+     * - 'ipad_spotlight_legacy_2x': '100x100',
+     * - 'ipad_app_legacy': '72x72',
+     * - 'ipad_app_legacy_2x': '144x144',
      * - `android_mdpi` (48x48)
      * - `android_hdpi` (72x72)
      * - `android_xhdpi` (96x96)


### PR DESCRIPTION
Related issues:

[`App.icons` for iOs are incomplete](https://github.com/meteor/meteor/issues/9006)
[Current set does not include a few key icons](https://github.com/lpender/meteor-assets/issues/10)

## App Icons Before

![image](https://user-images.githubusercontent.com/1406554/29220305-a2a9d3cc-7e88-11e7-8f07-355fae1194ac.png)

## App Icons After

![image](https://user-images.githubusercontent.com/1406554/29226351-a9ae0f6e-7e9f-11e7-8787-54a532546776.png)

*Note*

The notification sizes don't work yet but I suspect this may be an [issue with phonegap](https://github.com/phonegap/phonegap-plugin-push/issues/1218#issuecomment-321882253)