### PR TITLE
Test improvements to async_hooks support in node-fibers.

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.9.8
+BUNDLE_VERSION=8888.9999.0
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -10,7 +10,7 @@ var packageJson = {
   version: "0.0.0",
   dependencies: {
     "meteor-promise": "0.8.6",
-    fibers: "2.0.0",
+    fibers: "https://github.com/laverdet/node-fibers/tarball/c6fec5c378dc94f290382a44d60802541c0ac9c8",
     promise: "8.0.1",
     // Not yet upgrading Underscore from 1.5.2 to 1.7.0 (which should be done
     // in the package too) because we should consider using lodash instead

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -19,7 +19,7 @@ var packageJson = {
     "meteor-promise": "0.8.6",
     promise: "8.0.1",
     reify: "0.13.5",
-    fibers: "2.0.0",
+    fibers: "https://github.com/laverdet/node-fibers/tarball/c6fec5c378dc94f290382a44d60802541c0ac9c8",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
     "@babel/runtime": "7.0.0-beta.35",
     // For backwards compatibility with isopackets that still depend on


### PR DESCRIPTION
The [async_hooks API](https://nodejs.org/api/async_hooks.html) seems not entirely thread-aware, which can cause problems when fibers are used, since fibers behave a lot like threads from the perspective of Node/V8.

The author of [`node-fibers`](https://github.com/laverdet/node-fibers) (@laverdet) has found a way to save/restore the `async_hooks` stack, and wants feedback on the effectiveness of the changes: https://github.com/laverdet/node-fibers/issues/357#issuecomment-356175889

The relevant commit (not yet published to npm): https://github.com/laverdet/node-fibers/commit/c6fec5c378dc94f290382a44d60802541c0ac9c8

If these changes work, I hope to turn them into a proper Node PR, but in the meantime it seems useful to run Meteor's test suite against them.