### PR TITLE
Patch Node 4.8.4 to fix segmetation faults.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,9 +124,9 @@ jobs:
           name: Get Ready
           command: |
             eval $PRE_TEST_COMMANDS;
-            ./meteor --help
-          # shouldn't take longer than 5 minutes
-          no_output_timeout: 5m
+            ./meteor --get-ready
+          # shouldn't take longer than 10 minutes
+          no_output_timeout: 10m
       # Clear dev_bundle/.npm to ensure consistent test runs.
       - run:
           name: Clear npm cache

--- a/History.md
+++ b/History.md
@@ -2,6 +2,15 @@
 
 ## v1.5.2, TBD
 
+* Node 4.8.4 has been patched to include
+  https://github.com/nodejs/node/pull/14829, an important PR implemented
+  by our own @abernix (:tada:), which fixes a faulty backport of garbage
+  collection-related logic in V8 that was causing occasional segmentation
+  faults during Meteor development and testing, ever since Node 4.6.2
+  (Meteor 1.4.2.3). When Node 4.8.5 is officially released with these
+  changes, we will immediately cut a small follow-up release.
+  [Issue #8648](https://github.com/meteor/meteor/issues/8648)
+
 * The `meteor-babel` package has been upgraded to version 0.23.1.
 
 * The `reify` npm package has been upgraded to version 0.12.0, which

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.8.32
+BUNDLE_VERSION=4.8.33
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.8.31
+BUNDLE_VERSION=4.8.32
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.8.33
+BUNDLE_VERSION=4.8.34
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -10,7 +10,7 @@ NODE_VERSION=4.8.4
 NPM_VERSION=4.6.1
 
 # If we built Node from source on Jenkins, this is the build number.
-NODE_BUILD_NUMBER=27
+NODE_BUILD_NUMBER=33
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -9,6 +9,9 @@ MONGO_VERSION=3.2.15
 NODE_VERSION=4.8.4
 NPM_VERSION=4.6.1
 
+# If we built Node from source on Jenkins, this is the build number.
+NODE_BUILD_NUMBER=27
+
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then
         echo "Unsupported architecture: $ARCH"

--- a/scripts/build-node-for-dev-bundle.sh
+++ b/scripts/build-node-for-dev-bundle.sh
@@ -33,7 +33,7 @@ function downloadNode {
 
 if [ ! -z ${NODE_FROM_SRC+x} ]
 then
-    mkdir node-src/ && cd node-src/
+    mkdir node-build && cd node-build
     downloadNode
     if [ "${NODE_FROM_SRC:-}" = "debug" ]
     then
@@ -45,7 +45,6 @@ then
     # PORTABLE=1 is a node hack to make npm look relative to itself instead
     # of hard coding the PREFIX.
     make install PORTABLE=1
-    export npm_config_nodedir="${DIR}/node-src"
     cd "$DIR"
 else
     downloadNode
@@ -63,7 +62,7 @@ npm version
 echo BUNDLING
 
 cd "$DIR"
-rm -rf build
+rm -rf node-build
 tar czvf "${CHECKOUT_DIR}/node_${PLATFORM}_v${NODE_VERSION}.tar.gz" .
 
 echo DONE

--- a/scripts/build-node-for-dev-bundle.sh
+++ b/scripts/build-node-for-dev-bundle.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+source "$(dirname $0)/build-dev-bundle-common.sh"
+echo CHECKOUT DIR IS "$CHECKOUT_DIR"
+echo BUILDING NODE "v$NODE_VERSION" IN "$DIR"
+
+cd "$DIR"
+
+if [ ! -z ${NODE_FROM_SRC+x} ] || [ ! -z ${NODE_COMMIT_HASH+x} ]
+then
+    if [ ! -z ${NODE_COMMIT_HASH+x} ]
+    then
+        NODE_FROM_SRC=${NODE_FROM_SRC:=true}
+        echo "Building Node source from Git hash ${NODE_COMMIT_HASH}...";
+        NODE_URL="https://github.com/meteor/node/archive/${NODE_COMMIT_HASH}.tar.gz"
+    else
+        echo "Building Node source from ${NODE_VERSION} src tarball...";
+        NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz"
+    fi
+else
+    NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TGZ}"
+fi
+
+# Update these values after building the dev-bundle-node Jenkins project.
+# Also make sure to update NODE_VERSION in generate-dev-bundle.ps1.
+function downloadNode {
+    echo "Downloading Node from ${NODE_URL}"
+    curl -sL "${NODE_URL}" | tar zx --strip-components 1
+}
+
+if [ ! -z ${NODE_FROM_SRC+x} ]
+then
+    mkdir node-src/ && cd node-src/
+    downloadNode
+    if [ "${NODE_FROM_SRC:-}" = "debug" ]
+    then
+        ./configure --debug --prefix "${DIR}"
+    else
+        ./configure --prefix "${DIR}"
+    fi
+    make -j4
+    # PORTABLE=1 is a node hack to make npm look relative to itself instead
+    # of hard coding the PREFIX.
+    make install PORTABLE=1
+    export npm_config_nodedir="${DIR}/node-src"
+    cd "$DIR"
+else
+    downloadNode
+fi
+
+cd "$DIR"
+stripBinary bin/node
+
+# export path so we use our new node for later builds
+PATH="$DIR/bin:$PATH"
+which node
+which npm
+npm version
+
+echo BUNDLING
+
+cd "$DIR"
+rm -rf build
+tar czvf "${CHECKOUT_DIR}/node_${PLATFORM}_v${NODE_VERSION}.tar.gz" .
+
+echo DONE

--- a/scripts/build-node-for-dev-bundle.sh
+++ b/scripts/build-node-for-dev-bundle.sh
@@ -35,12 +35,25 @@ if [ ! -z ${NODE_FROM_SRC+x} ]
 then
     mkdir node-build && cd node-build
     downloadNode
+
+    # Build with International Components for Unicode (ICU) Support...
+    # Node 4.x used 56.x. Node 8.x uses 59.x.   I believe the only
+    # reliable location to find the correct version of ICU for a Node.js
+    # release is to check `process.config.icu_ver_major` from an
+    # official, compiled Node.js release.
+    # https://github.com/nodejs/node/wiki/Intl#configure-node-with-specific-icu-source
+    echo "Downloading International Components for Unicode (ICU)..."
+    curl -sL http://download.icu-project.org/files/icu4c/56.1/icu4c-56_1-src.tgz | \
+      tar zx -C deps/
+
+    node_configure_flags=("--prefix=${DIR}" '--with-intl=small-icu')
+
     if [ "${NODE_FROM_SRC:-}" = "debug" ]
     then
-        ./configure --debug --prefix "${DIR}"
-    else
-        ./configure --prefix "${DIR}"
+        node_configure_flags+=('--debug')
     fi
+
+    ./configure "${node_configure_flags[@]}"
     make -j4
     # PORTABLE=1 is a node hack to make npm look relative to itself instead
     # of hard coding the PREFIX.

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -68,6 +68,15 @@ which node
 which npm
 npm version
 
+# Make node-gyp use Node headers and libraries from $DIR/include/node.
+export HOME="$DIR"
+export USERPROFILE="$DIR"
+export npm_config_nodedir="$DIR"
+
+INCLUDE_PATH="${DIR}/include/node"
+echo "Contents of ${INCLUDE_PATH}:"
+ls -al "$INCLUDE_PATH"
+
 # When adding new node modules (or any software) to the dev bundle,
 # remember to update LICENSE.txt! Also note that we include all the
 # packages that these depend on, so watch out for new dependencies when
@@ -114,15 +123,6 @@ cp -R node_modules/* "${DIR}/lib/node_modules/"
 # Also include node_modules/.bin, so that `meteor npm` can make use of
 # commands like node-gyp and node-pre-gyp.
 cp -R node_modules/.bin "${DIR}/lib/node_modules/"
-
-# Make node-gyp install Node headers and libraries in $DIR/.node-gyp/.
-# https://github.com/nodejs/node-gyp/blob/4ee31329e0/lib/node-gyp.js#L52
-export HOME="$DIR"
-export USERPROFILE="$DIR"
-node "${DIR}/lib/node_modules/node-gyp/bin/node-gyp.js" install
-INCLUDE_PATH="${DIR}/.node-gyp/${NODE_VERSION}/include/node"
-echo "Contents of ${INCLUDE_PATH}:"
-ls -al "$INCLUDE_PATH"
 
 cd "${DIR}/lib"
 

--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -100,8 +100,8 @@ exports.getEnv = function (options) {
     }
 
     // This allows node-gyp to find Node headers and libraries in
-    // dev_bundle/.node-gyp.
-    env.USERPROFILE = devBundleDir;
+    // dev_bundle/include/node.
+    env.NPM_CONFIG_NODEDIR = devBundleDir;
 
     var PATH = env.PATH || env.Path;
     if (PATH) {


### PR DESCRIPTION
Brings https://github.com/nodejs/node/pull/14829 to the version of Node that ships with Meteor, hopefully preventing segmentation faults like those reported in #8648.

These changes will be officially released in Node 4.8.5, but we didn't want to [wait until September or October](https://github.com/nodejs/node/pull/14829#issuecomment-323350770) for that release.

All credit for these changes belongs to @abernix. I simply adapted his script to run in a separate Jenkins job, so that we don't have to rebuild Node from source every time we publish a new dev bundle.