### PR TITLE
update cordova-plugin-meteor-webapp dependency to 1.6.0

### DIFF
--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -22,7 +22,7 @@ Npm.strip({
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.2',
   'cordova-plugin-wkwebview-engine': '1.1.3',
-  'cordova-plugin-meteor-webapp': '1.4.2'
+  'cordova-plugin-meteor-webapp': '1.6.0'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
update to latest version of cordova-plugin-meteor-webapp (1.6.0) which resolve issue about IOS and local web server restart after device sleep :
https://github.com/meteor/cordova-plugin-meteor-webapp/commit/963cef8392d0fdd43700cc2b80e2fc2d4f692baf
Hard to say if issues depend on this.

until it's merged you can update to 1.6.0 manually with
`meteor add cordova:cordova-plugin-meteor-webapp@1.6.0`