### PR TITLE
Make behaviour of cursor.count() on client reflect server

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+## v.NEXT
+
+* Enables passing `false` to `cursor.count()` on the client to prevent skip
+  and limit from having an effect on the result.
+  [Issue #1201](https://github.com/meteor/meteor/issues/1201)
+  [PR #9205](https://github.com/meteor/meteor/pull/9205)
+
 ## v1.5.2.2, 2017-10-02
 
 * Fixes a regression in 1.5.2.1 which resulted in the macOS firewall

--- a/packages/minimongo/cursor.js
+++ b/packages/minimongo/cursor.js
@@ -44,15 +44,16 @@ export default class Cursor {
    * @summary Returns the number of documents that match a query.
    * @memberOf Mongo.Cursor
    * @method  count
-   * @param {boolean} [applySkipLimit=false] If set to `true`, the value
-   *                                         returned will be limited to the
-   *                                         value supplied for `limit`, if one
-   *                                         was provided.
+   * @param {boolean} [applySkipLimit=true] If set to `false`, the value
+   *                                         returned will reflect the total
+   *                                         number of matching documents,
+   *                                         ignoring any value supplied for
+   *                                         limit
    * @instance
    * @locus Anywhere
    * @returns {Number}
    */
-  count(applySkipLimit = false) {
+  count(applySkipLimit = true) {
     if (this.reactive) {
       // allow the observe to be unordered
       this._depend({added: true, removed: true}, true);

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -137,31 +137,47 @@ Tinytest.add('minimongo - basics', test => {
   test.equal(c.find('abc').count(), 0);
   test.equal(c.find(undefined).count(), 0);
   test.equal(c.find().count(), 3);
-  test.equal(c.find(1, {skip: 1}).count(), 0);
-  test.equal(c.find({_id: 1}, {skip: 1}).count(), 0);
+  test.equal(c.find(1, {skip: 1}).count(), 1);
+  test.equal(c.find(1, {skip: 1}).count(true), 0);
+  test.equal(c.find({_id: 1}, {skip: 1}).count(), 1);
+  test.equal(c.find({_id: 1}, {skip: 1}).count(true), 0);
   test.equal(c.find({_id: undefined}).count(), 0);
   test.equal(c.find({_id: false}).count(), 0);
   test.equal(c.find({_id: null}).count(), 0);
   test.equal(c.find({_id: ''}).count(), 0);
   test.equal(c.find({_id: 0}).count(), 0);
-  test.equal(c.find({}, {skip: 1}).count(), 2);
-  test.equal(c.find({}, {skip: 2}).count(), 1);
-  test.equal(c.find({}, {limit: 2}).count(), 2);
-  test.equal(c.find({}, {limit: 1}).count(), 1);
-  test.equal(c.find({}, {skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(), 0);
-  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(), 0);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(), 2);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 2}).count(), 1);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(), 2);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 1}).count(), 1);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 1);
+  test.equal(c.find({}, {skip: 1}).count(), 3);
+  test.equal(c.find({}, {skip: 1}).count(true), 2);
+  test.equal(c.find({}, {skip: 2}).count(true), 1);
+  test.equal(c.find({}, {limit: 2}).count(), 3);
+  test.equal(c.find({}, {limit: 2}).count(true), 2);
+  test.equal(c.find({}, {limit: 1}).count(true), 1);
+  test.equal(c.find({}, {skip: 1, limit: 1}).count(), 3);
+  test.equal(c.find({}, {skip: 1, limit: 1}).count(true), 1);
+  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(), 2);
+  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(true), 1);
+  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(), 2);
+  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(true), 1);
+  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(), 2);
+  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(true), 1);
+  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(), 1);
+  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(true), 0);
+  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(), 1);
+  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(true), 0);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(), 3);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(true), 2);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 2}).count(true), 1);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(), 3);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(true), 2);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 1}).count(true), 1);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 3);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(true), 1);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(), 2);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(true), 1);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(), 2);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(true), 1);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 2);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(true), 1);
 
   // Regression test for #455.
   c.insert({foo: {bar: 'baz'}});
