### PR TITLE
Define Sandbox `clients` when running `versioning hot code push test`.

### DIFF
--- a/tools/tests/hot-code-push.js
+++ b/tools/tests/hot-code-push.js
@@ -98,21 +98,22 @@ jquery`);
 });
 
 selftest.define("versioning hot code push", function (options) {
-  var s = new Sandbox();
+  var s = new Sandbox({
+    clients: options.clients,
+  });
 
   s.set("AUTOUPDATE_VERSION", "1.0");
   s.createApp("myapp", "hot-code-push-test");
   s.cd("myapp");
 
   s.testWithAllClients(function (run) {
-    run.baseTimeout = 20;
     run.match("myapp");
     run.match("proxy");
     run.match("MongoDB");
     run.match("running at");
     run.match("localhost");
     run.connectClient();
-    run.waitSecs(20);
+    run.waitSecs(40);
 
     run.match("client connected: 0");
 


### PR DESCRIPTION
Since this test utilizes the `testWithAllClients` technique, which runs
the tests in various clients/browsers, it's necessary for the tests
`Sandbox` to define `clients`, otherwise the function within
`testWithAllClients` will not be executed at all.  This was causing this
particular test to always return success (it was running without failure
on exactly zero clients).

Also the technique of setting `this.baseTimeout` appeared to cause
problems, likely because it overrides various other values instead of
using `waitSecs` (we don't use the `baseTimeout` technique in other
places within self-tests either).

Discovered during testing, as mentioned in
https://github.com/meteor/meteor/pull/9439#pullrequestreview-83139232.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
