### PR TITLE
Be more considerate of interactive environments and expired tokens.

### DIFF
--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -584,6 +584,10 @@ class Console extends ConsoleBase {
     });
   }
 
+  isInteractive() {
+    return !this._headless;
+  }
+
   setPretty(pretty) {
     // If we're being forced, do nothing.
     if (FORCE_PRETTY !== undefined) {

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -179,6 +179,15 @@ function authedRpc(options) {
   delete rpcOptions.printDeployURL;
 
   if (infoResult.statusCode === 401 && rpcOptions.promptIfAuthFails) {
+    Console.error("Authentication failed or login token expired.");
+
+    if (!Console.isInteractive()) {
+      return {
+        statusCode: 401,
+        errorMessage: "login failed."
+      };
+    }
+
     // Our authentication didn't validate, so prompt the user to log in
     // again, and resend the RPC if the login succeeds.
     var username = Console.readLine({


### PR DESCRIPTION
If a login token is expired, or no longer valid, make sure that Meteor doesn't
just sit there at a login prompt that the user can't see.

This currently only applies if `headless` mode is enabled, though a follow-up
to this commit might consider setting `headless = true` automatically
in a CI environment using environment variables such as: `CI`, `TRAVIS`,
`JENKINS_URL`, etc., as the npm-registry-client does in a similar way.

See: https://github.com/npm/npm-registry-client/pull/129/files

Fixes #8839.