### PR TITLE
Delay building web.browser.legacy bundle until after development server restarts.

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -24,28 +24,46 @@
 
 // The client version of the client code currently running in the
 // browser.
-var autoupdateVersion = __meteor_runtime_config__.autoupdateVersion || "unknown";
-var autoupdateVersionRefreshable =
-  __meteor_runtime_config__.autoupdateVersionRefreshable || "unknown";
 
-// The collection of acceptable client versions.
-ClientVersions = new Mongo.Collection("meteor_autoupdate_clientVersions");
+const clientArch = Meteor.isCordova ? "web.cordova" :
+  Meteor.isModern ? "web.browser" : "web.browser.legacy";
+
+const autoupdateVersions =
+  __meteor_runtime_config__.autoupdate.versions[clientArch] || {
+    version: "unknown",
+    versionRefreshable: "unknown",
+    versionNonRefreshable: "unknown",
+    assets: [],
+  };
 
 Autoupdate = {};
 
+// The collection of acceptable client versions.
+ClientVersions =
+  Autoupdate._ClientVersions = // Used by a self-test.
+  new Mongo.Collection("meteor_autoupdate_clientVersions");
+
 Autoupdate.newClientAvailable = function () {
-  return !! ClientVersions.findOne({
-               _id: "version",
-               version: {$ne: autoupdateVersion} }) ||
-         !! ClientVersions.findOne({
-               _id: "version-refreshable",
-               version: {$ne: autoupdateVersionRefreshable} });
+  return !! (
+    ClientVersions.findOne({
+      _id: clientArch,
+      versionNonRefreshable: {
+        $ne: autoupdateVersions.versionNonRefreshable,
+      }
+    }) ||
+    ClientVersions.findOne({
+      _id: clientArch,
+      versionRefreshable: {
+        $ne: autoupdateVersions.versionRefreshable,
+      }
+    })
+  );
 };
-Autoupdate._ClientVersions = ClientVersions;  // Used by a self-test
 
-var knownToSupportCssOnLoad = false;
+// Set to true if the link.onload callback ever fires for any <link> node.
+let knownToSupportCssOnLoad = false;
 
