### PR TITLE
Do not report errors if _suppressSameNameError is true

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -264,7 +264,6 @@ Object.assign(Mongo.Collection.prototype, {
         // for now we will skip the error only when _suppressSameNameError
         // is `true`, allowing people to opt in and give this some real
         // world testing.
-        console.warn ? console.warn(message) : console.log(message);
       } else {
         throw new Error(message);
       }


### PR DESCRIPTION
## Motivation

There is a popular question on StackOverflow [Get Meteor collection by name](https://stackoverflow.com/questions/10984030/get-meteor-collection-by-name). By far the most elegant way how to do that is just create new collection with same name and set _suppressSameNameError to true:
```js
new Mongo.Collection("test", { defineMutationMethods: false, _suppressSameNameError: true })
```
But if you do that you got warn in console `There is already a collection named "test"` even when you specify that you wan to suppress it.

This PR get's rid of warning since you specify to suppress it anyway.