### PR TITLE
Allow dynamic import() requests from any origin on any device.

### DIFF
--- a/packages/dynamic-import/server.js
+++ b/packages/dynamic-import/server.js
@@ -66,8 +66,9 @@ function middleware(request, response) {
   response.setHeader("Access-Control-Allow-Origin", "*");
 
   if (request.method === "OPTIONS") {
-    if (request.headers["access-control-request-headers"] !== undefined) {
-      response.setHeader("Access-Control-Allow-Headers", request.headers["access-control-request-headers"]);
+    const requestedHeaders = request.headers["access-control-request-headers"];
+    if (requestedHeaders !== undefined) {
+      response.setHeader("Access-Control-Allow-Headers", requestedHeaders);
     } else {
       response.setHeader("Access-Control-Allow-Headers", "*");
     }

--- a/packages/dynamic-import/server.js
+++ b/packages/dynamic-import/server.js
@@ -66,7 +66,11 @@ function middleware(request, response) {
   response.setHeader("Access-Control-Allow-Origin", "*");
 
   if (request.method === "OPTIONS") {
-    response.setHeader("Access-Control-Allow-Headers", "*");
+    if (request.headers["access-control-request-headers"] !== undefined) {
+      response.setHeader("Access-Control-Allow-Headers", request.headers["access-control-request-headers"]);
+    } else {
+      response.setHeader("Access-Control-Allow-Headers", "*");
+    }
     response.setHeader("Access-Control-Allow-Methods", "POST");
     response.end();
   } else if (request.method === "POST") {


### PR DESCRIPTION
A tweak to the change introduced in c4b5707747ce3c5bf339b62940da84628680a1d3 to fix #9952.
This will allow clients that don't support the * value in `Access-Control-Allow-Headers`,
but do specify the `Access-Control-Request-Headers` (such as electron 2.0.2) to use dynamic import.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
