### PR TITLE
Manually track number of crossbar listeners by collection

### DIFF
--- a/packages/ddp-server/crossbar.js
+++ b/packages/ddp-server/crossbar.js
@@ -11,6 +11,7 @@ DDPServer._Crossbar = function (options) {
   // keys 'trigger', 'callback'.  As a hack, the empty string means "no
   // collection".
   self.listenersByCollection = {};
+  self.listenersByCollectionCount = {};
   self.factPackage = options.factPackage || "livedata";
   self.factName = options.factName || null;
 };
@@ -48,8 +49,10 @@ _.extend(DDPServer._Crossbar.prototype, {
     var record = {trigger: EJSON.clone(trigger), callback: callback};
     if (! _.has(self.listenersByCollection, collection)) {
       self.listenersByCollection[collection] = {};
+      self.listenersByCollectionCount[collection] = 0;
     }
     self.listenersByCollection[collection][id] = record;
+    self.listenersByCollectionCount[collection]++;
 
     if (self.factName && Package['facts-base']) {
       Package['facts-base'].Facts.incrementServerFact(
@@ -63,8 +66,10 @@ _.extend(DDPServer._Crossbar.prototype, {
             self.factPackage, self.factName, -1);
         }
         delete self.listenersByCollection[collection][id];
-        if (_.isEmpty(self.listenersByCollection[collection])) {
+        self.listenersByCollectionCount[collection]--;
+        if (self.listenersByCollectionCount[collection] === 0) {
           delete self.listenersByCollection[collection];
+          delete self.listenersByCollectionCount[collection];
         }
       }
     };


### PR DESCRIPTION
I've noticed that almost all of the time spent in `ObserveHandle.stop` (called when publications/observes are stopped) is spent calling the `_.isEmpty` function. This PR manually tracks the number of listeners so that it isn't necessary to call this function.

Here is a profile before the change: https://app.box.com/s/g2uxbqu1kduik9a4sb6kb9aw3jrfinex

Here is a profile after the change: https://app.box.com/s/evqvytvp07pasuobl1c42n1cz82liyv7

I produced these profiles using this reproduction code https://gist.github.com/veered/931624389163916ded3a4f5617b558d1. The time spent in `ObserveHandle.stop` went from 1390ms to 34ms.

I know that this reproduction code is pretty extreme, but I've noticed this performance issue in production. It's possible that this PR could help resolve https://github.com/meteor/meteor/issues/9828.