### PR TITLE
Sanitize compiler name for environment variables

### DIFF
--- a/packages/caching-compiler/caching-compiler.js
+++ b/packages/caching-compiler/caching-compiler.js
@@ -13,7 +13,9 @@ CachingCompilerBase = class CachingCompilerBase {
   }) {
     this._compilerName = compilerName;
     this._maxParallelism = maxParallelism;
-    const envVarPrefix = 'METEOR_' + compilerName.toUpperCase() + '_CACHE_';
+    const compilerNameForEnvar = compilerName.toUpperCase()
+      .replace('/-/g', '_').replace(/[^A-Z0-9_]/g, '');
+    const envVarPrefix = 'METEOR_' + compilerNameForEnvar + '_CACHE_';
 
     const debugEnvVar = envVarPrefix + 'DEBUG';
     this._cacheDebugEnabled = !! process.env[debugEnvVar];


### PR DESCRIPTION
While strictly speaking more characters are allowed, they are not usable in a shell except for uppercase / digits / underscore.
( https://stackoverflow.com/a/2821183 )