### PR TITLE
Fix falsy `_id` in selector object not being treated as ID

### DIFF
--- a/packages/minimongo/cursor.js
+++ b/packages/minimongo/cursor.js
@@ -1,4 +1,5 @@
 import LocalCollection from './local_collection.js';
+import { hasOwn } from './common.js';
 
 // Cursor: a specification for a particular subset of documents, w/ a defined
 // order, limit, and offset.  creating a Cursor with LocalCollection.find(),
@@ -11,7 +12,9 @@ export default class Cursor {
 
     if (LocalCollection._selectorIsIdPerhapsAsObject(selector)) {
       // stash for fast _id and { _id }
-      this._selectorId = selector._id || selector;
+      this._selectorId = hasOwn.call(selector, '_id')
+        ? selector._id
+        : selector;
     } else {
       this._selectorId = undefined;
 

--- a/packages/minimongo/matcher.js
+++ b/packages/minimongo/matcher.js
@@ -88,7 +88,9 @@ export default class Matcher {
 
     // shorthand -- scalar _id and {_id}
     if (LocalCollection._selectorIsIdPerhapsAsObject(selector)) {
-      const _id = selector._id || selector;
+      const _id = hasOwn.call(selector, '_id')
+        ? selector._id
+        : selector;
 
       this._selector = {_id};
       this._recordPathUsed('_id');

--- a/packages/minimongo/matcher.js
+++ b/packages/minimongo/matcher.js
@@ -86,16 +86,12 @@ export default class Matcher {
       return doc => ({result: !!selector.call(doc)});
     }
 
-    // shorthand -- scalar _id and {_id}
-    if (LocalCollection._selectorIsIdPerhapsAsObject(selector)) {
-      const _id = hasOwn.call(selector, '_id')
-        ? selector._id
-        : selector;
-
-      this._selector = {_id};
+    // shorthand -- scalar _id
+    if (LocalCollection._selectorIsId(selector)) {
+      this._selector = {_id: selector};
       this._recordPathUsed('_id');
 
-      return doc => ({result: EJSON.equals(doc._id, _id)});
+      return doc => ({result: EJSON.equals(doc._id, selector)});
     }
 
     // protect against dangerous selectors.  falsey and {_id: falsey} are both

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -139,6 +139,11 @@ Tinytest.add('minimongo - basics', test => {
   test.equal(c.find().count(), 3);
   test.equal(c.find(1, {skip: 1}).count(), 0);
   test.equal(c.find({_id: 1}, {skip: 1}).count(), 0);
+  test.equal(c.find({_id: undefined}).count(), 0);
+  test.equal(c.find({_id: false}).count(), 0);
+  test.equal(c.find({_id: null}).count(), 0);
+  test.equal(c.find({_id: ''}).count(), 0);
+  test.equal(c.find({_id: 0}).count(), 0);
   test.equal(c.find({}, {skip: 1}).count(), 2);
   test.equal(c.find({}, {skip: 2}).count(), 1);
   test.equal(c.find({}, {limit: 2}).count(), 2);
@@ -379,6 +384,8 @@ Tinytest.add('minimongo - selector_compiler', test => {
   nomatch({_id: undefined}, {_id: 'foo'});
   nomatch({_id: false}, {_id: 'foo'});
   nomatch({_id: null}, {_id: 'foo'});
+  nomatch({_id: ''}, {_id: ''});
+  nomatch({_id: 0}, {_id: 0});
 
   // matching one or more keys
   nomatch({a: 12}, {});


### PR DESCRIPTION
In #8893 (Minimongo refactoring), [this commit](https://github.com/meteor/meteor/commit/92555c32ba40e969a0bd905975961326d2365f1e) changed how the `_id` property of a selector object is handled, but the new version fails for falsy `_id`s, e.g., empty strings (see #9060).
This pull request fixes the bug by checking if the selector object has an `_id` property instead of looking for a truthy value.

**Regarding falsy selectors and `_id`s:** 

The bug is fixed by the changes to `cursor.js`. Since `matcher.js` contains the same logic, I made the same changes there but I'm not sure if that's correct. Since the refactoring, `_selectorIsIdPerhapsAsObject` is called instead of `_selectorIsId` on the following line:

https://github.com/meteor/meteor/blob/5f13b20e1e4023a23a50b9c4f1c9e1ad9d88136c/packages/minimongo/matcher.js#L90

I think that, ~in combination with my changes,~ this contradicts the comment (and code) a few lines below (the one that starts with "protect against dangerous selectors") because falsy values are now allowed if they are valid IDs (`''` and `0`). Maybe @radekmie knows more about this? 🙂 

Fixes #9060