### PR TITLE
Stop serving the application manifest from /manifest.json

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 * The previously served `/manifest.json` application metadata file is now
   served from `/__meteor__/webapp/manifest.json`.
   [Issue #6674](https://github.com/meteor/meteor/issues/6674)
+  [PR #9424](https://github.com/meteor/meteor/pull/9424)
 
 * The bundled version of MongoDB used by `meteor run` in development
   on 64-bit architectures has been updated to 3.4.10. 32-bit architectures

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 ## v.NEXT
 
+* The previously served `/manifest.json` application metadata file is now
+  served from `/__meteor__/webapp/manifest.json`.
+  [Issue #6674](https://github.com/meteor/meteor/issues/6674)
+
 * The bundled version of MongoDB used by `meteor run` in development
   on 64-bit architectures has been updated to 3.4.10. 32-bit architectures
   will continue to use MongoDB 3.2.x versions since MongoDB is no longer
@@ -13,9 +17,9 @@
   `standard-minifier-css` package that uses it didn't have to change for
   example), but now that we're using `postcss` the AST accepted and returned
   from certain functions is different. This could impact developers who are
-  tying into Meteor's internal `minifier-css` package directly. The AST based 
+  tying into Meteor's internal `minifier-css` package directly. The AST based
   function changes are:
-  
+
   * `CssTools.parseCss` now returns a PostCSS
     [`Root`](http://api.postcss.org/Root.html) object.    
   * `CssTools.stringifyCss` expects a PostCSS `Root` object as its first
@@ -24,7 +28,7 @@
     first parameter.    
   * `CssTools.rewriteCssUrls` expects a PostCSS `Root` object as its first
     parameter.
-    
+
   [PR #9263](https://github.com/meteor/meteor/pull/9263)
 
 * Dynamically `import()`ed modules will now be fetched from the

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -550,9 +550,11 @@ function runWebAppServer() {
 
         WebApp.clientPrograms[arch] = program;
 
-        // Serve the program as a string at /foo/<arch>/manifest.json
-        // XXX change manifest.json -> program.json
-        staticFiles[urlPrefix + getItemPathname('/manifest.json')] = {
+        // Expose program details as a string reachable via the following
+        // URL.
+        const manifestUrl =
+          urlPrefix + getItemPathname("/__meteor__/webapp/manifest.json");
+        staticFiles[manifestUrl] = {
           content: JSON.stringify(program),
           cacheable: false,
           hash: program.version,


### PR DESCRIPTION
As discussed in #6674, Meteor currently serves its own manifest file from `/manifest.json`. This location is not application configurable, and can conflict with other non-Meteor defined manifest files, that are already being served from this location. For example, [Google's progressive web app documentation](https://developers.google.com/web/fundamentals/web-app-manifest/) suggests using the `/manifest.json` location for its manifest. The newest version of the [web app manifest spec](https://developer.mozilla.org/en-US/docs/Web/Manifest) recommends using a different location for the web app manifest, like

```html
<link rel="manifest" href="/manifest.webmanifest">
```

but the `/manifest.json` location was recommended at one point. Regardless, there isn't really any reason why Meteor needs to use the `/manifest.json` location, so let's move it elsewhere.

This PR moves moves `/manifest.json` to `/__meteor__/webapp/manifest.json`.

A few extra notes:

- It's worth noting that Meteor core doesn't appear to rely on or use the served `/manifest.json` file in any way. We could consider removing it, but as discussed in #6674, there are a few ways in which applications can leverage this information. Since we're already serving it up this PR assumes we're going to keep it, but let me know if you think we should drop it instead.

- At some point we might want to consider serving all application metadata via a similar `/__meteor__/[package name]/[file]` endpoint. The `bundle-visualizer` is using `_meteor/[package name]/stats` for example - at some point we might want to consolidate this. For now though this PR is just addressing the issue raised in #6674 directly.

Fixes https://github.com/meteor/meteor/issues/6674.

Thanks!