### PR TITLE
Support fetching dynamic modules via HTTP POST requests.

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,17 @@
 
 * The `minifier-js` package has been updated to use `uglify-es` 3.1.9.
 
+* The `request` npm package used by the `http` package has been upgraded
+  to version 2.83.0.
+
+* The deprecated `Meteor.http` object has been removed. If your
+  application is still using `Meteor.http`, you should now use `HTTP`
+  instead:
+  ```js
+  import { HTTP } from "meteor/http";
+  HTTP.call("GET", url, ...);
+  ```
+
 * [`cordova-lib`](https://github.com/apache/cordova-cli) has been updated to
   version 7.1.0, [`cordova-android`](https://github.com/apache/cordova-android/)
   has been updated to version 6.3.0, and [`cordova-ios`](https://github.com/apache/cordova-ios/)

--- a/History.md
+++ b/History.md
@@ -1,5 +1,26 @@
 ## v.NEXT
 
+* Dynamically `import()`ed modules will now be fetched from the
+  application server using an HTTP POST request, rather than a WebSocket
+  message. This strategy has all the benefits of the previous strategy,
+  except that it does not require establishing a WebSocket connection
+  before fetching dynamic modules, in exchange for slightly higher latency
+  per request. [PR #9384](https://github.com/meteor/meteor/pull/9384)
+
+* To reduce the total number of HTTP requests for dynamic modules, rapid
+  sequences of `import()` calls within the same tick of the event loop
+  will now be automatically batched into a single HTTP request. In other
+  words, the following code will result in only one HTTP request:
+  ```js
+  const [
+    React,
+    ReactDOM
+  ] = await Promise.all([
+    import("react"),
+    import("react-dom")
+  ]);
+  ```
+
 * The `minifier-js` package has been updated to use `uglify-es` 3.1.9.
 
 * The `request` npm package used by the `http` package has been upgraded

--- a/packages/dynamic-import/client.js
+++ b/packages/dynamic-import/client.js
@@ -1,5 +1,7 @@
 var Module = module.constructor;
 var cache = require("./cache.js");
+var HTTP = require("meteor/http").HTTP;
+var meteorInstall = require("meteor/modules").meteorInstall;
 
 // Call module.dynamicImport(id) to fetch a module and any/all of its
 // dependencies that have not already been fetched, and evaluate them as
@@ -111,16 +113,12 @@ function makeModuleFunction(id, source, options) {
 }
 
 function fetchMissing(missingTree) {
-  // Update lastFetchMissingPromise immediately, without waiting for
-  // the results to be delivered.
   return new Promise(function (resolve, reject) {
-    Meteor.call(
-      "__dynamicImport",
-      missingTree,
-      function (error, resultsTree) {
-        error ? reject(error) : resolve(resultsTree);
-      }
-    );
+    HTTP.call("POST", Meteor.absoluteUrl("__dynamicImport"), {
+      data: missingTree
+    }, function (error, result) {
+      error ? reject(error) : resolve(result.data);
+    });
   });
 }
 

--- a/packages/dynamic-import/client.js
+++ b/packages/dynamic-import/client.js
@@ -112,9 +112,15 @@ function makeModuleFunction(id, source, options) {
   };
 }
 
+var secretKey = null;
+exports.setSecretKey = function (key) {
+  secretKey = key;
+};
+
 function fetchMissing(missingTree) {
   return new Promise(function (resolve, reject) {
     HTTP.call("POST", Meteor.absoluteUrl("__dynamicImport"), {
+      query: secretKey ? "key=" + secretKey : void 0,
       data: missingTree
     }, function (error, result) {
       error ? reject(error) : resolve(result.data);

--- a/packages/dynamic-import/package.js
+++ b/packages/dynamic-import/package.js
@@ -14,9 +14,8 @@ Package.onUse(function (api) {
 
   api.use("modules");
   api.use("promise");
-  api.use("ddp");
-  api.use("check", "server");
-  api.use("ecmascript", "server");
+  api.use("webapp", "server");
+  api.use("http");
 
   api.mainModule("client.js", "client");
   api.mainModule("server.js", "server");

--- a/packages/dynamic-import/package.js
+++ b/packages/dynamic-import/package.js
@@ -9,9 +9,6 @@ Package.onUse(function (api) {
   // Do not allow this package to be used in pre-Meteor 1.5 apps.
   api.use("isobuild:dynamic-import@1.5.0");
 
-  // Modify browser policy only if browser-policy packages are used.
-  api.use("browser-policy-content", { weak: true });
-
   api.use("modules");
   api.use("promise");
   api.use("http");

--- a/packages/dynamic-import/package.js
+++ b/packages/dynamic-import/package.js
@@ -16,9 +16,6 @@ Package.onUse(function (api) {
   api.use("promise");
   api.use("http");
 
-  api.use("webapp", "server");
-  api.use("random", "server");
-
   api.mainModule("client.js", "client");
   api.mainModule("server.js", "server");
 });

--- a/packages/dynamic-import/package.js
+++ b/packages/dynamic-import/package.js
@@ -14,8 +14,10 @@ Package.onUse(function (api) {
 
   api.use("modules");
   api.use("promise");
-  api.use("webapp", "server");
   api.use("http");
+
+  api.use("webapp", "server");
+  api.use("random", "server");
 
   api.mainModule("client.js", "client");
   api.mainModule("server.js", "server");

--- a/packages/dynamic-import/package.js
+++ b/packages/dynamic-import/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "dynamic-import",
-  version: "0.2.1",
+  version: "0.3.0",
   summary: "Runtime support for Meteor 1.5 dynamic import(...) syntax",
   documentation: "README.md"
 });

--- a/packages/dynamic-import/security.js
+++ b/packages/dynamic-import/security.js
@@ -1,20 +1,22 @@
-const bpc = Package["browser-policy-content"];
-const BP = bpc && bpc.BrowserPolicy;
-const BPc = BP && BP.content;
-if (BPc) {
-  // The ability to evaluate new code is essential for loading dynamic
-  // modules. Without eval, we would be forced to load modules using
-  // <script src=...> tags, and then there would be no way to save those
-  // modules to a local cache (or load them from the cache) without the
-  // unique response caching abilities of service workers, which are not
-  // available in all browsers, and cannot be polyfilled in a way that
-  // satisfies Content Security Policy eval restrictions. Moreover, eval
-  // allows us to evaluate dynamic module code in the original package
-  // scope, which would never be possible using <script> tags. If you're
-  // deploying an app in an environment that demands a Content Security
-  // Policy that forbids eval, your only option is to bundle all dynamic
-  // modules in the initial bundle. Fortunately, that works perfectly
-  // well; you just won't get the performance benefits of dynamic module
-  // fetching.
-  BPc.allowEval();
-}
+Meteor.startup(function () {
+  const bpc = Package["browser-policy-content"];
+  const BP = bpc && bpc.BrowserPolicy;
+  const BPc = BP && BP.content;
+  if (BPc) {
+    // The ability to evaluate new code is essential for loading dynamic
+    // modules. Without eval, we would be forced to load modules using
+    // <script src=...> tags, and then there would be no way to save those
+    // modules to a local cache (or load them from the cache) without the
+    // unique response caching abilities of service workers, which are not
+    // available in all browsers, and cannot be polyfilled in a way that
+    // satisfies Content Security Policy eval restrictions. Moreover, eval
+    // allows us to evaluate dynamic module code in the original package
+    // scope, which would never be possible using <script> tags. If you're
+    // deploying an app in an environment that demands a Content Security
+    // Policy that forbids eval, your only option is to bundle all dynamic
+    // modules in the initial bundle. Fortunately, that works perfectly
+    // well; you just won't get the performance benefits of dynamic module
+    // fetching.
+    BPc.allowEval();
+  }
+});

--- a/packages/dynamic-import/server.js
+++ b/packages/dynamic-import/server.js
@@ -96,29 +96,36 @@ function readTree(tree, platform) {
   const pathParts = [];
 
   function walk(node) {
-    if (node && typeof node === "object") {
-      let empty = true;
-      Object.keys(node).forEach(name => {
-        pathParts.push(name);
-        const result = walk(node[name]);
-        if (result === null) {
-          // If the read function returns null, omit this module from the
-          // resulting tree.
-          delete node[name];
-        } else {
-          node[name] = result;
-          empty = false;
-        }
-        assert.strictEqual(pathParts.pop(), name);
-      });
-      if (empty) {
-        // If every recursive call to walk(node[name]) returned null,
-        // remove this node from the resulting tree by returning null.
-        return null;
-      }
-    } else {
+    if (! node) {
+      return null;
+    }
+
+    if (typeof node !== "object") {
       return read(pathParts, platform);
     }
+
+    let empty = true;
+
+    Object.keys(node).forEach(name => {
+      pathParts.push(name);
+      const result = walk(node[name]);
+      if (result === null) {
+        // If the read function returns null, omit this module from the
+        // resulting tree.
+        delete node[name];
+      } else {
+        node[name] = result;
+        empty = false;
+      }
+      assert.strictEqual(pathParts.pop(), name);
+    });
+
+    if (empty) {
+      // If every recursive call to walk(node[name]) returned null,
+      // remove this node from the resulting tree by returning null.
+      return null;
+    }
+
     return node;
   }
 

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.9.0',
+  version: '0.9.1',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });
@@ -21,6 +21,9 @@ Package.onUse(function (api) {
   api.imply('ecmascript-runtime');
   api.imply('babel-runtime');
   api.imply('promise');
+
+  // Runtime support for Meteor 1.5 dynamic import(...) syntax.
+  api.imply('dynamic-import');
 
   api.addFiles("ecmascript.js", "server");
   api.export("ECMAScript", "server");

--- a/packages/http/.npm/package/npm-shrinkwrap.json
+++ b/packages/http/.npm/package/npm-shrinkwrap.json
@@ -1,15 +1,10 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    "ajv": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto="
     },
     "asn1": {
       "version": "0.2.3",
@@ -17,19 +12,19 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw=="
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.6.0",
@@ -41,35 +36,25 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40="
     },
-    "bl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g="
-    },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE="
     },
     "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
-    },
-    "commander": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
-      "integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -77,21 +62,21 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw=="
+        }
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -103,20 +88,25 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU="
     },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -124,86 +114,44 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w="
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8="
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0="
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ=="
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM="
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE="
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isstream": {
       "version": "0.1.2",
@@ -220,149 +168,100 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-    },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI="
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
     },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.2.tgz",
-      "integrity": "sha1-tZ2JJdDJme9tY6z0rFq7CtqiS1Q="
-    },
-    "readable-stream": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "request": {
-      "version": "2.72.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
-      "integrity": "sha1-DOOheVEmILEEQfFMguIcEsDdtOE="
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw=="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg=="
     },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M="
     },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
     "tough-cookie": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-      "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE="
     },
     "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA="
     }
   }
 }

