### PR TITLE
Add support for string padLeft/padRight

### DIFF
--- a/packages/ecmascript-runtime-client/package.js
+++ b/packages/ecmascript-runtime-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "ecmascript-runtime-client",
-  version: "0.6.1",
+  version: "0.6.2",
   summary: "Polyfills for new ECMAScript 2015 APIs like Map and Set",
   git: "https://github.com/meteor/meteor/tree/devel/packages/ecmascript-runtime-client",
   documentation: "README.md"

--- a/packages/ecmascript-runtime-client/runtime.js
+++ b/packages/ecmascript-runtime-client/runtime.js
@@ -46,6 +46,8 @@ if (typeof Reflect === "undefined") {
 // ECMAScript 2017 polyfills.
 require("core-js/es7/array");
 require("core-js/es7/object");
+require("core-js/modules/es7.string.pad-start");
+require("core-js/modules/es7.string.pad-end");
 
 // We want everything from the core-js/es6/number module except
 // es6.number.constructor.

--- a/packages/ecmascript-runtime/runtime-tests.js
+++ b/packages/ecmascript-runtime/runtime-tests.js
@@ -102,6 +102,8 @@ Tinytest.add("core-js - String", function (test) {
   test.equal(typeof "asdf".endsWith, "function");
   test.equal(typeof "asdf".repeat, "function");
   test.equal(typeof "asdf".trim, "function");
+  test.equal(typeof "asdf".padStart, "function");
+  test.equal(typeof "asdf".padEnd, "function");
 });
 
 Tinytest.add("core-js - Symbol", function (test) {


### PR DESCRIPTION
I think this should also fix the failing tests for https://github.com/meteor/meteor/pull/9636