### PR TITLE
Update minifier-js uglify-es dependency to latest version

### DIFF
--- a/History.md
+++ b/History.md
@@ -81,7 +81,7 @@
   ```
   [PR #9409](https://github.com/meteor/meteor/pull/9409)
 
-* The `minifier-js` package has been updated to use `uglify-es` 3.1.9.
+* The `minifier-js` package has been updated to use `uglify-es` 3.2.2.
 
 * The `request` npm package used by the `http` package has been upgraded
   to version 2.83.0.
@@ -135,7 +135,7 @@
 * `Accounts.config` now supports a `bcryptRounds` option that
   overrides the default 10 rounds currently used to secure passwords.
   [PR #9044](https://github.com/meteor/meteor/pull/9044)
-  
+
 * Developers running Meteor from an interactive shell within Emacs should
   notice a substantial performance improvement thanks to automatic
   disabling of the progress spinner, which otherwise reacts slowly.

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -12,9 +12,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "uglify-es": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.9.tgz",
-      "integrity": "sha512-wVSiJKHDgDDFmxTVVvnbAH6IpamAFHYDI+5JvwPdaqIMnk8kRTX2JKwq1Fx7gb2+Jj5Dus8kzvIpKkWOMNU51w=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.2.tgz",
+      "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug=="
     }
   }
 }

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "2.3.0"
+  version: "2.3.1"
 });
 
 Npm.depends({
-  "uglify-es": "3.1.9"
+  "uglify-es": "3.2.2"
 });
 
 Package.onUse(function (api) {

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '2.3.0',
+  version: '2.3.1',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md',
 });


### PR DESCRIPTION
I know we just went through this in https://github.com/meteor/meteor/pull/9368, but the `uglify-es` folks have released 4 new versions since that PR was merged. This PR updates to `uglify-es` 3.2.2, and will hopefully help fix https://github.com/meteor/meteor/issues/9430. Thanks!