### PR TITLE
Stop running test-packages twice in PhantomJS.

### DIFF
--- a/packages/test-in-console/package.js
+++ b/packages/test-in-console/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Run tests noninteractively, with results going to the console.",
-  version: '1.2.1'
+  version: '1.2.2'
 });
 
 Package.onUse(function (api) {

--- a/packages/test-in-console/runner.js
+++ b/packages/test-in-console/runner.js
@@ -3,8 +3,9 @@ var system = require("system");
 var platform = system.args[1] || "local";
 var platformUrl = system.env.URL + platform;
 var testUrls = [
+  // Additional application URLs can be added here to re-run tests in
+  // PhantomJS with different query parameter-based configurations.
   platformUrl,
-  platformUrl + "?force_sockjs=1",
 ];
 
 function runNextUrl() {


### PR DESCRIPTION
During the Meteor 1.6.1 beta period, we introduced logic to render a `<script>` tag to load the SockJS library in older browsers (#9353), and so it seemed important to run test-packages both with and without the `<script>` tag, using a special query parameter appended to the app URL.

The #9353 changes were ultimately reverted before Meteor 1.6.1 was released (see 365804218fc1c7d5a0d9c99a1f5635b4730e2356), and Meteor 1.6.2 will take a very different approach to bundling dependencies like SockJS for legacy browsers (#9439).

As part of this approach, PhantomJS is always considered a legacy browser, and as such provides valuable feedback on the behavior of `web.browser.legacy` bundles. However, since there's nothing to
configure with regard to SockJS anymore, there's no point in running the `test-packages` suite twice in PhantomJS.

In order to run these tests in a modern browser environment, we should probably revisit the idea of running tests in headless Chrome: https://github.com/meteor/meteor-feature-requests/issues/254