### PR TITLE
polyfill es7 array functions

### DIFF
--- a/packages/ecmascript-runtime-client/modern.js
+++ b/packages/ecmascript-runtime-client/modern.js
@@ -2,6 +2,8 @@ require("core-js/modules/es6.object.is");
 require("core-js/modules/es6.function.name");
 require("core-js/modules/es6.number.is-finite");
 require("core-js/modules/es6.number.is-nan");
+require("core-js/modules/es7.array.flatten");
+require("core-js/modules/es7.array.flat-map");
 require("core-js/modules/es7.object.values");
 require("core-js/modules/es7.object.entries");
 require("core-js/modules/es7.object.get-own-property-descriptors");


### PR DESCRIPTION
with the split of modern/legacy bundles we no longer polyfill already present standard features. While array.prototype.includes is available in modern browsers flatten and flatMap aren't. This pr readds the polyfills to the modern bundle.

------

If I got this right: https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md#submitting-pull-requests I should base of devel, but this seems kind of impossible as devel doesn't yet include the [modern/legacy](https://github.com/meteor/meteor/tree/devel/packages/ecmascript-runtime-client) split. Just ping me if I should rebase or sth.