### PR TITLE
Don't update npm dependencies when it's not needed

### DIFF
--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -920,6 +920,11 @@ function getInstalledDependenciesTree(dir) {
       const pkgDir = files.pathJoin(nodeModulesDir, item);
       const pkgJsonPath = files.pathJoin(pkgDir, "package.json");
 
+      if (item.startsWith("@")) {
+        Object.assign(result, ls(pkgDir));
+        return;
+      }
+
       let pkg;
       try {
         pkg = JSON.parse(files.readFile(pkgJsonPath));
@@ -927,7 +932,9 @@ function getInstalledDependenciesTree(dir) {
         if (! pkg) return;
       }
 
-      const info = result[item] = {
+      const name = pkg.name || item;
+
+      const info = result[name] = {
         version: pkg.version
       };
 

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -1136,7 +1136,8 @@ var minimizeDependencyTree = function (tree) {
   var minimizeModule = function (module) {
     var version;
     if (module.resolved &&
-        !module.resolved.match(/^https?:\/\/registry.npmjs.org\//)) {
+        !module.resolved.match(/^https?:\/\/registry.npmjs.org\//) &&
+        !module.resolved.startsWith(process.env.NPM_CONFIG_REGISTRY)) {
       version = module.resolved;
     } else if (utils.isNpmUrl(module.from)) {
       version = module.from;


### PR DESCRIPTION
Attempt to fix: https://github.com/meteor/meteor/issues/9381

Short story: Meteor updates a package's npm dependencies on every change to any of the package files when one of the npm dependencies was scoped or when using a private npm server.

Root causes explained here: https://github.com/meteor/meteor/issues/9381#issuecomment-345709113
and here: https://github.com/meteor/meteor/issues/9381#issuecomment-345746220

Basically the shrinkwrap meteor created didn't include scoped packages (weird this hasn't resulted in more bugs before) and the comparison between requested and installed modules couldn't deal with private npm servers. 

Don't know if this will fix every situation (e.g. what is the resolved URL if the private NPM server sends redirects to another url). But I don't know of any such servers. It also only works if you've set the `NPM_CONFIG_REGISTRY` envar, but I believe that's the only way to install meteor packages npm dependencies from a private npm server (CMIIW)?

This saves me about 2 minutes per initial run and around 10 seconds on every reload.
