### PR TITLE
Improved server rendering

### DIFF
--- a/packages/boilerplate-generator-tests/.npm/package/npm-shrinkwrap.json
+++ b/packages/boilerplate-generator-tests/.npm/package/npm-shrinkwrap.json
@@ -5,6 +5,16 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
       "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA="
+    },
+    "promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+    },
+    "stream-to-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+      "integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA="
     }
   }
 }

--- a/packages/boilerplate-generator-tests/package.js
+++ b/packages/boilerplate-generator-tests/package.js
@@ -7,7 +7,8 @@ Package.describe({
 });
 
 Npm.depends({
-  parse5: '3.0.2'
+  parse5: '3.0.2',
+  'stream-to-string': '1.1.0'
 });
 
 Package.onTest(function (api) {

--- a/packages/boilerplate-generator-tests/test-lib.js
+++ b/packages/boilerplate-generator-tests/test-lib.js
@@ -1,4 +1,4 @@
-import toString from "stream-to-string";
+import streamToString from "stream-to-string";
 
 export async function generateHTMLForArch(arch) {
   // Use a dummy manifest. None of these paths will be read from the filesystem, but css / js should be handled differently
@@ -52,7 +52,5 @@ export async function generateHTMLForArch(arch) {
     },
   });
 
-
-  return await toString(boilerplate.toHTML());
-};
-
+  return streamToString(boilerplate.toHTML());
+}

