### PR TITLE
Unescape ampersands in oauth redirect URLs

### DIFF
--- a/packages/oauth/end_of_redirect_response.js
+++ b/packages/oauth/end_of_redirect_response.js
@@ -4,9 +4,12 @@
 
   if (config.setCredentialToken) {
     sessionStorage[config.storagePrefix + config.credentialToken] =
-    config.credentialSecret;
+      config.credentialSecret;
   }
 
-  window.location = config.redirectUrl;
+  window.location =
+    config.redirectUrl
+      ? config.redirectUrl.replace(/&amp;/g, "&")
+      : config.redirectUrl;
 
 })();

--- a/packages/oauth/package.js
+++ b/packages/oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth-based services",
-  version: "1.2.0"
+  version: "1.2.1"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
When using the `oauth` package "redirect" `loginStyle`, the redirect URL is escaped before it is embedded in the HTML page that is used to finalize the oauth process. This escaped redirect URL is then assigned directly to `window.location` to finalize the redirect. Browsers can properly handle most of the escaped URL components, with the exception of HTML entity based ampersands: `&amp;`. The `&amp;`'s are left in the redirect URL after the redirect has completed, leading to broken redirects in some cases.

This PR makes sure `&amp;`'s are converted back to `&`'s before the redirect URL is assigned to
`window.location`.

Fixes #9279.