### PR TITLE
Use Package._define to reduce package boilerplate.

### DIFF
--- a/packages/meteor/define-package.js
+++ b/packages/meteor/define-package.js
@@ -1,2 +1,26 @@
+function PackageRegistry() {}
+
+var PRp = PackageRegistry.prototype;
+
+// Set global.Package[name] = pkg || {}. If additional arguments are
+// supplied, their keys will be copied into pkg if not already present.
+// This method is defined on the prototype of global.Package so that it
+// will not be included in Object.keys(Package).
+PRp._define = function definePackage(name, pkg) {
+  pkg = pkg || {};
+
+  var argc = arguments.length;
+  for (var i = 2; i < argc; ++i) {
+    var arg = arguments[i];
+    for (var s in arg) {
+      if (! (s in pkg)) {
+        pkg[s] = arg[s];
+      }
+    }
+  }
+
+  return this[name] = pkg;
+};
+
 // Initialize the Package namespace used by all Meteor packages.
-global.Package = {};
+global.Package = new PackageRegistry();

--- a/packages/meteor/define-package.js
+++ b/packages/meteor/define-package.js
@@ -24,3 +24,8 @@ PRp._define = function definePackage(name, pkg) {
 
 // Initialize the Package namespace used by all Meteor packages.
 global.Package = new PackageRegistry();
+
+if (typeof exports === "object") {
+  // This code is also used by meteor/tools/isobuild/bundler.js.
+  exports.PackageRegistry = PackageRegistry;
+}

--- a/packages/meteor/define-package.js
+++ b/packages/meteor/define-package.js
@@ -1,0 +1,2 @@
+// Initialize the Package namespace used by all Meteor packages.
+global.Package = {};

--- a/packages/meteor/global.js
+++ b/packages/meteor/global.js
@@ -1,1 +1,2 @@
+// Export a reliable global object for all Meteor code.
 global = this;

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.8.0'
+  version: '1.8.1'
 });
 
 Package.registerBuildPlugin({
@@ -28,6 +28,7 @@ Package.onUse(function (api) {
   api.export("meteorEnv");
 
   api.addFiles('cordova_environment.js', 'web.cordova');
+  api.addFiles('define-package.js', ['client', 'server']);
   api.addFiles('helpers.js', ['client', 'server']);
   api.addFiles('setimmediate.js', ['client', 'server']);
   api.addFiles('timers.js', ['client', 'server']);

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -172,6 +172,7 @@ var release = require('../packaging/release.js');
 import { loadIsopackage } from '../tool-env/isopackets.js';
 import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 import { gzipSync } from "zlib";
+import { PackageRegistry } from "../../packages/meteor/define-package.js";
 
 const SOURCE_URL_PREFIX = "meteor://\u{1f4bb}app";
 
@@ -1771,7 +1772,7 @@ class JsImage {
   // in a compartment of Package
   load(bindings) {
     var self = this;
-    var ret = {};
+    var ret = new PackageRegistry();
 
     // XXX This is mostly duplicated from
     // static-assets/server/boot.js, as is Npm.require below.

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -62,7 +62,7 @@ import { isTestFilePath } from './test-files.js';
 // Cache the (slightly post-processed) results of linker.fullLink.
 const CACHE_SIZE = process.env.METEOR_LINKER_CACHE_SIZE || 1024*1024*100;
 const CACHE_DEBUG = !! process.env.METEOR_TEST_PRINT_LINKER_CACHE_DEBUG;
-const LINKER_CACHE_SALT = 18; // Increment this number to force relinking.
+const LINKER_CACHE_SALT = 19; // Increment this number to force relinking.
 const LINKER_CACHE = new LRU({
   max: CACHE_SIZE,
   // Cache is measured in bytes. We don't care about servePath.

--- a/tools/isobuild/isopack.js
+++ b/tools/isobuild/isopack.js
@@ -1700,7 +1700,9 @@ _.extend(Isopack.prototype, {
       'tools', 'examples', 'LICENSE.txt', 'LICENSES',
       'meteor', 'meteor.bat', 'scripts/admin/launch-meteor',
       'packages/package-version-parser/package-version-parser.js',
-      'packages/meteor/flush-buffers-on-exit-in-windows.js');
+      'packages/meteor/define-package.js',
+      'packages/meteor/flush-buffers-on-exit-in-windows.js',
+    );
 
     // Trim blank line and unnecessary examples.
     pathsToCopy = _.filter(pathsToCopy.split('\n'), function (f) {

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -1028,21 +1028,25 @@ var getFooter = function ({
 
   if (name && exported) {
     chunks.push("\n\n/* Exports */\n");
-    const pkgInit = packageDot(name) + " = " + (exportsName || "{}");
-    if (_.isEmpty(exported)) {
-      // Even if there are no exports, we need to define Package.foo,
-      // because the existence of Package.foo is how another package
-      // (e.g., one that weakly depends on foo) can tell if foo is loaded.
-      chunks.push(pkgInit, ";\n");
-    } else {
+
+    // Even if there are no exports, we need to define Package.foo,
+    // because the existence of Package.foo is how another package
+    // (e.g., one that weakly depends on foo) can tell if foo is loaded.
+    chunks.push("Package._define(" + JSON.stringify(name));
+
+    if (exportsName) {
+      // If we have an exports object, use it as Package[name].
+      chunks.push(", ", exportsName);
+    }
+
+    if (! _.isEmpty(exported)) {
       const scratch = {};
       _.each(exported, symbol => scratch[symbol] = symbol);
       const symbolTree = writeSymbolTree(buildSymbolTree(scratch));
-      chunks.push("(function (pkg, symbols) {\n",
-                  "  for (var s in symbols)\n",
-                  "    (s in pkg) || (pkg[s] = symbols[s]);\n",
-                  "})(", pkgInit, ", ", symbolTree, ");\n");
+      chunks.push(", ", symbolTree);
     }
+
+    chunks.push(");\n");
   }
 
   chunks.push("\n})();\n");

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -1028,7 +1028,6 @@ var getFooter = function ({
 
   if (name && exported) {
     chunks.push("\n\n/* Exports */\n");
-    chunks.push("if (typeof Package === 'undefined') Package = {};\n");
     const pkgInit = packageDot(name) + " = " + (exportsName || "{}");
     if (_.isEmpty(exported)) {
       // Even if there are no exports, we need to define Package.foo,


### PR DESCRIPTION
This removes the need for
```js
if (typeof Package === 'undefined') Package = {};
```
at the bottom of every package, and replaces
```js
(function (pkg, symbols) {
  for (var s in symbols)
    (s in pkg) || (pkg[s] = symbols[s]);
})(Package.minimongo = exports, {
  LocalCollection: LocalCollection,
  Minimongo: Minimongo,
  MinimongoTest: MinimongoTest,
  MinimongoError: MinimongoError
});
```
with
```js
Package._define("minimongo", exports, {
  LocalCollection: LocalCollection,
  Minimongo: Minimongo,
  MinimongoTest: MinimongoTest,
  MinimongoError: MinimongoError
});
```
It's not a huge savings, but it opens the door for us to do more interesting things with the `Package` namespace, by adding other methods to it.