### PR TITLE
Improve lazy OutputResource error reporting.

### DIFF
--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -542,17 +542,8 @@ class InputFile extends buildPluginModule.InputFile {
   }
 
   _reportError(message, info) {
-    if (this.getFileOptions().lazy === true) {
-      // Files with fileOptions.lazy === true were not explicitly added to
-      // the source batch via api.addFiles or api.mainModule, so any
-      // compilation errors should not be fatal until the files are
-      // actually imported by the ImportScanner. Attempting compilation is
-      // still important for lazy files that might end up being imported
-      // later, which is why we defang the error here, instead of avoiding
-      // compilation preemptively. Note also that exceptions thrown by the
-      // compiler will still cause build errors.
-      this._resourceSlot.addError(message, info);
-    } else {
+    this._resourceSlot.addError(message, info);
+    if (! this.getFileOptions().lazy) {
       super._reportError(message, info);
     }
   }

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -910,17 +910,20 @@ class OutputResource {
     }
   }
 
-  reportPendingErrors() {
+  hasPendingErrors() {
     this.finalize();
-    const count = this._errors.length;
-    if (count > 0) {
+    return this._errors.length > 0;
+  }
+
+  reportPendingErrors() {
+    if (this.hasPendingErrors()) {
       const firstError = this._errors[0];
       buildmessage.error(
         firstError.message,
         firstError.info
       );
     }
-    return count;
+    return this._errors.length;
   }
 
   get data() { return this._get("data"); }
@@ -939,7 +942,14 @@ class OutputResource {
       return this[name];
     }
 
-    this.finalize();
+    if (this.hasPendingErrors()) {
+      // If you're considering using this resource, you should call
+      // hasPendingErrors or reportPendingErrors to find out if it's safe
+      // to access computed properties like .data, .hash, or .sourceMap.
+      // If you get here without checking for errors first, those errors
+      // will be fatal.
+      throw this._errors[0];
+    }
 
     switch (name) {
     case "data":

--- a/tools/isobuild/import-scanner.js
+++ b/tools/isobuild/import-scanner.js
@@ -671,6 +671,7 @@ export default class ImportScanner {
     return this.outputFiles.filter(file => {
       return file.absModuleId &&
         ! file[fakeSymbol] &&
+        ! file.hasErrors &&
         (! file.lazy ||
          file.imported === true ||
          file.imported === "dynamic");
@@ -820,6 +821,7 @@ export default class ImportScanner {
 
     if (file.reportPendingErrors &&
         file.reportPendingErrors() > 0) {
+      file.hasErrors = true;
       // Any errors reported to InputFile#error were saved but not
       // reported at compilation time. Now that we know the file has been
       // imported, it's time to report those errors.


### PR DESCRIPTION
This is a follow-up to PR #9983, which allowed misbehaving compiler plugins to fail to report errors when returning `null` from a lazy finalizer function (which always implies there was an error).