### PR TITLE
[autoupdate] be able to determine the current update status

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -25,7 +25,7 @@
 // The client version of the client code currently running in the
 // browser.
 
-import { ClientVersions } from "./client_versions.js";
+import { AutoUpdateBase } from "./autoupdate_client_base";
 
 const clientArch = Meteor.isCordova ? "web.cordova" :
   Meteor.isModern ? "web.browser" : "web.browser.legacy";
@@ -38,163 +38,123 @@ const autoupdateVersions =
     assets: [],
   };
 
-export const Autoupdate = {};
-
-// Stores acceptable client versions.
-const clientVersions =
-  Autoupdate._clientVersions = // Used by a self-test.
-  new ClientVersions();
-
-Meteor.connection.registerStore(
-  "meteor_autoupdate_clientVersions",
-  clientVersions.createStore()
-);
-
-Autoupdate.newClientAvailable = function () {
-  return clientVersions.newClientAvailable(
-    clientArch,
-    ["versionRefreshable", "versionNonRefreshable"],
-    autoupdateVersions
-  );
-};
-
 // Set to true if the link.onload callback ever fires for any <link> node.
 let knownToSupportCssOnLoad = false;
 
-const retry = new Retry({
-  // Unlike the stream reconnect use of Retry, which we want to be instant
-  // in normal operation, this is a wacky failure. We don't want to retry
-  // right away, we can start slowly.
-  //
-  // A better way than timeconstants here might be to use the knowledge
-  // of when we reconnect to help trigger these retries. Typically, the
-  // server fixing code will result in a restart and reconnect, but
-  // potentially the subscription could have a transient error.
-  minCount: 0, // don't do any immediate retries
-  baseTimeout: 30*1000 // start with 30s
-});
+class AutoUpdateClient extends AutoUpdateBase {
+  newClientAvailable = () => {
+    return this._clientVersions.newClientAvailable(
+      clientArch,
+      ["versionRefreshable", "versionNonRefreshable"],
+      autoupdateVersions
+    );
+  };
 
-let failures = 0;
-
-Autoupdate._retrySubscription = () => {
-  Meteor.subscribe("meteor_autoupdate_clientVersions", {
-    onError(error) {
-      Meteor._debug("autoupdate subscription failed", error);
-      failures++;
-      retry.retryLater(failures, function () {
-        // Just retry making the subscription, don't reload the whole
-        // page. While reloading would catch more cases (for example,
-        // the server went back a version and is now doing old-style hot
-        // code push), it would also be more prone to reload loops,
-        // which look really bad to the user. Just retrying the
-        // subscription over DDP means it is at least possible to fix by
-        // updating the server.
-        Autoupdate._retrySubscription();
-      });
-    },
-
-    onReady() {
-      // Call checkNewVersionDocument with a slight delay, so that the
-      // const handle declaration is guaranteed to be initialized, even if
-      // the added or changed callbacks are called synchronously.
-      const resolved = Promise.resolve();
-      function check(doc) {
-        resolved.then(() => checkNewVersionDocument(doc));
-      }
-
-      const stop = clientVersions.watch(check);
-
-      function checkNewVersionDocument(doc) {
-        if (doc._id !== clientArch) {
-          return;
-        }
-
-        if (doc.versionNonRefreshable !==
-            autoupdateVersions.versionNonRefreshable) {
-          // Non-refreshable assets have changed, so we have to reload the
-          // whole page rather than just replacing <link> tags.
-          if (stop) stop();
-          if (Package.reload) {
-            // The reload package should be provided by ddp-client, which
-            // is provided by the ddp package that autoupdate depends on.
-            Package.reload.Reload._reload();
-          }
-          return;
-        }
-
-        if (doc.versionRefreshable !== autoupdateVersions.versionRefreshable) {
-          autoupdateVersions.versionRefreshable = doc.versionRefreshable;
-
-          // Switch out old css links for the new css links. Inspired by:
-          // https://github.com/guard/guard-livereload/blob/master/js/livereload.js#L710
-          var newCss = doc.assets || [];
-          var oldLinks = [];
-
-          Array.prototype.forEach.call(
-            document.getElementsByTagName('link'),
-            function (link) {
-              if (link.className === '__meteor-css__') {
-                oldLinks.push(link);
-              }
-            }
-          );
-
-          function waitUntilCssLoads(link, callback) {
-            var called;
-
-            link.onload = function () {
-              knownToSupportCssOnLoad = true;
-              if (! called) {
-                called = true;
-                callback();
-              }
-            };
-
-            if (! knownToSupportCssOnLoad) {
-              var id = Meteor.setInterval(function () {
-                if (link.sheet) {
-                  if (! called) {
-                    called = true;
-                    callback();
-                  }
-                  Meteor.clearInterval(id);
-                }
-              }, 50);
-            }
-          }
-
-          let newLinksLeftToLoad = newCss.length;
-          function removeOldLinks() {
-            if (oldLinks.length > 0 &&
-                --newLinksLeftToLoad < 1) {
-              oldLinks.splice(0).forEach(link => {
-                link.parentNode.removeChild(link);
-              });
-            }
-          }
-
-          if (newCss.length > 0) {
-            newCss.forEach(css => {
-              const newLink = document.createElement("link");
-              newLink.setAttribute("rel", "stylesheet");
-              newLink.setAttribute("type", "text/css");
-              newLink.setAttribute("class", "__meteor-css__");
-              newLink.setAttribute("href", css.url);
-
-              waitUntilCssLoads(newLink, function () {
-                Meteor.setTimeout(removeOldLinks, 200);
-              });
-
-              const head = document.getElementsByTagName("head").item(0);
-              head.appendChild(newLink);
-            });
-          } else {
-            removeOldLinks();
-          }
-        }
-      }
+  _onReady = () => {
+    // Call checkNewVersionDocument with a slight delay, so that the
+    // const handle declaration is guaranteed to be initialized, even if
+    // the added or changed callbacks are called synchronously.
+    const resolved = Promise.resolve();
+    function check(doc) {
+      resolved.then(() => checkNewVersionDocument(doc));
     }
-  });
-};
+
+    const stop = this._clientVersions.watch(check);
+
+    const checkNewVersionDocument = (doc) => {
+      if (doc._id !== clientArch) {
+        return;
+      }
+
+      if (doc.versionNonRefreshable !==
+        autoupdateVersions.versionNonRefreshable) {
+        // Non-refreshable assets have changed, so we have to reload the
+        // whole page rather than just replacing <link> tags.
+        if (stop) stop();
+        this._setStatus('outdated');
+        if (Package.reload) {
+          // The reload package should be provided by ddp-client, which
+          // is provided by the ddp package that autoupdate depends on.
+          Package.reload.Reload._reload();
+        }
+        return;
+      }
+
+      if (doc.versionRefreshable !== autoupdateVersions.versionRefreshable) {
+        autoupdateVersions.versionRefreshable = doc.versionRefreshable;
+
+        // Switch out old css links for the new css links. Inspired by:
+        // https://github.com/guard/guard-livereload/blob/master/js/livereload.js#L710
+        var newCss = doc.assets || [];
+        var oldLinks = [];
+
+        Array.prototype.forEach.call(
+          document.getElementsByTagName('link'),
+          function (link) {
+            if (link.className === '__meteor-css__') {
+              oldLinks.push(link);
+            }
+          }
+        );
+
+        function waitUntilCssLoads(link, callback) {
+          var called;
+
+          link.onload = function () {
+            knownToSupportCssOnLoad = true;
+            if (! called) {
+              called = true;
+              callback();
+            }
+          };
+
+          if (! knownToSupportCssOnLoad) {
+            var id = Meteor.setInterval(function () {
+              if (link.sheet) {
+                if (! called) {
+                  called = true;
+                  callback();
+                }
+                Meteor.clearInterval(id);
+              }
+            }, 50);
+          }
+        }
+
+        let newLinksLeftToLoad = newCss.length;
+        function removeOldLinks() {
+          if (oldLinks.length > 0 &&
+            --newLinksLeftToLoad < 1) {
+            oldLinks.splice(0).forEach(link => {
+              link.parentNode.removeChild(link);
+            });
+          }
+        }
+
+        if (newCss.length > 0) {
+          newCss.forEach(css => {
+            const newLink = document.createElement("link");
+            newLink.setAttribute("rel", "stylesheet");
+            newLink.setAttribute("type", "text/css");
+            newLink.setAttribute("class", "__meteor-css__");
+            newLink.setAttribute("href", css.url);
+
+            waitUntilCssLoads(newLink, function () {
+              Meteor.setTimeout(removeOldLinks, 200);
+            });
+
+            const head = document.getElementsByTagName("head").item(0);
+            head.appendChild(newLink);
+          });
+        } else {
+          removeOldLinks();
+        }
+      }
+      this._setStatus('uptodate');
+    };
+  };
+}
+
+export const Autoupdate = new AutoUpdateClient();
 
 Autoupdate._retrySubscription();

--- a/packages/autoupdate/autoupdate_client_base.js
+++ b/packages/autoupdate/autoupdate_client_base.js
@@ -1,0 +1,144 @@
+// Provides reactive status updates as an reactive dict.
+//
+// Status can be one of:
+// "undefined": Autoupdate has been initialized but has not run yet
+// "connecting": a subscription attempt is currently ongoing
+// "uptodate": the current version matches the newest version
+// "outdated": a newer version has been found
+// "loading": the bundle is currently being downloaded (Cordova only)
+// "waiting":
+// a. either the latest version could not be fetched or
+// b. downloading the bundle failed (Cordova only).
+// In both cases a new check has been rescheduled.
+//
+// When status is in "waiting" state, "retryCount" describes the number of times
+// a check has been tried while "retryTime" describes the estimated time of
+// the next attempt. To turn "retryTime" into an interval until the next
+// reconnection, use retryTime - (new Date()).getTime()
+// Both values will be reset on a successful check ("uptodate" or "outdated")
+// or when Autoupdate.retry() is manually called.
+
+import { Retry } from "meteor/retry";
+import { Tracker } from "meteor/tracker";
+import { ClientVersions } from "./client_versions";
+
+export class AutoUpdateBase {
+  constructor(options = {}) {
+    // Stores acceptable client versions.
+    this._clientVersions = new ClientVersions();
+
+    Meteor.connection.registerStore(
+      "meteor_autoupdate_clientVersions",
+      this._clientVersions.createStore()
+    );
+
+    this._appId = options.appId;
+
+    this._retry = new Retry({
+      // Unlike the stream reconnect use of Retry, which we want to be instant
+      // in normal operation, this is a wacky failure. We don't want to retry
+      // right away, we can start slowly.
+      //
+      // A better way than timeconstants here might be to use the knowledge
+      // of when we reconnect to help trigger these retries. Typically, the
+      // server fixing code will result in a restart and reconnect, but
+      // potentially the subscription could have a transient error.
+      minCount: 0, // don't do any immediate retries
+      baseTimeout: 30 * 1000, // start with 30s
+    });
+
+    //// Reactive status
+    this._currentStatus = {
+      status: undefined,
+      retryCount: 0,
+      retryTime: undefined,
+    };
+
+    this._statusListeners = new Tracker.Dependency();
+  }
+
+  _statusChanged = () => {
+    if (this._statusListeners) {
+      this._statusListeners.changed();
+    }
+  };
+
+  _setStatus(status) {
+    if (status === this._currentStatus.status) return;
+    this._currentStatus.status = status;
+    // reset retryCount only on successful status updates
+    if (status === 'outdated' || status === 'uptodate') {
+      this._currentStatus.retryCount = 0;
+    }
+    this._currentStatus.retryTime = undefined;
+    this._statusChanged();
+  }
+
+  _retryLater() {
+    this._currentStatus.retryCount += 1;
+    const timeout = this._retry.retryLater(
+      this._currentStatus.retryCount,
+      () => this._retrySubscription()
+    );
+    this._currentStatus.status = 'waiting';
+    this._currentStatus.retryTime = new Date().getTime() + timeout;
+    this._statusChanged();
+  }
+
+  newClientAvailable = () => {
+    throw new Error('not implemented');
+  };
+
+  _onReady = () => {
+    throw new Error('not implemented');
+  };
+
+  _onError = (error) => {
+    Meteor._debug("autoupdate subscription failed", error);
+    // Just retry making the subscription, don't reload the whole
+    // page. While reloading would catch more cases (for example,
+    // the server went back a version and is now doing old-style hot
+    // code push), it would also be more prone to reload loops,
+    // which look really bad to the user. Just retrying the
+    // subscription over DDP means it is at least possible to fix by
+    // updating the server.
+    this._retryLater();
+  };
+
+  _retrySubscription() {
+    this._currentStatus.status = 'connecting';
+    this._currentStatus.retryTime = undefined;
+    this._statusChanged();
+    this.handle = Meteor.subscribe(
+      "meteor_autoupdate_clientVersions",
+      this._appId,
+      {
+        onError: this._onError,
+        onReady: this._onReady,
+      })
+  }
+
+  // Get current status. Reactive.
+  status = () => {
+    if (this._statusListeners) {
+      this._statusListeners.depend();
+    }
+    return this._currentStatus;
+  };
+
+  // only allow retries when a check is currently waiting to be retried,
+  // i.e. this method will short circuit the waiting process
+  retry() {
+    if (this._currentStatus.status === 'waiting') {
+      if (this.handle) this.handle.stop();
+      this._retry.clear();
+      // since this function is called manually reset retry related states
+      this._currentStatus.retryCount = 0;
+      this._currentStatus.retryTime = undefined;
+      this._statusChanged();
+      return true;
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
The purpose of this feature being able to determine the current status of `autoupdate`.
This makes dealing with HCP a lot easier if for example HCP should be controlled by the user.
The API is inspired by https://docs.meteor.com/api/connections.html#Meteor-status, the new property `Àutoupdate.status()` is a reactive data source which returns `{status, retryCount, retryTime}`.

Like in https://docs.meteor.com/api/connections.html#Meteor-reconnect `Autoupdate.retry()` has been added to be able to retry an update if the current `Àutoupdate.status().status` is in `waiting` state (e.g. a check failed and was rescheduled).

There is no breaking API change, just the behavior of `WebAppLocalServer.checkForUpdates()` changed as from now on the update check will be rescheduled on failure.

It was somehow cumbersome to achieve this without refactoring the code, hopefully, this is welcomed and I did not overstep the mark in terms of the contributing guidelines.

#### Todo (help needed)
- [ ] Determine a proper way to catch errors from `WebAppLocalServer` in Cordova, https://github.com/meteor/meteor/pull/10249/commits/7edf47cd42f4d880402bc06ad4bc797e66e0fc6d#diff-18b4baa4a385e9189014310db650068aR51 did not fire on errors discussed in https://github.com/meteor/meteor/issues/10277
- [ ] Why is [stop](https://github.com/meteor/meteor/commit/7edf47cd42f4d880402bc06ad4bc797e66e0fc6d#diff-aa9bb979275c59a3e432306e669f1fe0R62) not used in Cordova as well, possible bug? 
