### PR TITLE
Changes to npm installation methods for npm@5 / Meteor 1.6.

### DIFF
--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -86,13 +86,6 @@ exports.getEnv = function (options) {
       env.NPM_CONFIG_PREFIX = devBundleDir;
     }
 
-    // Make sure we don't try to use the global ~/.npm cache accidentally.
-    if (! env.NPM_CONFIG_CACHE) {
-      env.NPM_CONFIG_CACHE = path.join(
-        // If the user set NPM_CONFIG_PREFIX, respect that.
-        env.NPM_CONFIG_PREFIX, ".npm");
-    }
-
     if (env.METEOR_ALLOW_SUPERUSER) {
       // Note that env.METEOR_ALLOW_SUPERUSER could be "0" or "false", which
       // should propagate falsy semantics to NPM_CONFIG_UNSAFE_PERM.


### PR DESCRIPTION
This PR submits two changes for the `release-1.6` branch (Meteor 1.6) which uses `npm@5`.  Without this fix, on Windows 10 Insider Preview, somewhat cryptic errors were encountered when trying to `meteor npm install`, such as:

```
npm ERR! Command failed: C:\Program Files\Git\cmd\git.EXE submodule update -q --init --recursive
npm ERR! C:\Program Files\Git\mingw64/libexec/git-core\git-submodule: line 7: basename: command not found
npm ERR! C:\Program Files\Git\mingw64/libexec/git-core\git-submodule: line 7: sed: command not found
npm ERR! C:\Program Files\Git\mingw64/libexec/git-core\git-submodule: line 19: .: git-sh-setup: file not found
```

This appears to be fixed if we no longer set the `NPM_CONFIG_CACHE` variable to our own cache directory.  This should be fine given that `npm@5` has much more robust, self-healing, concurrency-touting [`cacache`](https://www.npmjs.com/package/cacache) implementation.  This should help reduce the amount of disk space by allowing Meteor to use your global npm cache (e.g. `~/.npm`, `%APPDATA%\npm`) instead of its own within the dev bundle.

Additionally, as there are now some more official recommendations on how to launch `.cmd` and `.bat` (i.e. Windows) scripts [in the docs](http://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows), this also changes the way we spawn `npm install` internally (such as when we build npms for packages, or when we install the default skeleton set of npms with `meteor create <app>` to launch the `npm.cmd` using `cmd.exe` as prescribed.  Without this change, `meteor create <app>` was not working for me with `1.6-beta.20`.