### PR TITLE
Add a self-test skip option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,13 +91,10 @@ build_machine_environment: &build_machine_environment
     METEOR_SAVE_TMPDIRS: 1
 
     # Skip these tests on every test run.
-    # For readability, this is a regex wrapped across multiple lines in quotes.
-    SELF_TEST_EXCLUDE: "\
-        ^old cli tests|\
-        ^minifiers can't register non-js|\
-        ^minifiers: apps can't use|\
-        ^compiler plugins - addAssets\
-        "
+    # If needed, for readability this should be a regex wrapped across
+    # multiple lines in quotes.
+    SELF_TEST_EXCLUDE: ""
+
     # These will be evaled before each command.
     PRE_TEST_COMMANDS: |-
         ulimit -c unlimited; # Set core dump size as Ubuntu 14.04 lacks prlimit.

--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## v.NEXT
 
+* Individual Meteor `self-test`'s can now be skipped by adjusting their
+  `define` call to be prefixed by `skip`. For example,
+  `selftest.skip.define('some test', ...` will skip running "some test".
+  [PR #9579](https://github.com/meteor/meteor/pull/9579)
+
 ## v1.6.1, 2018-01-19
 
 * Node has been updated to version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,12 +15,7 @@ environment:
   TOOL_NODE_FLAGS: --expose-gc
   TIMEOUT_SCALE_FACTOR: 8
   METEOR_HEADLESS: true
-  SELF_TEST_EXCLUDE: "\
-      ^old cli tests|\
-      ^minifiers can't register non-js|\
-      ^minifiers: apps can't use|\
-      ^compiler plugins - addAssets|\
-      ^NULL-LEAVE-THIS-HERE-NULL$"
+  SELF_TEST_EXCLUDE: "^NULL-LEAVE-THIS-HERE-NULL$"
 platform:
   - x64
 

--- a/tools/tests/command-line.js
+++ b/tools/tests/command-line.js
@@ -445,7 +445,7 @@ selftest.define("rails reminders", function () {
   run.expectExit(1);
 });
 
-selftest.define("old cli tests (converted)", function () {
+selftest.skip.define("old cli tests (converted)", function () {
   var s = new Sandbox;
   var run;
 

--- a/tools/tests/compiler-plugins.js
+++ b/tools/tests/compiler-plugins.js
@@ -416,7 +416,7 @@ selftest.define("compiler plugins - compiler addAsset", () => {
 
 // Test that a package can have a single file that is both source code and an
 // asset
-selftest.define("compiler plugins - addAssets", () => {
+selftest.skip.define("compiler plugins - addAssets", () => {
   const s = new Sandbox({ fakeMongo: true });
 
   s.createApp('myapp', 'compiler-plugin-asset-and-source');

--- a/tools/tests/minifier-bad-plugins.js
+++ b/tools/tests/minifier-bad-plugins.js
@@ -1,7 +1,7 @@
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 
-selftest.define("minifiers can't register non-js/non-css extensions", [], function () {
+selftest.skip.define("minifiers can't register non-js/non-css extensions", [], function () {
   var s = new Sandbox();
   var run;
 
@@ -13,7 +13,7 @@ selftest.define("minifiers can't register non-js/non-css extensions", [], functi
   run.stop();
 });
 
-selftest.define("minifiers: apps can't use more than one package providing a minifier for the same extension", [], function () {
+selftest.skip.define("minifiers: apps can't use more than one package providing a minifier for the same extension", [], function () {
   var s = new Sandbox();
   var run;
 
@@ -24,4 +24,3 @@ selftest.define("minifiers: apps can't use more than one package providing a min
   run.match("local-plugin, local-plugin-2: multiple packages registered minifiers for extension \"js\".");
   run.stop();
 });
-

--- a/tools/tests/old.js
+++ b/tools/tests/old.js
@@ -87,7 +87,7 @@ selftest.define("bundler-npm", ["slow", "net", "checkout"], function () {
 // in release mode. If we're not running from a checkout, just run it
 // against the installed copy.
 
-selftest.define("old cli tests (bash)", ["slow", "net", "yet-unsolved-windows-failure"], function () {
+selftest.skip.define("old cli tests (bash)", ["slow", "net", "yet-unsolved-windows-failure"], function () {
   var s = new Sandbox;
   var scriptToRun = files.pathJoin(files.convertToStandardPath(__dirname),
     'old', 'cli-test.sh');

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -153,9 +153,13 @@ export function define(name, tagsList, f) {
 
 // Prevent specific self-test's from being defined and run.
 // e.g. `selftest.skip.define("some test", ...` will skip running "some test".
+const selftestDefine = define;
 export const skip = {
-  define(testName) {
-    Console.info(`Ignoring "${testName}" test (excluded by selftest.skip)`);
+  define(name, tagsList, f) {
+    if (typeof tagsList === 'function') {
+      f = tagsList;
+    }
+    selftestDefine(name, ['manually-ignored'], f);
   }
 };
 
@@ -178,6 +182,7 @@ const tagDescriptions = {
   // These tests require a setup step which can be amortized across multiple
   // similar tests, so it makes sense to segregate them
   'custom-warehouse': "requires a custom warehouse",
+  'manually-ignored': 'excluded by selftest.skip'
 };
 
 // Returns a TestList object representing a filtered list of tests,
@@ -272,6 +277,8 @@ function getFilteredTests(options) {
   } else {
     tagsToSkip.push("windows");
   }
+
+  tagsToSkip.push('manually-ignored');
 
   const tagsToMatch = options['with-tag'] ? [options['with-tag']] : [];
   return new TestList(allTests, tagsToSkip, tagsToMatch, testState);

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -151,7 +151,7 @@ export function define(name, tagsList, f) {
   }));
 }
 
-// Prevent specific self-test's from being defined and run.
+// Prevent specific self-test's from being run.
 // e.g. `selftest.skip.define("some test", ...` will skip running "some test".
 const selftestDefine = define;
 export const skip = {

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -154,8 +154,8 @@ export function define(name, tagsList, f) {
 // Prevent specific self-test's from being defined and run.
 // e.g. `selftest.skip.define("some test", ...` will skip running "some test".
 export const skip = {
-  define() {
-    /* no-op */
+  define(testName) {
+    Console.info(`Ignoring "${testName}" test (excluded by selftest.skip)`);
   }
 };
 

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -151,6 +151,14 @@ export function define(name, tagsList, f) {
   }));
 }
 
+// Prevent specific self-test's from being defined and run.
+// e.g. `selftest.skip.define("some test", ...` will skip running "some test".
+export const skip = {
+  define() {
+    /* no-op */
+  }
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // Choosing tests
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
While doing some test work on another PR, I accidentally ran a `meteor self-test` without my usual `--exclude` list. When that happened, I noticed that  https://github.com/meteor/meteor/commit/cc472785641edc8d5d6c5da152ff00166c3d6e72 broke one of the `command-line: old cli tests (converted)` self-test's, that is no longer usually called (it's currently excluded by the CI configs).  Looking into fixing this has sent me on a complete tangent (it must be Friday 🙂), leading to this PR ...

Meteor's CI infrastructure is configured to exclude certain `self-test`'s on each run. These excludes are specified in each CI environment's config file, and included when running `meteor self-test`. Developers running `meteor self-test` locally however are not using these excludes by default, so developer's have to manually look up the current exclude list from one of the CI configs, then add these excludes to their own `meteor self-test` call manually.

This commit adds a new `skip` option to Meteor's `self-test` system, that can be used to skip adding/running a defined `self-test` (similar in concept to Mocha's `skip` feature). This provides a way to skip the running of older `self-test`'s that are no longer needed, but allows them to be preserved in the `self-test` suite, for future reference. With this functionality in place, and the older test suites updated to use it, Meteor's base CI excludes no longer need to be maintained in their respective config files. The excludes are all managed at the source (the test definition), and can be leveraged by anyone/anything calling `meteor self-test`.

Thanks!