### PR TITLE
Cache fetch and mongo-decimal npm dependencies in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,8 @@ jobs:
             - package-npm-deps-cache-group1-v1-
       - restore_cache:
           keys:
-            - package-npm-deps-cache-group2-v2-{{ checksum "shrinkwraps.txt" }}
-            - package-npm-deps-cache-group2-v2-
+            - package-npm-deps-cache-group2-v3-{{ checksum "shrinkwraps.txt" }}
+            - package-npm-deps-cache-group2-v3-
       - restore_cache:
           keys:
             - v2-other-deps-cache-{{ .Branch }}-{{ .Revision }}
@@ -737,7 +737,7 @@ jobs:
             - packages/package-version-parser/.npm/package/node_modules
             - packages/boilerplate-generator/.npm/package/node_modules
       - save_cache:
-          key: package-npm-deps-cache-group2-v2-{{ checksum "shrinkwraps.txt" }}
+          key: package-npm-deps-cache-group2-v3-{{ checksum "shrinkwraps.txt" }}
           paths:
             - packages/xmlbuilder/.npm/package/node_modules
             - packages/logging/.npm/package/node_modules
@@ -761,6 +761,8 @@ jobs:
             - packages/minifier-js/.npm/package/node_modules
             - packages/standard-minifier-css/.npm/plugin/minifyStdCSS/node_modules
             - packages/inter-process-messaging/.npm/package/node_modules
+            - packages/fetch/.npm/package/node_modules
+            - packages/non-core/mongo-decimal/.npm/package/node_modules
       - save_cache:
           key: v2-other-deps-cache-{{ .Branch }}-{{ .Revision }}
           paths:


### PR DESCRIPTION
Upon closer inspection of the CircleCI logs after last night's [armageddon](https://status.circleci.com/incidents/yj497xcsqxxf), I realized that in #10085 I missed a few other new packages in the codebase that have npm dependencies available for caching.

This PR adds those to npm deps cache group 2 and bumps the version numbers in the keys again. I think I got 'em all this time. 🤞