### PR TITLE
Make "meteor-dev-bundle" and "meteor-dev-bundle-tool" packages private

### DIFF
--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -6,8 +6,7 @@
 
 var packageJson = {
   name: "meteor-dev-bundle",
-  // Version is not important but is needed to prevent warnings.
-  version: "0.0.0",
+  private: true,
   dependencies: {
     "meteor-promise": "0.8.6",
     fibers: "2.0.0",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -6,8 +6,7 @@
 
 var packageJson = {
   name: "meteor-dev-bundle-tool",
-  // Version is not important but is needed to prevent warnings.
-  version: "0.0.0",
+  private: true,
   dependencies: {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version


### PR DESCRIPTION
Since these packages aren't published to the npm registry, they can be made private to avoid unnecessary warnings about missing description, repository, and license fields when installing server dependencies and generating dev bundles.

Example output of `npm install` in the `programs/server` directory of a production bundle:

Before:

```
  ...

  "node": "8.4.0",
  "openssl": "1.0.2l",
  "tz": "2017b",
  "unicode": "9.0",
  "uv": "1.13.1",
  "v8": "6.0.286.52",
  "zlib": "1.2.11"
}
npm WARN meteor-dev-bundle@0.0.0 No description
npm WARN meteor-dev-bundle@0.0.0 No repository field.
npm WARN meteor-dev-bundle@0.0.0 No license field.

added 136 packages in 11.314s
```

After:

```
  ...

  "node": "8.4.0",
  "openssl": "1.0.2l",
  "tz": "2017b",
  "unicode": "9.0",
  "uv": "1.13.1",
  "v8": "6.0.286.52",
  "zlib": "1.2.11"
}
added 136 packages in 9.028s
```