### PR TITLE
Update stylus deprecation notice to use proper last version

### DIFF
--- a/packages/deprecated/stylus/README.md
+++ b/packages/deprecated/stylus/README.md
@@ -4,7 +4,7 @@
 
 **DEPRECATED:** This package is no longer supported/maintained as part of the
 Meteor project. To continue using the last supported version of this package,
-pin your package version to 2.513.14 (`meteor add stylus@=2.513.14`).
+pin your package version to 2.513.13 (`meteor add stylus@=2.513.13`).
 
 [Stylus](http://learnboost.github.com/stylus/) is a CSS pre-processor with a
 simple syntax and expressive dynamic behavior. It allows for more compact

--- a/packages/deprecated/stylus/deprecation_notice.js
+++ b/packages/deprecated/stylus/deprecation_notice.js
@@ -3,5 +3,5 @@ console.warn([
   "",
   "To continue using the last supported version",
   "of this package, pin your package version to",
-  "2.513.14 (`meteor add stylus@=2.513.14`).",
+  "2.513.13 (`meteor add stylus@=2.513.13`).",
 ].join("\n"));

--- a/packages/deprecated/stylus/package.js
+++ b/packages/deprecated/stylus/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Expressive, dynamic, robust CSS',
-  version: "2.513.14"
+  version: "2.513.15"
 });
 
 Package.registerBuildPlugin({


### PR DESCRIPTION
The `stylus` deprecation notice is pointing to the wrong last non-deprecated version. It should refer to `2.513.13`. I've updated the references accordingly (and we'll need to publish a new version so I've bumped the patch version). Thanks!