### PR TITLE
Make `meteor deploy` synchronous

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1351,7 +1351,9 @@ main.registerCommand({
     // people to deploy from checkout or do other weird shit. We are not
     // responsible for the consequences.
     'override-architecture-with-local' : { type: Boolean },
-    'allow-incompatible-update': { type: Boolean }
+    'allow-incompatible-update': { type: Boolean },
+    'deploy-polling-timeout': { type: Number },
+    'no-wait': { type: Boolean },
   },
   allowUnrecognizedOptions: true,
   requiresApp: function (options) {
@@ -1412,12 +1414,21 @@ main.registerCommand({
     serverArch: buildArch
   };
 
+  let deployPollingTimeoutMs = null;
+  if (options['deploy-polling-timeout']) {
+    deployPollingTimeoutMs = options['deploy-polling-timeout'];
+  }
+
+  const waitForDeploy = !options['no-wait'];
+
   var deployResult = deploy.bundleAndDeploy({
     projectContext: projectContext,
     site: site,
     settingsFile: options.settings,
     buildOptions: buildOptions,
-    rawOptions
+    rawOptions,
+    deployPollingTimeoutMs,
+    waitForDeploy,
   });
 
   if (deployResult === 0) {

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -465,7 +465,7 @@ Reset the current project to a fresh state. Removes all local data.
 
 
 >>> deploy
-Deploy this project to Meteor.
+Deploy this project to Galaxy, Meteor's hosting service.
 Usage: meteor deploy <site> [--settings settings.json] [--debug] [--delete]
 
 Deploys the project in your current directory to Meteor's servers.
@@ -495,6 +495,11 @@ Options:
                   downgraded to versions that are potentially incompatible with
                   the current versions, if required to satisfy all package version
                   constraints.
+  --deploy-polling-timeout  The number of milliseconds to wait for build/deploy
+                  success or failure after a successful upload of your app's
+                  minified code; defaults to 15 minutes.
+  --no-wait       Exits when Meteor has uploaded the app's code instead of
+                  waiting for the deploy to conclude.
 
 >>> authorized
 View or change authorized users and organizations for a site.

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -22,6 +22,12 @@ import {
 import { recordPackages } from './stats.js';
 import { Console } from '../console/console.js';
 
+function sleepForMilliseconds(millisecondsToWait) {
+  return new Promise(function(resolve) {
+    let time = setTimeout(() => resolve(null), millisecondsToWait)
+  });
+}
+
 const hasOwn = Object.prototype.hasOwnProperty;
 
 const CAPABILITIES = ['showDeployMessages', 'canTransferAuthorization'];
@@ -43,8 +49,9 @@ const CAPABILITIES = ['showDeployMessages', 'canTransferAuthorization'];
 //
 // Options include:
 // - method: GET, POST, or DELETE. default GET
-// - operation: "info", "mongo", "deploy", "authorized-apps"
-// - site: site name
+// - operation: "info", "logs", "mongo", "deploy", "authorized-apps",
+//   "version-status"
+// - site: site name, version ID
 // - expectPayload: an array of key names. if present, then we expect
 //   the server to return JSON content on success and to return an
 //   object with all of these key names.
@@ -75,7 +82,13 @@ function deployRpc(options) {
   if (options.headers.cookie) {
     throw new Error("sorry, can't combine cookie headers yet");
   }
-  options.qs = Object.assign({}, options.qs, {capabilities: CAPABILITIES});
+  options.qs = Object.assign({}, options.qs,
+    {capabilities: CAPABILITIES.slice()});
+  // If we are waiting for deploy, we let Galaxy know so it can
+  // use that information to send us the right deploy message response.
+  if (options.waitForDeploy) {
+    options.qs.capabilities.push('willPollVersionStatus');
+  }
 
   const deployURLBase = getDeployURL(options.site).await();
 
@@ -174,7 +187,8 @@ function authedRpc(options) {
     site: rpcOptions.site,
     expectPayload: [],
     qs: options.qs,
-    printDeployURL: options.printDeployURL
+    printDeployURL: options.printDeployURL,
+    waitForDeploy: options.waitForDeploy,
   });
   delete rpcOptions.printDeployURL;
 
@@ -321,6 +335,113 @@ function canonicalizeSite(site) {
   return parsed.hostname;
 };
 
+// Executes the poll to check for deployment success and outputs proper messages
+// to user about the status of their app during the polling process
+async function pollForDeploymentSuccess(versionId, deployPollTimeout, result) {
+  // Create a default polling configuration for polling for deploy / build
+  // In the future, we may change this to be user-configurable or smart
+  // The user can only currently configure the polling timeout via a flag
+  const pollingState = new PollingState(deployPollTimeout);
+  await sleepForMilliseconds(pollingState.initialWaitTimeMs);
+  const deploymentPollResult = await pollForDeploy(pollingState, versionId);
+  if (deploymentPollResult && deploymentPollResult.isActive) {
+    return 0;
+  }
+  return 1;
+}
+
+// Creates a polling configuration with defaults if fields left unset
+// Right now we only use the default unless timeout is specified
+// We envision potentially creating this configuration object in a programmatic
+// way or via user-specification in the future.
+// Default initialWaitTime is 10 seconds – this is the time to wait before checking at all
+// Default pollInterval is 700 milliseconds – this is the wait interval between polls
+// Default timeout is 15 minutes
+// `start` tracks the time when we started polling
+// `currentMessage` tracks what the current status message is for this version
+class PollingState {
+  constructor(timeoutMs,
+    initialWaitTimeMs,
+    pollIntervalMs,
+    maxErrors) {
+      const FIFTEEN_MINUTES_MS = 15*60*1000;
+      const MAX_ERRORS = 5;
+      this.initialWaitTimeMs = initialWaitTimeMs || 10*1000;
+      this.pollIntervalMs = pollIntervalMs || 700;
+      this.deadline = timeoutMs ? new Date(new Date().getTime() + timeoutMs) :
+        new Date(new Date().getTime() + FIFTEEN_MINUTES_MS);
+      this.start = new Date();
+      this.currentMessage = '';
+      this.errors = 0;
+      this.maxErrors = maxErrors || MAX_ERRORS;
+  }
+}
+
+// Poll the "version-status" endpoint for the build and deploy status
+// of a specified version ID with a polling configuration.
+// This will only end successfully when the polling endpoint reports that
+// the version deployment is finished. The version-status endpoints will report
+// messages pertaining to the status of the version, which will then be reported
+// directly to the user. When the poll is complete, it will return an object
+// with information about the final state of the version and the app.
+async function pollForDeploy(pollingState, versionId, galaxyUrl) {
+  const {
+    deadline,
+    initialWaitTimeMs,
+    pollIntervalMs,
+    start,
+    currentMessage,
+  } = pollingState;
+
+  // Do a call to the version-status endpoint for the specified versionId
+  const versionStatusResult = deployRpc({
+    method: 'GET',
+    operation: 'version-status',
+    site: versionId,
+    expectPayload: ['message', 'finishStatus'],
+    printDeployURL: false,
+  });
+
+  // Check the details of the Version Status response and compare message to last call
+  if (versionStatusResult &&
+    versionStatusResult.payload &&
+    versionStatusResult.payload.message) {
+      const message = versionStatusResult.payload.message;
+      if (currentMessage !== message) {
+        Console.info(message);
+        pollingState.currentMessage = message;
+      }
+  } else {
+    // If we did not get a valid Version Status response, just fail silently and
+    // keep polling as per usual – this may have just been a whiff from Galaxy.
+    // We do the retry here because we might hit an error if we try to parse the
+    // result of the version-status call below.
+    Console.warn(versionStatusResult.errorMessage || 'Unexpected error from Galaxy');
+    pollingState.errors++;
+    if (pollingState.errors >= pollingState.maxErrors) {
+      Console.error(versionStatusResult.errorMessage);
+      return 1;
+    } else if (new Date() < deadline) {
+      await sleepForMilliseconds(pollIntervalMs);
+      return await pollForDeploy(pollingState, versionId);
+    }
+  }
+
+  const finishStatus = versionStatusResult.payload.finishStatus;
+  // Poll again if version isn't finished and we haven't exceeded the timeout
+  if(new Date() < deadline && !finishStatus.isFinished) {
+    // Wait for a set interval and then poll again
+    await sleepForMilliseconds(pollIntervalMs);
+    return await pollForDeploy(pollingState, versionId);
+  } else if (!finishStatus.isFinished) {
+    Console.info(`Polling timed out. To check the status of your app, visit
+    ${versionStatusResult.payload.galaxyUrl}. To wait longer, pass a timeout
+    in milliseconds to the '--deploy-polling-timeout' option of 'meteor deploy'.`);
+  }
+  return finishStatus;
+}
+
+
 // Run the bundler and deploy the result. Print progress
 // messages. Return a command exit code.
 //
@@ -334,7 +455,10 @@ function canonicalizeSite(site) {
 //   stats server.
 // - buildOptions: the 'buildOptions' argument to the bundler
 // - rawOptions: any unknown options that were passed to the command line tool
-export function bundleAndDeploy(options) {
+// - waitForDeploy: whether to poll Galaxy after upload for deploy status
+// - deployPollingTimeoutMs: user overridden timeout for polling Galaxy
+//   for deploy status
+export async function bundleAndDeploy(options) {
   if (options.recordPackageUsage === undefined) {
     options.recordPackageUsage = true;
   }
@@ -383,7 +507,7 @@ export function bundleAndDeploy(options) {
   var buildDir = mkdtemp('build_tar');
   var bundlePath = pathJoin(buildDir, 'bundle');
 
-  Console.info('Deploying your app...');
+  Console.info('Preparing to deploy your app...');
 
   var settings = null;
   var messages = buildmessage.capture({
@@ -434,6 +558,7 @@ export function bundleAndDeploy(options) {
       preflightPassword: preflight.preflightPassword,
       // Disable the HTTP timeout for this POST request.
       timeout: null,
+      waitForDeploy: options.waitForDeploy,
     });
   });
 
@@ -442,33 +567,22 @@ export function bundleAndDeploy(options) {
     return 1;
   }
 
+  // This will allow Galaxy to report messages to users ad-hoc
+  // Also if we are using the --no-wait flag, this will contain the message
+  // that Galaxy used to send after upload success.
   if (result.payload.message) {
     Console.info(result.payload.message);
-  } else {
-    var deployedAt = require('url').parse(result.payload.url);
-    var hostname = deployedAt.hostname;
-
-    Console.info('Now serving at http://' + hostname);
-
-    if (! hostname.match(/meteor\.com$/)) {
-      var dns = require('dns');
-      dns.resolve(hostname, 'CNAME', function (err, cnames) {
-        if (err || cnames[0] !== 'origin.meteor.com') {
-          dns.resolve(hostname, 'A', function (err, addresses) {
-            if (err || addresses[0] !== '107.22.210.133') {
-              Console.info('-------------');
-              Console.info(
-                "You've deployed to a custom domain.",
-                "Please be sure to CNAME your hostname",
-                "to origin.meteor.com, or set an A record to 107.22.210.133.");
-              Console.info('-------------');
-            }
-          });
-        }
-      });
-    }
   }
 
+  // After an upload succeeds, we want to poll Galaxy to see if the
+  // build / deploy succeed. We indicate that Meteor should poll for version
+  // status by including a newVersionId in the payload.
+  if (options.waitForDeploy && result.payload.newVersionId) {
+    return await pollForDeploymentSuccess(
+      result.payload.newVersionId,
+      options.deployPollingTimeoutMs,
+      result);
+  }
   return 0;
 };
 

--- a/tools/tests/galaxy.js
+++ b/tools/tests/galaxy.js
@@ -99,7 +99,7 @@ selftest.define('galaxy deploy - settings', ['galaxy'], function () {
   // Test that the app is actually running on Galaxy.
   checkAppIsRunning(appName, { text: "Hello" });
 
-  // Test that the public settins appear in the HTTP response body.
+  // Test that the public settings appear in the HTTP response body.
   if (! galaxyUtils.ignoreHttpChecks()) {
     testUtils.checkForSettings(appName, settings, 10);
   }


### PR DESCRIPTION
- This changes meteor deploy to poll the /version-status/ REST endpoint that Galaxy now exposes for the build and deploy status of the version being deployed
- Allows users to set a flag to change the polling timeout or to not wait at all
- Also fixes up some typos and outdated references


<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
