### PR TITLE
Bump diff-sequence package version to fix #10320.

### DIFF
--- a/packages/diff-sequence/package.js
+++ b/packages/diff-sequence/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "An implementation of a diff algorithm on arrays and objects.",
-  version: '1.1.0',
+  version: '1.1.1',
   documentation: null
 });
 


### PR DESCRIPTION
After @nathan-muir's PR #10053, we did not publish a new version of the `diff-sequence` package, which would have contained `DiffSequence.diffMaps`.

I honestly have no idea why #10320 did not manifest before now, but publishing these changes seems to fix it.