### PR TITLE
Updated example repositories with Angular 7 boilerplate.

### DIFF
--- a/tools/cli/example-repositories.js
+++ b/tools/cli/example-repositories.js
@@ -14,7 +14,7 @@ export const EXAMPLE_REPOSITORIES = {
     'repo': 'https://github.com/meteor/todos',
     'branch': 'react',
   },
-  'angular2-boilerplate': {
-    repo: 'https://github.com/bsliran/angular2-meteor-base'
+  'angular-boilerplate': {
+    repo: 'https://github.com/Urigo/angular-meteor-base.git'
   }
 };


### PR DESCRIPTION
Hello @benjamn,

this PR updates the example repositories with an Angular 7 boilerplate.
The repository URL has been updated to use the Angular-Meteor project (the old URL is just a redirect).

Meteor 1.8.0.1 with Angular 7.1.1 are supported.
(Based on already merged PRs in Angular-Meteor: https://github.com/Urigo/angular-meteor-base/pull/131 and https://github.com/Urigo/angular-meteor/pull/1927)

Thanks, Georgy