### PR TITLE
Fix isNpmUrl to handle http/https urls (Closes #9236)

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 * iOS icons and launch screens have been updated to support iOS 11
   [Issue #9196](https://github.com/meteor/meteor/issues/9196)
   [PR #9198](https://github.com/meteor/meteor/pull/9198)
+  [Issue #9236] Allow Npm.depends to specify any http or https URL [#9236](https://github.com/meteor/meteor/issues/9236)
 
 ## v1.5.2.2, 2017-10-02
 

--- a/tools/isobuild/package-npm.js
+++ b/tools/isobuild/package-npm.js
@@ -24,7 +24,7 @@ export class PackageNpm {
    * @param  {Object} dependencies An object where the keys are package
    * names and the values are one of:
    *   1. Version numbers in string form
-   *   2. Http(s) URLs to a git commit by SHA.
+   *   2. Http(s) URLs to a npm package
    *   3. Git URLs in the format described [here](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies)
    *
    * Https URL example:

--- a/tools/tests/utils-tests.js
+++ b/tools/tests/utils-tests.js
@@ -60,6 +60,16 @@ selftest.define("url has scheme", function () {
   selftest.expectEqual(utils.hasScheme("example_com+http://"), false);
 });
 
+
+selftest.define("isNpmUrl", function () {
+    selftest.expectTrue(utils.isNpmUrl("https://github.com/caolan/async/archive/v2.3.0.tar.gz"));
+    selftest.expectTrue(utils.isNpmUrl("http://github.com/caolan/async/archive/v2.3.0.tar.gz"));
+    selftest.expectTrue(utils.isNpmUrl("git://github.com/foo/bar"));
+    selftest.expectTrue(utils.isNpmUrl("git+ssh://github.com/foo/bar"));
+    selftest.expectTrue(utils.isNpmUrl("git+http://github.com/foo/bar"));
+    selftest.expectTrue(utils.isNpmUrl("git+https://github.com/foo/bar"));
+});
+
 selftest.define("parse url", function () {
   selftest.expectEqual(utils.parseUrl("http://localhost:3000"), {
     hostname: "localhost",

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -490,7 +490,7 @@ exports.isUrlWithSha = function (x) {
 exports.isNpmUrl = function (x) {
   // These are the various protocols that NPM supports, which we use to download NPM dependencies
   // See https://docs.npmjs.com/files/package.json#git-urls-as-dependencies
-  return exports.isUrlWithSha(x) || /^(git|git\+ssh|git\+http|git\+https)?:\/\//.test(x);
+  return /^(git|git\+ssh|git\+http|git\+https|https|http)?:\/\//.test(x);
 };
 
 exports.isPathRelative = function (x) {


### PR DESCRIPTION
See https://github.com/meteor/meteor/issues/9236 for the details about the bug.