### PR TITLE
Stop logging value of METEOR_SETTINGS when it is not valid JSON.

### DIFF
--- a/packages/meteor/server_environment.js
+++ b/packages/meteor/server_environment.js
@@ -21,7 +21,7 @@ if (process.env.METEOR_SETTINGS) {
   try {
     Meteor.settings = JSON.parse(process.env.METEOR_SETTINGS);
   } catch (e) {
-    throw new Error("METEOR_SETTINGS are not valid JSON: " + process.env.METEOR_SETTINGS);
+    throw new Error("METEOR_SETTINGS are not valid JSON.");
   }
 }
 


### PR DESCRIPTION
In many production systems logs from the application will be forwarded to various logging systems, sometimes third party ones. Since Meteor logs the value of `METEOR_SETTINGS` when it's not valid JSON, all credentials in your settings will be leaked to any third parties. This will prevent that. 

There was a short discussion on the [feature request](https://github.com/meteor/meteor-feature-requests/issues/293) on whether or not to make this change backwards compatible, but the conclusion was that logging the settings to stdout offers little value anyway, so let's just get rid of it.