### PR TITLE
facebook-oauth: upgrade api version to v3

### DIFF
--- a/packages/facebook-oauth/facebook_client.js
+++ b/packages/facebook-oauth/facebook_client.js
@@ -31,7 +31,7 @@ Facebook.requestCredential = function (options, credentialRequestCompleteCallbac
   var loginStyle = OAuth._loginStyle('facebook', config, options);
 
   var loginUrl =
-        'https://www.facebook.com/v2.12/dialog/oauth?client_id=' + config.appId +
+        'https://www.facebook.com/v3.0/dialog/oauth?client_id=' + config.appId +
         '&redirect_uri=' + OAuth._redirectUri('facebook', config) +
         '&display=' + display + '&scope=' + scope +
         '&state=' + OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl);

--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -2,10 +2,11 @@ Facebook = {};
 var crypto = Npm.require('crypto');
 
 Facebook.handleAuthFromAccessToken = function handleAuthFromAccessToken(accessToken, expiresAt) {
-  // include all fields from facebook
-  // http://developers.facebook.com/docs/reference/login/public-profile-and-friend-list/
-  var whitelisted = ['id', 'email', 'name', 'first_name',
-      'last_name', 'link', 'gender', 'locale', 'age_range'];
+  // include basic fields from facebook
+  // https://developers.facebook.com/docs/facebook-login/permissions/
+  var whitelisted = ['id', 'email', 'name', 'first_name', 'last_name',
+    'middle_name', 'name_format', 'picture', 'short_name', 'age_range',
+    'birthday', 'friends', 'gender', 'hometown', 'link', 'location'];
 
   var identity = getIdentity(accessToken, whitelisted);
 
@@ -53,7 +54,7 @@ var getTokenResponse = function (query) {
   try {
     // Request an access token
     responseContent = HTTP.get(
-      "https://graph.facebook.com/v2.12/oauth/access_token", {
+      "https://graph.facebook.com/v3.0/oauth/access_token", {
         params: {
           client_id: config.appId,
           redirect_uri: OAuth._redirectUri('facebook', config),
@@ -90,7 +91,7 @@ var getIdentity = function (accessToken, fields) {
   hmac.update(accessToken);
 
   try {
-    return HTTP.get("https://graph.facebook.com/v2.12/me", {
+    return HTTP.get("https://graph.facebook.com/v3.0/me", {
       params: {
         access_token: accessToken,
         appsecret_proof: hmac.digest('hex'),

--- a/packages/facebook-oauth/package.js
+++ b/packages/facebook-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Facebook OAuth flow",
-  version: "1.4.1"
+  version: "1.5.0"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
So, Facebook is once again upgrading their API.
They also require all apps which require more fields beyond `public_profile` and `email` permissions, [to go through the review process](https://developers.facebook.com/docs/apps/review/faqs/#faq_2159180284311114).

I have also updated the list of fields that are retrieved and saved, according to [the FB docs](https://developers.facebook.com/docs/facebook-login/permissions/v3.0) to retrieve a few more fields.

I was unable to locate under which permissions the `locale` field is retrievable, so I removed it.