### PR TITLE
Fix for 9167

### DIFF
--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -777,8 +777,8 @@ function getValueBitmask(value, length) {
 function insertIntoDocument(document, key, value) {
   Object.keys(document).forEach(existingKey => {
     if (
-      (existingKey.length > key.length && existingKey.indexOf(key + '.') === 0) ||
-      (key.length > existingKey.length && key.indexOf(existingKey + '.') === 0)
+      (existingKey.length > key.length && existingKey.indexOf(`${key}.`) === 0) ||
+      (key.length > existingKey.length && key.indexOf(`${existingKey}.`) === 0)
     ) {
       throw new Error(
         `cannot infer query fields to set, both paths '${existingKey}' and ` +

--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -777,8 +777,8 @@ function getValueBitmask(value, length) {
 function insertIntoDocument(document, key, value) {
   Object.keys(document).forEach(existingKey => {
     if (
-      (existingKey.length > key.length && existingKey.indexOf(key) === 0) ||
-      (key.length > existingKey.length && key.indexOf(existingKey) === 0)
+      (existingKey.length > key.length && existingKey.indexOf(key + '.') === 0) ||
+      (key.length > existingKey.length && key.indexOf(existingKey + '.') === 0)
     ) {
       throw new Error(
         `cannot infer query fields to set, both paths '${existingKey}' and ` +

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -3006,7 +3006,10 @@ Tinytest.add('minimongo - modify', test => {
   upsert({"_id": "foo", "foo": "bar"}, {"bar": "foo"}, {"_id": "foo", "bar": "foo"})
    // Replacement update keeps _id
   upsertUpdate({"_id": "foo", "bar": "baz"}, {"_id":"foo"}, {"bar": "crow"}, {"_id": "foo", "bar": "crow"});
-
+  // Test for https://github.com/meteor/meteor/issues/9167
+  upsert({key: 123, keyName: '321'}, {$set: {name: 'Todo'}}, {key: 123, keyName: '321', name: 'Todo'});
+  upsertException({key: 123, "key.name": '321'}, {$set:{}});
+  
   // Nested fields don't work with literal objects
   upsertException({"a": {}, "a.b": "foo"}, {});
    // You can't have an ambiguious ID


### PR DESCRIPTION
As @janowsiany noticed in https://github.com/meteor/meteor/issues/9167 , there was an error in the function that checks for ambiguous field definitions during an upsert. While this should only work for nested fields, it also threw errors in case some field name starts with some other field name. (e.g. a document with both 'foo' and 'fooBar')

This should fix this and add tests.
