### PR TITLE
Release 1.6.1.2

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,14 @@
 ## v.NEXT
 
+## v1.6.1.2, 2018-05-28
+
+* Meteor 1.6.1.2 is a very small release intended to fix
+  [#9863](https://github.com/meteor/meteor/issues/9863) by making
+  [#9887](https://github.com/meteor/meteor/pull/9887) available to Windows
+  users without forcing them to update to Meteor 1.7 (yet). Thanks very
+  much to [@zodern](https://github.com/zodern) for identifying a solution
+  to this problem. [PR #9910](https://github.com/meteor/meteor/pull/9910)
+
 ## v1.6.1.1, 2018-04-02
 
 * Node has been updated to version

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.6.1-2-rc.0'
+  version: '1.6.1_2'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.6.1_1'
+  version: '1.6.1-2-rc.0'
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.6.1.1-rc.0",
+  "version": "1.6.1.2-rc.0",
   "recommended": false,
   "official": false,
   "description": "Meteor"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,12 +1,13 @@
 {
   "track": "METEOR",
-  "version": "1.6.1.1",
+  "version": "1.6.1.2",
   "recommended": false,
   "official": true,
   "patchFrom": [
     "1.6",
     "1.6.0.1",
-    "1.6.1"
+    "1.6.1",
+    "1.6.1.1"
   ],
   "description": "The Official Meteor Distribution"
 }

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -582,7 +582,8 @@ main.registerCommand({
             return contents;
           }
         },
-        ignore: [/^local$/]
+        ignore: [/^local$/],
+        preserveSymlinks: true,
       });
     } catch (err) {
       Console.error("Could not create package: " + err.message);
@@ -750,7 +751,8 @@ main.registerCommand({
         return contents;
       }
     },
-    ignore: toIgnore
+    ignore: toIgnore,
+    preserveSymlinks: true,
   });
 
   // We are actually working with a new meteor project at this point, so

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -520,19 +520,23 @@ files.cp_r = function(from, to, options = {}) {
 // create a symlink, overwriting the target link, file, or directory
 // if it exists
 export function symlinkWithOverwrite(source, target) {
+  const args = [source, target];
+
+  if (process.platform === "win32") {
+    const absoluteSource = files.pathResolve(target, source);
+
+    if (files.stat(absoluteSource).isDirectory()) {
+      args[2] = "junction";
+    }
+  }
+
   try {
-    files.symlink(source, target);
+    files.symlink(...args);
   } catch (e) {
     if (e.code === "EEXIST") {
       // overwrite existing link, file, or directory
       files.rm_recursive(target);
-      files.symlink(source, target);
-    } else if (e.code === "EPERM" &&
-               process.platform === "win32") {
-      files.rm_recursive(target);
-      // This will work only if source refers to a directory, but that's a
-      // chance worth taking.
-      files.symlink(source, target, "junction");
+      files.symlink(...args);
     } else {
       throw e;
     }

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -495,7 +495,7 @@ files.cp_r = function(from, to, options = {}) {
   files.mkdir_p(files.pathDirname(to));
 
   if (stat.isSymbolicLink()) {
-    files.symlink(files.readlink(from), to);
+    symlinkWithOverwrite(files.readlink(from), to);
 
   } else {
     // Create the file as readable and writable by everyone, and
@@ -516,6 +516,28 @@ files.cp_r = function(from, to, options = {}) {
     }
   }
 };
+
+// create a symlink, overwriting the target link, file, or directory
+// if it exists
+export function symlinkWithOverwrite(source, target) {
+  try {
+    files.symlink(source, target);
+  } catch (e) {
+    if (e.code === "EEXIST") {
+      // overwrite existing link, file, or directory
+      files.rm_recursive(target);
+      files.symlink(source, target);
+    } else if (e.code === "EPERM" &&
+               process.platform === "win32") {
+      files.rm_recursive(target);
+      // This will work only if source refers to a directory, but that's a
+      // chance worth taking.
+      files.symlink(source, target, "junction");
+    } else {
+      throw e;
+    }
+  }
+}
 
 /**
  * Get every path in a directory recursively, treating symlinks as files
@@ -1003,7 +1025,9 @@ files.renameDirAlmostAtomically =
     // limitations, we'll resort to copying.
     if (forceCopy) {
       files.rm_recursive(toDir);
-      files.cp_r(fromDir, toDir);
+      files.cp_r(fromDir, toDir, {
+        preserveSymlinks: true,
+      });
     }
 
     // ... and take out the trash.
@@ -1750,7 +1774,7 @@ if (files.isWindowsLikeFilesystem()) {
     }
 
     if (! success) {
-      files.cp_r(from, to);
+      files.cp_r(from, to, { preserveSymlinks: true });
       files.rm_recursive(from);
     }
   };

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -1,6 +1,8 @@
 import assert from "assert";
 import {WatchSet, readAndWatchFile, sha1} from '../fs/watch.js';
-import files from '../fs/files.js';
+import files, {
+  symlinkWithOverwrite,
+} from '../fs/files.js';
 import NpmDiscards from './npm-discards.js';
 import {Profile} from '../tool-env/profile.js';
 import {
@@ -736,28 +738,6 @@ function symlinkIfPossible(source, target) {
     return true;
   } catch (e) {
     return false;
-  }
-}
-
-// create a symlink, overwriting the target link, file, or directory
-// if it exists
-function symlinkWithOverwrite(source, target) {
-  try {
-    files.symlink(source, target);
-  } catch (e) {
-    if (e.code === "EEXIST") {
-      // overwrite existing link, file, or directory
-      files.rm_recursive(target);
-      files.symlink(source, target);
-    } else if (e.code === "EPERM" &&
-               process.platform === "win32") {
-      files.rm_recursive(target);
-      // This will work only if source refers to a directory, but that's a
-      // chance worth taking.
-      files.symlink(source, target, "junction");
-    } else {
-      throw e;
-    }
   }
 }
 

--- a/tools/tests/old/test-bundler-assets.js
+++ b/tools/tests/old/test-bundler-assets.js
@@ -23,7 +23,9 @@ var makeProjectContext = function (appName) {
 
   var projectDir = files.mkdtemp("test-bundler-assets");
 
-  files.cp_r(testAppDir, projectDir);
+  files.cp_r(testAppDir, projectDir, {
+    preserveSymlinks: true,
+  });
 
   require("../../cli/default-npm-deps.js").install(projectDir);
 

--- a/tools/tests/old/test-bundler-npm.js
+++ b/tools/tests/old/test-bundler-npm.js
@@ -19,8 +19,11 @@ var tmpDir = function () {
 
 var makeProjectContext = function (appName) {
   var projectDir = files.mkdtemp("test-bundler-assets");
-  files.cp_r(files.pathJoin(files.convertToStandardPath(__dirname), appName),
-    projectDir);
+  files.cp_r(
+    files.pathJoin(files.convertToStandardPath(__dirname), appName),
+    projectDir,
+    { preserveSymlinks: true },
+  );
   var projectContext = new projectContextModule.ProjectContext({
     projectDir: projectDir
   });

--- a/tools/tests/old/test-bundler-options.js
+++ b/tools/tests/old/test-bundler-options.js
@@ -18,8 +18,11 @@ var tmpDir = function () {
 
 var makeProjectContext = function (appName) {
   var projectDir = files.mkdtemp("test-bundler-options");
-  files.cp_r(files.pathJoin(files.convertToStandardPath(__dirname), appName),
-    projectDir);
+  files.cp_r(
+    files.pathJoin(files.convertToStandardPath(__dirname), appName),
+    projectDir,
+    { preserveSymlinks: true },
+  );
   var projectContext = new projectContextModule.ProjectContext({
     projectDir: projectDir
   });

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -167,9 +167,14 @@ export default class Sandbox {
   createApp(to, template, options) {
     options = options || {};
     const absoluteTo = files.pathJoin(this.cwd, to);
-    files.cp_r(files.pathJoin(
-      files.convertToStandardPath(__dirname), '..', 'tests', 'apps', template),
-        absoluteTo, { ignore: [/^local$/] });
+    const absoluteFrom = files.pathJoin(
+      files.convertToStandardPath(__dirname),
+      '..', 'tests', 'apps', template
+    );
+    files.cp_r(absoluteFrom, absoluteTo, {
+      ignore: [/^local$/],
+      preserveSymlinks: true,
+    });
     // If the test isn't explicitly managing a mock warehouse, ensure that apps
     // run with our release by default.
     if (options.release) {
@@ -222,7 +227,9 @@ export default class Sandbox {
     const packagePath = files.pathJoin(this.cwd, packageDir);
     const templatePackagePath = files.pathJoin(
       files.convertToStandardPath(__dirname), '..', 'tests', 'packages', template);
-    files.cp_r(templatePackagePath, packagePath);
+    files.cp_r(templatePackagePath, packagePath, {
+      preserveSymlinks: true,
+    });
 
     files.readdir(packagePath).forEach((file) => {
       if (file.match(/^package.*\.js$/)) {


### PR DESCRIPTION
This is a very small release intended to fix #9863 by making #9887 available to Windows users without forcing them to update to Meteor 1.7 (yet). Thanks very much to @zodern for identifying a solution to this problem.

In short, after the Windows April 2018 Update, the Windows file system suddenly stopped reporting any error when `fs.symlink` failed, which caused Meteor to continue as if the symlink had been created, when in fact it had not. While I don't understand how this new behavior can be considered anything other than a bug, we don't have any control over the QA of Windows releases, so I suppose we just have to cope with their mistakes.