### PR TITLE
Ensure file.hash is always computed from sha1(file.data).

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -30,7 +30,6 @@ BCp.processFilesForTarget = function (inputFiles) {
     if (inputFile.supportsLazyCompilation) {
       inputFile.addJavaScript({
         path: inputFile.getPathInPackage(),
-        hash: inputFile.getSourceHash(),
         bare: !! inputFile.getFileOptions().bare
       }, function () {
         return compiler.processOneFileForTarget(inputFile);

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '7.2.1'
+  version: '7.2.2'
 });
 
 Npm.depends({

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -578,7 +578,6 @@ class ResourceSlot {
           // files.convertToStandardLineEndings only works on strings for now
           data: self.inputResource.data.toString('utf8'),
           path: self.inputResource.path,
-          hash: self.inputResource.hash,
           bare: self.inputResource.fileOptions &&
             (self.inputResource.fileOptions.bare ||
              // XXX eventually get rid of backward-compatibility "raw" name
@@ -594,14 +593,10 @@ class ResourceSlot {
       // Any resource that isn't handled by compiler plugins just gets passed
       // through.
       if (self.inputResource.type === "js") {
-        let resource = self.inputResource;
-        if (! _.isString(resource.sourcePath)) {
-          resource.sourcePath = self.inputResource.path;
-        }
-        if (! _.isString(resource.targetPath)) {
-          resource.targetPath = resource.sourcePath;
-        }
-        self.jsOutputResources.push(resource);
+        self.jsOutputResources.push(new JsOutputResource({
+          resourceSlot: self,
+          options: self.inputResource,
+        }));
       } else {
         self.outputResources.push(self.inputResource);
       }
@@ -964,8 +959,7 @@ class OutputResource {
       return this._set("data", data);
 
     case "hash":
-      const { hash } = this._initialOptions;
-      return this._set("hash", hash || sha1(this._get("data")));
+      return this._set("hash", sha1(this._get("data")));
 
     case "sourceMap":
       let { sourceMap } = this._initialOptions;


### PR DESCRIPTION
With the introduction of lazy compilation in Meteor 1.8, calling
```js
inputFile.addJavaScript({
  ...
  hash: inputFile.getSourceHash(),
  ...
}, function () {
  return compiler.processFilesForTarget(inputFile);
});
```
becomes problematic, since `inputFile.getSourceHash()` is usually different from `compiler.processFilesForTarget(inputFile).hash`, because the latter is computed from the compiled code, whereas the former is computed from the source code.

For example, when we use `file.hash` to cache imported module identifiers in [`ImportScanner#_findImportedModuleIdentifiers`](), we really need to be using the hash of the compiled code, since a single source module can be compiled in different ways. If we cache based on the source hash, there's a risk of reusing the scanned imports from the `web.browser` version for the
`web.browser.legacy` version, which can lead to all sorts of problems that are only apparent in legacy browsers.

The quick fix is easy enough: `BabelCompiler` can simply stop including a `hash` in the eager options to `inputFile.addJavaScript`. This fix can be published as a minor update to the `babel-compiler` and `ecmascript` packages.

The remaining changes in this commit add another layer of defense against this problem, by ignoring any hash options provided by compiler plugins, in favor of simply computing the hash from the compiled data buffer. These additional changes will become available in the next release of Meteor (likely 1.8.1).