### PR TITLE
More Cordova improvements for Meteor 1.8.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -52,6 +52,9 @@ N/A
   incompatibilities and hot code push errors due to duplicated
   images/assets. [PR #10339](https://github.com/meteor/meteor/pull/10339)
 
+* The `cordova-android` and `cordova-ios` npm dependencies have been
+  updated to 7.1.4 (from 6.4.0) and 4.5.5 (from 4.5.4), respectively.
+
 * The `meteor mongo` command no longer uses the `--quiet` option, so the
   normal startup text will be displayed, albeit without the banner about
   Mongo's free monitoring service. See this

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -22,7 +22,7 @@ Npm.strip({
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.3',
   'cordova-plugin-wkwebview-engine': '1.1.4',
-  'cordova-plugin-meteor-webapp': '1.6.3'
+  'cordova-plugin-meteor-webapp': '1.6.4'
 });
 
 Package.onUse(function (api) {

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -14,10 +14,7 @@ import query from "qs-middleware";
 import parseRequest from "parseurl";
 import basicAuth from "basic-auth-connect";
 import { lookup as lookupUserAgent } from "useragent";
-import {
-  isModern,
-  calculateHashOfMinimumVersions,
-} from "meteor/modern-browsers";
+import { isModern } from "meteor/modern-browsers";
 import send from "send";
 import {
   removeExistingSocketFile,
@@ -693,11 +690,6 @@ function runWebAppServer() {
     const { PUBLIC_SETTINGS } = __meteor_runtime_config__;
     const configOverrides = {
       PUBLIC_SETTINGS,
-      // Since the minimum modern versions defined in the modern-versions
-      // package affect which bundle a given client receives, any changes
-      // in those versions should trigger a corresponding change in the
-      // versions calculated below.
-      minimumModernVersionsHash: calculateHashOfMinimumVersions(),
     };
 
     const oldProgram = WebApp.clientPrograms[arch];
@@ -707,6 +699,10 @@ function runWebAppServer() {
       // Use arrow functions so that these versions can be lazily
       // calculated later, and so that they will not be included in the
       // staticFiles[manifestUrl].content string below.
+      //
+      // Note: these version calculations must be kept in agreement with
+      // CordovaBuilder#appendVersion in tools/cordova/builder.js, or hot
+      // code push will reload Cordova apps unnecessarily.
       version: () => WebAppHashing.calculateClientHash(
         manifest, null, configOverrides),
       versionRefreshable: () => WebAppHashing.calculateClientHash(

--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -451,6 +451,10 @@ export class CordovaBuilder {
   }
 
   appendVersion(program, publicSettings) {
+    // Note: these version calculations must be kept in agreement with
+    // generateClientProgram in packages/webapp/webapp_server.js, or hot
+    // code push will reload the app unnecessarily.
+
     let configDummy = {};
     configDummy.PUBLIC_SETTINGS = publicSettings || {};
 

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -14,11 +14,8 @@ export const CORDOVA_DEV_BUNDLE_VERSIONS = {
 };
 
 export const CORDOVA_PLATFORM_VERSIONS = {
-  // This commit represents cordova-android@6.4.0 plus
-  // https://github.com/apache/cordova-android/pull/417, aka
-  // https://github.com/meteor/cordova-android/tree/v6.4.0-with-pr-417:
-  'android': 'https://github.com/meteor/cordova-android/tarball/317db7df0f7a054444197bc6d28453cf4ab23280',
-  'ios': '4.5.4'
+  'android': '7.1.4',
+  'ios': '4.5.5',
 };
 
 const PLATFORM_TO_DISPLAY_NAME_MAP = {

--- a/tools/tests/cordova-builds.js
+++ b/tools/tests/cordova-builds.js
@@ -15,7 +15,7 @@ var checkMobileServer = selftest.markStack(function (s, expected) {
 
   checkIndexHtml(files.pathJoin(
     relBuildDir,
-    "android/project/assets/www/application/index.html"
+    "android/project/app/src/main/assets/www/application/index.html"
   ));
 
   if (isOSX) {


### PR DESCRIPTION
This PR updates the `cordova-android` and `cordova-ios` npm packages to their latest versions, updates `cordova-plugin-meteor-webapp` to version 1.6.4 to include https://github.com/meteor/cordova-plugin-meteor-webapp/pull/71 (which was necessary because of the `cordova-android` update), and hopefully fixes https://github.com/meteor/cordova-plugin-meteor-webapp/issues/69 by making the Cordova `program.json` client version consistent with the `manifest.json` client version served by the web server (cc @lorensr).

The last change is the most significant one. Details in the commit message: https://github.com/meteor/meteor/pull/10416/commits/a89b34c4c2d8335b337355eb61c382949ff762d9