### PR TITLE
[WIP] Automatically switch between 64- and 32-bit Windows builds.

### DIFF
--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -502,14 +502,10 @@ var springboard = function (rel, options) {
   if (files.realpath(newToolsDir) ===
       files.realpath(files.getCurrentToolsDir())) {
     if (options.mayReturn) {
-      // Return instead of springboarding (or throwing an exception), if
-      // we are allowed to keep using the current tools.
+      // Return instead of springboarding, if we are allowed to keep using
+      // the current tools without restarting the process.
       return;
     }
-
-    throw new Error(
-      "Cannot springboard to same tools directory: " + newToolsDir
-    );
   }
 
   const executable = files.pathJoin(newToolsDir, "meteor");

--- a/tools/packaging/catalog/catalog-remote.js
+++ b/tools/packaging/catalog/catalog-remote.js
@@ -640,6 +640,12 @@ _.extend(RemoteCatalog.prototype, {
     return solution;  // might be null!
   },
 
+  filterArchesWithBuilds: function (name, version, arches) {
+    return arches.filter(arch => {
+      return !! this.getBuildsForArches(name, version, [arch]);
+    });
+  },
+
   // Returns general (non-version-specific) information about a
   // release track, or null if there is no such release track.
   getReleaseTrack: function (name) {

--- a/tools/packaging/updater.js
+++ b/tools/packaging/updater.js
@@ -201,8 +201,11 @@ export function updateMeteorToolSymlink(printErrors) {
       latestReleaseToolPackage,
       tropohouse.default.packagePath(latestReleaseToolPackage,
                                      latestReleaseToolVersion));
-    var toolRecord = _.findWhere(toolIsopack.toolsOnDisk,
-                                 {arch: archinfo.host()});
+
+    var toolRecord = null;
+    archinfo.acceptableMeteorToolArches().some(arch => {
+      return toolRecord = _.findWhere(toolIsopack.toolsOnDisk, { arch });
+    });
 
     // XXX maybe we shouldn't throw from this background thing
     // counter: this is super weird and should never ever happen.

--- a/tools/utils/archinfo.js
+++ b/tools/utils/archinfo.js
@@ -201,6 +201,14 @@ exports.acceptableMeteorToolArches = function () {
   return [host()];
 };
 
+// 64-bit Windows machines that have been using a 32-bit version of Meteor
+// are eligible to switch to 64-bit beginning with Meteor 1.6, which is
+// the first version of Meteor that contains this code.
+exports.canSwitchTo64Bit = function () {
+  return utils.architecture() === "x86_64" &&
+    host === "os.windows.x86_32";
+};
+
 // True if `host` (an architecture name such as 'os.linux.x86_64') can run
 // programs of architecture `program` (which might be something like 'os',
 // 'os.linux', or 'os.linux.x86_64').

--- a/tools/utils/archinfo.js
+++ b/tools/utils/archinfo.js
@@ -182,6 +182,25 @@ var host = function () {
   return _host;
 };
 
+// In order to springboard to earlier Meteor releases that did not have
+// 64-bit Windows builds, Windows installations must be allowed to
+// download 32-bit builds of meteor-tool.
+exports.acceptableMeteorToolArches = function () {
+  if (os.platform() === "win32") {
+    switch (utils.architecture()) {
+    case "x86_32":
+      return ["os.windows.x86_32"];
+    case "x86_64":
+      return [
+        "os.windows.x86_64",
+        "os.windows.x86_32",
+      ];
+    }
+  }
+
+  return [host()];
+};
+
 // True if `host` (an architecture name such as 'os.linux.x86_64') can run
 // programs of architecture `program` (which might be something like 'os',
 // 'os.linux', or 'os.linux.x86_64').


### PR DESCRIPTION
This PR is a follow-up to https://github.com/meteor/meteor/pull/9218, which introduced support for 64-bit builds of Meteor for Windows.

I've attempted to solve two problems with this PR:
- 64-bit builds of Meteor 1.6 on Windows may be used to run older apps with 32-bit versions of Meteor, which requires downloading a 32-bit build of `meteor-tool` and springboarding to it: https://github.com/meteor/meteor/commit/e9db660d03bc58418b2601dd2f67d9256dfc49ce
- Running `meteor update` from a 32-bit Meteor installation can only download other 32-bit builds of Meteor, which means you may want to reinstall Meteor from scratch to get a 64-bit build. While reinstalling will work, I think it may be possible to catch the 32/64-bit discrepancy after springboarding, and perform a second springboard to the 64-bit version (if available): https://github.com/meteor/meteor/commit/5a9e837937319a9c4f49b6762408b7e3a307cda9

Even with these changes, I think we should still recommend that Windows developers reinstall Meteor 1.6 from scratch, rather than running `meteor update` as usual.

These changes are difficult to test without publishing a release, so the tests passing on this PR are not much guarantee that I got everything right. We'll need to publish another release candidate to really test that this works.