### PR TITLE
Define browser aliases for modern browser test

### DIFF
--- a/packages/modern-browsers/modern-tests.js
+++ b/packages/modern-browsers/modern-tests.js
@@ -7,6 +7,11 @@ Tinytest.add('modern-browsers - versions - basic', function (test) {
     major: 60,
   }));
 
+  test.isTrue(isModern({
+    name: "chromeMobile",
+    major: 60,
+  }));
+
   test.isFalse(isModern({
     name: "firefox",
     major: 25,

--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -1,5 +1,8 @@
 const minimumVersions = Object.create(null);
 const hasOwn = Object.prototype.hasOwnProperty;
+const browserAliases = {
+  chrome: ['chromeMobile'],
+}
 
 // TODO Should it be possible for callers to setMinimumBrowserVersions to
 // forbid any version of a particular browser?
@@ -35,6 +38,12 @@ function setMinimumBrowserVersions(versions, source) {
       version: copy(versions[browserName]),
       source: source || getCaller("setMinimumBrowserVersions")
     };
+
+    if (hasOwn.call(browserAliases, browserName)) {
+      browserAliases[browserName].forEach(browserAlias => {
+        minimumVersions[browserAlias] = minimumVersions[browserName];
+      });
+    }
   });
 }
 


### PR DESCRIPTION
This PR belongs to https://github.com/meteor/meteor/issues/9751 and will consider chrome for mobile as a modern browser. I took up the [idea](https://github.com/meteor/meteor/issues/9751#issuecomment-374955713) of @benjamn and kept it generic in case there are other browsers with the same relation.