### PR TITLE
Fix links to node-mongodb-native docs to use the correct version

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -685,7 +685,7 @@ Object.assign(Mongo.Collection.prototype, {
   },
 
   /**
-   * @summary Returns the [`Collection`](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html) object corresponding to this collection from the [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
+   * @summary Returns the [`Collection`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html) object corresponding to this collection from the [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
    * @locus Server
    * @memberof Mongo.Collection
    * @instance
@@ -699,7 +699,7 @@ Object.assign(Mongo.Collection.prototype, {
   },
 
   /**
-   * @summary Returns the [`Db`](http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html) object corresponding to this collection's database connection from the [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
+   * @summary Returns the [`Db`](http://mongodb.github.io/node-mongodb-native/3.0/api/Db.html) object corresponding to this collection's database connection from the [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
    * @locus Server
    * @memberof Mongo.Collection
    * @instance

--- a/packages/mongo/connection_options.js
+++ b/packages/mongo/connection_options.js
@@ -1,6 +1,6 @@
 /**
  * @summary Allows for user specified connection options
- * @example http://mongodb.github.io/node-mongodb-native/2.2/reference/connecting/connection-settings/
+ * @example http://mongodb.github.io/node-mongodb-native/3.0/reference/connecting/connection-settings/
  * @locus Server
  * @param {Object} options User specified Mongo connection options
  */


### PR DESCRIPTION
A quick fix for the docs & comments to link to `node-mongodb-native` docs of the version that is currently in use.