### PR TITLE
Support a meteor.testModule section in application package.json files.

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,9 +13,45 @@
   When specified, these entry points override Meteor's default module
   loading semantics, rendering `imports` directories unnecessary. If
   `mainModule` is left unspecified for either client or server, the
-  default rules will apply for that architecture, as before.
+  default rules will apply for that architecture, as before. To disable
+  eager loading of modules on a given architecture, simply provide a
+  `mainModule` value of `false`:
+  ```js
+  "meteor": {
+    "mainModule": {
+      "client": false,
+      "server": "server/main.js"
+    }
+  }
+  ```
   [Feature #135](https://github.com/meteor/meteor-feature-requests/issues/135)
   [PR #9690](https://github.com/meteor/meteor/pull/9690)
+
+* In addition to `meteor.mainModule`, the `"meteor"` section of
+  `package.json` may also specify `meteor.testModule` to control which
+  test modules are loaded by `meteor test` or `meteor test --full-app`:
+  ```js
+  "meteor": {
+    "mainModule": {...},
+    "testModule": "tests.js"
+  }
+  ```
+  If your client and server test files are different, you can expand the
+  `testModule` configuration using the same syntax as `mainModule`:
+  ```js
+  "meteor": {
+    "testModule": {
+      "client": "client/tests.js",
+      "server": "server/tests.js"
+    }
+  }
+  ```
+  The same test module will be loaded whether or not you use the
+  `--full-app` option. Any tests that need to detect `--full-app` should
+  check `Meteor.isAppTest`. The module(s) specified by `meteor.testModule`
+  can import other test modules at runtime, so you can still distribute
+  test files across your codebase; just make sure you import the ones you
+  want to run.
 
 * The `reify` npm package has been updated to version 0.14.2.
 

--- a/History.md
+++ b/History.md
@@ -51,7 +51,7 @@
   check `Meteor.isAppTest`. The module(s) specified by `meteor.testModule`
   can import other test modules at runtime, so you can still distribute
   test files across your codebase; just make sure you import the ones you
-  want to run.
+  want to run. [PR #9714](https://github.com/meteor/meteor/pull/9714)
 
 * The `reify` npm package has been updated to version 0.14.2.
 

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -618,25 +618,47 @@ Usage: meteor test --driver-package <driver> [options]
        meteor test --full-app --driver-package <driver> [options]
 
 Runs tests against the application.
-Will start a special app based on a test driver (specified with
---driver-package -- read more about driver packages at
-http://guide.meteor.com/testing.html#driver-packages) which handles the
-task of running tests and displaying the results in the browser when you
-visit it.
+Will start a temporary app based on a test driver (specified with
+--driver-package: http://guide.meteor.com/testing.html#driver-packages) which
+handles the task of running tests and displaying the results in the browser.
 
-In normal test mode, no files in your application are eagerly loaded, aside
-from test files (files named *.test[s].* or *.spec[s].* placed anywhere
-in your application). You can import your app's modules from within your
-tests and use them as normal.
+In normal 'meteor test' mode, no files in your application are eagerly loaded,
+aside from test files (files named *.test[s].* or *.spec[s].* placed anywhere
+in your application). These eagerly-loaded test modules can import application
+modules in order to test application logic.
 
-In "full app" test mode, your app is loaded as usual, and then made hidden,
-and your tests can inspect and effect the running state. Test files are
-loaded similarly to unit test mode, but must be called *.app-test[s].* or
-*.app-spec[s].*.
+In 'meteor test --full-app' mode, your app is loaded as usual, then hidden, so
+that your tests can inspect and interact with the full running application.
+Test files are loaded similarly to 'meteor test' mode, but must be called
+*.app-test[s].* or *.app-spec[s].*.
 
-Open the test dashboard in your browser to run the tests and see the
-results. By default the URL is localhost:3000 but that can be changed
-with --port.
+Note: as of Meteor 1.6.2, you can override the default test loading rules
+described in the previous two paragraphs by including a meteor.testModule
+section in your package.json file:
+
+  "meteor": {
+    "testModule": {
+      "client": "client/tests.js",
+      "server": "server/tests.js"
+    }
+  }
+
+If your client and server test files are the same, this can be simplified to
+
+  "meteor": {
+    "testModule": "tests.js"
+  }
+
+When meteor.testModule is defined in package.json, the same test module will
+be loaded whether or not you use the --full-app option. Any tests that need to
+know whether the --full-app option was used may check Meteor.isAppTest, which
+is true when running 'meteor test --full-app'. The module specified by
+meteor.testModule can import other test modules at runtime, so it is still
+possible to distribute test files across your codebase.
+
+Once your application starts up in testing mode, open the test dashboard in
+your browser to run the tests and see the results. By default the URL is
+localhost:3000 but that can be changed with --port.
 
 Read more about testing your application in the Testing Article of the
 Meteor Guide - https://guide.meteor.com/testing.html

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -616,20 +616,45 @@ class ResourceSlot {
       return false;
     }
 
-    const runningTests = global.testCommandMetadata &&
-      (global.testCommandMetadata.isTest ||
-       global.testCommandMetadata.isAppTest);
+    const {
+      isTest = false,
+      isAppTest = false,
+    } = global.testCommandMetadata || {};
 
-    if (runningTests &&
-        isTestFilePath(this.inputResource.path)) {
-      // Test files are never lazy if we're running tests.
-      return false;
-    }
+    const runningTests = isTest || isAppTest;
 
     if (isJavaScript) {
+      if (runningTests) {
+        const testModule = this._getOption("testModule", options);
+
+        // If we set fileOptions.testModule = true in _inferFileOptions,
+        // then consider this module an eager entry point for tests. If we
+        // set it to false (rather than leaving it undefined), that means
+        // a meteor.testModule was configured in package.json, and this
+        // test module was not it. In that case, we fall through to the
+        // mainModule check, ignoring isTestFilePath, because we can
+        // assume this is not an eager test module. If testModule was not
+        // set to a boolean, then isTestFilePath should determine if this
+        // is an eager test module.
+        const isEagerTestModule = typeof testModule === "boolean"
+          ? testModule
+          : isTestFilePath(this.inputResource.path);
+
+        if (isEagerTestModule) {
+          // If we know it's eager, then it isn't lazy.
+          return false;
+        }
+
+        if (! isAppTest) {
+          // If running `meteor test` without the --full-app option, then
+          // any JS modules that are not eager test modules must be lazy.
+          return true;
+        }
+      }
+
       // PackageSource#_inferFileOptions (in package-source.js) sets the
-      // mainModule option to false to indicate a meteor.mainModule was
-      // configured for this architecture, but this module was not it.
+      // mainModule option to false to indicate that a meteor.mainModule
+      // was configured for this architecture, but this module was not it.
       // It's important to wait until this point (ResourceSlot#_isLazy) to
       // make the final call, because we can finally tell whether the
       // output resource is JavaScript or not (non-JS resources are not

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -598,12 +598,21 @@ class ResourceSlot {
       return lazy;
     }
 
-    // If file.lazy was not previously defined, mark the file lazy if
-    // it is contained by an imports directory. Note that any files
-    // contained by a node_modules directory will already have been
-    // marked lazy in PackageSource#_inferFileOptions. Same for
-    // non-test files if running (non-full-app) tests (`meteor test`)
-    if (!this.packageSourceBatch.useMeteorInstall) {
+    const isApp = ! this.packageSourceBatch.unibuild.pkg.name;
+    if (! isApp) {
+      // Meteor package files must be explicitly added by api.addFiles or
+      // api.mainModule, and are implicitly eager unless specified
+      // otherwise via this.inputResource.fileOptions.lazy, which we
+      // already checked above.
+      return false;
+    }
+
+    // The rest of this method assumes we're considering a resource in an
+    // application rather than a Meteor package.
+
+    if (! this.packageSourceBatch.useMeteorInstall) {
+      // If this application is somehow still not using the module system,
+      // then everything is eagerly loaded.
       return false;
     }
 

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1014,6 +1014,12 @@ _.extend(PackageSource.prototype, {
     }
 
     if (typeof mainModule !== "undefined") {
+      // Note: if mainModule === false, no JavaScript modules will be
+      // loaded eagerly unless explicitly added with !fileOptions.lazy by
+      // a compiler plugin. This can be useful for building an app that
+      // does not run any application JS on the client (or the server). Of
+      // course, Meteor packages may still run JS on startup, but they
+      // have their own rules for lazy/eager loading of modules.
       if (relPath === mainModule) {
         fileOptions.lazy = false;
         fileOptions.mainModule = true;

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1640,25 +1640,7 @@ export class MeteorConfig {
   // Call this first if you plan to call getMainModuleForArch multiple
   // times, so that you can avoid repeating this work each time.
   getMainModulesByArch(arch) {
-    const configMainModule = this.get("mainModule");
-    const mainModulesByArch = Object.create(null);
-
-    if (typeof configMainModule === "string" ||
-        configMainModule === false) {
-      // If packageJson.meteor.mainModule is a string or false, use that
-      // value as the mainModule for all architectures.
-      mainModulesByArch["os"] = configMainModule;
-      mainModulesByArch["web"] = configMainModule;
-    } else if (configMainModule &&
-               typeof configMainModule === "object") {
-      // If packageJson.meteor.mainModule is an object, use its properties
-      // to select a mainModule for each architecture.
-      Object.keys(configMainModule).forEach(where => {
-        mainModulesByArch[mapWhereToArch(where)] = configMainModule[where];
-      });
-    }
-
-    return mainModulesByArch;
+    return this._getEntryModulesByArch("mainModule");
   }
 
   // Given an architecture like web.browser, get the best mainModule for
@@ -1669,21 +1651,63 @@ export class MeteorConfig {
     arch,
     mainModulesByArch = this.getMainModulesByArch(),
   ) {
-    const mainMatch = archinfo.mostSpecificMatch(
-      arch, Object.keys(mainModulesByArch));
+    return this._getEntryModuleForArch(arch, mainModulesByArch);
+  }
 
-    if (mainMatch) {
-      const mainModule = mainModulesByArch[mainMatch];
+  // Analogous to getMainModulesByArch, except for this.config.testModule.
+  getTestModulesByArch(arch) {
+    return this._getEntryModulesByArch("testModule");
+  }
 
-      if (mainModule === false) {
-        // If meteor.mainModule.{client,server,...} === false, no modules
-        // will be loaded eagerly on the {client,server...}. This is useful
-        // if you have an app with no special app/{client,server} directory
-        // structure and you want to specify an entry point for just the
-        // client (or just the server), without accidentally loading
-        // everything on the other architecture. Instead of omitting
-        // meteor.mainModule for the other architecture, set it to false.
-        return mainModule;
+  // Analogous to getMainModuleForArch, except for this.config.testModule.
+  getTestModuleForArch(
+    arch,
+    testModulesByArch = this.getTestModulesByArch(),
+  ) {
+    return this._getEntryModuleForArch(arch, testModulesByArch);
+  }
+
+  _getEntryModulesByArch(...keys) {
+    const configEntryModule = this.get(...keys);
+    const entryModulesByArch = Object.create(null);
+
+    if (typeof configEntryModule === "string" ||
+        configEntryModule === false) {
+      // If the top-level config value is a string or false, use that
+      // value as the entry module for all architectures.
+      entryModulesByArch["os"] = configEntryModule;
+      entryModulesByArch["web"] = configEntryModule;
+    } else if (configEntryModule && typeof configEntryModule === "object") {
+      // If the top-level config value is an object, use its properties to
+      // select an entry module for each architecture.
+      Object.keys(configEntryModule).forEach(where => {
+        entryModulesByArch[mapWhereToArch(where)] = configEntryModule[where];
+      });
+    }
+
+    return entryModulesByArch;
+  }
+
+  _getEntryModuleForArch(
+    arch,
+    entryModulesByArch,
+  ) {
+    const entryMatch = archinfo.mostSpecificMatch(
+      arch, Object.keys(entryModulesByArch));
+
+    if (entryMatch) {
+      const entryModule = entryModulesByArch[entryMatch];
+
+      if (entryModule === false) {
+        // If meteor.{main,test}Module.{client,server,...} === false, no
+        // modules will be loaded eagerly on the client or server. This is
+        // useful if you have an app with no special app/{client,server}
+        // directory structure and you want to specify an entry point for
+        // just the client (or just the server), without accidentally
+        // loading everything on the other architecture. Instead of
+        // omitting the entry module for the other architecture, simply
+        // set it to false.
+        return entryModule;
       }
 
       if (! this._resolversByArch[arch]) {
@@ -1698,7 +1722,7 @@ export class MeteorConfig {
       // containing package.json or index.js files.
       const res = this._resolversByArch[arch].resolve(
         // Only relative paths are allowed (not top-level packages).
-        "./" + files.pathNormalize(mainModule),
+        "./" + files.pathNormalize(entryModule),
         this.packageJsonPath
       );
 

--- a/tools/tests/app-config.js
+++ b/tools/tests/app-config.js
@@ -18,22 +18,21 @@ selftest.define("mainModule", function () {
   function check(mainModule) {
     const json = JSON.parse(s.read("package.json"));
 
-    let shouldWrite = true;
+    json.meteor = {
+      // Make sure the tests.js module is always loaded eagerly.
+      testModule: "tests.js"
+    };
+
     if (typeof mainModule === "undefined") {
-      if ("meteor" in json) {
-        delete json.meteor;
-      } else {
-        shouldWrite = false;
-      }
+      delete json.meteor.mainModule;
     } else {
-      json.meteor = { mainModule };
+      json.meteor.mainModule = mainModule;
     }
 
-    if (shouldWrite) {
-      s.write("package.json", JSON.stringify(json, null, 2) + "\n");
-    }
+    s.write("package.json", JSON.stringify(json, null, 2) + "\n");
 
     run.waitSecs(10);
+    run.forbid(" 0 passing ");
     run.match("SERVER FAILURES: 0");
     run.match("CLIENT FAILURES: 0");
   }

--- a/tools/tests/app-config.js
+++ b/tools/tests/app-config.js
@@ -46,6 +46,26 @@ selftest.define("mainModule", function () {
 
   check({});
 
+  check(false);
+
+  check({
+    client: false,
+    server: "abc",
+  });
+
+  check({
+    client: "abc",
+    server: false,
+  });
+
+  check({
+    web: false,
+  });
+
+  check({
+    os: false,
+  });
+
   check({
     client: "a",
     os: "bc",

--- a/tools/tests/app-config.js
+++ b/tools/tests/app-config.js
@@ -1,7 +1,7 @@
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 
-selftest.define("meteor.mainModule", function () {
+selftest.define("mainModule", function () {
   const s = new Sandbox();
   s.createApp("app-config-mainModule", "app-config");
   s.cd("app-config-mainModule");
@@ -134,7 +134,7 @@ function writeConfig(s, run, mainModule) {
   run.match("CLIENT FAILURES: 0");
 }
 
-selftest.define("meteor.testModule", function () {
+selftest.define("testModule", function () {
   const s = new Sandbox();
   s.createApp("app-config-mainModule", "app-config");
   s.cd("app-config-mainModule");

--- a/tools/tests/apps/app-config/.meteor/versions
+++ b/tools/tests/apps/app-config/.meteor/versions
@@ -15,7 +15,6 @@ ddp-client@2.3.1
 ddp-common@1.4.0
 ddp-server@2.1.2
 diff-sequence@1.1.0
-dispatch:mocha-browser@0.0.4
 dynamic-import@0.3.0
 ecmascript@0.10.5
 ecmascript-runtime@0.5.0
@@ -32,7 +31,7 @@ id-map@1.1.0
 less@2.7.12
 livedata@1.0.18
 logging@1.1.19
-meteor@1.8.3
+meteor@1.8.4
 meteor-base@1.3.0
 minifier-css@1.3.1
 minifier-js@2.3.3
@@ -44,7 +43,6 @@ mongo-dev-server@1.1.0
 mongo-id@1.0.6
 npm-mongo@2.2.33
 ordered-dict@1.1.0
-practicalmeteor:mocha-core@1.0.1
 promise@0.10.2
 random@1.1.0
 reload@1.2.0

--- a/tools/tests/apps/app-config/package.json
+++ b/tools/tests/apps/app-config/package.json
@@ -7,5 +7,8 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.36",
     "meteor-node-stubs": "^0.3.2"
+  },
+  "meteor": {
+    "testModule": "tests.js"
   }
 }

--- a/tools/tests/apps/app-config/tests.js
+++ b/tools/tests/apps/app-config/tests.js
@@ -89,14 +89,19 @@ describe("meteor.mainModule", () => {
 
     let mainId;
 
+    function tryArches(obj, arches) {
+      arches.some(arch => {
+        if (hasOwn.call(obj, arch)) {
+          mainId = obj[arch];
+          return true;
+        }
+      });
+    }
+
     if (Meteor.isClient) {
-      mainId =
-        config.mainModule.client ||
-        config.mainModule.web;
+      tryArches(config.mainModule, ["client", "web"]);
     } else if (Meteor.isServer) {
-      mainId =
-        config.mainModule.server ||
-        config.mainModule.os;
+      tryArches(config.mainModule, ["server", "os"]);
     }
 
     if (mainId === false) {

--- a/tools/tests/apps/modules/package.json
+++ b/tools/tests/apps/modules/package.json
@@ -25,5 +25,8 @@
     "test": "METEOR_PROFILE=100 ../../../../meteor test --full-app --driver-package dispatch:mocha-phantomjs",
     "browser": "METEOR_PROFILE=100 ../../../../meteor test --full-app --driver-package dispatch:mocha-browser",
     "test-packages": "../../../../meteor test-packages --driver-package dispatch:mocha-phantomjs packages/modules-test-package"
+  },
+  "meteor": {
+    "testModule": "tests.js"
   }
 }

--- a/tools/tests/apps/modules/tests.js
+++ b/tools/tests/apps/modules/tests.js
@@ -426,7 +426,9 @@ describe("Meteor packages", () => {
       assert.deepEqual(os.resources.map(function (res) {
         return res.path;
       }), ["server.js"]);
-      assert.deepEqual(os.resources[0].fileOptions, {});
+      assert.deepEqual(os.resources[0].fileOptions, {
+        lazy: false
+      });
 
       assert.deepEqual(ServerTypeof, {
         require: "undefined",


### PR DESCRIPTION
Similar to #9690, this PR adds support for a `meteor.testModule` configuration in application `package.json` files, allowing application developers complete control over what test files should load when running `meteor test` to test their applications.

Setting `meteor.testModule` is a great way to specify test entry points explicitly, rather than relying on Meteor's `isTestFilePath` [heuristics](https://github.com/meteor/meteor/blob/devel/tools/isobuild/test-files.js). However, this feature is entirely opt-in, so the old behavior is preserved if you do not configure `meteor.testModule`.

The syntax is identical to `meteor.mainModule`, so you can set a different `meteor.testModule.{client,server,...}` for each platform. If a `testModule` is not specified for a platform, then Meteor's existing rules about test file paths apply for that platform, as before.

Different `testModule`s for client and server:
```js
"meteor": {
  "testModule": {
    "client": "client/tests.js",
    "server": "server/tests.js"
  }
}
```

Same `testModule` for both client and server:
```js
"meteor": {
  "testModule": "tests.js"
}
```

Server tests without any client tests (note that simply omitting the `"client"` property would cause tests to behave as if there was no `meteor.testModule` on the client):
```js
"meteor": {
  "testModule": {
    "client": false,
    "server": "server/tests.js"
  }
}
```

If a `testModule` is specified, that module will always be loaded eagerly when running `meteor test`, in addition to any other modules that load eagerly due to `meteor.mainModule` or other rules regarding module loading. If you run `meteor test` without the `--full-app` option, then no application JS modules other than the `testModule` (and any modules imported by it) will be loaded eagerly. If you run `meteor test --full-app`, the `meteor.mainModule` module(s) will be loaded eagerly in addition to the `meteor.testModule` module(s).

The module(s) specified by `meteor.testModule` can import other test modules at runtime, so you can still distribute test files across your codebase; just make sure you import the ones you want to run.