### PR TITLE
Make error reporting more consistent

### DIFF
--- a/packages/accounts-base/localstorage_token.js
+++ b/packages/accounts-base/localstorage_token.js
@@ -126,7 +126,7 @@ Ap._initLocalStorage = function () {
       userId && self.connection.setUserId(userId);
       self.loginWithToken(token, function (err) {
         if (err) {
-          Meteor._debug("Error logging in with token: " + err);
+          Meteor._debug("Error logging in with token", err);
           self.makeClientLoggedOut();
         }
 

--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -418,7 +418,7 @@ CollectionPrototype._callMutatorMethod = function _callMutatorMethod(name, args,
     // not force a callback.
     callback = function (err) {
       if (err)
-        Meteor._debug(name + " failed: ", err);
+        Meteor._debug(name + " failed", err);
     };
   }
 

--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -418,7 +418,7 @@ CollectionPrototype._callMutatorMethod = function _callMutatorMethod(name, args,
     // not force a callback.
     callback = function (err) {
       if (err)
-        Meteor._debug(name + " failed: " + (err.reason || err.stack));
+        Meteor._debug(name + " failed: ", err);
     };
   }
 

--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -70,7 +70,7 @@ function after(times, func) {
 Autoupdate._retrySubscription = function () {
   Meteor.subscribe("meteor_autoupdate_clientVersions", {
     onError: function (error) {
-      Meteor._debug("autoupdate subscription failed:", error);
+      Meteor._debug("autoupdate subscription failed", error);
       failures++;
       retry.retryLater(failures, function () {
         // Just retry making the subscription, don't reload the whole

--- a/packages/callback-hook/hook.js
+++ b/packages/callback-hook/hook.js
@@ -120,7 +120,7 @@ function dontBindEnvironment(func, onException, _this) {
     onException = function (error) {
       Meteor._debug(
         "Exception in " + description + ":",
-        error && error.stack || error
+        error
       );
     };
   }

--- a/packages/callback-hook/hook.js
+++ b/packages/callback-hook/hook.js
@@ -119,7 +119,7 @@ function dontBindEnvironment(func, onException, _this) {
     var description = onException || "callback of async function";
     onException = function (error) {
       Meteor._debug(
-        "Exception in " + description + ":",
+        "Exception in " + description,
         error
       );
     };

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -730,7 +730,7 @@ export class Connection {
         // to the console.
         callback = err => {
           err &&
-            Meteor._debug("Error invoking Method '" + name + "':", err);
+            Meteor._debug("Error invoking Method '" + name + "'", err);
         };
       } else {
         // On the server, make the function synchronous. Throw on

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -713,8 +713,7 @@ export class Connection {
       } else if (!exception._expectedByTest) {
         Meteor._debug(
           "Exception while simulating the effect of invoking '" + name + "'",
-          exception,
-          exception.stack
+          exception
         );
       }
     }
@@ -731,7 +730,7 @@ export class Connection {
         // to the console.
         callback = err => {
           err &&
-            Meteor._debug("Error invoking Method '" + name + "':", err.message);
+            Meteor._debug("Error invoking Method '" + name + "':", err);
         };
       } else {
         // On the server, make the function synchronous. Throw on

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1399,8 +1399,7 @@ Server = function (options) {
         socket._meteorSession.processMessage(msg);
       } catch (e) {
         // XXX print stack nicely
-        Meteor._debug("Internal exception while processing message", msg,
-                      e.message, e.stack);
+        Meteor._debug("Internal exception while processing message", msg, e);
       }
     });
 
@@ -1735,9 +1734,9 @@ var wrapInternalException = function (exception, context) {
   // Tests can set the '_expectedByTest' flag on an exception so it won't go to
   // the server log.
   if (!exception._expectedByTest) {
-    Meteor._debug("Exception " + context, exception.stack);
+    Meteor._debug("Exception " + context, exception);
     if (exception.sanitizedError) {
-      Meteor._debug("Sanitized and reported to the client as:", exception.sanitizedError.message);
+      Meteor._debug("Sanitized and reported to the client as:", exception.sanitizedError);
       Meteor._debug();
     }
   }

--- a/packages/ddp-server/writefence.js
+++ b/packages/ddp-server/writefence.js
@@ -99,7 +99,7 @@ _.extend(DDPServer._WriteFence.prototype, {
         try {
           func(self);
         } catch (err) {
-          Meteor._debug("exception in write fence callback:", err);
+          Meteor._debug("exception in write fence callback", err);
         }
       }
 

--- a/packages/meteor/dynamics_browser.js
+++ b/packages/meteor/dynamics_browser.js
@@ -39,8 +39,7 @@ Meteor.bindEnvironment = function (func, onException, _this) {
     onException = function (error) {
       Meteor._debug(
         "Exception in " + description + ":",
-        error,
-        error.stack
+        error
       );
     };
   }

--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -90,7 +90,7 @@ Meteor.bindEnvironment = function (func, onException, _this) {
     onException = function (error) {
       Meteor._debug(
         "Exception in " + description + ":",
-        error && error.stack || error
+        error
       );
     };
   } else if (typeof(onException) !== 'function') {

--- a/packages/meteor/fiber_helpers.js
+++ b/packages/meteor/fiber_helpers.js
@@ -68,7 +68,7 @@ SQp.runTask = function (task) {
   var fut = new Future;
   var handle = {
     task: Meteor.bindEnvironment(task, function (e) {
-      Meteor._debug("Exception from task:", e && e.stack || e);
+      Meteor._debug("Exception from task:", e);
       throw e;
     }),
     future: fut,
@@ -152,7 +152,7 @@ SQp._run = function () {
       // We'll throw this exception through runTask.
       exception = err;
     } else {
-      Meteor._debug("Exception in queued task: " + (err.stack || err));
+      Meteor._debug("Exception in queued task: ", err);
     }
   }
   self._currentTaskFiber = undefined;

--- a/packages/meteor/fiber_helpers.js
+++ b/packages/meteor/fiber_helpers.js
@@ -68,7 +68,7 @@ SQp.runTask = function (task) {
   var fut = new Future;
   var handle = {
     task: Meteor.bindEnvironment(task, function (e) {
-      Meteor._debug("Exception from task:", e);
+      Meteor._debug("Exception from task", e);
       throw e;
     }),
     future: fut,
@@ -152,7 +152,7 @@ SQp._run = function () {
       // We'll throw this exception through runTask.
       exception = err;
     } else {
-      Meteor._debug("Exception in queued task: ", err);
+      Meteor._debug("Exception in queued task", err);
     }
   }
   self._currentTaskFiber = undefined;

--- a/packages/meteor/fiber_stubs_client.js
+++ b/packages/meteor/fiber_stubs_client.js
@@ -47,7 +47,7 @@ SQp.runTask = function (task) {
           // for.
           throw e;
         }
-        Meteor._debug("Exception in queued task: " + (e.stack || e));
+        Meteor._debug("Exception in queued task: ", e);
       }
     }
   } finally {

--- a/packages/meteor/fiber_stubs_client.js
+++ b/packages/meteor/fiber_stubs_client.js
@@ -47,7 +47,7 @@ SQp.runTask = function (task) {
           // for.
           throw e;
         }
-        Meteor._debug("Exception in queued task: ", e);
+        Meteor._debug("Exception in queued task", e);
       }
     }
   } finally {

--- a/packages/meteor/helpers.js
+++ b/packages/meteor/helpers.js
@@ -162,7 +162,7 @@ function logErr(err) {
   if (err) {
     return Meteor._debug(
       "Exception in callback of async function",
-      err.stack ? err.stack : err
+      err
     );
   }
 }

--- a/packages/mongo/oplog_observe_driver.js
+++ b/packages/mongo/oplog_observe_driver.js
@@ -511,7 +511,7 @@ _.extend(OplogObserveDriver.prototype, {
               finishIfNeedToPollQuery(function (err, doc) {
                 try {
                   if (err) {
-                    Meteor._debug("Got exception while fetching documents: " +
+                    Meteor._debug("Got exception while fetching documents",
                                   err);
                     // If we get an error from the fetcher (eg, trouble
                     // connecting to Mongo), let's just abandon the fetch phase
@@ -747,7 +747,7 @@ _.extend(OplogObserveDriver.prototype, {
 
         // During failover (eg) if we get an exception we should log and retry
         // instead of crashing.
-        Meteor._debug("Got exception while polling query: " + e);
+        Meteor._debug("Got exception while polling query", e);
         Meteor._sleepForMs(100);
       }
     }

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -143,7 +143,7 @@ _.extend(OplogHandle.prototype, {
       } catch (e) {
         // During failover (eg) if we get an exception we should log and retry
         // instead of crashing.
-        Meteor._debug("Got exception while reading last entry: " + e);
+        Meteor._debug("Got exception while reading last entry", e);
         Meteor._sleepForMs(100);
       }
     }

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -99,7 +99,7 @@ _.extend(OplogHandle.prototype, {
       // XXX can we avoid this clone by making oplog.js careful?
       originalCallback(EJSON.clone(notification));
     }, function (err) {
-      Meteor._debug("Error in oplog callback", err.stack);
+      Meteor._debug("Error in oplog callback", err);
     });
     var listenHandle = self._crossbar.listen(trigger, callback);
     return {

--- a/packages/mongo/polling_observe_driver.js
+++ b/packages/mongo/polling_observe_driver.js
@@ -173,7 +173,7 @@ _.extend(PollingObserveDriver.prototype, {
       // "cancel" the observe from the inside in this case.
       Array.prototype.push.apply(self._pendingWrites, writesForCycle);
       Meteor._debug("Exception while polling query " +
-                    JSON.stringify(self._cursorDescription) + ": ", e);
+                    JSON.stringify(self._cursorDescription), e);
       return;
     }
 

--- a/packages/mongo/polling_observe_driver.js
+++ b/packages/mongo/polling_observe_driver.js
@@ -173,7 +173,7 @@ _.extend(PollingObserveDriver.prototype, {
       // "cancel" the observe from the inside in this case.
       Array.prototype.push.apply(self._pendingWrites, writesForCycle);
       Meteor._debug("Exception while polling query " +
-                    JSON.stringify(self._cursorDescription) + ": " + e.stack);
+                    JSON.stringify(self._cursorDescription) + ": ", e);
       return;
     }
 

--- a/packages/oauth/oauth_cordova.js
+++ b/packages/oauth/oauth_cordova.js
@@ -10,7 +10,7 @@
 //   the popup. If not passed defaults to something sane.
 OAuth.showPopup = function (url, callback, dimensions) {
   var fail = function (err) {
-    Meteor._debug("Error from OAuth popup: " + JSON.stringify(err));
+    Meteor._debug("Error from OAuth popup: ", err);
   };
 
   // When running on an android device, we sometimes see the

--- a/packages/oauth/oauth_cordova.js
+++ b/packages/oauth/oauth_cordova.js
@@ -10,7 +10,7 @@
 //   the popup. If not passed defaults to something sane.
 OAuth.showPopup = function (url, callback, dimensions) {
   var fail = function (err) {
-    Meteor._debug("Error from OAuth popup: ", err);
+    Meteor._debug("Error from OAuth popup", err);
   };
 
   // When running on an android device, we sometimes see the


### PR DESCRIPTION
## Goal
The main goal of this PR is to make usage `Meteor._debug` consistently across Meteor. Main pattern should be eg:
```
Meteor._debug("Error configuring login service " + serviceName, error);
```
Then  Meteor._debug should take care about printing right things out.
