### PR TITLE
Adjust websocket endpoint testing to avoid CORS issues

### DIFF
--- a/packages/ddp-client/stream_tests.js
+++ b/packages/ddp-client/stream_tests.js
@@ -166,12 +166,12 @@ testAsyncMulti("stream - /websocket is a websocket endpoint", [
       test.equal(pageContent, result.content);
     });
 
-    HTTP.get(Meteor.absoluteUrl('/'), expect(function(error, result) {
+    HTTP.get(Meteor._relativeToSiteRootUrl('/'), expect(function(error, result) {
       test.isNull(error);
       pageContent = result.content;
 
       _.each(['/websockets', '/websockets/'], function(path) {
-        HTTP.get(Meteor.absoluteUrl(path), wrappedCallback);
+        HTTP.get(Meteor._relativeToSiteRootUrl(path), wrappedCallback);
       });
     }));
   }


### PR DESCRIPTION
When running the `ddp-client` package tests with `meteor test-packages`, and accessing the test runner via http://127.0.0.1:3000, the websocket endpoint test fails due to a CORS error. This PR replaces the use of `Meteor.absoluteUrl` with `Meteor._relativeToSiteRootUrl` to make sure test HTTP requests are kept within CORS restrictions.

Fixes #8094.
