### PR TITLE
Add support for $type aliasses.

### DIFF
--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -87,8 +87,40 @@ export const ELEMENT_OPERATORS = {
     // should *not* include it itself.
     dontIncludeLeafArrays: true,
     compileElementSelector(operand) {
-      if (typeof operand !== 'number') {
-        throw Error('$type needs a number');
+      if (typeof operand === 'string') {
+        const operandAliasMap = {
+          'double': 1,
+          'string': 2,
+          'object': 3,
+          'array': 4,
+          'binData': 5,
+          'undefined': 6,
+          'objectId': 7,
+          'bool': 8,
+          'date': 9,
+          'null': 10,
+          'regex': 11,
+          'dbPointer': 12,
+          'javascript': 13,
+          'symbol': 14,
+          'javascriptWithScope': 15,
+          'int': 16,
+          'timestamp': 17,
+          'long': 18,
+          'decimal': 19,
+          'minKey': -1,
+          'maxKey': 127,
+        };
+        if (!operandAliasMap.hasOwnProperty(operand)) {
+          throw Error(`unknown string alias for $type: ${operand}`);
+        }
+        operand = operandAliasMap[operand];
+      } else if (typeof operand === 'number') {
+        if (operand === 0 || operand < -1 || (operand > 19 && operand !== 127)) {
+          throw Error(`Invalid numerical $type code: ${operand}`);
+        }
+      } else {
+        throw Error('argument to $type is not a number or a string');
       }
 
       return value => (

--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -116,7 +116,8 @@ export const ELEMENT_OPERATORS = {
         }
         operand = operandAliasMap[operand];
       } else if (typeof operand === 'number') {
-        if (operand === 0 || operand < -1 || (operand > 19 && operand !== 127)) {
+        if (operand === 0 || operand < -1
+          || (operand > 19 && operand !== 127)) {
           throw Error(`Invalid numerical $type code: ${operand}`);
         }
       } else {

--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -111,7 +111,7 @@ export const ELEMENT_OPERATORS = {
           'minKey': -1,
           'maxKey': 127,
         };
-        if (!operandAliasMap.hasOwnProperty(operand)) {
+        if (!hasOwn.call(operandAliasMap, operand)) {
           throw Error(`unknown string alias for $type: ${operand}`);
         }
         operand = operandAliasMap[operand];

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -932,22 +932,28 @@ Tinytest.add('minimongo - selector_compiler', test => {
 
   // $type
   match({a: {$type: 1}}, {a: 1.1});
+  match({a: {$type: 'double'}}, {a: 1.1});
   match({a: {$type: 1}}, {a: 1});
   nomatch({a: {$type: 1}}, {a: '1'});
   match({a: {$type: 2}}, {a: '1'});
+  match({a: {$type: 'string'}}, {a: '1'});
   nomatch({a: {$type: 2}}, {a: 1});
   match({a: {$type: 3}}, {a: {}});
+  match({a: {$type: 'object'}}, {a: {}});
   match({a: {$type: 3}}, {a: {b: 2}});
   nomatch({a: {$type: 3}}, {a: []});
   nomatch({a: {$type: 3}}, {a: [1]});
   nomatch({a: {$type: 3}}, {a: null});
   match({a: {$type: 5}}, {a: EJSON.newBinary(0)});
+  match({a: {$type: 'binData'}}, {a: EJSON.newBinary(0)});
   match({a: {$type: 5}}, {a: EJSON.newBinary(4)});
   nomatch({a: {$type: 5}}, {a: []});
   nomatch({a: {$type: 5}}, {a: [42]});
   match({a: {$type: 7}}, {a: new MongoID.ObjectID()});
+  match({a: {$type: 'objectId'}}, {a: new MongoID.ObjectID()});
   nomatch({a: {$type: 7}}, {a: '1234567890abcd1234567890'});
   match({a: {$type: 8}}, {a: true});
+  match({a: {$type: 'bool'}}, {a: true});
   match({a: {$type: 8}}, {a: false});
   nomatch({a: {$type: 8}}, {a: 'true'});
   nomatch({a: {$type: 8}}, {a: 0});
@@ -955,13 +961,16 @@ Tinytest.add('minimongo - selector_compiler', test => {
   nomatch({a: {$type: 8}}, {a: ''});
   nomatch({a: {$type: 8}}, {});
   match({a: {$type: 9}}, {a: new Date});
+  match({a: {$type: 'date'}}, {a: new Date});
   nomatch({a: {$type: 9}}, {a: +new Date});
   match({a: {$type: 10}}, {a: null});
+  match({a: {$type: 'null'}}, {a: null});
   nomatch({a: {$type: 10}}, {a: false});
   nomatch({a: {$type: 10}}, {a: ''});
   nomatch({a: {$type: 10}}, {a: 0});
   nomatch({a: {$type: 10}}, {});
   match({a: {$type: 11}}, {a: /x/});
+  match({a: {$type: 'regex'}}, {a: /x/});
   nomatch({a: {$type: 11}}, {a: 'x'});
   nomatch({a: {$type: 11}}, {});
 
@@ -982,7 +991,22 @@ Tinytest.add('minimongo - selector_compiler', test => {
   // An exception to the normal rule is that an array found via numeric index is
   // examined itself, and its elements are not.
   match({'a.0': {$type: 4}}, {a: [[0]]});
+  match({'a.0': {$type: 'array'}}, {a: [[0]]});
   nomatch({'a.0': {$type: 1}}, {a: [[0]]});
+
+  // invalid types should throw errors
+  test.throws(() => {
+    match({a: {$type: 'foo'}}, {a: 1});
+  });
+  test.throws(() => {
+    match({a: {$type: -2}}, {a: 1});
+  });
+  test.throws(() => {
+    match({a: {$type: 0}}, {a: 1});
+  });
+  test.throws(() => {
+    match({a: {$type: 20}}, {a: 1});
+  });
 
   // regular expressions
   match({a: /a/}, {a: 'cat'});


### PR DESCRIPTION
Fix: https://github.com/meteor/meteor/issues/9401

Note: I added some extra code that checks the operand values which is not strictly necessary, but now the errors are exactly the same as when using mongo shell.