@@ -3441,7 +3457,7 @@ Tinytest.add('minimongo - immediate invalidate', test => {
 
 Tinytest.add('minimongo - count on cursor with limit', test => {
   const coll = new LocalCollection();
-  let count;
+  let count, unlimitedCount;
 
   coll.insert({_id: 'A'});
   coll.insert({_id: 'B'});
@@ -3450,27 +3466,33 @@ Tinytest.add('minimongo - count on cursor with limit', test => {
 
   const c = Tracker.autorun(c => {
     const cursor = coll.find({_id: {$exists: true}}, {sort: {_id: 1}, limit: 3});
-    count = cursor.count();
+    count = cursor.count(true);
+    unlimitedCount = cursor.count();
   });
 
   test.equal(count, 3);
+  test.equal(unlimitedCount, 4);
 
   coll.remove('A'); // still 3 in the collection
   Tracker.flush();
   test.equal(count, 3);
+  test.equal(unlimitedCount, 3);
 
   coll.remove('B'); // expect count now 2
   Tracker.flush();
   test.equal(count, 2);
+  test.equal(unlimitedCount, 2);
 
 
   coll.insert({_id: 'A'}); // now 3 again
   Tracker.flush();
   test.equal(count, 3);
+  test.equal(unlimitedCount, 3);
 
   coll.insert({_id: 'B'}); // now 4 entries, but count should be 3 still
   Tracker.flush();
   test.equal(count, 3);
+  test.equal(unlimitedCount, 4); // unlimitedCount should be 4 now
 
   c.stop();
 });
@@ -3749,30 +3771,37 @@ Tinytest.add('minimongo - fine-grained reactivity of query with fields projectio
 Tinytest.add('minimongo - reactive skip/limit count while updating', test => {
   const X = new LocalCollection;
   let count = -1;
+  let unlimitedCount = -1;
 
   const c = Tracker.autorun(() => {
-    count = X.find({}, {skip: 1, limit: 1}).count();
+    count = X.find({}, {skip: 1, limit: 1}).count(true);
+    unlimitedCount = X.find({}, {skip: 1, limit: 1}).count();
   });
 
   test.equal(count, 0);
+  test.equal(unlimitedCount, 0);
 
   X.insert({});
   Tracker.flush({_throwFirstError: true});
   test.equal(count, 0);
+  test.equal(unlimitedCount, 1);
 
   X.insert({});
   Tracker.flush({_throwFirstError: true});
   test.equal(count, 1);
+  test.equal(unlimitedCount, 2);
 
   X.update({}, {$set: {foo: 1}});
   Tracker.flush({_throwFirstError: true});
   test.equal(count, 1);
-
+  test.equal(unlimitedCount, 2);
+  
   // Make sure a second update also works
   X.update({}, {$set: {foo: 2}});
   Tracker.flush({_throwFirstError: true});
   test.equal(count, 1);
-
+  test.equal(unlimitedCount, 2);
+  
   c.stop();
 });
 

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -137,47 +137,47 @@ Tinytest.add('minimongo - basics', test => {
   test.equal(c.find('abc').count(), 0);
   test.equal(c.find(undefined).count(), 0);
   test.equal(c.find().count(), 3);
-  test.equal(c.find(1, {skip: 1}).count(), 1);
-  test.equal(c.find(1, {skip: 1}).count(true), 0);
-  test.equal(c.find({_id: 1}, {skip: 1}).count(), 1);
-  test.equal(c.find({_id: 1}, {skip: 1}).count(true), 0);
+  test.equal(c.find(1, {skip: 1}).count(false), 1);
+  test.equal(c.find(1, {skip: 1}).count(), 0);
+  test.equal(c.find({_id: 1}, {skip: 1}).count(false), 1);
+  test.equal(c.find({_id: 1}, {skip: 1}).count(), 0);
   test.equal(c.find({_id: undefined}).count(), 0);
   test.equal(c.find({_id: false}).count(), 0);
   test.equal(c.find({_id: null}).count(), 0);
   test.equal(c.find({_id: ''}).count(), 0);
   test.equal(c.find({_id: 0}).count(), 0);
-  test.equal(c.find({}, {skip: 1}).count(), 3);
-  test.equal(c.find({}, {skip: 1}).count(true), 2);
-  test.equal(c.find({}, {skip: 2}).count(true), 1);
-  test.equal(c.find({}, {limit: 2}).count(), 3);
-  test.equal(c.find({}, {limit: 2}).count(true), 2);
-  test.equal(c.find({}, {limit: 1}).count(true), 1);
-  test.equal(c.find({}, {skip: 1, limit: 1}).count(), 3);
-  test.equal(c.find({}, {skip: 1, limit: 1}).count(true), 1);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(), 2);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(true), 1);
-  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(), 2);
-  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(true), 1);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(), 2);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(true), 1);
-  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(), 1);
-  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(true), 0);
-  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(), 1);
-  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(true), 0);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(), 3);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(true), 2);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 2}).count(true), 1);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(), 3);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(true), 2);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 1}).count(true), 1);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 3);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(true), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(), 2);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(true), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(), 2);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(true), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 2);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(true), 1);
+  test.equal(c.find({}, {skip: 1}).count(false), 3);
+  test.equal(c.find({}, {skip: 1}).count(), 2);
+  test.equal(c.find({}, {skip: 2}).count(), 1);
+  test.equal(c.find({}, {limit: 2}).count(false), 3);
+  test.equal(c.find({}, {limit: 2}).count(), 2);
+  test.equal(c.find({}, {limit: 1}).count(), 1);
+  test.equal(c.find({}, {skip: 1, limit: 1}).count(false), 3);
+  test.equal(c.find({}, {skip: 1, limit: 1}).count(), 1);
+  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(false), 2);
+  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(), 1);
+  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(false), 2);
+  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(), 1);
+  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(false), 2);
+  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(), 1);
+  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(false), 1);
+  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(), 0);
+  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(false), 1);
+  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(), 0);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(false), 3);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(), 2);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 2}).count(), 1);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(false), 3);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(), 2);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 1}).count(), 1);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(false), 3);
+  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 1);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(false), 2);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(), 1);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(false), 2);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(), 1);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(false), 2);
+  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 1);
 
   // Regression test for #455.
   c.insert({foo: {bar: 'baz'}});
