### PR TITLE
Fixes should only contain one entry error

### DIFF
--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -723,6 +723,14 @@ files.extractTarGz = function (buffer, destPath, options) {
     // PaxHeader directory.
     .filter(file => ! file.startsWith("PaxHeader"));
 
+  // Sometimes windows fs does not catch up in time which makes readdir
+  // to return a wrong list of folders / files so we wait until
+  // the file system is in sync
+  if (topLevelOfArchive.length > 1 && process.platform === "win32") {
+	  waitFSToSync(tempDir);
+	  topLevelOfArchive = files.readdir(tempDir);
+  }
+
   if (topLevelOfArchive.length !== 1) {
     throw new Error(
       "Extracted archive '" + tempDir + "' should only contain one entry");
@@ -736,6 +744,32 @@ files.extractTarGz = function (buffer, destPath, options) {
     console.log("Finished extracting in", new Date - startTime, "ms");
   }
 };
+
+function waitFSToSync(dir) {
+	let waitToSync = true;
+
+	while (waitToSync) {
+		try {
+			// After a successful unlink operation, sometimes windows fs takes longer than expected to sync
+			// so readdir would still return already deleted files
+			const filesInTempDirArray = files.readdir(dir);
+
+			// If stat doesn't throw a known error, it means that any queued operations have already been performed
+			// and committed, so the list returned by readdir is the actual file list of the directory
+			filesInTempDirArray.forEach(file => files.stat(files.pathJoin(dir, file)));
+
+			waitToSync = false;
+		} catch (e) {
+			// EPERM is thrown eg after a successful unlink operation and readdir still returns it
+			// ENOENT is thrown if the file deletion is commited by fs between readdir and stat
+			if (e.code === 'EPERM' || e.code === 'ENOENT') {
+				waitToSync = true;
+			} else {
+				throw e;
+			}
+		}
+	}
+}
 
 function ensureDirectoryEmpty(dir) {
   files.readdir(dir).forEach(file => {


### PR DESCRIPTION
Fixes https://github.com/meteor/meteor/issues/9146

After investigating the problem, the problem observed is as follows (Only windows):

- Files created in the 7z.exe extraction process of a package, `out.tar.gz` and `out.tar` are removed here https://github.com/meteor/meteor/blob/devel/tools/fs/files.js#L812
- Then sometimes, windows fs doesn't catch up in time, and when `readdir` is called here https://github.com/meteor/meteor/blob/devel/tools/fs/files.js#L721, it returns the wrong file list, which includes the two that were deleted successfully earlier, which causes the exception to be throw here https://github.com/meteor/meteor/blob/devel/tools/fs/files.js#L728 

What we are observing is explained here https://github.com/nodejs/node/issues/4760#issuecomment-173174694 and also referenced here https://github.com/nodejs/node-v0.x-archive/issues/7176 so this pr aims to mitigate it

Note that the fix only works in meteor 1.6 and the nodejs version that comes with it