--- a/packages/boilerplate-generator-tests/test-lib.js
+++ b/packages/boilerplate-generator-tests/test-lib.js
@@ -1,4 +1,4 @@
-export function generateHTMLForArch(arch) {
+export async function generateHTMLForArch(arch) {
   // Use a dummy manifest. None of these paths will be read from the filesystem, but css / js should be handled differently
   const manifest = [
     {
@@ -50,5 +50,29 @@ export function generateHTMLForArch(arch) {
     },
   });
 
-  return boilerplate.toHTML();
+
+  const { start, stream, end } = boilerplate.toHTML();
+
+  const body = await toString(stream);
+  
+  return start + body + end;
 };
+
+
+function toString(stream) {
+  return new Promise((success, fail) => {
+    var string = ''
+    stream.on('readable', function(buffer) {
+      var part = buffer.read().toString();
+      string += part;
+    });
+
+    stream.on('end', function() {
+      success(string)
+    });
+
+    stream.on('error', function(error) {
+      fail(error);
+    });
+  });
+}

--- a/packages/boilerplate-generator-tests/test-lib.js
+++ b/packages/boilerplate-generator-tests/test-lib.js
@@ -1,3 +1,5 @@
+import toString from "stream-to-string";
+
 export async function generateHTMLForArch(arch) {
   // Use a dummy manifest. None of these paths will be read from the filesystem, but css / js should be handled differently
   const manifest = [
@@ -51,28 +53,6 @@ export async function generateHTMLForArch(arch) {
   });
 
 
-  const { start, stream, end } = boilerplate.toHTML();
-
-  const body = await toString(stream);
-  
-  return start + body + end;
+  return await toString(boilerplate.toHTML());
 };
 
-
-function toString(stream) {
-  return new Promise((success, fail) => {
-    var string = ''
-    stream.on('readable', function(buffer) {
-      var part = buffer.read().toString();
-      string += part;
-    });
-
-    stream.on('end', function() {
-      success(string)
-    });
-
-    stream.on('error', function(error) {
-      fail(error);
-    });
-  });
-}

--- a/packages/boilerplate-generator-tests/web.browser-tests.js
+++ b/packages/boilerplate-generator-tests/web.browser-tests.js
@@ -2,62 +2,69 @@ import { parse, serialize } from 'parse5';
 
 import { generateHTMLForArch } from './test-lib';
 
-const html = generateHTMLForArch('web.browser');
+const start = async () => {
+  const html = await generateHTMLForArch('web.browser');
 
-Tinytest.add("boilerplate-generator-tests - web.browser - well-formed html", function (test) {
-  const formatted = serialize(parse(html));
-  test.isTrue(formatted.replace(/\s/g, '') === html.replace(/\s/g, ''));
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - well-formed html", function (test) {
+    const formatted = serialize(parse(html));
+    test.isTrue(formatted.replace(/\s/g, '') === html.replace(/\s/g, ''));
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.browser - include htmlAttributes", function (test) {
-  test.matches(html, /foo="foobar"/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - include htmlAttributes", function (test) {
+    test.matches(html, /foo="foobar"/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.browser - escape htmlAttributes", function (test) {
-  test.matches(html, /gems="&amp;&quot;"/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - escape htmlAttributes", function (test) {
+    test.matches(html, /gems="&amp;&quot;"/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.browser - include js", function (test) {
-  test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - include js", function (test) {
+    test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.browser - escape js", function (test) {
-  test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - escape js", function (test) {
+    test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.browser - include css", function (test) {
-  test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - include css", function (test) {
+    test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.browser - escape css", function (test) {
-  test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - escape css", function (test) {
+    test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.browser - call rewriteHook", function (test) {
-  test.matches(html, /\+rewritten_url=true/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - call rewriteHook", function (test) {
+    test.matches(html, /\+rewritten_url=true/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.browser - include runtime config", function (test) {
-  test.matches(html, /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.browser - include runtime config", function (test) {
+    test.matches(html, /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/);
+  });
 
-// https://github.com/meteor/meteor/issues/9149
-Tinytest.add(
-  "boilerplate-generator-tests - web.browser - properly render boilerplate " +
-  "elements when _.template settings are overridden",
-  function (test) {
-    import { _ } from 'meteor/underscore';
-    _.templateSettings = {
-      interpolate: /\{\{(.+?)\}\}/g
-    };
-    const newHtml = generateHTMLForArch('web.browser');
-    test.matches(newHtml, /foo="foobar"/);
-    test.matches(newHtml, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
-    test.matches(newHtml, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
-    test.matches(newHtml, /<script>var a/);
-    test.matches(
-      newHtml,
-      /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/
-    );
-  }
-);
+  // https://github.com/meteor/meteor/issues/9149
+  Tinytest.addAsync(
+    "boilerplate-generator-tests - web.browser - properly render boilerplate " +
+    "elements when _.template settings are overridden",
+    function (test, onComplete) {
+      const run = async () => {
+        import { _ } from 'meteor/underscore';
+        _.templateSettings = {
+          interpolate: /\{\{(.+?)\}\}/g
+        };
+        const newHtml = await generateHTMLForArch('web.browser');
+        test.matches(newHtml, /foo="foobar"/);
+        test.matches(newHtml, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
+        test.matches(newHtml, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
+        test.matches(newHtml, /<script>var a/);
+        test.matches(
+          newHtml,
+          /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/
+        );
+      }
+      run().then(onComplete);
+    }
+  );
+};
+
+start();

--- a/packages/boilerplate-generator-tests/web.browser-tests.js
+++ b/packages/boilerplate-generator-tests/web.browser-tests.js
@@ -1,70 +1,60 @@
 import { parse, serialize } from 'parse5';
-
 import { generateHTMLForArch } from './test-lib';
+import { _ } from 'meteor/underscore';
 
-const start = async () => {
-  const html = await generateHTMLForArch('web.browser');
+Tinytest.addAsync(
+  "boilerplate-generator-tests - web.browser - basic output",
+  async function (test) {
+    const html = await generateHTMLForArch("web.browser");
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - well-formed html", function (test) {
+    // well-formed html
     const formatted = serialize(parse(html));
     test.isTrue(formatted.replace(/\s/g, '') === html.replace(/\s/g, ''));
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - include htmlAttributes", function (test) {
+    // include htmlAttributes
     test.matches(html, /foo="foobar"/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - escape htmlAttributes", function (test) {
+    // escape htmlAttributes
     test.matches(html, /gems="&amp;&quot;"/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - include js", function (test) {
+    // include js
     test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - escape js", function (test) {
+    // escape js
     test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - include css", function (test) {
+    // include css
     test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - escape css", function (test) {
+    // escape css
     test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - call rewriteHook", function (test) {
+    // call rewriteHook
     test.matches(html, /\+rewritten_url=true/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.browser - include runtime config", function (test) {
+    // include runtime config
     test.matches(html, /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/);
-  });
+  }
+);
 
-  // https://github.com/meteor/meteor/issues/9149
-  Tinytest.addAsync(
-    "boilerplate-generator-tests - web.browser - properly render boilerplate " +
+// https://github.com/meteor/meteor/issues/9149
+Tinytest.addAsync(
+  "boilerplate-generator-tests - web.browser - properly render boilerplate " +
     "elements when _.template settings are overridden",
-    function (test, onComplete) {
-      const run = async () => {
-        import { _ } from 'meteor/underscore';
-        _.templateSettings = {
-          interpolate: /\{\{(.+?)\}\}/g
-        };
-        const newHtml = await generateHTMLForArch('web.browser');
-        test.matches(newHtml, /foo="foobar"/);
-        test.matches(newHtml, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
-        test.matches(newHtml, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
-        test.matches(newHtml, /<script>var a/);
-        test.matches(
-          newHtml,
-          /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/
-        );
-      }
-      run().then(onComplete);
-    }
-  );
-};
+  async function (test) {
+    const newHtml = await generateHTMLForArch("web.browser");
 
-start();
+    _.templateSettings = {
+      interpolate: /\{\{(.+?)\}\}/g
+    };
+
+    test.matches(newHtml, /foo="foobar"/);
+    test.matches(newHtml, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
+    test.matches(newHtml, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
+    test.matches(newHtml, /<script>var a/);
+    test.matches(
+      newHtml,
+        /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/
+    );
+  }
+);

--- a/packages/boilerplate-generator-tests/web.cordova-tests.js
+++ b/packages/boilerplate-generator-tests/web.cordova-tests.js
@@ -1,63 +1,52 @@
 import { parse, serialize } from 'parse5';
-
 import { generateHTMLForArch } from './test-lib';
+import { _ } from 'meteor/underscore';
 
-const start = async () => {
-  
-  const html = await generateHTMLForArch('web.cordova');
+Tinytest.addAsync(
+  "boilerplate-generator-tests - web.cordova - basic output",
+  async function (test) {
+    const html = await generateHTMLForArch("web.cordova");
 
-  Tinytest.add("boilerplate-generator-tests - web.cordova - well-formed html", function (test) {
+    // well-formed html
     const formatted = serialize(parse(html));
     test.isTrue(formatted.replace(/\s/g, '') === html.replace(/\s/g, ''));
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.cordova - include js", function (test) {
+    // include js
     test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.cordova - escape js", function (test) {
+    // escape js
     test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.cordova - include css", function (test) {
+    // include css
     test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.cordova - escape css", function (test) {
+    // escape css
     test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.cordova - do not call rewriteHook", function (test) {
+    // do not call rewriteHook
     test.notMatches(html, /\+rewritten_url=true/);
-  });
 
-  Tinytest.add("boilerplate-generator-tests - web.cordova - include runtime config", function (test) {
+    // include runtime config
     test.matches(html, /<script[^<>]*>[^<>]*\n[^<>]*__meteor_runtime_config__ =[^<>]*decodeURIComponent\(config123\)\)/);
-  });
+  }
+);
 
-  // https://github.com/meteor/meteor/issues/9149
-  Tinytest.addAsync(
-    "boilerplate-generator-tests - web.cordova - properly render boilerplate " +
+// https://github.com/meteor/meteor/issues/9149
+Tinytest.addAsync(
+  "boilerplate-generator-tests - web.cordova - properly render boilerplate " +
     "elements when _.template settings are overridden",
-    function (test, onComplete) {
-      const run = async () => {
-        import { _ } from 'meteor/underscore';
-        _.templateSettings = {
-          interpolate: /\{\{(.+?)\}\}/g
-        };
-        const newHtml = await generateHTMLForArch('web.cordova');
-        test.matches(newHtml, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
-        test.matches(newHtml, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
-        test.matches(newHtml, /<script>var a/);
-        test.matches(
-          newHtml,
-          /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/
-        );
-      }
+  async function (test) {
+    const newHtml = await generateHTMLForArch('web.cordova');
 
-      run().then(onComplete)
-    }
-  );
-};
-
-start();
+    _.templateSettings = {
+      interpolate: /\{\{(.+?)\}\}/g
+    };
+    test.matches(newHtml, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
+    test.matches(newHtml, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
+    test.matches(newHtml, /<script>var a/);
+    test.matches(
+      newHtml,
+        /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/
+    );
+  }
+);

--- a/packages/boilerplate-generator-tests/web.cordova-tests.js
+++ b/packages/boilerplate-generator-tests/web.cordova-tests.js
@@ -2,53 +2,62 @@ import { parse, serialize } from 'parse5';
 
 import { generateHTMLForArch } from './test-lib';
 
-const html = generateHTMLForArch('web.cordova');
+const start = async () => {
+  
+  const html = await generateHTMLForArch('web.cordova');
 
-Tinytest.add("boilerplate-generator-tests - web.cordova - well-formed html", function (test) {
-  const formatted = serialize(parse(html));
-  test.isTrue(formatted.replace(/\s/g, '') === html.replace(/\s/g, ''));
-});
+  Tinytest.add("boilerplate-generator-tests - web.cordova - well-formed html", function (test) {
+    const formatted = serialize(parse(html));
+    test.isTrue(formatted.replace(/\s/g, '') === html.replace(/\s/g, ''));
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.cordova - include js", function (test) {
-  test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.cordova - include js", function (test) {
+    test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.cordova - escape js", function (test) {
-  test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.cordova - escape js", function (test) {
+    test.matches(html, /<script[^<>]*src="[^<>]*templating[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.cordova - include css", function (test) {
-  test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.cordova - include css", function (test) {
+    test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.cordova - escape css", function (test) {
-  test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.cordova - escape css", function (test) {
+    test.matches(html, /<link[^<>]*href="[^<>]*bootstrap[^<>]*&amp;v=&quot;1&quot;[^<>]*">/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.cordova - do not call rewriteHook", function (test) {
-  test.notMatches(html, /\+rewritten_url=true/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.cordova - do not call rewriteHook", function (test) {
+    test.notMatches(html, /\+rewritten_url=true/);
+  });
 
-Tinytest.add("boilerplate-generator-tests - web.cordova - include runtime config", function (test) {
-  test.matches(html, /<script[^<>]*>[^<>]*\n[^<>]*__meteor_runtime_config__ =[^<>]*decodeURIComponent\(config123\)\)/);
-});
+  Tinytest.add("boilerplate-generator-tests - web.cordova - include runtime config", function (test) {
+    test.matches(html, /<script[^<>]*>[^<>]*\n[^<>]*__meteor_runtime_config__ =[^<>]*decodeURIComponent\(config123\)\)/);
+  });
 
-// https://github.com/meteor/meteor/issues/9149
-Tinytest.add(
-  "boilerplate-generator-tests - web.cordova - properly render boilerplate " +
-  "elements when _.template settings are overridden",
-  function (test) {
-    import { _ } from 'meteor/underscore';
-    _.templateSettings = {
-      interpolate: /\{\{(.+?)\}\}/g
-    };
-    const newHtml = generateHTMLForArch('web.cordova');
-    test.matches(newHtml, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
-    test.matches(newHtml, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
-    test.matches(newHtml, /<script>var a/);
-    test.matches(
-      newHtml,
-      /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/
-    );
-  }
-);
+  // https://github.com/meteor/meteor/issues/9149
+  Tinytest.addAsync(
+    "boilerplate-generator-tests - web.cordova - properly render boilerplate " +
+    "elements when _.template settings are overridden",
+    function (test, onComplete) {
+      const run = async () => {
+        import { _ } from 'meteor/underscore';
+        _.templateSettings = {
+          interpolate: /\{\{(.+?)\}\}/g
+        };
+        const newHtml = await generateHTMLForArch('web.cordova');
+        test.matches(newHtml, /<link[^<>]*href="[^<>]*bootstrap[^<>]*">/);
+        test.matches(newHtml, /<script[^<>]*src="[^<>]*templating[^<>]*">/);
+        test.matches(newHtml, /<script>var a/);
+        test.matches(
+          newHtml,
+          /<script[^<>]*>[^<>]*__meteor_runtime_config__ =.*decodeURIComponent\(config123\)/
+        );
+      }
+
+      run().then(onComplete)
+    }
+  );
+};
+
+start();

--- a/packages/boilerplate-generator/.npm/package/.gitignore
+++ b/packages/boilerplate-generator/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/boilerplate-generator/.npm/package/README
+++ b/packages/boilerplate-generator/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/boilerplate-generator/.npm/package/npm-shrinkwrap.json
+++ b/packages/boilerplate-generator/.npm/package/npm-shrinkwrap.json
@@ -1,10 +1,30 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "combine-streams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/combine-streams/-/combine-streams-1.0.0.tgz",
-      "integrity": "sha1-U2W6BKdmGM8zshPDFtM+XBs8RgQ="
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "combined-stream2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/combined-stream2/-/combined-stream2-1.1.2.tgz",
+      "integrity": "sha1-9uFLegFWZvjHsKH6xQYkAWSsNXA="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "stream-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
+      "integrity": "sha1-gnfzy+5JpNqrz9tOL0qbXp8snwA="
     }
   }
 }

--- a/packages/boilerplate-generator/.npm/package/npm-shrinkwrap.json
+++ b/packages/boilerplate-generator/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,10 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "combine-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/combine-streams/-/combine-streams-1.0.0.tgz",
+      "integrity": "sha1-U2W6BKdmGM8zshPDFtM+XBs8RgQ="
+    }
+  }
+}

--- a/packages/boilerplate-generator/generator.js
+++ b/packages/boilerplate-generator/generator.js
@@ -1,5 +1,5 @@
 import { readFile } from 'fs';
-import { Readable } from 'stream';
+import combine from "combine-streams";
 
 import WebBrowserTemplate from './template-web.browser';
 import WebCordovaTemplate from './template-web.cordova';
@@ -22,21 +22,6 @@ export class Boilerplate {
     );
   }
 
-  stringToStream(str) {
-    if (!str) str = "";
-
-    // this is a stream
-    if (typeof str !== "string") return str;
-
-    const stream = new Readable();
-    stream._read = () => {};
-    stream.push(str);
-    // end the stream
-    stream.push(null);
-
-    return stream;
-  }
-
   // The 'extraData' argument can be used to extend 'self.baseData'. Its
   // purpose is to allow you to specify data that you might not know at
   // the time that you construct the Boilerplate object. (e.g. it is used
@@ -54,8 +39,10 @@ export class Boilerplate {
     const start = "<!DOCTYPE html>\n" + this.headTemplate(data);
 
     const { body, dynamicBody } = data;
-    const stream = this.stringToStream(body)
-        // .pipe(this.stringToStream(dynamicBody));
+    const stream = combine()
+      .append(body || "")
+      .append(dynamicBody || "")
+      .append(null);
 
     const end = this.closeTemplate(data);
 

--- a/packages/boilerplate-generator/package.js
+++ b/packages/boilerplate-generator/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "combine-streams": "1.0.0"
+  "combined-stream2": "1.1.2"
 });
 
 Package.onUse(api => {

--- a/packages/boilerplate-generator/package.js
+++ b/packages/boilerplate-generator/package.js
@@ -3,6 +3,10 @@ Package.describe({
   version: '1.3.1'
 });
 
+Npm.depends({
+  "combine-streams": "1.0.0"
+});
+
 Package.onUse(api => {
   api.use('ecmascript');
   api.use('underscore', 'server');

--- a/packages/boilerplate-generator/template-web.browser.js
+++ b/packages/boilerplate-generator/template-web.browser.js
@@ -6,29 +6,26 @@ export const headTemplate = ({
   bundledJsCssUrlRewriteHook,
   head,
   dynamicHead,
-}) => [].concat(
-  [
-    '<html' + Object.keys(htmlAttributes || {}).map(key =>
-      template(' <%= attrName %>="<%- attrValue %>"')({
-        attrName: key,
-        attrValue: htmlAttributes[key]
-      })
-    ).join('') + '>',
-    '<head>'
-  ],
+}) => [
+  '<html' + Object.keys(htmlAttributes || {}).map(
+    key => template(' <%= attrName %>="<%- attrValue %>"')({
+      attrName: key,
+      attrValue: htmlAttributes[key],
+    })
+  ).join('') + '>',
+  '<head>',
 
-  (css || []).map(({ url }) =>
+  ...(css || []).map(file =>
     template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>">')({
-      href: bundledJsCssUrlRewriteHook(url)
+      href: bundledJsCssUrlRewriteHook(file.url),
     })
   ),
-  [
-    head,
-    dynamicHead,
-    '</head>',
-    '<body>',
-  ],
-).join('\n')
+
+  head,
+  dynamicHead,
+  '</head>',
+  '<body>',
+].join('\n');
 
 // Template function for rendering the boilerplate html for browsers
 export const closeTemplate = ({
@@ -38,39 +35,35 @@ export const closeTemplate = ({
   js,
   additionalStaticJs,
   bundledJsCssUrlRewriteHook,
-}) => [].concat(
-  [
-    '',
-    (inlineScriptsAllowed
-      ? template('  <script type="text/javascript">__meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>))</script>')({
-        conf: meteorRuntimeConfig
-      })
-      : template('  <script type="text/javascript" src="<%- src %>/meteor_runtime_config.js"></script>')({
-        src: rootUrlPathPrefix
-      })
-    ) ,
-    ''
-  ],
+}) => [
+  '',
+  inlineScriptsAllowed
+    ? template('  <script type="text/javascript">__meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>))</script>')({
+      conf: meteorRuntimeConfig,
+    })
+    : template('  <script type="text/javascript" src="<%- src %>/meteor_runtime_config.js"></script>')({
+      src: rootUrlPathPrefix,
+    }),
+  '',
 
-  (js || []).map(({ url }) =>
+  ...(js || []).map(file =>
     template('  <script type="text/javascript" src="<%- src %>"></script>')({
-      src: bundledJsCssUrlRewriteHook(url)
+      src: bundledJsCssUrlRewriteHook(file.url),
     })
   ),
 
-  (additionalStaticJs || []).map(({ contents, pathname }) => (
-    (inlineScriptsAllowed
+  ...(additionalStaticJs || []).map(({ contents, pathname }) => (
+    inlineScriptsAllowed
       ? template('  <script><%= contents %></script>')({
-        contents: contents
+        contents,
       })
       : template('  <script type="text/javascript" src="<%- src %>"></script>')({
-        src: rootUrlPathPrefix + pathname
-      }))
+        src: rootUrlPathPrefix + pathname,
+      })
   )),
 
-  [
-    '', '',
-    '</body>',
-    '</html>'
-  ],
-).join('\n');
+  '',
+  '',
+  '</body>',
+  '</html>'
+].join('\n');

--- a/packages/boilerplate-generator/template-web.browser.js
+++ b/packages/boilerplate-generator/template-web.browser.js
@@ -1,76 +1,76 @@
 import template from './template';
 
-// Template function for rendering the boilerplate html for browsers
-export default function({
-  meteorRuntimeConfig,
-  rootUrlPathPrefix,
-  inlineScriptsAllowed,
+export const headTemplate = ({
   css,
-  js,
-  additionalStaticJs,
   htmlAttributes,
   bundledJsCssUrlRewriteHook,
   head,
-  body,
   dynamicHead,
-  dynamicBody,
-}) {
-  return [].concat(
-    [
-      '<html' + Object.keys(htmlAttributes || {}).map(key =>
-        template(' <%= attrName %>="<%- attrValue %>"')({
-          attrName: key,
-          attrValue: htmlAttributes[key]
-        })
-      ).join('') + '>',
-      '<head>'
-    ],
-
-    (css || []).map(({ url }) =>
-      template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>">')({
-        href: bundledJsCssUrlRewriteHook(url)
+}) => [].concat(
+  [
+    '<html' + Object.keys(htmlAttributes || {}).map(key =>
+      template(' <%= attrName %>="<%- attrValue %>"')({
+        attrName: key,
+        attrValue: htmlAttributes[key]
       })
-    ),
+    ).join('') + '>',
+    '<head>'
+  ],
 
-    [
-      head,
-      dynamicHead,
-      '</head>',
-      '<body>',
-      body,
-      dynamicBody,
-      '',
-      (inlineScriptsAllowed
-        ? template('  <script type="text/javascript">__meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>))</script>')({
-          conf: meteorRuntimeConfig
-        })
-        : template('  <script type="text/javascript" src="<%- src %>/meteor_runtime_config.js"></script>')({
-          src: rootUrlPathPrefix
-        })
-      ) ,
-      ''
-    ],
+  (css || []).map(({ url }) =>
+    template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>">')({
+      href: bundledJsCssUrlRewriteHook(url)
+    })
+  ),
+  [
+    head,
+    dynamicHead,
+    '</head>',
+    '<body>',
+  ],
+).join('\n')
 
-    (js || []).map(({ url }) =>
-      template('  <script type="text/javascript" src="<%- src %>"></script>')({
-        src: bundledJsCssUrlRewriteHook(url)
+// Template function for rendering the boilerplate html for browsers
+export const closeTemplate = ({
+  meteorRuntimeConfig,
+  rootUrlPathPrefix,
+  inlineScriptsAllowed,
+  js,
+  additionalStaticJs,
+  bundledJsCssUrlRewriteHook,
+}) => [].concat(
+  [
+    '',
+    (inlineScriptsAllowed
+      ? template('  <script type="text/javascript">__meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>))</script>')({
+        conf: meteorRuntimeConfig
       })
-    ),
+      : template('  <script type="text/javascript" src="<%- src %>/meteor_runtime_config.js"></script>')({
+        src: rootUrlPathPrefix
+      })
+    ) ,
+    ''
+  ],
 
-    (additionalStaticJs || []).map(({ contents, pathname }) => (
-      (inlineScriptsAllowed
-        ? template('  <script><%= contents %></script>')({
-          contents: contents
-        })
-        : template('  <script type="text/javascript" src="<%- src %>"></script>')({
-          src: rootUrlPathPrefix + pathname
-        }))
-    )),
+  (js || []).map(({ url }) =>
+    template('  <script type="text/javascript" src="<%- src %>"></script>')({
+      src: bundledJsCssUrlRewriteHook(url)
+    })
+  ),
 
-    [
-      '', '',
-      '</body>',
-      '</html>'
-    ],
-  ).join('\n');
-}
+  (additionalStaticJs || []).map(({ contents, pathname }) => (
+    (inlineScriptsAllowed
+      ? template('  <script><%= contents %></script>')({
+        contents: contents
+      })
+      : template('  <script type="text/javascript" src="<%- src %>"></script>')({
+        src: rootUrlPathPrefix + pathname
+      }))
+  )),
+
+  [
+    '', '',
+    '</body>',
+    '</html>'
+  ],
+).join('\n');

--- a/packages/boilerplate-generator/template-web.cordova.js
+++ b/packages/boilerplate-generator/template-web.cordova.js
@@ -1,7 +1,7 @@
 import template from './template';
 
 // Template function for rendering the boilerplate html for cordova
-export default function({
+export const headTemplate = ({
   meteorRuntimeConfig,
   rootUrlPathPrefix,
   inlineScriptsAllowed,
@@ -11,69 +11,65 @@ export default function({
   htmlAttributes,
   bundledJsCssUrlRewriteHook,
   head,
-  body,
   dynamicHead,
-  dynamicBody,
-}) {
-  return [].concat(
-    [
-      '<html>',
-      '<head>',
-      '  <meta charset="utf-8">',
-      '  <meta name="format-detection" content="telephone=no">',
-      '  <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, viewport-fit=cover">',
-      '  <meta name="msapplication-tap-highlight" content="no">',
-      '  <meta http-equiv="Content-Security-Policy" content="default-src * gap: data: blob: \'unsafe-inline\' \'unsafe-eval\' ws: wss:;">',
-    ],
-    // We are explicitly not using bundledJsCssUrlRewriteHook: in cordova we serve assets up directly from disk, so rewriting the URL does not make sense
-    (css || []).map(({ url }) =>
-      template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>">')({
-        href: url
-      })
-    ),
-    [
-      '  <script type="text/javascript">',
-      template('    __meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>));')({
-        conf: meteorRuntimeConfig
-      }),
-      '    if (/Android/i.test(navigator.userAgent)) {',
-      // When Android app is emulated, it cannot connect to localhost,
-      // instead it should connect to 10.0.2.2
-      // (unless we\'re using an http proxy; then it works!)
-      '      if (!__meteor_runtime_config__.httpProxyPort) {',
-      '        __meteor_runtime_config__.ROOT_URL = (__meteor_runtime_config__.ROOT_URL || \'\').replace(/localhost/i, \'10.0.2.2\');',
-      '        __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL = (__meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || \'\').replace(/localhost/i, \'10.0.2.2\');',
-      '      }',
-      '    }',
-      '  </script>',
-      '',
-      '  <script type="text/javascript" src="/cordova.js"></script>'
-    ],
-    (js || []).map(({ url }) =>
-      template('  <script type="text/javascript" src="<%- src %>"></script>')({
-        src: url
-      })
-    ),
+}) => [].concat(
+  [
+    '<html>',
+    '<head>',
+    '  <meta charset="utf-8">',
+    '  <meta name="format-detection" content="telephone=no">',
+    '  <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, viewport-fit=cover">',
+    '  <meta name="msapplication-tap-highlight" content="no">',
+    '  <meta http-equiv="Content-Security-Policy" content="default-src * gap: data: blob: \'unsafe-inline\' \'unsafe-eval\' ws: wss:;">',
+  ],
+  // We are explicitly not using bundledJsCssUrlRewriteHook: in cordova we serve assets up directly from disk, so rewriting the URL does not make sense
+  (css || []).map(({ url }) =>
+    template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>">')({
+      href: url
+    })
+  ),
+  [
+    '  <script type="text/javascript">',
+    template('    __meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>));')({
+      conf: meteorRuntimeConfig
+    }),
+    '    if (/Android/i.test(navigator.userAgent)) {',
+    // When Android app is emulated, it cannot connect to localhost,
+    // instead it should connect to 10.0.2.2
+    // (unless we\'re using an http proxy; then it works!)
+    '      if (!__meteor_runtime_config__.httpProxyPort) {',
+    '        __meteor_runtime_config__.ROOT_URL = (__meteor_runtime_config__.ROOT_URL || \'\').replace(/localhost/i, \'10.0.2.2\');',
+    '        __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL = (__meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || \'\').replace(/localhost/i, \'10.0.2.2\');',
+    '      }',
+    '    }',
+    '  </script>',
+    '',
+    '  <script type="text/javascript" src="/cordova.js"></script>'
+  ],
+  (js || []).map(({ url }) =>
+    template('  <script type="text/javascript" src="<%- src %>"></script>')({
+      src: url
+    })
+  ),
 
-    (additionalStaticJs || []).map(({ contents, pathname }) => (
-      (inlineScriptsAllowed
-        ? template('  <script><%= contents %></script>')({
-          contents: contents
-        })
-        : template('  <script type="text/javascript" src="<%- src %>"></script>')({
-          src: rootUrlPathPrefix + pathname
-        }))
-    )),
+  (additionalStaticJs || []).map(({ contents, pathname }) => (
+    (inlineScriptsAllowed
+      ? template('  <script><%= contents %></script>')({
+        contents: contents
+      })
+      : template('  <script type="text/javascript" src="<%- src %>"></script>')({
+        src: rootUrlPathPrefix + pathname
+      }))
+  )),
 
-    [
-      '',
-      head,
-      '</head>',
-      '',
-      '<body>',
-      body,
-      '</body>',
-      '</html>'
-    ],
-  ).join('\n');
-}
+  [
+    '',
+    head,
+    '</head>',
+    '',
+    '<body>',
+  ],
+).join('\n');
+
+export const closeTemplate = () => 
+  [].concat([ '</body>','</html>' ]).join('\n');

--- a/packages/boilerplate-generator/template-web.cordova.js
+++ b/packages/boilerplate-generator/template-web.cordova.js
@@ -12,64 +12,61 @@ export const headTemplate = ({
   bundledJsCssUrlRewriteHook,
   head,
   dynamicHead,
-}) => [].concat(
-  [
-    '<html>',
-    '<head>',
-    '  <meta charset="utf-8">',
-    '  <meta name="format-detection" content="telephone=no">',
-    '  <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, viewport-fit=cover">',
-    '  <meta name="msapplication-tap-highlight" content="no">',
-    '  <meta http-equiv="Content-Security-Policy" content="default-src * gap: data: blob: \'unsafe-inline\' \'unsafe-eval\' ws: wss:;">',
-  ],
+}) => [
+  '<html>',
+  '<head>',
+  '  <meta charset="utf-8">',
+  '  <meta name="format-detection" content="telephone=no">',
+  '  <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, viewport-fit=cover">',
+  '  <meta name="msapplication-tap-highlight" content="no">',
+  '  <meta http-equiv="Content-Security-Policy" content="default-src * gap: data: blob: \'unsafe-inline\' \'unsafe-eval\' ws: wss:;">',
+
   // We are explicitly not using bundledJsCssUrlRewriteHook: in cordova we serve assets up directly from disk, so rewriting the URL does not make sense
-  (css || []).map(({ url }) =>
+  ...(css || []).map(file =>
     template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>">')({
-      href: url
-    })
-  ),
-  [
-    '  <script type="text/javascript">',
-    template('    __meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>));')({
-      conf: meteorRuntimeConfig
-    }),
-    '    if (/Android/i.test(navigator.userAgent)) {',
-    // When Android app is emulated, it cannot connect to localhost,
-    // instead it should connect to 10.0.2.2
-    // (unless we\'re using an http proxy; then it works!)
-    '      if (!__meteor_runtime_config__.httpProxyPort) {',
-    '        __meteor_runtime_config__.ROOT_URL = (__meteor_runtime_config__.ROOT_URL || \'\').replace(/localhost/i, \'10.0.2.2\');',
-    '        __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL = (__meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || \'\').replace(/localhost/i, \'10.0.2.2\');',
-    '      }',
-    '    }',
-    '  </script>',
-    '',
-    '  <script type="text/javascript" src="/cordova.js"></script>'
-  ],
-  (js || []).map(({ url }) =>
-    template('  <script type="text/javascript" src="<%- src %>"></script>')({
-      src: url
+      href: file.url,
     })
   ),
 
-  (additionalStaticJs || []).map(({ contents, pathname }) => (
-    (inlineScriptsAllowed
+  '  <script type="text/javascript">',
+  template('    __meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>));')({
+    conf: meteorRuntimeConfig,
+  }),
+  '    if (/Android/i.test(navigator.userAgent)) {',
+  // When Android app is emulated, it cannot connect to localhost,
+  // instead it should connect to 10.0.2.2
+  // (unless we\'re using an http proxy; then it works!)
+  '      if (!__meteor_runtime_config__.httpProxyPort) {',
+  '        __meteor_runtime_config__.ROOT_URL = (__meteor_runtime_config__.ROOT_URL || \'\').replace(/localhost/i, \'10.0.2.2\');',
+  '        __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL = (__meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || \'\').replace(/localhost/i, \'10.0.2.2\');',
+  '      }',
+  '    }',
+  '  </script>',
+  '',
+  '  <script type="text/javascript" src="/cordova.js"></script>',
+
+  ...(js || []).map(file =>
+    template('  <script type="text/javascript" src="<%- src %>"></script>')({
+      src: file.url,
+    })
+  ),
+
+  ...(additionalStaticJs || []).map(({ contents, pathname }) => (
+    inlineScriptsAllowed
       ? template('  <script><%= contents %></script>')({
-        contents: contents
+        contents,
       })
       : template('  <script type="text/javascript" src="<%- src %>"></script>')({
         src: rootUrlPathPrefix + pathname
-      }))
+      })
   )),
+  '',
+  head,
+  '</head>',
+  '',
+  '<body>',
+].join('\n');
 
-  [
-    '',
-    head,
-    '</head>',
-    '',
-    '<body>',
-  ],
-).join('\n');
-
-export const closeTemplate = () => 
-  [].concat([ '</body>','</html>' ]).join('\n');
+export function closeTemplate() {
+  return "</body>\n</html>";
+}

--- a/packages/server-render/.npm/package/npm-shrinkwrap.json
+++ b/packages/server-render/.npm/package/npm-shrinkwrap.json
@@ -1,6 +1,11 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
+    "combine-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/combine-streams/-/combine-streams-1.0.0.tgz",
+      "integrity": "sha1-U2W6BKdmGM8zshPDFtM+XBs8RgQ="
+    },
     "magic-string": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.21.3.tgz",
@@ -12,9 +17,9 @@
       "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA="
     },
     "vlq": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
-      "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
     }
   }
 }

--- a/packages/server-render/.npm/package/npm-shrinkwrap.json
+++ b/packages/server-render/.npm/package/npm-shrinkwrap.json
@@ -1,20 +1,50 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "combine-streams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/combine-streams/-/combine-streams-1.0.0.tgz",
-      "integrity": "sha1-U2W6BKdmGM8zshPDFtM+XBs8RgQ="
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "combined-stream2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/combined-stream2/-/combined-stream2-1.1.2.tgz",
+      "integrity": "sha1-9uFLegFWZvjHsKH6xQYkAWSsNXA="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
     },
     "magic-string": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.21.3.tgz",
       "integrity": "sha1-h+IBAJ6/3m9G3FdXMFpwr3HjFiQ="
     },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "parse5": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
       "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA="
+    },
+    "promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+    },
+    "stream-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
+      "integrity": "sha1-gnfzy+5JpNqrz9tOL0qbXp8snwA="
+    },
+    "stream-to-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+      "integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA="
     },
     "vlq": {
       "version": "0.2.3",

--- a/packages/server-render/README.md
+++ b/packages/server-render/README.md
@@ -127,39 +127,7 @@ Although these examples have all involved React, the `onPageLoad` API is
 designed to be generically useful for any kind of server-side rendering.
 
 
-#### Meteor Accounts
-Meteor's authentication system uses cookies to store the login token for
-an authenticated user. To get access to this, you can use the `getCookies` method
-on the server sink and access the login token like so:
-
-```js
-import React from "react";
-import { Meteor } from "meteor/meteor";
-import { Accounts } from "meteor/accounts-server";
-import { renderToNodeStream } from "react-dom/server";
-import { onPageLoad } from "meteor/server-render";
-import App from "/imports/Server.js";
-
-onPageLoad(sink => {
-  const { meteor_login_token } = sink.getCookies();
-
-  let user;
-  if (meteor_login_token) {
-    const hashedToken = Accounts._hashLoginToken(meteor_login_token);
-    const query = {'services.resume.loginTokens.hashedToken': hashedToken };
-    const options = { fields: { _id: 1 } };
-    user = Meteor.users.findOne(query, options);
-  }
-                    
-  sink.renderIntoElementById("app", renderToNodeStream(
-    <App location={sink.request.url} user={user} />
-  ));
-});
-```
-
-
-
-#### React 16 renderToNodeStream
+#### React 16 `renderToNodeStream`
 Since React 16, it is possible to render a React app to a node stream which
 can be piped to the response. This can decrease time to first byte, and improve
 performance of server rendered apps.

--- a/packages/server-render/client-sink.js
+++ b/packages/server-render/client-sink.js
@@ -2,6 +2,10 @@ const doc = document;
 const head = doc.getElementsByTagName("head")[0];
 const body = doc.body;
 
+const isoError = (method) => {
+  return `sink.${method} was called on the client when
+    it should only be called on the server.`;
+}
 export class ClientSink {
   appendToHead(nodeOrHtml) {
     appendContent(head, nodeOrHtml);
@@ -22,7 +26,30 @@ export class ClientSink {
     }
     appendContent(element, nodeOrHtml);
   }
+
+  redirect(location) {
+    // code can't be set on the client
+    window.location = location;
+  }
+
+  // server only methods
+  setStatusCode() {
+    console.error(isoError("setStatusCode"));
+  }
+
+  setHeader() {
+    console.error(isoError("setHeader"));
+  }
+
+  getHeaders() {
+    console.error(isoError("getHeaders"));
+  }
+
+  getCookies() {
+    console.error(isoError("getCookies"));
+  }
 }
+
 
 function appendContent(destination, nodeOrHtml) {
   if (typeof nodeOrHtml === "string") {

--- a/packages/server-render/client-sink.js
+++ b/packages/server-render/client-sink.js
@@ -3,8 +3,8 @@ const head = doc.getElementsByTagName("head")[0];
 const body = doc.body;
 
 const isoError = (method) => {
-  return `sink.${method} was called on the client when
-    it should only be called on the server.`;
+  console.error(`sink.${method} was called on the client when
+    it should only be called on the server.`);
 }
 export class ClientSink {
   appendToHead(nodeOrHtml) {
@@ -34,19 +34,19 @@ export class ClientSink {
 
   // server only methods
   setStatusCode() {
-    console.error(isoError("setStatusCode"));
+    isoError("setStatusCode");
   }
 
   setHeader() {
-    console.error(isoError("setHeader"));
+    isoError("setHeader");
   }
 
   getHeaders() {
-    console.error(isoError("getHeaders"));
+    isoError("getHeaders");
   }
 
   getCookies() {
-    console.error(isoError("getCookies"));
+    isoError("getCookies");
   }
 }
 

--- a/packages/server-render/package.js
+++ b/packages/server-render/package.js
@@ -6,8 +6,9 @@ Package.describe({
 });
 
 Npm.depends({
-  "combine-streams": "1.0.0",
+  "combined-stream2": "1.1.2",
   "magic-string": "0.21.3",
+  "stream-to-string": "1.1.0",
   "parse5": "3.0.2"
 });
 

--- a/packages/server-render/package.js
+++ b/packages/server-render/package.js
@@ -6,6 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
+  "combine-streams": "1.0.0",
   "magic-string": "0.21.3",
   "parse5": "3.0.2"
 });

--- a/packages/server-render/server-register.js
+++ b/packages/server-render/server-register.js
@@ -45,18 +45,22 @@ WebAppInternals.registerBoilerplateDataCallback(
                 if (html) {
                   reallyMadeChanges = true;
                   const start = magic.slice(lastStart, loc.endOffset);
-                  const end = magic.slice(loc.endOffset);
                   stream
                     .append(start)
                     .append(html)
-                    .append(end)
-                    .append(null);
                   lastStart = loc.endOffset;
                 }
                 return true;
               }
             });
           });
+          parser.on("endTag", (name, location) => {
+            if (location.endOffset === html.length) {
+              // reached the end of the template
+              const end = magic.slice(lastStart);
+              stream.append(end).append(null);
+            }
+          })
 
           data[property] = stream;
         }

--- a/packages/server-render/server-register.js
+++ b/packages/server-render/server-register.js
@@ -81,6 +81,16 @@ WebAppInternals.registerBoilerplateDataCallback(
         reallyMadeChanges = true;
       }
 
+      if (sink.statusCode) {
+        data.statusCode = sink.statusCode;
+        reallyMadeChanges = true;
+      }
+
+      if (Object.keys(sink.responseHeaders)){
+        data.headers = sink.responseHeaders;
+        reallyMadeChanges = true;
+      }
+
       return reallyMadeChanges;
     });
   }