-var retry = new Retry({
+const retry = new Retry({
   // Unlike the stream reconnect use of Retry, which we want to be instant
   // in normal operation, this is a wacky failure. We don't want to retry
   // right away, we can start slowly.
@@ -57,19 +75,12 @@ var retry = new Retry({
   minCount: 0, // don't do any immediate retries
   baseTimeout: 30*1000 // start with 30s
 });
-var failures = 0;
 
-function after(times, func) {
-  return function() {
-    if (--times < 1) {
-      return func.apply(this, arguments);
-    }
-  };
-};
+let failures = 0;
 
-Autoupdate._retrySubscription = function () {
+Autoupdate._retrySubscription = () => {
   Meteor.subscribe("meteor_autoupdate_clientVersions", {
-    onError: function (error) {
+    onError(error) {
       Meteor._debug("autoupdate subscription failed", error);
       failures++;
       retry.retryLater(failures, function () {
@@ -83,94 +94,104 @@ Autoupdate._retrySubscription = function () {
         Autoupdate._retrySubscription();
       });
     },
-    onReady: function () {
-      if (Package.reload) {
-        var checkNewVersionDocument = function (doc) {
-          var self = this;
-          if (doc._id === 'version-refreshable' &&
-              doc.version !== autoupdateVersionRefreshable) {
-            autoupdateVersionRefreshable = doc.version;
-            // Switch out old css links for the new css links. Inspired by:
-            // https://github.com/guard/guard-livereload/blob/master/js/livereload.js#L710
-            var newCss = (doc.assets && doc.assets.allCss) || [];
-            var oldLinks = [];
 
-            Array.prototype.forEach.call(
-              document.getElementsByTagName('link'),
-              function (link) {
-                if (link.className === '__meteor-css__') {
-                  oldLinks.push(link);
-                }
-              }
-            );
+    onReady() {
+      const handle = ClientVersions.find().observe({
+        added: checkNewVersionDocument,
+        changed: checkNewVersionDocument
+      });
 
-            function waitUntilCssLoads(link, callback) {
-              var called;
-              function executeCallback(...args) {
-                if (! called) {
-                  called = true;
-                  return callback(...args);
-                }
-              }
+      function checkNewVersionDocument(doc) {
+        if (doc._id !== clientArch) {
+          return;
+        }
 
-              link.onload = function () {
-                knownToSupportCssOnLoad = true;
-                executeCallback();
-              };
+        if (doc.versionNonRefreshable !==
+            autoupdateVersions.versionNonRefreshable) {
+          // Non-refreshable assets have changed, so we have to reload the
+          // whole page rather than just replacing <link> tags.
+          if (handle) handle.stop();
+          if (Package.reload) {
+            // The reload package should be provided by ddp-client, which
+            // is provided by the ddp package that autoupdate depends on.
+            Package.reload.Reload._reload();
+          }
+          return;
+        }
 
-              if (! knownToSupportCssOnLoad) {
-                var id = Meteor.setInterval(function () {
-                  if (link.sheet) {
-                    executeCallback();
-                    Meteor.clearInterval(id);
-                  }
-                }, 50);
+        if (doc.versionRefreshable !== autoupdateVersions.versionRefreshable) {
+          autoupdateVersions.versionRefreshable = doc.versionRefreshable;
+
+          // Switch out old css links for the new css links. Inspired by:
+          // https://github.com/guard/guard-livereload/blob/master/js/livereload.js#L710
+          var newCss = doc.assets || [];
+          var oldLinks = [];
+
+          Array.prototype.forEach.call(
+            document.getElementsByTagName('link'),
+            function (link) {
+              if (link.className === '__meteor-css__') {
+                oldLinks.push(link);
               }
             }
+          );
 
-            var removeOldLinks = after(newCss.length, function () {
-              oldLinks.forEach(function (link) {
+          function waitUntilCssLoads(link, callback) {
+            var called;
+
+            link.onload = function () {
+              knownToSupportCssOnLoad = true;
+              if (! called) {
+                called = true;
+                callback();
+              }
+            };
+
+            if (! knownToSupportCssOnLoad) {
+              var id = Meteor.setInterval(function () {
+                if (link.sheet) {
+                  if (! called) {
+                    called = true;
+                    callback();
+                  }
+                  Meteor.clearInterval(id);
+                }
+              }, 50);
+            }
+          }
+
+          let newLinksLeftToLoad = newCss.length;
+          function removeOldLinks() {
+            if (oldLinks.length > 0 &&
+                --newLinksLeftToLoad < 1) {
+              oldLinks.splice(0).forEach(link => {
                 link.parentNode.removeChild(link);
               });
-            });
+            }
+          }
 
-            var attachStylesheetLink = function (newLink) {
-              document.getElementsByTagName("head").item(0).appendChild(newLink);
+          if (newCss.length > 0) {
+            newCss.forEach(css => {
+              const newLink = document.createElement("link");
+              newLink.setAttribute("rel", "stylesheet");
+              newLink.setAttribute("type", "text/css");
+              newLink.setAttribute("class", "__meteor-css__");
+              newLink.setAttribute("href", css.url);
 
               waitUntilCssLoads(newLink, function () {
                 Meteor.setTimeout(removeOldLinks, 200);
               });
-            };
 
-            if (newCss.length !== 0) {
-              newCss.forEach(function (css) {
-                var newLink = document.createElement("link");
-                newLink.setAttribute("rel", "stylesheet");
-                newLink.setAttribute("type", "text/css");
-                newLink.setAttribute("class", "__meteor-css__");
-                newLink.setAttribute("href", css.url);
-                attachStylesheetLink(newLink);
-              });
-            } else {
-              removeOldLinks();
-            }
-
+              const head = document.getElementsByTagName("head").item(0);
+              head.appendChild(newLink);
+            });
+          } else {
+            removeOldLinks();
           }
-          else if (doc._id === 'version' && doc.version !== autoupdateVersion) {
-            handle && handle.stop();
-
-            if (Package.reload) {
-              Package.reload.Reload._reload();
-            }
-          }
-        };
-
-        var handle = ClientVersions.find().observe({
-          added: checkNewVersionDocument,
-          changed: checkNewVersionDocument
-        });
+        }
       }
     }
   });
 };
+
 Autoupdate._retrySubscription();

--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -36,10 +36,10 @@ const autoupdateVersions =
     assets: [],
   };
 
-Autoupdate = {};
+export const Autoupdate = {};
 
 // The collection of acceptable client versions.
-ClientVersions =
+const ClientVersions =
   Autoupdate._ClientVersions = // Used by a self-test.
   new Mongo.Collection("meteor_autoupdate_clientVersions");
 

--- a/packages/autoupdate/autoupdate_cordova.js
+++ b/packages/autoupdate/autoupdate_cordova.js
@@ -4,9 +4,10 @@ var autoupdateVersionsCordova =
   };
 
 // The collection of acceptable client versions.
-ClientVersions = new Mongo.Collection("meteor_autoupdate_clientVersions");
+const ClientVersions =
+  new Mongo.Collection("meteor_autoupdate_clientVersions");
 
-Autoupdate = {};
+export const Autoupdate = {};
 
 Autoupdate.newClientAvailable =
   () => !! ClientVersions.findOne({

--- a/packages/autoupdate/autoupdate_cordova.js
+++ b/packages/autoupdate/autoupdate_cordova.js
@@ -1,16 +1,20 @@
-var autoupdateVersionCordova = __meteor_runtime_config__.autoupdateVersionCordova || "unknown";
+var autoupdateVersionsCordova =
+  __meteor_runtime_config__.autoupdate.versions["web.cordova"] || {
+    version: "unknown"
+  };
 
 // The collection of acceptable client versions.
 ClientVersions = new Mongo.Collection("meteor_autoupdate_clientVersions");
 
 Autoupdate = {};
 
-Autoupdate.newClientAvailable = function() {
-  return !! ClientVersions.findOne({
-    _id: 'version-cordova',
-    version: {$ne: autoupdateVersionCordova}
+Autoupdate.newClientAvailable =
+  () => !! ClientVersions.findOne({
+    _id: "web.cordova",
+    version: {
+      $ne: autoupdateVersionsCordova.version
+    }
   });
-};
 
 var retry = new Retry({
   // Unlike the stream reconnect use of Retry, which we want to be instant
@@ -24,12 +28,14 @@ var retry = new Retry({
   minCount: 0, // don't do any immediate retries
   baseTimeout: 30*1000 // start with 30s
 });
-var failures = 0;
 
-Autoupdate._retrySubscription = function() {
-  var appId = __meteor_runtime_config__.appId;
+let failures = 0;
+
+Autoupdate._retrySubscription = () => {
+  const { appId } = __meteor_runtime_config__;
+
   Meteor.subscribe("meteor_autoupdate_clientVersions", appId, {
-    onError: function(error) {
+    onError(error) {
       console.log("autoupdate subscription failed:", error);
       failures++;
       retry.retryLater(failures, function() {
@@ -43,16 +49,18 @@ Autoupdate._retrySubscription = function() {
         Autoupdate._retrySubscription();
       });
     },
-    onReady: function() {
+
+    onReady() {
       if (Package.reload) {
-        var checkNewVersionDocument = function(doc) {
-          var self = this;
-          if (doc.version !== autoupdateVersionCordova) {
+        function checkNewVersionDocument(doc) {
+          if (doc.version !== autoupdateVersionsCordova.version) {
             newVersionAvailable();
           }
-        };
+        }
 
-        var handle = ClientVersions.find({_id: 'version-cordova'}).observe({
+        ClientVersions.find({
+          _id: "web.cordova"
+        }).observe({
           added: checkNewVersionDocument,
           changed: checkNewVersionDocument
         });
@@ -61,8 +69,8 @@ Autoupdate._retrySubscription = function() {
   });
 };
 
-Meteor.startup(function() {
-  WebAppLocalServer.onNewVersionReady(function() {
+Meteor.startup(() => {
+  WebAppLocalServer.onNewVersionReady(() => {
     if (Package.reload) {
       Package.reload.Reload._reload();
     }
@@ -71,6 +79,6 @@ Meteor.startup(function() {
   Autoupdate._retrySubscription();
 });
 
-var newVersionAvailable = function() {
+function newVersionAvailable() {
   WebAppLocalServer.checkForUpdates();
 }

--- a/packages/autoupdate/autoupdate_server.js
+++ b/packages/autoupdate/autoupdate_server.js
@@ -1,39 +1,38 @@
-// Publish the current client versions to the client.  When a client
-// sees the subscription change and that there is a new version of the
-// client available on the server, it can reload.
+// Publish the current client versions for each client architecture
+// (web.browser, web.browser.legacy, web.cordova). When a client observes
+// a change in the versions associated with its client architecture,
+// it will refresh itself, either by swapping out CSS assets or by
+// reloading the page.
 //
-// By default there are two current client versions. The refreshable client
-// version is identified by a hash of the client resources seen by the browser
-// that are refreshable, such as CSS, while the non refreshable client version
-// is identified by a hash of the rest of the client assets
-// (the HTML, code, and static files in the `public` directory).
+// There are three versions for any given client architecture: `version`,
+// `versionRefreshable`, and `versionNonRefreshable`. The refreshable
+// version is a hash of just the client resources that are refreshable,
+// such as CSS, while the non-refreshable version is a hash of the rest of
+// the client assets, excluding the refreshable ones: HTML, JS, and static
+// files in the `public` directory. The `version` version is a combined
+// hash of everything.
 //
-// If the environment variable `AUTOUPDATE_VERSION` is set it will be
-// used as the client id instead.  You can use this to control when
-// the client reloads.  For example, if you want to only force a
-// reload on major changes, you can use a custom AUTOUPDATE_VERSION
-// which you only change when something worth pushing to clients
-// immediately happens.
+// If the environment variable `AUTOUPDATE_VERSION` is set, it will be
+// used in place of all client versions. You can use this variable to
+// control when the client reloads. For example, if you want to force a
+// reload only after major changes, use a custom AUTOUPDATE_VERSION and
+// change it only when something worth pushing to clients happens.
 //
-// The server publishes a `meteor_autoupdate_clientVersions`
-// collection. There are two documents in this collection, a document
-// with _id 'version' which represents the non refreshable client assets,
-// and a document with _id 'version-refreshable' which represents the
-// refreshable client assets. Each document has a 'version' field
-// which is equivalent to the hash of the relevant assets. The refreshable
-// document also contains a list of the refreshable assets, so that the client
-// can swap in the new assets without forcing a page refresh. Clients can
-// observe changes on these documents to detect when there is a new
-// version available.
-//
-// In this implementation only two documents are present in the collection
-// the current refreshable client version and the current nonRefreshable client
-// version.  Developers can easily experiment with different versioning and
-// updating models by forking this package.
+// The server publishes a `meteor_autoupdate_clientVersions` collection.
+// The ID of each document is the client architecture, and the fields of
+// the document are the versions described above.
 
 var Future = Npm.require("fibers/future");
 
-Autoupdate = {};
+Autoupdate = __meteor_runtime_config__.autoupdate = {
+  // Map from client architectures (web.browser, web.browser.legacy,
+  // web.cordova) to version fields { version, versionRefreshable,
+  // versionNonRefreshable, refreshable } that will be stored in
+  // ClientVersions documents (whose IDs are client architectures). This
+  // data gets serialized into the boilerplate because it's stored in
+  // __meteor_runtime_config__.autoupdate.versions.
+  versions: {}
+};
 
 // The collection of acceptable client versions.
 ClientVersions = new Mongo.Collection("meteor_autoupdate_clientVersions",
@@ -53,91 +52,47 @@ Autoupdate.appId = __meteor_runtime_config__.appId = process.env.APP_ID;
 
 var syncQueue = new Meteor._SynchronousQueue();
 
-// updateVersions can only be called after the server has fully loaded.
-var updateVersions = function (shouldReloadClientProgram) {
-  // Step 1: load the current client program on the server and update the
-  // hash values in __meteor_runtime_config__.
+function updateVersions(shouldReloadClientProgram) {
+  // Step 1: load the current client program on the server
   if (shouldReloadClientProgram) {
     WebAppInternals.reloadClientPrograms();
   }
 
-  // If we just re-read the client program, or if we don't have an autoupdate
-  // version, calculate it.
-  if (shouldReloadClientProgram || Autoupdate.autoupdateVersion === null) {
-    Autoupdate.autoupdateVersion =
-      process.env.AUTOUPDATE_VERSION ||
-      WebApp.calculateClientHashNonRefreshable();
-  }
-  // If we just recalculated it OR if it was set by (eg) test-in-browser,
-  // ensure it ends up in __meteor_runtime_config__.
-  __meteor_runtime_config__.autoupdateVersion =
-    Autoupdate.autoupdateVersion;
+  // Step 2: update __meteor_runtime_config__.autoupdate.versions.
+  const clientArchs = Object.keys(WebApp.clientPrograms);
+  clientArchs.forEach(arch => {
+    Autoupdate.versions[arch] = {
+      version: WebApp.calculateClientHashNonRefreshable(arch),
+      versionRefreshable: WebApp.calculateClientHashRefreshable(arch),
+      versionNonRefreshable:
+        WebApp.calculateClientHashNonRefreshable(arch),
+    };
+  });
 
-  Autoupdate.autoupdateVersionRefreshable =
-    __meteor_runtime_config__.autoupdateVersionRefreshable =
-      process.env.AUTOUPDATE_VERSION ||
-      WebApp.calculateClientHashRefreshable();
-
-  Autoupdate.autoupdateVersionCordova =
-    __meteor_runtime_config__.autoupdateVersionCordova =
-      process.env.AUTOUPDATE_VERSION ||
-      WebApp.calculateClientHashCordova();
-
-  // Step 2: form the new client boilerplate which contains the updated
+  // Step 3: form the new client boilerplate which contains the updated
   // assets and __meteor_runtime_config__.
   if (shouldReloadClientProgram) {
     WebAppInternals.generateBoilerplate();
   }
 
-  // XXX COMPAT WITH 0.8.3
-  if (! ClientVersions.findOne({current: true})) {
-    // To ensure apps with version of Meteor prior to 0.9.0 (in
-    // which the structure of documents in `ClientVersions` was
-    // different) also reload.
-    ClientVersions.insert({current: true});
-  }
-
-  if (! ClientVersions.findOne({_id: "version"})) {
-    ClientVersions.insert({
-      _id: "version",
-      version: Autoupdate.autoupdateVersion
-    });
-  } else {
-    ClientVersions.update("version", { $set: {
-      version: Autoupdate.autoupdateVersion
-    }});
-  }
-
-  if (! ClientVersions.findOne({_id: "version-cordova"})) {
-    ClientVersions.insert({
-      _id: "version-cordova",
-      version: Autoupdate.autoupdateVersionCordova,
-      refreshable: false
-    });
-  } else {
-    ClientVersions.update("version-cordova", { $set: {
-      version: Autoupdate.autoupdateVersionCordova
-    }});
-  }
-
-  // Use `onListening` here because we need to use
-  // `WebAppInternals.refreshableAssets`, which is only set after
+  // Step 4: update the ClientVersions collection.
+  // We use `onListening` here because we need to use
+  // `WebApp.getRefreshableAssets`, which is only set after
   // `WebApp.generateBoilerplate` is called by `main` in webapp.
-  WebApp.onListening(function () {
-    if (! ClientVersions.findOne({_id: "version-refreshable"})) {
-      ClientVersions.insert({
-        _id: "version-refreshable",
-        version: Autoupdate.autoupdateVersionRefreshable,
-        assets: WebAppInternals.refreshableAssets
-      });
-    } else {
-      ClientVersions.update("version-refreshable", { $set: {
-        version: Autoupdate.autoupdateVersionRefreshable,
-        assets: WebAppInternals.refreshableAssets
-      }});
-    }
+  WebApp.onListening(() => {
+    clientArchs.forEach(arch => {
+      const payload = {
+        ...Autoupdate.versions[arch],
+        assets: WebApp.getRefreshableAssets(arch),
+      };
+      if (! ClientVersions.findOne({ _id: arch })) {
+        ClientVersions.insert({ _id: arch, ...payload });
+      } else {
+        ClientVersions.update(arch, { $set: payload });
+      }
+    });
   });
-};
+}
 
 Meteor.publish(
   "meteor_autoupdate_clientVersions",

--- a/packages/autoupdate/autoupdate_server.js
+++ b/packages/autoupdate/autoupdate_server.js
@@ -142,11 +142,11 @@ var enqueueVersionsRefresh = function () {
 
 // Listen for the special {refresh: 'client'} message, which signals that a
 // client asset has changed.
-process.on('message', Meteor.bindEnvironment(function (m) {
+export async function onMessage(m) {
   if (m && m.refresh === 'client') {
     enqueueVersionsRefresh();
   }
-}, "handling client refresh message"));
+}
 
 // Another way to tell the process to refresh: send SIGHUP signal
 process.on('SIGHUP', Meteor.bindEnvironment(function () {

--- a/packages/autoupdate/autoupdate_server.js
+++ b/packages/autoupdate/autoupdate_server.js
@@ -24,7 +24,7 @@
 
 var Future = Npm.require("fibers/future");
 
-Autoupdate = __meteor_runtime_config__.autoupdate = {
+export const Autoupdate = __meteor_runtime_config__.autoupdate = {
   // Map from client architectures (web.browser, web.browser.legacy,
   // web.cordova) to version fields { version, versionRefreshable,
   // versionNonRefreshable, refreshable } that will be stored in
@@ -35,8 +35,10 @@ Autoupdate = __meteor_runtime_config__.autoupdate = {
 };
 
 // The collection of acceptable client versions.
-ClientVersions = new Mongo.Collection("meteor_autoupdate_clientVersions",
-  { connection: null });
+const ClientVersions =
+  new Mongo.Collection("meteor_autoupdate_clientVersions", {
+    connection: null
+  });
 
 // The client hash includes __meteor_runtime_config__, so wait until
 // all packages have loaded and have had a chance to populate the

--- a/packages/autoupdate/autoupdate_server.js
+++ b/packages/autoupdate/autoupdate_server.js
@@ -116,6 +116,17 @@ Meteor.publish(
 
 Meteor.startup(function () {
   updateVersions(false);
+
+  // Force any connected clients that are still looking for these older
+  // document IDs to reload.
+  ["version",
+   "version-refreshable",
+   "version-cordova",
+  ].forEach(_id => {
+    ClientVersions.upsert(_id, {
+      $set: { version: "outdated" }
+    });
+  });
 });
 
 var fut = new Future();
@@ -152,4 +163,3 @@ export async function onMessage(m) {
 process.on('SIGHUP', Meteor.bindEnvironment(function () {
   enqueueVersionsRefresh();
 }, "handling SIGHUP signal for refresh"));
-

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Update the client when new client code is available",
-  version: '1.4.1'
+  version: '1.5.0'
 });
 
 Package.onUse(function (api) {

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -20,9 +20,9 @@ Package.onUse(function (api) {
     'mongo',
   ], ['client', 'server']);
 
-  api.addFiles('autoupdate_server.js', 'server');
-  api.addFiles('autoupdate_client.js', 'web.browser');
-  api.addFiles('autoupdate_cordova.js', 'web.cordova');
+  api.mainModule('autoupdate_server.js', 'server');
+  api.mainModule('autoupdate_client.js', 'client');
+  api.mainModule('autoupdate_cordova.js', 'web.cordova');
 
   api.export('Autoupdate');
 });

--- a/packages/meteor/message-dispatch.js
+++ b/packages/meteor/message-dispatch.js
@@ -1,0 +1,61 @@
+// This code receives, dispatches, and responds to inter-process messages
+// sent by the parent (build) process. See tools/runners/run-app.js for
+// the other side of this communications system.
+
+// The process.send method is only defined when the current process was
+// spawned by another process with an IPC channel.
+if (typeof process.send === "function") {
+  const promises = Object.create(null);
+
+  // Listen for messages from the parent process and dispatch them to the
+  // appropriate package, as identified by packageName. To receive these
+  // messages, packages should export an onMessage function that takes the
+  // payload as a parameter.
+  process.on("message", ({
+    type = "FROM_PARENT",
+    responseId = null,
+    packageName,
+    payload,
+  }) => {
+    if (type === "FROM_PARENT" &&
+        typeof packageName === "string") {
+      // Keep the messages and their responses strictly ordered per
+      // package, one after the last. The first message waits for the
+      // package to call Package._define(packageName, exports).
+      promises[packageName] = (
+        promises[packageName] || new Promise(resolve => {
+          Package._on(packageName, resolve);
+        })
+      ).then(
+        // In order to receive messages, the package must export an
+        // onMessage function.
+        () => Package[packageName].onMessage(payload)
+      ).then(result => {
+        if (responseId) {
+          // Send the response value back to the parent using the provided
+          // responseId (if any).
+          process.send({
+            type: "FROM_CHILD",
+            responseId,
+            result,
+          });
+        }
+      }, error => {
+        const copy = {};
+        Reflect.ownKeys(error).forEach(key => copy[key] = error[key]);
+        process.send({
+          type: "FROM_CHILD",
+          responseId,
+          error: copy,
+        });
+      });
+    }
+  });
+
+  // Let the parent process know this child process is ready to receive
+  // messages.
+  process.send({
+    type: "CHILD_READY",
+    pid: process.pid,
+  });
+}

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.9.0'
+  version: '1.9.1'
 });
 
 Package.registerBuildPlugin({

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -29,6 +29,7 @@ Package.onUse(function (api) {
 
   api.addFiles('cordova_environment.js', 'web.cordova');
   api.addFiles('define-package.js', ['client', 'server']);
+  api.addFiles('message-dispatch.js', 'server');
   api.addFiles('helpers.js', ['client', 'server']);
   api.addFiles('setimmediate.js', ['client', 'server']);
   api.addFiles('timers.js', ['client', 'server']);

--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -95,6 +95,12 @@ function getCaller(calleeName) {
 Object.assign(exports, {
   isModern,
   setMinimumBrowserVersions,
+  calculateHashOfMinimumVersions() {
+    const { createHash } = require("crypto");
+    return createHash("sha1").update(
+      JSON.stringify(minimumVersions)
+    ).digest("hex");
+  }
 });
 
 // For making defensive copies of [major, minor, ...] version arrays, so

--- a/packages/modern-browsers/package.js
+++ b/packages/modern-browsers/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modern-browsers",
-  version: "0.1.1",
+  version: "0.1.2",
   summary: "API for defining the boundary between modern and legacy " +
     "JavaScript clients",
   documentation: "README.md"

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -1036,10 +1036,6 @@ function runWebAppServer() {
   };
 }
 
-
-runWebAppServer();
-
-
 var inlineScriptsAllowed = true;
 
 WebAppInternals.inlineScriptsAllowed = function () {
@@ -1083,3 +1079,6 @@ WebAppInternals.addStaticJs = function (contents) {
 // Exported for tests
 WebAppInternals.getBoilerplate = getBoilerplate;
 WebAppInternals.additionalStaticJs = additionalStaticJs;
+
+// Start the server!
+runWebAppServer();

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -583,11 +583,13 @@ function runWebAppServer() {
     });
   };
 
-  process.on("message", message => {
+  process.on("message", async (message) => {
     if (message.package !== "webapp") return;
     if (message.method === "generateClientProgram") {
-      delete staticFilesByArch[message.args[0]];
-      WebAppInternals.generateClientProgram(...message.args);
+      syncQueue.runTask(() => {
+        delete staticFilesByArch[message.args[0]];
+        WebAppInternals.generateClientProgram(...message.args);
+      });
     }
   });
 

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -583,6 +583,14 @@ function runWebAppServer() {
     });
   };
 
+  process.on("message", message => {
+    if (message.package !== "webapp") return;
+    if (message.method === "generateClientProgram") {
+      delete staticFilesByArch[message.args[0]];
+      WebAppInternals.generateClientProgram(...message.args);
+    }
+  });
+
   WebAppInternals.generateClientProgram = function (arch) {
     if (hasOwn.call(staticFilesByArch, arch)) {
       return;

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -14,7 +14,10 @@ import query from "qs-middleware";
 import parseRequest from "parseurl";
 import basicAuth from "basic-auth-connect";
 import { lookup as lookupUserAgent } from "useragent";
-import { isModern } from "meteor/modern-browsers";
+import {
+  isModern,
+  calculateHashOfMinimumVersions,
+} from "meteor/modern-browsers";
 import send from "send";
 import {
   removeExistingSocketFile,
@@ -641,7 +644,15 @@ function runWebAppServer() {
 
     const { AUTOUPDATE_VERSION } = process.env;
     const { PUBLIC_SETTINGS } = __meteor_runtime_config__;
-    const configOverrides = { PUBLIC_SETTINGS };
+    const configOverrides = {
+      PUBLIC_SETTINGS,
+      // Since the minimum modern versions defined in the modern-versions
+      // package affect which bundle a given client receives, any changes
+      // in those versions should trigger a corresponding change in the
+      // versions calculated below.
+      minimumModernVersionsHash: calculateHashOfMinimumVersions(),
+    };
+
     const program = {
       format: "web-program-pre1",
       manifest: manifest,

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -206,12 +206,6 @@ Meteor.startup(function () {
     ].versionNonRefreshable;
   };
 
-  WebApp.calculateClientHashCordova = function () {
-    return (WebApp.clientPrograms["web.cordova"] || {
-      version: "none"
-    }).version;
-  };
-
   WebApp.getRefreshableAssets = function (arch) {
     return WebApp.clientPrograms[
       arch || WebApp.defaultArch

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -179,7 +179,7 @@ Tinytest.addAsync(
       req.method = "GET";
       req.url = "/" + additionalScriptPathname;
       let nextCalled = false;
-      WebAppInternals.staticFilesMiddleware({
+      await WebAppInternals.staticFilesMiddleware({
         "web.browser": {},
         "web.browser.legacy": {},
       }, req, res, function () {
@@ -213,7 +213,7 @@ Tinytest.addAsync(
     req.headers = {};
     req.method = "GET";
     req.url = "/" + additionalScriptPathname;
-    WebAppInternals.staticFilesMiddleware({
+    await WebAppInternals.staticFilesMiddleware({
       "web.browser": {},
       "web.browser.legacy": {},
     }, req, res, function () {});

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -31,6 +31,7 @@ var packageJson = {
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
     semver: "5.4.1",
     request: "2.83.0",
+    uuid: "3.3.2",
     fstream: "https://github.com/meteor/fstream/tarball/cf4ea6c175355cec7bee38311e170d08c4078a5d",
     tar: "2.2.1",
     kexec: "3.0.0",

--- a/tools/fs/watch.js
+++ b/tools/fs/watch.js
@@ -260,21 +260,17 @@ export function readFile(absPath) {
   }
 };
 
-export function sha1(...args) {
-  return Profile.run("sha1", function () {
-    var hash = createHash('sha1');
-    args.forEach(arg => hash.update(arg));
-    return hash.digest('hex');
-  });
-}
+export const sha1 = Profile("sha1", function (...args) {
+  var hash = createHash('sha1');
+  args.forEach(arg => hash.update(arg));
+  return hash.digest('hex');
+});
 
-export function sha512(...args) {
-  return Profile.run("sha512", function () {
-    var hash = createHash('sha512');
-    args.forEach(arg => hash.update(arg));
-    return hash.digest('base64');
-  });
-}
+export const sha512 = Profile("sha512", function (...args) {
+  var hash = createHash('sha512');
+  args.forEach(arg => hash.update(arg));
+  return hash.digest('base64');
+});
 
 export function readDirectory({absPath, include, exclude, names}) {
   // Read the directory.

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2992,6 +2992,7 @@ function bundle({
   buildOptions,
   previousBuilders = Object.create(null),
   hasCachedBundle,
+  allowDelayedClientBuilds = false,
 }) {
   buildOptions = buildOptions || {};
 
@@ -3021,9 +3022,9 @@ function bundle({
   var starResult = null;
   var lintingMessages = null;
 
-  // Will be populated with callbacks to be called after the application
-  // process has started up.
-  const postStartupCallbacks = [];
+  // If delayed client builds are allowed, this array will be populated
+  // with callbacks to run after the application process has started up.
+  const postStartupCallbacks = allowDelayedClientBuilds && [];
 
   const bundlerCacheDir =
       projectContext.getProjectLocalDirectory('bundler-cache');
@@ -3161,11 +3162,13 @@ function bundle({
 
     // Client
     webArchs.forEach(arch => {
-      if (hasOwn.call(previousBuilders, arch) &&
+      if (allowDelayedClientBuilds &&
+          hasOwn.call(previousBuilders, arch) &&
           projectContext.platformList.canDelayBuildingArch(arch)) {
-        // If we have a previous builder for this arch, and it's an arch
-        // that we can safely build later (e.g. web.browser.legacy), then
-        // schedule it to be built after the others.
+        // If delayed client builds are allowed, and we have a previous
+        // builder for this arch, and it's an arch that we can safely
+        // build later (e.g. web.browser.legacy), then schedule it to be
+        // built after the server has started up.
         postStartupCallbacks.push(({
           childProcess,
           runLog,

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1583,8 +1583,6 @@ class ClientTarget extends Target {
   // Returns an object with the following keys:
   // - controlFile: the path (relative to 'builder') of the control file for
   // the target
-  // - nodePath: an array of paths required to be set in the NODE_PATH
-  // environment variable.
   write(builder, {minifyMode}) {
     builder.reserve("program.json");
 
@@ -1769,8 +1767,7 @@ class ClientTarget extends Target {
     builder.writeJson('program.json', program);
 
     return {
-      controlFile: "program.json",
-      nodePath: []
+      controlFile: "program.json"
     };
   }
 }
@@ -2195,8 +2192,6 @@ class JsImage {
   // Returns an object with the following keys:
   // - controlFile: the path (relative to 'builder') of the control file for
   // the image
-  // - nodePath: an array of paths required to be set in the NODE_PATH
-  // environment variable.
   write(builder, {
     buildMode,
     // falsy or 'symlink', documented on exports.bundle
@@ -2414,8 +2409,7 @@ class JsImage {
     });
 
     return {
-      controlFile: "program.json",
-      nodePath: []
+      controlFile: "program.json"
     };
   }
 
@@ -2551,7 +2545,6 @@ class ServerTarget extends JsImageTarget {
     includeNodeModules,
   }) {
     var self = this;
-    var nodePath = [];
 
     // This is where the dev_bundle will be downloaded and unpacked
     builder.reserve('dependencies');
@@ -2655,7 +2648,6 @@ class ServerTarget extends JsImageTarget {
     var controlFilePath = 'boot.js';
     return {
       controlFile: controlFilePath,
-      nodePath: nodePath
     };
   }
 }
@@ -2771,7 +2763,6 @@ var writeTargetToPath = Profile(
       name,
       arch: target.mostCompatibleArch(),
       path: files.pathJoin('programs', name, targetBuild.controlFile),
-      nodePath: targetBuild.nodePath,
       cordovaDependencies: target.cordovaDependencies || undefined,
       builder
     };
@@ -2794,8 +2785,6 @@ var writeTargetToPath = Profile(
 //     serverWatchSet: watch.WatchSet for all files and directories that
 //                     ultimately went into all server programs
 //     starManifest: the JSON manifest of the star
-//     nodePath: an array of paths required to be set in NODE_PATH. It's
-//               up to the called to determine what they should be.
 // }
 //
 // options:
@@ -2828,7 +2817,6 @@ var writeSiteArchive = Profile("bundler writeSiteArchive", function (
       nodeVersion: process.versions.node,
       npmVersion: meteorNpm.npmVersion,
     };
-    var nodePath = [];
 
     // Tell the deploy server what version of the dependency kit we're using, so
     // it can load the right modules. (Include this even if we copied or
@@ -2885,7 +2873,6 @@ Find out more about Meteor at meteor.com.
       const target = targets[name];
       const {
         arch, path, cordovaDependencies,
-        nodePath: targetNP,
         builder: targetBuilder
       } = writeTargetToPath(name, target, builder.buildPath, {
         includeNodeModules,
@@ -2901,8 +2888,6 @@ Find out more about Meteor at meteor.com.
       json.programs.push({
         name, arch, path, cordovaDependencies
       });
-
-      nodePath = nodePath.concat(targetNP);
     });
 
     // Control file
@@ -2925,7 +2910,6 @@ Find out more about Meteor at meteor.com.
       clientWatchSet,
       serverWatchSet,
       starManifest: json,
-      nodePath,
       builders,
     };
   } catch (e) {
@@ -3036,7 +3020,6 @@ function bundle({
   var clientWatchSet = new watch.WatchSet();
   var starResult = null;
   var targets = {};
-  var nodePath = [];
   var lintingMessages = null;
 
   const bundlerCacheDir =
@@ -3179,7 +3162,6 @@ function bundle({
             previousBuilder: previousBuilders[name],
             ...writeOptions,
           });
-          nodePath = nodePath.concat(targetBuild.nodePath);
           clientWatchSet.merge(target.getWatchSet());
           previousBuilders[name] = targetBuild.builder;
         });
@@ -3189,7 +3171,6 @@ function bundle({
           previousBuilders,
           ...writeOptions,
         });
-        nodePath = nodePath.concat(starResult.nodePath);
         serverWatchSet.merge(starResult.serverWatchSet);
         clientWatchSet.merge(starResult.clientWatchSet);
         Object.assign(previousBuilders, starResult.builders);
@@ -3210,7 +3191,6 @@ function bundle({
     serverWatchSet,
     clientWatchSet,
     starManifest: starResult && starResult.starManifest,
-    nodePath,
   };
 }
 

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1297,7 +1297,7 @@ _.extend(exports.PlatformList.prototype, {
     return ! _.isEmpty(self.getCordovaPlatforms());
   },
 
-  getWebArchs: function () {
+  getWebArchs() {
     var self = this;
     var archs = [
       "web.browser",
@@ -1307,6 +1307,10 @@ _.extend(exports.PlatformList.prototype, {
       archs.push("web.cordova");
     }
     return archs;
+  },
+
+  canDelayBuildingArch(arch) {
+    return arch === "web.browser.legacy";
   }
 });
 

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -389,7 +389,7 @@ var AppRunner = function (options) {
 
   // Builders saved across rebuilds, so that targets can be re-written in
   // place instead of created again from scratch.
-  self.builders = {};
+  self.builders = Object.create(null);
 };
 
 _.extend(AppRunner.prototype, {
@@ -576,7 +576,7 @@ _.extend(AppRunner.prototype, {
       }
 
       var bundleResult = Profile.run((firstRun?"B":"Reb")+"uild App", () => {
-        var bundleResult = bundler.bundle({
+        return bundler.bundle({
           projectContext: self.projectContext,
           outputPath: bundlePath,
           includeNodeModules: "symlink",
@@ -584,11 +584,6 @@ _.extend(AppRunner.prototype, {
           hasCachedBundle: !! cachedServerWatchSet,
           previousBuilders: self.builders
         });
-
-        // save new builders with their caches
-        self.builders = bundleResult.builders;
-
-        return bundleResult;
       });
 
       // Keep the server watch set from the initial bundle, because subsequent

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -573,7 +573,10 @@ _.extend(AppRunner.prototype, {
           includeNodeModules: "symlink",
           buildOptions: self.buildOptions,
           hasCachedBundle: !! cachedServerWatchSet,
-          previousBuilders: self.builders
+          previousBuilders: self.builders,
+          // Permit delayed bundling of client architectures if the
+          // console is interactive.
+          allowDelayedClientBuilds: ! Console.isHeadless(),
         });
       });
 

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -796,10 +796,11 @@ _.extend(AppRunner.prototype, {
         while (callbacks.length > 0) {
           const fn = callbacks.shift();
           try {
-            const message = Promise.await(fn(appProcess.proc));
-            if (message) {
-              runLog.log(message, { arrow: true });
-            }
+            Promise.await(fn({
+              // Miscellany that the callback might find useful.
+              childProcess: appProcess.proc,
+              runLog,
+            }));
           } catch (error) {
             buildmessage.error(error);
           }

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -845,8 +845,16 @@ _.extend(AppRunner.prototype, {
       setupClientWatcher();
     }
 
+    function pauseClient(arch) {
+      return appProcess.proc.sendMessage("webapp", {
+        method: "pauseClient",
+        args: [arch],
+      });
+    }
+
     async function refreshClient(arch) {
       if (typeof arch === "string") {
+        // This message will reload the client program and unpause it.
         await appProcess.proc.sendMessage("webapp", {
           method: "generateClientProgram",
           args: [arch],
@@ -870,6 +878,7 @@ _.extend(AppRunner.prototype, {
           try {
             Promise.await(fn({
               // Miscellany that the callback might find useful.
+              pauseClient,
               refreshClient,
               runLog,
             }));

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -65,7 +65,6 @@ var AppProcess = function (options) {
   self.onExit = options.onExit;
   self.onListen = options.onListen;
   self.nodeOptions = options.nodeOptions || [];
-  self.nodePath = options.nodePath || [];
   self.inspect = options.inspect;
   self.settings = options.settings;
   self.testMetadata = options.testMetadata;
@@ -224,13 +223,6 @@ _.extend(AppProcess.prototype, {
 
     env.METEOR_PRINT_ON_LISTEN = 'true';
 
-    // use node's path module and not 'files.js' because NODE_PATH is an
-    // environment variable passed to an external process and needs to be
-    // constructed in the OS-style.
-    var path = require('path');
-    env.NODE_PATH =
-      self.nodePath.join(path.delimiter);
-
     return env;
   },
 
@@ -239,7 +231,6 @@ _.extend(AppProcess.prototype, {
     var self = this;
 
     // Path conversions
-    var nodePath = process.execPath; // This path is an OS path already
     var entryPoint = files.convertToOSPath(
       files.pathJoin(self.bundlePath, 'main.js'));
 
@@ -263,7 +254,7 @@ _.extend(AppProcess.prototype, {
     var child_process = require('child_process');
     // setup the 'ipc' pipe if further communication between app and proxy is
     // expected
-    var child = child_process.spawn(nodePath, opts, {
+    var child = child_process.spawn(process.execPath, opts, {
       env: self._computeEnvironment(),
       stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
     });
@@ -728,7 +719,6 @@ _.extend(AppRunner.prototype, {
         self._resolvePromise("start");
       },
       nodeOptions: getNodeOptionsFromEnvironment(),
-      nodePath: _.map(bundleResult.nodePath, files.convertToOSPath),
       settings: settings,
       testMetadata: self.testMetadata,
     });

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -196,13 +196,13 @@ var specialArgPaths = {
 
   "packages/dynamic-import.js": function (file) {
     var dynamicImportInfo = {};
+    var programsDir = path.dirname(serverDir);
+    var clientArchs = configJson.clientArchs ||
+      Object.keys(configJson.clientPaths);
 
-    Object.keys(configJson.clientPaths).map(function (key) {
-      var programJsonPath = path.resolve(configJson.clientPaths[key]);
-      var programJson = require(programJsonPath);
-
-      dynamicImportInfo[key] = {
-        dynamicRoot: path.join(path.dirname(programJsonPath), "dynamic")
+    clientArchs.forEach(function (arch) {
+      dynamicImportInfo[arch] = {
+        dynamicRoot: path.join(programsDir, arch, "dynamic")
       };
     });
 


### PR DESCRIPTION
Now that Meteor [builds two client bundles](https://blog.meteor.com/meteor-1-7-and-the-evergreen-dream-a8c1270b0901), build times have naturally increased a bit. We are hard at work attacking this problem from multiple angles, such as #9983, and I'm confident that Meteor 1.7.1 build times will be shorter for most apps than they were before Meteor 1.7, despite building both `web.browser` and `web.browser.legacy` bundles.

Nevertheless, since most testing in development happens using one bundle/browser at a time, it has been suggested (#9948) that we could skip the legacy build in development, as a cheap short-cut to faster rebuild times. To be honest, I don't love most of these ideas for disabling the legacy build with some sort of additional configuration, because supporting older browsers is important, configuration is a creeping cancer, and ignoring errors in the legacy build seems like a recipe for frustration when it's time to deploy your app.

I would vastly prefer a zero-configuration solution to this problem, though that's challenging in this case because skipping an important part of the build process seems like a decision the developer should make consciously and carefully.

As this pull request demonstrates, it's possible to remove the legacy build from the critical path to restarting the development server, so you can continue testing and developing your app while the legacy bundle is built in the background. There's nothing to configure, because the legacy bundle still gets built in roughly the same amount of time as before; you just don't have to wait for it to finish, if you aren't currently interested in testing legacy code.

How it works in detail:
* All bundles are built when the build tool first starts up, so that there is always a legacy bundle available, even if it's slightly stale, and commands like `meteor build` and `meteor deploy` still work as before.
* On each subsequent rebuild of the application, we delay starting the `web.browser.legacy` build until after all other builds have finished and the development server has restarted.
* If you access your application using a legacy browser before the legacy build has finished, you'll just get the previous (possibly slightly stale) legacy code. Not the end of the world!
* As soon as the legacy build finishes, the build process sends a message to the `webapp` package running in the server process to tell it to reload the latest legacy bundle.
* Any errors building the legacy bundle get reported in the same way as before.
* Once everything has finished, you'll see the following message in the console:
  ```
  => Finished delayed build of web.browser.legacy in 951ms
  ```
  This message means it's now safe to test your app in a legacy browser, if that's something you were trying to do.

In short, when we talk about zero-configuration here at the Meteor project, we mean something much  deeper than just picking sensible defaults. No, we are striving to eliminate the _need_ for configuration whenever and wherever we can. If you want to hear more about this cornerstone of the Meteor philosophy, check out this [Meteor Night talk](https://youtu.be/vpCotlPieIY?t=34m35s) that I recently gave about the Meteor 1.7 modern/legacy bundling system (or read the [slides](https://slides.com/benjamn/meteor-night-may-2018#/49)).