### PR TITLE
Modernize check package

### DIFF
--- a/packages/check/isPlainObject.js
+++ b/packages/check/isPlainObject.js
@@ -1,24 +1,24 @@
 // Copy of jQuery.isPlainObject for the server side from jQuery v3.1.1.
 
-var class2type = {};
+const class2type = {};
 
-var toString = class2type.toString;
+const toString = class2type.toString;
 
-var hasOwn = class2type.hasOwnProperty;
+const hasOwn = Object.prototype.hasOwnProperty;
 
-var fnToString = hasOwn.toString;
+const fnToString = hasOwn.toString;
 
-var ObjectFunctionString = fnToString.call(Object);
+const ObjectFunctionString = fnToString.call(Object);
 
-var getProto = Object.getPrototypeOf;
+const getProto = Object.getPrototypeOf;
 
-exports.isPlainObject = function( obj ) {
-  var proto,
-    Ctor;
+export const isPlainObject = obj => {
+  let proto;
+  let Ctor;
 
   // Detect obvious negatives
   // Use toString instead of jQuery.type to catch host objects
-  if (!obj || toString.call(obj) !== "[object Object]") {
+  if (!obj || toString.call(obj) !== '[object Object]') {
     return false;
   }
 
@@ -30,6 +30,7 @@ exports.isPlainObject = function( obj ) {
   }
 
   // Objects with prototype are plain iff they were constructed by a global Object function
-  Ctor = hasOwn.call(proto, "constructor") && proto.constructor;
-  return typeof Ctor === "function" && fnToString.call(Ctor) === ObjectFunctionString;
+  Ctor = hasOwn.call(proto, 'constructor') && proto.constructor;
+  return typeof Ctor === 'function' && 
+    fnToString.call(Ctor) === ObjectFunctionString;
 };

--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -50,13 +50,30 @@ export const check = (value, pattern) => {
  * @summary The namespace for all Match types and methods.
  */
 export const Match = {
-  Optional: pattern => new Optional(pattern),
-  Maybe: pattern => new Maybe(pattern),
-  OneOf: (...args) => new OneOf(args),
+  Optional: function(pattern) {
+    return new Optional(pattern);
+  },
+
+  Maybe: function(pattern) {
+    return new Maybe(pattern);
+  },
+
+  OneOf: function(...args) {
+    return new OneOf(args);
+  },
+
   Any: ['__any__'],
-  Where: condition => new Where(condition),
-  ObjectIncluding: pattern => new ObjectIncluding(pattern),
-  ObjectWithValues: pattern => new ObjectWithValues(pattern),
+  Where: function(condition) {
+    return new Where(condition);
+  },
+
+  ObjectIncluding: function(pattern) {
+    return new ObjectIncluding(pattern)
+  },
+
+  ObjectWithValues: function(pattern) {
+    return new ObjectWithValues(pattern);
+  },
 
   // Matches only signed 32-bit integers
   Integer: ['__integer__'],

--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -1,11 +1,11 @@
 // XXX docs
+import { isPlainObject } from './isPlainObject';
 
 // Things we explicitly do NOT support:
 //    - heterogenous arrays
 
-var currentArgumentChecker = new Meteor.EnvironmentVariable;
-var isPlainObject = require("./isPlainObject.js").isPlainObject;
-var hasOwn = Object.prototype.hasOwnProperty;
+const currentArgumentChecker = new Meteor.EnvironmentVariable;
+const hasOwn = Object.prototype.hasOwnProperty;
 
 /**
  * @summary Check that a value matches a [pattern](#matchpatterns).
@@ -18,7 +18,8 @@ var hasOwn = Object.prototype.hasOwnProperty;
  * @param {MatchPattern} pattern The pattern to match
  * `value` against
  */
-export const check = function (value, pattern) {
+export const check = (value, pattern) => {
+
   // Record that check got called, if somebody cared.
   //
   // We use getOrNullIfOutsideFiber so that it's OK to call check()
@@ -27,16 +28,19 @@ export const check = function (value, pattern) {
   // it might not find the argumentChecker and you'll get an error about
   // not checking an argument that it looks like you're checking (instead
   // of just getting a "Node code must run in a Fiber" error).
-  var argChecker = currentArgumentChecker.getOrNullIfOutsideFiber();
-  if (argChecker)
+  const argChecker = currentArgumentChecker.getOrNullIfOutsideFiber();
+  if (argChecker) {
     argChecker.checking(value);
-  var result = testSubtree(value, pattern);
+  }
+
+  const result = testSubtree(value, pattern);
   if (result) {
-    var err = new Match.Error(result.message);
+    const err = new Match.Error(result.message);
     if (result.path) {
-      err.message += " in field " + result.path;
+      err.message += ` in field ${result.path}`;
       err.path = result.path;
     }
+
     throw err;
   }
 };
@@ -46,39 +50,30 @@ export const check = function (value, pattern) {
  * @summary The namespace for all Match types and methods.
  */
 export const Match = {
-  Optional: function (pattern) {
-    return new Optional(pattern);
-  },
-  Maybe: function (pattern) {
-    return new Maybe(pattern);
-  },
-  OneOf: function (...args) {
-    return new OneOf(args);
-  },
+  Optional: pattern => new Optional(pattern),
+  Maybe: pattern => new Maybe(pattern),
+  OneOf: (...args) => new OneOf(args),
   Any: ['__any__'],
-  Where: function (condition) {
-    return new Where(condition);
-  },
-  ObjectIncluding: function (pattern) {
-    return new ObjectIncluding(pattern);
-  },
-  ObjectWithValues: function (pattern) {
-    return new ObjectWithValues(pattern);
-  },
+  Where: condition => new Where(condition),
+  ObjectIncluding: pattern => new ObjectIncluding(pattern),
+  ObjectWithValues: pattern => new ObjectWithValues(pattern),
+
   // Matches only signed 32-bit integers
   Integer: ['__integer__'],
 
   // XXX matchers should know how to describe themselves for errors
-  Error: Meteor.makeErrorType("Match.Error", function (msg) {
-    this.message = "Match error: " + msg;
+  Error: Meteor.makeErrorType('Match.Error', function (msg) {
+    this.message = `Match error: ${msg}`;
+
     // The path of the value that failed to match. Initially empty, this gets
     // populated by catching and rethrowing the exception as it goes back up the
     // stack.
     // E.g.: "vals[3].entity.created"
-    this.path = "";
+    this.path = '';
+
     // If this gets sent over DDP, don't give full internal details but at least
     // provide something better than 500 Internal server error.
-    this.sanitizedError = new Meteor.Error(400, "Match failed");
+    this.sanitizedError = new Meteor.Error(400, 'Match failed');
   }),
 
   // Tests to see if value matches pattern. Unlike check, it merely returns true
@@ -101,12 +96,13 @@ export const Match = {
   // Runs `f.apply(context, args)`. If check() is not called on every element of
   // `args` (either directly or in the first level of an array), throws an error
   // (using `description` in the message).
-  //
   _failIfArgumentsAreNotAllChecked(f, context, args, description) {
-    var argChecker = new ArgumentChecker(args, description);
-    var result = currentArgumentChecker.withValue(argChecker, function () {
-      return f.apply(context, args);
-    });
+    const argChecker = new ArgumentChecker(args, description);
+    const result = currentArgumentChecker.withValue(
+      argChecker, 
+      () => f.apply(context, args)
+    );
+
     // If f didn't itself throw, make sure it checked all of its arguments.
     argChecker.throwUnlessAllArgumentsHaveBeenChecked();
     return result;
@@ -127,8 +123,10 @@ class Maybe {
 
 class OneOf {
   constructor(choices) {
-    if (!choices || choices.length === 0)
-      throw new Error("Must provide at least one choice to Match.OneOf");
+    if (!choices || choices.length === 0) {
+      throw new Error('Must provide at least one choice to Match.OneOf');
+    }
+
     this.choices = choices;
   }
 }
@@ -151,26 +149,27 @@ class ObjectWithValues {
   }
 }
 
-var stringForErrorMessage = function (value, options) {
-  options = options || {};
-
-  if ( value === null ) return "null";
+const stringForErrorMessage = (value, options = {}) => {
+  if ( value === null ) {
+    return 'null';
+  }
 
   if ( options.onlyShowType ) {
     return typeof value;
   }
 
   // Your average non-object things.  Saves from doing the try/catch below for.
-  if ( typeof value !== "object" ) {
+  if ( typeof value !== 'object' ) {
     return EJSON.stringify(value)
   }
 
   try {
+
     // Find objects with circular references since EJSON doesn't support them yet (Issue #4778 + Unaccepted PR)
     // If the native stringify is going to choke, EJSON.stringify is going to choke too.
     JSON.stringify(value);
   } catch (stringifyError) {
-    if ( stringifyError.name === "TypeError" ) {
+    if ( stringifyError.name === 'TypeError' ) {
       return typeof value;
     }
   }
@@ -178,31 +177,36 @@ var stringForErrorMessage = function (value, options) {
   return EJSON.stringify(value);
 };
 
-var typeofChecks = [
-  [String, "string"],
-  [Number, "number"],
-  [Boolean, "boolean"],
+const typeofChecks = [
+  [String, 'string'],
+  [Number, 'number'],
+  [Boolean, 'boolean'],
+
   // While we don't allow undefined/function in EJSON, this is good for optional
   // arguments with OneOf.
-  [Function, "function"],
-  [undefined, "undefined"]
+  [Function, 'function'],
+  [undefined, 'undefined'],
 ];
 
 // Return `false` if it matches. Otherwise, return an object with a `message` and a `path` field.
-var testSubtree = function (value, pattern) {
+const testSubtree = (value, pattern) => {
+
   // Match anything!
-  if (pattern === Match.Any)
+  if (pattern === Match.Any) {
     return false;
+  }
 
   // Basic atomic types.
   // Do not match boxed objects (e.g. String, Boolean)
-  for (var i = 0; i < typeofChecks.length; ++i) {
+  for (let i = 0; i < typeofChecks.length; ++i) {
     if (pattern === typeofChecks[i][0]) {
-      if (typeof value === typeofChecks[i][1])
+      if (typeof value === typeofChecks[i][1]) {
         return false;
+      }
+
       return {
-        message: "Expected " + typeofChecks[i][1] + ", got " + stringForErrorMessage(value, { onlyShowType: true }),
-        path: ""
+        message: `Expected ${typeofChecks[i][1]}, got ${stringForErrorMessage(value, { onlyShowType: true })}`,
+        path: '',
       };
     }
   }
@@ -211,141 +215,159 @@ var testSubtree = function (value, pattern) {
     if (value === null) {
       return false;
     }
+
     return {
-      message: "Expected null, got " + stringForErrorMessage(value),
-      path: ""
+      message: `Expected null, got ${stringForErrorMessage(value)}`,
+      path: '',
     };
   }
 
   // Strings, numbers, and booleans match literally. Goes well with Match.OneOf.
-  if (typeof pattern === "string" || typeof pattern === "number" || typeof pattern === "boolean") {
-    if (value === pattern)
+  if (typeof pattern === 'string' || typeof pattern === 'number' || typeof pattern === 'boolean') {
+    if (value === pattern) {
       return false;
+    }
+
     return {
-      message: "Expected " + pattern + ", got " + stringForErrorMessage(value),
-      path: ""
+      message: `Expected ${pattern}, got ${stringForErrorMessage(value)}`,
+      path: '',
     };
   }
 
   // Match.Integer is special type encoded with array
   if (pattern === Match.Integer) {
+
     // There is no consistent and reliable way to check if variable is a 64-bit
     // integer. One of the popular solutions is to get reminder of division by 1
     // but this method fails on really large floats with big precision.
     // E.g.: 1.348192308491824e+23 % 1 === 0 in V8
     // Bitwise operators work consistantly but always cast variable to 32-bit
     // signed integer according to JavaScript specs.
-    if (typeof value === "number" && (value | 0) === value)
+    if (typeof value === 'number' && (value | 0) === value) {
       return false;
+    }
+    
     return {
-      message: "Expected Integer, got " + stringForErrorMessage(value),
-      path: ""
+      message: `Expected Integer, got ${stringForErrorMessage(value)}`,
+      path: '',
     };
   }
 
-  // "Object" is shorthand for Match.ObjectIncluding({});
-  if (pattern === Object)
+  // 'Object' is shorthand for Match.ObjectIncluding({});
+  if (pattern === Object) {
     pattern = Match.ObjectIncluding({});
+  }
 
   // Array (checked AFTER Any, which is implemented as an Array).
   if (pattern instanceof Array) {
     if (pattern.length !== 1) {
       return {
-        message: "Bad pattern: arrays must have one type element" + stringForErrorMessage(pattern),
-        path: ""
-      };
-    }
-    if (!Array.isArray(value) && !isArguments(value)) {
-      return {
-        message: "Expected array, got " + stringForErrorMessage(value),
-        path: ""
+        message: `Bad pattern: arrays must have one type element ${stringForErrorMessage(pattern)}`,
+        path: '',
       };
     }
 
-    for (var i = 0, length = value.length; i < length; i++) {
-      var result = testSubtree(value[i], pattern[0]);
+    if (!Array.isArray(value) && !isArguments(value)) {
+      return {
+        message: `Expected array, got ${stringForErrorMessage(value)}`,
+        path: '',
+      };
+    }
+
+    for (let i = 0, length = value.length; i < length; i++) {
+      const result = testSubtree(value[i], pattern[0]);
       if (result) {
         result.path = _prependPath(i, result.path);
         return result;
       }
     }
+    
     return false;
   }
 
   // Arbitrary validation checks. The condition can return false or throw a
   // Match.Error (ie, it can internally use check()) to fail.
   if (pattern instanceof Where) {
-    var result;
+    let result;
     try {
       result = pattern.condition(value);
     } catch (err) {
-      if (!(err instanceof Match.Error))
+      if (!(err instanceof Match.Error)) {
         throw err;
+      }
+      
       return {
         message: err.message,
         path: err.path
       };
     }
-    if (result)
+
+    if (result) {
       return false;
+    }
+
     // XXX this error is terrible
     return {
-      message: "Failed Match.Where validation",
-      path: ""
+      message: 'Failed Match.Where validation',
+      path: '',
     };
   }
 
-
   if (pattern instanceof Maybe) {
     pattern = Match.OneOf(undefined, null, pattern.pattern);
-  }
-  else if (pattern instanceof Optional) {
+  } else if (pattern instanceof Optional) {
     pattern = Match.OneOf(undefined, pattern.pattern);
   }
 
   if (pattern instanceof OneOf) {
-    for (var i = 0; i < pattern.choices.length; ++i) {
-      var result = testSubtree(value, pattern.choices[i]);
+    for (let i = 0; i < pattern.choices.length; ++i) {
+      const result = testSubtree(value, pattern.choices[i]);
       if (!result) {
+
         // No error? Yay, return.
         return false;
       }
+
       // Match errors just mean try another choice.
     }
+
     // XXX this error is terrible
     return {
-      message: "Failed Match.OneOf, Match.Maybe or Match.Optional validation",
-      path: ""
+      message: 'Failed Match.OneOf, Match.Maybe or Match.Optional validation',
+      path: '',
     };
   }
 
   // A function that isn't something we special-case is assumed to be a
   // constructor.
   if (pattern instanceof Function) {
-    if (value instanceof pattern)
+    if (value instanceof pattern) {
       return false;
+    }
+
     return {
-      message: "Expected " + (pattern.name ||"particular constructor"),
-      path: ""
+      message: `Expected ${pattern.name || 'particular constructor'}`,
+      path: '',
     };
   }
 
-  var unknownKeysAllowed = false;
-  var unknownKeyPattern;
+  let unknownKeysAllowed = false;
+  let unknownKeyPattern;
   if (pattern instanceof ObjectIncluding) {
     unknownKeysAllowed = true;
     pattern = pattern.pattern;
   }
+
   if (pattern instanceof ObjectWithValues) {
     unknownKeysAllowed = true;
     unknownKeyPattern = [pattern.pattern];
     pattern = {};  // no required keys
   }
 
-  if (typeof pattern !== "object") {
+  if (typeof pattern !== 'object') {
     return {
-      message: "Bad pattern: unknown pattern type",
-      path: ""
+      message: 'Bad pattern: unknown pattern type',
+      path: '',
     };
   }
 
@@ -354,25 +376,27 @@ var testSubtree = function (value, pattern) {
   // the pattern: this really needs to be a plain old {Object}!
   if (typeof value !== 'object') {
     return {
-      message: "Expected object, got " + typeof value,
-      path: ""
-    };
-  }
-  if (value === null) {
-    return {
-      message: "Expected object, got null",
-      path: ""
-    };
-  }
-  if (! isPlainObject(value)) {
-    return {
-      message: "Expected plain object",
-      path: ""
+      message: `Expected object, got ${typeof value}`,
+      path: '',
     };
   }
 
-  var requiredPatterns = {};
-  var optionalPatterns = {};
+  if (value === null) {
+    return {
+      message: `Expected object, got null`,
+      path: '',
+    };
+  }
+
+  if (! isPlainObject(value)) {
+    return {
+      message: `Expected plain object`,
+      path: '',
+    };
+  }
+
+  const requiredPatterns = Object.create(null);
+  const optionalPatterns = Object.create(null);
 
   Object.keys(pattern).forEach(key => {
     const subPattern = pattern[key];
@@ -384,30 +408,33 @@ var testSubtree = function (value, pattern) {
     }
   });
 
-  for (var key in Object(value)) {
-    var subValue = value[key];
+  for (let key in Object(value)) {
+    const subValue = value[key];
     if (hasOwn.call(requiredPatterns, key)) {
-      var result = testSubtree(subValue, requiredPatterns[key]);
+      const result = testSubtree(subValue, requiredPatterns[key]);
       if (result) {
         result.path = _prependPath(key, result.path);
         return result;
       }
+
       delete requiredPatterns[key];
     } else if (hasOwn.call(optionalPatterns, key)) {
-      var result = testSubtree(subValue, optionalPatterns[key]);
+      const result = testSubtree(subValue, optionalPatterns[key]);
       if (result) {
         result.path = _prependPath(key, result.path);
         return result;
       }
+
     } else {
       if (!unknownKeysAllowed) {
         return {
-          message: "Unknown key",
-          path: key
+          message: 'Unknown key',
+          path: key,
         };
       }
+
       if (unknownKeyPattern) {
-        var result = testSubtree(subValue, unknownKeyPattern[0]);
+        const result = testSubtree(subValue, unknownKeyPattern[0]);
         if (result) {
           result.path = _prependPath(key, result.path);
           return result;
@@ -416,20 +443,22 @@ var testSubtree = function (value, pattern) {
     }
   }
 
-  var keys = Object.keys(requiredPatterns);
+  const keys = Object.keys(requiredPatterns);
   if (keys.length) {
     return {
-      message: "Missing key '" + keys[0] + "'",
-      path: ""
+      message: `Missing key '${keys[0]}'`,
+      path: '',
     };
   }
 };
 
 class ArgumentChecker {
   constructor (args, description) {
+
     // Make a SHALLOW copy of the arguments. (We'll be doing identity checks
     // against its contents.)
     this.args = [...args];
+
     // Since the common case will be to check arguments in order, and we splice
     // out arguments when we check them, make it so we splice out from the end
     // rather than the beginning.
@@ -438,8 +467,10 @@ class ArgumentChecker {
   }
 
   checking(value) {
-    if (this._checkingOneValue(value))
+    if (this._checkingOneValue(value)) {
       return;
+    }
+
     // Allow check(arguments, [String]) or check(arguments.slice(1), [String])
     // or check([foo, bar], [String]) to count... but only if value wasn't
     // itself an argument.
@@ -449,7 +480,8 @@ class ArgumentChecker {
   }
 
   _checkingOneValue(value) {
-    for (var i = 0; i < this.args.length; ++i) {
+    for (let i = 0; i < this.args.length; ++i) {
+
       // Is this value one of the arguments? (This can have a false positive if
       // the argument is an interned primitive, but it's still a good enough
       // check.)
@@ -465,47 +497,41 @@ class ArgumentChecker {
 
   throwUnlessAllArgumentsHaveBeenChecked() {
     if (this.args.length > 0)
-      throw new Error("Did not check() all arguments during " +
-                      this.description);
+      throw new Error(`Did not check() all arguments during ${this.description}`);
   }
 }
 
-var _jsKeywords = ["do", "if", "in", "for", "let", "new", "try", "var", "case",
-  "else", "enum", "eval", "false", "null", "this", "true", "void", "with",
-  "break", "catch", "class", "const", "super", "throw", "while", "yield",
-  "delete", "export", "import", "public", "return", "static", "switch",
-  "typeof", "default", "extends", "finally", "package", "private", "continue",
-  "debugger", "function", "arguments", "interface", "protected", "implements",
-  "instanceof"];
+const _jsKeywords = ['do', 'if', 'in', 'for', 'let', 'new', 'try', 'var', 'case',
+  'else', 'enum', 'eval', 'false', 'null', 'this', 'true', 'void', 'with',
+  'break', 'catch', 'class', 'const', 'super', 'throw', 'while', 'yield',
+  'delete', 'export', 'import', 'public', 'return', 'static', 'switch',
+  'typeof', 'default', 'extends', 'finally', 'package', 'private', 'continue',
+  'debugger', 'function', 'arguments', 'interface', 'protected', 'implements',
+  'instanceof'];
 
 // Assumes the base of path is already escaped properly
 // returns key + base
-function _prependPath(key, base) {
-  if ((typeof key) === "number" || key.match(/^[0-9]+$/)) {
-    key = "[" + key + "]";
+const _prependPath = (key, base) => {
+  if ((typeof key) === 'number' || key.match(/^[0-9]+$/)) {
+    key = `[${key}]`;
   } else if (!key.match(/^[a-z_$][0-9a-z_$]*$/i) ||
              _jsKeywords.indexOf(key) >= 0) {
     key = JSON.stringify([key]);
   }
 
-  if (base && base[0] !== "[") {
-    return key + '.' + base;
+  if (base && base[0] !== '[') {
+    return `${key}.${base}`;
   }
 
   return key + base;
 }
 
-function isObject(value) {
-  return typeof value === "object" && value !== null;
-}
+const isObject = value => typeof value === 'object' && value !== null;
 
-function baseIsArguments(item) {
-  return isObject(item) &&
-    Object.prototype.toString.call(item) === '[object Arguments]';
-}
+const baseIsArguments = item =>
+  isObject(item) &&
+  Object.prototype.toString.call(item) === '[object Arguments]';
 
-var isArguments = baseIsArguments(function() {
-  return arguments;
-}()) ? baseIsArguments : function(value) {
-  return isObject(value) && typeof value.callee === "function";
-};
+const isArguments = baseIsArguments(function() { return arguments; }()) ?
+  baseIsArguments :
+  value => isObject(value) && typeof value.callee === 'function';

--- a/packages/check/match_test.js
+++ b/packages/check/match_test.js
@@ -156,7 +156,7 @@ Tinytest.add('check - check', test => {
   const F = function () {
     this.x = 123;
   };
-  
+
   fails(new F, { x: 123 });
 
   matches({}, Match.ObjectWithValues(Number));
@@ -462,3 +462,19 @@ Meteor.isServer && Tinytest.addAsync('check - non-fiber check works', (test, onC
     report(success);
   });
 });
+
+Tinytest.add(
+  'check - Match methods that return class instances can be called as ' + 
+  'constructors', 
+  test => {
+
+    // Existing code sometimes uses these properties as constructors, so we can't
+    // switch them to arrow functions or method shorthand.
+    test.equal(new Match.Optional(), Match.Optional());
+    test.equal(new Match.Maybe(), Match.Maybe());
+    test.equal(new Match.OneOf([1]), Match.OneOf([1])); // Needs a non-empty array
+    test.equal(new Match.Where(), Match.Where());
+    test.equal(new Match.ObjectIncluding(), Match.ObjectIncluding());
+    test.equal(new Match.ObjectWithValues(), Match.ObjectWithValues());
+  }
+);

--- a/packages/check/match_test.js
+++ b/packages/check/match_test.js
@@ -1,30 +1,33 @@
-Tinytest.add("check - check", function (test) {
-  var matches = function (value, pattern) {
-    var error;
+Tinytest.add('check - check', test => {
+  const matches = (value, pattern) => {
+    let error;
     try {
       check(value, pattern);
     } catch (e) {
       error = e;
     }
+
     test.isFalse(error);
     test.isTrue(Match.test(value, pattern));
   };
-  var fails = function (value, pattern) {
-    var error;
+
+  const fails = (value, pattern) => {
+    let error;
     try {
       check(value, pattern);
     } catch (e) {
       error = e;
     }
+
     test.isTrue(error);
     test.instanceOf(error, Match.Error);
     test.isFalse(Match.test(value, pattern));
   };
 
   // Atoms.
-  var pairs = [
-    ["foo", String],
-    ["", String],
+  const pairs = [
+    ['foo', String],
+    ['', String],
     [0, Number],
     [42.59, Number],
     [NaN, Number],
@@ -35,9 +38,9 @@ Tinytest.add("check - check", function (test) {
     [undefined, undefined],
     [null, null]
   ];
-  _.each(pairs, function (pair) {
+  pairs.forEach(pair => {
     matches(pair[0], Match.Any);
-    _.each([String, Number, Boolean, undefined, null], function (type) {
+    [String, Number, Boolean, undefined, null].forEach(type => {
       if (type === pair[1]) {
         matches(pair[0], type);
         matches(pair[0], Match.Optional(type));
@@ -45,11 +48,11 @@ Tinytest.add("check - check", function (test) {
         matches(pair[0], Match.Maybe(type));
         matches(undefined, Match.Maybe(type));
         matches(null, Match.Maybe(type));
-        matches(pair[0], Match.Where(function () {
+        matches(pair[0], Match.Where(() => {
           check(pair[0], type);
           return true;
         }));
-        matches(pair[0], Match.Where(function () {
+        matches(pair[0], Match.Where(() => {
           try {
             check(pair[0], type);
             return true;
@@ -61,11 +64,11 @@ Tinytest.add("check - check", function (test) {
         fails(pair[0], type);
         matches(pair[0], Match.OneOf(type, pair[1]));
         matches(pair[0], Match.OneOf(pair[1], type));
-        fails(pair[0], Match.Where(function () {
+        fails(pair[0], Match.Where(() => {
           check(pair[0], type);
           return true;
         }));
-        fails(pair[0], Match.Where(function () {
+        fails(pair[0], Match.Where(() => {
           try {
             check(pair[0], type);
             return true;
@@ -74,21 +77,26 @@ Tinytest.add("check - check", function (test) {
           }
         }));
       }
-      if ( type !== null ) fails(null, Match.Optional(type)); // Optional doesn't allow null, but does match on null type
+      
+      if ( type !== null ) {
+
+        // Optional doesn't allow null, but does match on null type
+        fails(null, Match.Optional(type));
+       }
       fails(pair[0], [type]);
       fails(pair[0], Object);
     });
   });
   fails(true, Match.OneOf(String, Number, undefined, null, [Boolean]));
-  fails(new String("foo"), String);
+  fails(new String('foo'), String);
   fails(new Boolean(true), Boolean);
   fails(new Number(123), Number);
 
   matches([1, 2, 3], [Number]);
   matches([], [Number]);
-  fails([1, 2, 3, "4"], [Number]);
+  fails([1, 2, 3, '4'], [Number]);
   fails([1, 2, 3, [4]], [Number]);
-  matches([1, 2, 3, "4"], [Match.OneOf(Number, String)]);
+  matches([1, 2, 3, '4'], [Match.OneOf(Number, String)]);
 
   matches({}, Object);
   matches({}, {});
@@ -116,7 +124,7 @@ Tinytest.add("check - check", function (test) {
   matches(undefined, Match.Optional(null));
 
   fails(true, Match.Optional(String)); // different should still fail
-  matches("String", Match.Optional(String)); // same should pass
+  matches('String', Match.Optional(String)); // same should pass
 
   matches({}, {a: Match.Optional(Number)});
   matches({a: 1}, {a: Match.Optional(Number)});
@@ -133,38 +141,40 @@ Tinytest.add("check - check", function (test) {
   matches(undefined, Match.Maybe(null));
 
   fails(true, Match.Maybe(String)); // different should still fail
-  matches("String", Match.Maybe(String)); // same should pass
+  matches('String', Match.Maybe(String)); // same should pass
 
   matches({}, {a: Match.Maybe(Number)});
   matches({a: 1}, {a: Match.Maybe(Number)});
   fails({a: true}, {a: Match.Maybe(Number)});
+
   // Match.Optional means "or undefined" at the top level but "or absent" in
   // objects.
   // Match.Maybe should behave the same as Match.Optional in objects
   // including handling nulls
   fails({a: undefined}, {a: Match.Maybe(Number)});
   fails({a: null}, {a: Match.Maybe(Number)});
-  var F = function () {
+  const F = function () {
     this.x = 123;
   };
+  
   fails(new F, { x: 123 });
 
   matches({}, Match.ObjectWithValues(Number));
   matches({x: 1}, Match.ObjectWithValues(Number));
   matches({x: 1, y: 2}, Match.ObjectWithValues(Number));
-  fails({x: 1, y: "2"}, Match.ObjectWithValues(Number));
+  fails({x: 1, y: '2'}, Match.ObjectWithValues(Number));
 
-  matches("asdf", "asdf");
-  fails("asdf", "monkey");
+  matches('asdf', 'asdf');
+  fails('asdf', 'monkey');
   matches(123, 123);
   fails(123, 456);
-  fails("123", 123);
-  fails(123, "123");
+  fails('123', 123);
+  fails(123, '123');
   matches(true, true);
   matches(false, false);
   fails(true, false);
-  fails(true, "true");
-  fails("false", false);
+  fails(true, 'true');
+  fails('false', false);
 
   matches(/foo/, RegExp);
   fails(/foo/, String);
@@ -173,18 +183,24 @@ Tinytest.add("check - check", function (test) {
   matches(EJSON.newBinary(42), Match.Where(EJSON.isBinary));
   fails([], Match.Where(EJSON.isBinary));
 
-  matches(42, Match.Where(function (x) { return x % 2 === 0; }));
-  fails(43, Match.Where(function (x) { return x % 2 === 0; }));
+  matches(42, Match.Where(x => x % 2 === 0));
+  fails(43, Match.Where(x => x % 2 === 0));
 
   matches({
-    a: "something",
+    a: 'something',
     b: [
       {x: 42, k: null},
-      {x: 43, k: true, p: ["yay"]}
-    ]
-  }, {a: String, b: [Match.ObjectIncluding({
-    x: Number,
-    k: Match.OneOf(null, Boolean)})]});
+      {x: 43, k: true, p: ['yay']},
+    ],
+  }, {
+    a: String, 
+    b: [
+      Match.ObjectIncluding({
+        x: Number,
+        k: Match.OneOf(null, Boolean)
+      }),
+    ],
+  });
 
 
   // Match.Integer
@@ -206,8 +222,8 @@ Tinytest.add("check - check", function (test) {
 
 
   // Test non-plain objects.
-  var parentObj = {foo: "bar"};
-  var childObj = Object.assign(Object.create(parentObj), {bar: "foo"});
+  const parentObj = {foo: 'bar'};
+  const childObj = Object.assign(Object.create(parentObj), {bar: 'foo'});
   matches(parentObj, Object);
   fails(parentObj, {foo: String, bar: String});
   fails(parentObj, {bar: String});
@@ -218,20 +234,20 @@ Tinytest.add("check - check", function (test) {
   fails(childObj, {foo: String});
 
   // Functions
-  var testFunction = function () {};
+  const testFunction = () => {};
   matches(testFunction, Function);
   fails(5, Function);
 
   // Circular Reference "Classes"
 
-  var TestInstanceChild = function () {};
-  var TestInstanceParent = function (child) {
+  const TestInstanceChild = function () {};
+  const TestInstanceParent = function (child) {
     child._parent = this;
     this.child = child;
   };
 
-  var testInstanceChild = new TestInstanceChild()
-  var testInstanceParent = new TestInstanceParent(testInstanceChild);
+  const testInstanceChild = new TestInstanceChild()
+  const testInstanceParent = new TestInstanceParent(testInstanceChild);
 
   matches(TestInstanceParent, Function);
   matches(testInstanceParent, TestInstanceParent);
@@ -242,201 +258,199 @@ Tinytest.add("check - check", function (test) {
 
   // Circular Reference Objects
 
-  var circleFoo = {};
-  var circleBar = {};
+  const circleFoo = {};
+  const circleBar = {};
   circleFoo.bar = circleBar;
   circleBar.foo = circleFoo;
   fails(circleFoo, null);
 
   // Test that "arguments" is treated like an array.
-  var argumentsMatches = function () {
+  const argumentsMatches = function () {
     matches(arguments, [Number]);
   };
   argumentsMatches();
   argumentsMatches(1);
   argumentsMatches(1, 2);
-  var argumentsFails = function () {
+  const argumentsFails = function () {
     fails(arguments, [Number]);
   };
-  argumentsFails("123");
-  argumentsFails(1, "23");
+  argumentsFails('123');
+  argumentsFails(1, '23');
 });
 
-Tinytest.add("check - argument checker", function (test) {
-  var checksAllArguments = function (f /*arguments*/) {
-    Match._failIfArgumentsAreNotAllChecked(
-      f, {}, _.toArray(arguments).slice(1), "test");
-  };
-  checksAllArguments(function () {});
-  checksAllArguments(function (x) {check(x, Match.Any);}, undefined);
-  checksAllArguments(function (x) {check(x, Match.Any);}, null);
-  checksAllArguments(function (x) {check(x, Match.Any);}, false);
-  checksAllArguments(function (x) {check(x, Match.Any);}, true);
-  checksAllArguments(function (x) {check(x, Match.Any);}, 0);
-  checksAllArguments(function (a, b, c) {
+Tinytest.add('check - argument checker', test => {
+  const checksAllArguments = (f, ...args) =>
+    Match._failIfArgumentsAreNotAllChecked(f, {}, args, 'test');
+  checksAllArguments(() => {});
+  checksAllArguments(x => check(x, Match.Any), undefined);
+  checksAllArguments(x => check(x, Match.Any), null);
+  checksAllArguments(x => check(x, Match.Any), false);
+  checksAllArguments(x => check(x, Match.Any), true);
+  checksAllArguments(x => check(x, Match.Any), 0);
+  checksAllArguments((a, b, c) => {
     check(a, String);
     check(b, Boolean);
     check(c, Match.Optional(Number));
-  }, "foo", true);
-  checksAllArguments(function () {
-    check(arguments, [Number]);
-  }, 1, 2, 4);
-  checksAllArguments(function(x) {
+  }, 'foo', true);
+  checksAllArguments((...args) => check(args, [Number]), 1, 2, 4);
+  checksAllArguments((x, ...args) => {
     check(x, Number);
-    check(_.toArray(arguments).slice(1), [String]);
-  }, 1, "foo", "bar", "baz");
-  // NaN values
-  checksAllArguments(function (x) {
-    check(x, Number);
-  }, NaN);
+    check(args, [String]);
+  }, 1, 'foo', 'bar', 'baz');
 
-  var doesntCheckAllArguments = function (f /*arguments*/) {
+  // NaN values
+  checksAllArguments(x => check(x, Number), NaN);
+
+  const doesntCheckAllArguments = (f, ...args) => {
     try {
-      Match._failIfArgumentsAreNotAllChecked(
-        f, {}, _.toArray(arguments).slice(1), "test");
-      test.fail({message: "expected _failIfArgumentsAreNotAllChecked to throw"});
+      Match._failIfArgumentsAreNotAllChecked(f, {}, args, 'test');
+      test.fail({message: 'expected _failIfArgumentsAreNotAllChecked to throw'});
     } catch (e) {
-      test.equal(e.message, "Did not check() all arguments during test");
+      test.equal(e.message, 'Did not check() all arguments during test');
     }
   };
 
-  doesntCheckAllArguments(function () {}, undefined);
-  doesntCheckAllArguments(function () {}, null);
-  doesntCheckAllArguments(function () {}, 1);
-  doesntCheckAllArguments(function () {
-    check(_.toArray(arguments).slice(1), [String]);
-  }, 1, "asdf", "foo");
-  doesntCheckAllArguments(function (x, y) {
-    check(x, Boolean);
-  }, true, false);
+  doesntCheckAllArguments(() => {}, undefined);
+  doesntCheckAllArguments(() => {}, null);
+  doesntCheckAllArguments(() => {}, 1);
+  doesntCheckAllArguments((x, ...args) => check(args, [String]), 1, 'asdf', 'foo');
+  doesntCheckAllArguments((x, y) => check(x, Boolean), true, false);
+
   // One "true" check doesn't count for all.
-  doesntCheckAllArguments(function (x, y) {
-    check(x, Boolean);
-  }, true, true);
+  doesntCheckAllArguments((x, y) => check(x, Boolean), true, true);
+
   // For non-primitives, we really do require that each arg gets checked.
-  doesntCheckAllArguments(function (x, y) {
+  doesntCheckAllArguments((x, y) => {
     check(x, [Boolean]);
     check(x, [Boolean]);
   }, [true], [true]);
-
 
   // In an ideal world this test would fail, but we currently can't
   // differentiate between "two calls to check x, both of which are true" and
   // "check x and check y, both of which are true" (for any interned primitive
   // type).
-  checksAllArguments(function (x, y) {
+  checksAllArguments((x, y) => {
     check(x, Boolean);
     check(x, Boolean);
   }, true, true);
 });
 
-Tinytest.add("check - Match error path", function (test) {
-  var match = function (value, pattern, expectedPath) {
+Tinytest.add('check - Match error path', test => {
+  const match = (value, pattern, expectedPath) => {
     try {
       check(value, pattern);
     } catch (err) {
+
       // XXX just for FF 3.6, its JSON stringification prefers "\u000a" to "\n"
-      err.path = err.path.replace(/\\u000a/, "\\n");
-      if (err.path != expectedPath)
+      err.path = err.path.replace(/\\u000a/, '\\n');
+      if (err.path != expectedPath) {
         test.fail({
-          type: "match-error-path",
+          type: 'match-error-path',
           message: "The path of Match.Error doesn't match.",
           pattern: JSON.stringify(pattern),
           value: JSON.stringify(value),
           path: err.path,
-          expectedPath: expectedPath
+          expectedPath,
         });
+      }
     }
   };
 
-  match({ foo: [ { bar: 3 }, {bar: "something"} ] }, { foo: [ { bar: Number } ] }, "foo[1].bar");
+  match({ foo: [ { bar: 3 }, { bar: 'something' } ] }, { foo: [{ bar: Number }] }, 'foo[1].bar');
+
   // Complicated case with arrays, $, whitespace and quotes!
   match([{ $FoO: { "bar baz\n\"'": 3 } }], [{ $FoO: { "bar baz\n\"'": String } }], "[0].$FoO[\"bar baz\\n\\\"'\"]");
+
   // Numbers only, can be accessed w/o quotes
-  match({ "1231": 123 }, { "1231": String }, "[1231]");
-  match({ "1234abcd": 123 }, { "1234abcd": String }, "[\"1234abcd\"]");
-  match({ $set: { people: "nice" } }, { $set: { people: [String] } }, "$set.people");
-  match({ _underscore: "should work" }, { _underscore: Number }, "_underscore");
+  match({ '1231': 123 }, { '1231': String }, '[1231]');
+  match({ '1234abcd': 123 }, { '1234abcd': String }, '[\"1234abcd\"]');
+  match({ $set: { people: 'nice' } }, { $set: { people: [String] } }, '$set.people');
+  match({ _underscore: 'should work' }, { _underscore: Number }, '_underscore');
+
   // Nested array looks nice
-  match([[["something", "here"], []], [["string", 123]]], [[[String]]], "[1][0][1]");
+  match([[['something', 'here'], []], [['string', 123]]], [[[String]]], '[1][0][1]');
+
   // Object nested in arrays should look nice, too!
-  match([[[{ foo: "something" }, { foo: "here"}],
-          [{ foo: "asdf" }]],
+  match([[[{ foo: 'something' }, { foo: 'here'}],
+          [{ foo: 'asdf' }]],
          [[{ foo: 123 }]]],
-        [[[{ foo: String }]]], "[1][0][0].foo");
+        [[[{ foo: String }]]], '[1][0][0].foo');
 
   // JS keyword
-  match({ "return": 0 }, { "return": String }, "[\"return\"]");
+  match({ 'return': 0 }, { 'return': String }, '[\"return\"]');
 });
 
-Tinytest.add("check - Match error message", function (test) {
-  var match = function (value, pattern, expectedMessage) {
+Tinytest.add('check - Match error message', test => {
+  const match = (value, pattern, expectedMessage) => {
     try {
       check(value, pattern);
     } catch (err) {
-      if (err.message !== "Match error: " + expectedMessage)
+      if (err.message !== `Match error: ${expectedMessage}`) {
         test.fail({
-          type: "match-error-message",
+          type: 'match-error-message',
           message: "The message of Match.Error doesn't match.",
           pattern: JSON.stringify(pattern),
           value: JSON.stringify(value),
           errorMessage: err.message,
-          expectedErrorMessage: expectedMessage
+          expectedErrorMessage,
         });
+      }
     }
   };
 
-  match(2, String, "Expected string, got number");
-  match({key: 0}, Number, "Expected number, got object");
-  match(null, Boolean, "Expected boolean, got null");
-  match("string", undefined, "Expected undefined, got string");
-  match(true, null, "Expected null, got true");
+  match(2, String, 'Expected string, got number');
+  match({ key: 0 }, Number, 'Expected number, got object');
+  match(null, Boolean, 'Expected boolean, got null');
+  match('string', undefined, 'Expected undefined, got string');
+  match(true, null, 'Expected null, got true');
   match({}, Match.ObjectIncluding({ bar: String }), "Missing key 'bar'");
-  match(null, Object, "Expected object, got null");
-  match(null, Function, "Expected function, got null");
-  match("bar", "foo", "Expected foo, got \"bar\"");
-  match(3.14, Match.Integer, "Expected Integer, got 3.14");
-  match(false, [Boolean], "Expected array, got false");
-  match([null, null], [String], "Expected string, got null in field [0]");
-  match(2, {key: 2}, "Expected object, got number");
-  match(null, {key: 2}, "Expected object, got null");
-  match(new Date, {key: 2}, "Expected plain object");
+  match(null, Object, 'Expected object, got null');
+  match(null, Function, 'Expected function, got null');
+  match('bar', 'foo', 'Expected foo, got \"bar\"');
+  match(3.14, Match.Integer, 'Expected Integer, got 3.14');
+  match(false, [Boolean], 'Expected array, got false');
+  match([null, null], [String], 'Expected string, got null in field [0]');
+  match(2, { key: 2 }, 'Expected object, got number');
+  match(null, { key: 2 }, 'Expected object, got null');
+  match(new Date, { key: 2 }, 'Expected plain object');
 
-  var TestInstanceChild = function () {};
-  var TestInstanceParent = function (child) {
+  const TestInstanceChild = function () {};
+  const TestInstanceParent = function (child) {
     child._parent = this;
     this.child = child;
   };
 
-  var testInstanceChild = new TestInstanceChild()
-  var testInstanceParent = new TestInstanceParent(testInstanceChild);
-  match(testInstanceChild, TestInstanceParent, "Expected " + (TestInstanceParent.name || "particular constructor"));
+  const testInstanceChild = new TestInstanceChild()
+  const testInstanceParent = new TestInstanceParent(testInstanceChild);
+  match(testInstanceChild, TestInstanceParent, `Expected ${(TestInstanceParent.name || 'particular constructor')}`);
 
-  var circleFoo = {};
-  var circleBar = {};
+  const circleFoo = {};
+  const circleBar = {};
   circleFoo.bar = circleBar;
   circleBar.foo = circleFoo;
-  match(circleFoo, null, "Expected null, got object");
+  match(circleFoo, null, 'Expected null, got object');
 
 });
 
 // Regression test for https://github.com/meteor/meteor/issues/2136
-Meteor.isServer && Tinytest.addAsync("check - non-fiber check works", function (test, onComplete) {
-  var Fiber = Npm.require('fibers');
+Meteor.isServer && Tinytest.addAsync('check - non-fiber check works', (test, onComplete) => {
+  const Fiber = Npm.require('fibers');
 
   // We can only call test.isTrue inside normal Meteor Fibery code, so give us a
   // bindEnvironment way to get back.
-  var report = Meteor.bindEnvironment(function (success) {
+  const report = Meteor.bindEnvironment(success => {
     test.isTrue(success);
     onComplete();
   });
 
   // Get out of a fiber with process.nextTick and ensure that we can still use
   // check.
-  process.nextTick(function () {
-    var success = true;
-    if (Fiber.current)
+  process.nextTick(() => {
+    const success = true;
+    if (Fiber.current) {
       success = false;
+    }
+
     if (success) {
       try {
         check(true, Boolean);
@@ -444,6 +458,7 @@ Meteor.isServer && Tinytest.addAsync("check - non-fiber check works", function (
         success = false;
       }
     }
+
     report(success);
   });
 });

--- a/packages/check/package.js
+++ b/packages/check/package.js
@@ -1,9 +1,9 @@
 Package.describe({
-  summary: "Check whether a value matches a pattern",
-  version: '1.3.0'
+  summary: 'Check whether a value matches a pattern',
+  version: '1.3.1',
 });
 
-Package.onUse(function (api) {
+Package.onUse(api => {
   api.use('ecmascript');
   api.use('ejson');
 
@@ -13,8 +13,8 @@ Package.onUse(function (api) {
   api.export('Match');
 });
 
-Package.onTest(function (api) {
-  api.use(['check', 'tinytest', 'underscore', 'ejson', 'ecmascript'], ['client', 'server']);
+Package.onTest(api => {
+  api.use(['check', 'tinytest', 'ejson', 'ecmascript'], ['client', 'server']);
 
   api.addFiles('match_test.js', ['client', 'server']);
 });


### PR DESCRIPTION
The next package in the list, alphabetically. I considered switching the `Match` export to an instance of a class, but ended up leaving it alone. If there is a good reason to switch it, then I can go back and do that!