### PR TITLE
Avoid compiling lazy .less files unless they are imported.

### DIFF
--- a/packages/less/package.js
+++ b/packages/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.7.12',
+  version: '2.7.13',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });

--- a/packages/less/plugin/compile-less.js
+++ b/packages/less/plugin/compile-less.js
@@ -1,6 +1,7 @@
 const path = Plugin.path;
 const less = Npm.require('less');
 const Future = Npm.require('fibers/future');
+const hasOwn = Object.prototype.hasOwnProperty;
 
 Plugin.registerCompiler({
   // *.lessimport has been deprecated since 0.7.1, but it still works. We
@@ -36,8 +37,13 @@ class LessCompiler extends MultiFileCachingCompiler {
   // file option in api.addFiles.
   isRoot(inputFile) {
     const fileOptions = inputFile.getFileOptions();
-    if (fileOptions.hasOwnProperty('isImport')) {
-      return !fileOptions.isImport;
+
+    if (hasOwn.call(fileOptions, 'isImport')) {
+      return ! fileOptions.isImport;
+    }
+
+    if (fileOptions.lazy) {
+      return false;
     }
 
     const pathInPackage = inputFile.getPathInPackage();


### PR DESCRIPTION
During the Meteor 1.7 beta testing process, I noticed that npm packages installed in `node_modules` that have a lot of `.less` files in them (such as the `less` npm package or `antd`) can slow down rebuilds significantly, because every `.less` file gets compiled, even if it is never used.

With #9825, I attempted to solve this problem by completely removing the logic for scanning `node_modules` for files to process with compiler plugins, but that turned out to be a breaking change for existing apps that relied on that behavior, so we reverted that optimization in Meteor 1.7.0.1: https://github.com/meteor/meteor/pull/9917

Of course, this means the performance problem still occurs in Meteor 1.7.0.1, as demonstrated by #9957. After investigating the problem a bit further, I discovered that the [`LessCompiler#isRoot`](https://github.com/meteor/meteor/blob/0a336175c4a47cd264060891b5f66893b945afe4/packages/less/plugin/compile-less.js#L33-L46) method was simply ignoring whether a `.less` file comes from `node_modules` or not.

More specifically, Meteor sets `fileOptions.lazy = true` by default for any file found in `node_modules` [here](https://github.com/meteor/meteor/blob/0a336175c4a47cd264060891b5f66893b945afe4/tools/isobuild/package-source.js#L1020), so `LessCompiler#isRoot` should return `false` from `isRoot` when `fileOptions.lazy` is truthy.

Thanks to this much more precise solution, `.less` files in `node_modules` can still be imported by other `.less` files; they just won't be eagerly compiled by the `less` package.

Fixes #9957.