### PR TITLE
Added an environment variable to see if Meteor will restart automatically

### DIFF
--- a/tools/runners/run-all.js
+++ b/tools/runners/run-all.js
@@ -302,7 +302,6 @@ class Runner {
 exports.run = function (options) {
   var runOptions = _.clone(options);
   var once = runOptions.once;
-  delete runOptions.once;
 
   var promise = new Promise(function (resolve) {
     runOptions.onFailure = function () {

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -72,6 +72,7 @@ var AppProcess = function (options) {
   self.inspect = options.inspect;
   self.settings = options.settings;
   self.testMetadata = options.testMetadata;
+  self.autoRestart = options.autoRestart;
 
   self.proc = null;
   self.madeExitCallback = false;
@@ -197,6 +198,7 @@ _.extend(AppProcess.prototype, {
       delete env.BIND_IP;
     }
     env.APP_ID = self.projectContext.appIdentifier;
+    env.METEOR_AUTO_RESTART = self.autoRestart;
 
     // We run the server behind our own proxy, so we need to increment
     // the HTTP forwarded count.
@@ -298,7 +300,7 @@ _.extend(AppProcess.prototype, {
 //   for connections.
 //
 // - Other options: port, mongoUrl, oplogUrl, buildOptions, rootUrl,
-//   settingsFile, program, proxy, recordPackageUsage
+//   settingsFile, program, proxy, recordPackageUsage, once
 //
 // To use, construct an instance of AppRunner, and then call start() to start it
 // running. To stop it, either return false from onRunEnd, or call stop().  (But
@@ -357,6 +359,7 @@ var AppRunner = function (options) {
   self.testMetadata = options.testMetadata;
   self.inspect = options.inspect;
   self.proxy = options.proxy;
+  self.autoRestart = !options.once;
   self.watchForChanges =
     options.watchForChanges === undefined ? true : options.watchForChanges;
   self.onRunEnd = options.onRunEnd;
@@ -723,6 +726,7 @@ _.extend(AppRunner.prototype, {
       nodeOptions: getNodeOptionsFromEnvironment(),
       settings: settings,
       testMetadata: self.testMetadata,
+      autoRestart: self.autoRestart,
     });
 
     if (options.firstRun && self._beforeStartPromise) {


### PR DESCRIPTION
This PR will add the environment variable `METEOR_AUTO_RESTART`. It's default value is set to `true` and will fall to `false` once the parameter `--once` is added when running `meteor`.

For [meteortesting/meteor-mocha](https://github.com/meteortesting/meteor-mocha) we were long looking for a way to determine if we should end after all tests are run, to support running the tests in a CI/CD environment, but also have an easy way to keep the process running for development.

Our solution until now was to add a custom environment variable (`TEST_WATCH`) which must be together with the `--once` argument for Meteor itself. Since many people were confused by setting it to the wrong value, I wondered if there would be an easier way - and the simplest I could think of was to let our extension know if Meteor will autorestart if the process ends.

Another solution coming to my mind is to change the behavior when the meteor application is stopped, but this might also change other cases, which I didn't want to mess with.

Using this variable the user of [meteortesting/meteor-mocha](https://github.com/meteortesting/meteor-mocha) will finally be able to only use the `--once` flag to run the tests once and then exit or leave it out if he wants to continue watching for file changes after the tests are finished. No need for setting `TEST_WATCH` anymore.