### PR TITLE
Update the babel-compiler package use to Babel 7, like the command-line tool.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,22 @@
 ## v.NEXT
 
+* The `meteor-babel` npm package (along with its Babel-related
+  dependencies) has been updated to version 7.0.0-beta.34, a major update
+  from Babel 6. Thanks to the strong abstraction of the `meteor-babel`
+  package, the most noticeable consequence of the Babel 7 upgrade is that
+  the `babel-runtime` npm package has been replaced by `@babel/runtime`,
+  which can be installed by running
+  ```js
+  meteor npm install @babel/runtime
+  ```
+  in your application directory. There's a good chance that the old
+  `babel-runtime` package can be removed from your `package.json`
+  dependencies, though there's no harm in leaving it there. Please see
+  [this blog post](https://babeljs.io/blog/2017/09/12/planning-for-7.0)
+  for general information about updating to Babel 7 (note especially any
+  changes to plugins you've been using in any `.babelrc` files).
+  [PR #9440](https://github.com/meteor/meteor/pull/9440)
+
 * The previously served `/manifest.json` application metadata file is now
   served from `/__meteor__/webapp/manifest.json`.
   [Issue #6674](https://github.com/meteor/meteor/issues/6674)

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.8.3
+BUNDLE_VERSION=8.8.4
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.8.4
+BUNDLE_VERSION=8.8.5
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -1,75 +1,320 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.34.tgz",
+      "integrity": "sha512-CAEMoiuya1pvissuqLntIRkVFmFA54mvovKvdHmsdWETut9qJ+bASY8fT7yxSwHCwhAHj2Ed6Als87BSaS7nhg=="
     },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    "@babel/core": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.34.tgz",
+      "integrity": "sha512-A14rafWuxdqGFVNCYksQsY/pJX01lhWpdvXxwNSu18E7DrKK0wkXRCTNman43oDc7yR+BSxFkrdaQkTvNrxfuA=="
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.34.tgz",
+      "integrity": "sha512-2ymX/4tB4JzuLIpv2iYzWlMGz55Ixs/YjMVjtZ49qXaKvVhkJ0+a2p3rg0Nq98/1ngI1mTRtOzGnR6Or01Qc8A=="
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.34.tgz",
+      "integrity": "sha512-Sbf/3iLVGtq0SEI5qDV2uGKGLWsqMKFl/jKVWXomp0SYYuLtWxvMacvVaYa5EQ7U17y4yf9iao9GQrBJ6MOzXg=="
+    },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.34.tgz",
+      "integrity": "sha512-WiVAkxuaLxigXd8bdOLhbBIdN1gcf8NT+DWMQ8phAcF6njl8wxK7q7WQhLVBeAvRwloFXFtGdDOrJUNWsl5Zbg=="
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.34.tgz",
+      "integrity": "sha512-R0cjbmHfzNDILlRUC6GyuMieGqwcxcjmCwoOZU42pVz1NTrbE9pUYS9hAGBBdH2PANzXjOs5OzkM8xnBVetjLQ=="
+    },
+    "@babel/helper-define-map": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.34.tgz",
+      "integrity": "sha512-MG/xndS6/jLoZMm11i/YXVLgvDFo5gH4hKm9+2HW5qmiCW0v9T2k930yJoPhwjeOb0O38gxmy1vE9/35nmX1Qw=="
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.34.tgz",
+      "integrity": "sha512-2nkFlb5/sAeptgEtmAxxK+zELRlfExUymxncNcN996GARKFjn0dNYSnsYwS952nwG9fRpl2lAWLt3Ygk8LyF+Q=="
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.34.tgz",
+      "integrity": "sha512-e9WktWH2PyOzp2lNbIVx2NyiGR/pIc9j28vUnqoDvg9cD1bOqQKVxsDffDl76M0+cPr11C1SV5bN2Y5r24sTIQ=="
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.34.tgz",
+      "integrity": "sha512-8CHKEDXEW+4zFeBKuszkP5hr7vxuz7UBQ4QmrLEb5OaZp9djjcG7PIJ9+RQDVIVyL/GdQN2OqKNR/hE4Pb04IQ=="
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.34.tgz",
+      "integrity": "sha512-wlVrm72pIv+Vw4GF3KdQnklzCkL8nDOEyjnTtmeYpSAfawQwXXE/tvXw7uUW2Ut8PCde+nGuqfATMaD4hIUSRw=="
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.34.tgz",
+      "integrity": "sha512-wkKYPBH8eTwKDBDm24SdBHNh4E+4epY74pKd/+jBaGy/1nxOgPtq7wNVd+8XCHVpxbilvRWFSdDoG/sR/5PDJg=="
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.34.tgz",
+      "integrity": "sha512-amewaBxr7Sv/O+CtdQB1kjewMNOwl5C54W0nNuDsvj7Ria1xsyj5UHuA9Z432Hn9pAC6+BJwh0/dxqcBVOC3AQ=="
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.34.tgz",
+      "integrity": "sha512-IQss/f04tvVEvs7XyEyuQO9HerP6Sa/ZoaqV4E6BXa023s1OhNg0TqRjepRU80Evn+L4zdVy/m8K6xe0V5lnzw=="
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.34.tgz",
+      "integrity": "sha512-eCp5EyVYppTdY3OK9RK0p7GZH1x7PuXQzazS7sM3y2qwdrqOEEspMChV9aDub4yMFewhgqMCUkF+SClLjq8yJQ=="
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.34.tgz",
+      "integrity": "sha512-xetjlCPV6rrnuW3Q0mim9VEXZKsQHCu90UQO5AD3i79IYNVZcVNByTOJNP7Lcs4DIbKki4aPbaCA7Gt/GhMMvQ=="
+    },
+    "@babel/helpers": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.34.tgz",
+      "integrity": "sha512-2slsGVna3h6CWXsMm5nKdovDBr/6njwHUxInosttdBiV1WVjOj/pT5YJZ1VbXHcbfqq5TwMfOPU+Mhp+ws61gA=="
+    },
+    "@babel/plugin-check-constants": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.34.tgz",
+      "integrity": "sha512-H68lHIRXAD9OH8AMtfq9g7bnn2fEjuh68rlyLzUnaj443GxN2O8XLqhGJc2hFwFizqM6QfLLsafPzIelS7NnMQ=="
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.34.tgz",
+      "integrity": "sha512-KLIqA5aHR1Uz6phe2Mare8l5Zfogz6H/m+ukCEuAVpcCHR/2LZSqZCM24qYC2dnAwxvMRAl/QyUe8MclHhU3Dg=="
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.34.tgz",
+      "integrity": "sha512-yW9xsvPsXWwwDnOWzUm+Q8cIf+gkCOdsIXF51NTaLgX5TdOBmErLBFUrlbY3oveqsiEa26qlA6nwM9/Wkh4gog=="
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.34.tgz",
+      "integrity": "sha512-4y/+dUbzOgWE5gOgK1KKTd/3bSH1Tc97Ba5xlvZk+ufTBiHsG+WSvdaK0aNtPmBcA3mvfHFDYiLPRslU/X88ww=="
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.34.tgz",
+      "integrity": "sha512-XuTrpRivb04Pd8Knmduuo1ejgrmpK2dX5fftVmgVT+noX9/MC1s+A0lAqmAISRy029uth5hM34oappUYz0LrFw=="
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.34.tgz",
+      "integrity": "sha512-uw+hEEeSl9PCNR//d3pGEwLHXSrZSPmlXZND9N/IsZfY36f7i+Pe140UWVxwzOcNCr4IKWyTlsu3FxisFsxfzw=="
+    },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.34.tgz",
+      "integrity": "sha512-HwVw7EpN+WxjgVGpOxwwqAmst7xbxVeVDp/u74OT48TX2QGFe1UGw/NWyDIjfPf4l7r/HHtglWaAitjeiXeBlA=="
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.34.tgz",
+      "integrity": "sha512-ul0JfSnAyhhsaW+sUlLQTXNpFVrClUZrRNhS8UKgOtvT89X/1qyB6yINEGRULrFn8Ip7lsVFreib129b76UHQA=="
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.34.tgz",
+      "integrity": "sha512-tnSX0iX2vkKI6Alam/3Q4m8cuzuS0HeCIgQHVMkd6aVnIeHYJOaPwjCGeJJHAOg/lPXpc5sGecGI2cu2q0abiA=="
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.34.tgz",
+      "integrity": "sha512-ECCEH+tr0Ei5DPglMTR51KV/h1lLac0N06tf69/sKxjq+m+mLiYM2y82AgEFBtAxlRepkBt3LcnVM8AvWv+W4A=="
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.34.tgz",
+      "integrity": "sha512-yEXiN1GOkHdTd3ILpyaWrOHwEl3yk7kSuhkPpwevPDEbAazmcEKO73YWZz1b/pIbhTlP9swZvKiKVgaGDpc32A=="
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.34.tgz",
+      "integrity": "sha512-O1uLtQyaDYDDbKcib27yQnVmWQQYGWq1aR9wsQCHG9+qt24TOqN3NIUMWako1Blfq9w4bVX/2rIp4kIr1DPiOQ=="
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.34.tgz",
+      "integrity": "sha512-t7l8FnjgpYOIYAmdttb50EjaQxqt3tRBbzR8jJ1Q7m6qDmaY+pt0XjbSDE63vg4jjWL9N/2IkTWevgd0nbyoGQ=="
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.34.tgz",
+      "integrity": "sha512-aAD9Fweud+e7wE4uWRfPfWUhx+l63Ywez5ZZ5da/gLMV5dUV3wVg6Rjnduf4VWyUUvdr/meAgT32rMqDVxAb2A=="
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.34.tgz",
+      "integrity": "sha512-D7UNymLG3VmIib9S3u9sMPFmnOoWNKkJQz7GI/NLMgtNem0Ew900ZhS9fxsqGF9muawhQeni9adKr15WdDsUCg=="
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.34.tgz",
+      "integrity": "sha512-utmi5GVpGuBoTMACiy5a8gsq0fLxB9X9cgKRX3x3FpDu/JCaD7xquTx75JQ3vZB5J/cAyMaUOFcPZwamT7FBiQ=="
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.34.tgz",
+      "integrity": "sha512-BwSxmFpZJ0pWjokMiXdhuH+oApTkrn26m50LMQk346A6Zvu+HJ/UdmaS4zw58809twrggOMaEoip0XuPfMPLUw=="
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.34.tgz",
+      "integrity": "sha512-rqyb71ffA6Lqlt29G0QotDTt8z/vGghGJyftrG88+9/M6LC+azaR1yzoaoV2UQl+YsErEtm+OHfD+1F7aCVCNg=="
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.34.tgz",
+      "integrity": "sha512-Ipi7A5L7SsYdXKy4J73TKBLrm1SMA9yJq1KgjSDDpn94Q2Ylpo2cXRfr0OqwgYK7d2KzBSrFypIULLQgOXY2Ag=="
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.34.tgz",
+      "integrity": "sha512-jiP0H9E0rjLVBKYHiSxO47iFyyKZQeSvViXFHipw93W7Fk+nCFZmtM1dl4Vy8KaKd4ET8d2zck83EcPU6flPtw=="
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.34.tgz",
+      "integrity": "sha512-pEQtoqpwaEgE7ZIqgLJmJTrKIJ19kaUr2ExoxujbQe/m96eJF7d6TtBBLbpHbJEgGBbjzWI7uRQRSnTTfoomZQ=="
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.0.0-beta.34.tgz",
+      "integrity": "sha512-0wYzQDPtQylZjUlVhO+1sGS5sevkhJ7I4Fqm9g7GqroQxZU8CoXjNrybsb89YfUyV01qUfwRG/NtmJk7Kfi6Zw=="
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.34.tgz",
+      "integrity": "sha512-sx11AW/Vo3rtPLjUvzH7lPdHI4AqpL8OA04hGkfhMr9vwEf6f36+12m0lb6adK4rta6hyjXccN7B7nyjlQl3Yg=="
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.34.tgz",
+      "integrity": "sha512-J2TSjbhuXf9kEarsU3DlwwarVsQky5H/H5XNoIMPbWMoaTaG5q1GjRhQaYylvVe58siAkTvmXdy9JD/XJBDYcA=="
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.34.tgz",
+      "integrity": "sha512-pHfuWmIUgn4R78+9CvbtTeG1zx+3l7uVWOz0sqgTqnLnaWFzpDnwbPOeTYW73htP+NkqTHb5aNBQyN3hi3/85g=="
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.34.tgz",
+      "integrity": "sha512-2AQcMrZCACdAHhXIwopIyrs/UrkkL/NAJbKWuX2otiiw0f6+VWY6Y/FbPgYqMEGIkkXXgI1ctC2DT9SqwXdR3g=="
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.34.tgz",
+      "integrity": "sha512-r+RFXpfW11wlq9omPaw4ELCBQdTJDdYRoiO45G161xVRUBRVURU+acRe6VhNIhMv+fZGTVi9Y5/tuIZc/0sOIw=="
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.34.tgz",
+      "integrity": "sha512-Odn+26k1G7x5S65CSS5kFSme1WwvFZNjv4VTk+ukbx4g+lvDBrrsPZBYkC/BxR76gWgy/MYsiov6jL38DwYNOA=="
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.34.tgz",
+      "integrity": "sha512-ShonB4hSsHxSP3hhpyXIJShm2et0NW40nJCaSlZvw0yCPeIr0IEnwB4g8gjZXsYBUWLiEz3JanmWuZEIIrBBTA=="
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.34.tgz",
+      "integrity": "sha512-loj8b4CTpgOjmGCODMCZ6Nbn+CZWcgU9MsFBWomfliOyQpDu/9WqNuRdiGcMlUmbnIoVpiNUAf5ZKcd3wAgJnw=="
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.34.tgz",
+      "integrity": "sha512-tn7GJz07Z8pV8j2mCGeaqIc/pEtCtnLmCGpAfbwOBkccyEI81YUBF0HnvqHdMTLcmN6A7TXBZmaXovEOmlZuhQ=="
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.34.tgz",
+      "integrity": "sha512-3cZ6ZW8ONemEbhpA+zM+yEuINmxqyVNiU2vo3je/7FjslFwbYR75eU4sLGVTyGs00DJ5QVSImDOVM9eHdyc8yw=="
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.34.tgz",
+      "integrity": "sha512-zK2W/I6/eafbN7eWtrn7mWUpRdZMbV2GrOfS9yzbMifs9QvLK3jSmXXDSYu1dUPaG2sufxyp73mzvvr3owzpAg=="
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.34.tgz",
+      "integrity": "sha512-tMMOEBxLOzEJ59k3EFzOeU2RuF5cHndvto9LeBhtkrBmG6O+gZXmMSzIxv8QbWnS92ujmUIHvJSDSfgdsOHlsQ=="
+    },
+    "@babel/preset-react": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.34.tgz",
+      "integrity": "sha512-yITAUEZz7pqlXaIhn2nZZIB2wfjT/uSh5XuSMcWu2eIuUCJP162UYA1yqM6tLZ2dBmxcMmeF9FPL8fc1L1FFIQ=="
+    },
+    "@babel/runtime": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.34.tgz",
+      "integrity": "sha512-XmMTzvvZrQAyLGrzLyLyZprcfC5KsYc8ERbRNibJs0toeoAOGSJLsAKPXM++h7FLT+O4HILWZRA9uB7vEBFdpQ=="
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.34.tgz",
+      "integrity": "sha512-dldLn8DUQEb3aq8bIiMcmffKIKn4jetne3cnzS2nk0LBSm/8Uhh0yQc4REk4uRs0Bz24iUBdlrb/9cjDqTDgow=="
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.34.tgz",
+      "integrity": "sha512-FmqSqGu+x3kjzWOww7Ro9Od7BPNCwgqZOrzj9hmvACCrxXcHIhwqFG+mFZSDfew35QlAh54YIfWGq0xGW5ztJw=="
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.34.tgz",
+      "integrity": "sha512-KD5CF1dmZE8i9ggW9L+YSak7j+b3YTGQZUs9WMF6tgG/aw2x/VhTxfooqXR0Bbfzkb5M6WGiTHbzCmx8ll4tQQ=="
+    },
+    "acorn": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug=="
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s="
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8="
     },
