### PR TITLE
Added renderDocument in server-sink

### DIFF
--- a/packages/server-render/server-sink.js
+++ b/packages/server-render/server-sink.js
@@ -1,3 +1,6 @@
+const HEAD_REGEX = /<head[^>]*>((.|[\n\r])*)<\/head>/im
+const BODY_REGEX = /<body[^>]*>((.|[\n\r])*)<\/body>/im;
+
 export class ServerSink {
   constructor(request, arch) {
     this.request = request;
@@ -29,6 +32,16 @@ export class ServerSink {
   renderIntoElementById(id, html) {
     this.htmlById[id] = "";
     this.appendToElementById(id, html);
+  }
+
+  renderDocument(html){
+      // Extract head
+      const head = HEAD_REGEX.exec(html)[1];
+      this.appendToHead(head);
+
+      // Extract body
+      const body = BODY_REGEX.exec(html)[1];
+      this.appendToBody(body);
   }
 }
 


### PR DESCRIPTION
Some view frameworks like Angular returns the full document HTML. We can do some trick to get seperately head and body in project code, but it'd better to move this trick into this package.
This new method extracts head and body, and appends them seperately into server-sink.