### PR TITLE
Protect against missing results files in test load balancer

### DIFF
--- a/scripts/test-balancer/index.js
+++ b/scripts/test-balancer/index.js
@@ -11,16 +11,21 @@ const runningAvgLength = +args[args.indexOf('--running-avg-length') + 1];
 // Load the junit results from the various groups on this build
 const currentBuildResults = [];
 for (let i = 0; i < numGroups; i++) {
-  const data = fs.readFileSync(`../../tmp/results/junit/${i}.xml`);
-  parser.parseString(data, (err, { testsuites: { testsuite } }) => {
-    (testsuite || [])
-      .map(testsuite => testsuite.testcase)
-      .forEach((testcase = []) =>
-        testcase.forEach(({ $: { name, time } }) => {
-          currentBuildResults.push({ name, time: +time })
-        })
-      );
-  });
+  try {
+    const data = fs.readFileSync(`../../tmp/results/junit/${i}.xml`);
+    parser.parseString(data, (err, { testsuites: { testsuite } }) => {
+      (testsuite || [])
+        .map(testsuite => testsuite.testcase)
+        .forEach((testcase = []) =>
+          testcase.forEach(({ $: { name, time } }) => {
+            currentBuildResults.push({ name, time: +time })
+          })
+        );
+    });
+  } catch(e) {
+    console.log(`Could not find '/tmp/results/junit/${i}.xml'`);
+  }
+  
 }
 
 // Try to load previous test balance


### PR DESCRIPTION
Split from #9785.

This PR catches an error in the test load-balancer script that manifests if there is a mismatch between the CircleCI environment variable `NUM_GROUPS` and the actual number jobs in the workflow that are running test groups.

This can happen if you are testing from a checkout and comment out jobs in order to speed up CircleCI turnaround.