### PR TITLE
Update MongoDB driver to 3.0.7

### DIFF
--- a/History.md
+++ b/History.md
@@ -140,7 +140,8 @@
   [PR #9632](https://github.com/meteor/meteor/pull/9632)
 
 * The `mongodb` driver package has been updated from version 2.2.34 to
-  version 3.0.5. [PR #9790](https://github.com/meteor/meteor/pull/9790)
+  version 3.0.7. [PR #9790](https://github.com/meteor/meteor/pull/9790)
+  [PR #9831](https://github.com/meteor/meteor/pull/9831)
   [Feature #268](https://github.com/meteor/meteor-feature-requests/issues/268)
 
 * The `cordova-plugin-meteor-webapp` package depended on by the Meteor

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -175,13 +175,7 @@ MongoConnection = function (url, options) {
           throw err;
         }
 
-        // Use the internal `s` object to get the database name from the
-        // connection URL (parsed by the driver).
-        var db = client.db(
-          client.s.databaseName ||
-          // An older way of getting the name, supported as a fallback.
-          client.s.options.dbName
-        );
+        var db = client.db();
 
         // First, figure out what the current primary is, if any.
         if (db.serverConfig.isMasterDoc) {

--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -7,14 +7,14 @@
       "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
     },
     "mongodb": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.5.tgz",
-      "integrity": "sha512-8ioTyyc8tkNwZCTDa1FPWvmpJFfvE484DnugC8KpVrw4AKAE03OOAlORl2yYTNtz3TX4Ab7FRo00vzgexB/67A=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.7.tgz",
+      "integrity": "sha512-n/14kMJEoARXz1qhpNPhUocqy+z5130jhqgEIX1Tsl8UVpHrndQ8et+VmgC4yPK/I8Tcgc93JEMQCHTekBUnNA=="
     },
     "mongodb-core": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.5.tgz",
-      "integrity": "sha512-4A1nx/xAU5d/NPICjiyzVxzNrIdJQQsYRe3xQkV1O638t+fHHfAOLK+SQagqGnu1m0aeSxb1ixp/P0FGSQWIGA=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.7.tgz",
+      "integrity": "sha512-z6YufO7s40wLiv2ssFshqoLS4+Kf+huhHq6KZ7gDArsKNzXYjAwTMnhEIJ9GQ8fIfBGs5tBLNPfbIDoCKGPmOw=="
     },
     "require_optional": {
       "version": "1.0.1",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: "2.2.34",
+  version: "3.0.7",
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "3.0.5"
+  mongodb: "3.0.7"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Since version 3.0.6 of the MongoDB driver, the internal `client.s` property is no longer necessary to create the database object. If `MongoClient.prototype.db` is called without arguments, it will use the database name from the connection URI (https://jira.mongodb.org/projects/NODE/issues/NODE-1258).

This reverts 567e620a867a5e34188024d3175d4cc9dedaff3b, see https://github.com/meteor/meteor/issues/9827#issuecomment-383107731.

@abernix I had to target `release-1.7` instead of `devel` because the driver update from #9790 was merged into `release-1.6.2` and isn't on `devel` yet. :upside_down_face: