### PR TITLE
Prevent Tool crash when node_modules source watcher is removed

### DIFF
--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -526,11 +526,14 @@ var compileUnibuild = Profile(function (options) {
       // though; that happens via compiler.lint.
 
       if (isApp) {
-        // This shouldn't happen, because initFromAppDir's getFiles
+        // This shouldn't normally happen, because initFromAppDir's getFiles
         // should only return assets or sources which match
-        // sourceProcessorSet.
-        throw Error("app contains non-asset files without plugin? " +
-                    relPath + " - " + filename);
+        // sourceProcessorSet. That being said, this can happen when sources
+        // are being watched by a build plugin, and that build plugin is
+        // removed while the Tool is running. Given that this is not a
+        // common occurrence however, we'll ignore this situation and let the
+        // Tool rebuild continue.
+        return;
       }
 
       const linterClassification = linterSourceProcessorSet.classifyFilename(


### PR DESCRIPTION
When sources in the `node_modules` directory are being watched by a build plugin, if that build plugin is removed while the Tool is running, the Tool can crash. This is because the Tool currently see's this situation as an improbable edge case, and purposely errors out instead of allowing the Tool to continue. This commit adjusts the Tool to swallow this exception thereby allowing the rebuild process to continue normally (and avoiding a Tool crash). Given that the liklihood of this situation happening is quite low, and the impact of allowing the rebuild to continue is neglibile (if source files are no longer handled by a build plugin, app developers will notice quickly), this seems like an acceptable way forward.

Fixes #8644.
