### PR TITLE
npm-mongo: use fork of mongodb-core for #8598

### DIFF
--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -32,14 +32,12 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "mongodb": {
-      "version": "2.2.30",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.30.tgz",
-      "integrity": "sha1-jM2AH2dsgXIEDC8rR+lgKg1WNKs="
+      "version": "https://github.com/meteor/node-mongodb-native/tarball/0f54d887aef0f172fd48cf4eafd0cf7e5a2500af",
+      "integrity": "sha1-g85f5sJslDKIfoLc/mjbVoN05gA="
     },
     "mongodb-core": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.14.tgz",
-      "integrity": "sha1-E8uidkImtb49GJkq8Mljzl6g8P0="
+      "version": "https://github.com/meteor/mongodb-core/tarball/82608e807235ac744fc29d161ea1d75361a8f178",
+      "integrity": "sha1-DPVyqXHyrpzf9pQLWLq11vOJfk8="
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -67,9 +65,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "string_decoder": {
       "version": "1.0.3",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,17 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '2.2.30',
+  version: '2.2.31',
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "2.2.30"
+  // Fork of mongodb@2.2.31 whose only change is pointing at a mongodb-core
+  // with https://github.com/mongodb-js/mongodb-core/pull/224
+  // NOTE: For the time being, we have hard-coded "2.2.31" as the version
+  // number in wrapper.js. When reverting back to non-fork, revert that
+  // change too!
+  mongodb: "https://github.com/meteor/node-mongodb-native/tarball/0f54d887aef0f172fd48cf4eafd0cf7e5a2500af",
 });
 
 Package.onUse(function (api) {

--- a/packages/npm-mongo/wrapper.js
+++ b/packages/npm-mongo/wrapper.js
@@ -1,2 +1,9 @@
 NpmModuleMongodb = Npm.require('mongodb');
-NpmModuleMongodbVersion = Npm.require('mongodb/package.json').version;
+
+// Hard-code the version number of our fork. When we un-fork, revert this
+// change! Otherwise, NpmModuleMongodbVersion will either get the value of
+// "2.2.31" or the fork's URL, depending on in what order npm processes the
+// install commands.
+// Previously:
+// NpmModuleMongodbVersion = Npm.require('mongodb/package.json').version;
+NpmModuleMongodbVersion = "2.2.31";


### PR DESCRIPTION
This fixes the occurrences of #8598 that I've been able to personally reproduce.

Doing this on the release-1.6 branch, though a backport to 1.5.x-land would probably be a good idea if this works.

Unfortunately the Node Mongo maintainers (see @mbroadst in https://jira.mongodb.org/browse/NODE-1153) haven't indicated when they think they'll be able to review this PR so we'll probably have to push it out to Meteor users without any real review by the folks who know this code best, as this issue has been a major source of pain for many Meteor users.