### PR TITLE
Update minifier.js to remove server and development code

### DIFF
--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -7,18 +7,18 @@ meteorJsMinify = function (source) {
   terser = terser || Npm.require("terser");
 
   try {
-    source = source
-      .replace(/Meteor\.isServer|Meteor\.isDevelopment|process\.env\.NODE_DEBUG/g, 'UGLYFYJS_FALSE')
-      .replace(/Meteor\.isClient|Meteor\.isProduction/g, 'UGLYFYJS_TRUE');
-    var terserResult = terser.minify(source, {
+    var terserSource = source
+      .replace(/\b(Meteor\.isServer|Meteor\.isDevelopment|process\.env\.NODE_DEBUG)\b/g, 'UGLIFYJS_FALSE')
+      .replace(/\b(Meteor\.isClient|Meteor\.isProduction)\b/g, 'UGLIFYJS_TRUE');
+    var terserResult = terser.minify(terserSource, {
       compress: {
         drop_debugger: false,
         unused: false,
         dead_code: true,
         global_defs: {
           "process.env.NODE_ENV": NODE_ENV,
-          UGLYFYJS_FALSE: false,
-          UGLYFYJS_TRUE: true
+          UGLIFYJS_FALSE: false,
+          UGLIFYJS_TRUE: true
         }
       },
       mangle: {

--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -7,13 +7,18 @@ meteorJsMinify = function (source) {
   terser = terser || Npm.require("terser");
 
   try {
+    source = source
+      .replace(/Meteor\.isServer|Meteor\.isDevelopment|process\.env\.NODE_DEBUG/g, 'UGLYFYJS_FALSE')
+      .replace(/Meteor\.isClient|Meteor\.isProduction/g, 'UGLYFYJS_TRUE');
     var terserResult = terser.minify(source, {
       compress: {
         drop_debugger: false,
         unused: false,
         dead_code: true,
         global_defs: {
-          "process.env.NODE_ENV": NODE_ENV
+          "process.env.NODE_ENV": NODE_ENV,
+          UGLYFYJS_FALSE: false,
+          UGLYFYJS_TRUE: true
         }
       },
       mangle: {


### PR DESCRIPTION
A very simple change inspired by https://github.com/ssrwpo/uglifyjs2 to remove server (`Meteor.isServer`) and development code (`Meteor.isDevelopment`) easily (and speeds up client-side execution by removing `Meteor.isClient` and `Meteor.isProduction`)

We do this by search-replacing first to get simple var names (UGLIFYJS_FALSE and UGLIFYJS_TRUE) for `terser` to replace during conditional compilation

Notes: 
1. In addition to reducing JS load, removing server-side code is desirable for security purposes (and protecting server-side code as well)
2. Tested in production and works great

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
