### PR TITLE
Selectively disable compression based on the incoming request. Fixes #10377

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -64,6 +64,16 @@ var sha1 = function (contents) {
   return hash.digest('hex');
 };
 
+var shouldCompress = function (req, res) {
+  if (req.headers['x-no-compression']) {
+    // don't compress responses with this request header
+    return false;
+  }
+
+  // fallback to standard filter function
+  return compress.filter(req, res);
+};
+
 // #BrowserIdentification
 //
 // We have multiple places that want to identify the browser: the
@@ -819,7 +829,7 @@ function runWebAppServer() {
   app.use(rawConnectHandlers);
 
   // Auto-compress any json, javascript, or text.
-  app.use(compress());
+  app.use(compress({filter: shouldCompress}));
 
   // parse cookies into an object
   app.use(cookieParser());

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -64,7 +64,7 @@ var sha1 = function (contents) {
   return hash.digest('hex');
 };
 
-var shouldCompress = function (req, res) {
+ function shouldCompress(req, res) {
   if (req.headers['x-no-compression']) {
     // don't compress responses with this request header
     return false;


### PR DESCRIPTION
Hello @benjamn,

this a PR to fix https://github.com/meteor/meteor/issues/10377

Currently Auto-compress forces gzip compression, that cannot be disabled and therefore interferes with the possibility to enable a different Content-Encoding on a frontend-proxy.

Adding an environment variable to disable Auto-compress will allow to use Brotli compression through a front-end proxy, such as nginx, and provide better compression ratio than gzip.

`METEOR_DISABLE_AUTO_COMPRESS=1`

For more details, please see:
https://github.com/meteor/meteor/issues/10377

Thanks, Georgy