### PR TITLE
preserve error object in method callback

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -731,7 +731,11 @@ export class Connection {
         // to the console.
         callback = err => {
           err &&
-            Meteor._debug("Error invoking Method '" + name + "':", err.message);
+            Meteor._debug(
+              "Error invoking Method '" + name + "':",
+              err,
+              err.stack
+            );
         };
       } else {
         // On the server, make the function synchronous. Throw on

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data client",
-  version: '2.3.1',
+  version: '2.3.2',
   documentation: null
 });
 


### PR DESCRIPTION
This is an addition for #9654 and also solves the issue in #9684.
The error object (and with it the stack trace) is lost when calling a method without a callback.