### PR TITLE
ddp-client: fix usage of reload

### DIFF
--- a/packages/ddp-client/client/client_convenience.js
+++ b/packages/ddp-client/client/client_convenience.js
@@ -40,7 +40,7 @@ function onDDPVersionNegotiationFailure(description) {
       return [true, { DDPVersionNegotiationFailures: failures }];
     });
     retry.retryLater(failures, () => {
-      Package.reload.Reload._reload();
+      Package.reload.Reload._reload({ immediateMigration: true });
     });
   }
 }

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -246,10 +246,8 @@ export class Connection {
         ! options.reloadWithOutstanding) {
       Package.reload.Reload._onMigrate(retry => {
         if (! self._readyToMigrate()) {
-          if (self._retryMigrate)
-            throw new Error('Two migrations in progress?');
           self._retryMigrate = retry;
-          return false;
+          return [false];
         } else {
           return [true];
         }


### PR DESCRIPTION
 - Fix return type of onMigrate callback, as it should be an array.
 - Remove exception on retry, as onMigrate callback can be invoked repeatedly until all components are ready to migrate.
 - Force ddp negotiation failures to cause an uninterruptible reload.

---

I've been using these changes in a fork for some time. As, I have a lib that prevents reload until a page change occurs.

very difficult to write unit tests for these, but let me know if it's super necessary and I'll give it a shot.