### PR TITLE
Update URL for information about file watchers

### DIFF
--- a/tools/fs/safe-watcher.js
+++ b/tools/fs/safe-watcher.js
@@ -366,7 +366,7 @@ async function maybeSuggestRaisingWatchLimit(error) {
         "It looks like a simple tweak to your system's configuration will " +
           "make many tools (including this Meteor command) more efficient. " +
           "To learn more, see " +
-          Console.url("https://github.com/meteor/meteor/wiki/File-Change-Watcher-Efficiency"));
+          Console.url("https://github.com/meteor/docs/blob/master/long-form/file-change-watcher-efficiency.md"));
     }
   }
 }


### PR DESCRIPTION
The URL for the file watcher warning is out of date. Here it directly links to the new location.