### PR TITLE
Update minifier-js uglify-es dependency to latest version

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 ## v.NEXT
 
+* The `minifier-js` package has been updated to use `uglify-es` 3.1.9.
+
 * [`cordova-lib`](https://github.com/apache/cordova-cli) has been updated to
   version 7.1.0, [`cordova-android`](https://github.com/apache/cordova-android/)
   has been updated to version 6.3.0, and [`cordova-ios`](https://github.com/apache/cordova-ios/)

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -7,14 +7,14 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "uglify-es": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.0.28.tgz",
-      "integrity": "sha512-xw1hJsSp361OO0Sq0XvNyTI2wfQ4eKNljfSYyeYX/dz9lKEDj+DK+A8CzB0NmoCwWX1MnEx9f16HlkKXyG65CQ=="
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.9.tgz",
+      "integrity": "sha512-wVSiJKHDgDDFmxTVVvnbAH6IpamAFHYDI+5JvwPdaqIMnk8kRTX2JKwq1Fx7gb2+Jj5Dus8kzvIpKkWOMNU51w=="
     }
   }
 }

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "2.2.1"
+  version: "2.2.2"
 });
 
 Npm.depends({
-  "uglify-es": "3.0.28"
+  "uglify-es": "3.1.9"
 });
 
 Package.onUse(function (api) {

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '2.2.1',
+  version: '2.2.2',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md',
 });


### PR DESCRIPTION
There have been quite a few `uglify-es` bug fixes made since 3.0.28, some of which fix outstanding Meteor issues. This PR updates `minifier-js` to use the latest version (3.1.9). Unfortunately `uglify-es` doesn't maintain a changelog so it's a bit difficult to run through all of the changes, but I've stepped through the commit history and haven't found anything that jumps out as being problematic. I've also minified a few apps using 3.1.9, and everything looks good.

Fixes https://github.com/meteor/meteor/issues/9138 (and likely others).