### PR TITLE
Adjust css import warning text

### DIFF
--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -144,8 +144,9 @@ const CssTools = {
         if (ast.nodes.some(rulesPredicate('import'))) {
           warnCb(
             ast.filename,
-            'There are some @import rules those are not taking effect as ' +
-            'they are required to be in the beginning of the file.'
+            'There are some @import rules in the middle of a file. This ' +
+            'might be a bug, as imports are only valid at the beginning of ' +
+            'a file.'
           );
         }
       }


### PR DESCRIPTION
I saw this while using dynamic import on a css file that had an `@import` statement.

The previous error message has a grammar error, but also says that the rules are not taking effect. However, in my case the import seemed to work, despite the warning.

The explanatory comment above the warning seemed clearer to me and also doesn't claim that it is definitely an error, so I reused that text in the warning itself.