### PR TITLE
Make array-field sorting compatible with mongo 3.6+ behavior

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## v.NEXT
 
+* Minimongo's behavior for sorting fields containing an array
+  is now compatible with the behavior of [Mongo 3.6+](https://docs.mongodb.com/manual/release-notes/3.6-compatibility/#array-sort-behavior).
+  Note that this means it is now incompatible with the behavior of earlier MongoDB versions.
+  [PR #10214](https://github.com/meteor/meteor/pull/10214)
+
 * Meteor's `self-test` has been updated to use "headless" Chrome rather
   than PhantomJS for browser tests. PhantomJS can still be forced by
   passing the `--phantom` flag to the `meteor self-test` command.

--- a/packages/minimongo/cursor.js
+++ b/packages/minimongo/cursor.js
@@ -19,10 +19,7 @@ export default class Cursor {
       this._selectorId = undefined;
 
       if (this.matcher.hasGeoQuery() || options.sort) {
-        this.sorter = new Minimongo.Sorter(
-          options.sort || [],
-          {matcher: this.matcher}
-        );
+        this.sorter = new Minimongo.Sorter(options.sort || []);
       }
     }
 

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -2197,10 +2197,10 @@ Tinytest.add('minimongo - array sort', test => {
   // Similarly, "selected" is the index that the doc should have in the query
   // that sorts ascending on "a.x" and selects {'a.x': {$gt: 1}}. In this case,
   // the 1 in [1, 4] may not be used as a sort key.
-  c.insert({up: 1, down: 1, selected: 2, a: {x: [1, 4]}});
-  c.insert({up: 2, down: 2, selected: 0, a: [{x: [2]}, {x: 3}]});
+  c.insert({up: 1, down: 1, selected: 0, a: {x: [1, 4]}});
+  c.insert({up: 2, down: 2, selected: 1, a: [{x: [2]}, {x: 3}]});
   c.insert({up: 0, down: 4,              a: {x: 0}});
-  c.insert({up: 3, down: 3, selected: 1, a: {x: 2.5}});
+  c.insert({up: 3, down: 3, selected: 2, a: {x: 2.5}});
   c.insert({up: 4, down: 0, selected: 3, a: {x: 5}});
 
   // Test that the the documents in "cursor" contain values with the name
@@ -2281,87 +2281,6 @@ Tinytest.add('minimongo - sort keys', test => {
   testParallelError({'a.x': 1, 'a.y': 1},
     {a: [{x: 1, y: [2, 3]},
       {x: 2, y: [4, 5]}]});
-});
-
-Tinytest.add('minimongo - sort key filter', test => {
-  const testOrder = (sortSpec, selector, doc1, doc2) => {
-    const matcher = new Minimongo.Matcher(selector);
-    const sorter = new Minimongo.Sorter(sortSpec, {matcher});
-    const comparator = sorter.getComparator();
-    const comparison = comparator(doc1, doc2);
-    test.isTrue(comparison < 0);
-  };
-
-  testOrder({'a.x': 1}, {'a.x': {$gt: 1}},
-    {a: {x: 3}},
-    {a: {x: [1, 4]}});
-  testOrder({'a.x': 1}, {'a.x': {$gt: 0}},
-    {a: {x: [1, 4]}},
-    {a: {x: 3}});
-
-  const keyCompatible = (sortSpec, selector, key, compatible) => {
-    const matcher = new Minimongo.Matcher(selector);
-    const sorter = new Minimongo.Sorter(sortSpec, {matcher});
-    const actual = sorter._keyCompatibleWithSelector(key);
-    test.equal(actual, compatible);
-  };
-
-  keyCompatible({a: 1}, {a: 5}, [5], true);
-  keyCompatible({a: 1}, {a: 5}, [8], false);
-  keyCompatible({a: 1}, {a: {x: 5}}, [{x: 5}], true);
-  keyCompatible({a: 1}, {a: {x: 5}}, [{x: 5, y: 9}], false);
-  keyCompatible({'a.x': 1}, {a: {x: 5}}, [5], true);
-  // To confirm this:
-  //   > db.x.insert({_id: "q", a: [{x:1}, {x:5}], b: 2})
-  //   > db.x.insert({_id: "w", a: [{x:5}, {x:10}], b: 1})
-  //   > db.x.find({}).sort({'a.x': 1, b: 1})
-  //   { "_id" : "q", "a" : [  {  "x" : 1 },  {  "x" : 5 } ], "b" : 2 }
-  //   { "_id" : "w", "a" : [  {  "x" : 5 },  {  "x" : 10 } ], "b" : 1 }
-  //   > db.x.find({a: {x:5}}).sort({'a.x': 1, b: 1})
-  //   { "_id" : "q", "a" : [  {  "x" : 1 },  {  "x" : 5 } ], "b" : 2 }
-  //   { "_id" : "w", "a" : [  {  "x" : 5 },  {  "x" : 10 } ], "b" : 1 }
-  //   > db.x.find({'a.x': 5}).sort({'a.x': 1, b: 1})
-  //   { "_id" : "w", "a" : [  {  "x" : 5 },  {  "x" : 10 } ], "b" : 1 }
-  //   { "_id" : "q", "a" : [  {  "x" : 1 },  {  "x" : 5 } ], "b" : 2 }
-  // ie, only the last one manages to trigger the key compatibility code,
-  // not the previous one.  (The "b" sort is necessary because when the key
-  // compatibility code *does* kick in, both documents only end up with "5"
-  // for the first field as their only sort key, and we need to differentiate
-  // somehow...)
-  keyCompatible({'a.x': 1}, {a: {x: 5}}, [1], true);
-  keyCompatible({'a.x': 1}, {'a.x': 5}, [5], true);
-  keyCompatible({'a.x': 1}, {'a.x': 5}, [1], false);
-
-  // Regex key check.
-  keyCompatible({a: 1}, {a: /^foo+/}, ['foo'], true);
-  keyCompatible({a: 1}, {a: /^foo+/}, ['foooo'], true);
-  keyCompatible({a: 1}, {a: /^foo+/}, ['foooobar'], true);
-  keyCompatible({a: 1}, {a: /^foo+/}, ['afoooo'], false);
-  keyCompatible({a: 1}, {a: /^foo+/}, [''], false);
-  keyCompatible({a: 1}, {a: {$regex: '^foo+'}}, ['foo'], true);
-  keyCompatible({a: 1}, {a: {$regex: '^foo+'}}, ['foooo'], true);
-  keyCompatible({a: 1}, {a: {$regex: '^foo+'}}, ['foooobar'], true);
-  keyCompatible({a: 1}, {a: {$regex: '^foo+'}}, ['afoooo'], false);
-  keyCompatible({a: 1}, {a: {$regex: '^foo+'}}, [''], false);
-
-  keyCompatible({a: 1}, {a: /^foo+/i}, ['foo'], true);
-  // Key compatibility check appears to be turned off for regexps with flags.
-  keyCompatible({a: 1}, {a: /^foo+/i}, ['bar'], true);
-  keyCompatible({a: 1}, {a: /^foo+/m}, ['bar'], true);
-  keyCompatible({a: 1}, {a: {$regex: '^foo+', $options: 'i'}}, ['bar'], true);
-  keyCompatible({a: 1}, {a: {$regex: '^foo+', $options: 'm'}}, ['bar'], true);
-
-  // Multiple keys!
-  keyCompatible({a: 1, b: 1, c: 1},
-    {a: {$gt: 5}, c: {$lt: 3}}, [6, 'bla', 2], true);
-  keyCompatible({a: 1, b: 1, c: 1},
-    {a: {$gt: 5}, c: {$lt: 3}}, [6, 'bla', 4], false);
-  keyCompatible({a: 1, b: 1, c: 1},
-    {a: {$gt: 5}, c: {$lt: 3}}, [3, 'bla', 1], false);
-  // No filtering is done (ie, all keys are compatible) if the first key isn't
-  // constrained.
-  keyCompatible({a: 1, b: 1, c: 1},
-    {c: {$lt: 3}}, [3, 'bla', 4], true);
 });
 
 Tinytest.add('minimongo - sort function', test => {

--- a/packages/minimongo/sorter.js
+++ b/packages/minimongo/sorter.js
@@ -22,7 +22,7 @@ import {
 // first, or 0 if neither object comes before the other.
 
 export default class Sorter {
-  constructor(spec, options = {}) {
+  constructor(spec) {
     this._sortSpecParts = [];
     this._sortFunction = null;
 
@@ -82,15 +82,6 @@ export default class Sorter {
     this._keyComparator = composeComparators(
       this._sortSpecParts.map((spec, i) => this._keyFieldComparator(i))
     );
-
-    // If you specify a matcher for this Sorter, _keyFilter may be set to a
-    // function which selects whether or not a given "sort key" (tuple of values
-    // for the different sort spec fields) is compatible with the selector.
-    this._keyFilter = null;
-
-    if (options.matcher) {
-      this._useWithMatcher(options.matcher);
-    }
   }
 
   getComparator(options) {
@@ -279,10 +270,6 @@ export default class Sorter {
     let minKey = null;
 
     this._generateKeysFromDoc(doc, key => {
-      if (!this._keyCompatibleWithSelector(key)) {
-        return;
-      }
-
       if (minKey === null) {
         minKey = key;
         return;
@@ -306,10 +293,6 @@ export default class Sorter {
     return this._sortSpecParts.map(part => part.path);
   }
 
-  _keyCompatibleWithSelector(key) {
-    return !this._keyFilter || this._keyFilter(key);
-  }
-
   // Given an index 'i', returns a comparator that compares two key arrays based
   // on field 'i'.
   _keyFieldComparator(i) {
@@ -319,132 +302,6 @@ export default class Sorter {
       const compare = LocalCollection._f._cmp(key1[i], key2[i]);
       return invert ? -compare : compare;
     };
-  }
-
-  // In MongoDB, if you have documents
-  //    {_id: 'x', a: [1, 10]} and
-  //    {_id: 'y', a: [5, 15]},
-  // then C.find({}, {sort: {a: 1}}) puts x before y (1 comes before 5).
-  // But  C.find({a: {$gt: 3}}, {sort: {a: 1}}) puts y before x (1 does not
-  // match the selector, and 5 comes before 10).
-  //
-  // The way this works is pretty subtle!  For example, if the documents
-  // are instead {_id: 'x', a: [{x: 1}, {x: 10}]}) and
-  //             {_id: 'y', a: [{x: 5}, {x: 15}]}),
-  // then C.find({'a.x': {$gt: 3}}, {sort: {'a.x': 1}}) and
-  //      C.find({a: {$elemMatch: {x: {$gt: 3}}}}, {sort: {'a.x': 1}})
-  // both follow this rule (y before x).  (ie, you do have to apply this
-  // through $elemMatch.)
-  //
-  // So if you pass a matcher to this sorter's constructor, we will attempt to
-  // skip sort keys that don't match the selector. The logic here is pretty
-  // subtle and undocumented; we've gotten as close as we can figure out based
-  // on our understanding of Mongo's behavior.
-  _useWithMatcher(matcher) {
-    if (this._keyFilter) {
-      throw Error('called _useWithMatcher twice?');
-    }
-
-    // If we are only sorting by distance, then we're not going to bother to
-    // build a key filter.
-    // XXX figure out how geoqueries interact with this stuff
-    if (!this._sortSpecParts.length) {
-      return;
-    }
-
-    const selector = matcher._selector;
-
-    // If the user just passed a falsey selector to find(),
-    // then we can't get a key filter from it.
-    if (!selector) {
-      return;
-    }
-
-    // If the user just passed a literal function to find(), then we can't get a
-    // key filter from it.
-    if (selector instanceof Function) {
-      return;
-    }
-
-    const constraintsByPath = {};
-
-    this._sortSpecParts.forEach(spec => {
-      constraintsByPath[spec.path] = [];
-    });
-
-    Object.keys(selector).forEach(key => {
-      const subSelector = selector[key];
-
-      // XXX support $and and $or
-      const constraints = constraintsByPath[key];
-      if (!constraints) {
-        return;
-      }
-
-      // XXX it looks like the real MongoDB implementation isn't "does the
-      // regexp match" but "does the value fall into a range named by the
-      // literal prefix of the regexp", ie "foo" in /^foo(bar|baz)+/  But
-      // "does the regexp match" is a good approximation.
-      if (subSelector instanceof RegExp) {
-        // As far as we can tell, using either of the options that both we and
-        // MongoDB support ('i' and 'm') disables use of the key filter. This
-        // makes sense: MongoDB mostly appears to be calculating ranges of an
-        // index to use, which means it only cares about regexps that match
-        // one range (with a literal prefix), and both 'i' and 'm' prevent the
-        // literal prefix of the regexp from actually meaning one range.
-        if (subSelector.ignoreCase || subSelector.multiline) {
-          return;
-        }
-
-        constraints.push(regexpElementMatcher(subSelector));
-        return;
-      }
-
-      if (isOperatorObject(subSelector)) {
-        Object.keys(subSelector).forEach(operator => {
-          const operand = subSelector[operator];
-
-          if (['$lt', '$lte', '$gt', '$gte'].includes(operator)) {
-            // XXX this depends on us knowing that these operators don't use any
-            // of the arguments to compileElementSelector other than operand.
-            constraints.push(
-              ELEMENT_OPERATORS[operator].compileElementSelector(operand)
-            );
-          }
-
-          // See comments in the RegExp block above.
-          if (operator === '$regex' && !subSelector.$options) {
-            constraints.push(
-              ELEMENT_OPERATORS.$regex.compileElementSelector(
-                operand,
-                subSelector
-              )
-            );
-          }
-
-          // XXX support {$exists: true}, $mod, $type, $in, $elemMatch
-        });
-
-        return;
-      }
-
-      // OK, it's an equality thing.
-      constraints.push(equalityElementMatcher(subSelector));
-    });
-
-    // It appears that the first sort field is treated differently from the
-    // others; we shouldn't create a key filter unless the first sort field is
-    // restricted, though after that point we can restrict the other sort fields
-    // or not as we wish.
-    if (!constraintsByPath[this._sortSpecParts[0].path].length) {
-      return;
-    }
-
-    this._keyFilter = key =>
-      this._sortSpecParts.every((specPart, index) =>
-        constraintsByPath[specPart.path].every(fn => fn(key[index]))
-      )
-    ;
   }
 }
 

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1316,8 +1316,7 @@ MongoConnection.prototype._observeChanges = function (
         if (!cursorDescription.options.sort)
           return true;
         try {
-          sorter = new Minimongo.Sorter(cursorDescription.options.sort,
-                                        { matcher: matcher });
+          sorter = new Minimongo.Sorter(cursorDescription.options.sort);
           return true;
         } catch (e) {
           // XXX make all compilation errors MinimongoError or something


### PR DESCRIPTION
Fixes https://github.com/meteor/meteor/issues/10212 . Note that while it is now compatible with Mongo 3.6+, it's incompatible with mongo < 3.6