### PR TITLE
Release 1.5.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,12 @@
+## v1.5.4, 2017-11-08
+
+* Node has been updated to version 4.8.6. This release officially
+  includes our fix of a faulty backport of garbage collection-related
+  logic in V8 and ends Meteor's use of a custom Node with that patch.
+  In addition, it includes small OpenSSL updates as announced on the
+  Node blog: https://nodejs.org/en/blog/release/v4.8.6/.
+  [Issue #8648](https://github.com/meteor/meteor/issues/8648)
+
 ## v1.5.3, 2017-11-04
 
 * Node has been upgraded to version 4.8.5, a recommended security

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=4.8.43
+BUNDLE_VERSION=4.8.44
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: "1.5.4-rc.0"
+  version: "1.5.4"
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: "1.5.3"
+  version: "1.5.4-rc.0"
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
  "track": "METEOR",
- "version": "1.5.3-rc.1",
+ "version": "1.5.4-rc.0",
  "recommended": false,
  "official": false,
  "description": "Meteor"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,7 +1,8 @@
 {
   "track": "METEOR",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "recommended": false,
   "official": true,
+  "patchFrom": ["1.5", "1.5.1", "1.5.2", "1.5.2.1", "1.5.2.2", "1.5.3"],
   "description": "The Official Meteor Distribution"
 }

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -6,11 +6,11 @@ set -u
 UNAME=$(uname)
 ARCH=$(uname -m)
 MONGO_VERSION=3.2.15
-NODE_VERSION=4.8.5
+NODE_VERSION=4.8.6
 NPM_VERSION=4.6.1
 
 # If we built Node from source on Jenkins, this is the build number.
-NODE_BUILD_NUMBER=120
+NODE_BUILD_NUMBER=
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -28,6 +28,7 @@ extractNodeFromTarGz() {
 }
 
 downloadNodeFromS3() {
+    test -n "${NODE_BUILD_NUMBER}" || return 1
     S3_HOST="s3.amazonaws.com/com.meteor.jenkins"
     S3_TGZ="node_${UNAME}_${ARCH}_v${NODE_VERSION}.tar.gz"
     NODE_URL="https://${S3_HOST}/dev-bundle-node-${NODE_BUILD_NUMBER}/${S3_TGZ}"


### PR DESCRIPTION
This is a small but important update to the Meteor 1.5.x series, which follows up on the recent [Meteor 1.5.3](https://github.com/meteor/meteor/pull/9266) by updating Node.js to 4.8.6, released today (Nov 7, 2017) as part of the Node.js v4 "Maintenance" LTS updates.

The Node.js "notable changes" are below, but subtly and most notably for Meteor, the [detailed commits](https://nodejs.org/en/blog/release/v4.8.6/#commits) includes our fix to an improperly applied V8 garbage collection patch on Node.js core which was causing segmentation faults, as found in our test-suite, https://github.com/meteor/meteor/issues/8648 and https://github.com/nodejs/node/issues/14228 and fixed with https://github.com/nodejs/node/pull/14829, which had previously applied to Meteor releases 1.5.3, 1.5.2.2, 1.5.2.1 and 1.5.2 with a custom Node.js thanks to https://github.com/meteor/meteor/pull/9031.

Also included is, what is claimed by the Node.js Foundation to be a low-impact OpenSSL update, as announced in their blog last week: https://nodejs.org/en/blog/vulnerability/openssl-november-2017/.

The LTS maintenance window of the v4 series will end in April 2018 and while Meteor will continue to update Node.js versions through that period as appropriate, developers are encouraged to start making the transition to Meteor 1.6 which is built on Node.js 8.  Node.js 8 is slated to be under LTS by the Node.js Foundation until December 2019!

### 2017-11-07, Version 4.8.6 'Argon' (Maintenance)
Notable Changes:

* **crypto**:
  - update root certificates (Ben Noordhuis)
     nodejs/node#13279
  - update root certificates (Ben Noordhuis)
    nodejs/node#12402
* **deps**:
  - add support for more modern versions of INTL (Bruno Pagani)
    nodejs/node#13040
  - upgrade openssl sources to 1.0.2m (Shigeki Ohtsu)
    nodejs/node#16691
  - upgrade openssl sources to 1.0.2l (Daniel Bevenius)
    nodejs/node#13233

Notable Changes for Meteor:

* **deps**
  - cherry-pick 09db540,686558d from V8 upstream (Jesse Rosenberger)
    nodejs/node#14829
  - Revert "deps: backport e093a04, 09db540 from upstream V8" (Jesse Rosenberger)
    nodejs/node#14829