### PR TITLE
Use optimistic functions with assets

### DIFF
--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -479,12 +479,8 @@ var compileUnibuild = Profile(function (options) {
     const relPath = asset.relPath;
     const absPath = files.pathResolve(inputSourceArch.sourceRoot, relPath);
 
-    // readAndWatchFileWithHash returns an object carrying a buffer with the
-    // file-contents. The buffer contains the original data of the file (no EOL
-    // transforms from the tools/files.js part).
-    const file = watch.readAndWatchFileWithHash(watchSet, absPath);
-    const hash = file.hash;
-    const contents = file.contents;
+    const hash = optimisticHashOrNull(absPath)
+    const contents = optimisticReadFile(absPath)
 
     addAsset(contents, relPath, hash);
   });


### PR DESCRIPTION
Meteor currently reads and hashes each asset during every build. The watcher then uses the optimistic functions to read and hash the file, which stores a copy of the contents in memory. During rebuilds it then reads the file again, causing multiple copies of the file to be in memory.

This changes it to always use optimistic functions with assets. Starting with the second rebuild, this saves 1.5 - 2 seconds of garbage collection during each rebuild in one app in addition to not having to read or hash the files.

An alternative is to use `fs.copyFile` and avoid storing a copy of the file in memory: https://github.com/zodern/meteor/commit/3696b30e11261ab0d681591e62cc17cf2998dfe4. It did reduce the tool's memory usage by 400mb for this app, but the initial build is several hundred milliseconds slower and rebuilds are the same as using optimistic functions on a Linux computer with a file system that does not support copy  on write.