### PR TITLE
Replace uglify-es with terser, a more actively maintained fork.

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,11 @@
   defined by which compiler plugins you have enabled.
   [PR #10027](https://github.com/meteor/meteor/pull/10027)
 
+* The `uglify-es` npm package used by `minifier-js` has been replaced with
+  [`terser@3.7.6`](https://www.npmjs.com/package/terser), a fork of
+  `uglify-es` that appears to be (more actively) maintained.
+  [Issue #10042](https://github.com/meteor/meteor/issues/10042)
+
 ## v1.7.0.3, 2018-06-13
 
 * Fixed [Issue #9991](https://github.com/meteor/meteor/issues/9991),

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -2,19 +2,19 @@
   "lockfileVersion": 1,
   "dependencies": {
     "commander": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
     },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
-    "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ=="
+    "terser": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.7.6.tgz",
+      "integrity": "sha512-HbknfLRteizRcQWXTnpVK5rMleOEZh5g5y8sKzTm/W3pf4xrrdvajMSLMg2/45t0U8Hbk2+bcJ1IPXjO77kWtw=="
     }
   }
 }

--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -1,13 +1,13 @@
-var uglify;
+var terser;
 
 meteorJsMinify = function (source) {
   var result = {};
   var NODE_ENV = process.env.NODE_ENV || "development";
 
-  uglify = uglify || Npm.require("uglify-es");
+  terser = terser || Npm.require("terser");
 
   try {
-    var uglifyResult = uglify.minify(source, {
+    var terserResult = terser.minify(source, {
       compress: {
         drop_debugger: false,
         unused: false,
@@ -23,18 +23,18 @@ meteorJsMinify = function (source) {
       }
     });
 
-    if (typeof uglifyResult.code === "string") {
-      result.code = uglifyResult.code;
-      result.minifier = 'uglify-es';
+    if (typeof terserResult.code === "string") {
+      result.code = terserResult.code;
+      result.minifier = 'terser';
     } else {
-      throw uglifyResult.error ||
-        new Error("unknown uglify.minify failure");
+      throw terserResult.error ||
+        new Error("unknown terser.minify failure");
     }
 
   } catch (e) {
     // Although Babel.minify can handle a wider variety of ECMAScript
-    // 2015+ syntax, it is substantially slower than UglifyJS, so we use
-    // it only as a fallback.
+    // 2015+ syntax, it is substantially slower than UglifyJS/terser, so
+    // we use it only as a fallback.
     var options = Babel.getMinifierOptions({
       inlineNodeEnv: NODE_ENV
     });

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "2.3.5"
+  version: "2.4.0"
 });
 
 Npm.depends({
-  "uglify-es": "3.3.9"
+  terser: "3.7.6"
 });
 
 Package.onUse(function (api) {

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '2.3.4',
+  version: '2.4.0',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md',
 });


### PR DESCRIPTION
Thanks to @arrgh for suggesting this replacement: #10042 

This may help with lots of issues, most recently #10044 but also #10034, #9976, #9711, and #9568, to name a few. In particular, since we silently fall back to `Babel.minify` when `uglify-es` (now `terser`) fails, there should be fewer problems with `Babel.minify` (parse errors, performance, memory usage) if `terser` succeeds more often.

Note: because we have bumped the minor versions of `minifier-js` and `standard-minifier-js`, and they are core packages, you'll have to be using the next beta version of Meteor 1.7.1 in order to update to these versions, unless you clone those packages into your local `packages/` directory. However, if we can validate that `terser` is fully backwards compatible with `uglify-es`, we might be able to back-port this fix as a patch update, or publish a Meteor 1.7.0.4 release that permits `minifier-js@2.4.x`.