### PR TITLE
adding *breaking changes* and *migration steps* sections to History.MD

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,16 @@
 
 ## v1.7.1, TBD
 
+### Breaking changes
+N/A
+
+### Migration Steps
+* Update `@babel/runtime` npm package to version 7.0.0-beta.56 or later
+```sh
+    meteor npm install @babel/runtime@latest
+```
+
+### Changes
 * Meteor 1.7 introduced a new client bundle called `web.browser.legacy` in
   addition to the `web.browser` (modern) and `web.cordova` bundles.
   Naturally, this extra bundle increased client (re)build times. Since


### PR DESCRIPTION
Creating two new sections for each release note on History.MD text: *breaking changes* and *migration steps*.

I think it's better than currently that we need to read everything to find these important parts.

Discussed here: https://github.com/meteor/meteor/pull/9942#issuecomment-419479182