### PR TITLE
[WIP] Lazily read and watch files

### DIFF
--- a/packages/meteor/plugin/basic-file-types.js
+++ b/packages/meteor/plugin/basic-file-types.js
@@ -11,11 +11,25 @@ Plugin.registerCompiler({
 
 var CssCompiler = function () {
 };
+
+function hasDir(path, dirName) {
+  var pathParts = path.split('/');
+  var index = pathParts.indexOf(dirName);
+
+  return index > -1 && index < pathParts.length - 1;
+}
+
 CssCompiler.prototype.processFilesForTarget = function (inputFiles) {
   inputFiles.forEach(function (inputFile) {
+    let path = inputFile.getPathInPackage();
+
+    if (hasDir(path, 'node_modules')) {
+      return;
+    }
+
     inputFile.addStylesheet({
       data: inputFile.getContentsAsString(),
-      path: inputFile.getPathInPackage()
+      path: path
     });
   });
 };

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -882,9 +882,12 @@ class OutputResource {
       sourcePath,
       targetPath,
       servePath,
+      // When a lazy finalizer is provided, we delay reading and
+      // hashing the file until we know the file will be used
+      _inputResource: lazyFinalizer ? resourceSlot.inputResource : null,
       // Remember the source hash so that changes to the source that
       // disappear after compilation can still contribute to the hash.
-      _inputHash: resourceSlot.inputResource.hash,
+      _inputHash: lazyFinalizer ? null : resourceSlot.inputResource.hash,
     });
   }
 
@@ -892,6 +895,11 @@ class OutputResource {
     if (this._finalizerPromise) {
       this._finalizerPromise.await();
     } else if (this._lazyFinalizer) {
+      if (!this._inputHash) {
+        this._inputHash = this._inputResource.hash;
+        this._inputResource = null;
+      }
+
       const finalize = this._lazyFinalizer;
       this._lazyFinalizer = null;
       (this._finalizerPromise =


### PR DESCRIPTION
Meteor currently reads, hashes, and watches the files that compiler plugins could compile. With Meteor 1.8, compilers can lazily compile files once Meteor knows the file will be used in the architecture. This PR delays reading and watching the file until that moment.

While this does decrease memory usage and save time from reading and hashing fewer files, the difference will probably not be noticeable for most apps. Instead, most of the improvement will be around watching. Adding, removing, or renaming files in directories Meteor watches will continue to cause a rebuild, but modifying a file not used by the app will not. Also, Meteor will do a client rebuild instead of a full rebuild when a file only used on the client is modified, even if it is not in a folder named `client`.

This does not change how local packages are watched since Meteor reads all of their files when the package is modified.

What is left:
- [ ] handle data being null when lazily reading file
- [ ] ensure the watch set includes all of the files it should in all situations
- [ ] lazily read html files in `node_modules`