### PR TITLE
typo fixed

### DIFF
--- a/packages/oauth/oauth_browser.js
+++ b/packages/oauth/oauth_browser.js
@@ -54,7 +54,7 @@ const openCenteredPopup = function(url, width, height) {
   const left = screenX + (outerWidth - width) / 2;
   const top = screenY + (outerHeight - height) / 2;
   const features = (`width=${width},height=${height}` +
-                  `,left=${left},top=${top},scrollbars=yes'`);
+                  `,left=${left},top=${top},scrollbars=yes`);
 
   const newwindow = window.open(url, 'Login', features);
 

--- a/packages/oauth/oauth_browser.js
+++ b/packages/oauth/oauth_browser.js
@@ -56,6 +56,7 @@ const openCenteredPopup = function(url, width, height) {
   const features = (`width=${width},height=${height}` +
                   `,left=${left},top=${top},scrollbars=yes`);
 
+
   const newwindow = window.open(url, 'Login', features);
 
   if (typeof newwindow === 'undefined') {


### PR DESCRIPTION
This bugfix enables scrollbars in OAuth popup in Mozilla Firefox.
Related to #10473