### PR TITLE
Remove `mongo` dependency from `autoupdate` package

### DIFF
--- a/packages/autoupdate/client_versions.js
+++ b/packages/autoupdate/client_versions.js
@@ -1,0 +1,104 @@
+import { Tracker } from "meteor/tracker";
+
+export class ClientVersions {
+  constructor() {
+    this._versions = new Map();
+    this._watchCallbacks = new Set();
+  }
+
+  // Creates a Livedata store for use with `Meteor.connection.registerStore`.
+  // After the store is registered, document updates reported by Livedata are
+  // merged with the documents in this `ClientVersions` instance.
+  createStore() {
+    return {
+      update: ({ id, msg, fields }) => {
+        if (msg === "added" || msg === "changed") {
+          this.set(id, fields);
+        }
+      }
+    };
+  }
+
+  hasVersions() {
+    return this._versions.size > 0;
+  }
+
+  get(id) {
+    return this._versions.get(id);
+  }
+
+  // Adds or updates a version document and invokes registered callbacks for the
+  // added/updated document. If a document with the given ID already exists, its
+  // fields are merged with `fields`.
+  set(id, fields) {
+    let version = this._versions.get(id);
+    let isNew = false;
+
+    if (version) {
+      Object.assign(version, fields);
+    } else {
+      version = {
+        _id: id,
+        ...fields
+      };
+
+      isNew = true;
+      this._versions.set(id, version);
+    }
+
+    this._watchCallbacks.forEach(({ fn, filter }) => {
+      if (! filter || filter === version._id) {
+        fn(version, isNew);
+      }
+    });
+  }
+
+  // Registers a callback that will be invoked when a version document is added
+  // or changed. Calling the function returned by `watch` removes the callback.
+  // If `skipInitial` is true, the callback isn't be invoked for existing
+  // documents. If `filter` is set, the callback is only invoked for documents
+  // with ID `filter`.
+  watch(fn, { skipInitial, filter } = {}) {
+    if (! skipInitial) {
+      const resolved = Promise.resolve();
+
+      this._versions.forEach((version) => {
+        if (! filter || filter === version._id) {
+          resolved.then(() => fn(version, true));
+        }
+      });
+    }
+
+    const callback = { fn, filter };
+    this._watchCallbacks.add(callback);
+
+    return () => this._watchCallbacks.delete(callback);
+  }
+
+  // A reactive data source for `Autoupdate.newClientAvailable`.
+  newClientAvailable(id, fields, currentVersion) {
+    function isNewVersion(version) {
+      return (
+        version._id === id &&
+        fields.some((field) => version[field] !== currentVersion[field])
+      );
+    }
+
+    const dependency = new Tracker.Dependency();
+    const version = this.get(id);
+
+    dependency.depend();
+
+    const stop = this.watch(
+      (version) => {
+        if (isNewVersion(version)) {
+          dependency.changed();
+          stop();
+        }
+      },
+      { skipInitial: true }
+    );
+
+    return !! version && isNewVersion(version);
+  }
+}

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -15,6 +15,8 @@ Package.onUse(function (api) {
     'retry'
   ], 'client');
 
