### PR TITLE
Adjust force-ssl localhost regex to handle IPv4 in IPv6 addresses

### DIFF
--- a/packages/force-ssl-common/force_ssl_common.js
+++ b/packages/force-ssl-common/force_ssl_common.js
@@ -4,7 +4,7 @@ import forwarded from 'forwarded-http';
 // received it on localhost, and all proxies involved received on
 // localhost (supports "forwarded" and "x-forwarded-for").
 const isLocalConnection = (req) => {
-  const localhostRegexp = /^\s*(127\.0\.0\.1|\[?::1\]?)\s*$/;
+  const localhostRegexp = /^\s*(.*127\.0\.0\.1|\[?::1\]?)\s*$/;
   const request = Object.create(req);
   request.connection = Object.assign(
     {},

--- a/packages/force-ssl-common/force_ssl_tests.js
+++ b/packages/force-ssl-common/force_ssl_tests.js
@@ -8,7 +8,7 @@ Tinytest.add('force-ssl - check for a local connection', function (test) {
 
   // Remote address check (connection)
 
-  ['127.0.0.1', '::1'].forEach((ip) => {
+  ['127.0.0.1', '::1', '::ffff:127.0.0.1'].forEach((ip) => {
     req.connection.remoteAddress = ip;
     test.isTrue(isLocalConnection(req), 'Is a local connection');
   });
@@ -20,7 +20,7 @@ Tinytest.add('force-ssl - check for a local connection', function (test) {
 
   // Remote address check (socket)
 
-  ['127.0.0.1', '::1'].forEach((ip) => {
+  ['127.0.0.1', '::1', '::ffff:127.0.0.1'].forEach((ip) => {
     req.connection = {};
     req.socket.remoteAddress = ip;
     test.isTrue(isLocalConnection(req), 'Is a local connection');

--- a/packages/force-ssl-common/package.js
+++ b/packages/force-ssl-common/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Internal force-ssl common code.',
-  version: '1.0.14'
+  version: '1.0.15'
 });
 
 Npm.depends({

--- a/packages/force-ssl/package.js
+++ b/packages/force-ssl/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Require this application to use HTTPS",
-  version: "1.0.14",
+  version: "1.0.15",
   prodOnly: true
 });
 


### PR DESCRIPTION
`force-ssl`'s current `isLocalConnection` regex does not handle IPv4-mapped and/or IPv4-compatible IPv6 addresses, when checking if the connection is local. This means a local address of `::ffff:127.0.0.1` is being marked as non-local. These changes adjust the `isLocalConnection` regex to handle a wider range of localhost address representations.

Fixes #9072.
