### PR TITLE
Stop pre-installing phantomjs-prebuilt and browserstack-webdriver.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,11 +126,6 @@ jobs:
       - run:
           name: Clear npm cache
           command: ./meteor npm cache clear --force
-      # Since PhantomJS has been removed from dev_bundle/lib/node_modules
-      # (#6905), but self-test still needs it, install it now.
-      - run:
-          name: Test Prereqs
-          command: ./meteor npm install -g phantomjs-prebuilt browserstack-webdriver
       - run:
           <<: *run_save_node_bin
       - persist_to_workspace:

--- a/scripts/windows/appveyor/install.ps1
+++ b/scripts/windows/appveyor/install.ps1
@@ -24,17 +24,3 @@ Write-Host "Running 'meteor --get-ready'..." -ForegroundColor Magenta
 If ($LASTEXITCODE -ne 0) {
   throw "Running .\meteor --get-ready failed."
 }
-
-# This should no longer be necessary with Meteor 1.6, which will
-# automatically install these dependencies when they're not found in the
-# dev bundle, but for good measure, we'll install them ahead of time,
-# and to also cover Meteor 1.5.
-Write-Host "Installing test npm dependencies..." `
-  -ForegroundColor Magenta
-& "$meteorBat" npm install --prefix "${dirCheckout}\dev_bundle\lib" `
-  phantomjs-prebuilt `
-  browserstack-webdriver
-
-If ($LASTEXITCODE -ne 0) {
-  throw "Installing npm dependencies required for testing has failed."
-}


### PR DESCRIPTION
While this was necessary in previous versions of Meteor, as of 1.6 the
`self-test` tooling will automatically install the dependencies it needs
at runtime. (Thanks to https://github.com/meteor/meteor/pull/8981)

Not only does this allow the installation to be avoided when tests using
those facilities aren't invoked, it also allows us to reliably install
the same version of these npms, rather than falling back to the
`latest` npm tag on each CI run.

Note that this doesn't change the behavior of the [`test-packages` `run.sh`](https://github.com/meteor/meteor/blob/abernix/stop-installing-self-test-npms/packages/test-in-console/run.sh#L8)
script (used by Travis) which still installs the `latest` version of these npms.
