### PR TITLE
Update cordova-ios to 4.5.1, to add in iOS 11 / Xcode 9 support

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,9 +2,9 @@
 
 * [`cordova-ios`](https://github.com/apache/cordova-ios) has been updated to
   version 4.5.1, to add in iOS 11 / Xcode 9 compatibility.
-  [Issue 9098](https://github.com/meteor/meteor/issues/9098)
-  [Issue 9126](https://github.com/meteor/meteor/issues/9126)
-  [PR TODO]()
+  [Issue #9098](https://github.com/meteor/meteor/issues/9098)
+  [Issue #9126](https://github.com/meteor/meteor/issues/9126)
+  [PR #9137](https://github.com/meteor/meteor/pull/9137)
 
 ## v1.5.2.1, 2017-09-26
 

--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 ## v.NEXT
 
+* [`cordova-ios`](https://github.com/apache/cordova-ios) has been updated to
+  version 4.5.1, to add in iOS 11 / Xcode 9 compatibility.
+  [Issue 9098](https://github.com/meteor/meteor/issues/9098)
+  [Issue 9126](https://github.com/meteor/meteor/issues/9126)
+  [PR TODO]()
+
 ## v1.5.2.1, 2017-09-26
 
 * Updating to Meteor 1.5.2.1 will automatically patch a security

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.8.37
+BUNDLE_VERSION=4.8.38
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -12,7 +12,7 @@ export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
 export const CORDOVA_PLATFORM_VERSIONS = {
   'android': '6.2.3',
-  'ios': '4.4.0'
+  'ios': '4.5.1'
 };
 
 const PLATFORM_TO_DISPLAY_NAME_MAP = {


### PR DESCRIPTION
Meteor's iOS 11 emulation is currently broken when using the latest version of Xcode (9.x). This PR updates the `cordova-ios` dependency to 4.5.1, which includes an iOS 11 fix (https://github.com/apache/cordova-ios/commit/a20aeddbc25dca293f412cce80f6e0ef90f09b9d).

These changes will require a new `dev_bundle`.

Fixes #9098.
Fixes #9126.