### PR TITLE
Removed fiber wrapper around OAuth middleware.

### DIFF
--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -139,14 +139,6 @@ OAuth._checkRedirectUrlOrigin = function (redirectUrl) {
 
 
 // Listen to incoming OAuth http requests
-WebApp.connectHandlers.use(function(req, res, next) {
-  // Need to create a Fiber since we're using synchronous http calls and nothing
-  // else is wrapping this in a fiber automatically
-  Fiber(function () {
-    middleware(req, res, next);
-  }).run();
-});
-
 var middleware = function (req, res, next) {
   // Make sure to catch any exceptions because otherwise we'd crash
   // the runner
@@ -206,6 +198,8 @@ var middleware = function (req, res, next) {
     }
   }
 };
+
+WebApp.connectHandlers.use(middleware);
 
 OAuthTest.middleware = middleware;
 

--- a/packages/oauth/package.js
+++ b/packages/oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth-based services",
-  version: "1.2.1"
+  version: "1.2.2"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
With commit 3b18863, connect handlers are guaranteed to run in a fiber, making the fiber wrapper in the OAuth middleware superfluous. Additionally, because it manually wraps the middleware in a Fiber directly, it is losing access to the properties stored in the existing fiber (meteor/meteor-feature-requests#156).