### PR TITLE
prefetch dynamic modules when appcache is active

### DIFF
--- a/packages/dynamic-import/dynamic-versions.js
+++ b/packages/dynamic-import/dynamic-versions.js
@@ -80,5 +80,5 @@ function precacheOnLoad(event) {
 if (global.addEventListener) {
   global.addEventListener('load', precacheOnLoad, false);
 } else if (global.attachEvent) {
-  global.attachEvent('load', precacheOnLoad);
+  global.attachEvent('onload', precacheOnLoad);
 }

--- a/packages/dynamic-import/dynamic-versions.js
+++ b/packages/dynamic-import/dynamic-versions.js
@@ -61,7 +61,7 @@ if (Package.appcache) {
     // If we call module.prefetch(id) multiple times in the same tick of
     // the event loop, all those modules will be fetched in one request.
     function prefetchInChunks(modules, amount) {
-      var promises = Promise.all(modules.splice(0, amount).map(function (id) {
+      Promise.all(modules.splice(0, amount).map(function (id) {
         return module.prefetch(id)
       })).then(function () {
         if (modules.length > 0) {


### PR DESCRIPTION
This prefetches modules into the cache when the `appcache` package is detected.

As described in meteor/meteor-feature-requests#236

Couple of notes:

- I coped the useful `flattenModuleTree` from `client.js` - I'm sure there's a better way to do that
- I'm driving the initial preload off of window.load - I assume this is a good time to start it, as the initial application should already have been loaded, and started. I had it off of Meteor.startup at first, but window.load fires later - after images have loaded. If there's a better event, let me know.