### PR TITLE
Statically import SockJS in both modern and legacy bundles.

### DIFF
--- a/packages/socket-stream-client/browser.js
+++ b/packages/socket-stream-client/browser.js
@@ -5,6 +5,11 @@ import {
 
 import { StreamClientCommon } from "./common.js";
 
+// Statically importing SockJS here will prevent native WebSocket usage
+// below (in favor of SockJS), but will ensure maximum compatibility for
+// clients stuck in unusual networking environments.
+import "./sockjs-0.3.4.js";
+
 export class ClientStream extends StreamClientCommon {
   // @param url {String} URL to Meteor app
   //   "http://subdomain.meteor.com/" or "/" or

--- a/packages/socket-stream-client/package.js
+++ b/packages/socket-stream-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "socket-stream-client",
-  version: "0.2.1",
+  version: "0.2.2",
   summary: "Provides the ClientStream abstraction used by ddp-client",
   documentation: "README.md"
 });


### PR DESCRIPTION
Not including `SockJS` in the modern JS bundle was a nice bundle size savings (28KB before gzip), but `SockJS` works better than a native `WebSocket` for clients that are stuck in unusual networking situations, and the fallback of using dynamic `import()` to load `SockJS` when the native `WebSocket` failed was much slower than simply including `SockJS` in the bundle and using it from the start.

Moreover, the new `meteor create --minimal` starter app does not use `socket-stream-client` (nor DDP), so going back to including `SockJS` in both the modern and the legacy bundles should have no impact on the minimal modern bundle size.

If you want to continue using a native `WebSocket` instead of `SockJS`, you can always pin the older version of the socket-stream-client package:
```sh
meteor add socket-stream-client@0.2.1
```

Once this change is published, the workaround I suggested to @p3pp8 here will no longer be necessary: https://github.com/meteor/meteor/pull/9917#issuecomment-395798377