### PR TITLE
Add `shell-server` package to scaffold app skeleton

### DIFF
--- a/tools/static-assets/skel-full/.meteor/packages
+++ b/tools/static-assets/skel-full/.meteor/packages
@@ -15,6 +15,7 @@ standard-minifier-css   # CSS minifier run for production mode
 standard-minifier-js    # JS minifier run for production mode
 es5-shim                # ECMAScript 5 compatibility for older browsers
 ecmascript              # Enable ECMAScript2015+ syntax in app code
+shell-server            # Server-side component of the `meteor shell` command
 
 kadira:flow-router      # FlowRouter is a very simple router for Meteor
 kadira:blaze-layout     # Layout manager for blaze (works well with FlowRouter)


### PR DESCRIPTION
The `shell-server` package was missing in the scaffold app skeleton, see https://github.com/meteor/docs/pull/161#issuecomment-328767441.