### PR TITLE
Linker performance

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -34,7 +34,7 @@ var packageJson = {
     fstream: "https://github.com/meteor/fstream/tarball/cf4ea6c175355cec7bee38311e170d08c4078a5d",
     tar: "2.2.1",
     kexec: "3.0.0",
-    "source-map": "0.5.3",
+    "source-map": "0.5.7",
     chalk: "0.5.1",
     sqlite3: "3.1.8",
     netroute: "1.0.2",

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -21,6 +21,10 @@ const APP_PRELINK_CACHE = new LRU({
     return prelinked.source.length + sourceMapLength(prelinked.sourceMap);
   }
 });
+// Caches code with source map for dynamic files
+const DYNAMIC_PRELINKED_OUTPUT_CACHE = new LRU({
+  max: Math.pow(2, 11)
+});
 
 var packageDot = function (name) {
   if (/^[a-zA-Z][a-zA-Z0-9]*$/.exec(name)) {
@@ -271,11 +275,7 @@ _.extend(Module.prototype, {
       if (file.isDynamic()) {
         const servePath = files.pathJoin("dynamic", file.absModuleId);
         const { code: source, map } =
-          file.getPrelinkedOutput({
-            sourceWidth: sourceWidth,
-          }).toStringWithSourceMap({
-            file: servePath,
-          });
+          getOutputWithSourceMapCached(file, servePath, { sourceWidth })
 
         results.push({
           source,
@@ -812,12 +812,15 @@ const getPrelinkedOutputCached = require("optimism").wrap(
     }
 
     return new sourcemap.SourceNode(null, null, null, chunks);
-
   }, {
     // Store at most 4096 Files worth of prelinked output in this cache.
     max: Math.pow(2, 12),
 
     makeCacheKey(file, options) {
+      if (options.disableCache) {
+        return;
+      }
+
       return JSON.stringify({
         hash: file._inputHash,
         arch: file.module.bundleArch,
@@ -828,6 +831,33 @@ const getPrelinkedOutputCached = require("optimism").wrap(
     }
   }
 );
+
+function getOutputWithSourceMapCached (file,servePath, options) {
+  const key = JSON.stringify({
+    hash: file._inputHash,
+    arch: file.module.bundleArch,
+    bare: file.bare,
+    servePath: file.servePath,
+    dynamic: file.isDynamic(),
+    options,
+  });
+
+  if (DYNAMIC_PRELINKED_OUTPUT_CACHE.has(key)) {
+    return DYNAMIC_PRELINKED_OUTPUT_CACHE.get(key);
+  }
+
+
+  const result = file.getPrelinkedOutput({
+    ...options,
+    disableCache: true
+  })
+    .toStringWithSourceMap({
+      file: servePath,
+    });
+  DYNAMIC_PRELINKED_OUTPUT_CACHE.set(key, result);
+
+  return result;
+}
 
 // Given a list of lines (not newline-terminated), returns a string placing them
 // in a pretty banner of width bannerWidth. All lines must have length at most

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -26,6 +26,11 @@ const DYNAMIC_PRELINKED_OUTPUT_CACHE = new LRU({
   max: Math.pow(2, 11)
 });
 
+// Caches main bundle for client architectures that have dynamic imports
+const PRELINKED_MAIN_CACHE = new LRU({
+  max: Math.pow(2, 3)
+});
+
 var packageDot = function (name) {
   if (/^[a-zA-Z][a-zA-Z0-9]*$/.exec(name)) {
     return "Package." + name;
@@ -209,6 +214,54 @@ _.extend(Module.prototype, {
       });
     }
 
+    // Caching is only useful when there are dynamic files.
+    const canCache = results.find(result => result.dynamic) && self.useGlobalNamespace;
+    let inputHash;
+    let key;
+
+    // When only dynamic files changed, reuse the main result from 
+    // the last time it was generated
+    if (canCache) {
+      const files = [];
+
+      self.files.forEach(file => {
+        if (file.bare || !file.isDynamic()) {
+          files.push({
+            hash: file._inputHash,
+            meteorInstallOptions: file.meteorInstallOptions,
+            sourceMap: !!file.sourceMap,
+            mainModule: file.imported,
+            alias: file.alias,
+            lazy: file.lazy,
+            bare: file.bare
+          });
+        }
+      });
+      inputHash = watch.sha1(JSON.stringify({
+        useGlobalNamespace: this.useGlobalNamespace,
+        combinedServePath: this.combinedServePath,
+        name: self.name,
+        files
+      }));
+      key = `${self.bundleArch}-${self.name}`;
+
+      // By using a more general key only the latest result is stored
+      // The inputHash is used to know when the cache is stale
+      if (PRELINKED_MAIN_CACHE.has(key)) {
+        let {
+          inputHash: cachedInputHash,
+          result: cachedResult
+        } = PRELINKED_MAIN_CACHE.get(key);
+
+        if (cachedInputHash === inputHash) {
+          result.source = cachedResult.source;
+          result.sourceMap = cachedResult.sourceMap;
+
+          return results;
+        }
+      }
+    }
+
     var node = new sourcemap.SourceNode(null, null, null, chunks);
 
     Profile.time(
@@ -231,6 +284,13 @@ _.extend(Module.prototype, {
         }
       }
     );
+
+    if (canCache) {
+      PRELINKED_MAIN_CACHE.set(key, {
+        inputHash,
+        result
+      });
+    }
 
     return results;
   }),

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -215,11 +215,11 @@ _.extend(Module.prototype, {
     }
 
     // Caching is only useful when there are dynamic files.
-    const canCache = results.find(result => result.dynamic) && self.useGlobalNamespace;
+    const canCache = self.useGlobalNamespace && results.find(result => result.dynamic);
+    const key = `${self.bundleArch}-${self.name}`;
     let inputHash;
-    let key;
 
-    // When only dynamic files changed, reuse the main result from 
+    // When only dynamic files changed, reuse the main result from
     // the last time it was generated
     if (canCache) {
       const files = [];
@@ -237,13 +237,13 @@ _.extend(Module.prototype, {
           });
         }
       });
+
       inputHash = watch.sha1(JSON.stringify({
         useGlobalNamespace: this.useGlobalNamespace,
         combinedServePath: this.combinedServePath,
         name: self.name,
         files
       }));
-      key = `${self.bundleArch}-${self.name}`;
 
       // By using a more general key only the latest result is stored
       // The inputHash is used to know when the cache is stale
@@ -892,7 +892,7 @@ const getPrelinkedOutputCached = require("optimism").wrap(
   }
 );
 
-function getOutputWithSourceMapCached (file,servePath, options) {
+function getOutputWithSourceMapCached(file, servePath, options) {
   const key = JSON.stringify({
     hash: file._inputHash,
     arch: file.module.bundleArch,
@@ -906,14 +906,13 @@ function getOutputWithSourceMapCached (file,servePath, options) {
     return DYNAMIC_PRELINKED_OUTPUT_CACHE.get(key);
   }
 
-
   const result = file.getPrelinkedOutput({
     ...options,
     disableCache: true
-  })
-    .toStringWithSourceMap({
-      file: servePath,
-    });
+  }).toStringWithSourceMap({
+    file: servePath,
+  });
+
   DYNAMIC_PRELINKED_OUTPUT_CACHE.set(key, result);
 
   return result;


### PR DESCRIPTION
- Updates source-map to 0.5.7 which includes some performance improvements for source nodes. In one app it saves up to 1.2 seconds during full rebuilds  
- Caches the stringified output of dynamic files instead of a source node, which allows skipping stringifying the source node when the dynamic file didn't change since the last build.
- The main client bundle is not recreated when only dynamic files change. In one app this saves 2 - 3 seconds during rebuilds when a dynamic file is changed.  It only stores the latest bundle in the cache for each architecture instead of waiting until the cache has reached its max size to remove old entries.  That is to avoid increasing the tool's memory usage, though I am not sure if it is needed.