### PR TITLE
Adjust observeChanges skip/limit ordered observe error message

### DIFF
--- a/packages/minimongo/cursor.js
+++ b/packages/minimongo/cursor.js
@@ -231,8 +231,8 @@ export default class Cursor {
     // XXX allow skip/limit with unordered observe
     if (!options._allow_unordered && !ordered && (this.skip || this.limit)) {
       throw new Error(
-        'must use ordered observe (ie, \'addedBefore\' instead of \'added\') ' +
-        'with skip or limit'
+        "Must use an ordered observe with skip or limit (i.e. 'addedBefore' " +
+        "for observeChanges or 'addedAt' for observe, instead of 'added')."
       );
     }
 

--- a/packages/minimongo/package.js
+++ b/packages/minimongo/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's client-side datastore: a port of MongoDB to Javascript",
-  version: '1.4.1'
+  version: '1.4.2'
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
The `Cursor.observeChanges` function throws an error when there is an attempt to use an unordered observe with skip/limit. This error can also be thrown when attempting the same thing with `Cursor.observe`. This is because `Cursor.observe` ends up calling back to `Cursor.observeChanges`. When using `Cursor.observe` however, the shared error message is a bit misleading, as `addedAt` should be used instead of `addedBefore`. This commit adjusts the shared error message to cover both `observeChanges` and `observe` scenarios.

Fixes #4996.