### PR TITLE
Add setTimeout to prefetch invocation to avoid long running synchrono…

### DIFF
--- a/packages/dynamic-import/dynamic-versions.js
+++ b/packages/dynamic-import/dynamic-versions.js
@@ -69,7 +69,9 @@ function precacheOnLoad(event) {
       return module.prefetch(id);
     })).then(function () {
       if (modules.length > 0) {
-        prefetchInChunks(modules, amount);
+        setTimeout(function () {
+          prefetchInChunks(modules, amount);
+        }, 0);
       }
     });
   }


### PR DESCRIPTION
Fixes high CPU usage (and UI locking) when `appcache` prefetches assets which have already been stored for offline use. #10350 