### PR TITLE
Don't update Minimongo if the update will be a no-op

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -210,6 +210,9 @@ Object.assign(Mongo.Collection.prototype, {
             var modifier = {};
             keys.forEach(key => {
               const value = msg.fields[key];
+              if (EJSON.equals(doc[key], value)) {
+                return;
+              }
               if (typeof value === "undefined") {
                 if (!modifier.$unset) {
                   modifier.$unset = {};
@@ -222,7 +225,9 @@ Object.assign(Mongo.Collection.prototype, {
                 modifier.$set[key] = value;
               }
             });
-            self._collection.update(mongoId, modifier);
+            if (Object.keys(modifier).length > 0) {
+              self._collection.update(mongoId, modifier);
+            }
           }
         } else {
           throw new Error("I don't know how to deal with this message");


### PR DESCRIPTION
When the client receives a "changed" message from the server, it currently always calls an update on Minimongo. However, if the update was initiated on that same client, Minimongo will already be up-to-date. 

In many applications, this is a very common situation. And for applications that are using collection hooks, even a no-op update will trigger all "before" hooks (this includes people using SimpleSchema and https://github.com/matb33/meteor-collection-hooks). So even no-op updates can have a fair amount of overhead.

This PR ensures that no-op updates aren't happening in response to a "changed" message on the client.

Note: I've been running this change in production for almost 2 years, and I've had no issues. Figured it was time to make a PR for it :)