### PR TITLE
Merge release-1.4.4.x and release-1.5.x into master.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,3 @@
-## v.NEXT
-
 ## v1.6.1, 2018-01-19
 
 * Node has been updated to version
@@ -992,6 +990,20 @@
   `install`, `preinstall`, or `postinstall`. Previously, a package was
   considered non-portable only if it contained any `.node` binary modules.
   [Issue #8225](https://github.com/meteor/meteor/issues/8225)
+
+## v1.4.4.6, 2018-04-02
+
+* Node has been upgraded to version
+  [4.9.0](https://nodejs.org/en/blog/release/v4.9.0/), an important
+  [security release](https://nodejs.org/en/blog/vulnerability/march-2018-security-releases/).
+  The Node v4.x release line will exit the Node.js Foundation's
+  [long-term support (LTS) status](https://github.com/nodejs/LTS) on April 30,
+  2018. We strongly advise updating to a version of Meteor using a newer
+  version of Node which is still under LTS status, such as Meteor 1.6.x
+  which uses Node 8.x.
+
+* The `npm` package has been upgraded to version
+  [4.6.1](https://github.com/npm/npm/releases/tag/v4.6.1).
 
 ## v1.4.4.5, 2017-12-08
 

--- a/History.md
+++ b/History.md
@@ -480,6 +480,12 @@
   [Issue #9196](https://github.com/meteor/meteor/issues/9196)
   [PR #9198](https://github.com/meteor/meteor/pull/9198)
 
+## v1.5.4.2, 2018-04-02
+
+* Node has been upgraded to version
+  [4.9.0](https://nodejs.org/en/blog/release/v4.9.0/), an important
+  [security release](https://nodejs.org/en/blog/vulnerability/march-2018-security-releases/).
+
 ## v1.5.4.1, 2017-12-08
 
 * Node has been upgraded to version


### PR DESCRIPTION
Since these are legacy release branches, we want to make extra sure we resolve any merge conflicts in favor of the current `master` branch (1.6.1), without accidentally reverting to older code. Also, I can't merge these branches into `master` from the command line without overriding GitHub's branch protection, so it seems easiest just to open a PR, wait for the tests to pass, and merge from the web.