### PR TITLE
Add JSDoc comments to reactive-dict to fix meteor/docs#52

### DIFF
--- a/packages/reactive-dict/reactive-dict.js
+++ b/packages/reactive-dict/reactive-dict.js
@@ -21,6 +21,14 @@ function changed(v) {
 }
 
 // XXX COMPAT WITH 0.9.1 : accept migrationData instead of dictName
+/**
+ * @class
+ * @instanceName ReactiveDict
+ * @summary Constructor for a ReactiveDict, which represents a reactive dictionary of key/value pairs.
+ * @locus Client
+ * @param {String} [name] Optional.  When a name is passed, preserves contents across Hot Code Pushes
+ * @param {Object} [initialValue] Optional.  The default values for the dictionary
+ */
 export class ReactiveDict {
   constructor(dictName, dictData) {
     // this.keys: key -> value
@@ -64,6 +72,15 @@ export class ReactiveDict {
   // set() began as a key/value method, but we are now overloading it
   // to take an object of key/value pairs, similar to backbone
   // http://backbonejs.org/#Model-set
+  /**
+   * @summary Set a value for a key in the ReactiveDict. Notify any listeners
+   * that the value has changed (eg: redraw templates, and rerun any
+   * [`Tracker.autorun`](#tracker_autorun) computations, that called
+   * [`ReactiveDict.get`](#ReactiveDict_get) on this `key`.)
+   * @locus Client
+   * @param {String} key The key to set, eg, `selectedItem`
+   * @param {EJSONable | undefined} value The new value for `key`
+   */
   set(keyOrObject, value) {
     if ((typeof keyOrObject === 'object') && (value === undefined)) {
       // Called as `dict.set({...})`
@@ -99,6 +116,13 @@ export class ReactiveDict {
     }
   }
 
+  /**
+   * @summary Set a value for a key if it hasn't been set before.
+   * Otherwise works exactly the same as [`ReactiveDict.set`](#ReactiveDict-set).
+   * @locus Client
+   * @param {String} key The key to set, eg, `selectedItem`
+   * @param {EJSONable | undefined} value The new value for `key`
+   */
   setDefault(keyOrObject, value) {
     if ((typeof keyOrObject === 'object') && (value === undefined)) {
       // Called as `dict.setDefault({...})`
@@ -114,12 +138,32 @@ export class ReactiveDict {
     }
   }
 
+  /**
+   * @summary Get the value assiciated with a key. If inside a [reactive
+   * computation](#reactivity), invalidate the computation the next time the
+   * value associated with this key is changed by
+   * [`ReactiveDict.set`](#ReactiveDict-set).
+   * This returns a clone of the value, so if it's an object or an array,
+   * mutating the returned value has no effect on the value stored in the
+   * ReactiveDict.
+   * @locus Client
+   * @param {String} key The key of the element to return
+   */
   get(key) {
     this._ensureKey(key);
     this.keyDeps[key].depend();
     return parse(this.keys[key]);
   }
 
+  /**
+   * @summary Test if the stored entry for a key is equal to a value. If inside a
+   * [reactive computation](#reactivity), invalidate the computation the next
+   * time the variable changes to or from the value.
+   * @locus Client
+   * @param {String} key The name of the session variable to test
+   * @param {String | Number | Boolean | null | undefined} value The value to
+   * test against
+   */
   equals(key, value) {
     // Mongo.ObjectID is in the 'mongo' package
     let ObjectID = null;
@@ -172,6 +216,16 @@ export class ReactiveDict {
     return EJSON.equals(oldValue, value);
   }
 
+  /**
+   * @summary Get all key-value pairs as a plain object. If inside a [reactive
+   * computation](#reactivity), invalidate the computation the next time the
+   * value associated with any key is changed by
+   * [`ReactiveDict.set`](#ReactiveDict-set).
+   * This returns a clone of each value, so if it's an object or an array,
+   * mutating the returned value has no effect on the value stored in the
+   * ReactiveDict.
+   * @locus Client
+   */
   all() {
     this.allDeps.depend();
     let ret = {};
@@ -181,6 +235,13 @@ export class ReactiveDict {
     return ret;
   }
 
+  /**
+   * @summary remove all key-value pairs from the ReactiveDict. Notify any
+   * listeners that the value has changed (eg: redraw templates, and rerun any
+   * [`Tracker.autorun`](#tracker_autorun) computations, that called
+   * [`ReactiveDict.get`](#ReactiveDict_get) on this `key`.)
+   * @locus Client
+   */
   clear() {
     const oldKeys = this.keys;
     this.keys = {};
@@ -196,6 +257,14 @@ export class ReactiveDict {
     });
   }
 
+  /**
+   * @summary remove a key-value pair from the ReactiveDict. Notify any listeners
+   * that the value has changed (eg: redraw templates, and rerun any
+   * [`Tracker.autorun`](#tracker_autorun) computations, that called
+   * [`ReactiveDict.get`](#ReactiveDict_get) on this `key`.)
+   * @locus Client
+   * @param {String} key The key to delete, eg, `selectedItem`
+   */
   delete(key) {
     let didRemove = false;
 
@@ -213,6 +282,14 @@ export class ReactiveDict {
     return didRemove;
   }
 
+  /**
+   * @summary Clear all values from the reactiveDict and prevent it from being
+   * migrated on a Hot Code Pushes. Notify any listeners
+   * that the value has changed (eg: redraw templates, and rerun any
+   * [`Tracker.autorun`](#tracker_autorun) computations, that called
+   * [`ReactiveDict.get`](#ReactiveDict_get) on this `key`.)
+   * @locus Client
+   */
   destroy() {
     this.clear();
     if (this.name && hasOwn.call(ReactiveDict._dictsToMigrate, this.name)) {


### PR DESCRIPTION
Adding documentation for `ReactiveDict` (meteor/docs#52) depends on generated data from JSDoc comments. This PR adds those JSDocs to accompany a future PR on meteor/docs