### PR TITLE
Stop prefixing legacy URLs with /__browser.legacy

### DIFF
--- a/packages/non-core/bundle-visualizer/package.js
+++ b/packages/non-core/bundle-visualizer/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.1.3',
+  version: '1.2.0',
   summary: 'Meteor bundle analysis and visualization.',
   documentation: 'README.md',
 });

--- a/packages/non-core/bundle-visualizer/server.js
+++ b/packages/non-core/bundle-visualizer/server.js
@@ -33,21 +33,38 @@ function getStatBundles() {
     f.absolutePath.endsWith(".stats.json");
 
   // Read the stat file, but if it's in any way unusable just return null.
-  const readOrNull = file => {
+  function readOrNull(file) {
     try {
       return JSON.parse(fsReadFileSync(file, "utf8"));
     } catch (err) {
       return null;
     }
-  };
+  }
 
-  return Object.keys(WebAppInternals.staticFiles)
-    .map(staticFile => WebAppInternals.staticFiles[staticFile])
-    .filter(statFileFilter)
-    .map(statFile => ({
-      name: statFile.hash,
-      stats: readOrNull(statFile.absolutePath),
-    }));
+  const {
+    staticFiles,
+    staticFilesByArch,
+  } = WebAppInternals;
+
+  const files = [];
+
+  if (staticFilesByArch) {
+    Object.keys(staticFilesByArch).forEach(arch => {
+      const staticFiles = staticFilesByArch[arch];
+      Object.keys(staticFiles).forEach(path => {
+        files.push(staticFiles[path]);
+      });
+    });
+  } else if (staticFiles) {
+    Object.keys(staticFiles).forEach(path => {
+      files.push(staticFiles[path]);
+    });
+  }
+
+  return files.filter(statFileFilter).map(file => ({
+    name: file.hash,
+    stats: readOrNull(file.absolutePath),
+  }));
 }
 
 function _childModules(node) {

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -44,16 +44,19 @@ MockResponse.prototype.getBody = function () {
 };
 
 Tinytest.add("webapp - content-type header", function (test) {
+  const staticFiles = WebAppInternals.staticFilesByArch["web.browser"];
+
   const cssResource = _.find(
-    _.keys(WebAppInternals.staticFiles),
+    _.keys(staticFiles),
     function (url) {
-      return WebAppInternals.staticFiles[url].type === "css";
+      return staticFiles[url].type === "css";
     }
   );
+
   const jsResource = _.find(
-    _.keys(WebAppInternals.staticFiles),
+    _.keys(staticFiles),
     function (url) {
-      return WebAppInternals.staticFiles[url].type === "js";
+      return staticFiles[url].type === "js";
     }
   );
 
@@ -98,10 +101,12 @@ Tinytest.addAsync(
       req.method = "GET";
       req.url = "/" + additionalScriptPathname;
       let nextCalled = false;
-      WebAppInternals.staticFilesMiddleware(
-        staticFilesOpts, req, res, function () {
-          nextCalled = true;
-        });
+      WebAppInternals.staticFilesMiddleware({
+        "web.browser": {},
+        "web.browser.legacy": {},
+      }, req, res, function () {
+        nextCalled = true;
+      });
       test.isTrue(nextCalled);
 
       // When inline scripts are disallowed, the script body should not be
@@ -130,8 +135,10 @@ Tinytest.addAsync(
     req.headers = {};
     req.method = "GET";
     req.url = "/" + additionalScriptPathname;
-    WebAppInternals.staticFilesMiddleware(staticFilesOpts, req, res,
-                                          function () { });
+    WebAppInternals.staticFilesMiddleware({
+      "web.browser": {},
+      "web.browser.legacy": {},
+    }, req, res, function () {});
     const resBody = res.getBody();
     test.isTrue(resBody.indexOf(additionalScript) !== -1);
     test.equal(res.statusCode, 200);

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -567,8 +567,16 @@ class File {
     this.url = null;
 
     // A prefix that will be prepended to this.url.
-    // Prefixing is currently restricted to Cordova URLs.
-    if (options.arch === "web.cordova") {
+    // Prefixing is currently restricted to web.cordova URLs.
+    if (options.arch.startsWith("web.") &&
+        // Using the isModern function from the modern-browsers package,
+        // the webapp and dynamic-import packages can automatically
+        // determine whether a client should receive resources from the
+        // web.browser or web.browser.legacy architecture, so those
+        // architectures do not need a URL prefix. Other architectures,
+        // such as web.cordova, still need a prefix like /__cordova/.
+        options.arch !== "web.browser" &&
+        options.arch !== "web.browser.legacy") {
       this.urlPrefix = "/__" +
         options.arch.split(".").slice(1).join(".");
     } else {

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -567,20 +567,8 @@ class File {
     this.url = null;
 
     // A prefix that will be prepended to this.url.
-    if (options.arch.startsWith("web.") &&
-        // Use /__browser.legacy/... as a prefix for web.browser.legacy
-        // URLs, but avoid adding a special prefix to resource URLs for
-        // modern browsers. Though boilerplate-generator will happily use
-        // whatever URLs we invent here, it's important that assets like
-        // images are available from predictable URLs (without any
-        // arch-specific prefixes), since humans might use those URLs in
-        // hand-written code. Moreover, non-JS assets are typically the
-        // same for both modern and legacy browsers, so the URL prefix
-        // doesn't actually make a difference. In the unlikely event that
-        // someone adds different assets with the same path to web.browser
-        // and web.browser.legacy, the legacy version can always be
-        // fetched from the /__browser.legacy/... URL.
-        options.arch !== "web.browser") {
+    // Prefixing is currently restricted to Cordova URLs.
+    if (options.arch === "web.cordova") {
       this.urlPrefix = "/__" +
         options.arch.split(".").slice(1).join(".");
     } else {


### PR DESCRIPTION
Inspired by discussion with @CaptainN in #9776, I think we can (and should) stop relying on URL prefixes to determine whether to load static files from the `web.browser` (modern) or `web.browser.legacy` (legacy) architectures. If this works, it will be a major ergonomic simplification for the modern/legacy system coming in Meteor 1.7.

This PR makes `webapp` serve different static files based on `isModern(request.browser)`, which is something we already have to do without the help of URL prefixes [in the `dynamic-import` package](https://github.com/meteor/meteor/blob/8e6f673fd066a69b2b4779526d200a7be0f1fc73/packages/dynamic-import/server.js#L80-L82).

Note that `web.cordova` URLs will still be prefixed with `/__cordova/`, as they always were, even before #9439 split `web.browser` and `web.browser.legacy`. Additionally, URL prefixes like `/__browser/` and `/__browser.legacy/` can still be used explicitly to request resources from non-default architectures.

It feels a little weird for the server to respond with different resources for the same URL, depending on the user agent string, but any given client will only see one version of the resource for a given URL, so clients can still safely cache the resources they receive. Furthermore, JS and CSS resources are always requested using a hash of the resource's contents (in both development and production), so the modern and legacy URLs for those kinds of resources will be different anyway.