### PR TITLE
Cordova plugin handling algorithm consistency improvements

### DIFF
--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -432,15 +432,16 @@ from Cordova project`, async () => {
   // tell us if plugins have been fetched from a Git SHA URL or a local path.
   // So we overwrite the declared versions with versions from
   // listFetchedPluginVersions that do contain this information.
-  listInstalledPluginVersions() {
+  listInstalledPluginVersions(usePluginInfoId = false) {
     const pluginInfoProvider = new PluginInfoProvider();
     const installedPluginVersions = pluginInfoProvider.getAllWithinSearchPath(
       files.convertToOSPath(this.pluginsDir));
     const fetchedPluginVersions = this.listFetchedPluginVersions();
     return _.object(installedPluginVersions.map(pluginInfo => {
-      const id = pluginInfo.id;
-      const version = fetchedPluginVersions[id] || pluginInfo.version;
-      return [id, version];
+      const fetchedPlugin = fetchedPluginVersions[pluginInfo.id];
+      const id = fetchedPlugin.id;
+      const version = fetchedPlugin.version || pluginInfo.version;
+      return [usePluginInfoId ? pluginInfo.id : id, version];
     }));
   }
 
@@ -459,17 +460,21 @@ from Cordova project`, async () => {
 
     const fetchedPluginsMetadata = JSON.parse(files.readFile(
       fetchJsonPath, 'utf8'));
-    return _.object(_.map(fetchedPluginsMetadata, (metadata, id) => {
+    return _.object(_.map(fetchedPluginsMetadata, (metadata, name) => {
       const source = metadata.source;
+
+      const idWithVersion = source.id ? source.id : name;
+      const scoped = idWithVersion[0] === '@';
+      const id = `${scoped ? '@' : ''}${idWithVersion.split('@')[scoped ? 1 : 0]}`;
       let version;
       if (source.type === 'registry') {
-        version = source.id.split('@')[1];
+        version = idWithVersion.split('@')[scoped ? 2 : 1];
       } else if (source.type === 'git') {
-        version = `${source.url}#${source.ref}`;
+        version = `${source.url}${'ref' in source ? `#${source.ref}` : ''}`;
       } else if (source.type === 'local') {
         version = `file://${source.path}`;
       }
-      return [id, version];
+      return [name, { id, version }];
     }));
   }
 
@@ -521,9 +526,7 @@ from Cordova project`, async () => {
         { cli_variables: config, link: utils.isUrlWithFileScheme(version) });
 
       this.runCommands(`adding plugin ${target} \
-to Cordova project`, async () => {
-        await cordova_lib.plugin('add', [target], commandOptions);
-      });
+to Cordova project`, cordova_lib.plugin.bind(undefined, 'add', [target], commandOptions));
     }
   }
 
@@ -534,9 +537,7 @@ to Cordova project`, async () => {
     }
 
     this.runCommands(`removing plugins ${plugins} \
-from Cordova project`, async () => {
-      await cordova_lib.plugin('rm', plugins, this.defaultOptions);
-    });
+from Cordova project`, cordova_lib.plugin.bind(undefined, 'rm', plugins, this.defaultOptions));
   }
 
   // Ensures that the Cordova plugins are synchronized with the app-level
