### PR TITLE
Use environment variable to control file watcher coalescence delay

### DIFF
--- a/tools/fs/watch.js
+++ b/tools/fs/watch.js
@@ -496,11 +496,13 @@ export class Watcher {
     // --hard), or a file was deleted and then recreated by an editor like
     // Vim. Because detecting changes can be costly, and because we care
     // most about the settled state of the file system, we use the
-    // funcUtils.coalesce helper to delay calls to the callback by 100ms,
-    // canceling any additional calls if they happen within that window of
-    // time, so that a rapid succession of calls will tend to trigger only
-    // one inspection of the file system.
-    return coalesce(100, function onWatchEvent() {
+    // funcUtils.coalesce helper to delay calls to the callback by
+    // METEOR_FILE_WATCH_COALESCE_MS or 100 milliseconds, canceling any
+    // additional calls if they happen within that window of time, so that
+    // a rapid succession of calls will tend to trigger only one inspection
+    // of the file system.
+    const coalesceMs = process.env.METEOR_FILE_WATCH_COALESCE_MS || 100;
+    return coalesce(coalesceMs, function onWatchEvent() {
       if (self.stopped) {
         return;
       }


### PR DESCRIPTION
Allows users to set the `METEOR_FILE_WATCH_COALESCE_MS` environment variable (https://github.com/meteor/meteor/issues/9896#issuecomment-391812382) to control how long Meteor waits before a file change is processed.

Fixes #9896.