-    "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g="
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
-    "babel-generator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU="
-    },
-    "babel-helper-builder-react-jsx": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
-      "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA="
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
-    },
-    "babel-helper-define-map": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8="
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "babel-helper-evaluate-path": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.0.3.tgz",
-      "integrity": "sha1-HRA6ydSlnl1DGEIhLxUXhfesVHs="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.2.0.tgz",
+      "integrity": "sha512-0EK9TUKMxHL549hWDPkQoS7R0Ozg1CDLheVBHYds2B2qoAvmr9ejY3zOXFsrICK73TN7bPhU14PBeKc8jcBTwg=="
     },
     "babel-helper-flip-expressions": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.0.2.tgz",
-      "integrity": "sha1-e6ss9hFivJJwPpspjvUSvPd9Z4c="
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.2.0.tgz",
+      "integrity": "sha512-rAsPA1pWBc7e2E6HepkP2e1sXugT+Oq/VCqhyuHJ8aJ2d/ifwnJfd4Qxjm21qlW43AN8tqaeByagKK6wECFMSw=="
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
@@ -77,268 +322,89 @@
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.0.1.tgz",
-      "integrity": "sha1-7XRVO4g+aCJq5F+YmpmwLBkPEFo="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.2.0.tgz",
+      "integrity": "sha512-Axj1AYuD0E3Dl7nT3KxROP7VekEofz3XtEljzURf3fABalLpr8PamtgLFt+zuxtaCxRf9iuZmbAMMYWri5Bazw=="
     },
     "babel-helper-mark-eval-scopes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.1.1.tgz",