@@ -606,28 +607,57 @@ mobile-config.js accordingly.`);
             installedPluginVersions[id] !== version) {
             // We do not have the plugin installed or the version has changed.
             shouldReinstallAllPlugins = true;
+            Console.debug(`Plugin ${id} version have changed or it was added, will \
+perform cordova plugins reinstall`);
           }
         }
       });
 
-      if (!_.isEmpty(pluginsFromLocalPath)) {
-        Console.debug('Reinstalling Cordova plugins added from the local path');
-      }
+      const installedPluginsByName = Object.keys(this.listInstalledPluginVersions(true));
 
       // Check to see if we have any installed plugins that are not in the
       // current set of plugins.
-      _.each(installedPluginVersions, (version, id) => {
-        if (!_.has(pluginVersions, id)) {
-          shouldReinstallAllPlugins = true;
-        }
-      });
+      if (!shouldReinstallAllPlugins) {
+        // We need to know which plugins were installed because they were
+        // declared in cordova-plugins and which are just dependencies of others.
+        // Luckily for us android.json and ios.json have that information.
+        const androidJsonPath = files.pathJoin(this.pluginsDir, 'android.json');
+        const iosJsonPath = files.pathJoin(this.pluginsDir, 'ios.json');
+
+        const androidJson = files.exists(androidJsonPath) ? JSON.parse(files.readFile(
+          androidJsonPath, 'utf8')) : { installed_plugins: {} };
+        const iosJson = files.exists(iosJsonPath) ? JSON.parse(files.readFile(
+          iosJsonPath, 'utf8')) : { installed_plugins: {} };
+
+        let previouslyInstalledPlugins = _.union(
+          Object.keys(androidJson.installed_plugins), Object.keys(iosJson.installed_plugins));
+
+        // Now the problem is we have a list of names the plugins (name defined in the plugin.xml)
+        // while in cordova-plugins we have can have their npm ids. We need to translate the list.
+        const fetched = this.listFetchedPluginVersions();
+        previouslyInstalledPlugins = previouslyInstalledPlugins.map(name => {
+          return fetched[name].id;
+        });
+
+        previouslyInstalledPlugins.forEach(id => {
+          if (!_.has(pluginVersions, id)) {
+            Console.debug(`Plugin ${id} was removed, will \
+perform cordova plugins reinstall`);
+            shouldReinstallAllPlugins = true;
+          }
+        });
+      }
+
+      if (!_.isEmpty(pluginsFromLocalPath) && !shouldReinstallAllPlugins) {
+        Console.debug('Reinstalling Cordova plugins added from the local path');
+      }
 
       // We either reinstall all plugins or only those fetched from a local
       // path.
       if (shouldReinstallAllPlugins || !_.isEmpty(pluginsFromLocalPath)) {
         let pluginsToRemove;
         if (shouldReinstallAllPlugins) {
-          pluginsToRemove = Object.keys(installedPluginVersions);
+          pluginsToRemove = installedPluginsByName;
         } else {
           // Only try to remove plugins that are currently installed.
           pluginsToRemove = _.intersection(
@@ -659,53 +689,49 @@ mobile-config.js accordingly.`);
           });
         });
 
-        logIfVerbose('Validating Cordova plugins installation');
         this.ensurePluginsWereInstalled(pluginVersionsToInstall, pluginsConfiguration, true);
       }
     });
   }
 
   // Ensures that the Cordova plugins are installed
