### PR TITLE
Bump CoffeeScript to version 2.3.2 and enable lazy compilation.

### DIFF
--- a/packages/caching-compiler/caching-compiler.js
+++ b/packages/caching-compiler/caching-compiler.js
@@ -25,6 +25,10 @@ CachingCompilerBase = class CachingCompilerBase {
 
     // For testing.
     this._callCount = 0;
+
+    // Callbacks that will be called after the linker is done processing
+    // files, after all lazy compilation has finished.
+    this._afterLinkCallbacks = [];
   }
 
   // Your subclass must override this method to define the key used to identify
@@ -111,6 +115,14 @@ CachingCompilerBase = class CachingCompilerBase {
       + (sm.sourcesContent || []).reduce(function (soFar, current) {
         return soFar + (current ? current.length : 0);
       }, 0);
+  }
+
+  // Called by the compiler plugins system after all linking and lazy
+  // compilation has finished.
+  afterLink() {
+    this._afterLinkCallbacks.splice(0).forEach(callback => {
+      callback();
+    });
   }
 
   // Borrowed from another MIT-licensed project that benjamn wrote:
@@ -327,17 +339,19 @@ CachingCompiler = class CachingCompiler extends CachingCompilerBase {
     });
 
     if (this._cacheDebugEnabled) {
-      cacheMisses.sort();
+      this._afterLinkCallbacks.push(() => {
+        cacheMisses.sort();
 
-      this._cacheDebug(
-        `Ran (#${
-          ++this._callCount
-        }) on: ${
-          JSON.stringify(cacheMisses)
-        } ${
-          JSON.stringify(Object.keys(arches).sort())
-        }`
-      );
+        this._cacheDebug(
+          `Ran (#${
+            ++this._callCount
+          }) on: ${
+            JSON.stringify(cacheMisses)
+          } ${
+            JSON.stringify(Object.keys(arches).sort())
+          }`
+        );
+      });
     }
   }
 

--- a/packages/caching-compiler/multi-file-caching-compiler.js
+++ b/packages/caching-compiler/multi-file-caching-compiler.js
@@ -172,17 +172,19 @@ extends CachingCompilerBase {
     });
 
     if (this._cacheDebugEnabled) {
-      cacheMisses.sort();
+      this._afterLinkCallbacks.push(() => {
+        cacheMisses.sort();
 
-      this._cacheDebug(
-        `Ran (#${
-          ++this._callCount
-        }) on: ${
-          JSON.stringify(cacheMisses)
-        } ${
-          JSON.stringify(Object.keys(arches).sort())
-        }`
-      );
+        this._cacheDebug(
+          `Ran (#${
+            ++this._callCount
+          }) on: ${
+            JSON.stringify(cacheMisses)
+          } ${
+            JSON.stringify(Object.keys(arches).sort())
+          }`
+        );
+      });
     }
   }
 

--- a/packages/non-core/coffeescript-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/non-core/coffeescript-compiler/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "coffeescript": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.3.1.tgz",
-      "integrity": "sha512-DNJmSPMyiz+OjWYyuDXNBcFutDjP2TS2owsZ8YvT65hA8c5IdHWIBqdA3Yf/XHoK23d/f1HqLjQbEJJZJoeV1w=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.3.2.tgz",
+      "integrity": "sha512-YObiFDoukx7qPBi/K0kUKyntEZDfBQiqs/DbrR1xzASKOBjGT7auD85/DiPeRr9k++lRj7l3uA9TNMLfyfcD/Q=="
     },
     "source-map": {
       "version": "0.5.7",

--- a/packages/non-core/coffeescript-compiler/package.js
+++ b/packages/non-core/coffeescript-compiler/package.js
@@ -13,11 +13,11 @@ Package.describe({
   summary: 'Compiler for CoffeeScript code, supporting the coffeescript package',
   // This version of NPM `coffeescript` module, with _1, _2 etc.
   // If you change this, make sure to also update ../coffeescript/package.js to match.
-  version: '2.3.1_2'
+  version: '2.3.2_1'
 });
 
 Npm.depends({
-  'coffeescript': '2.3.1',
+  'coffeescript': '2.3.2',
   'source-map': '0.5.7'
 });
 

--- a/packages/non-core/coffeescript/.npm/plugin/compile-coffeescript/npm-shrinkwrap.json
+++ b/packages/non-core/coffeescript/.npm/plugin/compile-coffeescript/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA=="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
+      "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg=="
     },
     "regenerator-runtime": {
       "version": "0.12.1",

--- a/packages/non-core/coffeescript/compile-coffeescript.js
+++ b/packages/non-core/coffeescript/compile-coffeescript.js
@@ -28,6 +28,20 @@ class CachedCoffeeScriptCompiler extends CachingCompiler {
     return super.setDiskCacheDirectory(cacheDir);
   }
 
+  compileOneFileLater(inputFile, getResult) {
+    inputFile.addJavaScript({
+      path: this.coffeeScriptCompiler.outputFilePath(inputFile),
+      sourcePath: inputFile.getPathInPackage(),
+      bare: inputFile.getFileOptions().bare
+    }, async () => {
+      const result = await getResult();
+      return result && {
+        data: result.source,
+        sourceMap: result.sourceMap,
+      };
+    });
+  }
+
   compileOneFile(inputFile) {
     return this.coffeeScriptCompiler.compileOneFile(inputFile);
   }

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // so bumping the version of this package will be how they get newer versions
   // of `coffeescript-compiler`. If you change this, make sure to also update
   // ../coffeescript-compiler/package.js to match.
-  version: '2.3.1_2'
+  version: '2.3.2_1'
 });
 
 Package.registerBuildPlugin({
@@ -22,7 +22,7 @@ Package.registerBuildPlugin({
     // rather than delegating to the one installed in the application's
     // node_modules directory, so the coffeescript package can work in
     // Meteor 1.7.1 apps as well as 1.7.0.x and earlier.
-    '@babel/runtime': '7.0.0'
+    '@babel/runtime': '7.1.2'
   }
 });
 

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1286,6 +1286,19 @@ class Target {
         ), "utf8")
       );
     });
+
+    // Call any plugin.afterLink callbacks defined by compiler plugins,
+    // now that all compilation (including lazy compilation) is finished.
+    sourceBatches.forEach(batch => {
+      batch.resourceSlots.forEach(slot => {
+        const plugin =
+          slot.sourceProcessor &&
+          slot.sourceProcessor.userPlugin;
+        if (plugin && typeof plugin.afterLink === "function") {
+          plugin.afterLink();
+        }
+      });
+    });
   }
 
   // Minify the JS in this target

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -28,6 +28,10 @@ import {
 
 import Resolver from "./isobuild/resolver.js";
 
+const CAN_DELAY_LEGACY_BUILD = ! JSON.parse(
+  process.env.METEOR_DISALLOW_DELAYED_LEGACY_BUILD || "false"
+);
+
 // The ProjectContext represents all the context associated with an app:
 // metadata files in the `.meteor` directory, the choice of package versions
 // used by it, etc.  Any time you want to work with an app, create a
@@ -1310,7 +1314,8 @@ _.extend(exports.PlatformList.prototype, {
   },
 
   canDelayBuildingArch(arch) {
-    return arch === "web.browser.legacy";
+    return CAN_DELAY_LEGACY_BUILD &&
+      arch === "web.browser.legacy";
   }
 });
 


### PR DESCRIPTION
Lazy compilation became possible in Meteor 1.8, thanks to #9983, but it's up to individual compiler plugin packages to take advantage of it.

Using lazy compilation in the `coffeescript` package should help with #10298.