### PR TITLE
Fix issues with Infinity based login token lifetimes

### DIFF
--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -214,18 +214,20 @@ export class AccountsCommon {
   }
 
   // The options argument is only used by tests.
-  _getTokenLifetimeMs(options) {
-    options = options || this._options;
-    if (options.loginExpirationInDays === null) {
-      // We disable login expiration by returning Infinity
-      return Infinity;
-    }
-    return (options.loginExpirationInDays ||
-            DEFAULT_LOGIN_EXPIRATION_DAYS) * 24 * 60 * 60 * 1000;
+  _getTokenLifetimeMs() {
+    // When loginExpirationInDays is set to null, we'll use a really high
+    // number of days (LOGIN_UNEXPIRABLE_TOKEN_DAYS) to simulate an
+    // unexpiring token.
+    const loginExpirationInDays =
+      (this._options.loginExpirationInDays === null)
+        ? LOGIN_UNEXPIRING_TOKEN_DAYS
+        : this._options.loginExpirationInDays;
+    return (loginExpirationInDays
+        || DEFAULT_LOGIN_EXPIRATION_DAYS) * 24 * 60 * 60 * 1000;
   }
 
   _getPasswordResetTokenLifetimeMs() {
-   return (this._options.passwordResetTokenExpirationInDays ||
+    return (this._options.passwordResetTokenExpirationInDays ||
             DEFAULT_PASSWORD_RESET_TOKEN_EXPIRATION_DAYS) * 24 * 60 * 60 * 1000;
   }
 
@@ -273,7 +275,10 @@ Meteor.user = function () {
 };
 
 // how long (in days) until a login token expires
-var DEFAULT_LOGIN_EXPIRATION_DAYS = 90;
+const DEFAULT_LOGIN_EXPIRATION_DAYS = 90;
+// Expose for testing.
+Ap.DEFAULT_LOGIN_EXPIRATION_DAYS = DEFAULT_LOGIN_EXPIRATION_DAYS;
+
 // how long (in days) until reset password token expires
 var DEFAULT_PASSWORD_RESET_TOKEN_EXPIRATION_DAYS = 3;
 // how long (in days) until enrol password token expires
@@ -287,6 +292,12 @@ EXPIRE_TOKENS_INTERVAL_MS = 600 * 1000; // 10 minutes
 // how long we wait before logging out clients when Meteor.logoutOtherClients is
 // called
 CONNECTION_CLOSE_DELAY_MS = 10 * 1000;
+
+// A large number of expiration days (approximately 100 years worth) that is
+// used when creating unexpiring tokens.
+const LOGIN_UNEXPIRING_TOKEN_DAYS = 365 * 100;
+// Expose for testing.
+Ap.LOGIN_UNEXPIRING_TOKEN_DAYS = LOGIN_UNEXPIRING_TOKEN_DAYS;
 
 // loginServiceConfiguration and ConfigError are maintained for backwards compatibility
 Meteor.startup(function () {

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -213,7 +213,6 @@ export class AccountsCommon {
     }
   }
 
-  // The options argument is only used by tests.
   _getTokenLifetimeMs() {
     // When loginExpirationInDays is set to null, we'll use a really high
     // number of days (LOGIN_UNEXPIRABLE_TOKEN_DAYS) to simulate an

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -23,7 +23,7 @@ Tinytest.add('accounts - config - token lifetime', function (test) {
 Tinytest.add('accounts - config - unexpiring tokens', function (test) {
   const loginExpirationInDays = Accounts._options.loginExpirationInDays;
 
-  // When settings loginExpirationInDays to null in the global Accounts
+  // When setting loginExpirationInDays to null in the global Accounts
   // config object, make sure the returned token lifetime represents an
   // unexpiring token date (is very far into the future).
   Accounts._options.loginExpirationInDays = null;

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -13,23 +13,49 @@ Tinytest.add('accounts - config validates keys', function (test) {
   });
 });
 
-// test the loginExpirationInDays config
-
-Tinytest.add( 'accounts - config - token limetime', function (test) {
-  var config = { loginExpirationInDays: 2 };
-  test.equal(Accounts._getTokenLifetimeMs(config), 2 * 24 * 60 * 60 * 1000);
+Tinytest.add('accounts - config - token lifetime', function (test) {
+  const loginExpirationInDays = Accounts._options.loginExpirationInDays;
+  Accounts._options.loginExpirationInDays = 2;
+  test.equal(Accounts._getTokenLifetimeMs(), 2 * 24 * 60 * 60 * 1000);
+  Accounts._options.loginExpirationInDays = loginExpirationInDays;
 });
 
-Tinytest.add( 'accounts - config - unexpiring tokens', function (test) {
-  var config = { loginExpirationInDays: null };
-  test.equal(Accounts._getTokenLifetimeMs(config), Infinity);
+Tinytest.add('accounts - config - unexpiring tokens', function (test) {
+  const loginExpirationInDays = Accounts._options.loginExpirationInDays;
+
+  // When settings loginExpirationInDays to null in the global Accounts
+  // config object, make sure the returned token lifetime represents an
+  // unexpiring token date (is very far into the future).
+  Accounts._options.loginExpirationInDays = null;
+  test.equal(
+    Accounts._getTokenLifetimeMs(),
+    Accounts.LOGIN_UNEXPIRING_TOKEN_DAYS * 24 * 60 * 60 * 1000,
+  );
+
+  // Verify token expiration date retrieval returns a Date.
+  // (verifies https://github.com/meteor/meteor/issues/9066)
+  test.isTrue(
+    !isNaN(Accounts._tokenExpiration(new Date())),
+    'Returned token expiration should be a Date',
+  );
+
+  // Verify the token expiration check works properly.
+  // (verifies https://github.com/meteor/meteor/issues/9066)
+  const futureDate = new Date();
+  futureDate.setDate(futureDate.getDate() + 200);
+  test.isFalse(Accounts._tokenExpiresSoon(futureDate));
+
+  Accounts._options.loginExpirationInDays = loginExpirationInDays;
 });
 
-Tinytest.add( 'accounts - config - default token limetime', function(test) {
-  var DEFAULT_LOGIN_EXPIRATION_DAYS = 90; // copied from accounts_common.js
-  var config1 = {};
-  var config2 = { loginExpirationInDays: DEFAULT_LOGIN_EXPIRATION_DAYS };
-  test.equal(Accounts._getTokenLifetimeMs(config1), Accounts._getTokenLifetimeMs(config2));
+Tinytest.add('accounts - config - default token lifetime', function (test) {
+  const options = Accounts._options;
+  Accounts._options = {};
+  test.equal(
+    Accounts._getTokenLifetimeMs(),
+    Accounts.DEFAULT_LOGIN_EXPIRATION_DAYS * 24 * 60 * 60 * 1000,
+  );
+  Accounts._options = options;
 });
 
 var idsInValidateNewUser = {};


### PR DESCRIPTION
Hi all - as mentioned in https://github.com/meteor/meteor/issues/9066, the changes made in https://github.com/meteor/meteor/pull/8917 use `Infinity` to represent an unexpiring login token millisecond lifetime. The problem with this approach is that Accounts is attempting to perform `Date` based operations on the value returned from [`_getTokenLifetimeMs`](https://github.com/meteor/meteor/blob/4f43008aa0b02db79eb791d9103d696288a5bfb9/packages/accounts-base/accounts_common.js#L217), in several locations:

- https://github.com/meteor/meteor/blob/4f43008aa0b02db79eb791d9103d696288a5bfb9/packages/accounts-base/accounts_common.js#L240
- https://github.com/meteor/meteor/blob/4f43008aa0b02db79eb791d9103d696288a5bfb9/packages/accounts-base/accounts_common.js#L248
- https://github.com/meteor/meteor/blob/4f43008aa0b02db79eb791d9103d696288a5bfb9/packages/accounts-base/accounts_server.js#L1108

Since `Infinity` can't be converted to a `Date`, this is causing the problems outlined in https://github.com/meteor/meteor/issues/9066.

This PR replaces the use of `Infinity` to represent an unexpiring token millisecond lifetime with a far future (non-infinity) millisecond lifetime (currently set to be 100 years). Using a non-infinity based value like this means all `Date` based token lifetime calculations will work properly again (while preserving the `loginExpirationInDays: null` unexpiring login functionality using `Infinity` was intended to help address). Picking an expiration date of 100 years in the future seemed like an acceptable alternative to `Infinity`, but let me know if anyone disagrees. 

Fixes #9066.
