### PR TITLE
Revert "Allow EnvironmentVariable#withValue callbacks to return Promises."

### DIFF
--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -54,7 +54,7 @@ EVp.withValue = function (value, func) {
   var saved = currentValues[this.slot];
   try {
     currentValues[this.slot] = value;
-    return Promise.await(func());
+    return func();
   } finally {
     currentValues[this.slot] = saved;
   }

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.8.4'
+  version: '1.8.5'
 });
 
 Package.registerBuildPlugin({


### PR DESCRIPTION
This reverts commit 573f14f171251d475be0d590a72b0f2ce94a35b2.

As discussed with @glasser, this change may have been more disruptive than helpful (e.g. #9730) and could also have negative performance consequences. Since we don't actually rely on `withValue` awaiting the result of the callback (yet), it seems safest to revert this change, and possibly add a different method called something like `withAwaitedValue` at some later time, if necessary.

Fixes #9730.