### PR TITLE
Improve "oplog - entry skipping" test, which has been failing intermittently.

### DIFF
--- a/packages/mongo/oplog_tests.js
+++ b/packages/mongo/oplog_tests.js
@@ -68,8 +68,8 @@ process.env.MONGO_OPLOG_URL && testAsyncMulti(
       // possible to make this test fail with TOO_FAR_BEHIND = 2000.
       // The documents waiting to be processed would hardly go beyond 1000
       // using mongo 3.2 with WiredTiger
-      MongoInternals.defaultRemoteCollectionDriver().mongo
-      ._oplogHandle._defineTooFarBehind(800);
+      MongoInternals.defaultRemoteCollectionDriver()
+        .mongo._oplogHandle._defineTooFarBehind(500);
 
       self.IRRELEVANT_SIZE = 15000;
       self.RELEVANT_SIZE = 10;
@@ -95,6 +95,7 @@ process.env.MONGO_OPLOG_URL && testAsyncMulti(
         test.isFalse(err);
       })));
     },
+
     function (test, expect) {
       var self = this;
 
@@ -105,25 +106,33 @@ process.env.MONGO_OPLOG_URL && testAsyncMulti(
       var gotSpot = false;
 
       // Watch for blue dogs.
-      self.subHandle =
-        self.collection.find({species: 'dog', color: 'blue'}).observeChanges({
-          added: function (id, fields) {
-            if (fields.name === 'dog 5')
+      const gotSpotPromise = new Promise(resolve => {
+        self.subHandle = self.collection.find({
+          species: 'dog',
+          color: 'blue',
+        }).observeChanges({
+          added(id, fields) {
+            if (fields.name === 'dog 5') {
               blueDog5Id = id;
+            }
           },
-          changed: function (id, fields) {
-            if (EJSON.equals(id, blueDog5Id) && fields.name === 'spot')
+          changed(id, fields) {
+            if (EJSON.equals(id, blueDog5Id) &&
+                fields.name === 'spot') {
               gotSpot = true;
-          }
+              resolve();
+            }
+          },
         });
+      });
+
       test.isTrue(self.subHandle._multiplexer._observeDriver._usesOplog);
       test.isTrue(blueDog5Id);
       test.isFalse(gotSpot);
 
       self.skipped = false;
-      self.skipHandle =
-        MongoInternals.defaultRemoteCollectionDriver().mongo
-        ._oplogHandle.onSkippedEntries(function () {
+      self.skipHandle = MongoInternals.defaultRemoteCollectionDriver()
+        .mongo._oplogHandle.onSkippedEntries(function () {
           self.skipped = true;
         });
 
@@ -136,21 +145,17 @@ process.env.MONGO_OPLOG_URL && testAsyncMulti(
                              {multi: true});
       self.collection.update(blueDog5Id, {$set: {name: 'spot'}});
 
-      // We ought to see the spot change soon!  It's important to keep this
-      // timeout relatively small (ie, small enough that if we set
-      // $METEOR_OPLOG_TOO_FAR_BEHIND to something enormous, say 200000, that
-      // the test fails).
-      pollUntil(expect, function () {
-        return gotSpot;
-      }, 2000);
+      // We ought to see the spot change soon!
+      return gotSpotPromise;
     },
+
     function (test, expect) {
       var self = this;
       test.isTrue(self.skipped);
 
       //This gets the TOO_FAR_BEHIND back to its initial value
-      MongoInternals.defaultRemoteCollectionDriver().mongo
-      ._oplogHandle._resetTooFarBehind();
+      MongoInternals.defaultRemoteCollectionDriver()
+        .mongo._oplogHandle._resetTooFarBehind();
 
       self.skipHandle.stop();
       self.subHandle.stop();

--- a/packages/test-helpers/async_multi.js
+++ b/packages/test-helpers/async_multi.js
@@ -139,16 +139,18 @@ testAsyncMulti = function (name, funcs) {
         }, timeout);
 
         test.extraDetails.asyncBlock = i++;
-        try {
-          func.apply(context, [test, _.bind(em.expect, em)]);
-        } catch (exception) {
-          if (em.cancel())
+
+        new Promise(resolve => {
+          resolve(func.apply(context, [test, _.bind(em.expect, em)]));
+        }).then(result => {
+          em.done();
+        }, exception => {
+          if (em.cancel()) {
             test.exception(exception);
+            // Because we called test.exception, we're not to call onComplete.
+          }
           Meteor.clearTimeout(timer);
-          // Because we called test.exception, we're not to call onComplete.
-          return;
-        }
-        em.done();
+        });
       }
     };
 

--- a/packages/test-helpers/package.js
+++ b/packages/test-helpers/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   summary: "Utility functions for tests",
-  version: '1.0.12'
+  version: '1.0.13'
 });
 
 Package.onUse(function (api) {
   api.use(['underscore', 'tracker', 'ejson', 'tinytest', 'random', 'blaze']);
-  api.use(['jquery@1.11.1'], 'client');
+  api.use(['jquery@1.12.1'], 'client');
 
   // XXX for connection.js. Not sure this really belongs in
   // test-helpers. It probably would be better off in livedata. But it's


### PR DESCRIPTION
As the comment in the code suggests, we've had to decrease the `TOO_FAR_BEHIND` timeout before, due to Mongo performance improvements, so I've decreased it yet again, from 800ms to 500ms.

While I was at it, I also replaced the `gotSpot` polling logic with a `Promise`, after making it possible for `testAsyncMulti` functions to return promises to delay execution of the remaining functions.