### PR TITLE
Do not treat client and server directories specially in packages.

### DIFF
--- a/History.md
+++ b/History.md
@@ -8,6 +8,14 @@ N/A
 
 ### Changes
 
+* In Meteor packages, `client/` and `server/` directories no longer have
+  any special meaning. In application code, `client/` directories are
+  ignored during the server build, and `server/` directories are ignored
+  during the client build, as before. This special behavior previously
+  applied to packages as well, but has now been removed.
+  [Issue #10393](https://github.com/meteor/meteor/issues/10393)
+  [PR #10414](https://github.com/meteor/meteor/pull/10414)
+
 ## v1.8.0.2, 2019-01-07
 
 ### Breaking changes

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -65,7 +65,7 @@ const hasOwn = Object.prototype.hasOwnProperty;
 // Cache the (slightly post-processed) results of linker.fullLink.
 const CACHE_SIZE = process.env.METEOR_LINKER_CACHE_SIZE || 1024*1024*100;
 const CACHE_DEBUG = !! process.env.METEOR_TEST_PRINT_LINKER_CACHE_DEBUG;
-const LINKER_CACHE_SALT = 21; // Increment this number to force relinking.
+const LINKER_CACHE_SALT = 22; // Increment this number to force relinking.
 const LINKER_CACHE = new LRU({
   max: CACHE_SIZE,
   // Cache is measured in bytes. We don't care about servePath.

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -34,7 +34,7 @@ var compiler = exports;
 // dependencies. (At least for now, packages only used in target creation (eg
 // minifiers) don't require you to update BUILT_BY, though you will need to quit
 // and rerun "meteor run".)
-compiler.BUILT_BY = 'meteor/31';
+compiler.BUILT_BY = 'meteor/32';
 
 // This is a list of all possible architectures that a build can target. (Client
 // is expanded into 'web.browser' and 'web.cordova')

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1157,10 +1157,18 @@ _.extend(PackageSource.prototype, {
       }
     }
 
+    if (isApp) {
+      // In the app, server/ directories are ignored by client builds, and
+      // client/ directories are ignored by server builds. In packages,
+      // these directories should not matter (#10393).
+      anyLevelExcludes.push(
+        archinfo.matches(arch, "os")
+          ? /^client\/$/
+          : /^server\/$/
+      );
+    }
+
     anyLevelExcludes.push(
-      archinfo.matches(arch, "os")
-        ? /^client\/$/
-        : /^server\/$/,
       ...sourceReadOptions.exclude,
     );
 

--- a/tools/tests/apps/modules/packages/modules-test-package/client.js
+++ b/tools/tests/apps/modules/packages/modules-test-package/client.js
@@ -1,8 +1,13 @@
 import assert from "assert";
-import {checkPackageVars} from "./common";
+import {
+  checkWhere,
+  checkPackageVars,
+} from "./common";
 
 export const where = "client";
 export * from "./common";
+
+checkWhere(where);
 
 var style = require("./css/imported.css");
 if (! style) {

--- a/tools/tests/apps/modules/packages/modules-test-package/client/where.js
+++ b/tools/tests/apps/modules/packages/modules-test-package/client/where.js
@@ -1,0 +1,1 @@
+export * from "../server/where.js";

--- a/tools/tests/apps/modules/packages/modules-test-package/common.js
+++ b/tools/tests/apps/modules/packages/modules-test-package/common.js
@@ -5,6 +5,13 @@ export const ModulesTestPackage = "loaded";
 import { parse } from "acorn";
 assert.strictEqual(typeof parse, "function");
 
+export function checkWhere(where) {
+  const { where: serverWhere } = require("./server/where.js");
+  const { where: clientWhere } = require("./client/where.js");
+  assert.strictEqual(serverWhere, where);
+  assert.strictEqual(clientWhere, where);
+}
+
 export function checkPackageVars() {
   if (Meteor.isClient) {
     assert.strictEqual(ClientPackageVar, "client");

--- a/tools/tests/apps/modules/packages/modules-test-package/server.js
+++ b/tools/tests/apps/modules/packages/modules-test-package/server.js
@@ -6,6 +6,7 @@ assert.strictEqual(common.ModulesTestPackage, "loaded");
 export { ModulesTestPackage } from "./common";
 
 export const where = "server";
+common.checkWhere(where);
 
 ServerPackageVar = "server";
 common.checkPackageVars();

--- a/tools/tests/apps/modules/packages/modules-test-package/server/where.js
+++ b/tools/tests/apps/modules/packages/modules-test-package/server/where.js
@@ -1,0 +1,2 @@
+import { Meteor } from "meteor/meteor";
+export const where = Meteor.isServer ? "server" : "client";


### PR DESCRIPTION
The `client/` and `server/` directories should be meaningful only for organizing application code.

Before this commit, if a Meteor package contained a `client/` or `server/` directory, any modules inside it could be imported, but they would not be properly compiled, because the `PackageSource#_findSources` method would ignore them in its initial scan, which determines the set of modules that get passed into compiler plugins.

Fixes #10393.