### PR TITLE
Avoid creating a watcher when --settings is set to a directory

### DIFF
--- a/tools/fs/watch.js
+++ b/tools/fs/watch.js
@@ -562,14 +562,6 @@ export class Watcher {
     });
   }
 
-  // XXX Erk! This is wrong!  A null entry in a WatchSet means "is not a file",
-  // not "does not exist"; if you look at readAndWatchFileWithHash, "a directory
-  // where a file was expected" leads to the entry being null.  Right now this
-  // leads to infinite watcher refresh loops if something that needs to be a
-  // directory ends up as a file.  This all needs to be changed so that null
-  // means "not a file" again. A simple way to reproduce is to run
-  //    $ meteor --settings /tmp
-  // See #3854.
   _mustNotExist(absPath) {
     var wsFiles = this.watchSet.files;
     if (_.has(wsFiles, absPath)) {
@@ -726,10 +718,13 @@ export function readAndWatchFileWithHash(watchSet, absPath) {
   var contents = readFile(absPath);
   var hash = null;
 
+  var stat = files.statOrNull(absPath);
+  var isDirectory = stat && stat.isDirectory();
+
   // Allow null watchSet, if we want to use readFile-style error handling in a
   // context where we might not always have a WatchSet (eg, reading
   // settings.json where we watch for "meteor run" but not for "meteor deploy").
-  if (watchSet) {
+  if (! isDirectory && watchSet) {
     hash = contents === null ? null : sha1(contents);
     watchSet.addFile(absPath, hash);
   }


### PR DESCRIPTION
This fixes #3854 (where passing a directory via the `meteor --settings` option causes the Meteor Tool to get caught up in an infinite rebuild loop).

Looking over the Meteor codebase, it doesn't look like [`tools/fs/watch.js#readAndWatchFileWithHash`](https://github.com/meteor/meteor/blob/65c8b481e20d02aa06b994c75d83c7db79ce37df/tools/fs/watch.js#L725-L738) needs to ever allow directory watching (since [`tools/fs/watch.js#readAndWatchDirectory`](https://github.com/meteor/meteor/blob/65c8b481e20d02aa06b994c75d83c7db79ce37df/tools/fs/watch.js#L712-L716) exists for this purpose). To this end, I've adjusted `readAndWatchFileWithHash` to skip adding directories to the `watchSet`, which fixes the infinite `--settings` rebuild loop. I'm happy to move this around if anyone thinks this should go somewhere else. Thanks!