### PR TITLE
Stop adding line number comments to linked JavaScript files.

### DIFF
--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -1301,7 +1301,6 @@ export class PackageSourceBatch {
       // XXX report an error if there is a package called global-imports
       importStubServePath: isApp && '/packages/global-imports.js',
       includeSourceMapInstructions: isWeb,
-      noLineNumbers: !isWeb
     };
 
     const fileHashes = [];

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -61,9 +61,6 @@ compiler.compile = Profile(function (packageSource, options) {
         "` in package `" + packageSource.name + "`",
       rootPath: packageSource.sourceRoot
     }, function () {
-      // XXX we should probably also pass options.noLineNumbers into
-      //     buildJsImage so it can pass it back to its call to
-      //     compiler.compile
       var buildResult = bundler.buildJsImage({
         name: info.name,
         packageMap: packageMap,
@@ -186,7 +183,6 @@ compiler.compile = Profile(function (packageSource, options) {
         sourceArch: architecture,
         isopackCache: isopackCache,
         nodeModulesPath: nodeModulesPath,
-        noLineNumbers: options.noLineNumbers
       });
 
       _.extend(pluginProviderPackageNames,
@@ -345,8 +341,6 @@ var compileUnibuild = Profile(function (options) {
   const inputSourceArch = options.sourceArch;
   const isopackCache = options.isopackCache;
   const nodeModulesPath = options.nodeModulesPath;
-  const noLineNumbers = options.noLineNumbers;
-
   const isApp = ! inputSourceArch.pkg.name;
   const resources = [];
   const pluginProviderPackageNames = {};

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -51,8 +51,6 @@ export class IsopackCache {
     // Map from package name to Isopack.
     self._isopacks = Object.create(null);
 
-    self._noLineNumbers = !! options.noLineNumbers;
-
     self._lintLocalPackages = !! options.lintLocalPackages;
     self._lintPackageWithSourceRoot = options.lintPackageWithSourceRoot;
 
@@ -362,7 +360,6 @@ export class IsopackCache {
           isopack = compiler.compile(packageInfo.packageSource, {
             packageMap: self._packageMap,
             isopackCache: self,
-            noLineNumbers: self._noLineNumbers,
             includeCordovaUnibuild: self._includeCordovaUnibuild,
             includePluginProviderPackageMap: true,
             pluginCacheDir: pluginCacheDir


### PR DESCRIPTION
Several years ago, before all major browsers supported source maps, we felt it was important to provide line number information in generated files using end-of-line comments like `// 123\n`.

Adding all these comments was always slower than leaving the code unmodified, and recently they have begun interacting badly with certain newer ECMAScript syntax, such as multi-line template strings (#9160).

Since source maps are well supported in most browsers that developers are likely to be using for development, and the line number comments are now causing substantive problems beyond the performance cost, I think it's time we stopped using them once and for all.

Fixes #9160.