### PR TITLE
Limit size of DDP messages

### DIFF
--- a/packages/ddp-common/utils.js
+++ b/packages/ddp-common/utils.js
@@ -42,6 +42,7 @@ DDPCommon.SUPPORTED_DDP_VERSIONS = [ '1', 'pre2', 'pre1' ];
 
 DDPCommon.parseDDP = function (stringMessage) {
   try {
+    // Reject based on size of string here (Option 1/2)
     var msg = JSON.parse(stringMessage);
   } catch (e) {
     Meteor._debug("Discarding message with invalid JSON", stringMessage);
@@ -77,6 +78,7 @@ DDPCommon.parseDDP = function (stringMessage) {
 };
 
 DDPCommon.stringifyDDP = function (msg) {
+  // Reject based on size of buffer here (Option 2/2)
   const copy = EJSON.clone(msg);
 
   // swizzle 'changed' messages from 'fields undefined' rep to 'fields

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -475,6 +475,8 @@ _.extend(Session.prototype, {
   sendError: function (reason, offendingMessage) {
     var self = this;
     var msg = {msg: 'error', reason: reason};
+    
+    // Don't send offendingMessage back here
     if (offendingMessage)
       msg.offendingMessage = offendingMessage;
     self.send(msg);


### PR DESCRIPTION
To prevent DOS attacks, it can be important to limit the amount of resources a client can consume on the server. As such, there are three main things to accomplish:

1) Optionally limit the maximum size of DDP messages. I assume by default it'd be better to leave it uncapped.
2) Optionally limit the size of DDP error messages in easy to hit error conditions, like unconnected clients (i.e. clients that have not completed the DDP connect phase of the protocol)
3) Set a lower maximum size for unconnected clients which are perhaps easier to provision during a real DOS attack.

The first goal is rather easy to accomplish in the code (see comments in the PR commit), but I'd like to get feedback on whether a new env var should be used to control this or if there's another preferred way to control a setting like this.

The second goal is also easily mitigated by not replaying the initial (potentially large) message to the client. Would love feedback on whether or not this behavior should be the new default or whether another new env var should should be used to control this. It seems unlikely than an existing client would be dependent on the behavior, but could be possible. Leaving the field in the message, but blank or limited could be a backwards compatible middle group.

The third goal seems hard to accomplish before the message is parsed and potentially useless to do afterwards. Unfortunately, there's no way to differentiate a connect message from other message types until that happens so it seems necessary to parse the whole message and then reject it if its too large or otherwise problematic.

This PR is not ready to merge, just pointing out potential areas in the code that could be changed to accomplish goals desired here.