### PR TITLE
Source maps in standard-minifier-js

### DIFF
--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -20,6 +20,9 @@ Package.registerBuildPlugin({
     'plugin/stats.js',
     'plugin/utils.js',
   ],
+  npmDependencies: {
+    'concat-with-sourcemaps': '1.0.4'
+  }
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
This is directly pulled from @zodern’s [zodern/minify-js-sourcemaps](https://github.com/zodern/minify-js-sourcemaps) and would finally solve meteor/meteor-feature-requests/issues/30

Still TBD is hiding sourcemaps in production, but there’s also `zodern:hide-production-sourcemaps` which could be integrated into this PR.
