### PR TITLE
user.services is not an array.

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1515,9 +1515,9 @@ function defaultValidateNewUserHook(user) {
     emailIsGood = user.emails.reduce(
       (prev, email) => prev || this._testEmailDomain(email.address), false
     );
-  } else if (user.services && user.services.length > 0) {
+  } else if (user.services && Object.values(user.services).length > 0) {
     // Find any email of any service and check it
-    emailIsGood = user.services.reduce(
+    emailIsGood = Object.values(user.services).reduce(
       (prev, service) => service.email && this._testEmailDomain(service.email),
       false,
     );


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
Fixes a bug in `accounts-base` introduced by "modernization".  The check whether the email address matches the restriction pattern fails currently for external login services, since it treats `user.services` like an array rather than as an object.