### PR TITLE
Provide isomorphic implementation of WHATWG fetch() API.

### DIFF
--- a/packages/appcache/package.js
+++ b/packages/appcache/package.js
@@ -15,7 +15,7 @@ Package.onUse(api => {
 Package.onTest(api => {
   api.use('tinytest');
   api.use('appcache');
-  api.use('http', 'client');
+  api.use('fetch');
   api.use('webapp', 'server');
   api.addFiles('appcache_tests-server.js', 'server');
   api.addFiles('appcache_tests-client.js', 'client');

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Update the client when new client code is available",
-  version: '1.4.0'
+  version: '1.4.1'
 });
 
 Package.onUse(function (api) {
@@ -19,8 +19,6 @@ Package.onUse(function (api) {
     'ddp',
     'mongo',
   ], ['client', 'server']);
-
-  api.use(['http', 'random'], 'web.cordova');
 
   api.addFiles('autoupdate_server.js', 'server');
   api.addFiles('autoupdate_client.js', 'web.browser');

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data client",
-  version: '2.3.2',
+  version: '2.3.3',
   documentation: null
 });
 
@@ -54,8 +54,6 @@ Package.onTest((api) => {
     'ddp-common',
     'check'
   ]);
-
-  api.use('http', 'client');
 
   api.addFiles('test/stub_stream.js');
   api.addFiles('test/livedata_connection_tests.js');

--- a/packages/dynamic-import/client.js
+++ b/packages/dynamic-import/client.js
@@ -1,6 +1,5 @@
 var Module = module.constructor;
 var cache = require("./cache.js");
-var HTTP = require("meteor/http").HTTP;
 var meteorInstall = require("meteor/modules").meteorInstall;
 
 // Call module.dynamicImport(id) to fetch a module and any/all of its
@@ -120,21 +119,26 @@ exports.setSecretKey = function (key) {
 var fetchURL = require("./common.js").fetchURL;
 
 function fetchMissing(missingTree) {
-  return new Promise(function (resolve, reject) {
-    // If the hostname of the URL returned by Meteor.absoluteUrl differs
-    // from location.host, then we'll be making a cross-origin request
-    // here, but that's fine because the dynamic-import server sets
-    // appropriate CORS headers to enable fetching dynamic modules from
-    // any origin. Browsers that check CORS do so by sending an additional
-    // preflight OPTIONS request, which may add latency to the first
-    // dynamic import() request, so it's a good idea for ROOT_URL to match
-    // location.host if possible, though not strictly necessary.
-    HTTP.call("POST", Meteor.absoluteUrl(fetchURL), {
-      query: secretKey ? "key=" + secretKey : void 0,
-      data: missingTree
-    }, function (error, result) {
-      error ? reject(error) : resolve(result.data);
-    });
+  // If the hostname of the URL returned by Meteor.absoluteUrl differs
+  // from location.host, then we'll be making a cross-origin request here,
+  // but that's fine because the dynamic-import server sets appropriate
+  // CORS headers to enable fetching dynamic modules from any
+  // origin. Browsers that check CORS do so by sending an additional
+  // preflight OPTIONS request, which may add latency to the first dynamic
+  // import() request, so it's a good idea for ROOT_URL to match
+  // location.host if possible, though not strictly necessary.
+  var url = Meteor.absoluteUrl(fetchURL);
+
+  if (secretKey) {
+    url += "key=" + secretKey;
+  }
+
+  return fetch(url, {
+    method: "POST",
+    body: JSON.stringify(missingTree)
+  }).then(function (res) {
+    if (! res.ok) throw res;
+    return res.json();
   });
 }
 

--- a/packages/dynamic-import/package.js
+++ b/packages/dynamic-import/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "dynamic-import",
-  version: "0.4.1",
+  version: "0.5.0",
   summary: "Runtime support for Meteor 1.5 dynamic import(...) syntax",
   documentation: "README.md"
 });
@@ -11,7 +11,7 @@ Package.onUse(function (api) {
 
   api.use("modules");
   api.use("promise");
-  api.use("http");
+  api.use("fetch");
   api.use("modern-browsers");
 
   api.mainModule("client.js", "client");

--- a/packages/fetch/.npm/package/.gitignore
+++ b/packages/fetch/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/fetch/.npm/package/README
+++ b/packages/fetch/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/fetch/.npm/package/npm-shrinkwrap.json
+++ b/packages/fetch/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,15 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    }
+  }
+}

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -1,0 +1,25 @@
+# fetch
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/fetch) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/fetch)
+***
+
+Isomorphic polyfill for the [WHATWG `fetch()` API](https://fetch.spec.whatwg.org/).
+
+In [modern browsers](https://github.com/meteor/meteor/tree/release-1.7/packages/modern-browsers),
+the native `fetch()` API can be used without a polyfill. In other words,
+this package has almost no footprint in modern browsers. This package
+[calls `setMinimumBrowserVersions`](./server.js) to enforce minimum modern
+browser versions. However, `fetch()` has been supported natively by most
+browsers for long enough that these minimum versions are unlikely to make
+any difference in the `isModern` test, compared to more recent features
+like `async` functions.
+
+In legacy browsers, the
+[`whatwg-fetch`](http://npmjs.org/package/whatwg-fetch) polyfill is
+used. Thanks to Meteor's modern/legacy system, this polyfill adds no weight
+to the modern JS bundle.
+
+In Node, the [`node-fetch`](https://www.npmjs.com/package/node-fetch)
+polyfill is used. Note: unlike the client polyfills, the Node polyfill
+does not define the `fetch` function globally. However, any application or
+package that depends on the Meteor `fetch` package can refer to `fetch` as
+if it was a global function (or `import { fetch } from "meteor/fetch"`).

--- a/packages/fetch/fetch-tests.js
+++ b/packages/fetch/fetch-tests.js
@@ -1,0 +1,8 @@
+// Import Tinytest from the tinytest Meteor package.
+import { Tinytest } from "meteor/tinytest";
+
+// Write your tests here!
+// Here is an example.
+Tinytest.add('fetch - example', function (test) {
+  test.equal(typeof fetch, "function");
+});

--- a/packages/fetch/fetch-tests.js
+++ b/packages/fetch/fetch-tests.js
@@ -1,8 +1,0 @@
-// Import Tinytest from the tinytest Meteor package.
-import { Tinytest } from "meteor/tinytest";
-
-// Write your tests here!
-// Here is an example.
-Tinytest.add('fetch - example', function (test) {
-  test.equal(typeof fetch, "function");
-});

--- a/packages/fetch/legacy.js
+++ b/packages/fetch/legacy.js
@@ -1,0 +1,6 @@
+require("whatwg-fetch");
+
+exports.fetch = global.fetch;
+exports.Headers = global.Headers;
+exports.Request = global.Request;
+exports.Response = global.Response;

--- a/packages/fetch/modern.js
+++ b/packages/fetch/modern.js
@@ -1,0 +1,4 @@
+exports.fetch = global.fetch;
+exports.Headers = global.Headers;
+exports.Request = global.Request;
+exports.Response = global.Response;

--- a/packages/fetch/package.js
+++ b/packages/fetch/package.js
@@ -1,0 +1,32 @@
+Package.describe({
+  name: "fetch",
+  version: "0.1.0",
+  summary: "Isomorphic modern/legacy/Node polyfill for WHATWG fetch()",
+  documentation: "README.md"
+});
+
+Npm.depends({
+  "node-fetch": "2.1.2",
+  "whatwg-fetch": "2.0.4"
+});
+
+Package.onUse(function(api) {
+  api.use("modules");
+  api.use("modern-browsers");
+  api.use("promise");
+
+  api.mainModule("modern.js", "web.browser");
+  api.mainModule("legacy.js", "legacy");
+  api.mainModule("server.js", "server");
+
+  // The other exports (Headers, Request, Response) can be imported
+  // explicitly from the "meteor/fetch" package.
+  api.export("fetch");
+});
+
+Package.onTest(function(api) {
+  api.use("ecmascript");
+  api.use("tinytest");
+  api.use("fetch");
+  api.mainModule("fetch-tests.js");
+});

--- a/packages/fetch/package.js
+++ b/packages/fetch/package.js
@@ -28,5 +28,6 @@ Package.onTest(function(api) {
   api.use("ecmascript");
   api.use("tinytest");
   api.use("fetch");
-  api.mainModule("fetch-tests.js");
+  api.mainModule("tests/main.js");
+  api.addAssets("tests/asset.json", ["client", "server"]);
 });

--- a/packages/fetch/server.js
+++ b/packages/fetch/server.js
@@ -1,0 +1,21 @@
+const fetch = require("node-fetch");
+
+exports.fetch = fetch;
+exports.Headers = fetch.Headers;
+exports.Request = fetch.Request;
+exports.Response = fetch.Response;
+
+const { setMinimumBrowserVersions } = require("meteor/modern-browsers");
+
+// https://caniuse.com/#feat=fetch
+setMinimumBrowserVersions({
+  chrome: 42,
+  edge: 14,
+  firefox: 39,
+  mobile_safari: [10, 3],
+  opera: 29,
+  safari: [10, 1],
+  phantomjs: Infinity,
+  // https://github.com/Kilian/electron-to-chromium/blob/master/full-versions.js
+  electron: [0, 25],
+}, module.id);

--- a/packages/fetch/tests/asset.json
+++ b/packages/fetch/tests/asset.json
@@ -1,0 +1,5 @@
+{
+  "word": "oyez",
+  "times": 3,
+  "where": "SCOTUS"
+}

--- a/packages/fetch/tests/main.js
+++ b/packages/fetch/tests/main.js
@@ -1,0 +1,17 @@
+import { Tinytest } from "meteor/tinytest";
+
+Tinytest.add("fetch - sanity", function (test) {
+  test.equal(typeof fetch, "function");
+});
+
+Tinytest.addAsync("fetch - asset", function (test) {
+  return fetch(
+    Meteor.absoluteUrl("/packages/local-test_fetch/tests/asset.json")
+  ).then(res => {
+    if (! res.ok) throw res;
+    return res.json();
+  }).then(json => {
+    test.equal(json.word, "oyez");
+    test.equal(json.times, 3);
+  });
+});

--- a/packages/non-core/bundle-visualizer/package.js
+++ b/packages/non-core/bundle-visualizer/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.2.1',
+  version: '1.2.2',
   summary: 'Meteor bundle analysis and visualization.',
   documentation: 'README.md',
 });
@@ -18,7 +18,7 @@ Package.onUse(function(api) {
   api.use([
     'ecmascript',
     'dynamic-import',
-    'http',
+    'fetch',
     'webapp',
   ]);
   api.mainModule('server.js', 'server');


### PR DESCRIPTION
As described in my [talk](https://youtu.be/vpCotlPieIY?t=29m18s) about Meteor 1.7's modern/legacy bundling system (relevant [slides](https://slides.com/benjamn/meteor-night-may-2018#/46)), the [WHATWG `fetch()` API](https://fetch.spec.whatwg.org/) is a great example of a feature that requires a totally different implementation in modern browsers, legacy browsers, and Node.

The `fetch()` API is already widely used in the JavaScript community, and I suspect it will eventually replace the core Meteor `http` package for most HTTP request needs, especially since it is essentially free in modern browsers.