### PR TITLE
Remove oauth fiber import

### DIFF
--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -1,4 +1,3 @@
-var Fiber = Npm.require('fibers');
 var url = Npm.require('url');
 
 OAuth = {};

--- a/packages/oauth/package.js
+++ b/packages/oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth-based services",
-  version: "1.2.2"
+  version: "1.2.3"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Fiber no longer needs to be imported because its only usage was removed. See https://github.com/meteor/meteor/pull/9740.