### PR TITLE
Exposing information about target architeture

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -105,7 +105,7 @@ BCp.processOneFileForTarget = function (inputFile, source) {
     }
 
     var babelOptions = Babel.getDefaultOptions(extraFeatures);
-    babelOptions.caller = {name: 'meteor', arch: arch};
+    babelOptions.caller = { name: "meteor", arch };
 
     this.inferExtraBabelOptions(
       inputFile,

--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -105,6 +105,7 @@ BCp.processOneFileForTarget = function (inputFile, source) {
     }
 
     var babelOptions = Babel.getDefaultOptions(extraFeatures);
+    babelOptions.caller = {name: 'meteor', arch: arch};
 
     this.inferExtraBabelOptions(
       inputFile,


### PR DESCRIPTION
When creating plugin it can be useful to have accessible info about target architecture of current transpilation. Plugin could therefore alter transformations of code. Based on architecture it would be possible to determine whether result will be run on server or client and therefore hide some critical logic or perform different operations. This allows for more isomorphic code which could be easier to write.

meteor/meteor-feature-requests#326