### PR TITLE
Avoid AppVeyor failures from EPERM errors

### DIFF
--- a/scripts/windows/appveyor/install.ps1
+++ b/scripts/windows/appveyor/install.ps1
@@ -15,12 +15,26 @@ If ($LASTEXITCODE -ne 0) {
   throw "Updating submodules failed."
 }
 
-Write-Host "Running 'meteor --get-ready'..." -ForegroundColor Magenta
-# By redirecting error to host, we avoid a shocking/false error color,
-# since --get-ready and --version can print (anything) to STDERR and
-# PowerShell will interpret that as something being terribly wrong.
-& "$meteorBat" --get-ready 2>&1 | Write-Host -ForegroundColor Green
+# The `meteor --get-ready` command is susceptible to EPERM errors, so 
+# we attempt it three times.
+$attempt = 3
+$success = $false
+while ($attempt -gt 0 -and -not $success) {
+
+  Write-Host "Running 'meteor --get-ready'..." -ForegroundColor Magenta
+  # By redirecting error to host, we avoid a shocking/false error color,
+  # since --get-ready and --version can print (anything) to STDERR and
+  # PowerShell will interpret that as something being terribly wrong.
+  & "$meteorBat" --get-ready 2>&1 | Write-Host -ForegroundColor Green
+
+  If ($LASTEXITCODE -eq 0) {
+    $success = $true
+  } else {
+    $attempt--
+  }
+
+}
 
 If ($LASTEXITCODE -ne 0) {
-  throw "Running .\meteor --get-ready failed."
+  throw "Running .\meteor --get-ready failed three times."
 }


### PR DESCRIPTION
We seem to get misleading AppVeyor failures a lot from EPERM errors on `meteor --get-ready`, so this PR modifies the script `install.ps1` to attempt three times before failing.