### PR TITLE
Fix #9305 by including `default` when mirroring module exports.

### DIFF
--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -17,9 +17,9 @@
       "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ=="
     },
     "reify": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/reify/-/reify-0.13.1.tgz",
-      "integrity": "sha512-mwumMhtBZmKoDKamiCxufgUp7Jxugh9JFOlDYlZ7W3lEy9mXGNSHwasF0u9DDFd2ygqs3FRs/9iRp8uD8ClRqQ=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/reify/-/reify-0.13.3.tgz",
+      "integrity": "sha512-gIEzdATAGecCFSJgAqb7xyqdoTC9cXp4fOEP8IqyFrza91FIMSmvyvzM3pl2CLtc3ijP7bnDLjAe0eAsgKHwJA=="
     },
     "semver": {
       "version": "5.4.1",

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  reify: "0.13.1"
+  reify: "0.13.3"
 });
 
 Package.onUse(function(api) {

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -18,7 +18,7 @@ var packageJson = {
     "meteor-babel": "7.0.0-beta.34-1",
     "meteor-promise": "0.8.6",
     promise: "8.0.1",
-    reify: "0.13.1",
+    reify: "0.13.3",
     fibers: "2.0.0",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
     "@babel/runtime": "7.0.0-beta.34",

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -1203,7 +1203,10 @@ export class PackageSourceBatch {
       const parts = id.split("/");
 
       if ("./".indexOf(id.charAt(0)) < 0) {
-        const packageDir = parts[0];
+        const packageDir = parts[0].startsWith("@")
+          ? parts[0] + "/" + parts[1]
+          : parts[0];
+
         if (packageDir === "meteor") {
           // Don't print warnings for uninstalled Meteor packages.
           return;

--- a/tools/isobuild/import-scanner.js
+++ b/tools/isobuild/import-scanner.js
@@ -323,7 +323,7 @@ export default class ImportScanner {
       // paths, code, laziness, etc.
       sourceFile.dataString += [
         "module.watch(require(" + JSON.stringify(relativeId) + "), {",
-        '  "*": module.makeNsSetter()',
+        '  "*": module.makeNsSetter(true)',
         "});",
         ""
       ].join("\n");

--- a/tools/tests/apps/modules/package-lock.json
+++ b/tools/tests/apps/modules/package-lock.json
@@ -3,6 +3,15 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.34.tgz",
+      "integrity": "sha512-XmMTzvvZrQAyLGrzLyLyZprcfC5KsYc8ERbRNibJs0toeoAOGSJLsAKPXM++h7FLT+O4HILWZRA9uB7vEBFdpQ==",
+      "requires": {
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -14,9 +23,9 @@
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "aws-sdk": {
-      "version": "2.145.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.145.0.tgz",
-      "integrity": "sha1-CFu0VTIx3v2TuWsNlQI3F8nDwJM=",
+      "version": "2.168.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.168.0.tgz",
+      "integrity": "sha1-Vh4KIxuPcKK+5W/15Qi27/9gT+M=",
       "requires": {
         "buffer": "4.9.1",
         "crypto-browserify": "1.0.9",
@@ -49,15 +58,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-        }
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "base64-js": {
@@ -99,9 +101,9 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "core-js": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -138,7 +140,7 @@
       "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
       "integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=",
       "requires": {
-        "mime": "1.4.1"
+        "mime": "1.6.0"
       }
     },
     "iconv-lite": {
@@ -844,9 +846,9 @@
       }
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "moment": {
       "version": "2.11.1",
@@ -911,9 +913,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-      "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/tools/tests/apps/modules/package.json
+++ b/tools/tests/apps/modules/package.json
@@ -4,15 +4,15 @@
   "description": "Test app exercising many aspects of the Meteor module system.",
   "private": true,
   "dependencies": {
+    "@babel/runtime": "^7.0.0-beta.34",
     "aws-sdk": "^2.2.41",
     "babel-plugin-transform-do-expressions": "^6.22.0",
-    "@babel/runtime": "^7.0.0-beta.34",
     "github": "^0.2.4",
     "idle-gc": "^1.0.1",
     "meteor-node-stubs": "^0.3.2",
     "moment": "2.11.1",
     "mssql": "^3.1.1",
-    "regenerator-runtime": "^0.9.5",
+    "regenerator-runtime": "^0.11.1",
     "stripe": "^4.4.0",
     "uuid": "^3.1.0",
     "winston": "^2.3.1"

--- a/tools/tests/apps/modules/packages/modules-test-plugin/plugin.js
+++ b/tools/tests/apps/modules/packages/modules-test-plugin/plugin.js
@@ -30,9 +30,13 @@ class ArsonCompiler {
       encoded = arson.encode(decoded);
 
       file.addJavaScript({
-        path: file.getPathInPackage(),
-        data: 'module.exports = require("arson").decode(' +
-          '  ' + JSON.stringify(encoded) + ");",
+        path: file.getPathInPackage() + ".js",
+        data: [
+          'module.exportDefault(require("arson").decode(',
+          "  " + JSON.stringify(encoded),
+          "));",
+          ""
+        ].join("\n"),
         hash: file.getSourceHash()
       });
     });


### PR DESCRIPTION
Detailed explanation [here](https://github.com/meteor/meteor/issues/9305#issuecomment-351126362).

Underlying Reify functionality implemented [here](https://github.com/benjamn/reify/commit/10c90cd0a2bfc328964820799845ac3d5d69f493).

Note that this does not affect `export * from "./module"` (which still skips any `default` export), but only hand-written code of the form:
```js
module.watch(require("./module"), {
  "*": module.makeNsSetter(true)
});
```
The Reify compiler only generates code with `module.makeNsSetter()`, not `module.makeNsSetter(true)`, so this new functionality is backwards compatible with existing Reify-generated code.