--- a/packages/server-render/server-register.js
+++ b/packages/server-render/server-register.js
@@ -1,18 +1,10 @@
 import { WebAppInternals } from "meteor/webapp";
-import { Readable } from "stream";
 import MagicString from "magic-string";
 import { SAXParser } from "parse5";
 import combine from "combine-streams";
 import { ServerSink, isReadable } from "./server-sink.js";
 import { onPageLoad } from "./server.js";
 
-function stringToStream(str) {
-  const stream = new Readable();
-  stream._read = function() {};
-  stream.push(str);
-  stream.push(null);;
-  return stream;
-}
 
 WebAppInternals.registerBoilerplateDataCallback(
   "meteor/server-render",
@@ -50,10 +42,7 @@ WebAppInternals.registerBoilerplateDataCallback(
             attrs.some(attr => {
               if (attr.name === "id") {
                 let html = sink.htmlById[attr.value];
-                if (typeof html === "string") {
-                  html = stringToStream(html);
-                }
-                if (html && isReadable(html)) {
+                if (html) {
                   reallyMadeChanges = true;
                   const start = magic.slice(lastStart, loc.endOffset);
                   const end = magic.slice(loc.endOffset);

--- a/packages/server-render/server-render-tests.js
+++ b/packages/server-render/server-render-tests.js
@@ -2,7 +2,7 @@ import { Tinytest } from "meteor/tinytest";
 import { WebAppInternals } from "meteor/webapp";
 import { onPageLoad } from "meteor/server-render";
 import { parse } from "parse5";
-import toString from "stream-to-string";
+import streamToString from "stream-to-string";
 
 const skeleton = `
   <h1>Look, Ma... static HTML!</h1>
@@ -12,8 +12,9 @@ const skeleton = `
     </div>
   </p>`;
 
-Tinytest.addAsync('server-render - boilerplate', function (test, onComplete) {
-  const run = async () => {
+Tinytest.addAsync(
+  'server-render - boilerplate',
+  async function (test) {
     // This test is not a very good demonstration of the server-render
     // abstraction. In normal usage, you would call renderIntoElementById
     // and not think about the rest of this stuff. The extra complexity owes
@@ -53,10 +54,10 @@ Tinytest.addAsync('server-render - boilerplate', function (test, onComplete) {
       const { stream } = WebAppInternals.getBoilerplate({
         isServerRenderTest: true,
         browser: { name: "fake" },
-        url: "/server-render/test"
+        url: "/server-render/test",
       }, "web.browser");
 
-      const boilerplate = await toString(stream);
+      const boilerplate = await streamToString(stream);
 
       const ids = [];
       const seen = new Set;
@@ -106,6 +107,4 @@ Tinytest.addAsync('server-render - boilerplate', function (test, onComplete) {
       onPageLoad.remove(callback2);
     }
   }
-
-  run().then(onComplete).catch(console.error);
-});
+);

--- a/packages/server-render/server-render-tests.js
+++ b/packages/server-render/server-render-tests.js
@@ -3,6 +3,26 @@ import { WebAppInternals } from "meteor/webapp";
 import { onPageLoad } from "meteor/server-render";
 import { parse } from "parse5";
 
+// convert a stream to a string via promise
+function toString(stream) {
+  return new Promise((success, fail) => {
+    var string = ''
+    stream.on('data', function(data) {
+      string += data.toString();
+    });
+
+    stream.on('end', function() {
+      success(string)
+    });
+
+    stream.on('error', function(error) {
+      fail(error);
+    });
+  });
+}
+
+
+
 const skeleton = `
   <h1>Look, Ma... static HTML!</h1>
   <div id="container-2"></div>
@@ -11,94 +31,102 @@ const skeleton = `
     </div>
   </p>`;
 
-Tinytest.add('server-render - boilerplate', function (test) {
-  // This test is not a very good demonstration of the server-render
-  // abstraction. In normal usage, you would call renderIntoElementById
-  // and not think about the rest of this stuff. The extra complexity owes
-  // to the trickiness of testing this package without using a real
-  // browser to parse the resulting HTTP response.
+Tinytest.addAsync('server-render - boilerplate', function (test, onComplete) {
+  const run = async () => {
+    // This test is not a very good demonstration of the server-render
+    // abstraction. In normal usage, you would call renderIntoElementById
+    // and not think about the rest of this stuff. The extra complexity owes
+    // to the trickiness of testing this package without using a real
+    // browser to parse the resulting HTTP response.
 
-  const realCallback =
-    // Use the underlying abstraction to set the static HTML skeleton.
-    WebAppInternals.registerBoilerplateDataCallback(
-      "meteor/server-render",
-      (request, data, arch) => {
-        if (request.isServerRenderTest) {
-          test.equal(arch, "web.browser");
-          test.equal(request.url, "/server-render/test");
-          data.body = skeleton;
+    const realCallback =
+      // Use the underlying abstraction to set the static HTML skeleton.
+      WebAppInternals.registerBoilerplateDataCallback(
+        "meteor/server-render",
+        (request, data, arch) => {
+          if (request.isServerRenderTest) {
+            test.equal(arch, "web.browser");
+            test.equal(request.url, "/server-render/test");
+            data.body = skeleton;
+          }
+          return realCallback.call(this, request, data, arch);
         }
-        return realCallback.call(this, request, data, arch);
-      }
-    );
+      );
 
-  const callback1 = onPageLoad(sink => {
-    sink.renderIntoElementById("container-1", "<oyez/>");
-  });
+    const callback1 = onPageLoad(sink => {
+      sink.renderIntoElementById("container-1", "<oyez/>");
+    });
 
-  // This callback is async, and that's fine because
-  // WebAppInternals.getBoilerplate is able to yield. Internally the
-  // webapp package uses a function called getBoilerplateAsync, so the
-  // Fiber power-tools need not be involved in typical requests.
-  const callback2 = onPageLoad(async sink => {
-    sink.renderIntoElementById(
-      "container-2",
-      (await "oy") + (await "ez")
-    );
-  });
+    // This callback is async, and that's fine because
+    // WebAppInternals.getBoilerplate is able to yield. Internally the
+    // webapp package uses a function called getBoilerplateAsync, so the
+    // Fiber power-tools need not be involved in typical requests.
+    const callback2 = onPageLoad(async sink => {
+      sink.renderIntoElementById(
+        "container-2",
+        (await "oy") + (await "ez")
+      );
+    });
 
-  try {
-    const boilerplate = WebAppInternals.getBoilerplate({
-      isServerRenderTest: true,
-      browser: { name: "fake" },
-      url: "/server-render/test"
-    }, "web.browser");
+    try {
+      const { start, stream, end } = WebAppInternals.getBoilerplate({
+        isServerRenderTest: true,
+        browser: { name: "fake" },
+        url: "/server-render/test"
+      }, "web.browser");
 
-    const ids = [];
-    const seen = new Set;
 
-    function walk(node) {
-      if (node && ! seen.has(node)) {
-        seen.add(node);
+      const body = await toString(stream);
+      const boilerplate = start + "\n" + body + "\n" + end;
 
-        if (node.nodeName === "div" && node.attrs) {
-          node.attrs.some(attr => {
-            if (attr.name === "id") {
-              const id = attr.value;
+      const ids = [];
+      const seen = new Set;
 
-              if (id === "container-1") {
-                test.equal(node.childNodes[0].nodeName, "oyez");
-                ids.push(id);
-              } else if (id === "container-2") {
-                const child = node.childNodes[0];
-                test.equal(child.nodeName, "#text");
-                test.equal(child.value.trim(), "oyez");
-                ids.push(id);
+      function walk(node) {
+        if (node && ! seen.has(node)) {
+          seen.add(node);
+
+          if (node.nodeName === "div" && node.attrs) {
+            node.attrs.some(attr => {
+              if (attr.name === "id") {
+                const id = attr.value;
+
+                if (id === "container-1") {
+                  test.equal(node.childNodes[0].nodeName, "oyez");
+                  ids.push(id);
+                } else if (id === "container-2") {
+                  const child = node.childNodes[0];
+                  test.equal(child.nodeName, "#text");
+                  test.equal(child.value.trim(), "oyez");
+                  ids.push(id);
+                }
+
+                return true;
               }
+            });
+          }
 
-              return true;
-            }
-          });
-        }
-
-        if (node.childNodes) {
-          node.childNodes.forEach(walk)
+          if (node.childNodes) {
+            node.childNodes.forEach(walk)
+          }
         }
       }
+
+      walk(parse(boilerplate));
+
+      test.equal(ids, ["container-2", "container-1"]);
+
+    } finally {
+      // Cleanup to minimize interference with other tests:
+      WebAppInternals.registerBoilerplateDataCallback(
+        "meteor/server-render",
+        realCallback
+      );
+
+      onPageLoad.remove(callback1);
+      onPageLoad.remove(callback2);
     }
-
-    walk(parse(boilerplate));
-
-    test.equal(ids, ["container-2", "container-1"]);
-
-  } finally {
-    // Cleanup to minimize interference with other tests:
-    WebAppInternals.registerBoilerplateDataCallback(
-      "meteor/server-render",
-      realCallback
-    );
-
-    onPageLoad.remove(callback1);
-    onPageLoad.remove(callback2);
   }
+
+  run().then(onComplete).catch(console.error);
 });

--- a/packages/server-render/server-render-tests.js
+++ b/packages/server-render/server-render-tests.js
@@ -2,26 +2,7 @@ import { Tinytest } from "meteor/tinytest";
 import { WebAppInternals } from "meteor/webapp";
 import { onPageLoad } from "meteor/server-render";
 import { parse } from "parse5";
-
-// convert a stream to a string via promise
-function toString(stream) {
-  return new Promise((success, fail) => {
-    var string = ''
-    stream.on('data', function(data) {
-      string += data.toString();
-    });
-
-    stream.on('end', function() {
-      success(string)
-    });
-
-    stream.on('error', function(error) {
-      fail(error);
-    });
-  });
-}
-
-
+import toString from "stream-to-string";
 
 const skeleton = `
   <h1>Look, Ma... static HTML!</h1>
@@ -69,15 +50,13 @@ Tinytest.addAsync('server-render - boilerplate', function (test, onComplete) {
     });
 
     try {
-      const { start, stream, end } = WebAppInternals.getBoilerplate({
+      const { stream } = WebAppInternals.getBoilerplate({
         isServerRenderTest: true,
         browser: { name: "fake" },
         url: "/server-render/test"
       }, "web.browser");
 
-
-      const body = await toString(stream);
-      const boilerplate = start + "\n" + body + "\n" + end;
+      const boilerplate = await toString(stream);
 
       const ids = [];
       const seen = new Set;

--- a/packages/server-render/server-sink.js
+++ b/packages/server-render/server-sink.js
@@ -85,7 +85,6 @@ function appendContent(object, property, content) {
   } else if ((content = content && content.toString("utf8"))) {
     object[property] = (object[property] || "") + content;
     madeChanges = true;
-    // should we join streams here?
   } 
   return madeChanges;
 }

--- a/packages/server-render/server-sink.js
+++ b/packages/server-render/server-sink.js
@@ -6,6 +6,8 @@ export class ServerSink {
     this.body = "";
     this.htmlById = Object.create(null);
     this.maybeMadeChanges = false;
+    this.statusCode = null;
+    this.responseHeaders = {};
   }
 
   appendToHead(html) {
@@ -31,17 +33,29 @@ export class ServerSink {
     this.appendToElementById(id, html);
   }
 
-  redirect(code, location) {
-    
+  redirect(location, code) {
+    this.maybeMadeChanges = true;
+    this.statusCode = code;
+    this.responseHeaders.Location = location;
   }
 
   // server only methods
   setStatusCode(code) {
-    
+    this.maybeMadeChanges = true;
+    this.statusCode = code;
+  }
+
+  setHeader(key, value) {
+    this.maybeMadeChanges = true;
+    this.responseHeaders[key] = value;
   }
 
   getHeaders() {
-    
+    return this.request.headers;
+  }
+
+  getCookies() {
+    return this.request.cookies;
   }
 }
 

--- a/packages/server-render/server-sink.js
+++ b/packages/server-render/server-sink.js
@@ -33,7 +33,7 @@ export class ServerSink {
     this.appendToElementById(id, html);
   }
 
-  redirect(location, code) {
+  redirect(location, code = 301) {
     this.maybeMadeChanges = true;
     this.statusCode = code;
     this.responseHeaders.Location = location;

--- a/packages/server-render/server-sink.js
+++ b/packages/server-render/server-sink.js
@@ -30,6 +30,30 @@ export class ServerSink {
     this.htmlById[id] = "";
     this.appendToElementById(id, html);
   }
+
+  redirect(code, location) {
+    
+  }
+
+  // server only methods
+  setStatusCode(code) {
+    
+  }
+
+  getHeaders() {
+    
+  }
+}
+
+export function isReadable(stream) {
+  return (
+    stream !== null &&
+    typeof stream === 'object' &&
+    typeof stream.pipe === 'function' &&
+    stream.readable !== false &&
+    typeof stream._read === 'function' &&
+    typeof stream._readableState === 'object'
+  );
 }
 
 function appendContent(object, property, content) {
@@ -41,10 +65,13 @@ function appendContent(object, property, content) {
         madeChanges = true;
       }
     });
+  } else if (isReadable(content)) {
+    object[property] = content;
+    madeChanges = true;
   } else if ((content = content && content.toString("utf8"))) {
     object[property] = (object[property] || "") + content;
     madeChanges = true;
-  }
-
+    // should we join streams here?
+  } 
   return madeChanges;
 }

--- a/packages/webapp/.npm/package/npm-shrinkwrap.json
+++ b/packages/webapp/.npm/package/npm-shrinkwrap.json
@@ -170,6 +170,11 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+    },
     "qs": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
@@ -204,6 +209,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "stream-to-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+      "integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA="
     },
     "tmp": {
       "version": "0.0.33",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -10,6 +10,7 @@ Npm.depends({"basic-auth-connect": "1.0.0",
              errorhandler: "1.5.0",
              parseurl: "1.3.2",
              send: "0.16.1",
+             "stream-to-string": "1.1.0",
              "qs-middleware": "1.0.3",
              useragent: "2.2.1"});
 

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -314,9 +314,9 @@ function getBoilerplateAsync(request, arch) {
       madeChanges
     );
 
-    if (! useMemoized) {
+    // if (! useMemoized) {
       return boilerplate.toHTML(data);
-    }
+    // }
 
     // The only thing that changes from request to request (unless extra
     // content is added to the head or body, or boilerplateDataCallbacks
@@ -799,12 +799,16 @@ function runWebAppServer() {
       return getBoilerplateAsync(
         request,
         archKey
-      ).then(boilerplate => {
+      ).then(({ start, stream, end }) => {
         var statusCode = res.statusCode ? res.statusCode : 200;
         res.writeHead(statusCode, headers);
-        res.write(boilerplate);
-        res.end();
-      }, error => {
+        res.write(start);
+        stream.pipe(res, { end: false })
+        stream.on("end", () => {
+          res.write(end);
+          res.end();
+        })
+      }).catch(error => {
         Log.error("Error running template: " + error.stack);
         res.writeHead(500, headers);
         res.end();

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -280,8 +280,6 @@ WebAppInternals.registerBoilerplateDataCallback = function (key, callback) {
 // memoizes on HTML attributes (used by, eg, appcache) and whether inline
 // scripts are currently allowed.
 // XXX so far this function is always called with arch === 'web.browser'
-var memoizedBoilerplate = {};
-
 function getBoilerplate(request, arch) {
   return getBoilerplateAsync(request, arch).await();
 }
@@ -307,38 +305,11 @@ function getBoilerplateAsync(request, arch) {
     });
   });
 
-  return promise.then(() => {
-    const useMemoized = ! (
-      data.dynamicHead ||
-      data.dynamicBody ||
-      madeChanges
-    );
-
-    // if (! useMemoized) {
-    return {
-      stream: boilerplate.toHTML(data),
-      statusCode: data.statusCode,
-      headers: data.headers,
-    };
-    // }
-
-    // The only thing that changes from request to request (unless extra
-    // content is added to the head or body, or boilerplateDataCallbacks
-    // modified the data) are the HTML attributes (used by, eg, appcache)
-    // and whether inline scripts are allowed, so memoize based on that.
-    var memHash = JSON.stringify({
-      inlineScriptsAllowed,
-      htmlAttributes: data.htmlAttributes,
-      arch,
-    });
-
-    if (! memoizedBoilerplate[memHash]) {
-      memoizedBoilerplate[memHash] =
-        boilerplateByArch[arch].toHTML(data);
-    }
-
-    return memoizedBoilerplate[memHash];
-  });
+  return promise.then(() => ({
+    stream: boilerplate.toHTML(data),
+    statusCode: data.statusCode,
+    headers: data.headers,
+  }));
 }
 
 WebAppInternals.generateBoilerplateInstance = function (arch,

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -778,12 +778,18 @@ function runWebAppServer() {
         if (!statusCode) {
           statusCode = res.statusCode ? res.statusCode : 200;
         }
+
         if (newHeaders) {
-          headers = {...headers, ...newHeaders };
+          Object.assign(headers, newHeaders);
         }
 
         res.writeHead(statusCode, headers);
-        stream.pipe(res)
+
+        stream.pipe(res, {
+          // End the response when the stream ends.
+          end: true,
+        });
+
       }).catch(error => {
         Log.error("Error running template: " + error.stack);
         res.writeHead(500, headers);

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -316,7 +316,7 @@ function getBoilerplateAsync(request, arch) {
 
     // if (! useMemoized) {
     return {
-      ...boilerplate.toHTML(data),
+      stream: boilerplate.toHTML(data),
       statusCode: data.statusCode,
       headers: data.headers,
     };
@@ -803,7 +803,7 @@ function runWebAppServer() {
       return getBoilerplateAsync(
         request,
         archKey
-      ).then(({ start, stream, end, statusCode, headers: newHeaders }) => {
+      ).then(({ stream,  statusCode, headers: newHeaders }) => {
         if (!statusCode) {
           statusCode = res.statusCode ? res.statusCode : 200;
         }
@@ -812,12 +812,7 @@ function runWebAppServer() {
         }
 
         res.writeHead(statusCode, headers);
-        res.write(start);
-        stream.pipe(res, { end: false })
-        stream.on("end", () => {
-          res.write(end);
-          res.end();
-        })
+        stream.pipe(res)
       }).catch(error => {
         Log.error("Error running template: " + error.stack);
         res.writeHead(500, headers);

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -811,7 +811,6 @@ function runWebAppServer() {
           headers = {...headers, ...newHeaders };
         }
 
-        console.log("setting status code")
         res.writeHead(statusCode, headers);
         res.write(start);
         stream.pipe(res, { end: false })


### PR DESCRIPTION
👋 With the release of React 16, a new way to render on the server is [streaming](https://hackernoon.com/whats-new-with-server-side-rendering-in-react-16-9b0d78585d67) the rendering of the react portion of your app to the client. This PR adjusts Meteor's internal markup generation for the server to move to a stream first API. With this change, you can use a string (renderToString) or a stream (renderToNodeStream) when adding content into an id.

In initial testing, it results in a 40% reduction of TTFB 🌮 (Time To First Byte [of taco]).

**Todo**
- [x] ensure support for multiple id based additions of streams of strings
- [x] update tests
- [x] add support for redirects
- [x] add support for changing status code
- [x] provide access to headers
- [ ] write tests for new features

Wanted to get this up early enough for review though!

This PR address [setting status codes](https://github.com/meteor/meteor-feature-requests/issues/210) including for [SEO](https://github.com/meteor/meteor-feature-requests/issues/198), improved [alignment with react features](https://github.com/meteor/meteor-feature-requests/issues/182), setting headers [like eTag](https://github.com/meteor/meteor-feature-requests/issues/176), and accessing [headers and cookies](https://github.com/meteor/meteor-feature-requests/issues/174)