-      "integrity": "sha1-RVQ0Xt+fJUlCe9IJjlMCU/ivKZI="
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.2.0.tgz",
+      "integrity": "sha512-KJuwrOUcHbvbh6he4xRXZFLaivK9DF9o3CrvpWnK1Wp0B+1ANYABXBMgwrnNFIDK/AvicxQ9CNr8wsgivlp4Aw=="
     },
     "babel-helper-remove-or-void": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.1.1.tgz",
-      "integrity": "sha1-nX4YVtxvr8tBsoOkFnMNwYRPZtc="
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.2.0.tgz",
+      "integrity": "sha512-1Z41upf/XR+PwY7Nd+F15Jo5BiQi5205ZXUuKed3yoyQgDkMyoM7vAdjEJS/T+M6jy32sXjskMUgms4zeiVtRA=="
     },
     "babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.0.3.tgz",
-      "integrity": "sha1-x4mg+szSZpxRI0vizqej5aBXPCU="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.2.0.tgz",
+      "integrity": "sha512-ij9lpfdP3+Zc/7kNwa+NXbTrUlsYEWPwt/ugmQO0qflzLrveTIkbfOqQztvitk81aG5NblYDQXDlRohzu3oa8Q=="
     },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
+    "babel-plugin-minify-builtins": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.2.0.tgz",
+      "integrity": "sha512-4i+8ntaS8gwVUcOz5y+zE+55OVOl2nTbmHV51D4wAIiKcRI8U5K//ip1GHfhsgk/NJrrHK7h97Oy5jpqt0Iixg=="
     },
     "babel-plugin-minify-constant-folding": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.0.4.tgz",
