### PR TITLE
Standardize Npm.require exceptions and limit lookup paths.

### DIFF
--- a/packages/modules-runtime/server.js
+++ b/packages/modules-runtime/server.js
@@ -15,7 +15,7 @@ makeInstallerOptions.fallback = function (id, parentId, error) {
   if (topLevelIdPattern.test(id)) {
     if (typeof Npm === "object" &&
         typeof Npm.require === "function") {
-      return Npm.require(id);
+      return Npm.require(id, error);
     }
   }
 

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -217,8 +217,9 @@ files.getCurrentNodeBinDir = function () {
 
 // Return the top-level directory for this meteor install or checkout
 files.getCurrentToolsDir = function () {
-  var dirname = files.convertToStandardPath(__dirname);
-  return files.pathJoin(dirname, '..', '..');
+  return files.pathDirname(
+    files.pathDirname(
+      files.convertToStandardPath(__dirname)));
 };
 
 // Read a settings file and sanity-check it. Returns a string on

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1840,6 +1840,12 @@ class JsImage {
       });
     });
 
+    const toolsNodeModulesDir = files.pathJoin(
+      files.getCurrentToolsDir(),
+      "tools",
+      "node_modules"
+    );
+
     // Eval each JavaScript file, providing a 'Npm' symbol in the same
     // way that the server environment would, a 'Package' symbol
     // so the loaded image has its own private universe of loaded
@@ -1856,40 +1862,42 @@ class JsImage {
         Npm: {
           require: Profile(function (name) {
             return "Npm.require(" + JSON.stringify(name) + ")";
-          }, function (name) {
+          }, function (name, error) {
             let fullPath;
 
-            _.some(item.nodeModulesDirectories, nmd => {
-              if (nmd.local) {
-                // Npm.require doesn't consider local node_modules
-                // directories.
-                return false;
-              }
-
+            function tryLookup(nodeModulesPath, name) {
               var nodeModulesTopDir = files.pathJoin(
-                nmd.sourcePath,
+                nodeModulesPath,
                 name.split("/")[0]
               );
 
               if (files.exists(nodeModulesTopDir)) {
                 return fullPath = files.convertToOSPath(
-                  files.pathJoin(nmd.sourcePath, name)
+                  files.pathJoin(nodeModulesPath, name)
                 );
               }
+            }
+
+            const found = _.some(item.nodeModulesDirectories, nmd => {
+              // Npm.require doesn't consider local node_modules
+              // directories.
+              return ! nmd.local && tryLookup(nmd.sourcePath, name);
             });
 
-            if (fullPath) {
+            if (found || tryLookup(toolsNodeModulesDir, name)) {
               return require(fullPath);
             }
 
-            try {
-              return require(name);
-            } catch (e) {
-              buildmessage.error(
-                "Can't load npm module '" + name + "' from " +
-                  item.targetPath + ". Check your Npm.depends().");
-              return undefined;
+            const resolved = require.resolve(name);
+            if (resolved === name && ! files.pathIsAbsolute(resolved)) {
+              // If require.resolve(id) === id and id is not an absolute
+              // identifier, it must be a built-in module like fs or http.
+              return require(resolved);
             }
+
+            throw error || new Error(
+              "Cannot find module " + JSON.stringify(name)
+            );
           })
         },
 

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -175,6 +175,9 @@ var loadServerBundles = Profile("Load server bundles", function () {
       });
     }
 
+    // Add dev_bundle/server-lib/node_modules.
+    addNodeModulesPath("node_modules");
+
     function statOrNull(path) {
       try {
         return fs.statSync(path);
@@ -193,47 +196,41 @@ var loadServerBundles = Profile("Load server bundles", function () {
        */
       require: Profile(function getBucketName(name) {
         return "Npm.require(" + JSON.stringify(name) + ")";
-      }, function (name) {
-        if (nonLocalNodeModulesPaths.length === 0) {
-          return require(name);
+      }, function (name, error) {
+        if (nonLocalNodeModulesPaths.length > 0) {
+          var fullPath;
+
+          nonLocalNodeModulesPaths.some(function (nodeModuleBase) {
+            var packageBase = files.convertToOSPath(files.pathResolve(
+              nodeModuleBase,
+              name.split("/", 1)[0]
+            ));
+
+            if (statOrNull(packageBase)) {
+              return fullPath = files.convertToOSPath(
+                files.pathResolve(nodeModuleBase, name)
+              );
+            }
+          });
+
+          if (fullPath) {
+            return require(fullPath);
+          }
         }
 
-        var fullPath;
-
-        nonLocalNodeModulesPaths.some(function (nodeModuleBase) {
-          var packageBase = files.convertToOSPath(files.pathResolve(
-            nodeModuleBase,
-            name.split("/", 1)[0]
-          ));
-
-          if (statOrNull(packageBase)) {
-            return fullPath = files.convertToOSPath(
-              files.pathResolve(nodeModuleBase, name)
-            );
-          }
-        });
-
-        if (fullPath) {
-          return require(fullPath);
+        var resolved = require.resolve(name);
+        if (resolved === name && ! path.isAbsolute(resolved)) {
+          // If require.resolve(id) === id and id is not an absolute
+          // identifier, it must be a built-in module like fs or http.
+          return require(resolved);
         }
 
-        try {
-          return require(name);
-        } catch (e) {
-          // Try to guess the package name so we can print a nice
-          // error message
-          // fileInfo.path is a standard path, use files.pathSep
-          var filePathParts = fileInfo.path.split(files.pathSep);
-          var packageName = filePathParts[1].replace(/\.js$/, '');
-
-          // XXX better message
-          throw new Error(
-            "Can't find npm module '" + name +
-              "'. Did you forget to call 'Npm.depends' in package.js " +
-              "within the '" + packageName + "' package?");
-          }
+        throw error || new Error(
+          "Cannot find module " + JSON.stringify(name)
+        );
       })
     };
+
     var getAsset = function (assetPath, encoding, callback) {
       var fut;
       if (! callback) {


### PR DESCRIPTION
Ever since Meteor 1.3 first introduced a module system based on something other than `Npm.require`, we've continued throwing missing module exceptions that refer to `Npm.depends` and/or `Npm.require`, even if the developer called `require` or used an `import` declaration. This commit fixes that, so that all missing module exceptions look like `Cannot find module "module/name"`.

I also noticed recently that `Npm.require` is capable of returning modules installed in `node_modules` directories completely outside the app, which is bad news for development/production reproducibility. Fixed that too.

CC @hwillson who has spoken of deprecating `Npm.require` entirely, and
just using `require` everywhere, instead.