### PR TITLE
tools: allow explicitly opting in to low-fi status display

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ build_machine_environment: &build_machine_environment
 
     # These, mostly overlapping, flags ensure that CircleCI is as pretty as
     # possible for a non-interactive environment.  See also: --headless.
-    EMACS: t
     METEOR_HEADLESS: true
     METEOR_PRETTY_OUTPUT: 0
 

--- a/History.md
+++ b/History.md
@@ -28,8 +28,8 @@
   [PR #9044](https://github.com/meteor/meteor/pull/9044)
   
 * Developers running Meteor from an interactive shell within Emacs should
-  notice a substantial performance improvement thanks automatic disabling
-  of the progress spinner, which otherwise reacts slowly within Emacs.
+  notice a substantial performance improvement thanks to automatic
+  disabling of the progress spinner, which otherwise reacts slowly.
   [PR #9341](https://github.com/meteor/meteor/pull/9341)
 
 ## v1.6, 2017-10-30

--- a/History.md
+++ b/History.md
@@ -26,6 +26,11 @@
 * `Accounts.config` now supports a `bcryptRounds` option that
   overrides the default 10 rounds currently used to secure passwords.
   [PR #9044](https://github.com/meteor/meteor/pull/9044)
+  
+* Developers running Meteor from an interactive shell within Emacs should
+  notice a substantial performance improvement thanks automatic disabling
+  of the progress spinner, which otherwise reacts slowly within Emacs.
+  [PR #9341](https://github.com/meteor/meteor/pull/9341)
 
 ## v1.6, 2017-10-30
 

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -16,6 +16,7 @@ var catalog = require('../packaging/catalog/catalog.js');
 var buildmessage = require('../utils/buildmessage.js');
 var httpHelpers = require('../utils/http-helpers.js');
 const archinfo = require('../utils/archinfo.js');
+import { isEmacs } from "../utils/utils.js";
 
 var main = exports;
 
@@ -583,7 +584,7 @@ Fiber(function () {
   // reversing node's normal setting of O_NONBLOCK on the evaluation
   // of process.stdin (because Node unblocks stdio when forking). This
   // fixes execution of Mongo from within Emacs shell.
-  if (process.env.EMACS == "t") {
+  if (isEmacs()) {
     process.stdin;
     var child_process = require('child_process');
     child_process.spawn('true', [], {stdio: 'inherit'});

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -238,7 +238,7 @@ class SpinnerRenderer {
 // Renders a progressbar.  Based on the npm 'progress' module, but tailored to our needs (i.e. renders to string)
 class ProgressBarRenderer {
   constructor(format, options) {
-    options = options || {};
+    options = options || Object.create(null);
 
     this.fmt = format;
     this.curr = 0;
@@ -550,7 +550,7 @@ class Console extends ConsoleBase {
   constructor(options) {
     super();
 
-    options = options || {};
+    options = options || Object.create(null);
 
     this._headless = !! (
       process.env.METEOR_HEADLESS &&
@@ -567,8 +567,8 @@ class Console extends ConsoleBase {
     this.verbose = false;
 
     // Legacy helpers
-    this.stdout = {};
-    this.stderr = {};
+    this.stdout = Object.create(null);
+    this.stderr = Object.create(null);
 
     this._stream = process.stdout;
 
@@ -727,7 +727,7 @@ class Console extends ConsoleBase {
       options = _.last(args).options;
     } else {
       msgArgs = args;
-      options = {};
+      options = Object.create(null);
     }
     var message = this._format(msgArgs);
     return { message: message, options: options };
@@ -1057,7 +1057,7 @@ class Console extends ConsoleBase {
   //        printing directories, for examle.
   //      - indent: indent the entire table by a given number of spaces.
   printTwoColumns(rows, options) {
-    options = options || {};
+    options = options || Object.create(null);
 
     var longest = '';
     _.each(rows, row => {
@@ -1106,7 +1106,7 @@ class Console extends ConsoleBase {
   //   - indent: (see: Console.options)
   //
   _wrapText(text, options) {
-    options = options || {};
+    options = options || Object.create(null);
 
     // Compute the maximum offset on the bulk of the message.
     var maxIndent = 0;

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -55,7 +55,6 @@
 ///
 /// In addition to printing functions, the Console class provides progress bar
 /// support, that is mostly handled through buildmessage.js.
-import _ from "underscore";
 import { createInterface } from "readline";
 import { format as utilFormat }  from "util";
 import { getRootProgress } from "../utils/buildmessage.js";
@@ -722,9 +721,10 @@ class Console extends ConsoleBase {
     // If the last argument is an instance of ConsoleOptions, then we should
     // separate it out, and only send the first N-1 arguments to be parsed as a
     // message.
-    if (_.last(args) instanceof ConsoleOptions) {
-      msgArgs = _.initial(args);
-      options = _.last(args).options;
+    const lastArg = args && args.length && args[args.length - 1];
+    if (lastArg instanceof ConsoleOptions) {
+      msgArgs = args.slice(0, -1);
+      options = lastArg.options;
     } else {
       msgArgs = args;
       options = Object.create(null);
@@ -1060,7 +1060,7 @@ class Console extends ConsoleBase {
     options = options || Object.create(null);
 
     var longest = '';
-    _.each(rows, row => {
+    rows.forEach(row => {
       var col0 = row[0] || '';
       if (col0.length > longest.length) {
         longest = col0;
@@ -1073,7 +1073,7 @@ class Console extends ConsoleBase {
       options.indent ? Array(options.indent + 1).join(' ') : "";
 
     var out = '';
-    _.each(rows, row => {
+    rows.forEach(row => {
       var col0 = row[0] || '';
       var col1 = row[1] || '';
       var line = indent + this.bold(col0) + pad.substr(col0.length);
@@ -1130,7 +1130,7 @@ class Console extends ConsoleBase {
       } else {
         wrappedText = text;
       }
-      wrappedText = _.map(wrappedText.split('\n'), s => {
+      wrappedText = wrappedText.split('\n').map(s => {
         if (s === "") {
           return "";
         }
@@ -1240,7 +1240,7 @@ class Console extends ConsoleBase {
   //   - prompt (string)
   //   - stream: defaults to process.stdout (you might want process.stderr)
   readLine(options) {
-    options = _.extend({
+    options = Object.assign(Object.create(null), {
       echo: true,
       stream: this._stream
     }, options);

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -66,6 +66,8 @@ var utils = require('../utils/utils.js');
 var wordwrap = require('wordwrap');
 
 var PROGRESS_DEBUG = !!process.env.METEOR_PROGRESS_DEBUG;
+// Recommended for better performance for Emacs shell users.
+var PROGRESS_STATUS_ONLY = !!process.env.METEOR_PROGRESS_STATUS_ONLY;
 var FORCE_PRETTY=undefined;
 // Set the default CR to \r unless we're running with cmd
 var CARRIAGE_RETURN = process.platform === 'win32' &&
@@ -1180,7 +1182,8 @@ class Console extends ConsoleBase {
     } else if ((! this._stream.isTTY) || (! this._pretty)) {
       // No progress bar if not in pretty / on TTY.
       newProgressDisplay = new ProgressDisplayNone(this);
-    } else if (this._stream.isTTY && ! this._stream.columns) {
+    } else if (PROGRESS_STATUS_ONLY ||
+               (this._stream.isTTY && ! this._stream.columns)) {
       // We might be in a pseudo-TTY that doesn't support
       // clearLine() and cursorTo(...).
       // It's important that we only enter status message mode

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -69,16 +69,14 @@ import {
   ThrottledYield,
 } from "../utils/utils.js";
 
-var PROGRESS_DEBUG = !!process.env.METEOR_PROGRESS_DEBUG;
-var FORCE_PRETTY=undefined;
+const PROGRESS_DEBUG = !!process.env.METEOR_PROGRESS_DEBUG;
 // Set the default CR to \r unless we're running with cmd
-var CARRIAGE_RETURN = process.platform === 'win32' &&
+const CARRIAGE_RETURN = process.platform === 'win32' &&
       process.stdout.isTTY &&
       process.argv[1].toLowerCase().includes('cmd') ? new Array(249).join('\b') : '\r';
 
-if (process.env.METEOR_PRETTY_OUTPUT) {
-  FORCE_PRETTY = process.env.METEOR_PRETTY_OUTPUT != '0';
-}
+const FORCE_PRETTY = process.env.METEOR_PRETTY_OUTPUT &&
+  process.env.METEOR_PRETTY_OUTPUT != '0';
 
 if (! process.env.METEOR_COLOR) {
   chalk.enabled = false;

--- a/tools/shell-client.js
+++ b/tools/shell-client.js
@@ -4,6 +4,7 @@ var path = require("path");
 var net = require("net");
 var chalk = require("chalk");
 var EOL = require("os").EOL;
+import { isEmacs } from "./utils/utils.js";
 
 // These two values (EXITING_MESSAGE and getInfoFile) must match the
 // values used by the shell-server package.
@@ -137,7 +138,7 @@ Cp.setUpSocket = function setUpSocket(sock, key) {
     // object) over the socket is required to start the REPL session.
     sock.write(JSON.stringify({
       columns: process.stdout.columns,
-      terminal: ! process.env.EMACS,
+      terminal: ! isEmacs(),
       key: key
     }) + "\n");
 
@@ -195,7 +196,7 @@ function shellBanner() {
     "Welcome to the server-side interactive shell!"
   ];
 
-  if (! process.env.EMACS) {
+  if (! isEmacs()) {
     // Tab completion sadly does not work in Emacs.
     bannerLines.push(
       "",

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -735,3 +735,15 @@ export function architecture() {
 
   return supportedArchitectures[osType][osArch];
 };
+
+let emacsDetected;
+export function isEmacs() {
+  // Checking `process.env` is expensive, so only check once.
+  if (typeof emacsDetected === "boolean") {
+    return emacsDetected;
+  }
+
+  // Prior to v22, Emacs only set EMACS. After v27, it only sets INSIDE_EMACS.
+  emacsDetected = !! (process.env.EMACS === "t" || process.env.INSIDE_EMACS);
+  return emacsDetected;
+}


### PR DESCRIPTION
I think this was originally designed for Emacs shell but at some point Emacs or
Node improved so that Node finds columns for Emacs shell and switches to the
full display.

Switching to the status-only display leads to massive speedups when doing builds
in my Emacs shell.
