### PR TITLE
Fix #9428 by registering dynamic-import HTTP endpoint earlier.

### DIFF
--- a/packages/dynamic-import/server.js
+++ b/packages/dynamic-import/server.js
@@ -34,7 +34,7 @@ Meteor.startup(() => {
 
   Object.keys(dynamicImportInfo).forEach(setUpPlatform);
 
-  Package.webapp.WebApp.connectHandlers.use(
+  Package.webapp.WebAppInternals.meteorInternalHandlers.use(
     fetchURL,
     middleware
   );

--- a/packages/non-core/bundle-visualizer/server.js
+++ b/packages/non-core/bundle-visualizer/server.js
@@ -106,7 +106,7 @@ Meteor.startup(() => {
     return;
   }
 
-  Package.webapp.WebApp.connectHandlers.use(
+  Package.webapp.WebAppInternals.meteorInternalHandlers.use(
     methodNameStats,
     statsMiddleware
   );

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -690,6 +690,10 @@ function runWebAppServer() {
     });
   });
 
+  // Core Meteor packages like dynamic-import can add handlers before
+  // other handlers added by package and application code.
+  app.use(WebAppInternals.meteorInternalHandlers = connect());
+
   // Packages and apps can add handlers to this via WebApp.connectHandlers.
   // They are inserted before our default handler.
   var packageAndAppHandlers = connect();


### PR DESCRIPTION
This should fix #9428.

Specifically, I've added an additional set of `connect` handlers that run before `WebApp.connectHandlers`, and that are meant for Meteor-internal HTTP endpoints, such as these:
```
/__meteor__/dynamic-import/fetch
/__meteor__/bundle-visualizer/stats
```

I'm not particularly worried about malicious use of this "private" feature by packages trying to register their handlers earlier. If that really seems like the best way to solve a problem, I just hope those packages take precautions to call `next()` as appropriate, and realize that we might change the way this feature works without notice (because it's supposed to be a private API).