### PR TITLE
Request less than 4GB memory on 32-bit platforms

### DIFF
--- a/meteor
+++ b/meteor
@@ -132,7 +132,14 @@ fi
 # the script take precedence over $NODE_PATH; it used to be that users would
 # screw up their meteor installs by have a ~/node_modules
 
+if [ "$ARCH" = "i686" ]; then
+    # 32-bit platforms cannot request 4GB
+    MAX_OLD_SPACE_SIZE=3072
+else
+    MAX_OLD_SPACE_SIZE=4096
+fi
+
 exec "$DEV_BUNDLE/bin/node" \
-     --max-old-space-size=4096 \
+     --max-old-space-size=${MAX_OLD_SPACE_SIZE} \
      ${TOOL_NODE_FLAGS} \
      "$METEOR" "$@"


### PR DESCRIPTION
A recent commit (5c1ba3a85ec17141f02c61cea03044596c9b4a78) added a flag to request 4GB space for
node, which causes an immediate segmentation fault on 32-bit Linux. Fixes #10080 .

