### PR TITLE
Add more information on logs when Mongo and Meteor query disagree

### DIFF
--- a/packages/mongo/oplog_observe_driver.js
+++ b/packages/mongo/oplog_observe_driver.js
@@ -878,6 +878,8 @@ _.extend(OplogObserveDriver.prototype, {
       // there.
       // XXX if this is slow, remove it later
       if (self._published.size() !== newResults.size()) {
+        console.error('The Mongo server and the Meteor query disagree on how ' +
+          'many documents match your query. Cursor description: ', self._cursorDescription);
         throw Error(
           "The Mongo server and the Meteor query disagree on how " +
             "many documents match your query. Maybe it is hitting a Mongo " +

--- a/packages/mongo/oplog_observe_driver.js
+++ b/packages/mongo/oplog_observe_driver.js
@@ -879,7 +879,8 @@ _.extend(OplogObserveDriver.prototype, {
       // XXX if this is slow, remove it later
       if (self._published.size() !== newResults.size()) {
         console.error('The Mongo server and the Meteor query disagree on how ' +
-          'many documents match your query. Cursor description: ', self._cursorDescription);
+          'many documents match your query. Cursor description: ',
+          self._cursorDescription);
         throw Error(
           "The Mongo server and the Meteor query disagree on how " +
             "many documents match your query. Maybe it is hitting a Mongo " +


### PR DESCRIPTION
We need to have more information to understand where the error `The Mongo server and the Meteor query disagree on how many documents match your query. Maybe it is hitting a Mongo edge case? The query selector is` is happening.

I had to run Meteor locally with more logs to be able to discover where was the problem. That was necessary because the error message is using `EJSON.stringify` in the selector hiding the undefined fields and it's also not showing the `collectionName` and `options`.

This PR is pretty simple, it just adds a new `console.error` without using any stringify to preserve the objects.

We have open issues like #10205 that probably can benefit from this change.

Logs examples:
Before this PR:
```
The Mongo server and the Meteor query disagree on how many documents match your query. Maybe it is hitting a Mongo edge case? The query selector is: {}
```
After this PR:
```
The Mongo server and the Meteor query disagree on how many documents match your query. Cursor description: {“collectionName”:“import-logs”,"selector": {“importRunId”: undefined},“options”:{“transform”:null,“fields”:{}}


The Mongo server and the Meteor query disagree on how many documents match your query. Maybe it is hitting a Mongo edge case? The query selector is: {}
```

I did not change the original error just to keep this change as small as possible.