--- a/packages/http/deprecated.js
+++ b/packages/http/deprecated.js
@@ -1,3 +1,0 @@
-// The HTTP object used to be called Meteor.http.
-// XXX COMPAT WITH 0.6.4
-Meteor.http = HTTP;

--- a/packages/http/httpcall_common.js
+++ b/packages/http/httpcall_common.js
@@ -1,10 +1,11 @@
-const MAX_LENGTH = 500; // if you change this, also change the appropriate test
+var MAX_LENGTH = 500; // if you change this, also change the appropriate test
+var slice = Array.prototype.slice;
 
-makeErrorByStatus = function(statusCode, content) {
-  let message = `failed [${statusCode}]`;
+exports.makeErrorByStatus = function(statusCode, content) {
+  var message = "failed [" + statusCode + "]";
 
   if (content) {
-    const stringContent = typeof content == "string" ?
+    var stringContent = typeof content == "string" ?
       content : content.toString();
 
     message += ' ' + truncate(stringContent.replace(/\n/g, ' '), MAX_LENGTH);
@@ -18,15 +19,18 @@ function truncate(str, length) {
 }
 
 // Fill in `response.data` if the content-type is JSON.
-populateData = function(response) {
+exports.populateData = function(response) {
   // Read Content-Type header, up to a ';' if there is one.
   // A typical header might be "application/json; charset=utf-8"
   // or just "application/json".
   var contentType = (response.headers['content-type'] || ';').split(';')[0];
 
   // Only try to parse data as JSON if server sets correct content type.
-  if (_.include(['application/json', 'text/javascript',
-      'application/javascript', 'application/x-javascript'], contentType)) {
+  if (['application/json',
+       'text/javascript',
+       'application/javascript',
+       'application/x-javascript',
+      ].indexOf(contentType) >= 0) {
     try {
       response.data = JSON.parse(response.content);
     } catch (err) {
@@ -37,7 +41,7 @@ populateData = function(response) {
   }
 };
 
-HTTP = {};
+var HTTP = exports.HTTP = {};
 
 /**
  * @summary Send an HTTP `GET` request. Equivalent to calling [`HTTP.call`](#http_call) with "GET" as the first argument.
@@ -47,7 +51,7 @@ HTTP = {};
  * @locus Anywhere
  */
 HTTP.get = function (/* varargs */) {
-  return HTTP.call.apply(this, ["GET"].concat(_.toArray(arguments)));
+  return HTTP.call.apply(this, ["GET"].concat(slice.call(arguments)));
 };
 
 /**
@@ -58,7 +62,7 @@ HTTP.get = function (/* varargs */) {
  * @locus Anywhere
  */
 HTTP.post = function (/* varargs */) {
-  return HTTP.call.apply(this, ["POST"].concat(_.toArray(arguments)));
+  return HTTP.call.apply(this, ["POST"].concat(slice.call(arguments)));
 };
 
 /**
@@ -69,7 +73,7 @@ HTTP.post = function (/* varargs */) {
  * @locus Anywhere
  */
 HTTP.put = function (/* varargs */) {
-  return HTTP.call.apply(this, ["PUT"].concat(_.toArray(arguments)));
+  return HTTP.call.apply(this, ["PUT"].concat(slice.call(arguments)));
 };
 
 /**
@@ -80,7 +84,7 @@ HTTP.put = function (/* varargs */) {
  * @locus Anywhere
  */
 HTTP.del = function (/* varargs */) {
-  return HTTP.call.apply(this, ["DELETE"].concat(_.toArray(arguments)));
+  return HTTP.call.apply(this, ["DELETE"].concat(slice.call(arguments)));
 };
 
 /**
@@ -91,5 +95,5 @@ HTTP.del = function (/* varargs */) {
  * @locus Anywhere
  */
 HTTP.patch = function (/* varargs */) {
-  return HTTP.call.apply(this, ["PATCH"].concat(_.toArray(arguments)));
+  return HTTP.call.apply(this, ["PATCH"].concat(slice.call(arguments)));
 };

--- a/packages/http/package.js
+++ b/packages/http/package.js
@@ -1,25 +1,26 @@
 Package.describe({
   summary: "Make HTTP calls to remote servers",
-  version: '1.3.0'
+  version: '1.4.0'
 });
 
 Npm.depends({
-  request: "2.72.0"
+  request: "2.83.0"
 });
 
 Package.onUse(function (api) {
   api.use([
-    'underscore',
     'url',
-    'ecmascript'
+    // This package intentionally does not depend on ecmascript, so that
+    // ecmascript and its dependencies can depend on http without creating
+    // package dependency cycles.
+    'modules'
   ]);
+
+  api.mainModule('httpcall_client.js', 'client');
+  api.mainModule('httpcall_server.js', 'server');
 
   api.export('HTTP');
   api.export('HTTPInternals', 'server');
-  api.addFiles('httpcall_common.js', ['client', 'server']);
-  api.addFiles('httpcall_client.js', 'client');
-  api.addFiles('httpcall_server.js', 'server');
-  api.addFiles('deprecated.js', ['client', 'server']);
 });
 
 Package.onTest(function (api) {

--- a/packages/meteor-base/package.js
+++ b/packages/meteor-base/package.js
@@ -25,9 +25,6 @@ Package.onUse(function(api) {
     'ddp',
     'livedata', // XXX COMPAT WITH PACKAGES BUILT FOR 0.9.0.
 
-    // Runtime support for Meteor 1.5 dynamic import(...) syntax.
-    'dynamic-import',
-
     // These packages use the user agent of each incoming HTTP request to
     // decide whether to inject <script> tags into the <head> of the
     // response document to polyfill Web Sockets and/or ES5 support.

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.8.1'
+  version: '1.8.2'
 });
 
 Package.registerBuildPlugin({

--- a/packages/meteor/startup_server.js
+++ b/packages/meteor/startup_server.js
@@ -14,8 +14,10 @@ Meteor.startup = function startup(callback) {
       .replace(/^Error: /, ""); // Not really an Error per se.
   }
 
-  if (__meteor_bootstrap__.startupHooks) {
-    __meteor_bootstrap__.startupHooks.push(callback);
+  var bootstrap = global.__meteor_bootstrap__;
+  if (bootstrap &&
+      bootstrap.startupHooks) {
+    bootstrap.startupHooks.push(callback);
   } else {
     // We already started up. Just call it now.
     callback();

--- a/packages/modules-runtime/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules-runtime/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "install": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.10.1.tgz",
-      "integrity": "sha1-HHtTyN1zNe9TTCZI3ij1md8b3Zc="
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.10.2.tgz",
+      "integrity": "sha512-CcH+s/Z1Eir84zHRe5S2Hw/UWsTrgtQHdootbrjVopShGOcPe+aCfLq9Yyw1sEq8dZbeLWxXAqm2QwDx4hrE0w=="
     }
   }
 }

--- a/packages/modules-runtime/package.js
+++ b/packages/modules-runtime/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: "modules-runtime",
-  version: "0.9.0",
+  version: "0.9.1",
   summary: "CommonJS module system",
   git: "https://github.com/benjamn/install",
   documentation: "README.md"
 });
 
 Npm.depends({
-  install: "0.10.1"
+  install: "0.10.2"
 });
 
 Package.onUse(function(api) {

--- a/packages/non-core/bundle-visualizer/client.js
+++ b/packages/non-core/bundle-visualizer/client.js
@@ -1,4 +1,5 @@
 import { Meteor } from "meteor/meteor";
+import { HTTP } from "meteor/http";
 import {
   classPrefix,
   methodNameStats,
@@ -18,18 +19,22 @@ function main(builder) {
   document.body.appendChild(mask);
   document.body.appendChild(container);
 
-  Meteor.call(methodNameStats, (error, result) => {
+  HTTP.call("GET", Meteor.absoluteUrl(methodNameStats), {
+    params: {
+      cacheBuster: Math.random().toString(36).slice(2)
+    }
+  }, (error, { data }) => {
     if (error) {
       console.error([
-        `${packageName}: Couldn't load stats for visualization.`,
+        packageName + ": Couldn't load stats for visualization.",
         "Are you using standard-minifier-js >= 2.1.0 as the minifier?",
       ].join(" "));
       return;
     }
 
     // Load the JSON, which is `d3-hierarchy` digestible.
-    if (result) {
-      new builder({ container }).loadJson(result);
+    if (data) {
+      new builder({ container }).loadJson(data);
     }
   });
 }

--- a/packages/non-core/bundle-visualizer/package.js
+++ b/packages/non-core/bundle-visualizer/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.4',
+  version: '1.1.0',
   summary: 'Meteor bundle analysis and visualization.',
   documentation: 'README.md',
 });
@@ -17,7 +17,7 @@ Package.onUse(function(api) {
   api.use('isobuild:dynamic-import@1.5.0');
   api.use([
     'ecmascript',
-    'dynamic-import',
+    'http',
   ]);
   api.mainModule('server.js', 'server');
   api.mainModule('client.js', 'client');

--- a/packages/url/package.js
+++ b/packages/url/package.js
@@ -1,14 +1,13 @@
 Package.describe({
   summary: "Utility code for constructing URLs",
-  version: "1.1.0"
+  version: "1.2.0"
 });
 
 Package.onUse(function(api) {
+  api.use('modules');
+  api.mainModule('url_client.js', 'client');
+  api.mainModule('url_server.js', 'server');
   api.export('URL');
-  api.use('underscore', ['client', 'server']);
-  api.addFiles('url_common.js', ['client', 'server']);
-  api.addFiles('url_client.js', 'client');
-  api.addFiles('url_server.js', 'server');
 });
 
 Package.onTest(function (api) {

--- a/packages/url/url_client.js
+++ b/packages/url/url_client.js
@@ -1,4 +1,12 @@
+var common = require("./url_common.js");
+var URL = exports.URL = common.URL;
+
 URL._constructUrl = function (url, query, params) {
   var query_match = /^(.*?)(\?.*)?$/.exec(url);
-  return buildUrl(query_match[1], query_match[2], query, params);
+  return common.buildUrl(
+    query_match[1],
+    query_match[2],
+    query,
+    params
+  );
 };

--- a/packages/url/url_common.js
+++ b/packages/url/url_common.js
@@ -1,8 +1,8 @@
-URL = {};
+var URL = exports.URL = {};
 
-var encodeString = function (str) {
+function encodeString(str) {
   return encodeURIComponent(str).replace(/\*/g, '%2A');
-};
+}
 
 // Encode URL paramaters into a query string, handling nested objects and
 // arrays properly.
@@ -25,7 +25,7 @@ URL._encodeParams = function (params, prefix) {
   return str.join('&').replace(/%20/g, '+');
 };
 
-buildUrl = function(before_qmark, from_qmark, opt_query, opt_params) {
+exports.buildUrl = function(before_qmark, from_qmark, opt_query, opt_params) {
   var url_without_query = before_qmark;
   var query = from_qmark ? from_qmark.slice(1) : null;
 

--- a/packages/url/url_server.js
+++ b/packages/url/url_server.js
@@ -1,8 +1,13 @@
-var url_util = Npm.require('url');
+var url_util = require('url');
+var common = require("./url_common.js");
+var URL = exports.URL = common.URL;
 
 URL._constructUrl = function (url, query, params) {
   var url_parts = url_util.parse(url);
-  return buildUrl(
+  return common.buildUrl(
     url_parts.protocol + "//" + url_parts.host + url_parts.pathname,
-    url_parts.search, query, params);
+    url_parts.search,
+    query,
+    params
+  );
 };


### PR DESCRIPTION
Ever since Meteor 1.5 first shipped, dynamic modules have been fetched over a WebSocket, which is appealing because sockets have very little latency and metadata overhead per round-trip.

However, using a WebSocket requires first establishing a socket connection to the server, which takes time and may require a WebSocket polyfill.

An even more subtle problem is that we cannot use dynamic imports in any of the code that implements the `ddp-client` package, as long as the `dynamic-import` package depends on `ddp-client`.

By switching from WebSockets to HTTP POST requests, this commit radically reduces the dependencies of the `dynamic-import` package, while preserving (or even exceeding) the benefits of socket-based dynamic module fetching:

* The client makes a single HTTP POST request for the exact set of dynamic modules that it needs, which is much cheaper/faster than making several/many HTTP requests in parallel, with or without HTTP/2.

* Because the client uses a permanent cache (IndexedDB) to avoid requesting any modules it has ever previously received, the lack of HTTP caching for POST requests is not a problem.

* Because the HTTP response contains all the requested dynamic modules in a single JSON payload, gzip compression works across modules, which produces a smaller total response size than if each individual module was compressed by itself.

* Although HTTP requests have more latency than WebSocket messages, the ability to make HTTP requests begins much sooner than a WebSocket connection can be established, which more than makes up for the latency disadvantage.

* HTTP requests are a little easier to inspect and debug in the dev tools than WebSocket frames.

* The new `/__dynamicImport` HTTP endpoint is a raw Connect/Express-style endpoint, so it bypasses the Meteor method-calling system altogether, which eliminates some additional overhead.

* Fetching dynamic modules no longer competes with other WebSocket traffic such as DDP and Livedata.

* Although the implementation of the `/__dynamicImport` endpoint is a bit too complicated to allow serving dynamic modules from a CDN, fetching modules individually from a CDN remains a possibility for future experimentation. In other words, how modules are fetched is still just an implementation detail of the [`meteorInstall.fetch`](https://github.com/meteor/meteor/blob/305abbefb8e357a8512f4b062078093318e8a3ad/packages/dynamic-import/client.js#L19) callback.

* As with the WebSocket implementation, the module server is totally stateless, so it should be easy to scale up if necessary.

I wish I had appreciated the advantages of an HTTP-based implementation sooner, but I think the transition will be pretty seamless, since the new implementation is completely backwards compatible with the old.