### PR TITLE
Modernize browser-policy packages

### DIFF
--- a/packages/browser-policy-common/browser-policy-common.js
+++ b/packages/browser-policy-common/browser-policy-common.js
@@ -4,11 +4,18 @@ const BrowserPolicy = {};
 
 let inTest = false;
 
-BrowserPolicy._runningTest = () => inTest;
+Object.assign(BrowserPolicy, {
+  _runningTest() {
+    return inTest;
+  },
 
-BrowserPolicy._setRunningTest = () => inTest = true;
+  _setRunningTest() {
+    inTest = true;
+  },
+})
 
 WebApp.connectHandlers.use((req, res, next) => {
+  
   // Never set headers inside tests because they could break other tests.
   if (BrowserPolicy._runningTest()) {
     return next();
@@ -21,9 +28,11 @@ WebApp.connectHandlers.use((req, res, next) => {
   if (xFrameOptions) {
     res.setHeader("X-Frame-Options", xFrameOptions);
   }
+
   if (csp) {
     res.setHeader("Content-Security-Policy", csp);
   }
+  
   next();
 });
 
@@ -43,6 +52,7 @@ WebApp.rawConnectHandlers.use((req, res, next) => {
   if (contentTypeOptions) {
     res.setHeader("X-Content-Type-Options", contentTypeOptions);
   }
+
   next();
 });
 

--- a/packages/browser-policy-common/browser-policy-common.js
+++ b/packages/browser-policy-common/browser-policy-common.js
@@ -1,23 +1,22 @@
-BrowserPolicy = {};
+import { Webapp } from 'meteor/webapp';
 
-var inTest = false;
+const BrowserPolicy = {};
 
-BrowserPolicy._runningTest = function () {
-  return inTest;
-};
+let inTest = false;
 
-BrowserPolicy._setRunningTest = function () {
-  inTest = true;
-};
+BrowserPolicy._runningTest = () => inTest;
 
-WebApp.connectHandlers.use(function (req, res, next) {
+BrowserPolicy._setRunningTest = () => inTest = true;
+
+WebApp.connectHandlers.use((req, res, next) => {
   // Never set headers inside tests because they could break other tests.
-  if (BrowserPolicy._runningTest())
+  if (BrowserPolicy._runningTest()) {
     return next();
+  }
 
-  var xFrameOptions = BrowserPolicy.framing &&
+  const xFrameOptions = BrowserPolicy.framing &&
         BrowserPolicy.framing._constructXFrameOptions();
-  var csp = BrowserPolicy.content &&
+  const csp = BrowserPolicy.content &&
         BrowserPolicy.content._constructCsp();
   if (xFrameOptions) {
     res.setHeader("X-Frame-Options", xFrameOptions);
@@ -34,14 +33,17 @@ WebApp.connectHandlers.use(function (req, res, next) {
 // and Content-Security-Policy too, but let's make sure that doesn't
 // break anything first (e.g. the OAuth popup flow won't work well with
 // a CSP that disallows inline scripts).
-WebApp.rawConnectHandlers.use(function (req, res, next) {
-  if (BrowserPolicy._runningTest())
+WebApp.rawConnectHandlers.use((req, res, next) => {
+  if (BrowserPolicy._runningTest()) {
     return next();
+  }
 
-  var contentTypeOptions = BrowserPolicy.content &&
+  const contentTypeOptions = BrowserPolicy.content &&
         BrowserPolicy.content._xContentTypeOptions();
   if (contentTypeOptions) {
     res.setHeader("X-Content-Type-Options", contentTypeOptions);
   }
   next();
 });
+
+export { BrowserPolicy };

--- a/packages/browser-policy-common/package.js
+++ b/packages/browser-policy-common/package.js
@@ -1,10 +1,10 @@
 Package.describe({
-  summary: "Common code for browser-policy packages",
-  version: "1.0.11"
+  summary: 'Common code for browser-policy packages',
+  version: '1.0.12',
 });
 
-Package.onUse(function (api) {
-  api.use('webapp', 'server');
-  api.addFiles('browser-policy-common.js', 'server');
+Package.onUse(api => {
+  api.use(['ecmascript', 'webapp'], 'server');
   api.export('BrowserPolicy', 'server');
+  api.mainModule('browser-policy-common.js', 'server');
 });

--- a/packages/browser-policy-content/package.js
+++ b/packages/browser-policy-content/package.js
@@ -1,11 +1,10 @@
 Package.describe({
-  summary: "Configure content security policies",
-  version: "1.1.0"
+  summary: 'Configure content security policies',
+  version: '1.1.1',
 });
 
-Package.onUse(function (api) {
-  api.use("modules");
-  api.use(["underscore", "browser-policy-common", "webapp"], "server");
-  api.imply(["browser-policy-common"], "server");
-  api.mainModule("browser-policy-content.js", "server");
+Package.onUse(api => {
+  api.use(['ecmascript', 'browser-policy-common', 'webapp'], 'server');
+  api.imply(['browser-policy-common'], 'server');
+  api.mainModule('browser-policy-content.js', 'server');
 });

--- a/packages/browser-policy-framing/browser-policy-framing.js
+++ b/packages/browser-policy-framing/browser-policy-framing.js
@@ -13,15 +13,23 @@ let xFrameOptions = defaultXFrameOptions;
 BrowserPolicy.framing = {};
 
 Object.assign(BrowserPolicy.framing, {
+
   // Exported for tests and browser-policy-common.
-  _constructXFrameOptions: () => xFrameOptions,
+  _constructXFrameOptions() {
+    return xFrameOptions;
+  },
 
-  _reset: () => xFrameOptions = defaultXFrameOptions,
+  _reset() {
+    xFrameOptions = defaultXFrameOptions;
+  },
 
-  disallow: () => xFrameOptions = "DENY",
+  disallow() {
+    xFrameOptions = "DENY";
+  },
 
   // ALLOW-FROM not supported in Chrome or Safari.
-  restrictToOrigin: origin => {
+  restrictToOrigin(origin) {
+
     // Trying to specify two allow-from throws to prevent users from
     // accidentally overwriting an allow-from origin when they think they are
     // adding multiple origins.
@@ -29,10 +37,14 @@ Object.assign(BrowserPolicy.framing, {
       throw new Error("You can only specify one origin that is allowed to" +
                       " frame this app.");
     }
+
     xFrameOptions = `ALLOW-FROM ${origin}`;
   },
 
-  allowAll: () => xFrameOptions = null,
+  allowAll() {
+    xFrameOptions = null;
+  },
+  
 });
 
 export { BrowserPolicy };

--- a/packages/browser-policy-framing/browser-policy-framing.js
+++ b/packages/browser-policy-framing/browser-policy-framing.js
@@ -5,38 +5,34 @@
 // BrowserPolicy.framing.disallow()
 // BrowserPolicy.framing.restrictToOrigin(origin)
 // BrowserPolicy.framing.allowByAnyOrigin()
+import { BrowserPolicy } from 'meteor/browser-policy-common';
 
-var defaultXFrameOptions = "SAMEORIGIN";
-var xFrameOptions = defaultXFrameOptions;
+const defaultXFrameOptions = 'SAMEORIGIN';
+let xFrameOptions = defaultXFrameOptions;
 
-const BrowserPolicy = require("meteor/browser-policy-common").BrowserPolicy;
 BrowserPolicy.framing = {};
 
-_.extend(BrowserPolicy.framing, {
+Object.assign(BrowserPolicy.framing, {
   // Exported for tests and browser-policy-common.
-  _constructXFrameOptions: function () {
-    return xFrameOptions;
-  },
-  _reset: function () {
-    xFrameOptions = defaultXFrameOptions;
-  },
+  _constructXFrameOptions: () => xFrameOptions,
 
-  disallow: function () {
-    xFrameOptions = "DENY";
-  },
+  _reset: () => xFrameOptions = defaultXFrameOptions,
+
+  disallow: () => xFrameOptions = "DENY",
+
   // ALLOW-FROM not supported in Chrome or Safari.
-  restrictToOrigin: function (origin) {
+  restrictToOrigin: origin => {
     // Trying to specify two allow-from throws to prevent users from
     // accidentally overwriting an allow-from origin when they think they are
     // adding multiple origins.
-    if (xFrameOptions && xFrameOptions.indexOf("ALLOW-FROM") === 0)
+    if (xFrameOptions && xFrameOptions.indexOf("ALLOW-FROM") === 0) {
       throw new Error("You can only specify one origin that is allowed to" +
                       " frame this app.");
-    xFrameOptions = "ALLOW-FROM " + origin;
+    }
+    xFrameOptions = `ALLOW-FROM ${origin}`;
   },
-  allowAll: function () {
-    xFrameOptions = null;
-  }
+
+  allowAll: () => xFrameOptions = null,
 });
 
-exports.BrowserPolicy = BrowserPolicy;
+export { BrowserPolicy };

--- a/packages/browser-policy-framing/package.js
+++ b/packages/browser-policy-framing/package.js
@@ -1,11 +1,10 @@
 Package.describe({
-  summary: "Restrict which websites can frame your app",
-  version: "1.1.0"
+  summary: 'Restrict which websites can frame your app',
+  version: '1.1.1',
 });
 
-Package.onUse(function (api) {
-  api.use("modules");
-  api.use(["underscore", "browser-policy-common"], "server");
-  api.imply(["browser-policy-common"], "server");
-  api.mainModule("browser-policy-framing.js", "server");
+Package.onUse(api => {
+  api.use(['ecmascript', 'browser-policy-common'], 'server');
+  api.imply(['browser-policy-common'], 'server');
+  api.mainModule('browser-policy-framing.js', 'server');
 });

--- a/packages/browser-policy/browser-policy-test.js
+++ b/packages/browser-policy/browser-policy-test.js
@@ -1,4 +1,4 @@
-import { BrowserPolicy } from './browser-policy';
+import { BrowserPolicy } from './browser-policy.js';
 
 BrowserPolicy._setRunningTest();
 

--- a/packages/browser-policy/browser-policy-test.js
+++ b/packages/browser-policy/browser-policy-test.js
@@ -1,17 +1,15 @@
+import { BrowserPolicy } from './browser-policy';
+
 BrowserPolicy._setRunningTest();
 
-var cspsEqual = function (csp1, csp2) {
-  var cspToObj = function (csp) {
+const cspsEqual = (csp1, csp2) => {
+  const cspToObj = csp => {
     csp = csp.substring(0, csp.length - 1);
-    var parts = _.map(csp.split("; "), function (part) {
-      return part.split(" ");
-    });
-    var keys = _.map(parts, _.first);
-    var values = _.map(parts, _.rest);
-    _.each(values, function (value) {
-      value.sort();
-    });
-    return _.object(keys, values);
+    const parts = csp.split('; ').map(part => part.split(' '));
+    const keys = parts.map(part => part[0]);
+    const values = parts.map(part => part.slice(1));
+    values.forEach(value => value.sort());
+    return keys.reduce((prev, key, i) => ({ ...prev, [key]: values[i] }), {});
   };
 
   return EJSON.equals(cspToObj(csp1), cspToObj(csp2));
@@ -20,8 +18,8 @@ var cspsEqual = function (csp1, csp2) {
 // It's important to call _reset() at the beginnning of these tests; otherwise
 // the headers left over at the end of the last test run will be used.
 
-Tinytest.add("browser-policy - csp", function (test) {
-  var defaultCsp = "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
+Tinytest.add("browser-policy - csp", test => {
+  const defaultCsp = "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
         "connect-src * 'self'; img-src data: 'self'; style-src 'self' 'unsafe-inline';"
 
   BrowserPolicy.content._reset();
@@ -137,15 +135,15 @@ Tinytest.add("browser-policy - csp", function (test) {
                         "default-src 'none'; frame-src https://foo.com; " +
                         "object-src http://foo.com https://foo.com;"));
 
-  // Check that frame-ancestors property is set correctly. 
-  BrowserPolicy.content.allowFrameAncestorsOrigin("https://foo.com/"); 
-  test.isTrue(cspsEqual(BrowserPolicy.content._constructCsp(), 
-                        "default-src 'none'; frame-src https://foo.com; " + 
-                        "object-src http://foo.com https://foo.com; " + 
+  // Check that frame-ancestors property is set correctly.
+  BrowserPolicy.content.allowFrameAncestorsOrigin("https://foo.com/");
+  test.isTrue(cspsEqual(BrowserPolicy.content._constructCsp(),
+                        "default-src 'none'; frame-src https://foo.com; " +
+                        "object-src http://foo.com https://foo.com; " +
                         "frame-ancestors https://foo.com;"));
 });
 
-Tinytest.add("browser-policy - x-frame-options", function (test) {
+Tinytest.add("browser-policy - x-frame-options", test => {
   BrowserPolicy.framing._reset();
   test.equal(BrowserPolicy.framing._constructXFrameOptions(), "SAMEORIGIN");
   BrowserPolicy.framing.disallow();
@@ -154,12 +152,10 @@ Tinytest.add("browser-policy - x-frame-options", function (test) {
   test.equal(BrowserPolicy.framing._constructXFrameOptions(), null);
   BrowserPolicy.framing.restrictToOrigin("foo.com");
   test.equal(BrowserPolicy.framing._constructXFrameOptions(), "ALLOW-FROM foo.com");
-  test.throws(function () {
-    BrowserPolicy.framing.restrictToOrigin("bar.com");
-  });
+  test.throws(() => BrowserPolicy.framing.restrictToOrigin("bar.com"));
 });
 
-Tinytest.add("browser-policy - X-Content-Type-Options", function (test) {
+Tinytest.add("browser-policy - X-Content-Type-Options", test => {
   BrowserPolicy.content._reset();
   test.equal(BrowserPolicy.content._xContentTypeOptions(), "nosniff");
   BrowserPolicy.content.allowContentTypeSniffing();

--- a/packages/browser-policy/browser-policy.js
+++ b/packages/browser-policy/browser-policy.js
@@ -1,1 +1,1 @@
-exports.BrowserPolicy = require("meteor/browser-policy-common").BrowserPolicy;
+export { BrowserPolicy } from 'meteor/browser-policy-common';

--- a/packages/browser-policy/package.js
+++ b/packages/browser-policy/package.js
@@ -1,16 +1,24 @@
 Package.describe({
-  summary: "Configure security policies enforced by the browser",
-  version: "1.1.0"
+  summary: 'Configure security policies enforced by the browser',
+  version: '1.1.1',
 });
 
-Package.onUse(function (api) {
-  api.use('modules');
-  api.use(['browser-policy-content', 'browser-policy-framing'], 'server');
+Package.onUse(api => {
+  api.use([
+    'ecmascript', 
+    'browser-policy-content', 
+    'browser-policy-framing',
+  ], 'server');
   api.imply(['browser-policy-common'], 'server');
   api.mainModule('browser-policy.js', 'server');
 });
 
-Package.onTest(function (api) {
-  api.use(["tinytest", "browser-policy", "ejson", "underscore"], "server");
-  api.addFiles("browser-policy-test.js", "server");
+Package.onTest(api => {
+  api.use([
+    'ecmascript',
+    'tinytest',
+    'browser-policy',
+    'ejson',
+  ], 'server');
+  api.addFiles('browser-policy-test.js', 'server');
 });


### PR DESCRIPTION
This PR modernizes the following packages:
- `browser-policy`
- `browser-policy-common`
- `browser-policy-content`
- `browser-policy-framing`