### PR TITLE
Fix check for Google OAuth2 expiresIn property in tokens

### DIFF
--- a/packages/google-oauth/google_server.js
+++ b/packages/google-oauth/google_server.js
@@ -17,7 +17,7 @@ function getServiceDataFromTokens(tokens) {
     scope: scopes
   };
 
-  if (hasOwn.call(tokens, "expiresAt")) {
+  if (hasOwn.call(tokens, "expiresIn")) {
     serviceData.expiresAt =
       Date.now() + 1000 * parseInt(tokens.expiresIn, 10);
   }

--- a/packages/google-oauth/package.js
+++ b/packages/google-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Google OAuth flow",
-  version: "1.2.4"
+  version: "1.2.5"
 });
 
 var cordovaPluginGooglePlusURL =


### PR DESCRIPTION
Google's OAuth2 token endpoint (https://accounts.google.com/o/oauth2/token) returns an `expires_in` property in its response, which was being stored internally as `expiresIn`. The `getServiceDataFromTokens` function would only attempt to work with the `expiresIn` value if the `tokens` object had a set `expiresAt` property, meaning the `expiresIn` property was never used. This PR switches the `expiresAt` check to `expiresIn`.

Fixes #9435.
