### PR TITLE
[WIP] Allow interrupting delayed builds.

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -752,68 +752,54 @@ class Target {
     // for resolving package dependencies
     packageMap,
     isopackCache,
-
     // Path to the root source directory for this Target.
     sourceRoot,
-
-    // the architecture to build
+    // Something like "web.browser" or "os" or "os.osx.x86_64"
     arch,
-    // projectContextModule.CordovaPluginsFile object
+    // The project's cordova plugins file (which lists plugins used
+    // directly by the project).
     cordovaPluginsFile,
     // 'development', 'production' or 'test'; determines whether
     // debugOnly, prodOnly and testOnly packages are included;
     // defaults to 'production'
-    buildMode,
+    buildMode = "production",
     // directory on disk where to store the cache for things like linker
     bundlerCacheDir,
     // ... see subclasses for additional options
   }) {
-    this.packageMap = packageMap;
-    this.isopackCache = isopackCache;
-
-    this.sourceRoot = sourceRoot;
-
-    // Something like "web.browser" or "os" or "os.osx.x86_64"
-    this.arch = arch;
-
-    // All of the Unibuilds that are to go into this target, in the order
-    // that they are to be loaded.
-    this.unibuilds = [];
-
-    // JavaScript files. List of File. They will be loaded at startup in
-    // the order given.
-    this.js = [];
-
-    // On-disk dependencies of this target.
-    this.watchSet = new watch.WatchSet();
-
-    // List of all package names used in this target.
-    this.usedPackages = {};
-
-    // node_modules directories that we need to copy into the target (or
-    // otherwise make available at runtime). A map from an absolute path
-    // on disk (NodeModulesDirectory.sourcePath) to a
-    // NodeModulesDirectory object that we have created to represent it.
-    //
-    // The NodeModulesDirectory objects in this map are de-duplicated
-    // aliases to the objects in the nodeModulesDirectory fields of
-    // the File objects in this.js.
-    this.nodeModulesDirectories = Object.create(null);
-
-    // Static assets to include in the bundle. List of File.
-    // For client targets, these are served over HTTP.
-    this.asset = [];
-
-    // The project's cordova plugins file (which lists plugins used directly by
-    // the project).
-    this.cordovaPluginsFile = cordovaPluginsFile;
-
-    // A mapping from Cordova plugin name to Cordova plugin version number.
-    this.cordovaDependencies = this.cordovaPluginsFile ? {} : null;
-
-    this.buildMode = buildMode || 'production';
-
-    this.bundlerCacheDir = bundlerCacheDir;
+    Object.assign(this, {
+      packageMap,
+      isopackCache,
+      sourceRoot,
+      arch,
+      // All of the Unibuilds that are to go into this target, in the
+      // order that they are to be loaded.
+      unibuilds: [],
+      // JavaScript files. List of File. They will be loaded at startup in
+      // the order given.
+      js: [],
+      // On-disk dependencies of this target.
+      watchSet: new watch.WatchSet(),
+      // List of all package names used in this target.
+      usedPackages: {},
+      // node_modules directories that we need to copy into the target (or
+      // otherwise make available at runtime). A map from an absolute path
+      // on disk (NodeModulesDirectory.sourcePath) to a
+      // NodeModulesDirectory object that we have created to represent it.
+      //
+      // The NodeModulesDirectory objects in this map are de-duplicated
+      // aliases to the objects in the nodeModulesDirectory fields of the
+      // File objects in this.js.
+      nodeModulesDirectories: Object.create(null),
+      // Static assets to include in the bundle. List of File.
+      // For client targets, these are served over HTTP.
+      asset: [],
+      cordovaPluginsFile,
+      // A mapping from Cordova plugin name to Cordova plugin version number.
+      cordovaDependencies: cordovaPluginsFile ? {} : null,
+      buildMode,
+      bundlerCacheDir,
+    });
   }
 
   // Top-level entry point for building a target. Generally to build a

