### PR TITLE
Enable Facebook and Google OAuth login handlers to be called from outside Meteor

### DIFF
--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -1,3 +1,5 @@
+var Accounts = require("meteor/accounts-base").Accounts;
+
 Facebook = {};
 var crypto = Npm.require('crypto');
 
@@ -22,6 +24,18 @@ Facebook.handleAuthFromAccessToken = function handleAuthFromAccessToken(accessTo
     options: {profile: {name: identity.name}}
   };
 };
+
+Accounts.registerLoginHandler('facebook', function (request) {
+  if (request.facebookSignIn !== true) {
+    return;
+  }
+
+  const identity = Facebook.handleAuthFromAccessToken(request.accessToken, (+new Date) + (1000 * request.expiresIn));
+
+  return Accounts.updateOrCreateUserFromExternalService("facebook", {
+    ...identity.serviceData,
+  }, identity.options);
+});
 
 OAuth.registerService('facebook', 2, null, function(query) {
   var response = getTokenResponse(query);

--- a/packages/google-oauth/google_server.js
+++ b/packages/google-oauth/google_server.js
@@ -48,7 +48,7 @@ function getServiceDataFromTokens(tokens) {
   };
 }
 
-Accounts.registerLoginHandler(function (request) {
+Accounts.registerLoginHandler('google', function (request) {
   if (request.googleSignIn !== true) {
     return;
   }

--- a/packages/google-oauth/google_server.js
+++ b/packages/google-oauth/google_server.js
@@ -68,11 +68,11 @@ Accounts.registerLoginHandler('google', function (request) {
   const result = getServiceDataFromTokens(tokens);
 
   return Accounts.updateOrCreateUserFromExternalService("google", {
-    id: request.userId,
+    id: result.serviceData.id,
     idToken: request.idToken,
     accessToken: request.accessToken,
-    email: request.email,
-    picture: request.imageUrl,
+    email: result.serviceData.email,
+    picture: result.serviceData.picture,
     ...result.serviceData,
   }, result.options);
 });


### PR DESCRIPTION
Hi! I'm working on a React Native app which also uses Expo. As a backend I'm using Meteor. In the backend app, I'm able to gracefully login with Google and Facebook OAuth APIs with minimum effort by using accounts-facebook and accounts-google packages which work very well both of them.

After reading these articles, I realized that most of the OAuth work was already done by thoose packages and decided to write login handlers for both platforms so I can access them from outside Meteor

The inspirational articles are these:
- https://medium.com/differential/react-native-meteor-oauth-with-facebook-3d1346d7cdb7
- https://medium.com/@spencer_carli/meteor-google-oauth-from-react-native-e30d146dfad6

With the proposed changes I can access thoose login handlers by calling 'login' method like this (using React Native package **react-native-meteor**)

```
import Meteor from 'react-native-meteor';
...
...
var request = {
  facebook: {
    facebookSignIn: true,
    accessToken: // token from Facebook sign in,
    expiresIn: // expirationTime returned from facebook sign in
  },
},

Meteor._login(
  request,
  err => {
    if (err) {
      // Something went wrong...
    } else {
      // Perform navigation to private area...
    }
  },
);

var request = {
  google: {
    googleSignIn: true,
    accessToken: // token from Google sign in,
    refreshToken: // token from Google sign in,
    idToken: // token from Google sign in,
    serverAuthCode: // token from Google sign in, Seems to be optional. I don't include in my tests because login fails for me
  },
};

Meteor._login(
  request,
  err => {
    if (err) {
      // Something went wrong...
    } else {
      // Perform navigation to private area...
    }
  },
);
...
...

Meteor._login internals detailed here https://github.com/inProgress-team/react-native-meteor/blob/master/src/user/User.js#L69-L78
```



