### PR TITLE
CoffeeScript 2.3.1, support for setMinimumBrowserVersions

### DIFF
--- a/packages/non-core/coffeescript-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/non-core/coffeescript-compiler/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "coffeescript": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.2.1.tgz",
-      "integrity": "sha512-UFSs0WDed7ZiQGtWZ401PZnlgnP5jtlr4Gk+aPMTIkFkKY6Kz2gRp+WIu0QzllR30nV2XheicAhKwDJQcor6lg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.3.1.tgz",
+      "integrity": "sha512-DNJmSPMyiz+OjWYyuDXNBcFutDjP2TS2owsZ8YvT65hA8c5IdHWIBqdA3Yf/XHoK23d/f1HqLjQbEJJZJoeV1w=="
     },
     "source-map": {
       "version": "0.5.7",

--- a/packages/non-core/coffeescript-compiler/package.js
+++ b/packages/non-core/coffeescript-compiler/package.js
@@ -13,11 +13,11 @@ Package.describe({
   summary: 'Compiler for CoffeeScript code, supporting the coffeescript package',
   // This version of NPM `coffeescript` module, with _1, _2 etc.
   // If you change this, make sure to also update ../coffeescript/package.js to match.
-  version: '2.2.1_2'
+  version: '2.3.1_1'
 });
 
 Npm.depends({
-  'coffeescript': '2.2.1',
+  'coffeescript': '2.3.1',
   'source-map': '0.5.7'
 });
 

--- a/packages/non-core/coffeescript-compiler/package.js
+++ b/packages/non-core/coffeescript-compiler/package.js
@@ -13,7 +13,7 @@ Package.describe({
   summary: 'Compiler for CoffeeScript code, supporting the coffeescript package',
   // This version of NPM `coffeescript` module, with _1, _2 etc.
   // If you change this, make sure to also update ../coffeescript/package.js to match.
-  version: '2.2.1_1'
+  version: '2.2.1_2'
 });
 
 Npm.depends({
@@ -22,8 +22,8 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.use('babel-compiler@6.19.4||7.0.3');
-  api.use('ecmascript@0.10.3');
+  api.use('babel-compiler@6.24.7||7.1.1');
+  api.use('ecmascript@0.11.1');
 
   api.mainModule('coffeescript-compiler.js', 'server');
 

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'coffeescript',
-  summary: 'Javascript dialect with fewer braces and semicolons',
+  summary: 'JavaScript dialect with fewer braces and semicolons',
   // This package version should track the version of the `coffeescript-compiler`
   // package, because people will likely only have this one added to their apps;
   // so bumping the version of this package will be how they get newer versions

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -6,12 +6,12 @@ Package.describe({
   // so bumping the version of this package will be how they get newer versions
   // of `coffeescript-compiler`. If you change this, make sure to also update
   // ../coffeescript-compiler/package.js to match.
-  version: '2.2.1_1'
+  version: '2.2.1_2'
 });
 
 Package.registerBuildPlugin({
   name: 'compile-coffeescript',
-  use: ['caching-compiler@1.1.9', 'ecmascript@0.8.3', 'coffeescript-compiler@2.2.1_1'],
+  use: ['caching-compiler@1.1.12', 'ecmascript@0.11.1', 'coffeescript-compiler@2.2.1_2'],
   sources: ['compile-coffeescript.js']
 });
 
@@ -24,10 +24,10 @@ Package.onUse(function (api) {
   // same runtime environment that the 'ecmascript' package provides.
   // The following api.imply calls should match those in ../../ecmascript/package.js,
   // except that coffeescript does not api.imply('modules').
-  api.imply('ecmascript-runtime@0.5.0');
-  api.imply('babel-runtime@1.2.2');
-  api.imply('promise@0.10.1');
-  api.imply('dynamic-import@0.3.0');
+  api.imply('ecmascript-runtime@0.7.0');
+  api.imply('babel-runtime@1.2.4');
+  api.imply('promise@0.11.1');
+  api.imply('dynamic-import@0.4.1');
 });
 
 Package.onTest(function (api) {

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -31,7 +31,7 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use(['coffeescript', 'tinytest']);
+  api.use(['coffeescript', 'tinytest', 'modern-browsers']);
   api.use(['coffeescript-test-helper', 'ecmascript'], ['client', 'server']); // Need ecmascript to compile tests/es2015_module.js
   api.addFiles('tests/bare_test_setup.coffee', ['client'], {bare: true});
   api.addFiles('tests/bare_tests.js', ['client']);
@@ -45,4 +45,5 @@ Package.onTest(function (api) {
     'tests/litcoffeescript_tests.coffee.md',
     'tests/coffeescript_tests.js'
   ], ['client', 'server']);
+  api.addFiles('tests/modern_browsers.coffee', ['server']);
 });

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -6,12 +6,12 @@ Package.describe({
   // so bumping the version of this package will be how they get newer versions
   // of `coffeescript-compiler`. If you change this, make sure to also update
   // ../coffeescript-compiler/package.js to match.
-  version: '2.2.1_2'
+  version: '2.3.1_1'
 });
 
 Package.registerBuildPlugin({
   name: 'compile-coffeescript',
-  use: ['caching-compiler@1.1.12', 'ecmascript@0.11.1', 'coffeescript-compiler@2.2.1_2'],
+  use: ['caching-compiler@1.1.12', 'ecmascript@0.11.1', 'coffeescript-compiler@2.3.1_1'],
   sources: ['compile-coffeescript.js']
 });
 

--- a/packages/non-core/coffeescript/tests/bare_tests.js
+++ b/packages/non-core/coffeescript/tests/bare_tests.js
@@ -1,3 +1,5 @@
+import { Tinytest } from "meteor/tinytest";
+
 Tinytest.add("coffeescript - bare", function (test) {
   test.equal(VariableSetByCoffeeBareTestSetup, 5678);
 });

--- a/packages/non-core/coffeescript/tests/coffeescript_strict_tests.coffee
+++ b/packages/non-core/coffeescript/tests/coffeescript_strict_tests.coffee
@@ -9,4 +9,4 @@ x in y
 
 Tinytest.add "coffeescript - shared", (test) ->
   test.equal share.coffeeShared, 789
-  test.equal sharedFromJavascript, 135
+  test.equal sharedFromJavaScript, 135

--- a/packages/non-core/coffeescript/tests/coffeescript_test_setup.js
+++ b/packages/non-core/coffeescript/tests/coffeescript_test_setup.js
@@ -1,1 +1,1 @@
-sharedFromJavascript = 135;
+sharedFromJavaScript = 135;

--- a/packages/non-core/coffeescript/tests/coffeescript_tests.coffee
+++ b/packages/non-core/coffeescript/tests/coffeescript_tests.coffee
@@ -48,6 +48,7 @@ Tinytest.add "coffeescript - JSX", (test) ->
   test.isTrue <div>Hello from JSX!</div> is '<div>Hello from JSX!</div>'
 
 
-Tinytest.add "coffeescript - modern browsers", (test) ->
-  klass = class Klass
-  test.isTrue klass.toString().startsWith 'class'
+if Meteor.isModern
+  Tinytest.add "coffeescript - modern browsers", (test) ->
+    klass = class Klass
+    test.isTrue klass.toString().startsWith 'class'

--- a/packages/non-core/coffeescript/tests/coffeescript_tests.coffee
+++ b/packages/non-core/coffeescript/tests/coffeescript_tests.coffee
@@ -1,3 +1,7 @@
+import { Meteor } from "meteor/meteor"
+import { Tinytest } from "meteor/tinytest"
+
+
 Meteor.__COFFEESCRIPT_PRESENT = true
 
 # This is read in coffeescript_strict_tests.coffee.
@@ -20,12 +24,12 @@ import { Meteor as testingForNativeImportedSymbol } from "meteor/meteor"
 Tinytest.add "coffeescript - import external package via native import statement", (test) ->
   test.isTrue testingForNativeImportedSymbol?
 
-import { testingForImportedModule123456789 } from "./es2015_module.js";
+import { testingForImportedModule123456789 } from "./es2015_module.js"
 Tinytest.add "coffeescript - import local module via native import statement", (test) ->
   test.isTrue testingForImportedModule123456789?
 
 
-import { testingForNativeImportedModule123456789 } from "./coffeescript_module.coffee";
+import { testingForNativeImportedModule123456789 } from "./coffeescript_module.coffee"
 Tinytest.add "coffeescript - import local module exported by a CoffeeScript native export statement, via native import statement", (test) ->
   test.isTrue testingForNativeImportedModule123456789?
 
@@ -35,10 +39,15 @@ Tinytest.add "coffeescript - ES2015 conformity", (test) ->
   f = (a = 1) -> a
   test.isTrue f(null) is null # `f(null)` would be 1 in CoffeeScript 1.x
 
-# JSX
+
 Tinytest.add "coffeescript - JSX", (test) ->
   # Mock React
   React =
     createElement: (tag, attributes, body) ->
       "<#{tag}>#{body}</#{tag}>"
   test.isTrue <div>Hello from JSX!</div> is '<div>Hello from JSX!</div>'
+
+
+Tinytest.add "coffeescript - modern browsers", (test) ->
+  klass = class Klass
+  test.isTrue klass.toString().startsWith 'class'

--- a/packages/non-core/coffeescript/tests/coffeescript_tests.js
+++ b/packages/non-core/coffeescript/tests/coffeescript_tests.js
@@ -1,3 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import { Tinytest } from "meteor/tinytest";
+
 Tinytest.add("coffeescript - presence", function(test) {
   test.isTrue(Meteor.__COFFEESCRIPT_PRESENT);
 });

--- a/packages/non-core/coffeescript/tests/litcoffeescript_tests.coffee.md
+++ b/packages/non-core/coffeescript/tests/litcoffeescript_tests.coffee.md
@@ -1,6 +1,9 @@
-This file is just the same as `coffeescript_tests.coffee`, first we set a 
+This file is just the same as `coffeescript_tests.coffee`, first we set a
 property, which we check for in `coffeescript_tests.js`, and then a trivial
 testcase.
+
+    import { Meteor } from "meteor/meteor"
+    import { Tinytest } from "meteor/tinytest"
 
     Meteor.__COFFEEMDSCRIPT_PRESENT = true
     Tinytest.add "markdown coffeescript - compile", (test) -> test.isTrue true

--- a/packages/non-core/coffeescript/tests/litcoffeescript_tests.litcoffee
+++ b/packages/non-core/coffeescript/tests/litcoffeescript_tests.litcoffee
@@ -1,6 +1,9 @@
-This file is just the same as `coffeescript_tests.coffee`, first we set a 
+This file is just the same as `coffeescript_tests.coffee`, first we set a
 property, which we check for in `coffeescript_tests.js`, and then a trivial
 testcase.
+
+    import { Meteor } from "meteor/meteor"
+    import { Tinytest } from "meteor/tinytest"
 
     Meteor.__LITCOFFEESCRIPT_PRESENT = true
     Tinytest.add "literate coffeescript - compile", (test) -> test.isTrue true

--- a/packages/non-core/coffeescript/tests/modern_browsers.coffee
+++ b/packages/non-core/coffeescript/tests/modern_browsers.coffee
@@ -1,0 +1,12 @@
+import { setMinimumBrowserVersions } from "meteor/modern-browsers"
+
+setMinimumBrowserVersions
+  chrome: 49
+  firefox: 45
+  edge: 12
+  ie: Infinity
+  mobileSafari: [9, 2]
+  opera: 36
+  safari: 9
+  electron: 1
+, 'classes'


### PR DESCRIPTION
@benjamn All I needed to do to add support for `setMinimumBrowserVersions`/the `modern-browsers` package was update the versions of the Meteor core packages that the `coffeescript` package was depending on. Once `coffeescript` was using the latest `ecmascript`, `caching-compiler` and so on, `setMinimumBrowserVersions` just started working.

While I was at it, I updated to the latest CoffeeScript and added some missing `import` statements and did some other general cleanup.

I can’t really find a good test for `setMinimumBrowserVersions` in the codebase; from what I can tell, my browser always gets the modern bundle when I load the tests app, whether or not I call `setMinimumBrowserVersions`. Please let me know if there’s some way to make this test more robust, or if I should take it out.

I tested in a real app created via `meteor create coffeetest` with the `.js` files converted into CoffeeScript and me adding a class and ensuring that the JS bundle output by Meteor preserved the `class` keyword. It does (using these new versions of the packages).