### PR TITLE
Identify Chromium and Headless Chrome as "modern" browsers.

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,13 @@ N/A
 
 * The `meteor-babel` npm package has been updated to version 7.1.5.
 
+* The `useragent` npm package used by `webapp` and (indirectly) by the
+  `modern-browsers` package has been updated from 2.2.1 to 2.3.0. The
+  `chromium` browser name has been aliased to use the same minimum modern
+  version as `chrome`, and browser names are now processed
+  case-insensitively by the `modern-browsers` package.
+  [PR #10334](https://github.com/meteor/meteor/pull/10334)
+
 ## v1.8, 2018-10-08
 
 ### Breaking changes

--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -1,15 +1,24 @@
 const minimumVersions = Object.create(null);
 const hasOwn = Object.prototype.hasOwnProperty;
 
-// By default, any minimum versions specified for chrome should apply to
-// chromeMobile too, per https://github.com/meteor/meteor/pull/9793,
-// though it should also be possible to specify minimum versions
-// specifically for chromeMobile. This map defines that aliasing behavior
-// in a generic way that could work for other browsers as well.
+// This map defines aliasing behavior in a generic way which still permits
+// minimum versions to be specified for a specific browser family.
 const browserAliases = {
   chrome: [
+    // chromeMobile*, per https://github.com/meteor/meteor/pull/9793,
     "chromeMobile",
     "chromeMobileIOS",
+
+    // The major version number of Chromium and Headless Chrome track with the
+    // releases of Chrome Dev, Canary and Stable, so we should be okay to
+    // alias them to Chrome in a generic sense.
+    // https://www.chromium.org/developers/version-numbers
+    //
+    // Chromium is particularly important to list here since, unlike macOS
+    // builds, Linux builds list Chromium in the userAgent along with Chrome:
+    //   e.g. Chromium/70.0.3538.77 Chrome/70.0.3538.77
+    "chromium",
+    "headlesschrome",
   ],
 
   // If a call to setMinimumBrowserVersions specifies Edge 12 as a minimum

--- a/packages/modern-browsers/package.js
+++ b/packages/modern-browsers/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modern-browsers",
-  version: "0.1.2",
+  version: "0.1.3",
   summary: "API for defining the boundary between modern and legacy " +
     "JavaScript clients",
   documentation: "README.md"

--- a/packages/webapp/.npm/package/npm-shrinkwrap.json
+++ b/packages/webapp/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I="
     },
     "basic-auth-connect": {
       "version": "1.0.0",
@@ -17,9 +17,9 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "compressible": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY="
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+      "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw=="
     },
     "compression": {
       "version": "1.7.1",
@@ -59,9 +59,9 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
@@ -74,9 +74,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "errorhandler": {
       "version": "1.5.0",
@@ -111,9 +111,16 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY="
+      "version": "1.6.3",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dependencies": {
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -121,9 +128,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "lru-cache": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-      "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA=="
     },
     "mime": {
       "version": "1.4.1",
@@ -131,14 +138,14 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg=="
     },
     "ms": {
       "version": "2.0.0",
@@ -175,6 +182,11 @@
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
       "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "qs": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
@@ -201,9 +213,9 @@
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A=="
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "statuses": {
       "version": "1.3.1",
@@ -226,9 +238,9 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "useragent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
-      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw=="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -239,6 +251,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.7.0'
+  version: '1.7.1'
 });
 
 Npm.depends({"basic-auth-connect": "1.0.0",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -12,7 +12,7 @@ Npm.depends({"basic-auth-connect": "1.0.0",
              send: "0.16.1",
              "stream-to-string": "1.1.0",
              "qs-middleware": "1.0.3",
-             useragent: "2.2.1"});
+             useragent: "2.3.0"});
 
 Npm.strip({
   multiparty: ["test/"],


### PR DESCRIPTION
This PR introduces changes to treat "Headless Chrome" and Chromium the same as Chrome in terms of identifying them as "modern" browsers (and thus serving them the modern, rather than legacy, bundles).

Best I can tell, the major version portion of Chromium versions has always tracked all the way through to Chrome Canary, Dev and Stable releases.  The [Chromium versioning documentation](https://www.chromium.org/developers/version-numbers) seems to back this up.

Furthermore, Headless Chrome isn't really a "different" Chrome — in fact, all recent versions of Chrome can be run with the `--headless` flag (yes, even the one on your — the reader's — local computer!) to be run without the visual element (and driven programmatically).  However, when run with the `--headless` flag, Chrome switches its primary `navigator.userAgent` from `Chrome/a.b.c.d` to `HeadlessChrome/a.b.c.d`.

This was initially problematic since the `useragent` npm we use for parsing user agents didn't understand this designation, however, with the update of `webapp`'s `useragent` npm in 058351b, `headlesschrome` will now have its version available from `WebAppInternals.identifyBrowser`, so we can accurately identify it and serve it the modern bundle.

Chromium on the other hand, hasn't been a prominent issue since on macOS the `navigator.userAgent` is very much the same as Chrome itself.  For example, my own macOS Chromium identifies itself as:

```
> navigator.userAgent
< "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3611.0 Safari/537.36"
```

(Note, no presence of `Chromium`)

However, on my Linux Chromium, a different behavior introduces a second `Chromium/` identifier _before_ the `Chrome/` version identifier with the same `MAJOR.MINOR.BUILD.PATCH`:

```
> navigator.userAgent
< "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/70.0.3538.77 Chrome/70.0.3538.77 Safari/537.36"
```

By updating `useragent` (https://github.com/meteor/meteor/pull/10334/commits/058351b728bfbf3d5101b467ded42ed23be62f81) and aliasing `chromium` to `chrome` (https://github.com/meteor/meteor/pull/10334/commits/845c45a51a4ff03d73d0fec35dcd5bb29e706f94), both of these situations should be improved.