### PR TITLE
Update meteor create --full to use meteortesting:mocha

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -797,11 +797,11 @@ main.registerCommand({
   // in the template's versions file).
 
   // Since some of the project skeletons include npm `devDependencies`, we need
-  // to make sure the current node environment is set to development (so those
-  // `devDependencies` are covered by `npm install`).
-  process.env.NODE_ENV = 'development';
-
-  require("./default-npm-deps.js").install(appPath);
+  // to make sure they're included when running `npm install`.
+  require("./default-npm-deps.js").install(
+    appPath,
+    { includeDevDependencies: true }
+  );
 
   var appNameToDisplay = appPathAsEntered === "." ?
     "current directory" : `'${appPathAsEntered}'`;

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -796,6 +796,11 @@ main.registerCommand({
   // the packages (or maybe an unpredictable subset based on what happens to be
   // in the template's versions file).
 
+  // Since some of the project skeletons include npm `devDependencies`, we need
+  // to make sure the current node environment is set to development (so those
+  // `devDependencies` are covered by `npm install`).
+  process.env.NODE_ENV = 'development';
+
   require("./default-npm-deps.js").install(appPath);
 
   var appNameToDisplay = appPathAsEntered === "." ?

--- a/tools/cli/default-npm-deps.js
+++ b/tools/cli/default-npm-deps.js
@@ -8,7 +8,7 @@ import {
 
 const INSTALL_JOB_MESSAGE = "installing npm dependencies";
 
-export function install(appDir) {
+export function install(appDir, options) {
   const packageJsonPath = pathJoin(appDir, "package.json");
   const needTempPackageJson = ! statOrNull(packageJsonPath);
 
@@ -25,9 +25,13 @@ export function install(appDir) {
   }
 
   const ok = buildmessage.enterJob(INSTALL_JOB_MESSAGE, function () {
-    const { runNpmCommand } = require("../isobuild/meteor-npm.js");
+    const npmCommand = ["install"];
+    if (options && options.includeDevDependencies) {
+      npmCommand.push("--production=false");
+    }
 
-    const installResult = runNpmCommand(["install"], appDir);
+    const { runNpmCommand } = require("../isobuild/meteor-npm.js");
+    const installResult = runNpmCommand(npmCommand, appDir);
     if (! installResult.success) {
       buildmessage.error(
         "Could not install npm dependencies for test-packages: " +

--- a/tools/static-assets/skel-full/.meteor/packages
+++ b/tools/static-assets/skel-full/.meteor/packages
@@ -21,6 +21,5 @@ kadira:flow-router      # FlowRouter is a very simple router for Meteor
 kadira:blaze-layout     # Layout manager for blaze (works well with FlowRouter)
 less                    # Leaner CSS language
 
-
-practicalmeteor:mocha             # A package for writing and running your meteor app and package tests with mocha
+meteortesting:mocha               # A package for writing and running your meteor app and package tests with mocha
 johanbrook:publication-collector  # Test a Meteor publication by collecting its output

--- a/tools/static-assets/skel-full/imports/api/links/links.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/links.tests.js
@@ -3,7 +3,7 @@
 // https://guide.meteor.com/testing.html
 
 import { Meteor } from 'meteor/meteor';
-import { assert } from 'meteor/practicalmeteor:chai';
+import { assert } from 'chai';
 import { Links } from './links.js';
 
 if (Meteor.isServer) {

--- a/tools/static-assets/skel-full/imports/api/links/methods.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/methods.tests.js
@@ -3,7 +3,7 @@
 // https://guide.meteor.com/testing.html
 
 import { Meteor } from 'meteor/meteor';
-import { assert } from 'meteor/practicalmeteor:chai';
+import { assert } from 'chai';
 import { Links } from './links.js';
 import './methods.js';
 

--- a/tools/static-assets/skel-full/imports/api/links/server/publications.tests.js
+++ b/tools/static-assets/skel-full/imports/api/links/server/publications.tests.js
@@ -2,7 +2,7 @@
 //
 // https://guide.meteor.com/testing.html
 
-import { assert } from 'meteor/practicalmeteor:chai';
+import { assert } from 'chai';
 import { Links } from '../links.js';
 import { PublicationCollector } from 'meteor/johanbrook:publication-collector';
 import './publications.js';

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -2,10 +2,14 @@
   "name": "~name~",
   "private": true,
   "scripts": {
-    "start": "meteor run"
+    "start": "meteor run",
+    "test": "meteor test --once --driver-package meteortesting:mocha"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.34",
     "meteor-node-stubs": "^0.3.2"
+  },
+  "devDependencies": {
+    "chai": "^4.1.2"
   }
 }


### PR DESCRIPTION
While looking into issue #9480 I noticed that running `meteor create --full` (`devel` branch) returns errors caused by the `--full` app skeleton using the deprecated `practicalmeteor:mocha` package. This PR replaces `practicalmeteor:mocha` with the more up to date and maintained `meteortesting:mocha` package, in the `--full` app skeleton, along with using `chai` from npm instead of `practicalmeteor:chai`.