### PR TITLE
npm-mongo: unfork now that upstream has released #8598 fix

### DIFF
--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -32,12 +32,14 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "mongodb": {
-      "version": "https://github.com/meteor/node-mongodb-native/tarball/0f54d887aef0f172fd48cf4eafd0cf7e5a2500af",
-      "integrity": "sha1-g85f5sJslDKIfoLc/mjbVoN05gA="
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.32.tgz",
+      "integrity": "sha1-Yg6qoZlftFfE73BU5fVgJXppflg="
     },
     "mongodb-core": {
-      "version": "https://github.com/meteor/mongodb-core/tarball/82608e807235ac744fc29d161ea1d75361a8f178",
-      "integrity": "sha1-DPVyqXHyrpzf9pQLWLq11vOJfk8="
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.16.tgz",
+      "integrity": "sha1-XcIKSLHwolFf1X2q6ixIU0Z0VOA="
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,17 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '2.2.31',
+  version: '2.2.32',
   documentation: null
 });
 
 Npm.depends({
-  // Fork of mongodb@2.2.31 whose only change is pointing at a mongodb-core
-  // with https://github.com/mongodb-js/mongodb-core/pull/224
-  // NOTE: For the time being, we have hard-coded "2.2.31" as the version
-  // number in wrapper.js. When reverting back to non-fork, revert that
-  // change too!
-  mongodb: "https://github.com/meteor/node-mongodb-native/tarball/0f54d887aef0f172fd48cf4eafd0cf7e5a2500af",
+  mongodb: "2.2.32"
 });
 
 Package.onUse(function (api) {

--- a/packages/npm-mongo/wrapper.js
+++ b/packages/npm-mongo/wrapper.js
@@ -1,9 +1,3 @@
 NpmModuleMongodb = Npm.require('mongodb');
 
-// Hard-code the version number of our fork. When we un-fork, revert this
-// change! Otherwise, NpmModuleMongodbVersion will either get the value of
-// "2.2.31" or the fork's URL, depending on in what order npm processes the
-// install commands.
-// Previously:
-// NpmModuleMongodbVersion = Npm.require('mongodb/package.json').version;
-NpmModuleMongodbVersion = "2.2.31";
+NpmModuleMongodbVersion = Npm.require('mongodb/package.json').version;


### PR DESCRIPTION
Our fix is in mongodb-core 2.1.16.

Effectively reverts #9200.