### PR TITLE
Throw more meaningful error if .babelrc is not a valid JSON file

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -160,8 +160,16 @@ BCp._inferFromBabelRc = function (inputFile, babelOptions, cacheDeps) {
   var babelrcPath = inputFile.findControlFile(".babelrc");
   if (babelrcPath) {
     if (! hasOwn.call(this._babelrcCache, babelrcPath)) {
-      this._babelrcCache[babelrcPath] =
-        JSON.parse(inputFile.readAndWatchFile(babelrcPath));
+      try {
+        this._babelrcCache[babelrcPath] =
+          JSON.parse(inputFile.readAndWatchFile(babelrcPath));
+      } catch (e) {
+        if (e instanceof SyntaxError) {
+          e.message = ".babelrc is not a valid JSON file: " + e.message;
+        }
+
+        throw e;
+      }
     }
 
     return this._inferHelper(


### PR DESCRIPTION
Just a small improvement of the error that is thrown if a `.babelrc` file doesn't contain valid JSON. For example, the error message will be
```
.babelrc is not a valid JSON file: Unexpected token }
```
instead of
```
Unexpected token }
```
for the invalid `.babelrc` file
```
{
  "plugins":
}
```

Resolves #8792