### PR TITLE
fix setting bcryptRounds using Accounts.config()

### DIFF
--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -5,7 +5,7 @@ Package.describe({
   // 2.2.x in the future. The version was also bumped to 2.0.0 temporarily
   // during the Meteor 1.5.1 release process, so versions 2.0.0-beta.2
   // through -beta.5 and -rc.0 have already been published.
-  version: "1.5.0"
+  version: "1.5.1"
 });
 
 Package.onUse(function(api) {

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -22,7 +22,7 @@ var bcryptCompare = Meteor.wrapAsync(bcrypt.compare);
 // "sha-256" and then passes the digest to bcrypt.
 
 
-Accounts._bcryptRounds = Accounts._options.bcryptRounds || 10;
+Accounts._bcryptRounds = () => Accounts._options.bcryptRounds || 10;
 
 // Given a 'password' from the client, extract the string that we should
 // bcrypt. 'password' can be one of:
@@ -49,7 +49,7 @@ var getPasswordString = function (password) {
 //
 var hashPassword = function (password) {
   password = getPasswordString(password);
-  return bcryptHash(password, Accounts._bcryptRounds);
+  return bcryptHash(password, Accounts._bcryptRounds());
 };
 
 // Extract the number of rounds used in the specified bcrypt hash.
@@ -81,13 +81,13 @@ Accounts._checkPassword = function (user, password) {
 
   if (! bcryptCompare(formattedPassword, hash)) {
     result.error = handleError("Incorrect password", false);
-  } else if (hash && Accounts._bcryptRounds != hashRounds) {
+  } else if (hash && Accounts._bcryptRounds() != hashRounds) {
     // The password checks out, but the user's bcrypt hash needs to be updated.
     Meteor.defer(() => {
       Meteor.users.update({ _id: user._id }, {
         $set: {
           'services.password.bcrypt':
-            bcryptHash(formattedPassword, Accounts._bcryptRounds)
+            bcryptHash(formattedPassword, Accounts._bcryptRounds())
         }
       });
     });

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1900,21 +1900,20 @@ if (Meteor.isServer) (function () {
       const userId1 = Accounts.createUser({ username, password });
       let user1 = Meteor.users.findOne(userId1);
       let rounds = getUserHashRounds(user1);
-      test.equal(rounds, Accounts._bcryptRounds);
+      test.equal(rounds, Accounts._bcryptRounds());
 
       // When a custom number of bcrypt rounds is set via Accounts.config,
       // and an account was already created using the default number of rounds,
       // make sure that a new hash is created (and stored) using the new number
       // of rounds, the next time the password is checked.
-      const defaultRounds = Accounts._bcryptRounds;
+      const defaultRounds = Accounts._bcryptRounds();
       const customRounds = 11;
-      Accounts._bcryptRounds = customRounds;
+      Accounts._options.bcryptRounds = customRounds;
       Accounts._checkPassword(user1, password);
       Meteor.setTimeout(() => {
         user1 = Meteor.users.findOne(userId1);
         rounds = getUserHashRounds(user1);
         test.equal(rounds, customRounds);
-        Accounts._options.bcryptRounds = null;
 
         // When a custom number of bcrypt rounds is set, make sure it's
         // used for new bcrypt password hashes.
@@ -1925,7 +1924,7 @@ if (Meteor.isServer) (function () {
         test.equal(rounds, customRounds);
 
         // Cleanup
-        Accounts._bcryptRounds = defaultRounds;
+        Accounts._options.bcryptRounds = defaultRounds;
         Meteor.users.remove(userId1);
         Meteor.users.remove(userId2);
         done();


### PR DESCRIPTION
This PR fixes #9651 by dynamically evaluating `Accounts._bcryptRounds`.