### PR TITLE
Replace generic bundle names with arch names in bundle-visualizer

### DIFF
--- a/packages/non-core/bundle-visualizer/package.js
+++ b/packages/non-core/bundle-visualizer/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.2.0',
+  version: '1.2.1',
   summary: 'Meteor bundle analysis and visualization.',
   documentation: 'README.md',
 });

--- a/packages/non-core/bundle-visualizer/server.js
+++ b/packages/non-core/bundle-visualizer/server.js
@@ -52,17 +52,18 @@ function getStatBundles() {
     Object.keys(staticFilesByArch).forEach(arch => {
       const staticFiles = staticFilesByArch[arch];
       Object.keys(staticFiles).forEach(path => {
-        files.push(staticFiles[path]);
+        files.push({ ...staticFiles[path], arch });
       });
     });
   } else if (staticFiles) {
     Object.keys(staticFiles).forEach(path => {
-      files.push(staticFiles[path]);
+      files.push({ ...staticFiles[path], arch: 'bundle' });
     });
   }
 
   return files.filter(statFileFilter).map(file => ({
     name: file.hash,
+    arch: file.arch,
     stats: readOrNull(file.absolutePath),
   }));
 }
@@ -152,10 +153,7 @@ function statsMiddleware(request, response) {
   sendJSON({
     name: "main",
     children: statBundles.map((statBundle, index, array) => ({
-      // TODO: If multiple bundles, could
-      // show abbr. bundle names with:
-      //   `...${bundle.name.substr(-3)}`,
-      name: "bundle" + (array.length > 1 ? ` (${index + 1})` : ""),
+      name: statBundle.arch,
       type: typeBundle,
       children: d3TreeFromStats(statBundle.stats),
     }))


### PR DESCRIPTION
Fixes the issue mentioned in the recent [Meteor Night talk on 1.7](https://youtu.be/vpCotlPieIY?t=1525). 

Instead of `bundle (1)` and `bundle (2)`, you should now see `web.browser` and `web.browser.legacy`.

<img width="861" alt="bundle_names" src="https://user-images.githubusercontent.com/15968012/41785211-f3ac74c4-7652-11e8-8c1f-f6b17a7fc19b.png">