-  ensurePluginsWereInstalled(requiredPlugins, pluginsConfiguration, tryInstall) {
-    // List of all installed plugins. This should work for global / local / private cordova plugins.
+  ensurePluginsWereInstalled(requiredPlugins, pluginsConfiguration, retryInstall) {
+    // List of all installed plugins. This should work for global / local / scoped cordova plugins.
     // Examples:
     // cordova-plugin-whitelist@1.3.2 => { 'cordova-plugin-whitelist': '1.3.2' }
     // com.cordova.plugin@file://.cordova-plugins/plugin => { 'com.cordova.plugin': 'file://.cordova-plugins/plugin' }
-    // @darqs/plugin@1.0.0 => { 'com.cordova.plugin': 'darqs/plugin' }
+    // @scope/plugin@1.0.0 => { 'com.cordova.plugin': 'scope/plugin' }
     const installed = this.listInstalledPluginVersions();
-    const installedName = Object.keys(installed);
-    const installedValue = Object.values(installed);
-    const missedPlugins = {};
+    const installedPluginsNames = Object.keys(installed);
+    const installedPluginsVersions = Object.values(installed);
+    const missingPlugins = {};
+
     Object.keys(requiredPlugins).filter(plugin => {
-      if (installedName.includes(plugin)) {
-        logIfVerbose(`Plugin ${plugin} was installed.`);
-      } else if (plugin[0] === '@' && installedValue.includes(plugin.substr(1))) {
-        logIfVerbose(`Plugin ${plugin} was installed from private npm repository.`);
-      } else if (tryInstall) {
-        log(`Plugin ${plugin} wasn't installed. Trying again...`);
-        this.addPlugin(
-          plugin,
-          requiredPlugins[plugin],
-          pluginsConfiguration[plugin]
-        );
-        missedPlugins[plugin] = requiredPlugins[plugin];
-      } else {
-        log(`Plugin ${plugin} wasn't installed.`);
-        missedPlugins[plugin] = requiredPlugins[plugin];
+      if (!installedPluginsNames.includes(plugin)) {
+        Console.debug(`Plugin ${plugin} was not installed.`);
+        if (retryInstall) {
+          Console.debug(`Retrying to install ${plugin}.`);
+          this.addPlugin(
+            plugin,
+            requiredPlugins[plugin],
+            pluginsConfiguration[plugin]
+          );
+        }
+        missingPlugins[plugin] = requiredPlugins[plugin];
       }
     });
 
-    // All plugin were installed
-    if (Object.keys(missedPlugins).length === 0) {
+    // All plugins were installed
+    if (Object.keys(missingPlugins).length === 0) {
       return;
     }
 
-    // Check one more time after reinstallation
-    if (tryInstall) {
-      this.ensurePluginsWereInstalled(missedPlugins, pluginsConfiguration, false);
+    // Check one more time after re-installation.
+    if (retryInstall) {
+      this.ensurePluginsWereInstalled(missingPlugins, pluginsConfiguration, false);
     } else {
-      // Fail, to prevent build and publishing faulty mobile app without some of the Cordova plugins
-      throw new Error(`Some Cordova plugins wasn't installed`);
+      // Fail, to prevent building and publishing faulty mobile app without at this moment we need to stop.
+      throw new Error(`Some Cordova plugins installation failed: (${Object.keys(missingPlugins).join(', ')}).`);
     }
   }
 

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1446,26 +1446,43 @@ class Target {
     }
   }
 
+  // Overrides a cordova dependency version.
+  _overrideCordovaDependencyVersion(scoped, id, name, version) {
+    if (!scoped) {
+      this.cordovaDependencies[id] = version;
+    } else {
+      if (id in this.cordovaDependencies) {
+        delete this.cordovaDependencies[id];
+      }
+      this.cordovaDependencies[name] = version;
+    }
+  }
+
   // Add a Cordova plugin dependency to the target. If the same plugin
   // has already been added at a different version and `override` is
   // false, use whichever version is newest. If `override` is true, then
   // we always add the exact version specified, overriding any other
   // version that has already been added.
+  // Additionally we need to be sure that a cordova-plugin-name gets
+  // overriden with @scope/cordova-plugin-name.
   _addCordovaDependency(name, version, override) {
     if (! this.cordovaDependencies) {
       return;
     }
+    const scoped = name[0] === '@';
+    const id = scoped ? name.split('/')[1] : name;
 
     if (override) {
-      this.cordovaDependencies[name] = version;
+      this._overrideCordovaDependencyVersion(scoped, id, name, version);
     } else {
-      if (_.has(this.cordovaDependencies, name)) {
-        var existingVersion = this.cordovaDependencies[name];
+      if (_.has(this.cordovaDependencies, id)) {
+        const existingVersion = this.cordovaDependencies[id];
 
         if (existingVersion === version) { return; }
 
-        this.cordovaDependencies[name] = packageVersionParser.
+        const versionToSet = packageVersionParser.
           lessThan(existingVersion, version) ? version : existingVersion;
+          this._overrideCordovaDependencyVersion(scoped, id, name, versionToSet);
       } else {
         this.cordovaDependencies[name] = version;
       }


### PR DESCRIPTION
This strives to fix several issues with cordova integration plugins handling:

Fixes several cases causing cordova plugins reinstall on every build:
- proper handling of scoped npm cordova plugins (adding one would cause reinstall on every build)
- proper detection of plugin removal (previously a cordova plugin containing a dependency would make the algorithm think a package was removed from cordova-plugins)
- proper handling of plugins which have plugin.xml id different than the npm package name

Additionally:
- rechecks the build integrity verifying if packages were really installed and perform a retry if needed.
- allows to override a meteor package cordova dependency with scoped package i.e. @scope/cordova-dummy-plugin will now override a cordova-dummy-plugin dependency. (now in this case the same plugin will be installed twice, cordova will leave the last one installed)
- fixes `<dependency id="es6-promise-plugin" url="https://github.com/vstirbu/PromisesPlugin.git"/>` being translated by `listFetchedPluginVersions` as `https://github.com/vstirbu/PromisesPlugin.git#undefined`

The main benefit is that the full plugins uninstall and reinstall will only happen on plugin being updated, removed or added. Now for most projects it happens every build even though cordova-plugins file did not change. Additionally because cordova_lib is not handling properly the promises from plugin remove a situation is happening when plugins are missing - this adds a re-check of plugins state and retries to add missing plugins.

Fixes: https://github.com/meteor/meteor/issues/9548 https://github.com/meteor/meteor/issues/9973
