### PR TITLE
open Xcode project folder instead of project file

### DIFF
--- a/tools/cordova/run-targets.js
+++ b/tools/cordova/run-targets.js
@@ -60,7 +60,7 @@ function openXcodeProject(projectDir) {
 
 
   try {
-    execFileSync('open', ['-a', 'Xcode',projectDir]);
+    execFileSync('open', ['-a', 'Xcode', projectDir]);
 
     Console.info();
     Console.info(

--- a/tools/cordova/run-targets.js
+++ b/tools/cordova/run-targets.js
@@ -58,10 +58,9 @@ function openXcodeProject(projectDir) {
     return;
   }
 
-  const projectFilePath = files.pathJoin(projectDir, projectFilename);
 
   try {
-    execFileSync('open', [projectFilePath]);
+    execFileSync('open', ['-a', 'Xcode',projectDir]);
 
     Console.info();
     Console.info(


### PR DESCRIPTION
Hi,
by using a pod-based cordova plugin (like phonegap-push-plugin) in a project, opening the configuration file instead of the folder prevents these pods from being included.
This PR change the way Xcode is opened.
Regards,
