### PR TITLE
remove dynamic js and map files from appcache (app.manifest)

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -39,7 +39,7 @@ var browserDisabled = function (request) {
   return disabledBrowsers[request.browser.name];
 };
 
-function isDynamic (resource) {
+function isDynamic(resource) {
   return resource.type === 'dynamic js' ||
     (resource.type === 'json' &&
       resource.url.startsWith('/dynamic/') &&
@@ -105,7 +105,7 @@ WebApp.connectHandlers.use(function (req, res, next) {
   _.each(WebApp.clientPrograms[WebApp.defaultArch].manifest, function (resource) {
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(resource.url) &&
-        !isDynamic(resource)) {
+        ! isDynamic(resource)) {
       manifest += resource.url;
       // If the resource is not already cacheable (has a query
       // parameter, presumably with a hash or version of some sort),
@@ -136,7 +136,7 @@ WebApp.connectHandlers.use(function (req, res, next) {
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(resource.url) &&
         !resource.cacheable &&
-        !isDynamic(resource)) {
+        ! isDynamic(resource)) {
       manifest += resource.url + " " + resource.url +
         "?" + resource.hash + "\n";
     }
@@ -172,7 +172,7 @@ var sizeCheck = function () {
   _.each(WebApp.clientPrograms[WebApp.defaultArch].manifest, function (resource) {
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(resource.url) &&
-        !isDynamic(resource)) {
+        ! isDynamic(resource)) {
       totalSize += resource.size;
     }
   });


### PR DESCRIPTION
As described in issue #9407, dynamic-imports does not load modules from the appcache, and since we don't want the browser to download these assets twice, this patch avoids adding those files to app.manifest.

This patch does pass the appcache unit test, but I'm not sure how to create a test for this, as I'm not sure how to set gt it to load dynamic imports to test with.