### PR TITLE
Automate rebalancing of CircleCI test groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
             - test-groups-v1-{{ .Branch }}
             - test-groups-v1
       - run:
-          name: Create Test Results Directory If Missing
+          name: Create Test Results Directory
           command: |
             sudo mkdir -p ./tmp/results/junit
             sudo chmod a+rwx ./tmp/results/junit
@@ -688,7 +688,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Create ./test-groups
+          name: Create Test Groups Directory
           command: |
             sudo mkdir -p ./tmp/test-groups
             sudo chmod a+rwx ./tmp/test-groups

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,6 @@ run_env_change: &run_env_change
     sudo mkdir -p /tmp/core_dumps
     sudo chmod a+rwx /tmp/core_dumps
 
-    # Make a place for JUnit tests to live.
-    sudo mkdir -p /tmp/results/junit
-    sudo chmod -R a+rwx /tmp/results/
-
     # Bake the locale we expect into the image.
     echo "en_US.UTF-8 UTF-8" | sudo tee /etc/locale.gen
     sudo locale-gen
@@ -93,7 +89,7 @@ build_machine_environment: &build_machine_environment
     # Skip these tests on every test run.
     # If needed, for readability this should be a regex wrapped across
     # multiple lines in quotes.
-    SELF_TEST_EXCLUDE: ""
+    SELF_TEST_EXCLUDE: "add debugOnly and prodOnly packages"
 
     # These will be evaled before each command.
     PRE_TEST_COMMANDS: |-
@@ -107,6 +103,10 @@ build_machine_environment: &build_machine_environment
     # This is only to make Meteor self-test not remind us that we can set
     # this argument for self-tests.
     SELF_TEST_TOOL_NODE_FLAGS: " "
+
+    # Variables for load-balancing
+    NUM_GROUPS: 11
+    RUNNING_AVG_LENGTH: 5
 
 jobs:
   Get Ready:
@@ -123,6 +123,15 @@ jobs:
           command: (git submodule sync && git submodule update --init --recursive) || (rm -fr .git/config .git/modules && git submodule deinit -f . && git submodule update --init --recursive)
       - restore_cache:
           key: meteor-cache
+      - restore_cache:
+          keys: 
+            - test-groups-v1-{{ .Branch }}
+            - test-groups-v1
+      - run:
+          name: Create Test Results Directory If Missing
+          command: |
+            sudo mkdir -p ./tmp/results/junit
+            sudo chmod a+rwx ./tmp/results/junit
       - run:
           name: Get Ready
           command: |
@@ -153,7 +162,7 @@ jobs:
           key: meteor-cache
           <<: *meteor_cache_dirs
 
-  Group 0:
+  Isolated Tests:
     <<: *build_machine_environment
     steps:
       - run:
@@ -166,43 +175,36 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running warehouse self-tests"
+          name: "Running self-test ('package-tests: add debugOnly and prodOnly packages')"
+          command: |
+            eval $PRE_TEST_COMMANDS;
+            ./meteor self-test \
+              'add debugOnly and prodOnly packages' \
+              --retries ${METEOR_SELF_TEST_RETRIES} \
+              --headless
+          no_output_timeout: 20m
+      - run:
+          name: "Running self-test (Custom Warehouse Tests)"
           command: |
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/0-1.xml \
               --with-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
-          name: "Running self-test (0): A-Comm"
-          command: |
-            eval $PRE_TEST_COMMANDS;
-            ./meteor self-test \
-              --retries ${METEOR_SELF_TEST_RETRIES} \
-              --exclude "${SELF_TEST_EXCLUDE}" \
-              --headless \
-              --junit /tmp/results/junit/0-2.xml \
-              --file '^[a-b]|^c[a-n]|^co[a-l]|^comm' \
-              --without-tag "custom-warehouse"
-          no_output_timeout: 20m
-      - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 1:
+  Test Group 0:
     <<: *build_machine_environment
     steps:
       - run:
@@ -215,32 +217,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (1): Comn-Comz"
+          name: "Running self-test (Test Group 0)"
           command: |
