### PR TITLE
Remove Blaze repo based dependencies from static-html

### DIFF
--- a/packages/caching-html-compiler/README.md
+++ b/packages/caching-html-compiler/README.md
@@ -1,0 +1,49 @@
+# caching-html-compiler
+
+Provides a pluggable class used to compile HTML-style templates in Meteor build
+plugins. This abstracts out a lot of the functionality you would need to
+implement the following plugins:
+
+1. `templating`
+2. `static-html`
+3. `simple:markdown-templating`
+
+It provides automatic caching and handles communicating with the build plugin
+APIs. The actual functions that convert HTML into compiled form are passed in
+as arguments into the constructor, allowing those functions to be unit tested
+separately from the caching and file system functionality.
+
+-------
+
+### new CachingHtmlCompiler(name, tagScannerFunc, tagHandlerFunc)
+
+Constructs a new CachingHtmlCompiler that can be passed into
+`Plugin.registerCompiler`.
+
+#### Arguments
+
+1. `name` The name of the compiler, used when printing errors. Should probably
+   be the same as the name of the build plugin and package it is used in.
+2. `tagScannerFunc` A function that takes a string representing a template
+   file as input, and returns an array of Tag objects. See the README for
+   `templating-tools` for more information about the Tag object.
+3. `tagHandlerFunc` A function that takes an array of Tag objects (the output
+   of the previous argument) and returns an object with `js`, `body`, `head`,
+   and `bodyAttr` properties, which will be added to the app through the build
+   plugin API.
+
+#### Example
+
+Here is some example code from the `templating` package:
+
+```js
+Plugin.registerCompiler({
+  extensions: ['html'],
+  archMatching: 'web',
+  isTemplate: true
+}, () => new CachingHtmlCompiler(
+  "templating",
+  TemplatingTools.scanHtmlForTags,
+  TemplatingTools.compileTagsWithSpacebars
+));
+```

