### PR TITLE
Improve File hashing logic in bundler.js.

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,11 @@
   `uglify-es` that appears to be (more actively) maintained.
   [Issue #10042](https://github.com/meteor/meteor/issues/10042)
 
+* Sub-resource integrity hashes (sha512) can now be enabled for static CSS
+  and JS assets by calling `WebAppInternals.enableSubresourceIntegrity()`.
+  [PR #9933](https://github.com/meteor/meteor/pull/9933)
+  [PR #10050](https://github.com/meteor/meteor/pull/10050)
+
 ## v1.7.0.3, 2018-06-13
 
 * Fixed [Issue #9991](https://github.com/meteor/meteor/issues/9991),

--- a/tools/fs/watch.js
+++ b/tools/fs/watch.js
@@ -261,19 +261,19 @@ export function readFile(absPath) {
 };
 
 export function sha1(...args) {
-  return Profile("sha1", function () {
+  return Profile.run("sha1", function () {
     var hash = createHash('sha1');
     args.forEach(arg => hash.update(arg));
     return hash.digest('hex');
-  })();
+  });
 }
 
-export function sri(...args) {
-  return Profile("sri", function () {
+export function sha512(...args) {
+  return Profile.run("sha512", function () {
     var hash = createHash('sha512');
     args.forEach(arg => hash.update(arg));
     return hash.digest('base64');
-  })();
+  });
 }
 
 export function readDirectory({absPath, include, exclude, names}) {


### PR DESCRIPTION
Follow-up to https://github.com/meteor/meteor/pull/9933.

As recommended by @abernix, the sha1 hash of every file is now computed from the file's sha512 hash, so we don't have to hash the entire contents of the file twice with two different algorithms.

Other changes/improvements:

* Invalidate the hashes when/if `File#setContents` is called.
* Ignore `options.hash` and just compute hashes from actual file contents. Disagreement here would be worse than any performance benefits from precomputing the hash.