+            if [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=$(<./tmp/test-groups/0.txt); else TEST_GROUP='^[a-b]|^c[a-n]|^co[a-l]|^comm'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/1.xml \
-              --file '^com[n-z]' \
+              --junit ./tmp/results/junit/0.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 2:
+  Test Group 1:
     <<: *build_machine_environment
     steps:
       - run:
@@ -253,32 +257,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (2): Con-Coz"
+          name: "Running self-test (Test Group 1)"
           command: |
+            if [ -f ./tmp/test-groups/1.txt ]; then TEST_GROUP=$(<./tmp/test-groups/1.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^com[n-z]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/2.xml \
-              --file '^co[n-z]' \
+              --junit ./tmp/results/junit/1.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 3:
+  Test Group 2:
     <<: *build_machine_environment
     steps:
       - run:
@@ -291,32 +297,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (3): Cp-He"
+          name: "Running self-test (Test Group 2)"
           command: |
+            if [ -f ./tmp/test-groups/2.txt ]; then TEST_GROUP=$(<./tmp/test-groups/2.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^co[n-z]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/3.xml \
-              --file '^c[p-z]|^[d-g]|^h[a-e]' \
+              --junit ./tmp/results/junit/2.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 4:
+  Test Group 3:
     <<: *build_machine_environment
     steps:
       - run:
@@ -329,32 +337,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (4): Hf-Hz"
-          command:  |
+          name: "Running self-test (Test Group 3)"
+          command: |
+            if [ -f ./tmp/test-groups/3.txt ]; then TEST_GROUP=$(<./tmp/test-groups/3.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^c[p-z]|^[d-g]|^h[a-e]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/4.xml \
-              --file '^h[f-z]' \
+              --junit ./tmp/results/junit/3.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 5:
+  Test Group 4:
     <<: *build_machine_environment
     steps:
       - run:
@@ -367,32 +377,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (5): I-L"
+          name: "Running self-test (Test Group 4)"
           command: |
+            if [ -f ./tmp/test-groups/4.txt ]; then TEST_GROUP=$(<./tmp/test-groups/4.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^h[f-z]|^[i-l]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/5.xml \
-              --file '^[i-l]' \
+              --junit ./tmp/results/junit/4.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 6:
+  Test Group 5:
     <<: *build_machine_environment
     steps:
       - run:
@@ -405,32 +417,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (6): Ma-Mod"
+          name: "Running self-test (Test Group 5)"
           command: |
+            if [ -f ./tmp/test-groups/5.txt ]; then TEST_GROUP=$(<./tmp/test-groups/5.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^m[a-n]|^mo[a-d]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/6.xml \
-              --file '^m[a-n]|^mo[a-d]' \
+              --junit ./tmp/results/junit/5.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
-
-  Group 7:
+ 
+  Test Group 6:
     <<: *build_machine_environment
     steps:
       - run:
@@ -443,32 +457,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (7): Moe-O"
+          name: "Running self-test (Test Group 6)"
           command: |
+            if [ -f ./tmp/test-groups/6.txt ]; then TEST_GROUP=$(<./tmp/test-groups/6.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^mo[e-z]|^m[p-z]|^[n-o]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/7.xml \
-              --file '^mo[e-z]|^m[p-z]|^[n-o]' \
+              --junit ./tmp/results/junit/6.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 8:
+  Test Group 7:
     <<: *build_machine_environment
     steps:
       - run:
@@ -481,32 +497,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (8): P-Re"
+          name: "Running self-test (Test Group 7)"
           command: |
+            if [ -f ./tmp/test-groups/7.txt ]; then TEST_GROUP=$(<./tmp/test-groups/7.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^[p-q]|^r[a-e]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/8.xml \
-              --file '^[p-q]|^r[a-e]' \
+              --junit ./tmp/results/junit/7.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 9:
+  Test Group 8:
     <<: *build_machine_environment
     steps:
       - run:
@@ -519,32 +537,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (9): Rf-Rz"
+          name: "Running self-test (Test Group 8)"
           command: |
+            if [ -f ./tmp/test-groups/8.txt ]; then TEST_GROUP=$(<./tmp/test-groups/8.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^r[f-z]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/9.xml \
-              --file '^r[f-z]' \
+              --junit ./tmp/results/junit/8.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 10:
+  Test Group 9:
     <<: *build_machine_environment
     steps:
       - run:
@@ -557,32 +577,34 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (10): S"
+          name: "Running self-test (Test Group 9)"
           command: |
+            if [ -f ./tmp/test-groups/9.txt ]; then TEST_GROUP=$(<./tmp/test-groups/9.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^s'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/10.xml \
-              --file '^s' \
+              --junit ./tmp/results/junit/9.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
 
-  Group 11:
+  Test Group 10:
     <<: *build_machine_environment
     steps:
       - run:
@@ -595,26 +617,28 @@ jobs:
           name: "Print environment"
           command: printenv
       - run:
-          name: "Running self-test (11): T-Z"
+          name: "Running self-test (Test Group 10)"
           command: |
+            if [ -f ./tmp/test-groups/10.txt ]; then TEST_GROUP=$(<./tmp/test-groups/10.txt); elif [ -f ./tmp/test-groups/0.txt ]; then TEST_GROUP=XXXXX; else TEST_GROUP='^[t-z]'; fi
+            echo $TEST_GROUP;
             eval $PRE_TEST_COMMANDS;
             ./meteor self-test \
+              "$TEST_GROUP" \
               --retries ${METEOR_SELF_TEST_RETRIES} \
               --exclude "${SELF_TEST_EXCLUDE}" \
               --headless \
-              --junit /tmp/results/junit/11.xml \
-              --file '^[t-z]' \
+              --junit ./tmp/results/junit/10.xml \
               --without-tag "custom-warehouse"
           no_output_timeout: 20m
       - run:
           <<: *run_save_node_bin
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
       - store_test_results:
-          path: /tmp/results
+          path: ./tmp/results
+      - persist_to_workspace:
+          root: .
+          paths: ./tmp/results/junit
       - store_artifacts:
-          path: /tmp/results
+          path: ./tmp/results
       - store_artifacts:
           path: /tmp/core_dumps
       - store_artifacts:
@@ -658,45 +682,80 @@ jobs:
             npm install
             npm test
 
+  Clean Up:
+    <<: *build_machine_environment
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Create ./test-groups
+          command: |
+            sudo mkdir -p ./tmp/test-groups
+            sudo chmod a+rwx ./tmp/test-groups
+      - run:
+          name: Calculate Balanced Test Groups
+          command: |
+            npm install --prefix ./scripts/test-balancer
+            npm start --prefix ./scripts/test-balancer --num-groups ${NUM_GROUPS} --running-avg-length ${RUNNING_AVG_LENGTH}
+      - save_cache:
+          key: test-groups-v1-{{ .Branch }}-{{ .BuildNum }}
+          paths:
+            - ./tmp/test-groups
+          when: on_success
+
 workflows:
   version: 2
   Build and Test:
     jobs:
       - Docs
       - Get Ready
-      - Group 0:
+      - Isolated Tests:
           requires:
             - Get Ready
-      - Group 1:
+      - Test Group 0:
           requires:
             - Get Ready
-      - Group 2:
+      - Test Group 1:
           requires:
             - Get Ready
-      - Group 3:
+      - Test Group 2:
           requires:
             - Get Ready
-      - Group 4:
+      - Test Group 3:
           requires:
             - Get Ready
-      - Group 5:
+      - Test Group 4:
           requires:
             - Get Ready
-      - Group 6:
+      - Test Group 5:
           requires:
             - Get Ready
-      - Group 7:
+      - Test Group 6:
           requires:
             - Get Ready
-      - Group 8:
+      - Test Group 7:
           requires:
             - Get Ready
-      - Group 9:
+      - Test Group 8:
           requires:
             - Get Ready
-      - Group 10:
+      - Test Group 9:
           requires:
             - Get Ready
-      - Group 11:
+      - Test Group 10:
           requires:
             - Get Ready
+      - Clean Up:
+          requires:
+            - Isolated Tests
+            - Test Group 0
+            - Test Group 1
+            - Test Group 2
+            - Test Group 3
+            - Test Group 4
+            - Test Group 5
+            - Test Group 6
+            - Test Group 7
+            - Test Group 8
+            - Test Group 9
+            - Test Group 10

--- a/scripts/test-balancer/.gitignore
+++ b/scripts/test-balancer/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/scripts/test-balancer/index.js
+++ b/scripts/test-balancer/index.js
@@ -6,7 +6,7 @@ const parser = new xml2js.Parser();
 // Grab the command options
 const args = process.argv.slice(2);
 const numGroups = +args[args.indexOf('--num-groups') + 1];
-const runningAvgLenth = +args[args.indexOf('--running-avg-length') + 1];
+const runningAvgLength = +args[args.indexOf('--running-avg-length') + 1];
 
 // Load the junit results from the various groups on this build
 const currentBuildResults = [];
@@ -38,7 +38,7 @@ try {
 // Add new results and limit the record to the specified number for the running
 // average
 const allBuildResults =
-  [currentBuildResults, ...previousBuildResults].slice(0, runningAvgLenth);
+  [currentBuildResults, ...previousBuildResults].slice(0, runningAvgLength);
 
 let averageResults = [];
 

--- a/scripts/test-balancer/index.js
+++ b/scripts/test-balancer/index.js
@@ -26,7 +26,8 @@ for (let i = 0; i < numGroups; i++) {
 // Try to load previous test balance
 let previousBuildResults = [];
 try {
-  previousBuildResults = JSON.parse(fs.readFileSync(`../../tmp/test-groups/data.json`));
+  previousBuildResults = 
+    JSON.parse(fs.readFileSync(`../../tmp/test-groups/data.json`));
 } catch (err) {
   console.log([
     'No historical data found! Perhaps the test groups cache key format has ',
@@ -122,4 +123,7 @@ console.log(`Total Tests Balanced: ${averageResults.length}`)
 
 // Write the results so we can use them for calculating averages in the next
 // build
-fs.writeFileSync('../../tmp/test-groups/data.json', JSON.stringify(allBuildResults)); 
+fs.writeFileSync(
+  '../../tmp/test-groups/data.json', 
+  JSON.stringify(allBuildResults)
+); 

--- a/scripts/test-balancer/index.js
+++ b/scripts/test-balancer/index.js
@@ -1,0 +1,125 @@
+const fs = require('fs');
+const xml2js = require('xml2js');
+
+const parser = new xml2js.Parser();
+
+// Grab the command options
+const args = process.argv.slice(2);
+const numGroups = +args[args.indexOf('--num-groups') + 1];
+const runningAvgLenth = +args[args.indexOf('--running-avg-length') + 1];
+
+// Load the junit results from the various groups on this build
+const currentBuildResults = [];
+for (let i = 0; i < numGroups; i++) {
+  const data = fs.readFileSync(`../../tmp/results/junit/${i}.xml`);
+  parser.parseString(data, (err, { testsuites: { testsuite } }) => {
+    (testsuite || [])
+      .map(testsuite => testsuite.testcase)
+      .forEach((testcase = []) =>
+        testcase.forEach(({ $: { name, time } }) => {
+          currentBuildResults.push({ name, time: +time })
+        })
+      );
+  });
+}
+
+// Try to load previous test balance
+let previousBuildResults = [];
+try {
+  previousBuildResults = JSON.parse(fs.readFileSync(`../../tmp/test-groups/data.json`));
+} catch (err) {
+  console.log([
+    'No historical data found! Perhaps the test groups cache key format has ',
+    'been changed since the last successful build.'
+  ].join('\n'));
+}
+
+// Add new results and limit the record to the specified number for the running
+// average
+const allBuildResults =
+  [currentBuildResults, ...previousBuildResults].slice(0, runningAvgLenth);
+
+let averageResults = [];
+
+// We assume that all the tests that were run this time will be the ones run 
+// next time, so we only calculate the averages for those. This is will ignore
+// any tests that were not run most recently but which were run in previous
+// builds
+currentBuildResults.forEach(({ name }) => {
+  const times = [];
+
+  // Check each build result to see if the test was run
+  allBuildResults.forEach(buildResults => {
+    const { time } = buildResults.find(test => test.name === name) || {};
+
+    // It's possible this particular test wasn't run in this build
+    if (time !== undefined) {
+      times.push(!isNaN(time) ? time : 0);
+    }
+  })
+
+  const averageTime =
+    Math.floor(times.reduce((p, x) => p + x, 0) / times.length * 1000) / 1000;
+
+  averageResults.push({ name, time: averageTime });
+});
+
+// This is a naïve but simple allocation which just take the largest remaining
+// test and puts it in the group with the lowest total
+const groupTestNames = Array(numGroups);
+const totals = Array(numGroups).fill(0);
+const getMin = () =>
+  totals.reduce((min, total, i) => total < totals[min] ? i : min, 0);
+
+averageResults.sort((a, b) => b.time - a.time);
+
+averageResults.forEach(({ name, time }) => {
+  const min = getMin();
+
+  groupTestNames[min]
+    ? groupTestNames[min].push(name)
+    : groupTestNames[min] = [name];
+
+  totals[min] += time;
+});
+
+// Create the (long) regular expressions for each group
+groupTestNames.forEach((names, i) => {
+  const escapedNames = names.map(
+    name => name.replace(/['"-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+  );
+  
+  let testMatcher = `^${escapedNames.join('$|^')}$`;
+
+  // Put any new tests on the first group - in case the number of groups happens
+  // to reduce we can still catch these tests
+  if (i === 0) {
+
+    // Create the (even longer) regular expression to catch any other tests that
+    // might get added to the suite or which may have been turned off for the 
+    // most recent build
+    const otherTestsMatcher = groupTestNames.map(names => {
+      const escapedNames = names.map(
+        name => name.replace(/['"-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+      );
+      
+      return `^${escapedNames.join('$|^')}$`;
+    }).join('|');
+    
+
+    testMatcher += `|^(?!.*(${otherTestsMatcher})).*$`;
+  }
+  
+  fs.writeFileSync(`../../tmp/test-groups/${i}.txt`, testMatcher);
+  console.log([
+    `Group ${i} Tests (${names.length} tests, ~${Math.round(totals[i])}s):`, 
+    ...names, 
+    ' '
+  ].join('\n'));
+});
+
+console.log(`Total Tests Balanced: ${averageResults.length}`)
+
+// Write the results so we can use them for calculating averages in the next
+// build
+fs.writeFileSync('../../tmp/test-groups/data.json', JSON.stringify(allBuildResults)); 

--- a/scripts/test-balancer/package-lock.json
+++ b/scripts/test-balancer/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "test-balancer",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    }
+  }
+}

--- a/scripts/test-balancer/package.json
+++ b/scripts/test-balancer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-balancer",
+  "version": "0.0.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "xml2js": "^0.4.19"
+  }
+}


### PR DESCRIPTION
This PR builds on the work done to improve TTGC (time to green check) in #9627. In that PR, file-matching regular expressions were manually adjusted to try to balance the test groups. In this PR we optimize at the test level instead of the file level, and automate the process, readjusting after every build. Thanks for the suggestions @abernix!

This PR still has some gaps, but the stats look like they are going in the right direction:
* Automated balancing standard deviation: [123 seconds](https://circleci.com/workflow-run/440f8e4f-8b60-4306-986b-142f42671e3a)
* Manual balancing standard deviation: [182 seconds](https://circleci.com/workflow-run/f64f6df7-0820-4164-977f-68f243aa05ac)

Some notes:
- A new job now runs after all test groups finish. It runs a node app that reads the persisted test results from the current build, combining it with average test times from previous builds to calculate a close split between the groups
- Group tests are run according to the cache file generated by the app at the end of the previous build
- The number of groups to use and the number of builds to use in the running average are configurable in `.circleci/config.yml`
- The path for test results was switched to relative due to restrictions on workspace paths
- There are a series of fallbacks used to decide which tests to run on any given group: either 1) the optimized group from the cache, 2) a manually-determined set of tests because no cache was found, or 3) no tests at all because no tests are assigned to the group (for instance, group number 14 in the first build after the number of groups is increased from 12 to 16)

Outstanding todos:
- [x] Isolate tests that don't play well with others
- [x] Remove `wip-` prefix from cache keys
- [x] Test that the catch-all for new tests is working properly
- [x] Check that all tests are getting run (escape regexps properly)

Items for a subsequent PR:
 - Fix flakey tests, especially `package-tests: add debugOnly and prodOnly packages`
This test always fails when certain other tests run before it
Known conflicting tests: `autoupdate: autoupdate`, and `assets: assets - helper exists to unicode normalize path strings`
- Confirm that test timing is accurate
It looks like retries are not included in the test time, and maybe also tests that print `Testing with phantomjs` (need to check)
- Handle more edge cases: tests with the same name, number of groups is reduced since last build, invalid number of groups, ...?
- Switch away from super-long regular expressions to `meteor self-test` reading a list from a json file?
- Unit tests for `test-balancer` (mocha?)
- Exclude `Clean Up` job from GitHub green check
- Optimize fallback groups further (currently they are based on the file-level optimization and aren't balanced very well)