### PR TITLE
Batching Oplog Entries & DDP messages

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -1607,9 +1607,8 @@ export class Connection {
   }
 
   onMessage(raw_msg) {
-    let msg;
     try {
-      msg = DDPCommon.parseDDP(raw_msg);
+      var messages = DDPCommon.parseDDP(raw_msg);
     } catch (e) {
       Meteor._debug('Exception while parsing DDP', e);
       return;
@@ -1621,46 +1620,52 @@ export class Connection {
       this._heartbeat.messageReceived();
     }
 
-    if (msg === null || !msg.msg) {
-      // XXX COMPAT WITH 0.6.6. ignore the old welcome message for back
-      // compat.  Remove this 'if' once the server stops sending welcome
-      // messages (stream_server.js).
-      if (!(msg && msg.server_id))
-        Meteor._debug('discarding invalid livedata message', msg);
-      return;
-    }
+    messages = Array.isArray(messages) ? messages : [messages];
 
-    if (msg.msg === 'connected') {
-      this._version = this._versionSuggestion;
-      this._livedata_connected(msg);
-      this.options.onConnected();
-    } else if (msg.msg === 'failed') {
-      if (this._supportedDDPVersions.indexOf(msg.version) >= 0) {
-        this._versionSuggestion = msg.version;
-        this._stream.reconnect({ _force: true });
-      } else {
-        const description =
-          'DDP version negotiation failed; server requested version ' +
-          msg.version;
-        this._stream.disconnect({ _permanent: true, _error: description });
-        this.options.onDDPVersionNegotiationFailure(description);
+    for (var i = 0; i < messages.length; i++) {
+      var msg = messages[i];
+
+      if (msg === null || !msg.msg) {
+        // XXX COMPAT WITH 0.6.6. ignore the old welcome message for back
+        // compat.  Remove this 'if' once the server stops sending welcome
+        // messages (stream_server.js).
+        if (!(msg && msg.server_id))
+          Meteor._debug('discarding invalid livedata message', msg);
+        return;
       }
-    } else if (msg.msg === 'ping' && this.options.respondToPings) {
-      this._send({ msg: 'pong', id: msg.id });
-    } else if (msg.msg === 'pong') {
-      // noop, as we assume everything's a pong
-    } else if (
-      ['added', 'changed', 'removed', 'ready', 'updated'].includes(msg.msg)
-    ) {
-      this._livedata_data(msg);
-    } else if (msg.msg === 'nosub') {
-      this._livedata_nosub(msg);
-    } else if (msg.msg === 'result') {
-      this._livedata_result(msg);
-    } else if (msg.msg === 'error') {
-      this._livedata_error(msg);
-    } else {
-      Meteor._debug('discarding unknown livedata message type', msg);
+
+      if (msg.msg === 'connected') {
+        this._version = this._versionSuggestion;
+        this._livedata_connected(msg);
+        this.options.onConnected();
+      } else if (msg.msg === 'failed') {
+        if (this._supportedDDPVersions.indexOf(msg.version) >= 0) {
+          this._versionSuggestion = msg.version;
+          this._stream.reconnect({ _force: true });
+        } else {
+          const description =
+            'DDP version negotiation failed; server requested version ' +
+            msg.version;
+          this._stream.disconnect({ _permanent: true, _error: description });
+          this.options.onDDPVersionNegotiationFailure(description);
+        }
+      } else if (msg.msg === 'ping' && this.options.respondToPings) {
+        this._send({ msg: 'pong', id: msg.id });
+      } else if (msg.msg === 'pong') {
+        // noop, as we assume everything's a pong
+      } else if (
+        ['added', 'changed', 'removed', 'ready', 'updated'].includes(msg.msg)
+      ) {
+        this._livedata_data(msg);
+      } else if (msg.msg === 'nosub') {
+        this._livedata_nosub(msg);
+      } else if (msg.msg === 'result') {
+        this._livedata_result(msg);
+      } else if (msg.msg === 'error') {
+        this._livedata_error(msg);
+      } else {
+        Meteor._debug('discarding unknown livedata message type', msg);
+      }
     }
   }
 

--- a/packages/ddp-common/utils.js
+++ b/packages/ddp-common/utils.js
@@ -38,80 +38,102 @@ export function last(array, n, guard) {
   return slice.call(array, Math.max(array.length - n, 0));
 }
 
-DDPCommon.SUPPORTED_DDP_VERSIONS = [ '1', 'pre2', 'pre1' ];
+DDPCommon.SUPPORTED_DDP_VERSIONS = [ '2', '1', 'pre2', 'pre1' ];
 
 DDPCommon.parseDDP = function (stringMessage) {
   try {
-    var msg = JSON.parse(stringMessage);
+    var messages = JSON.parse(stringMessage);
   } catch (e) {
-    Meteor._debug("Discarding message with invalid JSON", stringMessage);
+    Meteor._debug("Discarding message(s) with invalid JSON", stringMessage);
     return null;
   }
-  // DDP messages must be objects.
-  if (msg === null || typeof msg !== 'object') {
-    Meteor._debug("Discarding non-object DDP message", stringMessage);
-    return null;
-  }
+  
+  // Convert all DDP messages to Array form
+  messages = Array.isArray(messages) ? messages : [messages];
 
-  // massage msg to get it into "abstract ddp" rather than "wire ddp" format.
+  for (let i = 0; i < messages.length; i++) {
+    var msg = messages[i];
 
-  // switch between "cleared" rep of unsetting fields and "undefined"
-  // rep of same
-  if (hasOwn.call(msg, 'cleared')) {
-    if (! hasOwn.call(msg, 'fields')) {
-      msg.fields = {};
+    // Each individual DDP message must be an object.
+    if (msg === null || typeof msg !== 'object') {
+      Meteor._debug("Discarding non-object DDP message", stringMessage);
+      
+      messages.splice(i, 1);
+
+      i--;
+
+      continue;
     }
-    msg.cleared.forEach(clearKey => {
-      msg.fields[clearKey] = undefined;
+
+    // massage msg to get it into "abstract ddp" rather than "wire ddp" format.
+
+    // switch between "cleared" rep of unsetting fields and "undefined"
+    // rep of same
+    if (hasOwn.call(msg, 'cleared')) {
+      if (! hasOwn.call(msg, 'fields')) {
+        msg.fields = {};
+      }
+      msg.cleared.forEach(clearKey => {
+        msg.fields[clearKey] = undefined;
+      });
+      delete msg.cleared;
+    }
+
+    ['fields', 'params', 'result'].forEach(field => {
+      if (hasOwn.call(msg, field)) {
+        msg[field] = EJSON._adjustTypesFromJSONValue(msg[field]);
+      }
     });
-    delete msg.cleared;
   }
 
-  ['fields', 'params', 'result'].forEach(field => {
-    if (hasOwn.call(msg, field)) {
-      msg[field] = EJSON._adjustTypesFromJSONValue(msg[field]);
-    }
-  });
-
-  return msg;
+  return messages;
 };
 
-DDPCommon.stringifyDDP = function (msg) {
-  const copy = EJSON.clone(msg);
+DDPCommon.stringifyDDP = function (messages) {
+  messages = Array.isArray(messages) ? messages : [messages];
 
-  // swizzle 'changed' messages from 'fields undefined' rep to 'fields
-  // and cleared' rep
-  if (hasOwn.call(msg, 'fields')) {
-    const cleared = [];
+  const clonedMessages = [];
 
-    Object.keys(msg.fields).forEach(key => {
-      const value = msg.fields[key];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    const copy = EJSON.clone(msg);
 
-      if (typeof value === "undefined") {
-        cleared.push(key);
-        delete copy.fields[key];
+    // swizzle 'changed' messages from 'fields undefined' rep to 'fields
+    // and cleared' rep
+    if (hasOwn.call(msg, 'fields')) {
+      const cleared = [];
+
+      Object.keys(msg.fields).forEach(key => {
+        const value = msg.fields[key];
+
+        if (typeof value === "undefined") {
+          cleared.push(key);
+          delete copy.fields[key];
+        }
+      });
+
+      if (! isEmpty(cleared)) {
+        copy.cleared = cleared;
+      }
+
+      if (isEmpty(copy.fields)) {
+        delete copy.fields;
+      }
+    }
+
+    // adjust types to basic
+    ['fields', 'params', 'result'].forEach(field => {
+      if (hasOwn.call(copy, field)) {
+        copy[field] = EJSON._adjustTypesToJSONValue(copy[field]);
       }
     });
 
-    if (! isEmpty(cleared)) {
-      copy.cleared = cleared;
+    if (msg.id && typeof msg.id !== 'string') {
+      throw new Error("Message id is not a string");
     }
 
-    if (isEmpty(copy.fields)) {
-      delete copy.fields;
-    }
+    clonedMessages.push(copy);
   }
 
-  // adjust types to basic
-  ['fields', 'params', 'result'].forEach(field => {
-    if (hasOwn.call(copy, field)) {
-      copy[field] = EJSON._adjustTypesToJSONValue(copy[field]);
-    }
-  });
-
-  if (msg.id && typeof msg.id !== 'string') {
-    throw new Error("Message id is not a string");
-  }
-
-  return JSON.stringify(copy);
+  return JSON.stringify(clonedMessages);
 };

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -92,7 +92,7 @@ _.extend(OplogHandle.prototype, {
       self._tailHandle.stop();
     // XXX should close connections too
   },
-  onOplogEntry: function (trigger, callback) {
+  onOplogEntries: function (trigger, callback) {
     var self = this;
     if (self._stopped)
       throw new Error("Called onOplogEntry on stopped handle!");
@@ -101,15 +101,17 @@ _.extend(OplogHandle.prototype, {
     self._readyFuture.wait();
 
     var originalCallback = callback;
-    callback = Meteor.bindEnvironment(function (notification) {
-      originalCallback(notification);
+    callback = Meteor.bindEnvironment(function (notifications) {
+      originalCallback(notifications);
     }, function (err) {
       Meteor._debug("Error in oplog callback", err);
     });
-    var listenHandle = self._crossbar.listen(trigger, callback);
+
+    var bufferHandle = self._crossbar.buffer(trigger, callback);
+
     return {
       stop: function () {
-        listenHandle.stop();
+        bufferHandle.stop();
       }
     };
   },


### PR DESCRIPTION
This PR implements a couple of things:
- DDP now supports sending an Array of messages, rather than a singular message;
- In the Session on the Server, the messages for every individual client are buffered (if additional messages are received within 10ms, the buffer fills up until at most 1000 messages have accrued or 500ms has passed);
- In the Crossbar on the server OplogEntries are buffered for every (potentially re-used) ObserveHandle (if additional entries are received for the same ObserveHandle within 5ms, the buffer fills up until at most 1000 entries or 500ms have passed).

This decreases the load on server setup for two reasons:
- when messages are buffered inside the Session on the Server there is less overhead while stringifying individual messages and sending individual messages over the WebSocket;
- when messages are buffered when they are received in the Crossbar we give the server a chance to recognize the fact it is falling behind too far (and possibly fall back to polling).

To see the effect of this PR I would recommend cloning this repository (https://github.com/koenlav/meteor-fiber-repro) and comparing the performance with the development branch.

=====

This PR supersedes both https://github.com/meteor/meteor/pull/9862 and https://github.com/meteor/meteor/pull/9885, but does not (yet) achieve the desired end-result from https://github.com/meteor/meteor/pull/9876.

While this PR makes sure we buffer at the start and end of the process from MongoDB => socket, it is likely to be possible to refactor all classes involved in between to accept 'messages' (rather than added, changed, removed), which would allow us to make use of the full potential of these buffers; we would only need to unwind the array of messages in one or two places on the server.