### PR TITLE
Replace http with fetch in bundle-visualizer

### DIFF
--- a/packages/non-core/bundle-visualizer/package.js
+++ b/packages/non-core/bundle-visualizer/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.2.1',
+  version: '1.2.2',
   summary: 'Meteor bundle analysis and visualization.',
   documentation: 'README.md',
 });
@@ -18,7 +18,7 @@ Package.onUse(function(api) {
   api.use([
     'ecmascript',
     'dynamic-import',
-    'http',
+    'fetch',
     'webapp',
   ]);
   api.mainModule('server.js', 'server');


### PR DESCRIPTION
Zapped the one use of `http` here! ⚡

I wasn't really sure which version number to bump the package to due to #10025 not yet being merged.