### PR TITLE
Pass login type to client side Accounts.onLogin callbacks

### DIFF
--- a/History.md
+++ b/History.md
@@ -184,6 +184,7 @@
   successful password based login, `{ type: resume }` after a DDP reconnect,
   etc.).
   [Issue #5127](https://github.com/meteor/meteor/issues/5127)
+  [PR #9512](https://github.com/meteor/meteor/pull/9512)
 
 ## v1.6.0.1, 2017-12-08
 

--- a/History.md
+++ b/History.md
@@ -179,6 +179,12 @@
   supported/maintained.
   [PR #9445](https://github.com/meteor/meteor/pull/9445)  
 
+* Client side `Accounts.onLogin` callbacks now receive a login details
+  object, with the attempted login type (e.g. `{ type: password }` after a
+  successful password based login, `{ type: resume }` after a DDP reconnect,
+  etc.).
+  [Issue #5127](https://github.com/meteor/meteor/issues/5127)
+
 ## v1.6.0.1, 2017-12-08
 
 * Node has been upgraded to version

--- a/packages/accounts-base/accounts_client_tests.js
+++ b/packages/accounts-base/accounts_client_tests.js
@@ -71,3 +71,32 @@ Tinytest.addAsync(
     });
   }
 );
+
+Tinytest.addAsync(
+  'accounts - onLogin callback receives { type: "password" } param on login',
+  (test, done) => {
+    const onLogin = Accounts.onLogin((loginDetails) => {
+      test.equal('password', loginDetails.type);
+      onLogin.stop();
+      removeTestUser(done);
+    });
+    logoutAndCreateUser(test, done, () => {});
+  }
+);
+
+Tinytest.addAsync(
+  'accounts - onLogin callback receives { type: "resume" } param on ' +
+  'reconnect, if already logged in',
+  (test, done) => {
+    logoutAndCreateUser(test, done, () => {
+      const onLogin = Accounts.onLogin((loginDetails) => {
+        test.equal('resume', loginDetails.type);
+        onLogin.stop();
+        removeTestUser(done);
+      });
+
+      Meteor.disconnect();
+      Meteor.reconnect();
+    });
+  }
+);

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -160,6 +160,12 @@ export class AccountsCommon {
    * @summary Register a callback to be called after a login attempt succeeds.
    * @locus Anywhere
    * @param {Function} func The callback to be called when login is successful.
+   *                        The callback receives a single object that
+   *                        holds login details. This object contains the login
+   *                        result type (password, resume, etc.) on both the
+   *                        client and server. `onLogin` callbacks registered
+   *                        on the server also receive extra data, such
+   *                        as user details, connection information, etc.
    */
   onLogin(func) {
     return this._onLoginHook.register(func);

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -364,6 +364,7 @@ Ap._attemptLogin = function (
       ),
       result.options || {}
     );
+    ret.type = attempt.type;
     this._successfulLogin(methodInvocation.connection, attempt);
     return ret;
   }

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "A user account system",
-  version: "1.4.1"
+  version: "1.4.2"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Client side `Accounts.onLogin` callbacks are triggered after a successful login, but they're also triggered after a successful DDP reconnect (if already logged in). As discussed in #5127, some people think this is the correct behaviour, while others feel that `onLogin` callbacks should really only fire after a user has actually logged in (e.g. after using something like `Meteor.loginWithPassword`). Since people are split on the proper approach here, an alternative solution would be to provide client side `Accounts.onLogin` callbacks with a way to tell if they're being called after a login or after a reconnect, then let them decide what to do.

Server side `Accounts.onLogin` callbacks receive an object that contains various login details. One of those items is a login `type`, that can hold values like `password`, `resume`, etc. When a user completes a true password based login, the returned login `type` is `password`. When the user is already logged in but undergoes a DDP disconnect + reconnect, the returned login `type` is `resume`. This means server side `Accounts.onLogin` callbacks have a way to tell which type of login is happening, allowing them to respond accordingly.

This PR adjusts client side `Accounts.onLogin` callbacks such that they also receive a single login details object, that contains login type information. Unlike the server side login details object, the client side login details object only contains the login type (to help reduce network transfer overhead, make sure we're not exposing server details on the client we shouldn't be, etc.). 

This approach should give developers a better way to respond to different client side login types, and act accordingly.

Fixes #5127.