### PR TITLE
Fix deprecated toHTML method

### DIFF
--- a/packages/boilerplate-generator/generator.js
+++ b/packages/boilerplate-generator/generator.js
@@ -44,7 +44,7 @@ export class Boilerplate {
     }
 
     // Calling .await() requires a Fiber.
-    return toHTMLAsync(extraData).await();
+    return this.toHTMLAsync(extraData).await();
   }
 
   // Returns a Promise that resolves to a string of HTML.


### PR DESCRIPTION
Got this error with meteor `1.4.2.3`:

```
(webapp_server.js:730) Error running template: ReferenceError: toHTMLAsync is not defined
    at Boilerplate.toHTML (packages/boilerplate-generator/generator.js:47:12)
    at getBoilerplate (packages/webapp/webapp_server.js:269:62)
    at packages/webapp/webapp_server.js:728:23
```

Looked into it and it just was that the method was being called without `this.`.