### PR TITLE
Disable unsafe `cssnano` minification optimizations

### DIFF
--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -67,7 +67,7 @@ const CssTools = {
    */
   minifyCss(cssText) {
     const f = new Future;
-    postcss([ cssnano ]).process(cssText).then(result => {
+    postcss([ cssnano({ safe: true }) ]).process(cssText).then(result => {
       f.return(result.css);
     }).catch(error => {
       f.throw(error);

--- a/packages/minifier-css/package.js
+++ b/packages/minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'CSS minifier',
-  version: '1.3.0'
+  version: '1.3.1'
 });
 
 Npm.depends({

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.4.0',
+  version: '1.4.1',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });


### PR DESCRIPTION
This PR disables [unsafe `cssnano` minification optimizations](https://github.com/ben-eb/cssnano/blob/6bef71fb165a364ab97c6aad66d69e122d585b7a/src/index.js#L102-L122), which change semantics and make assumptions about CSS that aren't valid for all Meteor apps. For example, the [`discardUnused`](http://cssnano.co/optimisations/discardunused/), [`mergeIdents`](http://cssnano.co/optimisations/mergeidents/), and [`zindex`](http://cssnano.co/optimisations/zindex/) optimizations assume that all CSS files of an app are concatenated before minification. However, CSS files that are imported as modules are processed separately from eagerly loaded CSS.

Fixes #9616, fixes #9633