### PR TITLE
Ignore inline source maps when minifying CSS files.

### DIFF
--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.5.0',
+  version: '1.5.1',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -120,7 +120,8 @@ var mergeCss = Profile("mergeCss", function (css) {
   // Add the contents of the input files to the source map of the new file
   stringifiedCss.map.sourcesContent =
     stringifiedCss.map.sources.map(function (filename) {
-      return originals[filename].getContentsAsString();
+      const file = originals[filename] || null;
+      return file && file.getContentsAsString();
     });
 
   // Compose the concatenated file's source map with source maps from the

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -51,6 +51,11 @@ var hashFiles = Profile("hashFiles", function (files) {
   return hash.digest("hex");
 });
 
+function disableSourceMappingURLs(css) {
+  return css.replace(/# sourceMappingURL=/g,
+                     "# sourceMappingURL_DISABLED=");
+}
+
 // Lints CSS files and merges them into one file, fixing up source maps and
 // pulling any @import directives up to the top since the CSS spec does not
 // allow them to appear in the middle of a file.
@@ -69,7 +74,8 @@ var mergeCss = Profile("mergeCss", function (css) {
     originals[filename] = file;
     try {
       var parseOptions = { source: filename, position: true };
-      var ast = CssTools.parseCss(file.getContentsAsString(), parseOptions);
+      var css = disableSourceMappingURLs(file.getContentsAsString());
+      var ast = CssTools.parseCss(css, parseOptions);
       ast.filename = filename;
     } catch (e) {
       if (e.reason) {


### PR DESCRIPTION
https://github.com/meteor/meteor/issues/10112#issuecomment-428646872

Further down in the `mergeCss` function, when we call `CssTools.stringifyCss`, we pass the following option:
```js
// don't try to read the referenced sourcemaps from the input
inputSourcemaps: false
```

Apparently this isn't enough to avoid reading inline source maps from the input file, so we should be a bit more aggressive about preventing `postcss` from picking up inline source maps.

This change mostly affects `.css` files imported from `node_modules`, and possibly raw `.css` files in the application that happen to have inline `sourceMappingURL=` comments. For CSS output from compiler plugins like LESS and SCSS, we have a totally different mechanism of handling source maps, namely `file.getSourceMap()`.

Should fix #10112.