### PR TITLE
webapp: add runtime config overrides when inline scripts are disabled

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -386,12 +386,7 @@ WebAppInternals.staticFilesMiddleware = async function (
     res.end();
   };
 
-  if (pathname === "/meteor_runtime_config.js" &&
-      ! WebAppInternals.inlineScriptsAllowed()) {
-    serveStaticJs("__meteor_runtime_config__ = " +
-                  JSON.stringify(__meteor_runtime_config__) + ";");
-    return;
-  } else if (_.has(additionalStaticJs, pathname) &&
+  if (_.has(additionalStaticJs, pathname) &&
               ! WebAppInternals.inlineScriptsAllowed()) {
     serveStaticJs(additionalStaticJs[pathname]);
     return;
@@ -404,7 +399,14 @@ WebAppInternals.staticFilesMiddleware = async function (
 
   // If pauseClient(arch) has been called, program.paused will be a
   // Promise that will be resolved when the program is unpaused.
-  await WebApp.clientPrograms[arch].paused;
+  const program = WebApp.clientPrograms[arch];
+  await program.paused;
+
+  if (path === "/meteor_runtime_config.js" &&
+      ! WebAppInternals.inlineScriptsAllowed()) {
+    serveStaticJs(`__meteor_runtime_config__ = ${program.meteorRuntimeConfig};`);
+    return;
+  }
 
   const info = getStaticFileInfo(pathname, path, arch);
   if (! info) {
@@ -789,13 +791,18 @@ function runWebAppServer() {
 
   function generateBoilerplateForArch(arch) {
     const program = WebApp.clientPrograms[arch];
+    const additionalOptions = defaultOptionsForArch[arch] || {};
     const { baseData } = boilerplateByArch[arch] =
       WebAppInternals.generateBoilerplateInstance(
         arch,
         program.manifest,
-        defaultOptionsForArch[arch],
+        additionalOptions,
       );
-
+    // we need the runtime config w/ overrides for meteor_runtime_config.js
+    program.meteorRuntimeConfig = JSON.stringify(_.extend(
+      _.clone(__meteor_runtime_config__),
+      additionalOptions.runtimeConfigOverrides || {}
+    ));
     program.refreshableAssets = baseData.css.map(file => ({
       url: bundledJsCssUrlRewriteHook(file.url),
     }));
@@ -835,7 +842,7 @@ function runWebAppServer() {
   // Do this before the next middleware destroys req.url if a path prefix
   // is set to close #10111.
   app.use(query());
-  
+
   function getPathParts(path) {
     const parts = path.split("/");
     while (parts[0] === "") parts.shift();


### PR DESCRIPTION
When generating boilerplate, `__meteor_runtime_config__` includes overrides based on the arch. (See `defaultOptionsForArch`)

However, when inline scripts are disabled, these overrides were not present. As the response to `GET /meteor_runtime_config.js` did not add the overrides based on the arch.

This change fixes `Meteor.isModern` in those cases.
---

There's a little code duplication, as I have made these changes without affecting the api of `boilerplate` & `WebAppInternals.generateBoilerplateInstance`.

Potentially, we could decode `boilerplate.baseData.meteorRuntimeConfig`, or change `boilerplate` to perform it's own escaping.

