### PR TITLE
Add Subresource Integrity for JS and CSS files

### DIFF
--- a/packages/boilerplate-generator-tests/test-lib.js
+++ b/packages/boilerplate-generator-tests/test-lib.js
@@ -10,8 +10,7 @@ export async function generateHTMLForArch(arch, includeHead) {
       cacheable: true,
       url: '/packages/bootstrap/css/bootstrap-responsive.css?hash=785760fc5ad665d7b54d56a3c2522797bb2cc150&v="1"',
       size: 22111,
-      hash: '785760fc5ad665d7b54d56a3c2522797bb2cc150',
-      sha512: 'FgwCpUKZj/5DORw0OQWACh65bi8wxnLGcoHxNq9bbErR9TLacgBisdqhg4uBLZ2sctoiSjG+hWLRigs1mBZY/Q==',
+      hash: '785760fc5ad665d7b54d56a3c2522797bb2cc150'
     },
     {
       path: 'packages/templating-runtime.js',
@@ -20,8 +19,7 @@ export async function generateHTMLForArch(arch, includeHead) {
       cacheable: true,
       url: '/packages/templating-runtime.js?hash=c18de19afda6e9f0db7faf3d4382a4c953cabe18&v="1"',
       size: 24132,
-      hash: 'c18de19afda6e9f0db7faf3d4382a4c953cabe18',
-      sha512: 'mJ9OEOi4HbVMzqiVGOjxCiIIImgnzEg6QhorPno46yULMu/3tKmENYriasWP9RrM+wLNwlTzw6+9d+nWY9/A0A==',
+      hash: 'c18de19afda6e9f0db7faf3d4382a4c953cabe18'
     },
   ];
 

--- a/packages/boilerplate-generator-tests/test-lib.js
+++ b/packages/boilerplate-generator-tests/test-lib.js
@@ -10,7 +10,8 @@ export async function generateHTMLForArch(arch, includeHead) {
       cacheable: true,
       url: '/packages/bootstrap/css/bootstrap-responsive.css?hash=785760fc5ad665d7b54d56a3c2522797bb2cc150&v="1"',
       size: 22111,
-      hash: '785760fc5ad665d7b54d56a3c2522797bb2cc150'
+      hash: '785760fc5ad665d7b54d56a3c2522797bb2cc150',
+      sha512: 'FgwCpUKZj/5DORw0OQWACh65bi8wxnLGcoHxNq9bbErR9TLacgBisdqhg4uBLZ2sctoiSjG+hWLRigs1mBZY/Q==',
     },
     {
       path: 'packages/templating-runtime.js',
@@ -19,7 +20,8 @@ export async function generateHTMLForArch(arch, includeHead) {
       cacheable: true,
       url: '/packages/templating-runtime.js?hash=c18de19afda6e9f0db7faf3d4382a4c953cabe18&v="1"',
       size: 24132,
-      hash: 'c18de19afda6e9f0db7faf3d4382a4c953cabe18'
+      hash: 'c18de19afda6e9f0db7faf3d4382a4c953cabe18',
+      sha512: 'mJ9OEOi4HbVMzqiVGOjxCiIIImgnzEg6QhorPno46yULMu/3tKmENYriasWP9RrM+wLNwlTzw6+9d+nWY9/A0A==',
     },
   ];
 

--- a/packages/boilerplate-generator/generator.js
+++ b/packages/boilerplate-generator/generator.js
@@ -1,6 +1,5 @@
 import { readFile } from 'fs';
 import { create as createStream } from "combined-stream2";
-import { createHash } from 'crypto';
 
 import WebBrowserTemplate from './template-web.browser';
 import WebCordovaTemplate from './template-web.cordova';
