### PR TITLE
Cache inter-process-messaging dependencies in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
             - v2-other-deps-cache-{{ .Branch }}-{{ .Revision }}
             - v2-other-deps-cache-{{ .Branch }}-
       - restore_cache:
-          keys: 
+          keys:
             - v1-test-groups-{{ .Branch }}
             - v1-test-groups-
       - run:
@@ -449,7 +449,7 @@ jobs:
           path: /tmp/core_dumps
       - store_artifacts:
           path: /tmp/memuse.txt
- 
+
   Test Group 6:
     <<: *build_machine_environment
     steps:
@@ -760,6 +760,7 @@ jobs:
             - packages/minifier-css/.npm/package/node_modules
             - packages/minifier-js/.npm/package/node_modules
             - packages/standard-minifier-css/.npm/plugin/minifyStdCSS/node_modules
+            - packages/inter-process-messaging/.npm/package/node_modules
       - save_cache:
           key: v2-other-deps-cache-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,8 @@ jobs:
             - package-npm-deps-cache-group1-v1-
       - restore_cache:
           keys:
-            - package-npm-deps-cache-group2-v1-{{ checksum "shrinkwraps.txt" }}
-            - package-npm-deps-cache-group2-v1-
+            - package-npm-deps-cache-group2-v2-{{ checksum "shrinkwraps.txt" }}
+            - package-npm-deps-cache-group2-v2-
       - restore_cache:
           keys:
             - v2-other-deps-cache-{{ .Branch }}-{{ .Revision }}
@@ -737,7 +737,7 @@ jobs:
             - packages/package-version-parser/.npm/package/node_modules
             - packages/boilerplate-generator/.npm/package/node_modules
       - save_cache:
-          key: package-npm-deps-cache-group2-v1-{{ checksum "shrinkwraps.txt" }}
+          key: package-npm-deps-cache-group2-v2-{{ checksum "shrinkwraps.txt" }}
           paths:
             - packages/xmlbuilder/.npm/package/node_modules
             - packages/logging/.npm/package/node_modules


### PR DESCRIPTION
With the creation of a new package that has npm dependencies and self-tests, there was a gap in the CircleCI cache. I've added the path for the dependencies to the list, so they will be picked up in the future.

Since we've already run some tests with the current set of dependencies, there is an existing immutable cache for the combined shrinkwrap checksum. To generate a new cache for the same checksum, I've bumped the version numbers on the cache keys. And since I've added the new deps to cache group 2, I've only bumped the version numbers for that group.