### PR TITLE
Fail test when reverse.meteor.com cannot be connected to

### DIFF
--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -1903,8 +1903,8 @@ testAsyncMulti('livedata connection - reconnect to a different server', [
       },
       5000,
       100,
-      true
-    ); // poll until connected, but don't fail if we don't connect
+      false
+    );
   },
   function(test, expect) {
     var self = this;


### PR DESCRIPTION
For a while the livedata `reconnect to a different server` test was failing since the `reverse.meteor.com` host and application were taken down, but nobody noticed. This is because even though the test was still enabled, it was configured to swallow the failure if the connection failed. `reverse.meteor.com` has been brought back up, so this commit adjusts the test to make sure it will properly fail if `reverse.meteor.com` goes down again.

Fixes https://github.com/meteor/meteor/issues/8092.
