### PR TITLE
Always include es5-shim in Cordova JS bundles.

### DIFF
--- a/packages/es5-shim/package.js
+++ b/packages/es5-shim/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "es5-shim",
-  version: "4.7.0",
+  version: "4.7.1",
   summary: "Shims and polyfills to improve ECMAScript 5 support",
   documentation: "README.md"
 });
@@ -9,6 +9,12 @@ Package.onUse(function(api) {
   api.use("modules");
   api.use("server-render");
   api.use("shim-common");
+
+  // Since Cordova renders boilerplate HTML at build time, and doesn't use
+  // the server-render system through the webapp package, it's important
+  // that we include es5-shim (and sham) statically for Cordova clients.
+  api.addFiles("es5-shim-sham.js", "web.cordova");
+
   api.mainModule("console.js", "client");
   api.mainModule("server.js", "server");
   api.addAssets([


### PR DESCRIPTION
Since Cordova renders boilerplate HTML at build time, and doesn't use the server-render system through the webapp package, it's important that we include `es5-shim` (and sham) statically for Cordova clients.

This logic will go away once we have the `web.browser.legacy` system to control differential bundling (#9439), but for now it's necessary for any Cordova clients that still don't have full ECMAScript 5 support.