### PR TITLE
Configure polling throttle and polling interval

### DIFF
--- a/packages/mongo/polling_observe_driver.js
+++ b/packages/mongo/polling_observe_driver.js
@@ -1,3 +1,6 @@
+var POLLING_THROTTLE_MS = +process.env.METEOR_POLLING_THROTTLE_MS || 50;
+var POLLING_INTERVAL_MS = +process.env.METEOR_POLLING_INTERVAL_MS || 10 * 1000;
+
 PollingObserveDriver = function (options) {
   var self = this;
 
@@ -29,7 +32,7 @@ PollingObserveDriver = function (options) {
   // PollingObserveDriver object.
   self._ensurePollIsScheduled = _.throttle(
     self._unthrottledEnsurePollIsScheduled,
-    self._cursorDescription.options.pollingThrottleMs || 50 /* ms */);
+    self._cursorDescription.options.pollingThrottleMs || POLLING_THROTTLE_MS /* ms */);
 
   // XXX figure out if we still need a queue
   self._taskQueue = new Meteor._SynchronousQueue();
@@ -64,7 +67,7 @@ PollingObserveDriver = function (options) {
     var pollingInterval =
           self._cursorDescription.options.pollingIntervalMs ||
           self._cursorDescription.options._pollingInterval || // COMPAT with 1.2
-          10 * 1000;
+          POLLING_INTERVAL_MS;
     var intervalHandle = Meteor.setInterval(
       _.bind(self._ensurePollIsScheduled, self), pollingInterval);
     self._stopCallbacks.push(function () {


### PR DESCRIPTION
This PR adds two new environment variables to the polling observe driver. Both of these values are already configurable on a cursor-by-cursor level, but it is helpful to be able to configure them globally.

First, it adds `METEOR_POLLING_THROTTLE_MS`. This controls the maximum number of times a poll can be scheduled within a given time span. Increasing this value can greatly help performance when the result set of active publications are experiencing high write velocity.

Second, it adds `METEOR_POLLING_INTERVAL_MS`. Polling observers re-poll every `METEOR_POLLING_INTERVAL_MS` milliseconds even if the Meteor server has made no updates. This can be super expensive. It is also completely unnecessary if there is only one server updating the db (which is often the case).

Although polling observes should be avoided at pretty much all costs, sometimes they are extremely difficult to avoid. Tweaking these settings can provide large performance improvements.

At Qualia we have `METEOR_POLLING_THROTTLE_MS` at `250ms` and `METEOR_POLLING_INTERVAL_MS` at `60s` (our Meteor servers each have their own db so this value could be a billion years and it'd be fine). We've been running at these values in production for a very long time and it's been great.

Note to the random reader: Seriously try to remove any polling observe drivers in your application. It'll provide much larger benefits than tweaking these environment variables. This package can help you find them and figure out how to remove them https://github.com/qualialabs/analyze-observes