### PR TITLE
Remove multiple restart feature

### DIFF
--- a/History.md
+++ b/History.md
@@ -30,7 +30,10 @@ N/A
 * The `node-gyp` npm package has been updated to version 6.0.1, and
   `node-pre-gyp` has been updated to version 0.14.0.
 
-## v1.8.3
+* The feature that restarts the application up to two times if it crashes
+  on startup has been removed.
+  [Feature #335](https://github.com/meteor/meteor-feature-requests/issues/335)
+  [PR #10345](https://github.com/meteor/meteor/pull/10345)
 
 ## v1.8.3
 
@@ -196,17 +199,6 @@ N/A
 
 * The `--test-app-path <directory>` option for `meteor test-packages` and
   `meteor test` now accepts relative paths as well as absolute paths.
-
-### Breaking changes
-
-### Migration steps
-
-### Changes
-
-* The feature that restarts the application up to two times if it crashes
-  on startup has been removed.
-  [Feature #335](https://github.com/meteor/meteor-feature-requests/issues/335)
-  [PR #10345](https://github.com/meteor/meteor/pull/10345)
 
 ## v1.8.1, 2019-04-03
 

--- a/History.md
+++ b/History.md
@@ -197,6 +197,17 @@ N/A
 * The `--test-app-path <directory>` option for `meteor test-packages` and
   `meteor test` now accepts relative paths as well as absolute paths.
 
+### Breaking changes
+
+### Migration steps
+
+### Changes
+
+* The feature that restarts the application up to two times if it crashes
+  on startup has been removed.
+  [Feature #335](https://github.com/meteor/meteor-feature-requests/issues/335)
+  [PR #10345](https://github.com/meteor/meteor/pull/10345)
+
 ## v1.8.1, 2019-04-03
 
 ### Breaking changes

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -913,19 +913,9 @@ _.extend(AppRunner.prototype, {
 
   _fiber: function () {
     var self = this;
-
-    var crashCount = 0;
-    var crashTimer = null;
     var firstRun = true;
 
     while (true) {
-
-      var resetCrashCount = function () {
-        crashTimer = setTimeout(function () {
-          crashCount = 0;
-        }, 8000);
-      };
-
       var runResult = self._runOnce({
         onListen: function () {
           if (! self.noRestartBanner && ! firstRun) {
@@ -933,15 +923,9 @@ _.extend(AppRunner.prototype, {
             Console.enableProgressDisplay(false);
           }
         },
-        beforeRun: resetCrashCount,
         firstRun: firstRun
       });
       firstRun = false;
-
-      clearTimeout(crashTimer);
-      if (runResult.outcome !== "terminated") {
-        crashCount = 0;
-      }
 
       var wantExit = self.onRunEnd ? !self.onRunEnd(runResult) : false;
       if (wantExit || self.exitPromise || runResult.outcome === "stopped") {
@@ -977,11 +961,6 @@ _.extend(AppRunner.prototype, {
           runLog.log('Exited with code: ' + runResult.code, { arrow: true });
         } else {
           // explanation should already have been logged
-        }
-
-        crashCount ++;
-        if (crashCount < 3) {
-          continue;
         }
 
         if (self.watchForChanges) {

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -81,24 +81,7 @@ selftest.define("run", function () {
   s.unlink("junk.css");
   run.waitSecs(5);
   run.match("restarted");
-
-  // Crash just once, then restart successfully
-  s.write("crash_then_restart.js", `
-var fs = Npm.require('fs');
-var path = Npm.require('path');
-var crashmark = path.join(process.env.METEOR_TEST_TMP, 'crashed');
-try {
-  fs.readFileSync(crashmark);
-} catch (e) {
-  fs.writeFileSync(crashmark);
-  process.exit(137);
-}`);
-  run.waitSecs(5);
-  run.match("with code: 137");
-  run.waitSecs(5);
-  run.match("restarted");
   run.stop();
-  s.unlink("crash_then_restart.js");
 
   run = s.run('--settings', 's.json');
   run.waitSecs(5);


### PR DESCRIPTION
Removes the logic that restarts a crashing Meteor server twice if there is a runtime error.
Fixes meteor/meteor-feature-requests#335.