-      "integrity": "sha1-tuIxAmpgNeiM6t0gYSjX2ytcFeY=",
-      "dependencies": {
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
-        }
-      }
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.2.0.tgz",
+      "integrity": "sha512-B3ffQBEUQ8ydlIkYv2MkZtTCbV7FAkWAV7NkyhcXlGpD10PaCxNGQ/B9oguXGowR1m16Q5nGhvNn8Pkn1MO6Hw=="
     },
     "babel-plugin-minify-dead-code-elimination": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.1.7.tgz",
-      "integrity": "sha1-d09TbzR7mDk6J7qnF4cpaIE8NCw="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.2.0.tgz",
+      "integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg=="
     },
     "babel-plugin-minify-flip-comparisons": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.0.2.tgz",
-      "integrity": "sha1-fQlTqlh27eYRiWa9qe3sxjvzRqs="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.2.0.tgz",
+      "integrity": "sha512-QOqXSEmD/LhT3LpM1WCyzAGcQZYYKJF7oOHvS6QbpomHenydrV53DMdPX2mK01icBExKZcJAHF209wvDBa+CSg=="
     },
     "babel-plugin-minify-guarded-expressions": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.0.4.tgz",
-      "integrity": "sha1-lXEEp2Dmp//ZZwBaehFiG7Qv0Rw="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.2.0.tgz",
+      "integrity": "sha512-5+NSPdRQ9mnrHaA+zFj+D5OzmSiv90EX5zGH6cWQgR/OUqmCHSDqgTRPFvOctgpo8MJyO7Rt7ajs2UfLnlAwYg=="
     },
     "babel-plugin-minify-infinity": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.0.3.tgz",
-      "integrity": "sha1-TMmbYdErQ0zoCtZ1EDM1xYnLqaE="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.2.0.tgz",
+      "integrity": "sha512-U694vrla1lN6vDHWGrR832t3a/A2eh+kyl019LxEE2+sS4VTydyOPRsAOIYAdJegWRA4cMX1lm9azAN0cLIr8g=="
     },
     "babel-plugin-minify-mangle-names": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.0.7.tgz",
-      "integrity": "sha1-/MX5pMTJwHMec6Sk49AC/LgA70E=",
-      "dependencies": {
-        "babel-helper-mark-eval-scopes": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.0.2.tgz",
-          "integrity": "sha1-kJ/R8jhFcM0wAyg3c4UtnWOSKjc="
-        }
-      }
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.2.0.tgz",
+      "integrity": "sha512-Gixuak1/CO7VCdjn15/8Bxe/QsAtDG4zPbnsNoe1mIJGCIH/kcmSjFhMlGJtXDQZd6EKzeMfA5WmX9+jvGRefw=="
     },
     "babel-plugin-minify-numeric-literals": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.0.1.tgz",
-      "integrity": "sha1-lZfmwxFU19rzdE0L1BfBRLJ1vVM="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.2.0.tgz",
+      "integrity": "sha512-VcLpb+r1YS7+RIOXdRsFVLLqoh22177USpHf+JM/g1nZbzdqENmfd5v534MLAbRErhbz6SyK+NQViVzVtBxu8g=="
     },
     "babel-plugin-minify-replace": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.0.1.tgz",
-      "integrity": "sha1-XVrqfLmJkkUkjR7pznov5Vao+sw="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.2.0.tgz",
+      "integrity": "sha512-SEW6zoSVxh3OH6E1LCgyhhTWMnCv+JIRu5h5IlJDA11tU4ZeSF7uPQcO4vN/o52+FssRB26dmzJ/8D+z0QPg5Q=="
     },
     "babel-plugin-minify-simplify": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.0.7.tgz",
-      "integrity": "sha1-QZjVieoQtLxb+TECBmGadDwNBmQ="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.2.0.tgz",
+      "integrity": "sha512-Mj3Mwy2zVosMfXDWXZrQH5/uMAyfJdmDQ1NVqit+ArbHC3LlXVzptuyC1JxTyai/wgFvjLaichm/7vSUshkWqw=="
     },
     "babel-plugin-minify-type-constructors": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.0.3.tgz",
-      "integrity": "sha1-q1nBrYNba26OkyuHXU303Dk9nSY="
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-    },
-    "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
-    },
-    "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
-    },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-    },
-    "babel-plugin-syntax-flow": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-    },
-    "babel-plugin-transform-class-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw="
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8="
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM="
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.2.0.tgz",
+      "integrity": "sha512-NiOvvA9Pq6bki6nP4BayXwT5GZadw7DJFDDzHmkpnOQpENWe8RtHtKZM44MG1R6EQ5XxgbLdsdhswIzTkFlO5g=="
     },
     "babel-plugin-transform-es2015-modules-reify": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-reify/-/babel-plugin-transform-es2015-modules-reify-0.12.4.tgz",
-      "integrity": "sha512-9GLpoChHKLtrOc5x3ZAiLRIW9KF4+DqUnOF3J9l4bHTNTgWvS8hOnuHhMOHN3z2v1MIhx8R2mVEYhY1qEqnxMw=="
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40="
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA="
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw="
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek="
-    },
-    "babel-plugin-transform-es3-property-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
-      "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g="
-    },
-    "babel-plugin-transform-flow-strip-types": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988="
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-reify/-/babel-plugin-transform-es2015-modules-reify-0.13.2.tgz",
+      "integrity": "sha512-C/S8ykbUn/Mf/BKys0Q0PGcuKi8lAEmJwa/cY4vmsaLlkwv+z6pQBWOd82Vks35thOmzCiqWF2isJ4DQY21Wkg=="
     },
     "babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.0.2.tgz",
