### PR TITLE
Add missing let statment to the $elemMatch subMatcher function

### DIFF
--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -174,6 +174,7 @@ export const ELEMENT_OPERATORS = {
           .reduce((a, b) => Object.assign(a, {[b]: operand[b]}), {}),
         true);
 
+      let subMatcher;
       if (isDocMatcher) {
         // This is NOT the same as compileValueSelector(operand), and not just
         // because of the slightly different calling convention.

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -1423,6 +1423,31 @@ Tinytest.add('minimongo - selector_compiler', test => {
     {dogs: [{name: 'Fido', age: 5}, {name: 'Rex', age: 3}]});
   nomatch({dogs: {$elemMatch: {name: /e/, age: 5}}},
     {dogs: [{name: 'Fido', age: 5}, {name: 'Rex', age: 3}]});
+
+  // Tests for https://github.com/meteor/meteor/issues/9111.
+  match(
+    { dogs: { $elemMatch: { name: 'Rex' } } },
+    { dogs: [{ name: 'Rex', age: 3 }] });
+  nomatch(
+    { dogs: { $not: { $elemMatch: { name: 'Rex' } } } },
+    { dogs: [{ name: 'Rex', age: 3 }] });
+  match({
+    $or: [
+      { dogs: { $elemMatch: { name: 'Rex' } } },
+      { dogs: { $elemMatch: { name: 'Rex', age: 5 } } }
+    ]
+  }, {
+    dogs: [{ name: 'Rex', age: 3 }]
+  });
+  nomatch({
+    $or: [
+      { dogs: { $not: { $elemMatch: { name: 'Rex' } } } },
+      { dogs: { $elemMatch: { name: 'Rex', age: 5 } } }
+    ]
+  }, {
+    dogs: [{ name: 'Rex', age: 3 }]
+  });
+
   match({x: {$elemMatch: {y: 9}}}, {x: [{y: 9}]});
   nomatch({x: {$elemMatch: {y: 9}}}, {x: [[{y: 9}]]});
   match({x: {$elemMatch: {$gt: 5, $lt: 9}}}, {x: [8]});


### PR DESCRIPTION
The `subMatcher` function `let` statment was missing (dropped during the latest minimongo refactoring - see https://github.com/meteor/meteor/commit/fe576f60ce019212699af53660d2afbcb3a721e6). This turned `subMatcher` into a global function, which caused several minimongo issues.

Fixes #9111.
