### PR TITLE
Remove underscore from srp package

### DIFF
--- a/packages/srp/package.js
+++ b/packages/srp/package.js
@@ -5,12 +5,11 @@
 
 Package.describe({
   summary: "Library for Secure Remote Password (SRP) exchanges",
-  version: "1.0.10"
+  version: "1.0.11"
 });
 
 Package.onUse(function (api) {
   api.use(['random', 'check', 'sha'], ['client', 'server']);
-  api.use('underscore');
   api.export('SRP');
   api.addFiles(['biginteger.js', 'srp.js'],
                 ['client', 'server']);
@@ -19,6 +18,5 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   api.use('tinytest');
   api.use('srp', ['client', 'server']);
-  api.use('underscore');
   api.addFiles(['srp_tests.js'], ['client', 'server']);
 });

--- a/packages/srp/srp.js
+++ b/packages/srp/srp.js
@@ -77,9 +77,9 @@ var paramsFromOptions = function (options) {
   if (!options) // fast path
     return _defaults;
 
-  var ret = _.extend({}, _defaults);
+  var ret = { ..._defaults };
 
-  _.each(['N', 'g', 'k'], function (p) {
+  ['N', 'g', 'k'].forEach(function (p) {
     if (options[p]) {
       if (typeof options[p] === "string")
         ret[p] = new BigInteger(options[p], 16);


### PR DESCRIPTION
The `srp` (Secure Remote Password) package is required by the `accounts-password` package, so this change gets us one step closer to, if not completely, removing `underscore` from apps that have it solely due to use of the accounts packages.