+  api.use('reload', 'client', { weak: true });
+
   api.use([
     'ecmascript',
     'ddp'

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -17,8 +17,7 @@ Package.onUse(function (api) {
 
   api.use([
     'ecmascript',
-    'ddp',
-    'mongo',
+    'ddp'
   ], ['client', 'server']);
 
   api.mainModule('autoupdate_server.js', 'server');

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -34,11 +34,6 @@ Package.onUse(function (api) {
   api.use('facts-base', 'server', {weak: true});
 
   api.use('callback-hook', 'server');
-
-  // we depend on LocalCollection._diffObjects, _applyChanges,
-  // _idParse, _idStringify.
-  api.use('minimongo', 'server');
-
   api.export('DDPServer', 'server');
 
   api.addFiles('stream_server.js', 'server');

--- a/packages/reactive-dict/package.js
+++ b/packages/reactive-dict/package.js
@@ -6,7 +6,7 @@ Package.describe({
 Package.onUse(function (api) {
   api.use(['tracker', 'ejson', 'ecmascript']);
   // If we are loading mongo-livedata, let you store ObjectIDs in it.
-  api.use('mongo', {weak: true});
+  api.use(['mongo', 'reload'], { weak: true });
   api.mainModule('migration.js');
   api.export('ReactiveDict');
 });

--- a/tools/tests/apps/hot-code-push-test/hot-code-push-test.js
+++ b/tools/tests/apps/hot-code-push-test/hot-code-push-test.js
@@ -3,7 +3,7 @@ if (Meteor.isClient) {
 
   var maybeCall = function () {
     var A = Package.autoupdate.Autoupdate;
-    if (A._ClientVersions.findOne() && ! A.newClientAvailable()) {
+    if (A._clientVersions.hasVersions() && ! A.newClientAvailable()) {
       Meteor.call("clientLoad",
                   typeof jsVar === 'undefined' ? 'undefined' : jsVar,
                   typeof packageVar === 'undefined' ? 'undefined' : packageVar,

--- a/tools/tests/apps/standard-app/.meteor/packages
+++ b/tools/tests/apps/standard-app/.meteor/packages
@@ -4,4 +4,5 @@
 # but you can also edit it by hand.
 
 meteor-base
+mongo
 standard-minifiers

--- a/tools/tests/cordova-plugins.js
+++ b/tools/tests/cordova-plugins.js
@@ -142,8 +142,6 @@ selftest.define("change cordova plugins", ["cordova"], function () {
   run = s.run();
   run.match("myapp");
   run.match("proxy");
-  run.waitSecs(30);
-  run.match("MongoDB");
   run.match("your app");
   run.match("running at");
   run.match("localhost");

--- a/tools/tests/custom-minifier.js
+++ b/tools/tests/custom-minifier.js
@@ -12,7 +12,6 @@ selftest.define('custom minifier - devel vs prod', function (options) {
     run.waitSecs(5);
     run.match('myapp');
     run.match('proxy');
-    run.match('MongoDB');
 
     run.connectClient();
     run.waitSecs(20);
@@ -32,7 +31,6 @@ selftest.define('custom minifier - devel vs prod', function (options) {
     run.waitSecs(5);
     run.match('myapp');
     run.match('proxy');
-    run.match('MongoDB');
 
     run.connectClient();
     run.waitSecs(20);

--- a/tools/tests/hot-code-push.js
+++ b/tools/tests/hot-code-push.js
@@ -14,7 +14,6 @@ selftest.define("css hot code push", function (options) {
   s.testWithAllClients(function (run) {
     run.match("myapp");
     run.match("proxy");
-    run.match("MongoDB");
     run.match("running at");
     run.match("localhost");
 
@@ -109,7 +108,6 @@ selftest.define("versioning hot code push", function (options) {
   s.testWithAllClients(function (run) {
     run.match("myapp");
     run.match("proxy");
-    run.match("MongoDB");
     run.match("running at");
     run.match("localhost");
     run.connectClient();
@@ -133,7 +131,6 @@ selftest.define("javascript hot code push", function (options) {
   s.testWithAllClients(function (run) {
     run.match("myapp");
     run.match("proxy");
-    run.match("MongoDB");
     run.match("running at");
     run.match("localhost");
 

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -108,8 +108,6 @@ selftest.define("change packages during hot code push", [], function () {
   run.match("myapp");
   run.match("proxy");
   run.waitSecs(5);
-  run.match("MongoDB");
-  run.waitSecs(5);
   run.match("your app");
   run.waitSecs(5);
   run.match("running at");
@@ -160,7 +158,6 @@ selftest.define("change packages during hot code push", [], function () {
   run.waitSecs(5);
   run.match("myapp");
   run.match("proxy");
-  run.match("MongoDB");
   run.waitSecs(5);
   run.match("louder");  // the package actually loaded
 
@@ -363,8 +360,6 @@ selftest.define("add packages client archs", function (options) {
       run.waitSecs(5);
       run.match("myapp");
       run.match("proxy");
-      run.waitSecs(5);
-      run.match("MongoDB");
       run.waitSecs(5);
       run.match("running at");
       run.match("localhost");
@@ -981,8 +976,6 @@ selftest.define("tilde version constraints", [], function () {
   run.match("tilde-app");
   run.match("proxy");
   run.waitSecs(10);
-  run.match("MongoDB");
-  run.waitSecs(10);
   run.match("your app");
   run.waitSecs(10);
   run.match("running at");
@@ -1136,8 +1129,6 @@ selftest.define("override version constraints", [], function () {
 
   run.match("override-app");
   run.match("proxy");
-  run.waitSecs(10);
-  run.match("MongoDB");
   run.waitSecs(10);
   run.match("your app");
   run.waitSecs(10);

--- a/tools/tests/stylus-cross-packages.js
+++ b/tools/tests/stylus-cross-packages.js
@@ -12,7 +12,6 @@ selftest.define("can import stylus across packages", function (options) {
   s.testWithAllClients(function (run) {
     run.match("myapp");
     run.match("proxy");
-    run.match("MongoDB");
     run.match("running at");
     run.match("localhost");
 


### PR DESCRIPTION
The `autoupdate` package uses a local `Mongo.Collection` (i.e., not synchronized with MongoDB) to store hashes of current client resources, which are used to notify clients when new resources are available (in development and production). However, the collection is only used for storage and simple update operations for which a `Map` would be sufficient. If a Meteor app doesn't otherwise use MongoDB or Minimongo, this causes MongoDB to be started unnecessarily and a lot of unused code to be included in the client bundles.

This PR replaces the collection with a `Map`-based implementation, which reduces the bundle size (un-gzipped) by up to 63 kB.

To do:
- [x]  Find out if Minimongo can be removed on the server, too.
- [x] Test changes with Cordova.