### PR TITLE
Stop excluding test modules when meteor.testModule found in package.json.

### DIFF
--- a/History.md
+++ b/History.md
@@ -8,6 +8,12 @@ N/A
 
 ### Changes
 
+- Fixed a bug where modules named with `*.app-tests.js` (or `*.tests.js`)
+  file extensions sometimes could not be imported by the
+  `meteor.testModule` entry point when running the `meteor test` command
+  (or `meteor test --full-app`).
+  [PR #10402](https://github.com/meteor/meteor/pull/10402)
+
 ## v1.8.0.1, 2018-11-23
 
 ### Breaking changes

--- a/tools/tests/apps/modules/imports/imported.tests.js
+++ b/tools/tests/apps/modules/imports/imported.tests.js
@@ -1,0 +1,9 @@
+import assert from "assert";
+
+export const name = module.id.split("/").pop();
+
+describe(name, () => {
+  it("should be imported", () => {
+    assert.strictEqual(name, "imported.tests.js");
+  });
+});

--- a/tools/tests/apps/modules/tests.js
+++ b/tools/tests/apps/modules/tests.js
@@ -653,3 +653,10 @@ describe("circular package.json resolution chains", () => {
     );
   });
 });
+
+describe("imported *.tests.js modules", () => {
+  const { name } = require("./imports/imported.tests.js");
+  it("should be properly compiled", () => {
+    assert.strictEqual(name, "imported.tests.js");
+  });
+});

--- a/tools/tests/test-modes.js
+++ b/tools/tests/test-modes.js
@@ -17,17 +17,17 @@ selftest.define("'meteor test --port' accepts/rejects proper values", function (
   runAddPackage.expectExit(0);
 
   run = s.run("test", "--port", "3700", "--driver-package", "tmeasday:acceptance-test-driver");
-  run.waitSecs(120);
+  run.waitSecs(30);
   run.match('App running at: http://localhost:3700/');
   run.stop();
 
   run = s.run("test", "--port", "127.0.0.1:3700", "--driver-package", "tmeasday:acceptance-test-driver");
-  run.waitSecs(120);
+  run.waitSecs(30);
   run.match('App running at: http://127.0.0.1:3700/');
   run.stop();
 
   run = s.run("test", "--port", "[::]:3700", "--driver-package", "tmeasday:acceptance-test-driver");
-  run.waitSecs(120);
+  run.waitSecs(30);
   run.match('App running at: http://[::]:3700/');
   run.stop();
 });
@@ -80,7 +80,7 @@ selftest.define("'meteor test' eagerly loads correct files", () => {
 
   // `meteor` should load app files, but not test files or app-test files
   run = s.run();
-  run.waitSecs(120);
+  run.waitSecs(30);
   run.match('index.js');
   run.stop();
   run.forbid('foo.test.js');
@@ -88,7 +88,7 @@ selftest.define("'meteor test' eagerly loads correct files", () => {
 
   // `meteor test` should load test files, but not app files or app-test files
   run = s.run('test', '--driver-package', 'tmeasday:acceptance-test-driver');
-  run.waitSecs(120);
+  run.waitSecs(30);
   run.match('foo.test.js');
   run.stop();
   run.forbid('index.js');
@@ -102,9 +102,9 @@ selftest.define("'meteor test' eagerly loads correct files", () => {
     'tmeasday:acceptance-test-driver',
     '--full-app',
   );
-  run.waitSecs(120);
+  run.waitSecs(30);
   run.match('foo.app-test.js');
   run.match('index.js');
   run.stop();
   run.forbid('foo.test.js');  
-})
+});


### PR DESCRIPTION
New Meteor apps have the following `meteor.testModule` in their `package.json` files by default:
```json
"meteor": {
  "testModule": "tests/main.js"
}
```

When `meteor.testModule` is defined, it determines the test entry point when running the `meteor test` command, ignoring legacy file naming conventions like `*.tests.js` or `*.app-tests.js`.

The `package-source.js` code changed by this commit was incorrect because it ignored those specially-named test files even when running tests, which was a problem if the `meteor.testModule` tried to import them explicitly, because they would not be properly compiled.

If you're using `meteor.testModule`, the distinction between `meteor test` and `meteor test --full-app` matters a bit less, since the test entry point will be the same for both modes, though you can still check `Meteor.isTest` and `Meteor.isAppTest` at runtime to control test behavior.