### PR TITLE
Bumping sockjs-node to 0.3.19

### DIFF
--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -6,7 +6,7 @@ Package.describe({
 
 Npm.depends({
   "permessage-deflate": "0.1.6",
-  sockjs: "0.3.18"
+  sockjs: "0.3.19"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
New version has just been released which passes some useful headers on to the server from client. (Personally, I need DNT header.)

Also, I noticed that this file has been forked in the past and a relatively old version is being used. Probably it should be updated at some point as well: https://github.com/meteor/meteor/blob/devel/packages/ddp-client/sockjs-0.3.4.js