### PR TITLE
Report errors that is thrown in functions wrapped in bindEnvironment

### DIFF
--- a/packages/meteor/dynamics_browser.js
+++ b/packages/meteor/dynamics_browser.js
@@ -39,8 +39,7 @@ Meteor.bindEnvironment = function (func, onException, _this) {
     onException = function (error) {
       Meteor._debug(
         "Exception in " + description + ":",
-        error && error.stack || error,
-        error
+        error && error.message || error
       );
     };
   }

--- a/packages/meteor/dynamics_browser.js
+++ b/packages/meteor/dynamics_browser.js
@@ -39,7 +39,8 @@ Meteor.bindEnvironment = function (func, onException, _this) {
     onException = function (error) {
       Meteor._debug(
         "Exception in " + description + ":",
-        error && error.message || error
+        error,
+        error.stack
       );
     };
   }

--- a/packages/meteor/dynamics_browser.js
+++ b/packages/meteor/dynamics_browser.js
@@ -39,7 +39,8 @@ Meteor.bindEnvironment = function (func, onException, _this) {
     onException = function (error) {
       Meteor._debug(
         "Exception in " + description + ":",
-        error && error.stack || error
+        error && error.stack || error,
+        error
       );
     };
   }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

## Motivation
There is no way how to read errors thrown in functions that is wrapped in bindEnvironment.
If your function throws only what you get is eg:
"Exception in delivering result of invoking 'someMethod': call stack here", but there is no way how to get message or reason of Error that caused exception, you get only the call stack.

My pull request makes error reporting more consistent, making it same behaviour as Meteor.apply [livedata_connection.js#L731](https://github.com/pravdomil/meteor/blob/fb1fd254b0f938a8efa5662499cfe77b92105127/packages/ddp-client/common/livedata_connection.js#L731) or [livedata_connection.js#L712](https://github.com/pravdomil/meteor/blob/fb1fd254b0f938a8efa5662499cfe77b92105127/packages/ddp-client/common/livedata_connection.js#L712)