### PR TITLE
New methods for server-register (FR#259)

### DIFF
--- a/packages/server-render/README.md
+++ b/packages/server-render/README.md
@@ -37,7 +37,15 @@ class Sink {
   redirect(location, code)
 
 
+  //
   // server only methods
+  //
+
+  // Prepend / append / replace head content by tag
+  updateHeadElementByTag(tag, value, updateType, updateAttribute, searchAttribute, searchAttributeValue)
+
+  // Prepend / append / replace body content by id
+  updateBodyElementById(id, value, updateType, updateAttribute)
 
   // sets the status code of the response.
   setStatusCode(code)
@@ -61,7 +69,6 @@ architecture of the pending HTTP response (e.g. "web.browser").
 Here is a basic example of `onPageLoad` usage on the server:
 
 ```js
-import React from "react";
 import { renderToString } from "react-dom/server";
 import { onPageLoad } from "meteor/server-render";
 import App from "/imports/Server.js";
@@ -76,7 +83,6 @@ onPageLoad(sink => {
 Likewise on the client:
 
 ```js
-import React from "react";
 import ReactDOM from "react-dom";
 import { onPageLoad } from "meteor/server-render";
 
@@ -86,6 +92,60 @@ onPageLoad(async sink => {
     <App />,
     document.getElementById("app")
   );
+});
+```
+
+A few advanced server methods:
+
+There are two newly introduced `server only` methods called `updateHeadElementByTag` and 
+`updateBodyElementById`, which can be used to update the respective `head`
+and `body` sections of the html.
+
+```html
+updateHeadElementByTag(
+  tag <name e.g. "meta". Mandatory>, 
+  value <value e.g. "this is the page's description". Optional - if empty the matching element is deleted.>, 
+  updateType <e.g. "replace" | "prepend" | "amend". Optional - defaults to "replace".>, 
+  updateAttribute <update attribute instead of html e.g. "name". Optional - if undefined, html is updated.>, 
+  searchAttribute <e.g. "name". Optional - if undefined then only tag name is used for search.>, 
+  searchAttributeValue <e.g. "description". Optional - if maintained then the searchAttribute must be used.>
+)
+
+updateBodyElementById(
+  id <element ID e.g. "app". Mandatory>, 
+  value <value e.g. "this is the page's description". Optional - if empty the matching element is deleted.>, 
+  updateType <e.g. "replace" | "prepend" | "amend". Optional - defaults to "replace".>, 
+  updateAttribute <update attribute instead of html e.g. "name". Optional - if undefined, html is updated.>
+)
+```
+
+A few examples:
+
+```js
+import { onPageLoad } from "meteor/server-render";
+onPageLoad(sink => {
+  //
+  // Head update examples
+  //  
+
+  // Maybe there isn't a title at the start so let's insert one into the head
+  sink.updateHeadElementByTag('head', '<title>Awesome Site!!!</title>', 'prepend');
+  // And then later update the title
+  sink.updateHeadElementByTag('title', 'Awesome Site!!! - Page 1');
+  // Add a description
+  sink.updateHeadElementByTag('meta', 'Our website desc...', undefined, 'content', 'name', 'description');
+  // Well let's delete the description meta
+  sink.updateHeadElementByTag('meta', undefined, undefined, undefined, 'name', 'description');
+  
+  //
+  // Body update examples (similar to the above illustrations)
+  //
+
+  // Replace something
+  sink.updateBodyElementById("app", "<div>Some cool code</div>");
+
+  // Update something
+  sink.updateBodyElementById("app", "<div>Some cool code</div>", "prepend");
 });
 ```
 
@@ -102,7 +162,6 @@ Here is a more complicated example of `onPageLoad` usage on the server,
 involving the [`styled-components`](https://www.styled-components.com/docs/advanced#server-side-rendering) npm package:
 
 ```js
-import React from "react";
 import { onPageLoad } from "meteor/server-render";
 import { renderToString } from "react-dom/server";
 import { ServerStyleSheet } from "styled-components"

--- a/packages/server-render/package.js
+++ b/packages/server-render/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "server-render",
-  version: "0.3.0",
+  version: "0.4.0",
   summary: "Generic support for server-side rendering in Meteor apps",
   documentation: "README.md"
 });
@@ -9,7 +9,8 @@ Npm.depends({
   "combined-stream2": "1.1.2",
   "magic-string": "0.21.3",
   "stream-to-string": "1.1.0",
-  "parse5": "3.0.2"
+  "parse5": "3.0.2",
+  "cheerio": "^1.0.0-rc.2"
 });
 
 Package.onUse(function(api) {

--- a/packages/server-render/package.js
+++ b/packages/server-render/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "server-render",
-  version: "0.4.0",
+  version: "0.3.1",
   summary: "Generic support for server-side rendering in Meteor apps",
   documentation: "README.md"
 });
@@ -10,7 +10,7 @@ Npm.depends({
   "magic-string": "0.21.3",
   "stream-to-string": "1.1.0",
   "parse5": "3.0.2",
-  "cheerio": "^1.0.0-rc.2"
+  "cheerio": "1.0.0-rc.2"
 });
 
 Package.onUse(function(api) {

--- a/packages/server-render/server-sink.js
+++ b/packages/server-render/server-sink.js
@@ -5,6 +5,8 @@ export class ServerSink {
     this.head = "";
     this.body = "";
     this.htmlById = Object.create(null);
+    this.headHtmlByTag = [];
+    this.bodyHtmlById = [];
     this.maybeMadeChanges = false;
     this.statusCode = null;
     this.responseHeaders = {};
@@ -31,6 +33,44 @@ export class ServerSink {
   renderIntoElementById(id, html) {
     this.htmlById[id] = "";
     this.appendToElementById(id, html);
+  }
+
+  updateHeadElementByTag(
+    tag, 
+    value, 
+    updateType = "replace", 
+    updateAttribute, 
+    searchAttribute, 
+    searchAttributeValue
+  ) {
+    if (tag) {
+      this.headHtmlByTag.push({
+        tag,
+        value,
+        updateType,
+        updateAttribute,
+        searchAttribute,
+        searchAttributeValue
+      });
+      this.maybeMadeChanges = true;
+    }
+  }
+
+  updateBodyElementById(
+    id, 
+    value, 
+    updateType = "replace", 
+    updateAttribute
+  ) {
+    if (id) {
+      this.bodyHtmlById.push({
+        id, 
+        value, 
+        updateType, 
+        updateAttribute
+      });
+      this.maybeMadeChanges = true;
+    }
   }
 
   redirect(location, code = 301) {


### PR DESCRIPTION
The current server-register package seems to have a narrow use case and therefore request the attached changes. For my first overview and thoughts on the topic - please refer to the Feature request - https://github.com/meteor/meteor-feature-requests/issues/259.

BTW, when I tested some of the out-the-box methods I was getting some interesting results. For example when I did `sink.appendToElementById('noscript', 'this is additional stuff')` I was expecting the code to be added to the end of the current value and not prepended to the start - and the whole resulting html of the element was encapsulated in quotes and made into a string. 

I really need the PR to be approved in some form to support my SEO efforts. 

Thanks in advance - Luke.