### PR TITLE
Update references to `cordova_lib.raw` to account for `raw` deprecation.

### DIFF
--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -171,7 +171,7 @@ outdated platforms`);
       this.runCommands('creating Cordova project', async () => {
         // No need to pass in appName and appId because these are set from
         // the generated config.xml
-        await cordova_lib.raw.create(files.convertToOSPath(this.projectRoot),
+        await cordova_lib.create(files.convertToOSPath(this.projectRoot),
           undefined, undefined, config);
       }, undefined, null);
     }
@@ -238,7 +238,7 @@ outdated platforms`);
 
     this.runCommands(`preparing Cordova project for platform \
 ${displayNameForPlatform(platform)}`, async () => {
-      await cordova_lib.raw.prepare(commandOptions);
+      await cordova_lib.prepare(commandOptions);
     });
   }
 
@@ -252,7 +252,7 @@ ${displayNameForPlatform(platform)}`, async () => {
 
     this.runCommands(`building Cordova app for platform \
 ${displayNameForPlatform(platform)}`, async () => {
-      await cordova_lib.raw.build(commandOptions);
+      await cordova_lib.build(commandOptions);
     });
   }
 
@@ -301,7 +301,7 @@ platform to your project first.`);
     const allRequirements = this.runCommands(`checking Cordova \
 requirements for platform ${displayNameForPlatform(platform)}`,
       async () => {
-        return await cordova_lib.raw.requirements([platform],
+        return await cordova_lib.requirements([platform],
           this.defaultOptions);
       });
     let requirements = allRequirements && allRequirements[platform];
@@ -372,7 +372,7 @@ to build apps for ${displayNameForPlatform(platform)}.`);
   updatePlatforms(platforms = this.listInstalledPlatforms()) {
     this.runCommands(`updating Cordova project for platforms \
 ${displayNamesForPlatforms(platforms)}`, async () => {
-      await cordova_lib.raw.platform('update', platforms, this.defaultOptions);
+      await cordova_lib.platform('update', platforms, this.defaultOptions);
     });
   }
 
@@ -381,14 +381,14 @@ ${displayNamesForPlatforms(platforms)}`, async () => {
 to Cordova project`, async () => {
       let version = pinnedPlatformVersions[platform];
       let platformSpec = version ? `${platform}@${version}` : platform;
-      await cordova_lib.raw.platform('add', platformSpec, this.defaultOptions);
+      await cordova_lib.platform('add', platformSpec, this.defaultOptions);
     });
   }
 
   removePlatform(platform) {
     this.runCommands(`removing platform ${displayNameForPlatform(platform)} \
 from Cordova project`, async () => {
-      await cordova_lib.raw.platform('rm', platform, this.defaultOptions);
+      await cordova_lib.platform('rm', platform, this.defaultOptions);
     });
   }
 
@@ -516,7 +516,7 @@ from Cordova project`, async () => {
 
       this.runCommands(`adding plugin ${target} \
 to Cordova project`, async () => {
-        await cordova_lib.raw.plugin('add', [target], commandOptions);
+        await cordova_lib.plugin('add', [target], commandOptions);
       });
     }
   }
@@ -529,7 +529,7 @@ to Cordova project`, async () => {
 
     this.runCommands(`removing plugins ${plugins} \
 from Cordova project`, async () => {
-      await cordova_lib.raw.plugin('rm', plugins, this.defaultOptions);
+      await cordova_lib.plugin('rm', plugins, this.defaultOptions);
     });
   }
 


### PR DESCRIPTION
The changes made in #9213 were seemingly innocent, but when merging I missed the fact that the `cordova-lib` package bump was done to a new entry on the 'dev bundle', rather than on the `CORDOVA_DEV_BUNDLE_VERSIONS` object in tools/cordova/index.js which, as of meteor/meteor#8976, is responsible for auto-installing Cordova when it is used rather than including it in the pre-packaged 'dev bundle'.

That mistake was fixed with 958c44ff1b96c298c35ebe42ffb1755ef7e50a0f and d6adc1b3a92071eaa084de25b6a9de49ef23160f, but not before it caused the Cordova tests to falsely pass on the PR since it was functionally still testing the previous version of Cordova, 7.0.0.

Unfortunately, one of the changes in the 7.1.0 was the deprecation of an API we use within Meteor: the `raw` API on `cordova_lib`. Luckily, as seen on the following commit, that change was merely a re-organizational commit and still provides us access to that API by simply removing the `raw.` segment and accessing the various methods directly:

https://github.com/apache/cordova-lib/commit/90b6857f4d6c9d6169f1155d533ce4f7c487174c

Never saw that deprecation message, but we certainly saw the failure in CI: https://circleci.com/gh/meteor/meteor/10412.

With any luck, this commit/PR will fix the problem.
