### PR TITLE
Update to Cordova iOS v4.5.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -97,12 +97,14 @@
 * [`cordova-lib`](https://github.com/apache/cordova-cli) has been updated to
   version 7.1.0, [`cordova-android`](https://github.com/apache/cordova-android/)
   has been updated to version 6.3.0, and [`cordova-ios`](https://github.com/apache/cordova-ios/)
-  has been updated to version 4.5.3. The cordova-plugins `cordova-plugin-console`,
+  has been updated to version 4.5.4. The cordova-plugins `cordova-plugin-console`,
   `cordova-plugin-device-motion`, and `cordova-plugin-device-orientation` have been
   [deprecated](https://cordova.apache.org/news/2017/09/22/plugins-release.html)
   and will likely be removed in a future Meteor release.
   [Feature Request #196](https://github.com/meteor/meteor-feature-requests/issues/196)
   [PR #9213](https://github.com/meteor/meteor/pull/9213)
+  [Issue #9447](https://github.com/meteor/meteor/issues/9447)
+  [PR #9448](https://github.com/meteor/meteor/pull/9448)
 
 * Provide basic support for [iPhone X](https://developer.apple.com/ios/update-apps-for-iphone-x/)
   status bar and launch screens, which includes updates to

--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -55,11 +55,6 @@ const launchIosSizes = {
   'iphoneX_landscape': '2436x1125', 
   'ipad_portrait_2x': '1536x2048',
   'ipad_landscape_2x': '2048x1536',
-  // Not yet supported in Xcode 9 or Cordova iOS 4.5.3
-  // 'ipad_portrait_pro_10_5': '1668x2224',
-  // 'ipad_landscape_pro_10_5': '2224x1668',
-  // 'ipad_portrait_pro_12_9': '2048x2732',
-  // 'ipad_landscape_pro_12_9': '2732x2048',
   // Legacy
   'iphone': '320x480',
   'iphone_2x': '640x960',

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -15,7 +15,7 @@ export const CORDOVA_DEV_BUNDLE_VERSIONS = {
 
 export const CORDOVA_PLATFORM_VERSIONS = {
   'android': '6.3.0',
-  'ios': '4.5.3'
+  'ios': '4.5.4'
 };
 
 const PLATFORM_TO_DISPLAY_NAME_MAP = {


### PR DESCRIPTION
Update to Cordova iOS v4.5.4 to fix iPhone X splash screen issue.
Fixes https://github.com/meteor/meteor/issues/9447