### PR TITLE
Ensure npm scripts find correct meteor executable.

### DIFF
--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -70,6 +70,10 @@ exports.getEnv = function (options) {
     var paths = [
       // When npm looks for node, it must find dev_bundle/bin/node.
       path.join(devBundleDir, "bin"),
+
+      // When npm looks for meteor, it should find dev_bundle/../meteor.
+      path.dirname(devBundleDir),
+
       // Also make available any scripts installed by packages in
       // dev_bundle/lib/node_modules, such as node-gyp.
       path.join(devBundleDir, "lib", "node_modules", ".bin")


### PR DESCRIPTION
In my local development environment, the `meteor` command resolves to my Meteor checkout, and I use `~/.meteor/meteor` explicitly when I want to run a released version of Meteor.

If I run
```sh
~/.meteor/meteor npm test
```
and the `package.json` file defines an npm `test` script that refers to `meteor`, in my environment this `meteor` won't be the same as the one I used to run `~/.meteor/meteor npm test`, which can introduce weirdness such as pinning the versions of packages in `meteor/packages/non-core`, and all the usual Meteor version inconsistency risks.

This commit fixes that problem by prepending the directory that contains the `meteor` (or `meteor.bat`) executable to the `PATH` before running `meteor npm ...` commands.