### PR TITLE
Provide more detailed profiling of _buildLocalPackages.

### DIFF
--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -539,3 +539,14 @@ export class IsopackCache {
     return messages;
   }
 }
+
+const ICp = IsopackCache.prototype;
+[ // Include any methods here that need profiling and take a package name
+  // string as their first argument.
+  "_ensurePackageLoaded",
+].forEach(method => {
+  ICp[method] = Profile(
+    packageName => method + "(" + packageName + ")",
+    ICp[method],
+  );
+});


### PR DESCRIPTION
https://github.com/meteor/meteor-feature-requests/issues/283

The `ProjectContext#_buildLocalPackages` method calls `IsopackCache#buildLocalPackages` which calls `_ensurePackageLoaded` for each local package, so this commit exposes how long each of those
`_ensurePackageLoaded` calls takes (when `METEOR_PROFILE` is enabled).