### PR TITLE
Allow resolving index.* modules with non-.js file extensions.

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 * Importing a directory containing an `index.*` file now works for
   non-`.js` file extensions. As before, the list of possible extensions is
   defined by which compiler plugins you have enabled.
+  [PR #10027](https://github.com/meteor/meteor/pull/10027)
 
 ## v1.7.0.3, 2018-06-13
 

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 ## v.NEXT
 
+* Importing a directory containing an `index.*` file now works for
+  non-`.js` file extensions. As before, the list of possible extensions is
+  defined by which compiler plugins you have enabled.
+
 ## v1.7.0.3, 2018-06-13
 
 * Fixed [Issue #9991](https://github.com/meteor/meteor/issues/9991),

--- a/tools/isobuild/resolver.js
+++ b/tools/isobuild/resolver.js
@@ -182,7 +182,7 @@ export default class Resolver {
       // there's very little chance an `index.js` file will be a
       // directory. However, in principle it is remotely possible that a
       // file called `index.js` could be a directory instead of a file.
-      resolved = this._joinAndStat(dirPath, "index.js");
+      resolved = this._joinAndStat(dirPath, "index");
     }
 
     if (resolved) {


### PR DESCRIPTION
As reported by @justinanastos via Slack, files with non-`.js` file extensions (e.g. `index.tsx`) cannot be used to make a directory importable in the same way that an `index.js` module can.

Fixing this involves updating both [the runtime module system](https://github.com/meteor/meteor/commit/445fd3714a9e85ffe40975185f550faf4dcde099) and our build-time `Resolver` logic (this PR).

Unfortunately this fix will have to wait for the next Meteor release, since it involves changes to the build tool.