### PR TITLE
Remove underscore from meteor-base

### DIFF
--- a/History.md
+++ b/History.md
@@ -15,6 +15,16 @@
   `meteor-babel` now runs with the `loose:true` option, as required by
   other (optional) plugins like `@babel/plugin-proposal-decorators`.
   [Issue #9628](https://github.com/meteor/meteor/issues/9628)
+  
+* The `underscore` package has been removed as a dependency from `meteor-base`.
+  This opens up the possibility of removing 14.4 kb from production bundles.
+  Since this would be a breaking change for any apps may have been using `_` 
+  without having any packages that depend on `underscore` besides `meteor-base`,
+  we have added an upgrader that will automatically add `underscore` to the
+  `.meteor/packages` file of any project which lists `meteor-base`, but not
+  `underscore`. Apps which do not require this package can safely remove it
+  using `meteor remove underscore`.
+  [PR #9596](https://github.com/meteor/meteor/pull/9596)
 
 ## v1.6.1, 2018-01-19
 

--- a/History.md
+++ b/History.md
@@ -18,12 +18,12 @@
   
 * The `underscore` package has been removed as a dependency from `meteor-base`.
   This opens up the possibility of removing 14.4 kb from production bundles.
-  Since this would be a breaking change for any apps may have been using `_` 
-  without having any packages that depend on `underscore` besides `meteor-base`,
-  we have added an upgrader that will automatically add `underscore` to the
-  `.meteor/packages` file of any project which lists `meteor-base`, but not
-  `underscore`. Apps which do not require this package can safely remove it
-  using `meteor remove underscore`.
+  Since this would be a breaking change for any apps that may have been 
+  using `_` without having any packages that depend on `underscore` 
+  besides `meteor-base`, we have added an upgrader that will automatically 
+  add `underscore` to the `.meteor/packages` file of any project which 
+  lists `meteor-base`, but not `underscore`. Apps which do not require this 
+  package can safely remove it using `meteor remove underscore`.
   [PR #9596](https://github.com/meteor/meteor/pull/9596)
 
 ## v1.6.1, 2018-01-19

--- a/packages/meteor-base/package.js
+++ b/packages/meteor-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'meteor-base',
-  version: '1.3.0',
+  version: '1.4.0',
   // Brief, one-line summary of the package.
   summary: 'Packages that every Meteor app needs',
   // By default, Meteor will default to using README.md for documentation.
@@ -17,9 +17,6 @@ Package.onUse(function(api) {
     // only supports building client/server web applications so this is not
     // removable
     'webapp',
-
-    // Most Meteor core packages depend on Underscore right now
-    'underscore',
 
     // The protocol and client/server libraries that Meteor uses to send data
     'ddp',

--- a/tools/tests/apps/custom-minifier/.meteor/packages
+++ b/tools/tests/apps/custom-minifier/.meteor/packages
@@ -1,3 +1,4 @@
 meteor-base
 custom-minifier
 blaze-html-templates
+ecmascript

--- a/tools/tests/apps/custom-minifier/code.js
+++ b/tools/tests/apps/custom-minifier/code.js
@@ -1,6 +1,6 @@
 if (Meteor.isClient) {
   Meteor.startup(function () {
-    _.each(['production_css', 'development_css'], function (cls) {
+    ['production_css', 'development_css'].forEach(cls => {
       var color = getComputedStyle(document.querySelectorAll('.' + cls)[0]).color;
       Meteor.call('print', cls + ': ' + color);
     });

--- a/tools/tests/apps/ddp-heartbeat/.meteor/packages
+++ b/tools/tests/apps/ddp-heartbeat/.meteor/packages
@@ -4,5 +4,4 @@
 # but you can also edit it by hand.
 
 meteor-base
-underscore
 tracker

--- a/tools/tests/apps/ddp-heartbeat/server/heartbeat_test.js
+++ b/tools/tests/apps/ddp-heartbeat/server/heartbeat_test.js
@@ -54,7 +54,7 @@ var expectConnectAndReconnect = function (clientConnection) {
 var testClientTimeout = function () {
   console.log("Test client timeout");
 
-  var savedServerOptions = _.clone(Meteor.server.options);
+  var savedServerOptions = { ...Meteor.server.options };
   Meteor.server.options.heartbeatInterval = 0;
   Meteor.server.options.respondToPings = false;
 

--- a/tools/tests/apps/failover-test/.meteor/packages
+++ b/tools/tests/apps/failover-test/.meteor/packages
@@ -5,5 +5,4 @@
 
 meteor
 mongo-livedata
-underscore
 random

--- a/tools/tests/apps/failover-test/server/failover-test.js
+++ b/tools/tests/apps/failover-test/server/failover-test.js
@@ -69,7 +69,7 @@ C.find().observeChanges({
       Meteor.clearTimeout(nextStepTimeout);
       nextStepTimeout = null;
     }
-    if (!fields.step && _.has(steps, fields.step)) {
+    if (!fields.step && Object.prototoype.hasOwnProperty.call(steps, fields.step)) {
       console.log('Unexpected step:', fields.step);
       process.exit(1);
     }

--- a/tools/tests/apps/modules/.meteor/packages
+++ b/tools/tests/apps/modules/.meteor/packages
@@ -23,3 +23,4 @@ client-only-ecmascript
 modules-test-plugin
 shell-server@0.3.1
 dynamic-import@0.3.0
+underscore

--- a/tools/tests/apps/modules/tests.js
+++ b/tools/tests/apps/modules/tests.js
@@ -124,9 +124,9 @@ describe("template modules", () => {
   Meteor.isClient &&
   it("should be importable on the client", () => {
     assert.strictEqual(typeof Template, "function");
-    assert.ok(! _.has(Template, "lazy"));
+    assert.ok(! Object.prototype.hasOwnProperty.call(Template, "lazy"));
     require("./imports/lazy.html");
-    assert.ok(_.has(Template, "lazy"));
+    assert.ok(Object.prototype.hasOwnProperty.call(Template, "lazy"));
     assert.ok(Template.lazy instanceof Template);
   });
 

--- a/tools/upgraders.js
+++ b/tools/upgraders.js
@@ -291,6 +291,25 @@ be removed if there is no need for the Blaze configuration interface.`,
     packagesFile.writeIfModified();
   },
 
+  '1.6.2-split-underscore-from-meteor-base': projectContext => {
+    const packagesFile = projectContext.projectConstraintsFile;
+    if (! packagesFile.getConstraint(`underscore`) &&
+      packagesFile.getConstraint(`meteor-base`)) {
+
+      maybePrintNoticeHeader();
+      Console.info(
+`The underscore package has been removed as a dependency of all packages in \
+meteor-base. Since some apps may have been using underscore through this \
+dependency without having it listed in their .meteor/packages files, it has \
+been added automatically. If your app is not using underscore, then you can \
+safely remove it using 'meteor remove underscore'.`,
+        Console.options({ bulletPoint: "1.6.2: " })
+      );
+      packagesFile.addPackages([`underscore`]);
+      packagesFile.writeIfModified();
+    }
+  }
+
   ////////////
   // PLEASE. When adding new upgraders that print mesasges, follow the
   // examples for 0.9.0 and 0.9.1 above. Specifically, formatting

--- a/tools/upgraders.js
+++ b/tools/upgraders.js
@@ -291,7 +291,7 @@ be removed if there is no need for the Blaze configuration interface.`,
     packagesFile.writeIfModified();
   },
 
-  '1.6.2-split-underscore-from-meteor-base': projectContext => {
+  '1.6.2-split-underscore-from-meteor-base': function (projectContext) {
     const packagesFile = projectContext.projectConstraintsFile;
     if (! packagesFile.getConstraint(`underscore`) &&
       packagesFile.getConstraint(`meteor-base`)) {


### PR DESCRIPTION
This should shave down bundle sizes by 14.4 kb for many non-blaze projects.

The other core meteor packages have not depended on `underscore` since #9362. However, we are only able to remove this last dependency now due to the the first commit in this PR, which eliminates usages of `underscore` from apps that did not have the package listed in their `packages` files. This was causing CI test failures that now should be corrected.

Any meteor apps currently using `_` without `underscore` listed in their `packages` file will need to add the package explicitly.

`meteor-base` version number bumped from 1.3.0 to 1.3.1.

#### Adjustments to test apps:
There are only a few uses of `underscore` in these apps, and two of them actually used `underscore` without having it explicitly listed in their `packages` file.

This is a problem, because the apps were relying on the dependency from `meteor-base`, which we want to remove to cut down bundle sizes.

For the `modules` test app, I've added `underscore` to the `packages` file, because it is asserting that `require('meteor/underscore')._` equals `_`. For the other app and all other uses of `_`, rather than add `underscore` to the `packages` files, I took the modernization route and replaced the functions with their ES6 equivalents, and then removed `underscore` from all `packages` files.