### PR TITLE
Update npm to version 5.8.0.

### DIFF
--- a/History.md
+++ b/History.md
@@ -44,6 +44,10 @@
   application code. [PR #9771](https://github.com/meteor/meteor/pull/9771)
   [Feature #6](https://github.com/meteor/meteor-feature-requests/issues/6)
 
+* The `npm` package has been upgraded to version 5.8.0, and our
+  [fork](https://github.com/meteor/pacote/tree/v7.6.1-meteor) of its
+  `pacote` dependency has been rebased against version 7.6.1.
+
 * Applications may now specify client and server entry point modules in a
   newly-supported `"meteor"` section of `package.json`:
   ```js

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.9.26
+BUNDLE_VERSION=8.9.27
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -8,7 +8,7 @@ ARCH=$(uname -m)
 NODE_VERSION=8.9.4
 MONGO_VERSION_64BIT=3.6.3
 MONGO_VERSION_32BIT=3.2.19
-NPM_VERSION=5.6.0
+NPM_VERSION=5.8.0
 
 # If we built Node from source on Jenkins, this is the build number.
 NODE_BUILD_NUMBER=

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -10,8 +10,8 @@ var packageJson = {
   dependencies: {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version
-    npm: "5.6.0",
-    pacote: "https://github.com/meteor/pacote/tarball/30973f140df79b647dbade03f2d6f19800c2609b",
+    npm: "5.8.0",
+    pacote: "https://github.com/meteor/pacote/tarball/2c16c509074bbba8ca5dd410caf808412ce79e6c",
     "node-gyp": "3.6.2",
     "node-pre-gyp": "0.6.36",
     "meteor-babel": "7.0.0-beta.42",

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -158,11 +158,6 @@ delete () {
     rm -rf "$1"
 }
 
-delete npm/node_modules/node-gyp
-pushd npm/node_modules
-ln -s ../../node-gyp ./
-popd
-
 # Since we install a patched version of pacote in $DIR/lib/node_modules,
 # we need to remove npm's bundled version to make it use the new one.
 if [ -d "pacote" ]


### PR DESCRIPTION
Fairly self-explanatory, though there are a number of notable changes, since it's been a while since `npm` released a new version:

* http://blog.npmjs.org/post/171139955345/v570
* http://blog.npmjs.org/post/171169301000/v571
* http://blog.npmjs.org/post/171813275740/v580-next0
* http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable