### PR TITLE
Add back the possibility to use IstanbulJS as plugin

### DIFF
--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -390,12 +390,10 @@ var loadServerBundles = Profile("Load server bundles", function () {
     var scriptPath =
       parsedSourceMaps[absoluteFilePath] ? absoluteFilePath : fileInfoOSPath;
 
-    var script = new (require('vm').Script)(wrapped, {
+    var func = require('vm').runInThisContext(wrapped, {
       filename: scriptPath,
       displayErrors: true
     });
-
-    var func = script.runInThisContext();
 
     var args = [Npm, Assets];
 
@@ -403,10 +401,15 @@ var loadServerBundles = Profile("Load server bundles", function () {
       args.push(specialArgs[key]);
     });
 
-    infos.push({
-      fn: Profile(fileInfo.path, func),
-      args
-    });
+    if (meteorDebugFuture) {
+      infos.push({
+        fn: Profile(fileInfo.path, func),
+        args
+      });
+    } else {
+      // Allows us to use code-coverage if the debugger is not enabled
+      Profile(fileInfo.path, func).apply(global, args);
+    }
   });
 
   maybeWaitForDebuggerToAttach();


### PR DESCRIPTION
These changes are needed to get the plugin meteor-coverage working. IstanbulJS (shipped with meteor-coverage), can only generate the coverage-report for the code loaded after it's initialization. This is why the code, the plugin meteor-coverage contains, must be executed before the code is loaded, which should be tracked in the code-coverage. A suitable check I found was when a debugger isn't used, which makes it impossible to use code-coverage and the debugger at the same time. It's the only feasible condition I could come up with.

The package meteor-coverage also registers a hook of IstanbulJS which overwrites `vm.runInThisContext()` in order to start the coverage. As of now, IstanbulJS does not support overwriting `vm.Script.runInThisContext()`.

In order to get code-coverage fully working https://github.com/istanbuljs/istanbuljs/pull/99 and https://github.com/serut/meteor-coverage/pull/60 would need a merge as well - just for the record. These two merges change the way IstanbulJS hooks the method `vm.runInThisContext()`.

This will fix https://github.com/meteor/meteor/issues/9281