### PR TITLE
Use underscore on both client and server in github-oauth and meetup-oauth

### DIFF
--- a/packages/github-oauth/package.js
+++ b/packages/github-oauth/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   summary: 'GitHub OAuth flow',
-  version: '1.2.0'
+  version: '1.2.1'
 });
 
 Package.onUse(function (api) {
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
   api.use('http', ['server']);
-  api.use('underscore', 'server');
+  api.use('underscore', ['client', 'server']);
   api.use('random', 'client');
   api.use('service-configuration', ['client', 'server']);
 

--- a/packages/meetup-oauth/package.js
+++ b/packages/meetup-oauth/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   summary: 'Meetup OAuth flow',
-  version: '1.0.1'
+  version: '1.0.2'
 });
 
 Package.onUse(function (api) {
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
   api.use('http', ['server']);
-  api.use('underscore', 'client');
+  api.use('underscore', ['client', 'server']);
   api.use('random', 'client');
   api.use('service-configuration', ['client', 'server']);
 


### PR DESCRIPTION
Looking into https://github.com/meteor/meteor/pull/9558#issuecomment-402178859, it seems that `_` is being used in two packages' architectures where it is not specified in `package.js`. I thought that `_` would have been available anyway, because these packages are using oauth, which in turn uses underscore everywhere, but I suppose not.

So this PR makes those two usages of underscore explicit in the respective `package.js` files, hopefully resolving @jancurn's issue without having to wait for #9558 to get merged.