### PR TITLE
JUnit support for `meteor self-test` test runner.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ run_env_change: &run_env_change
     sudo mkdir -p /tmp/core_dumps
     sudo chmod a+rwx /tmp/core_dumps
 
+    # Make a place for JUnit tests to live.
+    sudo mkdir -p /tmp/results/junit
+    sudo chmod -R a+rwx /tmp/results/
+
     # Set the pattern for core dumps, so we can find them.
     echo kernel.core_pattern="/tmp/core_dumps/core.%e.%p.%h.%t" | \
         sudo tee -a /etc/sysctl.conf
@@ -167,6 +171,7 @@ jobs:
             ./meteor self-test \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
+              --junit /tmp/results/junit/0.xml \
               --with-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
@@ -174,6 +179,10 @@ jobs:
       - save_cache:
           key: meteor-cache
           <<: *meteor_cache_dirs
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
@@ -195,6 +204,7 @@ jobs:
             ./meteor self-test \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
+              --junit /tmp/results/junit/1.xml \
               --file '^[a-b]|^c[a-n]|^co[a-l]|^compiler-plugins' \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
@@ -203,6 +213,10 @@ jobs:
       - save_cache:
           key: meteor-cache
           <<: *meteor_cache_dirs
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
@@ -224,6 +238,7 @@ jobs:
             ./meteor self-test \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
+              --junit /tmp/results/junit/2.xml \
               --file "^co[n-z]|^c[p-z]|^[d-k]" \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
@@ -232,6 +247,10 @@ jobs:
       - save_cache:
           key: meteor-cache
           <<: *meteor_cache_dirs
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
@@ -253,6 +272,7 @@ jobs:
             ./meteor self-test \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
+              --junit /tmp/results/junit/3.xml \
               --file '^[l-o]' \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
@@ -261,6 +281,10 @@ jobs:
       - save_cache:
           key: meteor-cache
           <<: *meteor_cache_dirs
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
@@ -282,6 +306,7 @@ jobs:
             ./meteor self-test \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
+              --junit /tmp/results/junit/4.xml \
               --file '^p' \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
@@ -290,6 +315,10 @@ jobs:
       - save_cache:
           key: meteor-cache
           <<: *meteor_cache_dirs
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
@@ -311,6 +340,7 @@ jobs:
             ./meteor self-test \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
+              --junit /tmp/results/junit/5.xml \
               --file '^run' \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
@@ -319,6 +349,10 @@ jobs:
       - save_cache:
           key: meteor-cache
           <<: *meteor_cache_dirs
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
@@ -340,6 +374,7 @@ jobs:
             ./meteor self-test \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
+              --junit /tmp/results/junit/6.xml \
               --file '^r(?!un)|^s' \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
@@ -348,6 +383,10 @@ jobs:
       - save_cache:
           key: meteor-cache
           <<: *meteor_cache_dirs
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
@@ -369,6 +408,7 @@ jobs:
             ./meteor self-test \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
+              --junit /tmp/results/junit/7.xml \
               --file '^[t-z]|^command-line' \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
@@ -377,6 +417,10 @@ jobs:
       - save_cache:
           key: meteor-cache
           <<: *meteor_cache_dirs
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -2079,6 +2079,7 @@ main.registerCommand({
     'without-tag': { type: String },
     // Only run tests with this tag
     'with-tag': { type: String },
+    junit: { type: String },
   },
   hidden: true,
   catalogRefresh: new catalog.Refresh.Never()
@@ -2175,6 +2176,7 @@ main.registerCommand({
     // other options
     historyLines: options.history,
     clients: clients,
+    junit: options.junit && files.pathResolve(options.junit),
     'without-tag': options['without-tag'],
     'with-tag': options['with-tag']
   });


### PR DESCRIPTION
This started as a proof-of-concept, but I think it's worth submitting for consideration.

In an effort to get more fine-grained information out of the `meteor self-test` tool (which is used for testing of Meteor releases during development) and to take advantage of additional features in CircleCI (and other test environments), this introduces a `--junit=output.xml` argument to the `meteor self-test ...` command.

This gains us a couple relatively functionally pleasing features, such as the ability to see [failed tests without scrolling through all the results](https://circleci.com/gh/abernix/meteor/1358) and [CircleCI Insights on test timings](https://circleci.com/build-insights/gh/abernix/meteor/abernix%252Fmore-selftest2).

One of the more important historical pieces of information we will gain with this is the timings of each individual test.  Using this information, which is [stored by CircleCI automatically](https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-patterns) in `/.circleci-task-data/circle-test-results/` and also available through their API, we should be able to auto-balance tests using a partitioning algorithm and have our tests all run in as little time as possible.  Though, I think after we gather this information for a week, we may be able to just manually re-balance the containers as well.

This utilizes the JUnit output format as it seems to be the most widely supported by CI environments – if I'm missing some common knowledge here, please do tell.  A standardized, widely-supported, simple JSON format would be nice!  Unfortunately, without that, this has the requirement of generating XML from the `meteor self-test` code.  Given that the structure was relatively simple and I was hesitant to include an XML-building npm (we have [`xmlbuilder`](https://github.com/meteor/meteor/tree/devel/packages/xmlbuilder) already as a Meteor package, used in Cordova, but it's not an individual [isopacket](https://github.com/meteor/meteor/blob/93d0c5f2bad2d75b98ec5ecdacfc6bf1d323a9de/tools/tool-env/isopackets.js#L52-L60)).  If we wanted to, I could change this to auto-install some xml-building package via a similar method as https://github.com/meteor/meteor/pull/8981, though that would require Meteor `release-1.6`.