### PR TITLE
Fix host IP fallback for `webapp` server

### DIFF
--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.3.18'
+  version: '1.3.19'
 });
 
 Npm.depends({connect: "2.30.2",

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -883,8 +883,6 @@ function runWebAppServer() {
     };
 
     let localPort = process.env.PORT || 0;
-    const host = process.env.BIND_IP;
-    const localIp = host || "0.0.0.0";
     const unixSocketPath = process.env.UNIX_SOCKET_PATH;
 
     if (unixSocketPath) {
@@ -899,7 +897,10 @@ function runWebAppServer() {
         startHttpServer({ path: localPort });
       } else if (typeof localPort === "number") {
         // Start the HTTP server using TCP.
-        startHttpServer({ port: localPort, host: host });
+        startHttpServer({
+          port: localPort,
+          host: process.env.BIND_IP || "0.0.0.0"
+        });
       } else {
         throw new Error("Invalid PORT specified");
       }


### PR DESCRIPTION
The `localIp` constant was never used, so the HTTP server was started with an `undefined` host instead of "0.0.0.0" if `process.env.BIND_IP` was `undefined`.

Related to #9072.

👋  @aliogaili, @hwillson