### PR TITLE
Add temporary `dev_bundle.xxx` directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.meteor
 *~
 /dev_bundle
+/dev_bundle.xxx
 /dev_bundle*.tar.gz
 /android_bundle
 /android_bundle*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 /dev_bundle
 /dev_bundle.xxx
+/dev_bundle_XXX
 /dev_bundle*.tar.gz
 /android_bundle
 /android_bundle*.tar.gz


### PR DESCRIPTION
While downloading a new `dev_bundle`, thousands of files are created in the temporary `dev_bundle.xxx` directory, which can slow down editors and IDEs that are tracking the Git status in the background.