### PR TITLE
Support --inspect and --inspect-brk for all Meteor test/run commands.

### DIFF
--- a/History.md
+++ b/History.md
@@ -11,6 +11,23 @@
   version of `npm` used by `meteor npm ...` commands.
   [PR #8835](https://github.com/meteor/meteor/pull/8835)
 
+* The `meteor debug` command has been superseded by the more flexible
+  `--inspect` and `--inspect-brk` command-line flags, which work for any
+  `run`, `test`, or `test-packages` command.
+
+  The syntax of these flags is the same as the equivalent Node.js
+  [flags](https://nodejs.org/en/docs/inspector/#command-line-options),
+  with two notable differences:
+
+  * The flags affect the server process spawned by the build process,
+    rather than affecting the build process itself.
+
+  * The `--inspect-brk` flag causes the server process to pause just after
+    server code has loaded but before it begins to execute, giving the
+    developer a chance to set breakpoints in server code.
+
+  [Feature Request #194](https://github.com/meteor/meteor-feature-requests/issues/194)
+
 * The `meteor-babel` package has been upgraded to version 0.24.6, to take
   better advantage of native language features in Node 8.
 

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -3,7 +3,8 @@
 Usage: meteor [--release <release>] [--help] <built-in command> [args]
        meteor help <built-in command>
        meteor [--version] [--arch]
-       meteor <node | npm | other> [args]
+       meteor [run | test | test-packages] --inspect[-brk][=<port>]
+       meteor <node | npm | other> [args]
 
 
 With no arguments, 'meteor' runs the project in the current
@@ -16,6 +17,9 @@ Built-in Commands:
 {{commands}}
 
 See 'meteor help <built-in command>' for details on a command.
+
+Passing '--inspect' or '--inspect-brk' to 'meteor run', 'meteor test', or
+'meteor test-packages' will enable debugging of the server process.
 
 Other Commands:
 
@@ -67,10 +71,14 @@ Targets:
 Options:
   --port, -p       Port to listen on (instead of the default 3000). Also
                    uses port N+1 and a port specified by --app-port.
-                   Specify as --port=host:port to bind to a specific interface.
-  --debug-port     Specify a port to enable server-side debugging. The
-                   server will be paused at startup, waiting for incoming
-                   connections from debugger clients on the specified port.
+                   Specify as --port=host:port to bind to a specific
+                   interface.
+  --inspect[-brk][=<port>]
+                   Enable server-side debugging via debugging clients like
+                   the Node.js command-line debugger, Chrome DevTools, or
+                   Visual Studio Code. With --inspect-brk, the server will
+                   be paused at startup, waiting for clients to attach to
+                   the process on the specified port (default: 9229).
   --mobile-server  Location where mobile builds connect to the Meteor server.
                    Defaults to your local IP and the port that the Meteor
                    server binds to. Can include a URL scheme (for
@@ -81,35 +89,15 @@ Options:
   --release        Specify the release of Meteor to use.
   --verbose        Print all output from builds logs.
   --no-lint        Don't run linters used by the app on every rebuild.
-  --no-release-check            Don't run the release updater to check for new releases.
-  --allow-incompatible-update   Allow packages in your project to be upgraded or
+  --no-release-check
+                   Don't run the release updater to check for new releases.
+  --allow-incompatible-update
+                   Allow packages in your project to be upgraded or
                    downgraded to versions that are potentially incompatible with
                    the current versions, if required to satisfy all package
                    version constraints.
   --extra-packages Run with additional packages (comma separated, for example:
                    --extra-packages "package-name1, package-name2@1.2.3")
-
->>> debug
-Run the project, but suspend the server process for debugging.
-
-Usage: meteor debug [--debug-port <port>] [run options]
-       meteor run --debug-port <port> [run options]
-
-The server process will be suspended just before the first statement of
-server code that would normally execute. In order to continue execution of
-server code, use either the web-based Node Inspector or the command-line
-debugger (further instructions will be printed in the console).
-
-The easiest way to set breakpoints is to use the `debugger` keyword:
-https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger
-
-The options for 'meteor debug' are identical to those for 'meteor run',
-with one addition:
-
-Options:
-  --debug-port   Port on which the server process debugger should listen
-                 for incoming connections from debugging clients, such as
-                 node-inspector (default 9229).
 
 
 >>> create
@@ -560,9 +548,12 @@ with --port.
 Options:
   --port, -p        Port to listen on (instead of the default 3000). Also
                     uses port N+1 and N+2.
-  --debug-port      Specify a port to enable server-side debugging. The
-                    server will be paused before any tests run, waiting
-                    for incoming connections from debugger clients.
+  --inspect[-brk][=<port>]
+                    Enable server-side debugging via debugging clients like
+                    the Node.js command-line debugger, Chrome DevTools, or
+                    Visual Studio Code. With --inspect-brk, the server will
+                    be paused at startup, waiting for clients to attach to
+                    the process on the specified port (default: 9229).
   --mobile-server   If running tests in an emulator or on a mobile device,
                     the location where mobile builds connect to the
                     Meteor server. Defaults to your local IP and the
@@ -620,9 +611,12 @@ Meteor Guide - https://guide.meteor.com/testing.html
 Options:
   --port, -p        Port to listen on (instead of the default 3000). Also
                     uses port N+1 and N+2.
-  --debug-port      Specify a port to enable server-side debugging. The
-                    server will be paused before any tests run, waiting
-                    for incoming connections from debugger clients.
+  --inspect[-brk][=<port>]
+                    Enable server-side debugging via debugging clients like
+                    the Node.js command-line debugger, Chrome DevTools, or
+                    Visual Studio Code. With --inspect-brk, the server will
+                    be paused at startup, waiting for clients to attach to
+                    the process on the specified port (default: 9229).
   --mobile-server   If running tests in an emulator or on a mobile device,
                     the location where mobile builds connect to the
                     Meteor server. Defaults to your local IP and the

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -632,11 +632,14 @@ Fiber(function () {
   // tight timetable for 1.0 and there is no advantage to doing it now
   // rather than later. #ImprovingCrossVersionOptionParsing
 
+  const implicitValues = Object.create(null);
+
   var isBoolean = {
     "--help": true,
     "--unsafe-perm": true,
     "--allow-superuser": true,
   };
+
   var walkCommands = function (node) {
     _.each(node, function (value, key) {
       if (value instanceof Command) {
@@ -646,6 +649,9 @@ Fiber(function () {
             names.push("-" + optionInfo.short);
           }
           _.each(names, function (name) {
+            if (_.has(optionInfo, "implicitValue")) {
+              implicitValues[name] = optionInfo.implicitValue;
+            }
             var optionIsBoolean = (optionInfo.type === Boolean);
             if (_.has(isBoolean, name)) {
               if (isBoolean[name] !== optionIsBoolean)  {
@@ -726,6 +732,8 @@ Fiber(function () {
       } else if (value !== undefined) {
         // Handle '--foo=bar' and '--foo=' (which means "set to empty string").
         rawOptions[term].push(value);
+      } else if (_.has(implicitValues, term)) {
+        rawOptions[term].push(implicitValues[term]);
       } else if (i === argv.length - 1) {
         rawOptions[term].push(null);
       } else {


### PR DESCRIPTION
This PR replaces the `meteor debug` command with the more flexible `--inspect` and `--inspect-brk` command-line flags, which work for any `run`, `test`, or `test-packages` command.

The syntax of these flags is the same as the equivalent Node.js [options](https://nodejs.org/en/docs/inspector/#command-line-options). When no port value is provided, the default is 9229.

Two notable differences:

* The flags affect the server process spawned by the parent build process, rather than affecting the build process itself. The build process can be debugged (as before) by setting the `TOOL_NODE_FLAGS` environment variable to `--inspect` or `--inspect-brk`.

* The `--inspect-brk` flag causes the server process to pause just after server code has loaded but before it begins to execute. This timing is more useful than the Node.js `--inspect-brk` behavior, which is to pause on the first instruction executed by the process, since that is too early to set any useful breakpoints.

Implements https://github.com/meteor/meteor-feature-requests/issues/194, which was opened by @brucejo75.