### PR TITLE
Fix for UNIX sockets with node cluster.

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -11,6 +11,7 @@ import connect from "connect";
 import parseRequest from "parseurl";
 import { lookup as lookupUserAgent } from "useragent";
 import send from "send";
+import cluster from "cluster";
 import {
   removeExistingSocketFile,
   registerSocketFileCleanup,
@@ -886,6 +887,9 @@ function runWebAppServer() {
     const unixSocketPath = process.env.UNIX_SOCKET_PATH;
 
     if (unixSocketPath) {
+      if (cluster.isWorker) {
+        unixSocketPath += "." + cluster.worker.id.toString() + ".sock";
+      }
       // Start the HTTP server using a socket file.
       removeExistingSocketFile(unixSocketPath);
       startHttpServer({ path: unixSocketPath });

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -888,7 +888,7 @@ function runWebAppServer() {
 
     if (unixSocketPath) {
       if (cluster.isWorker) {
-        unixSocketPath += "." + cluster.worker.id.toString() + ".sock";
+        unixSocketPath += "." + cluster.worker.id + ".sock";
       }
       // Start the HTTP server using a socket file.
       removeExistingSocketFile(unixSocketPath);


### PR DESCRIPTION
Prevents cluster worker processes creating UNIX socket files with the same name as the one used by the cluster master. Code now detects whether the server-side meteor instance is a worker (forked) instance. If it is, it will append the worker id (an integer) to the name of the socket file. For example, if the socket file is "meteor.sock", worker id 3's socket file will be named "meteor.sock.3.sock".

The reason why this is necessary is because the Node.js cluster fork() does not work like POSIX fork(). The worker process(es) will begin executing from the beginning and NOT from the line of code after fork() is called.

Yes, there are other ways of handling this situation, but we needed an urgent fix to our production code after updating to Meteor 1.6 and I wanted to start the conversation by submitting this pull request.

