### PR TITLE
dynamic-import: fix modules version recognition to fix caching

### DIFF
--- a/packages/dynamic-import/client.js
+++ b/packages/dynamic-import/client.js
@@ -120,6 +120,8 @@ function fetchMissing(missingTree) {
 }
 
 function getFromTree(tree, id) {
+  id = id.replace(":", "_");
+
   id.split("/").every(function (part) {
     return ! part || (tree = tree[part]);
   });


### PR DESCRIPTION
A fix to the dynamic-import code to correctly detect modules version.

Without this fix dynamic-import can't detect correctly modules versions
which breaks the dynamic-import cache functionality.

[I prepared a video that demonstrates the issue and the fix.](https://drive.google.com/open?id=0B3MQ_v8orqd_QURnUVZOaDBFWms)

-Daniel