### PR TITLE
Show timestamp in Log only for production

### DIFF
--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -290,13 +290,16 @@ Log.format = (obj, options = {}) => {
 
   const stderrIndicator = stderr ? '(STDERR) ' : '';
 
-  const metaPrefix = [
+  const datePrefix = [
     level.charAt(0).toUpperCase(),
     dateStamp,
     '-',
     timeStamp,
     utcOffsetStr,
     timeInexact ? '? ' : ' ',
+  ];
+  const metaPrefix = [
+    ...(Meteor.isProduction ? datePrefix : []),
     appInfo,
     sourceInfo,
     stderrIndicator].join('');

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -288,7 +288,7 @@ Log.format = (obj, options = {}) => {
   if (satellite)
     sourceInfo += `[${satellite}]`;
 
-  const stderrIndicator = stderr ? '(STDERR) ' : '';
+  const stderrIndicator = stderr ? 'STDERR ' : '';
 
   const datePrefix = [
     dateStamp,

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -291,7 +291,6 @@ Log.format = (obj, options = {}) => {
   const stderrIndicator = stderr ? '(STDERR) ' : '';
 
   const datePrefix = [
-    level.charAt(0).toUpperCase(),
     dateStamp,
     '-',
     timeStamp,
@@ -299,6 +298,7 @@ Log.format = (obj, options = {}) => {
     timeInexact ? '? ' : ' ',
   ];
   const metaPrefix = [
+    level.charAt(0).toUpperCase(),
     ...(Meteor.isProduction ? datePrefix : []),
     appInfo,
     sourceInfo,

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -299,7 +299,7 @@ Log.format = (obj, options = {}) => {
   ];
   const metaPrefix = [
     level.charAt(0).toUpperCase(),
-    ...(Meteor.isProduction ? datePrefix : []),
+    ...(Meteor.isProduction ? datePrefix : [' ']),
     appInfo,
     sourceInfo,
     stderrIndicator].join('');

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -288,7 +288,7 @@ Log.format = (obj, options = {}) => {
   if (satellite)
     sourceInfo += `[${satellite}]`;
 
-  const stderrIndicator = stderr ? 'STDERR ' : '';
+  const stderrIndicator = stderr ? '(STDERR) ' : '';
 
   const datePrefix = [
     dateStamp,


### PR DESCRIPTION
Logs with timestamp can be very long, this PR shortens it for development mode only to reduce clutter.

before
```
=> Started proxy.
=> Started MongoDB.
W20180313-13:49:37.982(1)? (STDERR) Debugger listening on ws://127.0.0.1:9229/5d7b227c-e70a-4da2-8d60-063199d310e7
W20180313-13:49:38.022(1)? (STDERR) For help see https://nodejs.org/en/docs/inspector
=> Started your app.

=> App running at: http://localhost:3000/
```

after
```
=> Started proxy.
=> Started MongoDB.
W STDERR Debugger listening on ws://127.0.0.1:9229/5d7b227c-e70a-4da2-8d60-063199d310e7
W STDERR For help see https://nodejs.org/en/docs/inspector
=> Started your app.

=> App running at: http://localhost:3000/
```

**in production mode Logs stays the same format, nothing changed there**