### PR TITLE
Correct global _ destruction via `meteor shell`.

### DIFF
--- a/packages/shell-server/shell-server.js
+++ b/packages/shell-server/shell-server.js
@@ -10,7 +10,7 @@ import {
   writeSync,
 } from "fs";
 import { createServer } from "net";
-import { default as moduleRepl } from "repl";
+import { start as replStart } from "repl";
 
 const INFO_FILE_MODE = parseInt("600", 8); // Only the owner can read or write.
 const EXITING_MESSAGE = "Shell exiting...";
@@ -208,7 +208,7 @@ class Server {
       options.output = null;
     });
 
-    const repl = this.repl = moduleRepl.start(options);
+    const repl = this.repl = replStart(options);
 
     // This is technique of setting `repl.context` is similar to how the
     // `useGlobal` option would work during a normal `repl.start()` and

--- a/packages/shell-server/shell-server.js
+++ b/packages/shell-server/shell-server.js
@@ -447,12 +447,11 @@ function bailOnIllegalToken(parser) {
 
 // If the error is that we've unexpectedly ended the input,
 // then let the user try to recover by adding more input.
-function isRecoverableError(e, repl) {
+function isRecoverableError(e) {
   if (e && e.name === 'SyntaxError') {
     var message = e.message;
     if (message === 'Unterminated template literal' ||
         message === 'Missing } in template expression') {
-      repl._inTemplateLiteral = true;
       return true;
     }
 

--- a/packages/shell-server/shell-server.js
+++ b/packages/shell-server/shell-server.js
@@ -272,8 +272,6 @@ class Server {
 
     setRequireAndModule(repl.context);
 
-    repl.context.repl = repl;
-
     // Some improvements to the existing help messages.
     function addHelp(cmd, helpText) {
       const info = repl.commands[cmd] || repl.commands["." + cmd];

--- a/packages/shell-server/shell-server.js
+++ b/packages/shell-server/shell-server.js
@@ -359,23 +359,6 @@ function evalCommand(command, context, filename, callback) {
   }
 
   if (Package.ecmascript) {
-    var noParens = stripParens(command);
-    if (noParens !== command) {
-      var classMatch = /^\s*class\s+(\w+)/.exec(noParens);
-      if (classMatch && classMatch[1] !== "extends") {
-        // If the command looks like a named ES2015 class, we remove the
-        // extra layer of parentheses added by the REPL so that the
-        // command will be evaluated as a class declaration rather than as
-        // a named class expression. Note that you can still type (class A
-        // {}) explicitly to evaluate a named class expression. The REPL
-        // code that calls evalCommand handles named function expressions
-        // similarly (first with and then without parentheses), but that
-        // code doesn't know about ES2015 classes, which is why we have to
-        // handle them here.
-        command = noParens;
-      }
-    }
-
     try {
       command = Package.ecmascript.ECMAScript.compileForShell(command);
     } catch (error) {
@@ -404,14 +387,6 @@ function evalCommand(command, context, filename, callback) {
       callback(null, script.runInThisContext());
     }
   }).catch(callback);
-}
-
-function stripParens(command) {
-  if (command.charAt(0) === "(" &&
-      command.charAt(command.length - 1) === ")") {
-    return command.slice(1, command.length - 1);
-  }
-  return command;
 }
 
 // The isRecoverableError and isCodeRecoverable functions are taken from

--- a/packages/shell-server/shell-server.js
+++ b/packages/shell-server/shell-server.js
@@ -222,6 +222,8 @@ class Server {
     repl.context = global;
     repl.useGlobal = true;
 
+    setRequireAndModule(repl.context);
+
     // In order to avoid duplicating code here, specifically the complexities
     // of catching so-called "Recoverable Errors" (https://git.io/vbvbl),
     // we will wrap the default eval, run it in a Fiber (via a Promise), and
@@ -269,8 +271,6 @@ class Server {
       // time the server restarts).
       configurable: true
     });
-
-    setRequireAndModule(repl.context);
 
     // Some improvements to the existing help messages.
     function addHelp(cmd, helpText) {

--- a/tools/tests/apps/shell/server/main.js
+++ b/tools/tests/apps/shell/server/main.js
@@ -3,3 +3,14 @@ import { Meteor } from 'meteor/meteor';
 Meteor.startup(() => {
   Meteor.checkMeFromShell = "oky dok";
 });
+
+// Create a global underscore variable which should be preserved,
+// not overriden by the special REPL `_` variable, when a command
+// is executed on the shell.  The method will allow the test to call
+// back and confirm it's still set.
+_ = {_specialUnderscoreTestObject: true };
+Meteor.methods({
+  "__meteor__/__self_test__/shell-tests/underscore"() {
+    return typeof _ === "object" && Object.keys(_);
+  }
+})

--- a/tools/tests/shell-tests.js
+++ b/tools/tests/shell-tests.js
@@ -19,6 +19,19 @@ selftest.define("meteor shell", function () {
   shell.expectExit(0);
 
   shell = s.run("shell");
+  // Make sure that the special Node REPL _ variable is not stomping on any
+  // global `_` (i.e. Underscore) since the default `repl` behavior sets the
+  // special variable `_` to the result of the last operation. This method
+  // call to the server will make sure our special `_` remains intact after
+  // the shell is launched.
+  shell.write(
+    "Meteor.call('__meteor__/__self_test__/shell-tests/underscore')\n");
+  shell.proc.stdin.end();
+  shell.waitSecs(10);
+  shell.match('["_specialUnderscoreTestObject"]');
+  shell.expectExit(0);
+
+  shell = s.run("shell");
   // Now try with a bunch of newlines in the input.
   shell.write("500+\n4000\n+60\n\n+\n7\n");
   shell.proc.stdin.end();


### PR DESCRIPTION
_(PR body is the commit message body from https://github.com/meteor/meteor/commit/15b24ff6d1242dc80f52c94a053c5b1c8742efa5.)_

A truthy `useGlobal` option when calling Node's `repl.start()` will use the `global` context, which will allow global Meteor variables (such as the global `_` provided by the `underscore`) to be available in the context of the REPL shell.  This sounds desirable, and in fact, the original
implementation set it as such, only to be later changed to `false` in 7c7e52f, specifically to avoid the undesirable behavior of Node REPL stomping on the global `_` variable with its own special-meaning `_` variable which is set to the value of the most recently eval'd expression.

This `useGlobal ` was once again changed to `true` to fix the lost tab-completion functionality, thanks to 2443d83, which also implelented special mutator on `_` to avoid breaking it.  As it's probably clear now, this has been a struggle, and because of Node using its own `Object.defineProperty('_', ...)` as of Node.js 6 (in [node/node#5535](https://github.com/nodejs/node/pull/5535/files)), this problem has surfaced again, as reported in #9276.

This changes the behavior to another implementation which starts with `useGlobal` set to `false`, but then sets the context immediately to `global`, which seems to avoid the problem.

This does maintain the existing behavior of our special double-underscore variable, in order to get the value of the last REPL expression, in the same manner as `_` would in a normal REPL, by
accessing the internal `last` property.  Since this is also undocumented (on our end), this seemed reasonable.

---

I'd recommend reviewing this PR at one time, in it's entirety, but keep in mind that the individual commits provide additional commentary in their own commit messages (and changes).

I attempted to make tests for this, but since the self tests seem to invoke the `evaluateAndExit` functionality within `meteor shell` (due to their lack of a full TTY), the `context` is not affected in any way.

Fixes #9276.