--- a/tools/tool-env/profile.js
+++ b/tools/tool-env/profile.js
@@ -280,7 +280,11 @@ function Profile(bucketName, f) {
     var start = process.hrtime();
     var err = null;
     try {
-      return f.apply(this, arguments);
+      const result = f.apply(this, arguments);
+      if (result && typeof result.then === "function") {
+        return Promise.await(result);
+      }
+      return result;
     }
     catch (e) {
       err = e;

--- a/tools/utils/buildmessage.js
+++ b/tools/utils/buildmessage.js
@@ -280,7 +280,10 @@ function capture(options, f) {
   }
 
   try {
-    f();
+    const result = f();
+    if (result && typeof result.then === "function") {
+      Promise.await(result);
+    }
   } finally {
     progress.reportProgressDone();
 
@@ -353,7 +356,11 @@ function enterJob(options, f) {
     resetFns.push(currentNestingLevel.set(nestingLevel + 1));
 
     try {
-      return f();
+      const result = f();
+      if (result && typeof result.then === "function") {
+        return Promise.await(result);
+      }
+      return result;
     } finally {
       progress.reportProgressDone();
 
@@ -385,7 +392,11 @@ function enterJob(options, f) {
   }
 
   try {
-    return f();
+    const result = f();
+    if (result && typeof result.then === "function") {
+      return Promise.await(result);
+    }
+    return result;
   } finally {
     progress.reportProgressDone();
 

--- a/tools/utils/cancelation.js
+++ b/tools/utils/cancelation.js
@@ -1,0 +1,41 @@
+class CancelError extends Error {}
+
+export class CancelToken {
+  constructor(exec) {
+    let requested = false;
+    let message;
+
+    exec(function cancel(reason = "cancelation requested") {
+      requested = true;
+      message = String(reason);
+    });
+
+    this.throwIfRequested = function () {
+      // It's important to introduce a gap that's long enough for file
+      // change notifications to fire, and only setTimeout seems to work.
+      new Promise(resolve => setTimeout(resolve, 0)).await();
+      if (requested) {
+        throw new CancelError(message);
+      }
+    };
+  }
+
+  static isCancelError(error) {
+    return error instanceof CancelError;
+  }
+
+  static fromPromise(promise) {
+    return new this(cancel => {
+      promise.then(
+        result => cancel(),
+        error => cancel(error.message),
+      );
+    });
+  }
+
+  static empty() {
+    return Object.create(CancelToken.prototype);
+  }
+
+  throwIfRequested() {}
+}


### PR DESCRIPTION
Meteor 1.7 introduced a new `web.browser.legacy` build (#9439), which took about as long as the normal `web.browser` build, thereby almost doubling build times. Meteor 1.8 partially solved this problem by delaying the legacy build until after the development server restarted (#10055). However, long legacy builds could still be a problem if they were not finished by the time the next rebuild began, since they could not be interrupted.

This PR makes the build process more asynchronous, which is generally a good idea in any future where we rely less heavily on `Fiber`s. More immediately, this asynchronous behavior allows us to cancel builds when/if an event occurs that should trigger a rebuild (such as modifying a source file), instead of helplessly waiting for the useless legacy build to finish.

`Promise` cancelation has been proposed [multiple](https://github.com/tc39/proposal-cancelable-promises) [times](https://github.com/tc39/proposal-cancellation) for standardization, and now appears unlikely to make its way into any version of the specification ([overview](https://medium.com/@benlesh/promise-cancellation-is-dead-long-live-promise-cancellation-c6601f1f5082)). Nevertheless, the concept of a `CancelToken` still makes plenty of sense to implement as a library. The process of passing the `cancelToken` object through your code is still pretty tedious, which seems to be why cancelation was not incorporated into the language, but the effort is worthwhile when you really need to be able to cancel asynchronous work.

I will comment in the diff about other specific topics of interest.