### PR TITLE
Parse URL query parameters before it's destroyed

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -749,6 +749,13 @@ function runWebAppServer() {
     res.end();
   });
 
+  // Parse the query string into res.query. Used by oauth_server, but it's
+  // generally pretty handy..
+  //
+  // Do this before the next middleware destroys req.url if a path prefix
+  // is set to close #10111.
+  app.use(query());
+  
   function getPathParts(path) {
     const parts = path.split("/");
     while (parts[0] === "") parts.shift();
@@ -789,10 +796,6 @@ function runWebAppServer() {
 
     next();
   });
-
-  // Parse the query string into res.query. Used by oauth_server, but it's
-  // generally pretty handy..
-  app.use(query());
 
   // Serve static files from the manifest.
   // This is inspired by the 'static' middleware.


### PR DESCRIPTION
The inline middleware that strips the ROOT_URL_PATH_PREFIX destroys req.url. If this happens before the query parameters are parsed by use(query()) the query parameters are always missing. This causes OAuth authentication to fail when ROOT_URL_PATH_PREFIX is set.

A better fix would be to fix the path stripping logic so that it preserves the URL parameters, since other things may try to rely on them later. But this works for now.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
