### PR TITLE
Remove EJSON.clone from onOplogEntry handler

### DIFF
--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -97,8 +97,7 @@ _.extend(OplogHandle.prototype, {
 
     var originalCallback = callback;
     callback = Meteor.bindEnvironment(function (notification) {
-      // XXX can we avoid this clone by making oplog.js careful?
-      originalCallback(EJSON.clone(notification));
+      originalCallback(notification);
     }, function (err) {
       Meteor._debug("Error in oplog callback", err);
     });


### PR DESCRIPTION
Whenever there is any update to the oplog, each matched listener gets a cloned version of the oplog update. As the comment in the diff mentioned, this may not be necessary. As best as I can tell by looking through the code it is indeed not necessary.

This is a small change but has significant performance implications, since this clone may be executed many times for each oplog entry. 

For example, suppose you have 1000 publications/observes on the `Widgets` collection. Further suppose that the publications/observes don't include a specific `_id` in the selector. In that case, any update to any document in the `Widgets` collection would clone the oplog entry 1000 times.