@@ -125,14 +124,8 @@ export class Boilerplate {
         itemObj.scriptContent = readUtf8FileSync(
           pathMapper(item.path));
         itemObj.inline = true;
-      } else {
-        if (item.sha512) {
-          itemObj.hash = item.sha512;
-        } else {
-          const hash = createHash('sha512');
-          hash.update(readUtf8FileSync(pathMapper(item.path)));
-          itemObj.hash = hash.digest('base64');
-        }
+      } else if (item.sri) {
+        itemObj.sri = item.sri;
       }
 
       if (item.type === 'css' && item.where === 'client') {

--- a/packages/boilerplate-generator/generator.js
+++ b/packages/boilerplate-generator/generator.js
@@ -1,5 +1,6 @@
 import { readFile } from 'fs';
 import { create as createStream } from "combined-stream2";
+import { createHash } from 'crypto';
 
 import WebBrowserTemplate from './template-web.browser';
 import WebCordovaTemplate from './template-web.cordova';
@@ -124,6 +125,14 @@ export class Boilerplate {
         itemObj.scriptContent = readUtf8FileSync(
           pathMapper(item.path));
         itemObj.inline = true;
+      } else {
+        if (item.sha512) {
+          itemObj.hash = item.sha512;
+        } else {
+          const hash = createHash('sha512');
+          hash.update(readUtf8FileSync(pathMapper(item.path)));
+          itemObj.hash = hash.digest('base64');
+        }
       }
 
       if (item.type === 'css' && item.where === 'client') {

--- a/packages/boilerplate-generator/template-web.browser.js
+++ b/packages/boilerplate-generator/template-web.browser.js
@@ -1,17 +1,21 @@
 import template from './template';
 
+const sri = (sri, mode) =>
+  (sri && mode) ? ` integrity="sha512-${sri}" crossorigin="${mode}"` : '';
+
 export const headTemplate = ({
   css,
   htmlAttributes,
   bundledJsCssUrlRewriteHook,
+  sriMode,
   head,
   dynamicHead,
 }) => {
   var headSections = head.split(/<meteor-bundled-css[^<>]*>/, 2);
   var cssBundle = [...(css || []).map(file =>
-    template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>" integrity="sha512-<%- sri %>" crossorigin="anonymous">')({
+    template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>"<%= sri %>>')({
       href: bundledJsCssUrlRewriteHook(file.url),
-      sri: file.sri,
+      sri: sri(file.sri, sriMode),
     })
   )].join('\n');
 
@@ -43,6 +47,7 @@ export const closeTemplate = ({
   js,
   additionalStaticJs,
   bundledJsCssUrlRewriteHook,
+  sriMode,
 }) => [
   '',
   inlineScriptsAllowed
@@ -55,9 +60,9 @@ export const closeTemplate = ({
   '',
 
   ...(js || []).map(file =>
-    template('  <script type="text/javascript" src="<%- src %>" integrity="sha512-<%- sri %>" crossorigin="anonymous"></script>')({
+    template('  <script type="text/javascript" src="<%- src %>"<%= sri %>></script>')({
       src: bundledJsCssUrlRewriteHook(file.url),
-      sri: file.sri,
+      sri: sri(file.sri, sriMode),
     })
   ),
 

--- a/packages/boilerplate-generator/template-web.browser.js
+++ b/packages/boilerplate-generator/template-web.browser.js
@@ -9,9 +9,9 @@ export const headTemplate = ({
 }) => {
   var headSections = head.split(/<meteor-bundled-css[^<>]*>/, 2);
   var cssBundle = [...(css || []).map(file =>
-    template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>" integrity="sha512-<%- hash %>" crossorigin="anonymous">')({
+    template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>" integrity="sha512-<%- sri %>" crossorigin="anonymous">')({
       href: bundledJsCssUrlRewriteHook(file.url),
-      hash: file.hash,
+      sri: file.sri,
     })
   )].join('\n');
 
@@ -55,9 +55,9 @@ export const closeTemplate = ({
   '',
 
   ...(js || []).map(file =>
-    template('  <script type="text/javascript" src="<%- src %>" integrity="sha512-<%- hash %>" crossorigin="anonymous"></script>')({
+    template('  <script type="text/javascript" src="<%- src %>" integrity="sha512-<%- sri %>" crossorigin="anonymous"></script>')({
       src: bundledJsCssUrlRewriteHook(file.url),
-      hash: file.hash,
+      sri: file.sri,
     })
   ),
 

--- a/packages/boilerplate-generator/template-web.browser.js
+++ b/packages/boilerplate-generator/template-web.browser.js
@@ -9,8 +9,9 @@ export const headTemplate = ({
 }) => {
   var headSections = head.split(/<meteor-bundled-css[^<>]*>/, 2);
   var cssBundle = [...(css || []).map(file =>
-    template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>">')({
+    template('  <link rel="stylesheet" type="text/css" class="__meteor-css__" href="<%- href %>" integrity="sha512-<%- hash %>" crossorigin="anonymous">')({
       href: bundledJsCssUrlRewriteHook(file.url),
+      hash: file.hash,
     })
   )].join('\n');
 
@@ -21,7 +22,7 @@ export const headTemplate = ({
         attrValue: htmlAttributes[key],
       })
     ).join('') + '>',
-    
+
     '<head>',
 
     (headSections.length === 1)
@@ -54,8 +55,9 @@ export const closeTemplate = ({
   '',
 
   ...(js || []).map(file =>
-    template('  <script type="text/javascript" src="<%- src %>"></script>')({
+    template('  <script type="text/javascript" src="<%- src %>" integrity="sha512-<%- hash %>" crossorigin="anonymous"></script>')({
       src: bundledJsCssUrlRewriteHook(file.url),
+      hash: file.hash,
     })
   ),
 

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -351,6 +351,7 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
         encodeURIComponent(JSON.stringify(runtimeConfig))),
       rootUrlPathPrefix: __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '',
       bundledJsCssUrlRewriteHook: bundledJsCssUrlRewriteHook,
+      sriMode: sriMode,
       inlineScriptsAllowed: WebAppInternals.inlineScriptsAllowed(),
       inline: additionalOptions.inline
     }
@@ -1004,6 +1005,12 @@ WebAppInternals.setInlineScriptsAllowed = function (value) {
   WebAppInternals.generateBoilerplate();
 };
 
+var sriMode;
+
+WebAppInternals.enableSubresourceIntegrity = function(use_credentials = false) {
+  sriMode = use_credentials ? 'use-credentials' : 'anonymous';
+  WebAppInternals.generateBoilerplate();
+};
 
 WebAppInternals.setBundledJsCssUrlRewriteHook = function (hookFn) {
   bundledJsCssUrlRewriteHook = hookFn;

--- a/tools/fs/watch.js
+++ b/tools/fs/watch.js
@@ -268,6 +268,14 @@ export function sha1(...args) {
   })();
 }
 
+export function sri(...args) {
+  return Profile("sri", function () {
+    var hash = createHash('sha512');
+    args.forEach(arg => hash.update(arg));
+    return hash.digest('base64');
+  })();
+}
+
 export function readDirectory({absPath, include, exclude, names}) {
   // Read the directory.
   try {

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -530,6 +530,7 @@ export class NodeModulesDirectory {
 // - sourcePath: path to file on disk that will provide our contents
 // - data: contents of the file as a Buffer
 // - hash: optional, sha1 hash of the file contents, if known
+// - sri: sha512 hash of file contents in base64 encoding
 // - sourceMap: if 'data' is given, can be given instead of
 //   sourcePath. a string or a JS Object. Will be stored as Object.
 // - cacheable
@@ -600,6 +601,7 @@ class File {
     this._contents = options.data || null; // contents, if known, as a Buffer
     this._hashOfContents = options.hash || null;
     this._hash = null;
+    this._sri = null;
   }
 
   toString() {
@@ -625,6 +627,13 @@ class File {
 
     return this._hash;
   }
+
+  sri() {
+    if (! this._sri) {
+      this._sri = watch.sri(this.contents());
+    }
+    return this._sri;
+   }
 
   // Omit encoding to get a buffer, or provide something like 'utf8'
   // to get a string
@@ -1647,6 +1656,7 @@ class ClientTarget extends Target {
       // Set this now, in case we mutated the file's contents.
       manifestItem.size = file.size();
       manifestItem.hash = file.hash();
+      manifestItem.sri = file.sri();
 
       if (! file.targetPath.startsWith("dynamic/")) {
         writeFile(file, builder);


### PR DESCRIPTION
After moving our Meteor assets out to a CDN, the [Mozilla Observatory](https://observatory.mozilla.org/) kept complaining about missing [Subresouce Integrity](https://infosec.mozilla.org/guidelines/web_security#subresource-integrity) in our JavaScript files.
This PR adds a `sha512` hash to all basic Meteor files served to the client.

Solves meteor/meteor-feature-requests#35.