### PR TITLE
Write performance

### DIFF
--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -237,21 +237,20 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
   // sure the parent directories exist and are part of the cache.
   //
   // Returns true if the file was already written
-  usePreviousWrite (relPath, hash, sanitize) {
+  usePreviousWrite(relPath, hash, sanitize) {
     relPath = this._normalizeFilePath(relPath, sanitize);
 
-    const previouslyWritten = this.previousWrittenHashes[relPath] === hash;
-
-    if (previouslyWritten) {
+    if (this.previousWrittenHashes[relPath] === hash) {
       this._ensureDirectory(files.pathDirname(relPath));
       this.writtenHashes[relPath] = hash;
       this.usedAsFile[relPath] = true;
+      return true;
     }
 
-    return previouslyWritten;
+    return false;
   }
 
-  _normalizeFilePath (relPath, sanitize) {
+  _normalizeFilePath(relPath, sanitize) {
     // Ensure no trailing slash
     if (relPath.slice(-1) === files.pathSep) {
       relPath = relPath.slice(0, -1);
@@ -316,7 +315,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
 
       // Write is called multiple times for assets when they have multiple urls for the same file
       if (this.previousWrittenHashes[relPath] !== hash && this.writtenHashes[relPath] !== hash) {
-        
+
         // Builder is used to create build products, which should be read-only;
         // users shouldn't be manually editing automatically generated files and
         // expecting the results to "stick".

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -231,18 +231,19 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
 
     return partsOut.join(files.pathSep);
   }
+
   // Checks if a file with the same path and hash was written by
-  // the previous builder. If it was, it adds it to the cache.
-  // It also makes sure the parent directories exist and are part of the cache.
-  // 
+  // the previous builder. If it was, it adds it to the cache and makes
+  // sure the parent directories exist and are part of the cache.
+  //
   // Returns true if the file was already written
   usePreviousWrite (relPath, hash, sanitize) {
     relPath = this._normalizeFilePath(relPath, sanitize);
-    this._ensureDirectory(files.pathDirname(relPath));
 
     const previouslyWritten = this.previousWrittenHashes[relPath] === hash;
 
     if (previouslyWritten) {
+      this._ensureDirectory(files.pathDirname(relPath));
       this.writtenHashes[relPath] = hash;
       this.usedAsFile[relPath] = true;
     }

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -546,6 +546,9 @@ class File {
     // disk).
     this.sourcePath = options.sourcePath;
 
+    // Allows not calculating sri when the file doesn't support it
+    this._skipSri = options.skipSri
+
     // info is just for help with debugging the tool; it isn't written to disk or
     // anything.
     this.info = options.info || '?';
@@ -619,7 +622,9 @@ class File {
         hashes.push(this._inputHash);
       }
 
-      hashes.push(this.sri());
+      if (!this._skipSri) {
+        hashes.push(this.sri());
+      }
 
       this._hash = watch.sha1(...hashes);
     }
@@ -628,7 +633,7 @@ class File {
   }
 
   sri() {
-    if (! this._sri) {
+    if (! this._sri && !this._skipSri) {
       this._sri = watch.sha512(this.contents());
     }
 
@@ -1160,6 +1165,8 @@ class Target {
           data: resource.data,
           cacheable: false,
           hash: resource.hash,
+          sourcePath: resource.sourcePath,
+          skipSri: !!resource.sourcePath && resource.hash
         };
 
         const file = new File(fileOptions);

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2760,6 +2760,10 @@ var writeFile = Profile("bundler writeFile", function (file, builder, options) {
   let data = file.contents();
   const hash = file.hash();
 
+  if (builder.usePreviousWrite(file.targetPath, hash)) {
+    return;
+  }
+
   if (options && options.sourceMapUrl) {
     data = addSourceMappingURL(data, options.sourceMapUrl);
   } else {

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1168,7 +1168,6 @@ class Target {
           data: resource.data,
           cacheable: false,
           hash: resource.hash,
-          sourcePath: resource.sourcePath,
           skipSri: !!resource.hash
         };
 

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -549,7 +549,7 @@ class File {
     // disk).
     this.sourcePath = options.sourcePath;
 
-    // Allows not calculating sri when the file doesn't support it
+    // Allows not calculating sri when it isn't needed
     this._skipSri = options.skipSri
 
     // info is just for help with debugging the tool; it isn't written to disk or
@@ -1169,7 +1169,7 @@ class Target {
           cacheable: false,
           hash: resource.hash,
           sourcePath: resource.sourcePath,
-          skipSri: !!resource.sourcePath && resource.hash
+          skipSri: !!resource.hash
         };
 
         const file = new File(fileOptions);

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -457,7 +457,7 @@ var compileUnibuild = Profile(function (options) {
 
   // This function needs to be factored out to support legacy handlers later on
   // in the compilation process
-  function addAsset(contents, relPath, hash) {
+  function addAsset(contents, relPath, absPath, hash) {
     // XXX hack to strip out private and public directory names from app asset
     // paths
     if (! inputSourceArch.pkg.name) {
@@ -470,7 +470,8 @@ var compileUnibuild = Profile(function (options) {
       path: relPath,
       servePath: colonConverter.convert(
         files.pathJoin(inputSourceArch.pkg.serveRoot, relPath)),
-      hash: hash
+      hash: hash,
+      sourcePath: absPath
     });
   }
 
@@ -482,7 +483,7 @@ var compileUnibuild = Profile(function (options) {
     const hash = optimisticHashOrNull(absPath)
     const contents = optimisticReadFile(absPath)
 
-    addAsset(contents, relPath, hash);
+    addAsset(contents, relPath, absPath, hash);
   });
 
   // Add and compile all source files

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -457,7 +457,7 @@ var compileUnibuild = Profile(function (options) {
 
   // This function needs to be factored out to support legacy handlers later on
   // in the compilation process
-  function addAsset(contents, relPath, absPath, hash) {
+  function addAsset(contents, relPath, hash) {
     // XXX hack to strip out private and public directory names from app asset
     // paths
     if (! inputSourceArch.pkg.name) {
@@ -470,8 +470,7 @@ var compileUnibuild = Profile(function (options) {
       path: relPath,
       servePath: colonConverter.convert(
         files.pathJoin(inputSourceArch.pkg.serveRoot, relPath)),
-      hash: hash,
-      sourcePath: absPath
+      hash: hash
     });
   }
 
@@ -483,7 +482,7 @@ var compileUnibuild = Profile(function (options) {
     const hash = optimisticHashOrNull(absPath)
     const contents = optimisticReadFile(absPath)
 
-    addAsset(contents, relPath, absPath, hash);
+    addAsset(contents, relPath, hash);
   });
 
   // Add and compile all source files


### PR DESCRIPTION
**JS minify performance**
In development, most of the time spent minifying is from converting the content of the files to and from Buffers. This was done before minifying for dynamic files to rename the function, and afterwards for all files to restore the function name. These changes have it avoid converting the contents to and from buffers where possible, and only restores the function name for dynamic files. Saves ~400ms per rebuild in a larger app.

**Skip calculating SRI for assets**
The current SRI standard supports css and js files, and Meteor only uses it for the main css and js bundles. These changes disable calculating the SRI hash for assets since Meteor currently doesn't use it for assets. If some packages or apps want the SRI hash for js or css assets, then two alternatives are calculating it for production, or skipping it for assets that are not js and css files. Saves ~700ms per rebuild in one app.

**Skip removing source map comments if the content won't be written**
Before writing a file, Meteor removes source map comments that are in the middle of the file. These changes have it skip that step when the file's contents didn't change and it is building in place. Saved 300ms during rebuilds.