### PR TITLE
Update MongoDB driver to 3.0.5

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1345,7 +1345,7 @@ Ap.insertUserDoc = function (options, user) {
   } catch (e) {
     // XXX string parsing sucks, maybe
     // https://jira.mongodb.org/browse/SERVER-3069 will get fixed one day
-    if (e.name !== 'MongoError') throw e;
+    if (e.name !== 'MongoError' && e.name !== 'BulkWriteError') throw e;
     if (e.code !== 11000) throw e;
     if (e.errmsg.indexOf('emails.address') !== -1)
       throw new Meteor.Error(403, "Email already exists.");

--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -192,7 +192,11 @@ CollectionPrototype._defineMutationMethods = function(options) {
             throw new Meteor.Error(403, "Access denied");
           }
         } catch (e) {
-          if (e.name === 'MongoError' || e.name === 'MinimongoError') {
+          if (
+            e.name === 'MongoError' ||
+            e.name === 'BulkWriteError' ||
+            e.name === 'MinimongoError'
+          ) {
             throw new Meteor.Error(409, e.toString());
           } else {
             throw e;

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -3234,7 +3234,7 @@ Meteor.isServer && Tinytest.add(
 
 Meteor.isServer && Tinytest.add("mongo-livedata - npm modules", function (test) {
   // Make sure the version number looks like a version number.
-  test.matches(MongoInternals.NpmModules.mongodb.version, /^2\.(\d+)\.(\d+)/);
+  test.matches(MongoInternals.NpmModules.mongodb.version, /^3\.(\d+)\.(\d+)/);
   test.equal(typeof(MongoInternals.NpmModules.mongodb.module), 'function');
   test.equal(typeof(MongoInternals.NpmModules.mongodb.module.connect),
              'function');

--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -2,54 +2,19 @@
   "lockfileVersion": 1,
   "dependencies": {
     "bson": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
-      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "es6-promise": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.6.tgz",
+      "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
     },
     "mongodb": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
-      "integrity": "sha1-o09Zu+thdUrsQy3nLD/iFSakTBo="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.5.tgz",
+      "integrity": "sha512-8ioTyyc8tkNwZCTDa1FPWvmpJFfvE484DnugC8KpVrw4AKAE03OOAlORl2yYTNtz3TX4Ab7FRo00vzgexB/67A=="
     },
     "mongodb-core": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
-      "integrity": "sha1-TEYTm986HwMt7ZHbSfOO7AFlkFA="
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "readable-stream": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.5.tgz",
+      "integrity": "sha512-4A1nx/xAU5d/NPICjiyzVxzNrIdJQQsYRe3xQkV1O638t+fHHfAOLK+SQagqGnu1m0aeSxb1ixp/P0FGSQWIGA=="
     },
     "require_optional": {
       "version": "1.0.1",
@@ -61,25 +26,10 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     }
   }
 }

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -8,7 +8,7 @@ Package.describe({
 });
 
 Npm.depends({
-  mongodb: "2.2.34"
+  mongodb: "3.0.5"
 });
 
 Package.onUse(function (api) {

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -585,21 +585,24 @@ var launchMongo = function (options) {
   var initiateReplSetAndWaitForReady = function () {
     try {
       // Load mongo so we'll be able to talk to it.
-      const { Db, Server } = loadIsopackage('npm-mongo').NpmModuleMongodb;
+      const {
+        MongoClient,
+        Server
+      } = loadIsopackage('npm-mongo').NpmModuleMongodb;
 
       // Connect to the intended primary and start a replset.
-      var db = new Db(
-        'meteor',
+      const client = new MongoClient(
         new Server('127.0.0.1', options.port, {
           poolSize: 1,
           socketOptions: {
             connectTimeoutMS: 60000
           }
-        }),
-        { safe: true }
+        })
       );
 
-      yieldingMethod(db, 'open');
+      yieldingMethod(client, 'connect');
+      const db = client.db('meteor');
+
       if (stopped) {
         return;
       }
@@ -711,7 +714,7 @@ var launchMongo = function (options) {
         break;
       }
 
-      db.close(true /* means "the app is closing the connection" */);
+      client.close(true /* means "the app is closing the connection" */);
     } catch (e) {
       // If the process has exited, we're doing another form of error
       // handling. No need to throw random low-level errors farther.


### PR DESCRIPTION
This PR updates the MongoDB driver from 2.2.34 to 3.0.5 and addresses the breaking changes described in [`CHANGES_3.0.0.md` (`node-mongodb-native`)](
https://github.com/mongodb/node-mongodb-native/blob/3.0.0/CHANGES_3.0.0.md) and https://github.com/meteor/meteor-feature-requests/issues/268#issuecomment-366048866.

**Summary of the changes:**

* Create the `Db` instance manually because `MongoClient` passes a client instance instead of a database to the callback function. I'm using the undocumented `client.s.options.dbName` property to get the database name because I couldn't find better way to access it without parsing the URL in the `MongoConnection` constructor.

* Use `Cursor.prototype.next` instead of `Cursor.prototype.nextObject` (deprecated in version 2 and removed in version 3).

* Use `client` instead of `db` to close the connection in `MongoConnection.prototype.close`.

* Use the `projection` option instead of the `fields` parameter in `MongoConnection.prototype._createSynchronousCursor`.

I'll bump the versions and add an entry to `History.md` when the PR is ready to be approved. :slightly_smiling_face: :crossed_fingers:

Fixes meteor/meteor-feature-requests#268.