@@ -3466,8 +3466,8 @@ Tinytest.add('minimongo - count on cursor with limit', test => {
 
   const c = Tracker.autorun(c => {
     const cursor = coll.find({_id: {$exists: true}}, {sort: {_id: 1}, limit: 3});
-    count = cursor.count(true);
-    unlimitedCount = cursor.count();
+    count = cursor.count();
+    unlimitedCount = cursor.count(false);
   });
 
   test.equal(count, 3);
@@ -3774,8 +3774,8 @@ Tinytest.add('minimongo - reactive skip/limit count while updating', test => {
   let unlimitedCount = -1;
 
   const c = Tracker.autorun(() => {
-    count = X.find({}, {skip: 1, limit: 1}).count(true);
-    unlimitedCount = X.find({}, {skip: 1, limit: 1}).count();
+    count = X.find({}, {skip: 1, limit: 1}).count();
+    unlimitedCount = X.find({}, {skip: 1, limit: 1}).count(false);
   });
 
   test.equal(count, 0);


### PR DESCRIPTION
This PR changes the default behaviour of `cursor.count()` on the client. Previously, `.count()` on the client would return the number of matching documents taking into account `skip` and `limit`. Now, it will ignore those options unless it is passed `true` when invoked. (i.e. `cursor.count(true)`). This is consistent with the way it works on the server.

Issue: #1201 
Introduction of feature on server-side: 258b14a & bce4df9
Previous PR (incomplete): #5023
Test app: [meteor-issue-1201](https://github.com/carlevans719/meteor-issue-1201)