### PR TITLE
Switch to bright colors on Windows Powershell

### DIFF
--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -49,6 +49,18 @@ var LEVEL_COLORS = {
 
 var META_COLOR = 'blue';
 
+// Default colors cause readability problems on Windows Powershell,
+// switch to bright variants.
+if ('win32' === process.platform) {
+  LEVEL_COLORS = {
+    debug: 'greenBright',
+    warn: 'magentaBright',
+    error: 'redBright'
+  };
+
+  META_COLOR = 'blueBright';
+}
+
 // XXX package
 var RESTRICTED_KEYS = ['time', 'timeInexact', 'level', 'file', 'line',
                         'program', 'originApp', 'satellite', 'stderr'];

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -50,16 +50,16 @@ var LEVEL_COLORS = {
 var META_COLOR = 'blue';
 
 // Default colors cause readability problems on Windows Powershell,
-// switch to bright variants.
-if ('win32' === process.platform) {
-  LEVEL_COLORS = {
-    debug: 'greenBright',
-    warn: 'magentaBright',
-    error: 'redBright'
-  };
-
-  META_COLOR = 'blueBright';
-}
+// switch to bright variants. While still capable of millions of
+// operations per second, the benchmark showed a 25%+ increase in
+// ops per second (on Node 8) by caching "process.platform".
+var platform = process.platform;
+var platformColor = function (color) {
+  if (platform === 'win32') {
+    return color + 'Bright';
+  }
+  return color;
+};
 
 // XXX package
 var RESTRICTED_KEYS = ['time', 'timeInexact', 'level', 'file', 'line',
@@ -275,8 +275,8 @@ Log.format = function (obj, options) {
       require('cli-color')[color](line) : line;
   };
 
-  return prettify(metaPrefix, options.metaColor || META_COLOR) +
-    prettify(message, LEVEL_COLORS[level]);
+  return prettify(metaPrefix, platformColor(options.metaColor || META_COLOR)) +
+    prettify(message, platformColor(LEVEL_COLORS[level]));
 };
 
 // Turn a line of text into a loggable object.

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -40,25 +40,25 @@ Log._intercepted = function () {
 // other process that will be reading its standard output.
 Log.outputFormat = 'json';
 
-var levelColors = {
+var LEVEL_COLORS = {
   debug: 'green',
   // leave info as the default color
   warn: 'magenta',
   error: 'red'
 };
 
-var metaColor = 'blue';
+var META_COLOR = 'blue';
 
 // Default colors cause readability problems on Windows Powershell,
 // switch to bright variants.
-if (process.platform === 'win32') {
-  levelColors = {
+if ('win32' === process.platform) {
+  LEVEL_COLORS = {
     debug: 'greenBright',
     warn: 'magentaBright',
     error: 'redBright'
   };
 
-  metaColor = 'blueBright';
+  META_COLOR = 'blueBright';
 }
 
 // XXX package
@@ -275,8 +275,8 @@ Log.format = function (obj, options) {
       require('cli-color')[color](line) : line;
   };
 
-  return prettify(metaPrefix, options.metaColor || metaColor) +
-    prettify(message, levelColors[level]);
+  return prettify(metaPrefix, options.metaColor || META_COLOR) +
+    prettify(message, LEVEL_COLORS[level]);
 };
 
 // Turn a line of text into a loggable object.

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -53,9 +53,9 @@ var META_COLOR = 'blue';
 // switch to bright variants. While still capable of millions of
 // operations per second, the benchmark showed a 25%+ increase in
 // ops per second (on Node 8) by caching "process.platform".
-var platform = process.platform;
+var isWin32 = process && process.platform === 'win32';
 var platformColor = function (color) {
-  if (platform === 'win32' && !color.endsWith('Bright')) {
+  if (isWin32 && color.slice(-6) !== 'Bright') {
     return color + 'Bright';
   }
   return color;

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -40,25 +40,25 @@ Log._intercepted = function () {
 // other process that will be reading its standard output.
 Log.outputFormat = 'json';
 
-var LEVEL_COLORS = {
+var levelColors = {
   debug: 'green',
   // leave info as the default color
   warn: 'magenta',
   error: 'red'
 };
 
-var META_COLOR = 'blue';
+var metaColor = 'blue';
 
 // Default colors cause readability problems on Windows Powershell,
 // switch to bright variants.
-if ('win32' === process.platform) {
-  LEVEL_COLORS = {
+if (process.platform === 'win32') {
+  levelColors = {
     debug: 'greenBright',
     warn: 'magentaBright',
     error: 'redBright'
   };
 
-  META_COLOR = 'blueBright';
+  metaColor = 'blueBright';
 }
 
 // XXX package
@@ -275,8 +275,8 @@ Log.format = function (obj, options) {
       require('cli-color')[color](line) : line;
   };
 
-  return prettify(metaPrefix, options.metaColor || META_COLOR) +
-    prettify(message, LEVEL_COLORS[level]);
+  return prettify(metaPrefix, options.metaColor || metaColor) +
+    prettify(message, levelColors[level]);
 };
 
 // Turn a line of text into a loggable object.

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -53,7 +53,7 @@ var META_COLOR = 'blue';
 // switch to bright variants. While still capable of millions of
 // operations per second, the benchmark showed a 25%+ increase in
 // ops per second (on Node 8) by caching "process.platform".
-var isWin32 = process && process.platform === 'win32';
+var isWin32 = typeof process === 'object' && process.platform === 'win32';
 var platformColor = function (color) {
   if (isWin32 && color.slice(-6) !== 'Bright') {
     return color + 'Bright';

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -55,7 +55,7 @@ var META_COLOR = 'blue';
 // ops per second (on Node 8) by caching "process.platform".
 var platform = process.platform;
 var platformColor = function (color) {
-  if (platform === 'win32') {
+  if (platform === 'win32' && !color.endsWith('Bright')) {
     return color + 'Bright';
   }
   return color;

--- a/packages/logging/package.js
+++ b/packages/logging/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Logging facility.",
-  version: '1.1.17'
+  version: '1.1.18'
 });
 
 Npm.depends({


### PR DESCRIPTION
Fixes #9118

Uses [bright variant](https://www.npmjs.com/package/cli-color#bright-variants) of colors from cli-color.

CMD and windows Powershell, need bright colors for propercontrast difference for comfortable reading.
