### PR TITLE
Remove underscore from reactive-dict and session packages

### DIFF
--- a/packages/reactive-dict/migration.js
+++ b/packages/reactive-dict/migration.js
@@ -1,10 +1,12 @@
 import { ReactiveDict } from './reactive-dict';
 
+const hasOwn = Object.prototype.hasOwnProperty;
+
 ReactiveDict._migratedDictData = {}; // name -> data
 ReactiveDict._dictsToMigrate = {}; // name -> ReactiveDict
 
 ReactiveDict._loadMigratedDict = function (dictName) {
-  if (_.has(ReactiveDict._migratedDictData, dictName)) {
+  if (hasOwn.call(ReactiveDict._migratedDictData, dictName)) {
     const data = ReactiveDict._migratedDictData[dictName];
     delete ReactiveDict._migratedDictData[dictName];
     return data;
@@ -14,7 +16,7 @@ ReactiveDict._loadMigratedDict = function (dictName) {
 };
 
 ReactiveDict._registerDictForMigrate = function (dictName, dict) {
-  if (_.has(ReactiveDict._dictsToMigrate, dictName))
+  if (hasOwn.call(ReactiveDict._dictsToMigrate, dictName))
     throw new Error("Duplicate ReactiveDict name: " + dictName);
 
   ReactiveDict._dictsToMigrate[dictName] = dict;

--- a/packages/reactive-dict/package.js
+++ b/packages/reactive-dict/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Reactive dictionary",
-  version: '1.2.0'
+  version: '1.2.1'
 });
 
 Package.onUse(function (api) {
-  api.use(['underscore', 'tracker', 'ejson', 'ecmascript']);
+  api.use(['tracker', 'ejson', 'ecmascript']);
   // If we are loading mongo-livedata, let you store ObjectIDs in it.
   api.use('mongo', {weak: true});
   api.mainModule('migration.js');
@@ -15,7 +15,6 @@ Package.onTest(function (api) {
   api.use('tinytest');
   api.use('reactive-dict');
   api.use('tracker');
-  api.use('underscore');
   api.use('reload');
   api.addFiles('reactive-dict-tests.js');
 });

--- a/packages/reactive-dict/reactive-dict-tests.js
+++ b/packages/reactive-dict/reactive-dict-tests.js
@@ -1,7 +1,7 @@
 Tinytest.add('ReactiveDict - set to undefined', function (test) {
   var dict = new ReactiveDict;
   dict.set('foo', undefined);
-  test.equal(_.keys(dict.all()), ['foo']);
+  test.equal(Object.keys(dict.all()), ['foo']);
   dict.setDefault('foo', 'bar');
   test.equal(dict.get('foo'), undefined);
 });
@@ -190,7 +190,7 @@ Tinytest.add('ReactiveDict - destroy works', function (test) {
   test.equal(equals, false);
   test.equal(equalsUndefined, true);
   test.equal(all, {});
-  
+
   // Shouldn't throw now that we've destroyed the previous dict
   dict = new ReactiveDict('test');
 });

--- a/packages/session/package.js
+++ b/packages/session/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Session variable",
-  version: '1.1.7'
+  version: '1.1.8'
 });
 
 Package.onUse(function (api) {
-  api.use(['underscore', 'reactive-dict', 'ejson'], 'client');
+  api.use(['reactive-dict', 'ejson'], 'client');
 
   // Session can work with or without reload, but if reload is present
   // it should load first so we can detect it at startup and populate


### PR DESCRIPTION
Targeting `release-1.7.1` branch because testing against `devel` is causing babel errors and I think our tests will fall over.

This is not a full modernization - just removing underscore, so there is less surface area for bugs.