### PR TITLE
Revert " Update Mongo.Collection to strip undefined fields"

### DIFF
--- a/History.md
+++ b/History.md
@@ -60,14 +60,6 @@
   [Feature #24](https://github.com/meteor/meteor-feature-requests/issues/24)
   [PR #9657](https://github.com/meteor/meteor/pull/9657)
 
-* `Mongo.Collection` has been updated to strip `undefined` fields set in
-  documents/selectors passed to `find`, `findOne`, `insert`, `update`, etc.
-  This lines the codebase up with the changes made in
-  https://github.com/meteor/meteor/commit/ce3885b6df10f9f69f425af8698642a388efa6f2,
-  and helps prevent "The Mongo server and the Meteor query disagree on how
-  many documents match your query" errors.
-  [Issue #9619](https://github.com/meteor/meteor/issues/9619)
-
 ## v1.6.1, 2018-01-19
 
 * Node has been updated to version

--- a/packages/mongo/collection_tests.js
+++ b/packages/mongo/collection_tests.js
@@ -153,19 +153,3 @@ Tinytest.addAsync('collection - calling native find with good hint and maxTimeMs
     }).catch(error => test.fail(error.message));
   }
 );
-
-Tinytest.add(
-  'collection - undefined fields are stripped from selectors',
-  function (test) {
-    const collection = new Mongo.Collection(null);
-    let cursor = collection.find({ name: undefined });
-    test.equal(cursor.matcher._selector, {});
-
-    cursor = collection.find({
-      name: {
-        category: undefined
-      }
-    });
-    test.equal(cursor.matcher._selector, { name: {} });
-  }
-);


### PR DESCRIPTION
Reverts meteor/meteor#9671. 

As discussed in https://github.com/meteor/meteor/pull/9671#issuecomment-369462985, we're going to handle this a bit differently (we'll throw an error when an `undefined` field is found instead of automatically stripping it).