### PR TITLE
Fix uncaught TypeError in autoupdate_client.js

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -28,8 +28,8 @@
 const clientArch = Meteor.isCordova ? "web.cordova" :
   Meteor.isModern ? "web.browser" : "web.browser.legacy";
 
-const autoupdateVersions =
-  __meteor_runtime_config__.autoupdate.versions[clientArch] || {
+const autoupdateVersions = 
+  ((__meteor_runtime_config__.autoupdate || {}).versions || {})[clientArch] || {
     version: "unknown",
     versionRefreshable: "unknown",
     versionNonRefreshable: "unknown",


### PR DESCRIPTION
This fixes an issue (c.f. https://github.com/Urigo/meteor-client-bundler/issues/87) where when the __meteor_runtime_config__ does not contain a proper autoupdate configuration object, the client would fail to load properly.
