### PR TITLE
Use meteor.{mainModule,testModule} for `meteor create` starter apps.

### DIFF
--- a/tools/static-assets/skel/package.json
+++ b/tools/static-assets/skel/package.json
@@ -2,10 +2,20 @@
   "name": "~name~",
   "private": true,
   "scripts": {
-    "start": "meteor run"
+    "start": "meteor run",
+    "test": "meteor test --driver-package dispatch:mocha-browser",
+    "test-app": "meteor test --full-app --driver-package dispatch:mocha-browser",
+    "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.36",
+    "@babel/runtime": "^7.0.0-beta.40",
     "meteor-node-stubs": "^0.3.2"
+  },
+  "meteor": {
+    "mainModule": {
+      "client": "client/main.js",
+      "server": "server/main.js"
+    },
+    "testModule": "test/main.js"
   }
 }

--- a/tools/static-assets/skel/package.json
+++ b/tools/static-assets/skel/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "scripts": {
     "start": "meteor run",
-    "test": "meteor test --driver-package dispatch:mocha-browser",
-    "test-app": "meteor test --full-app --driver-package dispatch:mocha-browser",
+    "test": "meteor test --once --driver-package meteortesting:mocha",
+    "test-app": "TEST_WATCH=1 meteor test --full-app --driver-package meteortesting:mocha",
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {

--- a/tools/static-assets/skel/test/main.js
+++ b/tools/static-assets/skel/test/main.js
@@ -1,0 +1,27 @@
+import assert from "assert";
+
+export const testMessage = "Welcome to Meteor!";
+
+describe("~name~", () => {
+  it("package.json has correct name", () => {
+    const { name } = require("../package.json");
+    assert.strictEqual(name, "~name~");
+  });
+
+  if (Meteor.isClient) {
+    it("client is not server", () => {
+      assert.strictEqual(Meteor.isServer, false);
+    });
+  }
+
+  if (Meteor.isServer) {
+    it("server is not client", () => {
+      assert.strictEqual(Meteor.isClient, false);
+    });
+  }
+
+  it("async/await and dynamic import()", async () => {
+    const tests = await import("./main.js");
+    assert.strictEqual(tests.testMessage, testMessage);
+  });
+});

--- a/tools/static-assets/skel/test/main.js
+++ b/tools/static-assets/skel/test/main.js
@@ -1,27 +1,20 @@
 import assert from "assert";
 
-export const testMessage = "Welcome to Meteor!";
-
-describe("~name~", () => {
-  it("package.json has correct name", () => {
-    const { name } = require("../package.json");
+describe("~name~", function () {
+  it("package.json has correct name", async function () {
+    const { name } = await import("../package.json");
     assert.strictEqual(name, "~name~");
   });
 
   if (Meteor.isClient) {
-    it("client is not server", () => {
+    it("client is not server", function () {
       assert.strictEqual(Meteor.isServer, false);
     });
   }
 
   if (Meteor.isServer) {
-    it("server is not client", () => {
+    it("server is not client", function () {
       assert.strictEqual(Meteor.isClient, false);
     });
   }
-
-  it("async/await and dynamic import()", async () => {
-    const tests = await import("./main.js");
-    assert.strictEqual(tests.testMessage, testMessage);
-  });
 });


### PR DESCRIPTION
In order for Meteor to maintain its commitment to being a zero-configuration tool, any configuration options that we add must come pre-configured in the best way possible for newly created apps.

> **Important note:** Meteor is still, and always will be, to its core, a zero-configuration tool. Though it may be tempting to slide down the slippery slope towards even more configuration options in the `meteor` section of `package.json`, we are not interested in allowing configuration complexity to explode, and we intend to maintain an extremely strict standard of necessity for any future options. Please don't think of the `meteor` section as a place to solve one-off problems with ad-hoc options.

In particular, the default new Meteor app must contain a reasonable testing story, or else we are signaling to the community that testing is an afterthought.

With that said, this PR is still a work in progress. I welcome your feedback on how best to configure the default `meteor create` starter app.

Builds on #9690 and #9714.