### PR TITLE
Bump CoffeeScript to 2.2.1

### DIFF
--- a/packages/non-core/coffeescript-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/non-core/coffeescript-compiler/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "coffeescript": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.0.3.tgz",
-      "integrity": "sha512-iIfUN+71IyI2FQABXh1luzZeQgqwUPeWh6lDovJatQQs+30bvyGnBY0r4BnD0hoMAasNuZVHlL1U09Oy1ZfSeg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.2.1.tgz",
+      "integrity": "sha512-UFSs0WDed7ZiQGtWZ401PZnlgnP5jtlr4Gk+aPMTIkFkKY6Kz2gRp+WIu0QzllR30nV2XheicAhKwDJQcor6lg=="
     },
     "source-map": {
       "version": "0.5.7",

--- a/packages/non-core/coffeescript-compiler/package.js
+++ b/packages/non-core/coffeescript-compiler/package.js
@@ -22,8 +22,8 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.use('babel-compiler@6.19.4||7.0.0');
-  api.use('ecmascript@0.8.3');
+  api.use('babel-compiler@6.19.4||7.0.3');
+  api.use('ecmascript@0.10.3');
 
   api.mainModule('coffeescript-compiler.js', 'server');
 

--- a/packages/non-core/coffeescript-compiler/package.js
+++ b/packages/non-core/coffeescript-compiler/package.js
@@ -13,11 +13,11 @@ Package.describe({
   summary: 'Compiler for CoffeeScript code, supporting the coffeescript package',
   // This version of NPM `coffeescript` module, with _1, _2 etc.
   // If you change this, make sure to also update ../coffeescript/package.js to match.
-  version: '2.0.3_4'
+  version: '2.2.1_1'
 });
 
 Npm.depends({
-  'coffeescript': '2.0.3',
+  'coffeescript': '2.2.1',
   'source-map': '0.5.7'
 });
 

--- a/packages/non-core/coffeescript-test-helper/package.js
+++ b/packages/non-core/coffeescript-test-helper/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use('coffeescript@2.0.3_4', ['client', 'server']);
+  api.use('coffeescript@2.2.1_1', ['client', 'server']);
   api.export('COFFEESCRIPT_EXPORTED');
   api.export('COFFEESCRIPT_EXPORTED_ONE_MORE');
   api.export('COFFEESCRIPT_EXPORTED_WITH_BACKTICKS');

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -6,12 +6,12 @@ Package.describe({
   // so bumping the version of this package will be how they get newer versions
   // of `coffeescript-compiler`. If you change this, make sure to also update
   // ../coffeescript-compiler/package.js to match.
-  version: '2.0.3_4'
+  version: '2.2.1_1'
 });
 
 Package.registerBuildPlugin({
   name: 'compile-coffeescript',
-  use: ['caching-compiler@1.1.9', 'ecmascript@0.8.3', 'coffeescript-compiler@2.0.3_4'],
+  use: ['caching-compiler@1.1.9', 'ecmascript@0.8.3', 'coffeescript-compiler@2.2.1_1'],
   sources: ['compile-coffeescript.js']
 });
 

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -24,9 +24,10 @@ Package.onUse(function (api) {
   // same runtime environment that the 'ecmascript' package provides.
   // The following api.imply calls should match those in ../../ecmascript/package.js,
   // except that coffeescript does not api.imply('modules').
-  api.imply('ecmascript-runtime-server@0.4.1', 'server');
-  api.imply('babel-runtime@1.0.1');
-  api.imply('promise@0.9.0');
+  api.imply('ecmascript-runtime@0.5.0');
+  api.imply('babel-runtime@1.2.2');
+  api.imply('promise@0.10.1');
+  api.imply('dynamic-import@0.3.0');
 });
 
 Package.onTest(function (api) {


### PR DESCRIPTION
I also bumped the versions of its dependencies, and changed `ecmascript-runtime` to be implied on both client and server. @benjamn, was there a reason we were implying `ecmascript-runtime` only on the server? Don’t we want polyfills on the client as well?