### PR TITLE
Print nicer error message for missing Meteor package

### DIFF
--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -285,7 +285,19 @@ var loadServerBundles = Profile("Load server bundles", function () {
           }
         }
 
-        var resolved = require.resolve(name);
+        try {
+          var resolved = require.resolve(name);
+        } catch (err) {
+          const nameParts = name.split("/");
+          // If it looks like `meteor/xxx`, the user may forgot to add the
+          // package before importing it.
+          if (nameParts.length === 2 && nameParts[0] === "meteor") {
+            const meteorAddTip = ". Try `meteor add " + nameParts[1] + "` " +
+              "as it looks like you tried to import it without adding " +
+              "to the project.";
+            throw new Error("Cannot find module " + JSON.stringify(name) + meteorAddTip);
+          }
+        }
         if (resolved === name && ! path.isAbsolute(resolved)) {
           // If require.resolve(id) === id and id is not an absolute
           // identifier, it must be a built-in module like fs or http.


### PR DESCRIPTION
Fixes #8313 (see feature request [here](https://github.com/meteor/meteor-feature-requests/issues/46)).

Example error message:

```
Error: Cannot find module "meteor/xolvio:cleaner". Try `meteor add xolvio:cleaner` as it looks like you tried to import it without adding to the project.
```

It's the same message as defined [here](https://github.com/meteor/meteor/blob/devel/tools/static-assets/server/npm-require.js#L152) though maybe it should be changed to something else.