### PR TITLE
Update History.md with miscellaneous changes in Meteor 1.5.3.

### DIFF
--- a/History.md
+++ b/History.md
@@ -108,6 +108,25 @@
 * You can now run `meteor test --driver-package user:package` without
   first running `meteor add user:package`.
 
+## v1.5.3, 2017-11-04
+
+* Node has been upgraded to version 4.8.5, a recommended security
+  release: https://nodejs.org/en/blog/release/v4.8.5/. While it was
+  expected that Node 4.8.5 would also include our fix of a faulty
+  backport of garbage collection-related logic in V8, the timing
+  of this security release has caused that to be delayed until 4.8.6.
+  Therefore, this Node still includes our patch for this issue.
+  [Issue #8648](https://github.com/meteor/meteor/issues/8648)
+
+* Various backports from Meteor 1.6, as detailed in the
+  [PR for Meteor 1.5.3](https://github.com/meteor/meteor/pull/9266).
+  Briefly, these involve fixes for:
+  * Child imports of dynamically imported modules within packages.
+    [#9182](https://github.com/meteor/meteor/issues/9182)
+  * Unresolved circular dependencies.
+    [#9176](https://github.com/meteor/meteor/issues/9176)
+  * Windows temporary directory handling.
+
 ## v1.5.2.2, 2017-10-02
 
 * Fixes a regression in 1.5.2.1 which resulted in the macOS firewall


### PR DESCRIPTION
Meteor 1.5.3 is [now released](https://github.com/meteor/meteor/pull/9266) and the 1.5.x-series of Meteor now has its [own branch](https://github.com/meteor/meteor/commits/release-1.5.x) (which will remain forever as its own limb and not merge back to `master` now that Meteor 1.6 is out), however it remains important that the `History.md` changes from the 1.5.x-series make their way back to `master` and thus `devel` to maintain a complete `History.md` on the main trunk.