### PR TITLE
Update terser to 3.9.2

### DIFF
--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -18,12 +18,8 @@ meteorJsMinify = function (source) {
       },
       // Fix issue #9866, as explained in this comment:
       // https://github.com/mishoo/UglifyJS2/issues/1753#issuecomment-324814782
+      // And fix terser issue #117: https://github.com/terser-js/terser/issues/117
       safari10: true,
-      mangle: {
-        // Fix safari issue related to catch clause scoping
-        // https://github.com/terser-js/terser/issues/117
-        ie8: true,
-      }
     });
 
     if (typeof terserResult.code === "string") {

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Npm.depends({
-  terser: "3.9.1"
+  terser: "3.9.2"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Right after https://github.com/meteor/meteor/pull/10239 got merged, terser `3.9.2` got released with a fix for https://github.com/terser-js/terser/issues/117 . The previous pull request added the `ie8` option to workaround that specific safari bug.

However, since IE 8 hasn't been supported for a while ( https://github.com/meteor/meteor/issues/7761#issuecomment-247546074 ), it seems safer to only include the workarounds that are really necessary, to minimize the risk breaking compliant browsers.