-      "integrity": "sha1-pY/Oz8CcCPv5NzpaPnB0bAPQH8E="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.2.0.tgz",
+      "integrity": "sha512-GlhOuLOQ28ua9prg0hT33HslCrEmz9xWXy9ZNZSACppCyRxxRW+haYtRgm7uYXCcd0q8ggCWD2pfWEJp5iiZfQ=="
     },
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.8.5",
@@ -355,45 +421,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.3.tgz",
       "integrity": "sha512-bPbUhkeN2Nc0KH0/A19GwQGj8w+CvdJzyu8t59VoEDgsNMQ9Bopzi5DrVkrSsVjbYUaZpzq/DYLrH+wD5K2Tig=="
     },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY="
-    },
     "babel-plugin-transform-property-literals": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.8.5.tgz",
       "integrity": "sha512-MmiQsQ5AcIaRZMJD0zY5C4H3xuHm06/nWgtOsz7AXV44VEIXIlPiJ39IFYJ4Qx67/fEm8zJAedzR8t+B7d10Bg=="
     },
-    "babel-plugin-transform-react-display-name": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE="
-    },
-    "babel-plugin-transform-react-jsx": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM="
-    },
-    "babel-plugin-transform-react-jsx-self": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24="
-    },
-    "babel-plugin-transform-react-jsx-source": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY="
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8="
-    },
     "babel-plugin-transform-regexp-constructors": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.0.5.tgz",
-      "integrity": "sha1-dNleDFZ+b8HZxpmghIlNQN6OWB0="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.2.0.tgz",
+      "integrity": "sha512-7IsQ6aQx6LAaOqy97/PthTf+5Nx9grZww3r6E62IdWe76Yr8KsuwVjxzqSPQvESJqTE3EMADQ9S0RtwWDGNG9Q=="
     },
     "babel-plugin-transform-remove-console": {
       "version": "6.8.5",
@@ -406,99 +442,54 @@
       "integrity": "sha512-InDQDdHPOLJKM+G6oXrEesf+P29QFBmcTXID+TAvZziVz+38xe2VO/Bn3FcRcRtnOOycbgsJkUNp9jIK+ist6g=="
     },
     "babel-plugin-transform-remove-undefined": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.0.5.tgz",
-      "integrity": "sha1-Eu8RgF4G6GHdLrDHzAQdIYS49BA="
-    },
-    "babel-plugin-transform-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.2.0.tgz",
+      "integrity": "sha512-O8v57tPMHkp89kA4ZfQEYds/pzgvz/QYerBJjIuL5/Jc7RnvMVRA5gJY9zFKP7WayW8WOSBV4vh8Y8FJRio+ow=="
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.8.5.tgz",
       "integrity": "sha512-B3HlBZb+Uq86nRj5yNPO6pJ3noEdqHvzYkEYoUWtrsWTv48ZIRatYlumoOiif/v8llF13YjYjx9zhyznDx+N9g=="
     },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
-    },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.8.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.3.tgz",
       "integrity": "sha512-goYwp8dMrzHD6x9GjZ2M85Mk2vxf1h85CnUgAjfftUnlJvzF4uj5MrbReHBTbjQ96C8CuRzvhYZ3tv8H3Sc1ZA=="
     },
-    "babel-preset-babili": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/babel-preset-babili/-/babel-preset-babili-0.0.11.tgz",
-      "integrity": "sha1-lGH9kC1qPIvAMrjwbC9pFnTBKh8="
-    },
-    "babel-preset-flow": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0="
-    },
     "babel-preset-meteor": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-meteor/-/babel-preset-meteor-6.26.0.tgz",
-      "integrity": "sha1-v+/KEPMGfNPlYxsM1dpQKZb184s="
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/babel-preset-meteor/-/babel-preset-meteor-7.0.0-beta.34.tgz",
+      "integrity": "sha512-2NFKLlP+RA2eFCYCwNwRcGxbYm7KguMVFzA0yFJr5KY2RrUXK1kUu1z9maD6dIujjdELWzpwehPBMAIEdjy2Kg=="
     },
-    "babel-preset-react": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A="
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE="
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4="
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI="
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4="
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc="
+    "babel-preset-minify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.2.0.tgz",
+      "integrity": "sha512-mR8Q44RmMzm18bM2Lqd9uiPopzk5GDCtVuquNbLFmX6lOKnqWoenaNBxnWW0UhBFC75lEHTIgNGCbnsRI0pJVw=="
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.34.tgz",
+      "integrity": "sha512-ribEzWEhWKKjY+1FdKCryo+HiN/1idPjUB8vyR5Yf221MtGzCd5+7OwPvWvYHerHHC2eJLr6MhvumbTocXGY7Q=="
     },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc="
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q=="
     },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ=="
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "convert-source-map": {
       "version": "1.5.0",
@@ -511,14 +502,9 @@
       "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
-    },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -530,30 +516,120 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s="
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc="
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM="
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4="
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q="
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
+    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA=="
     },
-    "has-ansi": {
+    "has-flag": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
     },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ="
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -561,14 +637,19 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
     },
     "lodash": {
       "version": "4.17.4",
@@ -591,24 +672,19 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "meteor-babel": {
-      "version": "0.24.7",
-      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-0.24.7.tgz",
-      "integrity": "sha512-CQgTY8fQ+jxrdG3ZnCXJbGwy36SfWI89Bg3HoHEZUEM4P+p/SieLQeTKzFra9C24LyZyZB3AwHzRHjEnKgCcIA=="
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-7.0.0-beta.34.tgz",
+      "integrity": "sha512-DVyTivJcXVk6lFHEIe7/HFKQBrbKULaRWvLCWBWJD3GVP1SiyZFNoGhA3n2ZGXUzMGQCQJWpHUCfPDiuD5helw=="
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/meteor-babel-helpers/-/meteor-babel-helpers-0.0.3.tgz",
       "integrity": "sha1-8uXZ+HlvvS6JAQI9dpnlsgLqn7A="
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
     },
     "minipass": {
       "version": "2.2.1",
@@ -616,49 +692,78 @@
       "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q=="
     },
     "minizlib": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz",
-      "integrity": "sha1-1cGr93vhVGGZUuJTM27Mq5sqMvU="
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.4.tgz",
+      "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ=="
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo="
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw="
     },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
