### PR TITLE
Expose Meteor settings inside mobile-config

### DIFF
--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -231,7 +231,7 @@ export class CordovaBuilder {
         try {
           files.runJavaScript(code, {
             filename: 'mobile-config.js',
-            symbols: { App: createAppConfiguration(this) }
+            symbols: { App: createAppConfiguration(this), Settings: createSettings(this.options) }
           });
         } catch (error) {
           buildmessage.exception(error);
@@ -738,4 +738,18 @@ configuration. The key may be deprecated.`);
       });
     }
   };
+}
+
+function createSettings(options) {
+  let settings = {};
+
+  if (options.settingsFile) {
+    try {
+      settings = JSON.parse(files.readFile(options.settingsFile, 'utf8'));
+    } catch (e) {
+      throw new Error("METEOR_SETTINGS are not valid JSON.");
+    }
+  }
+
+  return settings;
 }


### PR DESCRIPTION
Hello,
this PR allows to access `Meteor.settings` inside `mobile-config.js` file which leads to better developer experience for Cordova i.e. credentials sharing.

there is a feature-request [meteor/meteor-feature-requests#37](https://github.com/meteor/meteor-feature-requests/issues/37)

**What is still missing?**
Documentation needs to be updated