### PR TITLE
Use isModern checks to decide which arch assets to put in the app.man…

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -44,22 +44,6 @@ const shouldSkip = resource =>
      (resource.url.endsWith('.map') ||
       resource.url.endsWith('.stats.json?meteor_js_resource=true')));
 
-const maybeRewriteUrl = resource => {
-  // If the asset comes from the public directory, and we are building
-  // a web.browser.legacy manifest, then we need to do a little url rewriting.
-  // This also fixes some other urls, such as /webapp-manifest.json
-  const legacyPrefix = '/__browser.legacy/';
-  if (resource.where === 'client' &&
-      resource.type === 'asset' &&
-      resource.url.startsWith(legacyPrefix)) {
-    const url = resource.url.substr(legacyPrefix.length);
-    if ('app/' + url === resource.path) {
-      return '/' + url;
-    }
-  }
-  return resource.url;
-};
-
 WebApp.addHtmlAttributeHook(request =>
   browserDisabled(request) ?
     null :
@@ -119,8 +103,7 @@ WebApp.connectHandlers.use((req, res, next) => {
   manifest += "/\n";
   const reqArch = isModern(request.browser) ? 'web.browser' : 'web.browser.legacy';
   WebApp.clientPrograms[reqArch].manifest.forEach(resource => {
-    // some public URLs have to be rewritten before RoutePolicy.classify is called
-    const url = maybeRewriteUrl(resource);
+    const {url} = resource
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(url) &&
         ! shouldSkip(resource)) {
@@ -152,8 +135,7 @@ WebApp.connectHandlers.use((req, res, next) => {
   // specifying the full URL with hash in their code (manually, with
   // some sort of URL rewriting helper)
   WebApp.clientPrograms[reqArch].manifest.forEach(resource => {
-    // some public URLs have to be rewritten before RoutePolicy.classify is called
-    const url = maybeRewriteUrl(resource)
+    const {url} = resource
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(url) &&
         ! resource.cacheable &&

--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -38,12 +38,10 @@ Meteor.AppCache = {
 
 const browserDisabled = request => disabledBrowsers[request.browser.name];
 
-const isDynamic = resource =>
+const isDynamicOrMap = resource =>
   resource.type === 'dynamic js' ||
     (resource.type === 'json' &&
-     resource.url.endsWith('.map') &&
-     (resource.url.startsWith('/dynamic/') ||
-      resource.url.startsWith('/__browser.legacy/dynamic/')));
+     resource.url.endsWith('.map'));
 
 WebApp.addHtmlAttributeHook(request =>
   browserDisabled(request) ?
@@ -106,7 +104,7 @@ WebApp.connectHandlers.use((req, res, next) => {
   WebApp.clientPrograms[reqArch].manifest.forEach(resource => {
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(resource.url) &&
-        ! isDynamic(resource)) {
+        ! isDynamicOrMap(resource)) {
       manifest += resource.url;
       // If the resource is not already cacheable (has a query
       // parameter, presumably with a hash or version of some sort),
@@ -137,7 +135,7 @@ WebApp.connectHandlers.use((req, res, next) => {
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(resource.url) &&
         ! resource.cacheable &&
-        ! isDynamic(resource)) {
+        ! isDynamicOrMap(resource)) {
       manifest += `${resource.url} ${resource.url}?${resource.hash}\n`;
     }
   });
@@ -169,7 +167,7 @@ const sizeCheck = () => WebApp.connectHandlers.use((req, res, next) => {
   WebApp.clientPrograms[reqArch].manifest.forEach(resource => {
     if (resource.where === 'client' &&
         ! RoutePolicy.classify(resource.url) &&
-        ! isDynamic(resource)) {
+        ! isDynamicOrMap(resource)) {
       totalSize += resource.size;
     }
   });

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -690,8 +690,11 @@ class File {
   // Given a relative path like 'a/b/c' (where '/' is this system's
   // path component separator), produce a URL that always starts with
   // a forward slash and that uses a literal forward slash as the
-  // component separator.
-  setUrlFromRelPath(relPath) {
+  // component separator. Also optionally add browser.legacy prefix.
+  // NOTE Files which come from /public must not contain legacy prefixes
+  // since users expect a fixed URL. These must match what the user
+  // uses for packages like Cordova and appcache to work properly.
+  setUrlFromRelPath(relPath, usePrefix = true) {
     var url = relPath;
 
     if (url.charAt(0) !== '/') {
@@ -701,7 +704,11 @@ class File {
     // XXX replacing colons with underscores as colon is hard to escape later
     // on different targets and generally is not a good separator for web.
     url = colonConverter.convert(url);
-    this.url = this.urlPrefix + url;
+    if (usePrefix) {
+      this.url = this.urlPrefix + url;
+    } else {
+      this.url = url;
+    }
   }
 
   setTargetPathFromRelPath(relPath) {
@@ -1115,7 +1122,7 @@ class Target {
         f.setTargetPathFromRelPath(relPath);
 
         if (isWeb) {
-          f.setUrlFromRelPath(resource.servePath);
+          f.setUrlFromRelPath(resource.servePath, false);
         } else {
           unibuildAssets[resource.path] = resource.data;
         }


### PR DESCRIPTION
This PR does two things:

1. It uses the `isModern` from the `meteor/modern-browsers` package to output content to the app.manifest based on the requesting browser.
2. For legacy browsers, it avoids outputing dynamic .map files. (Which also addresses the TODO note referencing PR #9439)

A couple of other notes/questions:

1. In the `isDynamic` method, we are checking to make sure `.map` files are dynamic to avoid putting them in the app.manifest - but should we just always avoid putting `.map` files in the manifest?
2. **This one may be important.** I'm not certain the static content from the `/public` directory is listed correctly in `WebApp.clientPrograms['web.browser.legacy'].manifest`. Assets from that location contain the `/__browser.legacy/` prefix, but those URLs don't resolve. Additionally, those `/public/` URLs do not match the links in the `NETWORK` section below, which uses a different method to populate its list. I imagine the fix for this is somewhere upstream of this package.