+        }
+      }
     },
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
       "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+    },
+    "regenerate-unicode-properties": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.3.tgz",
+      "integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A=="
     },
     "regenerator-runtime": {
       "version": "0.11.0",
@@ -666,24 +771,29 @@
       "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "regenerator-transform": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q=="
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.1.tgz",
+      "integrity": "sha512-RAcAGzEuU74v7FgnOLT7qG1Nk5mTJSXzZjYAfZ3gZWQxNI6aWn0ny2uX6ZRdYT/oZraT3o+YgFt3rDBEfUPZjw=="
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ=="
     },
     "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
+      "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A=="
     },
     "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+      "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M="
     },
     "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+      "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
@@ -693,54 +803,74 @@
       }
     },
     "reify": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.12.3.tgz",
-      "integrity": "sha512-s13k0kuZbhBzeRoJQGomWnLj2y10wK3FYXRXbZoydowAMmY0jTiFN98TgLkaE8uZkVCaoq3djnDo7mksWLsx4g=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.13.1.tgz",
+      "integrity": "sha512-mwumMhtBZmKoDKamiCxufgUp7Jxugh9JFOlDYlZ7W3lEy9mXGNSHwasF0u9DDFd2ygqs3FRs/9iRp8uD8ClRqQ=="
     },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw=="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA=="
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-    },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s="
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-iG/2t0F2LAU8aZYPkX5gi7ebukHnr3sWFESpb+zPQeeaQwOkfoO6ZW17YX7MdRPNG9pCy+tjzGill+Ah0Em0HA=="
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA=="
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.1.tgz",
+      "integrity": "sha512-lM8B0FDZQh9yYGgiabRQcyWicB27VLOolSBRIxsO7FeQPtg+79Oe7sC8Mzr8BObDs+G9CeYmC/shHo6OggNEog=="
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-TdDmDOTxEf2ad1g3ZBpM6cqKIb2nJpVlz1Q++casDryKz18tpeMBhSng9hjC1CTQCkOV9Rw2knlSB6iRo7ad1w=="
     },
     "yallist": {
       "version": "3.0.2",

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -672,9 +672,9 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "meteor-babel": {
-      "version": "7.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-7.0.0-beta.34.tgz",
-      "integrity": "sha512-DVyTivJcXVk6lFHEIe7/HFKQBrbKULaRWvLCWBWJD3GVP1SiyZFNoGhA3n2ZGXUzMGQCQJWpHUCfPDiuD5helw=="
+      "version": "7.0.0-beta.34-1",
+      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-7.0.0-beta.34-1.tgz",
+      "integrity": "sha512-+VJcfGDWMCF4aqCC0hbq4N2WOMnRW/uE1GUtmVomdyI+wAFsbmp2lGZyGCvU2M+K+76bLHw5BbJFvJNfRUSJBA=="
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -10,7 +10,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'meteor-babel': '7.0.0-beta.34'
+  'meteor-babel': '7.0.0-beta.34-1'
 });
 
 Package.onUse(function (api) {

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,11 +6,11 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '6.24.7'
+  version: '7.0.0'
 });
 
 Npm.depends({
-  'meteor-babel': '0.24.7'
+  'meteor-babel': '7.0.0-beta.34'
 });
 
 Package.onUse(function (api) {

--- a/packages/babel-runtime/babel-runtime.js
+++ b/packages/babel-runtime/babel-runtime.js
@@ -1,33 +1,24 @@
 exports.meteorBabelHelpers = require("meteor-babel-helpers");
 
-// Returns true if a given absolute identifier will be provided at runtime
-// by the babel-runtime package.
-exports.checkHelper = function checkHelper(id) {
-  // There used to be more complicated logic here, when the babel-runtime
-  // package provided helper implementations of its own, but now this
-  // function exists just for backwards compatibility.
-  return false;
-};
-
 try {
-  var babelRuntimeVersion = require("babel-runtime/package.json").version;
-  var regeneratorRuntime = require("babel-runtime/regenerator");
+  var babelRuntimeVersion = require("@babel/runtime/package.json").version;
+  var regeneratorRuntime = require("@babel/runtime/regenerator");
 } catch (e) {
   throw new Error([
-    "The babel-runtime npm package could not be found in your node_modules ",
+    "The @babel/runtime npm package could not be found in your node_modules ",
     "directory. Please run the following command to install it:",
     "",
-    "  meteor npm install --save babel-runtime",
+    "  meteor npm install --save @babel/runtime",
     ""
   ].join("\n"));
 }
 
 if (parseInt(babelRuntimeVersion, 10) < 6) {
   throw new Error([
-    "The version of babel-runtime installed in your node_modules directory ",
+    "The version of @babel/runtime installed in your node_modules directory ",
     "(" + babelRuntimeVersion + ") is out of date. Please upgrade it by running ",
     "",
-    "  meteor npm install --save babel-runtime",
+    "  meteor npm install --save @babel/runtime",
     "",
     "in your application directory.",
     ""

--- a/packages/ecmascript/transpilation-tests.js
+++ b/packages/ecmascript/transpilation-tests.js
@@ -52,8 +52,12 @@ class Foo {
   }
 }`);
 
-  // Babel 7 no longer uses classCallCheck in loose mode.
-  test.isTrue(contains(output, 'helpers/classCallCheck'));
+  // Babel 7 no longer imports the classCallCheck helper in loose mode.
+  test.equal(output, [
+    "var Foo = function Foo(x) {",
+    "  this.x = x;",
+    "};"
+  ].join("\n"));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - inherits", (test) => {
@@ -62,7 +66,7 @@ class Foo {}
 class Bar extends Foo {}
 `);
 
-  test.isTrue(contains(output, 'helpers/inherits'));
+  test.isTrue(contains(output, 'helpers/builtin/inherits'));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - bind", (test) => {
@@ -78,7 +82,7 @@ Tinytest.add("ecmascript - transpilation - helpers - extends", (test) => {
   var full = {a:1, ...middle, d:4};
 `);
 
-  test.isTrue(contains(output, 'helpers/extends'));
+  test.isTrue(contains(output, 'helpers/builtin/extends'));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - objectWithoutProperties", (test) => {
@@ -86,7 +90,7 @@ Tinytest.add("ecmascript - transpilation - helpers - objectWithoutProperties", (
 var {a, ...rest} = obj;
 `);
 
-  test.isTrue(contains(output, 'helpers/objectWithoutProperties'));
+  test.isTrue(contains(output, 'helpers/builtin/objectWithoutProperties'));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - objectDestructuringEmpty", (test) => {
@@ -94,7 +98,7 @@ Tinytest.add("ecmascript - transpilation - helpers - objectDestructuringEmpty", 
 var {} = null;
 `);
 
-  test.isTrue(contains(output, 'helpers/objectDestructuringEmpty'));
+  test.isTrue(contains(output, 'helpers/builtin/objectDestructuringEmpty'));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - taggedTemplateLiteralLoose", (test) => {
@@ -102,7 +106,7 @@ Tinytest.add("ecmascript - transpilation - helpers - taggedTemplateLiteralLoose"
 var x = asdf\`A\${foo}C\`
 `);
 
-  test.isTrue(contains(output, 'helpers/taggedTemplateLiteralLoose'));
+  test.isTrue(contains(output, 'helpers/builtin/taggedTemplateLiteralLoose'));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - createClass", (test) => {
@@ -112,7 +116,7 @@ class Foo {
 }
 `);
 
-  test.isTrue(contains(output, 'helpers/createClass'));
+  test.isTrue(contains(output, 'helpers/builtin/createClass'));
 });
 
 Tinytest.add("ecmascript - transpilation - flow", (test) => {

--- a/packages/ecmascript/transpilation-tests.js
+++ b/packages/ecmascript/transpilation-tests.js
@@ -66,7 +66,7 @@ class Foo {}
 class Bar extends Foo {}
 `);
 
-  test.isTrue(contains(output, 'helpers/builtin/inherits'));
+  test.isTrue(/helpers\/(builtin\/)?inherits/.test(output));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - bind", (test) => {
@@ -82,7 +82,7 @@ Tinytest.add("ecmascript - transpilation - helpers - extends", (test) => {
   var full = {a:1, ...middle, d:4};
 `);
 
-  test.isTrue(contains(output, 'helpers/builtin/extends'));
+  test.isTrue(/helpers\/(builtin\/)?extends/.test(output));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - objectWithoutProperties", (test) => {
@@ -90,7 +90,7 @@ Tinytest.add("ecmascript - transpilation - helpers - objectWithoutProperties", (
 var {a, ...rest} = obj;
 `);
 
-  test.isTrue(contains(output, 'helpers/builtin/objectWithoutProperties'));
+  test.isTrue(/helpers\/(builtin\/)?objectWithoutProperties/.test(output));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - objectDestructuringEmpty", (test) => {
@@ -98,7 +98,7 @@ Tinytest.add("ecmascript - transpilation - helpers - objectDestructuringEmpty", 
 var {} = null;
 `);
 
-  test.isTrue(contains(output, 'helpers/builtin/objectDestructuringEmpty'));
+  test.isTrue(/helpers\/(builtin\/)?objectDestructuringEmpty/.test(output));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - taggedTemplateLiteralLoose", (test) => {
@@ -106,7 +106,7 @@ Tinytest.add("ecmascript - transpilation - helpers - taggedTemplateLiteralLoose"
 var x = asdf\`A\${foo}C\`
 `);
 
-  test.isTrue(contains(output, 'helpers/builtin/taggedTemplateLiteralLoose'));
+  test.isTrue(/helpers\/(builtin\/)?taggedTemplateLiteralLoose/.test(output));
 });
 
 Tinytest.add("ecmascript - transpilation - helpers - createClass", (test) => {
@@ -116,7 +116,7 @@ class Foo {
 }
 `);
 
-  test.isTrue(contains(output, 'helpers/builtin/createClass'));
+  test.isTrue(/helpers\/(builtin\/)?createClass/.test(output));
 });
 
 Tinytest.add("ecmascript - transpilation - flow", (test) => {

--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
     },
     "minipass": {
       "version": "2.2.1",
@@ -12,14 +12,14 @@
       "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q=="
     },
     "minizlib": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz",
-      "integrity": "sha1-1cGr93vhVGGZUuJTM27Mq5sqMvU="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.4.tgz",
+      "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ=="
     },
     "reify": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.12.3.tgz",
-      "integrity": "sha512-s13k0kuZbhBzeRoJQGomWnLj2y10wK3FYXRXbZoydowAMmY0jTiFN98TgLkaE8uZkVCaoq3djnDo7mksWLsx4g=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.13.1.tgz",
+      "integrity": "sha512-mwumMhtBZmKoDKamiCxufgUp7Jxugh9JFOlDYlZ7W3lEy9mXGNSHwasF0u9DDFd2ygqs3FRs/9iRp8uD8ClRqQ=="
     },
     "semver": {
       "version": "5.4.1",

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  reify: "0.12.3"
+  reify: "0.13.1"
 });
 
 Package.onUse(function(api) {

--- a/packages/non-core/coffeescript-compiler/package.js
+++ b/packages/non-core/coffeescript-compiler/package.js
@@ -13,7 +13,7 @@ Package.describe({
   summary: 'Compiler for CoffeeScript code, supporting the coffeescript package',
   // This version of NPM `coffeescript` module, with _1, _2 etc.
   // If you change this, make sure to also update ../coffeescript/package.js to match.
-  version: '2.0.3_1'
+  version: '2.0.3_2'
 });
 
 Npm.depends({
@@ -22,7 +22,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.use('babel-compiler@6.19.4');
+  api.use('babel-compiler@6.19.4||7.0.0');
   api.use('ecmascript@0.8.3');
 
   api.mainModule('coffeescript-compiler.js', 'server');

--- a/packages/non-core/coffeescript-test-helper/package.js
+++ b/packages/non-core/coffeescript-test-helper/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Used by the coffeescript package's tests",
-  version: "1.1.0"
+  version: "1.1.1"
 });
 
 Package.onUse(function (api) {
-  api.use('coffeescript@2.0.3_1', ['client', 'server']);
+  api.use('coffeescript@2.0.3_2', ['client', 'server']);
   api.export('COFFEESCRIPT_EXPORTED');
   api.export('COFFEESCRIPT_EXPORTED_ONE_MORE');
   api.export('COFFEESCRIPT_EXPORTED_WITH_BACKTICKS');

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -6,12 +6,12 @@ Package.describe({
   // so bumping the version of this package will be how they get newer versions
   // of `coffeescript-compiler`. If you change this, make sure to also update
   // ../coffeescript-compiler/package.js to match.
-  version: '2.0.3_1'
+  version: '2.0.3_2'
 });
 
 Package.registerBuildPlugin({
   name: 'compile-coffeescript',
-  use: ['caching-compiler@1.1.9', 'ecmascript@0.8.3', 'coffeescript-compiler@=2.0.3_1'],
+  use: ['caching-compiler@1.1.9', 'ecmascript@0.8.3', 'coffeescript-compiler@=2.0.3_2'],
   sources: ['compile-coffeescript.js']
 });
 

--- a/packages/tinytest/tinytest.js
+++ b/packages/tinytest/tinytest.js
@@ -70,8 +70,9 @@ export class TestCaseResults {
         var frame = stack[i];
         // Heuristic: use the OUTERMOST line which is in a :tests.js
         // file (this is less likely to be a test helper function).
-        if (frame.getFileName().match(/:tests\.js/)) {
-          doc.filename = frame.getFileName();
+        const fileName = frame.getFileName();
+        if (fileName && fileName.match(/:tests\.js/)) {
+          doc.filename = fileName;
           doc.line = frame.getLineNumber();
           break;
         }

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -15,7 +15,7 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/4e58fa55e2a0ba7dc75b26ff5273730d98335a85",
     "node-gyp": "3.6.2",
     "node-pre-gyp": "0.6.36",
-    "meteor-babel": "7.0.0-beta.34",
+    "meteor-babel": "7.0.0-beta.34-1",
     "meteor-promise": "0.8.6",
     promise: "8.0.1",
     reify: "0.13.1",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -15,12 +15,15 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/4e58fa55e2a0ba7dc75b26ff5273730d98335a85",
     "node-gyp": "3.6.2",
     "node-pre-gyp": "0.6.36",
-    "meteor-babel": "7.0.0-beta.3-2",
+    "meteor-babel": "7.0.0-beta.34",
     "meteor-promise": "0.8.6",
     promise: "8.0.1",
-    reify: "0.12.3",
+    reify: "0.13.1",
     fibers: "2.0.0",
-    // So that Babel 6 can emit require("babel-runtime/helpers/...") calls.
+    // So that Babel can emit require("@babel/runtime/helpers/...") calls.
+    "@babel/runtime": "7.0.0-beta.34",
+    // For backwards compatibility with isopackets that still depend on
+    // babel-runtime rather than @babel/runtime.
     "babel-runtime": "7.0.0-beta.3",
     // Not yet upgrading Underscore from 1.5.2 to 1.7.0 (which should be done
     // in the package too) because we should consider using lodash instead

--- a/tools/static-assets/skel-bare/package.json
+++ b/tools/static-assets/skel-bare/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2"
   }
 }

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2"
   }
 }

--- a/tools/static-assets/skel/package.json
+++ b/tools/static-assets/skel/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2"
   }
 }

--- a/tools/tests/apps/dev-bundle-bin-commands/package.json
+++ b/tools/tests/apps/dev-bundle-bin-commands/package.json
@@ -7,7 +7,7 @@
     "exit-normally": "echo \"This script will exit normally\" && exit 0"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2"
   }
 }

--- a/tools/tests/apps/dynamic-import/package.json
+++ b/tools/tests/apps/dynamic-import/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "acorn": "^4.0.11",
     "arson": "^0.2.3",
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2",
     "moment": "^2.17.1",
     "optimism": "^0.3.3",

--- a/tools/tests/apps/meteor-ignore/package.json
+++ b/tools/tests/apps/meteor-ignore/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "babel-runtime": "^7.0.0-beta.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2"
   }
 }

--- a/tools/tests/apps/modules/package.json
+++ b/tools/tests/apps/modules/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "aws-sdk": "^2.2.41",
     "babel-plugin-transform-do-expressions": "^6.22.0",
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "github": "^0.2.4",
     "idle-gc": "^1.0.1",
     "meteor-node-stubs": "^0.3.2",

--- a/tools/tests/apps/shell/package.json
+++ b/tools/tests/apps/shell/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2"
   }
 }

--- a/tools/tests/create.js
+++ b/tools/tests/create.js
@@ -21,8 +21,8 @@ selftest.define("create", function () {
   }
 
   const packageJson = JSON.parse(s.read("package.json"));
-  if (! packageJson.dependencies.hasOwnProperty("babel-runtime")) {
-    selftest.fail("New app package.json does not depend on babel-runtime");
+  if (! packageJson.dependencies.hasOwnProperty("@babel/runtime")) {
+    selftest.fail("New app package.json does not depend on @babel/runtime");
   }
 
   // Install basic packages like babel-runtime and meteor-node-stubs from

--- a/tools/tests/old/app-with-private/package.json
+++ b/tools/tests/old/app-with-private/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2"
   }
 }


### PR DESCRIPTION
Since Meteor 1.6, we've been quietly beta-testing Babel 7 by using it to compile [the `meteor` command-line tool codebase](https://github.com/meteor/meteor/tree/devel/tools). This [dog-fooding](https://en.wikipedia.org/wiki/Eating_your_own_dog_food) was vital when we first introduced Babel compilation in Meteor 1.2, and it later helped us gain confidence in the upgrade from Babel 5 to Babel 6. Now it's time to make the leap to Babel 7!

There are a number of important changes hidden behind the abstraction of [`meteor-babel`](https://github.com/meteor/babel/commits/master), but the most disruptive change that will be visible to application developers is that the [`babel-runtime`](https://www.npmjs.com/package/babel-runtime) package is now called [`@babel/runtime`](https://www.npmjs.com/package/@babel/runtime). Since this package is typically installed in the application `node_modules` directory, developers will likely need to run `meteor npm install @babel/runtime` and/or edit their `package.json` files.

Probably the next most disruptive change is that the Meteor `babel-compiler` package has jumped a major version, from 6.24.7 to 7.0.0, which may require packages that depend directly on `babel-compiler` to adjust their version constraints.

There are a few other notable changes, but I think it will be easier if I comment on the commits themselves, below.