### PR TITLE
Improve messaging and friendliness of "pull request template".

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,5 +22,5 @@ Here are some important details to follow:
           Describe the big picture of your changes here to communicate to what your
           pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!
 
-We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context which can help you succeed with your contribution which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request but by following these guidelines, we can try to avoid disappointment.
+We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,26 @@
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+<!--
+First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!
 
-Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first (in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests/issues) repository) and discuss your ideas there before implementing them.
+Here are some important details to follow:
 
-Always follow the [contribution guidelines](https://github.com/meteor/meteor/blob/devel/Contributing.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
+* ⏰ Your time is important
+          To save your precious time, if the contribution you are making will take more
+          than an hour, please make sure it has been discussed in an issue first.
+          This is especially true for feature requests!
+* 💡 Features
+          Feature requests can be created and discussed by visiting:
+          https://github.com/meteor/meteor-feature-requests/issues
+* 🕷 Bug fixes
+          These can be created and discussed in this repository. When fixing a bug,
+          please _try_ to add a test which verifies the fix.  If you cannot, you should
+          still submit the PR but we may still ask you (and help you!) to create a test.
+* 📖 Contribution guidelines
+          Always follow https://github.com/meteor/meteor/blob/master/Contributing.md
+          when submitting a pull request.  Make sure existing tests still pass, and add
+          tests for all new behavior.
+* ✏️ Explain your pull request
+          Describe the big picture of your changes here to communicate to what your
+          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!
+
+We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context which can help you succeed with your contribution which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request but by following these guidelines, we can try to avoid disappointment.
+-->


### PR DESCRIPTION
The GitHub pull request template (i.e. `PULL_REQUEST_TEMPLATE.md`) is displayed to contributors when they are submitting a PR to the project.

In a similar attempt to what I did with the [`ISSUE_TEMPLATE.md`](https://raw.githubusercontent.com/meteor/meteor/devel/.github/ISSUE_TEMPLATE.md) (which is the same template except for filing issues), this change aims to improve the friendliness of the PR template by making it sound less intimidating, manage expectations and a hopefully provide a positive experience for someone filing a pull-request.

Having a pull-request rejected (and rejecting a pull request!) is not a "feel-good" situation and I think it's best to avoid that as much as possible.  I don't claim this will solve the problem, but I hope it helps.

Input (and iteration) appreciated and welcomed!