--- a/packages/caching-html-compiler/caching-html-compiler.js
+++ b/packages/caching-html-compiler/caching-html-compiler.js
@@ -1,0 +1,142 @@
+const path = Plugin.path;
+
+// The CompileResult type for this CachingCompiler is the return value of
+// htmlScanner.scan: a {js, head, body, bodyAttrs} object.
+CachingHtmlCompiler = class CachingHtmlCompiler extends CachingCompiler {
+  /**
+   * Constructor for CachingHtmlCompiler
+   * @param  {String} name The name of the compiler, printed in errors -
+   * should probably always be the same as the name of the build
+   * plugin/package
+   * @param  {Function} tagScannerFunc Transforms a template file (commonly
+   * .html) into an array of Tags
+   * @param  {Function} tagHandlerFunc Transforms an array of tags into a
+   * results object with js, body, head, and bodyAttrs properties
+   */
+  constructor(name, tagScannerFunc, tagHandlerFunc) {
+    super({
+      compilerName: name,
+      defaultCacheSize: 1024*1024*10,
+    });
+
+    this._bodyAttrInfo = null;
+
+    this.tagScannerFunc = tagScannerFunc;
+    this.tagHandlerFunc = tagHandlerFunc;
+  }
+
+  // Implements method from CachingCompilerBase
+  compileResultSize(compileResult) {
+    function lengthOrZero(field) {
+      return field ? field.length : 0;
+    }
+    return lengthOrZero(compileResult.head) + lengthOrZero(compileResult.body) +
+      lengthOrZero(compileResult.js);
+  }
+
+  // Overrides method from CachingCompiler
+  processFilesForTarget(inputFiles) {
+    this._bodyAttrInfo = {};
+    super.processFilesForTarget(inputFiles);
+  }
+
+  // Implements method from CachingCompilerBase
+  getCacheKey(inputFile) {
+    // Note: the path is only used for errors, so it doesn't have to be part
+    // of the cache key.
+    return inputFile.getSourceHash();
+  }
+
+  // Implements method from CachingCompiler
+  compileOneFile(inputFile) {
+    const contents = inputFile.getContentsAsString();
+    const inputPath = inputFile.getPathInPackage();
+    try {
+      const tags = this.tagScannerFunc({
+        sourceName: inputPath,
+        contents: contents,
+        tagNames: ["body", "head", "template"]
+      });
+
+      return this.tagHandlerFunc(tags);
+    } catch (e) {
+      const CompileError = class CompileError {};
+      if (e instanceof CompileError) {
+        inputFile.error({
+          message: e.message,
+          line: e.line
+        });
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  // Implements method from CachingCompilerBase
+  addCompileResult(inputFile, compileResult) {
+    let allJavaScript = "";
+
+    if (compileResult.head) {
+      inputFile.addHtml({ section: "head", data: compileResult.head });
+    }
+
+    if (compileResult.body) {
+      inputFile.addHtml({ section: "body", data: compileResult.body });
+    }
+
+    if (compileResult.js) {
+      allJavaScript += compileResult.js;
+    }
+
+    if (Object.keys(compileResult.bodyAttrs).length !== 0) {
+      Object.keys(compileResult.bodyAttrs).forEach((attr) => {
+        const value = compileResult.bodyAttrs[attr];
+        if (this._bodyAttrInfo.hasOwnProperty(attr) &&
+            this._bodyAttrInfo[attr].value !== value) {
+          // two conflicting attributes on <body> tags in two different template
+          // files
+          inputFile.error({
+            message:
+            `<body> declarations have conflicting values for the '${ attr }' ` +
+              `attribute in the following files: ` +
+              this._bodyAttrInfo[attr].inputFile.getPathInPackage() +
+              `, ${ inputFile.getPathInPackage() }`
+          });
+        } else {
+          this._bodyAttrInfo[attr] = {inputFile, value};
+        }
+      });
+
+      // Add JavaScript code to set attributes on body
+      allJavaScript +=
+`Meteor.startup(function() {
+  var attrs = ${JSON.stringify(compileResult.bodyAttrs)};
+  for (var prop in attrs) {
+    document.body.setAttribute(prop, attrs[prop]);
+  }
+});
+`;
+    }
+
+
+    if (allJavaScript) {
+      const filePath = inputFile.getPathInPackage();
+      // XXX this path manipulation may be unnecessarily complex
+      let pathPart = path.dirname(filePath);
+      if (pathPart === '.')
+        pathPart = '';
+      if (pathPart.length && pathPart !== path.sep)
+        pathPart = pathPart + path.sep;
+      const ext = path.extname(filePath);
+      const basename = path.basename(filePath, ext);
+
+      // XXX generate a source map
+
+      inputFile.addJavaScript({
+        path: path.join(pathPart, "template." + basename + ".js"),
+        data: allJavaScript
+      });
+    }
+  }
+}

--- a/packages/caching-html-compiler/package.js
+++ b/packages/caching-html-compiler/package.js
@@ -1,0 +1,19 @@
+Package.describe({
+  name: 'caching-html-compiler',
+  summary: "Pluggable class for compiling HTML into templates",
+  version: '1.1.3',
+  git: 'https://github.com/meteor/meteor.git'
+});
+
+Package.onUse(function (api) {
+  api.use([
+    'caching-compiler',
+    'ecmascript'
+  ]);
+
+  api.export('CachingHtmlCompiler', 'server');
+
+  api.addFiles([
+    'caching-html-compiler.js'
+  ], 'server');
+});

--- a/packages/html-scanner/README.md
+++ b/packages/html-scanner/README.md
@@ -1,0 +1,54 @@
+# html-scanner
+
+## `scanHtmlForTags(options)`
+
+Scan an HTML file for top-level tags as specified by `options.tagNames`, and
+return an array of `Tag` objects.
+
+### Options
+
+1. `sourceName` the name of the input file, used when throwing errors.
+2. `contents` the contents of the input file, these are parsed to find the
+   top-level tags.
+3. `tagNames` the top-level tags to look for in the HTML.
+
+### Example
+
+```js
+const tags = scanHtmlForTags({
+  sourceName: inputPath,
+  contents: contents,
+  tagNames: ["body", "head", "template"]
+});
+```
+
+### Tag object
+
+```js
+{
+  // Name of the tag - "body", "head", "template", etc
+  tagName: String,
+
+  // Attributes on the tag
+  attribs: { [attrName]: String },
+
+  // Contents of the tag
+  contents: String,
+
+  // Starting index of the opening tag in the source file
+  // (used to throw informative errors)
+  tagStartIndex: Number,
+
+  // Starting index of the contents of the tag in the source file
+  // (used to throw informative errors)
+  contentsStartIndex: Number,
+
+  // The contents of the entire source file, should be used only to
+  // throw informative errors (for example, this can be used to
+  // determine the line number for an error)
+  fileContents: String,
+
+  // The file name of the initial source file, used to throw errors
+  sourceName: String
+};
+```

--- a/packages/html-scanner/html-scanner-tests.js
+++ b/packages/html-scanner/html-scanner-tests.js
@@ -1,0 +1,191 @@
+import { scanHtmlForTags, CompileError } from './html-scanner.js';
+
+Tinytest.add("html-scanner - html scanner", function (test) {
+  var testInString = function(actualStr, wantedContents) {
+    if (actualStr.indexOf(wantedContents) >= 0)
+      test.ok();
+    else
+      test.fail("Expected "+JSON.stringify(wantedContents)+
+                " in "+JSON.stringify(actualStr));
+  };
+
+  var checkError = function(f, msgText, lineNum) {
+    try {
+      f();
+    } catch (e) {
+      if (! e instanceof CompileError) {
+        throw e;
+      }
+
+      if (e.line === lineNum)
+        test.ok();
+      else
+        test.fail("Error should have been on line " + lineNum + ", not " +
+                  e.line);
+      testInString(e.message, msgText);
+      return;
+    }
+    test.fail("Parse error didn't throw exception");
+  };
+
+  // returns the appropriate code to put content in the body,
+  // where content is something simple like the string "Hello"
+  // (passed in as a source string including the quotes).
+  var simpleBody = function (content) {
+    return "\nTemplate.body.addContent((function() {\n  var view = this;\n  return " + content + ";\n}));\nMeteor.startup(Template.body.renderToDocument);\n";
+  };
+
+  // arguments are quoted strings like '"hello"'
+  var simpleTemplate = function (templateName, content) {
+    // '"hello"' into '"Template.hello"'
+    var viewName = templateName.slice(0, 1) + 'Template.' + templateName.slice(1);
+
+    return '\nTemplate.__checkName(' + templateName + ');\nTemplate[' + templateName +
+      '] = new Template(' + viewName +
+      ', (function() {\n  var view = this;\n  return ' + content + ';\n}));\n';
+  };
+
+  var checkResults = function(results, expectJs, expectHead, expectBodyAttrs) {
+    test.equal(results.body, '');
+    test.equal(results.js, expectJs || '');
+    test.equal(results.head, expectHead || '');
+    test.equal(results.bodyAttrs, expectBodyAttrs || {});
+  };
+
+  function scanForTest(contents) {
+    const tags = scanHtmlForTags({
+      sourceName: "",
+      contents: contents,
+      tagNames: ["body", "head", "template"]
+    });
+
+    return TemplatingTools.compileTagsWithSpacebars(tags);
+  }
+
+  checkError(function() {
+    return scanForTest("asdf");
+  }, "Expected one of: <body>, <head>, <template>", 1);
+
+  // body all on one line
+  checkResults(
+    scanForTest("<body>Hello</body>"),
+    simpleBody('"Hello"'));
+
+  // multi-line body, contents trimmed
+  checkResults(
+    scanForTest("\n\n\n<body>\n\nHello\n\n</body>\n\n\n"),
+    simpleBody('"Hello"'));
+
+  // same as previous, but with various HTML comments
+  checkResults(
+    scanForTest("\n<!--\n\nfoo\n-->\n<!-- -->\n"+
+                      "<body>\n\nHello\n\n</body>\n\n<!----\n>\n\n"),
+    simpleBody('"Hello"'));
+
+  // head and body
+  checkResults(
+    scanForTest("<head>\n<title>Hello</title>\n</head>\n\n<body>World</body>\n\n"),
+    simpleBody('"World"'),
+    "<title>Hello</title>");
+
+  // head and body with tag whitespace
+  checkResults(
+    scanForTest("<head\n>\n<title>Hello</title>\n</head  >\n\n<body>World</body\n\n>\n\n"),
+    simpleBody('"World"'),
+    "<title>Hello</title>");
+
+  // head, body, and template
+  checkResults(
+    scanForTest("<head>\n<title>Hello</title>\n</head>\n\n<body>World</body>\n\n"+
+                      '<template name="favoritefood">\n  pizza\n</template>\n'),
+    simpleBody('"World"') + simpleTemplate('"favoritefood"', '"pizza"'),
+    "<title>Hello</title>");
+
+  // one-line template
+  checkResults(
+    scanForTest('<template name="favoritefood">pizza</template>'),
+    simpleTemplate('"favoritefood"', '"pizza"'));
+
+  // template with other attributes
+  checkResults(
+    scanForTest('<template foo="bar" name="favoritefood" baz="qux">'+
+                      'pizza</template>'),
+    simpleTemplate('"favoritefood"', '"pizza"'));
+
+  // whitespace around '=' in attributes and at end of tag
+  checkResults(
+    scanForTest('<template foo = "bar" name  ="favoritefood" baz= "qux"  >'+
+                      'pizza</template\n\n>'),
+    simpleTemplate('"favoritefood"', '"pizza"'));
+
+  // whitespace around template name
+  checkResults(
+    scanForTest('<template name=" favoritefood  ">pizza</template>'),
+    simpleTemplate('"favoritefood"', '"pizza"'));
+
+  // single quotes around template name
+  checkResults(
+    scanForTest('<template name=\'the "cool" template\'>'+
+                      'pizza</template>'),
+    simpleTemplate('"the \\"cool\\" template"', '"pizza"'));
+
+  checkResults(scanForTest('<body foo="bar">\n  Hello\n</body>'), simpleBody('"Hello"'), "", {foo: "bar"});
+
+  // error cases; exact line numbers are not critical, these just reflect
+  // the current implementation
+
+  // unclosed body (error mentions body)
+  checkError(function() {
+    return scanForTest("\n\n<body>\n  Hello\n</body");
+  }, "body", 3);
+
+  // bad open tag
+  checkError(function() {
+    return scanForTest("\n\n\n<bodyd>\n  Hello\n</body>");
+  }, "Expected one of: <body>, <head>, <template>", 4);
+  checkError(function() {
+    return scanForTest("\n\n\n\n<body foo=>\n  Hello\n</body>");
+  }, "error in tag", 5);
+
+  // unclosed tag
+  checkError(function() {
+    return scanForTest("\n<body>Hello");
+  }, "nclosed", 2);
+
+  // unnamed template
+  checkError(function() {
+    return scanForTest(
+      "\n\n<template>Hi</template>\n\n<template>Hi</template>");
+  }, "name", 3);
+
+  // helpful doctype message
+  checkError(function() {
+    return scanForTest(
+      '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" '+
+        '"http://www.w3.org/TR/html4/strict.dtd">'+
+        '\n\n<head>\n</head>');
+  }, "DOCTYPE", 1);
+
+  // lowercase basic doctype
+  checkError(function() {
+    return scanForTest(
+      '<!doctype html>');
+  }, "DOCTYPE", 1);
+
+  // attributes on head not supported
+  checkError(function() {
+    return scanForTest('<head foo="bar">\n  Hello\n</head>');
+  }, "<head>", 1);
+
+  // can't mismatch quotes
+  checkError(function() {
+    return scanForTest('<template name="foo\'>'+
+                             'pizza</template>');
+  }, "error in tag", 1);
+
+  // unexpected <html> at top level
+  checkError(function() {
+    return scanForTest('\n<html>\n</html>');
+  }, "Expected one of: <body>, <head>, <template>", 2);
+
+});

--- a/packages/html-scanner/html-scanner.js
+++ b/packages/html-scanner/html-scanner.js
@@ -1,0 +1,174 @@
+export const scanHtmlForTags = function scanHtmlForTags(options) {
+  const scan = new HtmlScan(options);
+  return scan.getTags();
+};
+
+export class CompileError {};
+
+/**
+ * Scan an HTML file for top-level tags and extract their contents. Pass them to
+ * a tag handler (an object with a handleTag method)
+ *
+ * This is a primitive, regex-based scanner.  It scans
+ * top-level tags, which are allowed to have attributes,
+ * and ignores top-level HTML comments.
+ */
+class HtmlScan {
+  /**
+   * Initialize and run a scan of a single file
+   * @param  {String} sourceName The filename, used in errors only
+   * @param  {String} contents   The contents of the file
+   * @param  {String[]} tagNames An array of tag names that are accepted at the
+   * top level. If any other tag is encountered, an error is thrown.
+   */
+  constructor({
+        sourceName,
+        contents,
+        tagNames
+      }) {
+    this.sourceName = sourceName;
+    this.contents = contents;
+    this.tagNames = tagNames;
+
+    this.rest = contents;
+    this.index = 0;
+
+    this.tags = [];
+
+    tagNameRegex = this.tagNames.join("|");
+    const openTagRegex = new RegExp(`^((<(${tagNameRegex})\\b)|(<!--)|(<!DOCTYPE|{{!)|$)`, "i");
+
+    while (this.rest) {
+      // skip whitespace first (for better line numbers)
+      this.advance(this.rest.match(/^\s*/)[0].length);
+
+      const match = openTagRegex.exec(this.rest);
+
+      if (! match) {
+        this.throwCompileError(`Expected one of: <${this.tagNames.join('>, <')}>`);
+      }
+
+      const matchToken = match[1];
+      const matchTokenTagName =  match[3];
+      const matchTokenComment = match[4];
+      const matchTokenUnsupported = match[5];
+
+      const tagStartIndex = this.index;
+      this.advance(match.index + match[0].length);
+
+      if (! matchToken) {
+        break; // matched $ (end of file)
+      }
+
+      if (matchTokenComment === '<!--') {
+        // top-level HTML comment
+        const commentEnd = /--\s*>/.exec(this.rest);
+        if (! commentEnd)
+          this.throwCompileError("unclosed HTML comment in template file");
+        this.advance(commentEnd.index + commentEnd[0].length);
+        continue;
+      }
+
+      if (matchTokenUnsupported) {
+        switch (matchTokenUnsupported.toLowerCase()) {
+        case '<!doctype':
+          this.throwCompileError(
+            "Can't set DOCTYPE here.  (Meteor sets <!DOCTYPE html> for you)");
+        case '{{!':
+          this.throwCompileError(
+            "Can't use '{{! }}' outside a template.  Use '<!-- -->'.");
+        }
+
+        this.throwCompileError();
+      }
+
+      // otherwise, a <tag>
+      const tagName = matchTokenTagName.toLowerCase();
+      const tagAttribs = {}; // bare name -> value dict
+      const tagPartRegex = /^\s*((([a-zA-Z0-9:_-]+)\s*=\s*(["'])(.*?)\4)|(>))/;
+
+      // read attributes
+      let attr;
+      while ((attr = tagPartRegex.exec(this.rest))) {
+        const attrToken = attr[1];
+        const attrKey = attr[3];
+        let attrValue = attr[5];
+        this.advance(attr.index + attr[0].length);
+
+        if (attrToken === '>') {
+          break;
+        }
+
+        // XXX we don't HTML unescape the attribute value
+        // (e.g. to allow "abcd&quot;efg") or protect against
+        // collisions with methods of tagAttribs (e.g. for
+        // a property named toString)
+        attrValue = attrValue.match(/^\s*([\s\S]*?)\s*$/)[1]; // trim
+        tagAttribs[attrKey] = attrValue;
+      }
+
+      if (! attr) { // didn't end on '>'
+        this.throwCompileError("Parse error in tag");
+      }
+
+      // find </tag>
+      const end = (new RegExp('</'+tagName+'\\s*>', 'i')).exec(this.rest);
+      if (! end) {
+        this.throwCompileError("unclosed <"+tagName+">");
+      }
+
+      const tagContents = this.rest.slice(0, end.index);
+      const contentsStartIndex = this.index;
+
+      // trim the tag contents.
+      // this is a courtesy and is also relied on by some unit tests.
+      var m = tagContents.match(/^([ \t\r\n]*)([\s\S]*?)[ \t\r\n]*$/);
+      const trimmedContentsStartIndex = contentsStartIndex + m[1].length;
+      const trimmedTagContents = m[2];
+
+      const tag = {
+        tagName: tagName,
+        attribs: tagAttribs,
+        contents: trimmedTagContents,
+        contentsStartIndex: trimmedContentsStartIndex,
+        tagStartIndex: tagStartIndex,
+        fileContents: this.contents,
+        sourceName: this.sourceName
+      };
+
+      // save the tag
+      this.tags.push(tag);
+
+      // advance afterwards, so that line numbers in errors are correct
+      this.advance(end.index + end[0].length);
+    }
+  }
+
+  /**
+   * Advance the parser
+   * @param  {Number} amount The amount of characters to advance
+   */
+  advance(amount) {
+    this.rest = this.rest.substring(amount);
+    this.index += amount;
+  }
+
+  throwCompileError(msg, overrideIndex) {
+    const finalIndex = (typeof overrideIndex === 'number' ? overrideIndex : this.index);
+
+    const err = new CompileError();
+    err.message = msg || "bad formatting in template file";
+    err.file = this.sourceName;
+    err.line = this.contents.substring(0, finalIndex).split('\n').length;
+
+    throw err;
+  }
+
+  throwBodyAttrsError(msg) {
+    this.parseError(msg);
+  }
+
+  getTags() {
+    return this.tags;
+  }
+}

--- a/packages/html-scanner/package.js
+++ b/packages/html-scanner/package.js
@@ -1,0 +1,20 @@
+Package.describe({
+  name: 'html-scanner',
+  version: '1.0.0',
+  summary: 'Scan and extract HTML tags',
+  git: 'https://github.com/meteor/meteor.git',
+  documentation: 'README.md'
+});
+
+Package.onUse(function (api) {
+  api.use('ecmascript');
+  api.mainModule('html-scanner.js');
+});
+
+Package.onTest(function (api) {
+  api.use('ecmascript');
+  api.use('tinytest');
+  api.use('templating-tools')
+  api.use('html-scanner');
+  api.mainModule('html-scanner-tests.js', 'server');
+});

--- a/packages/static-html/README.md
+++ b/packages/static-html/README.md
@@ -1,0 +1,14 @@
+# static-html
+
+Essentially, an alternative to the `templating` package that doesn't compile
+Blaze templates. Mostly useful if you want to use Angular or React as your
+view layer and just want to get some static HTML content on your page as a
+render target for your view framework.
+
+This build plugin parses all of the `.html` files in your app and looks for
+top-level tags:
+
+- `<head>` - appended to the `head` section of your HTML
+- `<body>` - appended to the `body` section of your HTML
+
+Attributes are supported on the `<body>` tag, but not on `<head>`.

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,0 +1,25 @@
+Package.describe({
+  name: 'static-html',
+  summary: 'Define static page content in .html files',
+  version: '1.2.3',
+  git: 'https://github.com/meteor/meteor.git'
+});
+
+Package.registerBuildPlugin({
+  name: 'compileStaticHtmlBatch',
+  use: [
+    'ecmascript',
+    'caching-html-compiler',
+    'html-scanner'
+  ],
+  sources: [
+    'static-html.js'
+  ]
+});
+
+Package.onUse(function (api) {
+  api.use('isobuild:compiler-plugin@1.0.0');
+
+  // Body attributes are compiled to code that uses Meteor.startup
+  api.imply('meteor@1.2.17', 'client');
+});

--- a/packages/static-html/static-html.js
+++ b/packages/static-html/static-html.js
@@ -1,0 +1,91 @@
+import { scanHtmlForTags } from 'meteor/html-scanner';
+
+Plugin.registerCompiler({
+  extensions: ['html'],
+  archMatching: 'web',
+  isTemplate: true
+}, () => new CachingHtmlCompiler("static-html", scanHtmlForTags, compileTagsToStaticHtml));
+
+// Same API as TutorialTools.compileTagsWithSpacebars, but instead of compiling
+// with Spacebars, it just returns static HTML
+function compileTagsToStaticHtml(tags) {
+  var handler = new StaticHtmlTagHandler();
+
+  tags.forEach((tag) => {
+    handler.addTagToResults(tag);
+  });
+
+  return handler.getResults();
+};
+
+class StaticHtmlTagHandler {
+  constructor() {
+    this.results = {
+      head: '',
+      body: '',
+      js: '',
+      bodyAttrs: {}
+    };
+  }
+
+  getResults() {
+    return this.results;
+  }
+
+  addTagToResults(tag) {
+    this.tag = tag;
+
+    // do we have 1 or more attributes?
+    const hasAttribs = Object.keys(this.tag.attribs).length;
+
+    if (this.tag.tagName === "head") {
+      if (hasAttribs) {
+        this.throwCompileError("Attributes on <head> not supported");
+      }
+
+      this.results.head += this.tag.contents;
+      return;
+    }
+
+
+    // <body> or <template>
+
+    try {
+      if (this.tag.tagName === "body") {
+        this.addBodyAttrs(this.tag.attribs);
+
+        // We may be one of many `<body>` tags.
+        this.results.body += this.tag.contents;
+      } else {
+        this.throwCompileError("Expected <head> or <body> tag", this.tag.tagStartIndex);
+      }
+    } catch (e) {
+      if (e.scanner) {
+        // The error came from Spacebars
+        this.throwCompileError(e.message, this.tag.contentsStartIndex + e.offset);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  addBodyAttrs(attrs) {
+    Object.keys(attrs).forEach((attr) => {
+      const val = attrs[attr];
+
+      // This check is for conflicting body attributes in the same file;
+      // we check across multiple files in caching-html-compiler using the
+      // attributes on results.bodyAttrs
+      if (this.results.bodyAttrs.hasOwnProperty(attr) && this.results.bodyAttrs[attr] !== val) {
+        this.throwCompileError(
+          `<body> declarations have conflicting values for the '${attr}' attribute.`);
+      }
+
+      this.results.bodyAttrs[attr] = val;
+    });
+  }
+
+  throwCompileError(message, overrideIndex) {
+    TemplatingTools.throwCompileError(this.tag, message, overrideIndex);
+  }
+}


### PR DESCRIPTION
I was playing around with the awesome new 1.6.2 `meteor create --minimal` feature, and noticed that `tracker` is being pulled into new minimal apps as a dependency. I was wondering why, and tracked the reason down to it being pulled in as one of the dependencies on the Blaze templating tools side. Currently the `static-html` package is dependent on several Blaze repo based packages, a lot of which include Blaze specific utilities / helpers, that are really not needed when using non-Blaze apps. This led me down a bit of a rabbit hole, but it turns out that the `static-html` package really only needs the following Blaze repo functionality to accomplish its role:

1. [`caching-html-compiler`](https://github.com/meteor/blaze/tree/555f3bb0d34c7553423e1f01f054189378e343ea/packages/caching-html-compiler)
2. The [`html-scanner.js`](https://github.com/meteor/blaze/blob/555f3bb0d34c7553423e1f01f054189378e343ea/packages/templating-tools/html-scanner.js) file from the [`templating-tools`](https://github.com/meteor/blaze/tree/555f3bb0d34c7553423e1f01f054189378e343ea/packages/templating-tools) package.
3. And of course itself, the [`static-html`](https://github.com/meteor/blaze/tree/555f3bb0d34c7553423e1f01f054189378e343ea/packages/static-html) package.

Since the above functionality isn't specific to Blaze, I'm thinking it might make sense to extract those files / packages from the Blaze repo, and bring them back into Meteor core. By doing so we can reduce a lot of template based dependency overhead, when not using Blaze.

This PR creates a new copy of the `static-html` and `caching-html-compiler` packages in core, and creates a new package called `html-scanner`, to house the `html-scanner.js` functionality from the `templating-tools` package. With these changes in place, we're able to replace the following dependencies in a `meteor create --minimal` app:

```
blaze-tools
caching-html-compiler
caching-compiler
deps
html-tools
htmljs
spacebars-compiler
static-html
templating-tools
tracker
```

with:

```
caching-html-compiler
html-scanner
static-html
```

(And this change will of course benefit non minimal `static-html` dependent apps as well.)

I've marked this PR as a work in progress, but I have verified it works properly by using it with a few apps. I would love to get feedback on this idea, to see if others agree it makes sense. If it does, then I'll finish polishing this PR up, and submit a sister PR over in the Blaze repo, to make sure Blaze is updated to use the new core packages (instead of using its own copies).