### PR TITLE
Upgrade to Mongo 3.6

### DIFF
--- a/History.md
+++ b/History.md
@@ -340,6 +340,9 @@
   [Issue #5127](https://github.com/meteor/meteor/issues/5127)
   [PR #9512](https://github.com/meteor/meteor/pull/9512)
 
+* Mongo has been upgraded to version 3.6.2 for 64-bit OS', and 3.2.18 for
+  32-bit OS'.
+
 ## v1.6.0.1, 2017-12-08
 
 * Node has been upgraded to version

--- a/History.md
+++ b/History.md
@@ -342,6 +342,7 @@
 
 * Mongo has been upgraded to version 3.6.2 for 64-bit OS', and 3.2.18 for
   32-bit OS'.
+  [PR #9533](https://github.com/meteor/meteor/pull/9533)
 
 ## v1.6.0.1, 2017-12-08
 

--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -32,14 +32,14 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "mongodb": {
-      "version": "2.2.33",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
-      "integrity": "sha1-tTfEcdNKZlG0jzb9vyl1A0Dgi1A="
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
+      "integrity": "sha1-o09Zu+thdUrsQy3nLD/iFSakTBo="
     },
     "mongodb-core": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
-      "integrity": "sha1-pBizN6FKFJkPtRC5I97mqBMXPfg="
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
+      "integrity": "sha1-TEYTm986HwMt7ZHbSfOO7AFlkFA="
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: "2.2.33",
+  version: "2.2.34",
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "2.2.33"
+  mongodb: "2.2.34"
 });
 
 Package.onUse(function (api) {

--- a/scripts/admin/test-packages-with-mongo-versions.rb
+++ b/scripts/admin/test-packages-with-mongo-versions.rb
@@ -7,8 +7,8 @@
 require 'tmpdir'
 
 mongo_install_urls = {
-  "3.4.9" => "https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.4.9.tgz",
-  "3.2.15" => "https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.2.15.tgz",
+  "3.6.2" => "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.2.tgz",
+  "3.2.18" => "https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.2.15.tgz",
   "3.0.5" => "https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.0.5.tgz",
   "2.6.10" => "http://downloads.mongodb.org/osx/mongodb-osx-x86_64-2.6.10.tgz"
 }
@@ -29,7 +29,7 @@ puts "Putting output in: #{path_to_output}/"
 
 test_env = "TEST_PACKAGES_EXCLUDE=\"less\""
 
-["3.4.9", "3.2.15", "3.0.5", "2.6.10"].each do |mongo_version|
+["3.6.2", "3.2.18", "3.0.5", "2.6.10"].each do |mongo_version|
   puts "Installing and testing with Mongo #{mongo_version}..."
 
   Dir.mktmpdir "mongo_install" do |mongo_install_dir|

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -6,8 +6,8 @@ set -u
 UNAME=$(uname)
 ARCH=$(uname -m)
 NODE_VERSION=8.9.4
-MONGO_VERSION_64BIT=3.4.10
-MONGO_VERSION_32BIT=3.2.15
+MONGO_VERSION_64BIT=3.6.2
+MONGO_VERSION_32BIT=3.2.18
 NPM_VERSION=5.6.0
 
 # If we built Node from source on Jenkins, this is the build number.

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -219,11 +219,11 @@ Function Add-NodeAndNpm {
 }
 
 Function Add-Mongo {
-  # Mongo 3.4 no longer supports 32-bit (x86) architectures, so we package
-  # the latest 3.2 version of Mongo for those builds and 3.4+ for x64.
+  # Mongo >= 3.4 no longer supports 32-bit (x86) architectures, so we package
+  # the latest 3.2 version of Mongo for those builds and >= 3.4 for x64.
   $mongo_filenames = @{
     windows_x86 = "mongodb-win32-i386-${MONGO_VERSION_32BIT}"
-    windows_x64 = "mongodb-win32-x86_64-2008plus-${MONGO_VERSION_64BIT}"
+    windows_x64 = "mongodb-win32-x86_64-2008plus-ssl-${MONGO_VERSION_64BIT}"
   }
 
   $previousCwd = $PWD

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -49,11 +49,22 @@ extractNodeFromTarGz || downloadNodeFromS3 || downloadOfficialNode
 # by default. Will download a 32-bit version of Mongo if using a 32-bit based
 # OS.
 MONGO_VERSION=$MONGO_VERSION_64BIT
+MONGO_SSL="-ssl"
+
+# The MongoDB "Generic" Linux option is not offered with SSL, which is reserved
+# for named distributions.  This works out better since the SSL support adds
+# size to the dev bundle though isn't necessary for local development.
+if [ $UNAME = "Linux" ]; then
+  MONGO_SSL=""
+fi
+
 if [ $ARCH = "i686" ]; then
   MONGO_VERSION=$MONGO_VERSION_32BIT
 fi
+
 MONGO_NAME="mongodb-${OS}-${ARCH}-${MONGO_VERSION}"
-MONGO_TGZ="${MONGO_NAME}.tgz"
+MONGO_NAME_SSL="mongodb-${OS}${MONGO_SSL}-${ARCH}-${MONGO_VERSION}"
+MONGO_TGZ="${MONGO_NAME_SSL}.tgz"
 MONGO_URL="http://fastdl.mongodb.org/${OS}/${MONGO_TGZ}"
 echo "Downloading Mongo from ${MONGO_URL}"
 curl "${MONGO_URL}" | tar zx

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -61,9 +61,6 @@ function spawnMongod(mongodPath, port, dbPath, replSetName) {
   // Use mmapv1 on 32bit platforms, as our binary doesn't support WT
   if (process.arch === 'ia32') {
     args.push('--storageEngine', 'mmapv1', '--smallfiles');
-  } else {
-    // The WT journal seems to be at least 300MB, which is just too much
-    args.push('--nojournal');
   }
 
   return child_process.spawn(mongodPath, args, {


### PR DESCRIPTION
This PR updates the Meteor Tool to use Mongo 3.6.2 for 64-bit OS' and Mongo 3.2.18 for 32-bit OS' (I've left the garbage `BUNDLE_VERSION` in place intentionally, since these changes will require a new `dev_bundle` publish from MDG). 

A few important mentions:

- As of Mongo 3.6, all Mongo binary downloads include SSL - there is no longer a non-SSL based download bundle (so it's a bit bigger, but that shouldn't be an issue).
- Using the `--nojournal` option with WiredTiger based replica sets is no longer supported (see https://jira.mongodb.org/browse/SERVER-30760). The `--nojournal` flag was added in https://github.com/meteor/meteor/commit/bcfe072d5233be5892f715d27ca9dce69089242d to help reduce the amount of disk space used by Mongo, but since this option is no longer supported, we'll have to live with the extra disk space usage.

**Mongo Node driver side note:**

The Mongo Node driver has recently jumped into the 3.x range, and has introduced a [few breaking changes](https://github.com/mongodb/node-mongodb-native/blob/HEAD/HISTORY.md). While we normally bump the Mongo Node driver to the most recent version when doing Mongo updates, I've left it in 2.x range for now. I'll submit a separate Mongo Node driver 3.x update PR, so we can keep the focus on the Mongo upgrade here. Mongo 3.6 will work with 2.x versions of the Mongo Node driver.

Thanks!