### PR TITLE
Improve CircleCI caching strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,5 @@
 version: 2
 
-# These directories are cached across all builds, currently with no
-# hashing mechanism, but we should consider doing it off dev_bundle.
-meteor_cache_dirs: &meteor_cache_dirs
-  paths:
-    - "dev_bundle"
-    - ".babel-cache"
-    - ".meteor"
-
 # A reusable "run" snippet which is ran before each test to setup the
 # environment for user-limits, core-dumps, etc.
 run_env_change: &run_env_change
@@ -122,7 +114,14 @@ jobs:
           name: Git Submodules.
           command: (git submodule sync && git submodule update --init --recursive) || (rm -fr .git/config .git/modules && git submodule deinit -f . && git submodule update --init --recursive)
       - restore_cache:
-          key: meteor-cache
+          keys:
+            - dev-bundle-cache-{{ checksum "meteor" }}
+            - dev-bundle-cache
+      - restore_cache:
+          keys:
+            - other-deps-cache-{{ .Branch }}-{{ .Revision }}
+            - other-deps-cache-{{ .Branch }}
+            - other-deps-cache
       - restore_cache:
           keys: 
             - test-groups-v1-{{ .Branch }}
@@ -152,15 +151,6 @@ jobs:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
-
-  save_caches:
-    <<: *build_machine_environment
-    steps:
-      - attach_workspace:
-          at: .
-      - save_cache:
-          key: meteor-cache
-          <<: *meteor_cache_dirs
 
   Isolated Tests:
     <<: *build_machine_environment
@@ -702,6 +692,15 @@ jobs:
           paths:
             - ./tmp/test-groups
           when: on_success
+      - save_cache:
+          key: dev-bundle-cache-{{ checksum "meteor" }}
+          paths:
+            - "dev_bundle"
+      - save_cache:
+          key: other-deps-cache-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ".babel-cache"
+            - ".meteor"
 
 workflows:
   version: 2


### PR DESCRIPTION
While working on #9656, I noticed that we are using a single immutable cache on all builds, rather than updating the cache as dependencies change. This means that the 'Get Ready' job on CircleCI ends up downloading the dev bundle every single time and updating a lot of dependencies that probably haven't changed for months.

This PR implements a caching strategy using [templates](https://circleci.com/docs/2.0/caching/#using-keys-and-templates) that will only download a new dev bundle when the `meteor` file is changed (this is where the dev bundle version number is maintained), and which re-caches `.babel-cache` and `.meteor` on every run, but is loaded based on the branch.

This isn't an ideal strategy, but it saves roughly 2-3 minutes on the 'Get Ready' job compared to what we have currently.

For a subsequent PR, we could cache all of the `node_modules` folders in the various packages, as this takes up the majority of the remaining running time for 'Get Ready'.

I'm also not sure how much caching the `.babel-cache` and `.meteor` folders is speeding up our builds, so I will also run some comparison tests to see their impact and if they can be excluded from the cache.