### PR TITLE
When starting mongod, yield until the heartbeat has pulsed after election.

### DIFF
--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -651,6 +651,8 @@ var launchMongo = function (options) {
         return;
       }
 
+      let wasJustSecondary = false;
+
       // XXX timeout eventually?
       while (!stopped) {
         var status = yieldingMethod(
@@ -669,10 +671,25 @@ var launchMongo = function (options) {
           continue;
         }
 
+        const firstMemberState = status.members[0].stateStr;
+
         // Is the intended primary currently a secondary? (It passes through
         // that phase briefly.)
-        if (status.members[0].stateStr === 'SECONDARY') {
+        if (firstMemberState === 'SECONDARY') {
           utils.sleepMs(20);
+          wasJustSecondary = true;
+          continue;
+        }
+
+        // Mongo 3.2 introduced a new heartbeatIntervalMillis property
+        // on replica sets, used during "primary" negotiation.
+        //
+        // If the first member was _just_ promoted, we'll wait until
+        // the heartbeat interval has elapsed before proceeding since
+        // the decision is not official until the heartbeat has elapsed.
+        if (firstMemberState === 'PRIMARY' && wasJustSecondary) {
+          wasJustSecondary = false;
+          utils.sleepMs(status.heartbeatIntervalMillis);
           continue;
         }
 

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -694,7 +694,7 @@ var launchMongo = function (options) {
         }
 
         // Anything else for the intended primary is probably an error.
-        if (status.members[0].stateStr !== 'PRIMARY') {
+        if (firstMemberState !== 'PRIMARY') {
           throw Error("Unexpected Mongo status: " + JSON.stringify(status));
         }
 


### PR DESCRIPTION
> Prologue: A heartbeat is used amongst members of a MongoDB replica set
to poll the status of said members.

When we are initiating a new replicaset for the test Mongo server, the replicaset is not fully prepared to accept writes until the voting members have negotiated and propagated their decision about who is the "primary" to all members involved.  This seems to be delayed by almost _exactly_ the default heartbeat interval, which is 2000ms.

The heartbeat interval is marked as an "internal only" property in Mongo so I was hesitant to lower it.  It's also a new property in Mongo 3.2 which might explain why this cropped up a while ago.

I believe this heartbeat delay is the only explanation for why the `rs.status()` (i.e. `replSetGetStatus`) believes it is ready before the `mongod` has actually printed "transition to primary complete" to the log (which was the sole, previous measurement we searched for).

It's not clear to me if watching that "transition to primary complete" message in the log is super relevant anymore, but it does indicate "readiness" which is what https://github.com/meteor/meteor/blob/4f43008aa0b02db79eb791d9103d696288a5bfb9/tools/runners/run-mongo.js#L546-L549 was meant to detect. 

Existing, surrounding code could use refactoring to match up with more modern Mongo versions, but that's beyond the scope of this more simple fix.

While I'm confident in this fix, it's worth pointing out (to assuage any would-be fears) that any fragility in this detection is isolated to the development Mongo server that Meteor starts, and not a production application (where your Mongo server is not managed automatically by Meteor, but rather an outside database provider).

Fixes meteor/meteor#9026.