### PR TITLE
Windows build performance

### DIFF
--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -314,6 +314,7 @@ class ProgressDisplayFull {
   }
 
   depaint() {
+    this._clearDelayedRender();
     this._stream.write(spacesString(this._printedLength) + CARRIAGE_RETURN);
   }
 
@@ -338,7 +339,7 @@ class ProgressDisplayFull {
     if (!this._renderTimeout && this._lastWrittenTime) {
       this._rerenderTimeout = setTimeout(() => {
         this._rerenderTimeout = null;
-        this._render.bind(this)
+        this._render()
       }, PROGRESS_THROTTLE_MS);
     } else if (this._lastWrittenTime === 0) {
       this._render();
@@ -353,10 +354,16 @@ class ProgressDisplayFull {
     this._headless = !! headless;
   }
 
-  _render() {
+  _clearDelayedRender() {
     if (this._rerenderTimeout) {
       clearTimeout(this._rerenderTimeout);
       this._rerenderTimeout = null;
+    }
+  }
+
+  _render() {
+    if (this._rerenderTimeout) {
+      this._clearDelayedRender();
     }
 
     // XXX: Or maybe just jump to the correct position?

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -1761,11 +1761,6 @@ function enableCache(name) {
   };
 }
 
-enableCache("readdir");
-enableCache("realpath");
-enableCache("stat");
-enableCache("lstat");
-
 // The fs.exists method is deprecated in Node v4:
 // https://nodejs.org/api/fs.html#fs_fs_exists_path_callback
 files.exists =
@@ -1874,3 +1869,8 @@ files.readBufferWithLengthAndOffset = function (filename, length, offset) {
   }
   return data;
 };
+
+enableCache("readdir");
+enableCache("realpath");
+enableCache("stat");
+enableCache("lstat");

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -528,7 +528,7 @@ files.cp_r = function(from, to, options = {}) {
 
 // create a symlink, overwriting the target link, file, or directory
 // if it exists
-export function symlinkWithOverwrite(source, target) {
+export const symlinkWithOverwrite = Profile("files.symlinkWithOverwrite", function symlinkWithOverwrite(source, target) {
   const args = [source, target];
 
   if (process.platform === "win32") {
@@ -543,8 +543,12 @@ export function symlinkWithOverwrite(source, target) {
     files.symlink(...args);
   } catch (e) {
     if (e.code === "EEXIST") {
+      function normalizePath (path) {
+        return files.convertToOSPath(path).replace(/[\/\\]$/, "")
+      }
+
       if (files.lstat(target).isSymbolicLink() &&
-          files.readlink(target) === source) {
+          normalizePath(files.readlink(target)) === normalizePath(source)) {
         // If the target already points to the desired source, we don't
         // need to do anything.
         return;
@@ -556,7 +560,7 @@ export function symlinkWithOverwrite(source, target) {
       throw e;
     }
   }
-}
+})
 
 /**
  * Get every path in a directory recursively, treating symlinks as files

--- a/tools/fs/files.js
+++ b/tools/fs/files.js
@@ -1054,7 +1054,7 @@ files.renameDirAlmostAtomically =
     // ... and take out the trash.
     if (cleanupGarbage) {
       // We don't care about how long this takes, so we'll let it go async.
-      files.rm_recursive(garbageDir);
+      files.rm_recursive_async(garbageDir);
     }
   });
 

--- a/tools/fs/watch.js
+++ b/tools/fs/watch.js
@@ -441,6 +441,7 @@ export class Watcher {
     const self = this;
     const keys = Object.keys(self.watchSet.files);
 
+    // Set up a watch for each file
     self._processBatches(keys, absPath => {
       if (! self.justCheckOnce) {
         self._watchFileOrDirectory(absPath, true);

--- a/tools/fs/watch.js
+++ b/tools/fs/watch.js
@@ -305,22 +305,22 @@ function readAndStatDirectory(absPath) {
 }
 
 function filterDirectoryContents(contents, { include, exclude, names }) {
-    // Filter based on regexps.
-    return contents.filter((entry) => {
-      // Is it one of the names we explicitly requested?
-      if (names && names.indexOf(entry) !== -1) {
-        return true;
-      }
-      // Is it ruled out by an exclude rule?
-      if (exclude && exclude.some(re => re.test(entry))) {
-        return false;
-      }
-      // Is it ruled in by an include rule?
-      if (include && include.some(re => re.test(entry))) {
-        return true;
-      }
+  // Filter based on regexps.
+  return contents.filter((entry) => {
+    // Is it one of the names we explicitly requested?
+    if (names && names.indexOf(entry) !== -1) {
+      return true;
+    }
+    // Is it ruled out by an exclude rule?
+    if (exclude && exclude.some(re => re.test(entry))) {
       return false;
-    }).sort(); 
+    }
+    // Is it ruled in by an include rule?
+    if (include && include.some(re => re.test(entry))) {
+      return true;
+    }
+    return false;
+  }).sort();
 }
 
 export function readDirectory({absPath, include, exclude, names}) {
@@ -656,7 +656,7 @@ export class Watcher {
     let index = 0;
 
     function processBatch() {
-      const stopTime = async ? Date.now() + 50 : Infinity // Math.min(index + amountPerBatch, array.length);
+      const stopTime = async ? Date.now() + 50 : Infinity;
       while (Date.now() < stopTime && index < array.length) {
         if (self.stopped) {
           return;

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -549,6 +549,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
         if (this.previousCreatedSymlinks[absFrom] !== absTo) {
         symlinkWithOverwrite(absFrom, absTo);
         }
+        this.usedAsFile[relTo] = false;
         this.createdSymlinks[absFrom] = absTo;
         return;
       }

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -285,13 +285,27 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     } else {
       hash = hash || sha1(getData());
 
-      if (this.previousWrittenHashes[relPath] !== hash) {
+      if (this.previousWrittenHashes[relPath] !== hash && this.writtenHashes[relPath] !== hash) {
+        
         // Builder is used to create build products, which should be read-only;
         // users shouldn't be manually editing automatically generated files and
         // expecting the results to "stick".
+        // Write is called multiple times for assets when they have multiple urls for the same file
+        const mode = executable ? 0o555 : 0o444
+
+        if (this.buildPath === this.outputPath || this.writtenHashes[relPath]) {
+          // atomicallyRewriteFile handles overwriting files that have already been created
         atomicallyRewriteFile(absPath, getData(), {
-          mode: executable ? 0o555 : 0o444
+            mode
         });
+        } else {
+          // Since builder is not updating in place, and
+          // this build is only used if every file is successfully written,
+          // it is not important to write atomically.
+          files.writeFile(absPath, getData(), {
+            mode
+          })
+      }
       }
 
       this.writtenHashes[relPath] = hash;

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -546,11 +546,11 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       if (symlink && ! (relTo in this.usedAsFile)) {
         this._ensureDirectory(files.pathDirname(relTo));
         const absTo = files.pathResolve(this.buildPath, relTo);
-        if (this.previousCreatedSymlinks[absFrom] !== absTo) {
-        symlinkWithOverwrite(absFrom, absTo);
+        if (this.previousCreatedSymlinks[absFrom] !== relTo) {
+          symlinkWithOverwrite(absFrom, absTo);
         }
         this.usedAsFile[relTo] = false;
-        this.createdSymlinks[absFrom] = absTo;
+        this.createdSymlinks[absFrom] = relTo;
         return;
       }
 

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -289,19 +289,19 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     } else {
       hash = hash || sha1(getData());
 
+      // Write is called multiple times for assets when they have multiple urls for the same file
       if (this.previousWrittenHashes[relPath] !== hash && this.writtenHashes[relPath] !== hash) {
         
         // Builder is used to create build products, which should be read-only;
         // users shouldn't be manually editing automatically generated files and
         // expecting the results to "stick".
-        // Write is called multiple times for assets when they have multiple urls for the same file
         const mode = executable ? 0o555 : 0o444
 
         if (this.buildPath === this.outputPath || this.writtenHashes[relPath]) {
           // atomicallyRewriteFile handles overwriting files that have already been created
-        atomicallyRewriteFile(absPath, getData(), {
-            mode
-        });
+          atomicallyRewriteFile(absPath, getData(), {
+              mode
+          });
         } else {
           // Since builder is not updating in place, and
           // this build is only used if every file is successfully written,

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -666,20 +666,20 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
           if (this.previousWrittenHashes[thisRelTo] !== hash) {
             const content = optimisticReadFile(thisAbsFrom);
 
-          files.writeFile(
-            files.pathResolve(this.buildPath, thisRelTo),
-            // The reason we call files.writeFile here instead of
-            // files.copyFile is so that we can read the file using
-            // optimisticReadFile instead of files.createReadStream.
+            files.writeFile(
+              files.pathResolve(this.buildPath, thisRelTo),
+              // The reason we call files.writeFile here instead of
+              // files.copyFile is so that we can read the file using
+              // optimisticReadFile instead of files.createReadStream.
               content,
-            // Logic borrowed from files.copyFile: "Create the file as
-            // readable and writable by everyone, and executable by everyone
-            // if the original file is executably by owner. (This mode will be
-            // modified by umask.) We don't copy the mode *directly* because
-            // this function is used by 'meteor create' which is copying from
-            // the read-only tools tree into a writable app."
-            { mode: (fileStatus.mode & 0o100) ? 0o777 : 0o666 },
-          );
+              // Logic borrowed from files.copyFile: "Create the file as
+              // readable and writable by everyone, and executable by everyone
+              // if the original file is executably by owner. (This mode will be
+              // modified by umask.) We don't copy the mode *directly* because
+              // this function is used by 'meteor create' which is copying from
+              // the read-only tools tree into a writable app."
+              { mode: (fileStatus.mode & 0o100) ? 0o777 : 0o666 },
+            );
           }
 
           this.writtenHashes[thisRelTo] = hash;

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2825,9 +2825,12 @@ var writeTargetToPath = Profile(
       // .meteor/local/build/programs/web.browser.legacy, because they
       // tend to be written atomically, and it's important on Windows to
       // avoid overwriting files that might be open currently in the build
-      // or server process. If in-place builds were safer on Windows, they
+      // or server process.
+      // Server builds do use an in-place build since the server is always stopped 
+      // during the build.
+      // If client in-place builds were safer on Windows, they
       // would be much quicker than from-scratch rebuilds.
-      forceInPlaceBuild: false,
+      forceInPlaceBuild: name === 'server',
     });
 
     var targetBuild = target.write(builder, {

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2420,7 +2420,9 @@ class JsImage {
     _.each(nodeModulesDirectories, function (nmd) {
       assert.strictEqual(typeof nmd.preferredBundlePath, "string");
 
-      if (! nmd.isPortable()) {
+      // Skip calculating isPortable in 'meteor run' since the
+      // modules are never rebuilt
+      if (includeNodeModules !== 'symlink' && !nmd.isPortable()) {
         const parentDir = files.pathDirname(nmd.preferredBundlePath);
         rebuildDirs[parentDir] = parentDir;
       }

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -478,8 +478,9 @@ const isPortable = Profile("meteorNpm.isPortable", dir => {
   const pkgJsonPath = files.pathJoin(dir, "package.json");
   const pkgJsonStat = optimisticStatOrNull(pkgJsonPath);
   const canCache = pkgJsonStat && pkgJsonStat.isFile();
-  const portableFile = files.pathJoin(
-    dir, ".meteor-portable-" + portableVersion + ".json");
+  const portableFile = files.convertToOSPath(
+    files.pathJoin(dir, ".meteor-portable-" + portableVersion + ".json")
+  );
 
   if (canCache) {
     // Cache previous results by writing a boolean value to a hidden file

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -841,7 +841,7 @@ _.extend(AppRunner.prototype, {
 
     const postStartupResult = Promise.race([
       listenPromise,
-      new Promise(resolve => setTimeout(resolve, 3000))
+      runPromise
     ]).then(() => {
       return runPostStartupCallbacks(bundleResult);
     }).await();


### PR DESCRIPTION
### Before:
The times are from the todos app. Rebuilds are for editing a file that is only used in the client, but not in a `client` folder, causing both the server and clients to be rebuilt.

#### Initial build (second and later runs):
resolveContraints: 2,149 2,261
prepareProjectForBuild: 10,299 11,230
build app: 20,656 18,792
App process started after: 36,902 35,839
Creating watchers finished: 12,383 13,462ms after app started
AppProcess onListen: 23,900 25,644ms after app started

Usuable after: 60,802 61,483

#### Rebuild

prepareProjectForBuild: 6,713 6,674 7,158
rebuildApp: 4,555 4,269 4,008
App process started after: 11,690 11,499 11,621
Creating watchers finished: 4,536 4,057 4,001ms after app started
AppProcess onListen: 8,746 8,090 8,015ms after app started
Delayed build: 9,469 8,484 8,406ms after app started

Usuable after: 20,436 19,589 19,636
Delayed build at: 21,159 19,983 20,027

### After:

#### Initial build (second and later runs):
resolveContraints: 1,392 1,879 2,053
prepareProjectForBuild: 6,601 7,267 6,708
build app: 16,056 14,270 12,810
App process started after: 28,662 26,679 24,557
AppProcess onListen: 2,007 2,214 1,593 after app started
Watchers are created after onListen and are no longer blocking

Usuable after: 30,669 28,893 26,150

#### Rebuild

prepareProjectForBuild: 6,187 6,013 6,359
rebuildApp: 2,587 2,297 1,842
App process started after: 9,256 8,757 8,811
AppProcess onListen: 1,936 1,894 1,697 after app started
Delayed build: 6,255 6,522 6,551 after app started

Usuable after: 11,192 10,651 10,508
Usuable + delayed build: 15,511 15,279 15,362

### Notable Changes

The large app times are from the rebuild profile at https://github.com/meteor/meteor/issues/5091#issuecomment-444993610.

#### Delete garbage directories async
Saves 500 - 1,100ms per rebuild (large app 9s)

#### Do not use atomicallyRewriteFile when not building in place
Saves ~650ms (large app ~29,000ms including legacy bundle) per build.
This should be safe since the build is only used once all files have been successfully written. Renaming the two files takes almost twice as long as writing it.

#### isPortable
Saves ~900ms. Since npm-rebuilds.json is never used from the bundle created by "meteor run", creating it's contents is skipped.
The `.meteor-portable` file to cache the results was never created on Windows due to the file path being in the wrong format, which slowed down the initial build and `meteor build` when using local packages.

#### inPlace server builds on windows and caching _copyDirectory
Saves 1 - 1.5s per rebuild. Most of the warnings against doing this on windows give the reason of interfering with the running app. Since the server is always stopped during the build, it should be safe to update it in place.

If it is safe to update the server in place, it might also be safe to do the same with the legacy bundle since the server doesn't serve it while it is being written.

#### Create file watcher and start legacy bundle after server started
Both of those were blocking the event loop, causing a delay between the server starting, and the tool process logging '=> server started' and letting the proxy know to forward requests.

Watcher now has an option to do the initial check async. The delayed legacy bundle blocking has not been fixed.