### PR TITLE
Add date to History.md for official 1.5.2 release.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,4 @@
-## v.NEXT
-
-## v1.5.2, TBD
+## v1.5.2, 2017-09-05
 
 * Node 4.8.4 has been patched to include
   https://github.com/nodejs/node/pull/14829, an important PR implemented


### PR DESCRIPTION
I previously failed to update the `History.md` with the date before landing the `release-1.5.2` PR in `master`.  Since `master` is a protected branch, I can't fix this without a pull request.