### PR TITLE
Add Promise.prototype.finally support

### DIFF
--- a/History.md
+++ b/History.md
@@ -19,6 +19,7 @@
 * Meteor's `promise` package has been updated to support
   [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally).
   [Issue 9639](https://github.com/meteor/meteor/issues/9639)
+  [PR #9663](https://github.com/meteor/meteor/pull/9663)
 
 ## v1.6.1, 2018-01-19
 

--- a/History.md
+++ b/History.md
@@ -16,6 +16,10 @@
   other (optional) plugins like `@babel/plugin-proposal-decorators`.
   [Issue #9628](https://github.com/meteor/meteor/issues/9628)
 
+* Meteor's `promise` package has been updated to support
+  [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally).
+  [Issue 9639](https://github.com/meteor/meteor/issues/9639)
+
 ## v1.6.1, 2018-01-19
 
 * Node has been updated to version

--- a/packages/promise/common.js
+++ b/packages/promise/common.js
@@ -20,3 +20,17 @@ exports.Promise.prototype.done = function (onFulfilled, onRejected) {
     });
   });
 };
+
+if (! exports.Promise.prototype.hasOwnProperty("finally")) {
+  exports.Promise.prototype.finally = function (f) {
+    return this.then(function (value) {
+      return exports.Promise.resolve(f()).then(function () {
+        return value;
+      });
+    }, function (err) {
+      return exports.Promise.resolve(f()).then(function () {
+        throw err;
+      });
+    });
+  };
+}

--- a/packages/promise/package.js
+++ b/packages/promise/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "promise",
-  version: "0.10.1",
+  version: "0.10.2",
   summary: "ECMAScript 2015 Promise polyfill with Fiber support",
   git: "https://github.com/meteor/promise",
   documentation: "README.md"

--- a/packages/promise/promise-tests.js
+++ b/packages/promise/promise-tests.js
@@ -14,3 +14,25 @@ Tinytest.addAsync("meteor-promise - sanity", function (test, done) {
     test.exception(error);
   });
 });
+
+Tinytest.addAsync("meteor-promise - finally", function (test, done) {
+  var finallyCalledAfterResolved = false;
+  Promise.resolve("working").then(function (result) {
+    test.equal(result, "working");
+  }).finally(function () {
+    finallyCalledAfterResolved = true;
+  }).then(function () {
+    test.isTrue(finallyCalledAfterResolved);
+    done();
+  });
+
+  var finallyCalledAfterRejected = false;
+  Promise.reject("failed").catch(function (result) {
+    test.equal(result, "failed");
+  }).finally(function () {
+    finallyCalledAfterRejected = true;
+  }).then(function () {
+    test.isTrue(finallyCalledAfterRejected);
+    done();
+  });
+});


### PR DESCRIPTION
Adds `Promise.prototype.finally` support to Meteor's `promise` package. Let me know if I missed anything. Thanks!

Fixes #9639.
