### PR TITLE
Allow json5 in babelrc

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -1,5 +1,5 @@
 var semver = Npm.require("semver");
-
+var JSON5 = Npm.require("json5");
 /**
  * A compiler that can be instantiated with features and used inside
  * Plugin.registerCompiler
@@ -195,7 +195,7 @@ BCp._inferFromBabelRc = function (inputFile, babelOptions, cacheDeps) {
       try {
         this._babelrcCache[babelrcPath] = {
           controlFilePath: babelrcPath,
-          controlFileData: JSON.parse(
+          controlFileData: JSON5.parse(
             inputFile.readAndWatchFile(babelrcPath)),
           deps: Object.create(null),
         };

--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -201,7 +201,7 @@ BCp._inferFromBabelRc = function (inputFile, babelOptions, cacheDeps) {
         };
       } catch (e) {
         if (e instanceof SyntaxError) {
-          e.message = ".babelrc is not a valid JSON file: " + e.message;
+          e.message = ".babelrc is not a valid JSON5 file: " + e.message;
         }
         throw e;
       }

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -10,7 +10,8 @@ Package.describe({
 });
 
 Npm.depends({
-  'meteor-babel': '7.0.0-rc.1'
+  'meteor-babel': '7.0.0-rc.1',
+  'json5': '1.0.1'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Currently we cannot us json5 in babel files which are used by meteor. That's a bit counter intuitive as babel itself supports json5 and we share babel files between jest and meteor. So atm we cannot e.g. add comments in babel files which are used by meteor.

This pr changes the parser the use json5 instead - which as i get should be fully backwards compatible and is already included via babel.

- fixes #10068 

-----

Not sure how to properly add a test for this, but I tested locally by adding a json5 .babelrc and running from checkout:
```
{
  env: {
    test: {
      plugins: ['dynamic-import-node']
    }
  }
}
```