### PR TITLE
Add missing ecmascript dependency to accounts-* packages

### DIFF
--- a/packages/accounts-facebook/package.js
+++ b/packages/accounts-facebook/package.js
@@ -1,9 +1,10 @@
 Package.describe({
   summary: "Login service for Facebook accounts",
-  version: "1.3.0"
+  version: "1.3.1"
 });
 
 Package.onUse(function(api) {
+  api.use('ecmascript');
   api.use('accounts-base', ['client', 'server']);
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);

--- a/packages/accounts-github/package.js
+++ b/packages/accounts-github/package.js
@@ -1,9 +1,10 @@
 Package.describe({
   summary: 'Login service for Github accounts',
-  version: '1.4.0'
+  version: '1.4.1'
 });
 
 Package.onUse(function (api) {
+  api.use('ecmascript');
   api.use('accounts-base', ['client', 'server']);
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);

--- a/packages/accounts-google/package.js
+++ b/packages/accounts-google/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Login service for Google accounts",
-  version: "1.3.0"
+  version: "1.3.1"
 });
 
 Package.onUse(function(api) {
-  api.use(['underscore', 'random']);
+  api.use(['ecmascript', 'underscore', 'random']);
   api.use('accounts-base', ['client', 'server']);
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);

--- a/packages/accounts-meetup/package.js
+++ b/packages/accounts-meetup/package.js
@@ -1,9 +1,10 @@
 Package.describe({
   summary: 'Login service for Meetup accounts',
-  version: '1.4.0'
+  version: '1.4.1'
 });
 
 Package.onUse(function (api) {
+  api.use('ecmascript');
   api.use('accounts-base', ['client', 'server']);
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);

--- a/packages/accounts-meteor-developer/package.js
+++ b/packages/accounts-meteor-developer/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: 'Login service for Meteor developer accounts',
-  version: '1.4.0'
+  version: '1.4.1'
 });
 
 Package.onUse(function (api) {
-  api.use(['underscore', 'random']);
+  api.use(['ecmascript', 'underscore', 'random']);
   api.use('accounts-base', ['client', 'server']);
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);

--- a/packages/accounts-twitter/package.js
+++ b/packages/accounts-twitter/package.js
@@ -1,9 +1,10 @@
 Package.describe({
   summary: "Login service for Twitter accounts",
-  version: "1.4.0"
+  version: "1.4.1"
 });
 
 Package.onUse(function(api) {
+  api.use('ecmascript');
   api.use('underscore', ['server']);
   api.use('accounts-base', ['client', 'server']);
   // Export Accounts (etc) to packages using this one.

--- a/packages/accounts-weibo/package.js
+++ b/packages/accounts-weibo/package.js
@@ -1,9 +1,10 @@
 Package.describe({
   summary: "Login service for Sina Weibo accounts",
-  version: "1.3.0"
+  version: "1.3.1"
 });
 
 Package.onUse(function(api) {
+  api.use('ecmascript');
   api.use('accounts-base', ['client', 'server']);
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);


### PR DESCRIPTION
All external service `accounts-*` packages (`accounts-facebook`, `accounts-github`, etc.) are currently using ES2015 syntax ([example](https://github.com/meteor/meteor/blob/3f8c90a29f26ec6dc8ff55f736c36a68fa40398f/packages/accounts-facebook/facebook.js#L4)), but do not explicitly declare a dependency on the `ecmascript` package. This means the ES2015 syntax being used is not transpiled by Meteor, and can lead to issues like #9506. Since `accounts-base` and `accounts-password` both already have `ecmascript` as a dependency, this PR adds an `ecmascript` dependency to all external service `accounts-*` packages.

Fixes #9506.