### PR TITLE
Visually notify of uncaught exceptions breaking client tests

### DIFF
--- a/packages/test-in-browser/driver.css
+++ b/packages/test-in-browser/driver.css
@@ -152,3 +152,7 @@ body {
   color: #ccc;
   margin-right: 15px;
 }
+
+.failedTests {
+  color: #900; /* red */
+}

--- a/packages/test-in-browser/driver.html
+++ b/packages/test-in-browser/driver.html
@@ -1,6 +1,7 @@
 <template name="testInBrowserBody">
   <div class="container-fluid">
   {{> navBars}}
+  {{> uncaughtErrors}}
   {{> failedTests}}
   {{> testTable}}
   </div>
@@ -71,14 +72,38 @@
   </div>
 </template>
 
+<template name="uncaughtErrors">
+  {{#if uncaughtErrors}}
+    <div class="row-fluid">
+      <div class="span12">
+        <div class="alert alert-danger">
+          <p>
+            <strong>WARNING:</strong> The following uncaught errors might be
+            preventing some client tests from running.
+          </p>
+          <ul>
+            {{#each uncaughtErrors}}
+              <li>{{this}}</li>
+            {{/each}}
+          </ul>
+        </div>
+      </div>
+    </div>
+  {{/if}}
+</template>
+
 <template name="failedTests">
-  <div class="row-fluid"><div class="span12">
-  <ul class="failedTests">
-    {{#each failedTests}}
-      <li>{{this}}</li>
-    {{/each}}
-  </ul>
-  </div></div>
+  {{#if failedTests}}
+    <div class="row-fluid">
+      <div class="span12">
+        <ul class="failedTests">
+          {{#each failedTests}}
+            <li>{{this}}</li>
+          {{/each}}
+        </ul>
+      </div>
+    </div>
+  {{/if}}
 </template>
 
 <template name="testTable">

--- a/packages/test-in-browser/driver.js
+++ b/packages/test-in-browser/driver.js
@@ -35,6 +35,12 @@ var topLevelGroupsDep = new Tracker.Dependency;
 // - dep: Tracker.Dependency object for this test. fires when the test completes.
 var resultTree = [];
 
+Session.set("uncaughtErrors", []);
+window.onerror = (message, source, line) => {
+  const uncaughtErrors = new Set(Session.get("uncaughtErrors"));
+  uncaughtErrors.add(message);
+  Session.set("uncaughtErrors", Array.from(uncaughtErrors));
+};
 
 Session.setDefault("groupPath", ["tinytest"]);
 Session.set("rerunScheduled", false);
@@ -359,6 +365,13 @@ Template.groupNav.onRendered(function () {
   };
 });
 
+//// Template - uncaughtErrors
+
+Template.uncaughtErrors.helpers({
+  uncaughtErrors() {
+    return Session.get("uncaughtErrors");
+  }
+});
 
 //// Template - failedTests
 

--- a/packages/test-in-browser/package.js
+++ b/packages/test-in-browser/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Run tests interactively in the browser",
-  version: '1.0.13',
+  version: '1.0.14',
   documentation: null
 });
 

--- a/packages/test-in-browser/package.js
+++ b/packages/test-in-browser/package.js
@@ -5,6 +5,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use('ecmascript');
   // XXX this should go away, and there should be a clean interface
   // that tinytest and the driver both implement?
   api.use('tinytest');


### PR DESCRIPTION
This PR is intended to help fix #4979. I know external package `Tinytest` use has dwindled since adding `--driver-package` support to `meteor test-packages`, but since we are still supporting it (and it's used by the Meteor core), we might as well improve the `test-in-browser` UI experience a bit (let me know if anyone disagrees!).

These changes add a global `window.onerror` event handler to the `test-in-browser` package, to catch any previously uncaught exceptions. When uncaught exceptions are found, an alert like the following is shown at the top of the `test-in-browser` UI:

![screenshot 2017-08-22 09 24 27](https://user-images.githubusercontent.com/137740/29567972-ddb08d02-871c-11e7-837b-67b29ffef3a7.png)

This should help notify developers of potential errors behind the scenes, that are preventing the client side tests from running.

(P.S. --> I snuck `ecmascript` in there ... hope that's okay!)