### PR TITLE
Document new bug triage timelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ Issues which *also* have the `confirmed` label ([bugs](https://github.com/meteor
 
 Any issue which does not have the `confirmed` label still requires discussion on implementation details but input and positive commentary is welcome!  Any pull request opened on an issue which is not `confirmed` is still welcome, however the pull-request is more likely to be sent back for reworking than a `confirmed` issue.  If in doubt about the best way to implement something, please create additional conversation on the issue.
 
+Please note that `pull-requests-encouraged` issues with low activity will often be closed without being implemented. These issues are tagged with an additional [`not-implemented`](https://github.com/meteor/meteor/issues?utf8=✓&q=label%3Apull-requests-encouraged+label%3Anot-implemented) label, and can still be considered good candidates to work on. If you're interested in working on a closed and `not-implemented` issue, please let us know by posting on that issue.
+
 ### Project roles
 
 We’ve just begun to create more defined project roles for Meteor. Here are descriptions of the existing project roles, along with the current contributors taking on those roles today.

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -44,12 +44,12 @@ To help keep issues in this repository under control, and make sure the most imp
 ##### Issues Labelled with `bug` and `confirmed`
 
 - Open `bug` + `confirmed` issues should be closed after two months of inactivity, unless someone has clearly identified that they are interested in working on the issue.
-- Triager's should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. This means helping clearly identify where the problem is, pointing towards parts of the codebase that someone might want to look into, documenting what a potential solution looks like, etc.
+- Triagers should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. This means helping clearly identify where the problem is, pointing towards parts of the codebase that someone might want to look into, documenting what a potential solution looks like, etc.
 
 ##### All Other Issues 
 
 - All open issues that can’t be labelled as `bug` + `confirmed` and/or `pull-requests-encouraged`, should be closed after one month of inactivity.
-- Triager's should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. 
+- Triagers should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. 
 
 ### Help questions
 

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -29,6 +29,28 @@ The first step is in determining whether the issue is a bug, help question or fe
 4. A reproduction should be confirmed by at least one person other than the original reporter. Run the reproduction and validate that the bug exists; then make a note of your findings on the issue. If a reproduction is supplied but doesn't work, add the `can't-reproduce` label and make a comment describing what happened.
 5. Finally, once you've confirmed the reproduction add the `confirmed` label and [classify](#classification) the issue (removing the `can't-reproduce` label if it exists).
 
+#### Bug Issue Lifespan
+
+To help keep issues in this repository under control, and make sure the most important problems are visible to maintainers, unresolved issues (lacking recent activity) should be closed after a certain amount of time has elapsed. 
+
+##### Issues Labelled with `pull-requests-encouraged`
+
+- Open `pull-requests-encouraged` issues should be closed after one month of inactivity, unless someone has clearly identified that they are interested in working on the issue.
+- When closing, the `not-implemented` label should be added.
+- A message similar to the following should be included:
+
+> While we think resolving this issue would be a great addition to the Meteor project, we're going to close it for now due to inactivity. If anyone comes across this issue in the future, and is interested in working on resolving it, please let us know by posting here and we'll consider re-opening this issue. Thanks!
+
+##### Issues Labelled with `bug` and `confirmed`
+
+- Open `bug` + `confirmed` issues should be closed after two months of inactivity, unless someone has clearly identified that they are interested in working on the issue.
+- Triager's should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. This means helping clearly identify where the problem is, pointing towards parts of the codebase that someone might want to look into, documenting what a potential solution looks like, etc.
+
+##### All Other Issues 
+
+- All open issues that can’t be labelled as `bug` + `confirmed` and/or `pull-requests-encouraged`, should be closed after one month of inactivity.
+- Triager's should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. 
+
 ### Help questions
 
 [Stack Overflow](http://stackoverflow.com/questions/tagged/meteor) and our [forums](https://forums.meteor.com/c/help) are the place to ask for help on using the framework. Close issues that are help requests and politely refer the author to the above locations.

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -29,11 +29,11 @@ The first step is in determining whether the issue is a bug, help question or fe
 4. A reproduction should be confirmed by at least one person other than the original reporter. Run the reproduction and validate that the bug exists; then make a note of your findings on the issue. If a reproduction is supplied but doesn't work, add the `can't-reproduce` label and make a comment describing what happened.
 5. Finally, once you've confirmed the reproduction add the `confirmed` label and [classify](#classification) the issue (removing the `can't-reproduce` label if it exists).
 
-#### Bug Issue Lifespan
+#### Bug issue lifespan
 
 To help keep issues in this repository under control, and make sure the most important problems are visible to maintainers, unresolved issues (lacking recent activity) should be closed after a certain amount of time has elapsed. 
 
-##### Issues Labelled with `pull-requests-encouraged`
+##### Issues labelled with `pull-requests-encouraged`
 
 - Open `pull-requests-encouraged` issues should be closed after one month of inactivity, unless someone has clearly identified that they are interested in working on the issue.
 - When closing, the `not-implemented` label should be added.
@@ -41,12 +41,12 @@ To help keep issues in this repository under control, and make sure the most imp
 
 > While we think resolving this issue would be a great addition to the Meteor project, we're going to close it for now due to inactivity. If anyone comes across this issue in the future, and is interested in working on resolving it, please let us know by posting here and we'll consider re-opening this issue. Thanks!
 
-##### Issues Labelled with `bug` and `confirmed`
+##### Issues labelled with `bug` and `confirmed`
 
 - Open `bug` + `confirmed` issues should be closed after two months of inactivity, unless someone has clearly identified that they are interested in working on the issue.
 - Triagers should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. This means helping clearly identify where the problem is, pointing towards parts of the codebase that someone might want to look into, documenting what a potential solution looks like, etc.
 
-##### All Other Issues 
+##### All other issues 
 
 - All open issues that can’t be labelled as `bug` + `confirmed` and/or `pull-requests-encouraged`, should be closed after one month of inactivity.
 - Triagers should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. 


### PR DESCRIPTION
Issue triage documentation changes outlining the new bug lifespan timelines we've discussed previously. Thanks!