### PR TITLE
Release 1.6.1.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 ## v.NEXT
 
+## v1.6.1.3, 2018-06-16
+
+* Node has been updated to version
+  [8.11.3](https://nodejs.org/en/blog/release/v8.11.3/), an important
+  [security release](https://nodejs.org/en/blog/vulnerability/june-2018-security-releases/).
+
 ## v1.6.1.2, 2018-05-28
 
 * Meteor 1.6.1.2 is a very small release intended to fix

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.11.1
+BUNDLE_VERSION=8.11.3-meteor-1.6.1.3
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.6.1_2'
+  version: '1.6.1-3-rc.0'
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.6.1.2-rc.0",
+  "version": "1.6.1.3-rc.0",
   "recommended": false,
   "official": false,
   "description": "Meteor"

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -5,13 +5,13 @@ set -u
 
 UNAME=$(uname)
 ARCH=$(uname -m)
-NODE_VERSION=8.11.1
+NODE_VERSION=8.11.3
 MONGO_VERSION_64BIT=3.4.10
 MONGO_VERSION_32BIT=3.2.15
 NPM_VERSION=5.6.0
 
 # If we built Node from source on Jenkins, this is the build number.
-NODE_BUILD_NUMBER=129
+NODE_BUILD_NUMBER=
 
 if [ "$UNAME" == "Linux" ] ; then
     if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then


### PR DESCRIPTION
This will be a quick patch release to update Node to version [8.11.3](https://nodejs.org/en/blog/release/v8.11.3/).