### PR TITLE
Downgrade uglify-es to version 3.3.9 (latest published version).

### DIFF
--- a/History.md
+++ b/History.md
@@ -105,7 +105,7 @@
 
 * The `optimism` npm package has been updated to version 0.4.0.
 
-* The `minifier-js` package has been updated to use `uglify-es` 3.3.10.
+* The `minifier-js` package has been updated to use `uglify-es` 3.3.9.
 
 * Individual Meteor `self-test`'s can now be skipped by adjusting their
   `define` call to be prefixed by `skip`. For example,

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "commander": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -12,9 +12,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "uglify-es": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.10.tgz",
-      "integrity": "sha512-rPzPisCzW68Okj1zNrfa2dR9uEm43SevDmpR6FChoZABFk9dANGnzzBMgHYUXI3609//63fnVkyQ1SQmAMyjww=="
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ=="
     }
   }
 }

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "2.3.3"
+  version: "2.3.4"
 });
 
 Npm.depends({
-  "uglify-es": "3.3.10"
+  "uglify-es": "3.3.9"
 });
 
 Package.onUse(function (api) {

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '2.3.2',
+  version: '2.3.3',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md',
 });


### PR DESCRIPTION
PR #9652 by @klaussner upgraded `uglify-es` from 3.2.2 to 3.3.10 to fix issue #9647, but 3.3.9 is the latest version published to npm, and 3.3.10 seems to suffer from this bug: https://github.com/mishoo/UglifyJS2/issues/2896

For that reason, I think it might be best to downgrade `uglify-es` to 3.3.9, at least until 3.3.11 is published.

Since this bug causes `uglify-es` to throw during minification, the `meteorJsMinify` function falls back to Babel's minifier, which is known to use massive amounts of memory, and may be contributing to OOM problems such as #9568. In other words, there's a chance that this downgrade will help with #9568.