### PR TITLE
Fix cordova lib dependency

### DIFF
--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -9,7 +9,7 @@ export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
   'cordova-lib': '7.1.0',
-  'cordova-common': '1.5.1',
+  'cordova-common': '2.1.1',
   'cordova-registry-mapper': '1.1.15',
 };
 


### PR DESCRIPTION
`cordova-lib@7.1.0` should use `cordova-common@2.1.1 ` as per https://github.com/apache/cordova-lib/blob/7.1.x/package.json and [this blog post](https://cordova.apache.org/news/2017/10/10/tools-release.html) . I missed this change in this PR https://github.com/meteor/meteor/pull/9213