### PR TITLE
Add os.windows.x86_64 to meteor build --architecture help

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -908,9 +908,8 @@ var buildCommand = function (options) {
   // of the file, not a constant 'bundle' (a bit obnoxious for
   // machines, but worth it for humans)
 
-  // Error handling for options.architecture. We must pass in only one of three
-  // architectures. See archinfo.js for more information on what the
-  // architectures are, what they mean, et cetera.
+  // Error handling for options.architecture. See archinfo.js for more
+  // information on what the architectures are, what they mean, et cetera.
   if (options.architecture &&
       !_.has(archinfo.VALID_ARCHITECTURES, options.architecture)) {
     showInvalidArchMsg(options.architecture);

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -386,13 +386,14 @@ Options:
   --architecture      Builds the server for a different architecture than your
                       developer machine's architecture. Valid architectures
                       include os.osx.x86_64, os.linux.x86_64, os.linux.x86_32,
-                      and os.windows.x86_32. Note: This option selects the
-                      architecture of the binary-dependent Atmosphere packages
-                      you would like bundled into your application, when those
-                      packages were specifically published for multiple
-                      architectures (i.e. with meteor publish-for-arch). If
-                      your project doesn't use any Atmosphere packages that
-                      have binary dependencies, --architecture has no effect.
+                      os.windows.x86_32, and os.windows.x86_64. Note: This
+                      option selects the architecture of the binary-dependent
+                      Atmosphere packages you would like bundled into your
+                      application, when those packages were specifically
+                      published for multiple architectures (i.e. with meteor
+                      publish-for-arch). If your project doesn't use any
+                      Atmosphere packages that have binary dependencies,
+                      --architecture has no effect.
   --allow-incompatible-update   Allow packages in your project to be upgraded or
                       downgraded to versions that are potentially incompatible
                       with the current versions, if required to satisfy all
@@ -615,7 +616,7 @@ Options:
                     test app rebuild.
   --extra-packages  Run with additional packages (comma separated, for example:
                     --extra-packages "package-name1, package-name2@1.2.3")
-  --driver-package  Test driver package to use to run tests and display results. 
+  --driver-package  Test driver package to use to run tests and display results.
                     For example: --driver-package meteortesting:mocha
 
 >>> test


### PR DESCRIPTION
The `meteor build --architecture` help was missing `os.windows.x86_64`. This commit adds it in and also updates an out of date comment in the source that referred to there only being 3 allowed architectures.
