### PR TITLE
Remove ddp-client's direct websocket-driver dependency

### DIFF
--- a/packages/ddp-client/.npm/package/npm-shrinkwrap.json
+++ b/packages/ddp-client/.npm/package/npm-shrinkwrap.json
@@ -21,13 +21,13 @@
       "from": "permessage-deflate@0.1.3"
     },
     "websocket-driver": {
-      "version": "0.6.5",
-      "resolved": "https://github.com/faye/websocket-driver-node/tarball/1325828a9e8b5e29c7b4758995efdb84703919ad",
-      "from": "https://github.com/faye/websocket-driver-node/tarball/1325828a9e8b5e29c7b4758995efdb84703919ad"
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "from": "websocket-driver@>=0.5.1"
     },
     "websocket-extensions": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
       "from": "websocket-extensions@>=0.1.1"
     }
   }

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -6,11 +6,6 @@ Package.describe({
 
 Npm.depends({
   "faye-websocket": "0.11.1",
-  // TODO Remove this direct websocket-driver dependency when a new
-  // version gets published, though that may not happen very soon:
-  // https://github.com/faye/websocket-driver-node/issues/21
-  "websocket-driver": "https://github.com/faye/websocket-driver-node/" +
-    "tarball/1325828a9e8b5e29c7b4758995efdb84703919ad",
   "lolex": "1.4.0",
   "permessage-deflate": "0.1.3"
 });


### PR DESCRIPTION
A new version of the `websocket-driver` package has been released, (0.7.0) that includes the fix discussed in https://github.com/faye/websocket-driver-node/issues/21, so the direct `websocket-driver` dependency is no longer needed.

Relates to https://github.com/meteor/meteor/commit/43ba3c9de5a792a32372d491785aa0bc9cabac1f.
