### PR TITLE
Bump MIN_NODE_VERSION to enforce Node >= 8 in production.

### DIFF
--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -592,7 +592,7 @@ Fiber(function () {
 
   // Check required Node version.
   // This code is duplicated in tools/server/boot.js.
-  var MIN_NODE_VERSION = 'v0.10.41';
+  var MIN_NODE_VERSION = 'v8.0.0';
   if (require('semver').lt(process.version, MIN_NODE_VERSION)) {
     Console.error(
       'Meteor requires Node ' + MIN_NODE_VERSION + ' or later.');

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -10,7 +10,7 @@ var npmRequire = require('./npm-require.js').require;
 var Profile = require('./profile.js').Profile;
 
 // This code is duplicated in tools/main.js.
-var MIN_NODE_VERSION = 'v0.10.41';
+var MIN_NODE_VERSION = 'v8.0.0';
 
 var hasOwn = Object.prototype.hasOwnProperty;
 


### PR DESCRIPTION
Clearly we haven't remembered to bump this version for some time now, which is too bad, because it could have provided a more helpful error for developers using an older version of Node in their non-Galaxy deployment environments: https://github.com/meteor/meteor/issues/9470

As a reminder, you can always find the exact version of Node that Meteor expects by examining the `.node_version.txt` file in the generated build archive.