### PR TITLE
Fix bug in minimongo fields projection

### DIFF
--- a/packages/minimongo/local_collection.js
+++ b/packages/minimongo/local_collection.js
@@ -878,7 +878,7 @@ LocalCollection._compileProjection = fields => {
     const result = details.including ? {} : EJSON.clone(doc);
 
     Object.keys(ruleTree).forEach(key => {
-      if (!hasOwn.call(doc, key)) {
+      if (doc == null || !hasOwn.call(doc, key)) {
         return;
       }
 
@@ -897,7 +897,7 @@ LocalCollection._compileProjection = fields => {
       }
     });
 
-    return result;
+    return doc != null ? result : doc;
   };
 
   return doc => {

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -1781,13 +1781,13 @@ Tinytest.add('minimongo - fetch with projection, subarrays', test => {
       fieldB: 'the bad',
       fieldC: 'the ugly',
     }],
-    setB: [{
+    setB: [null, {
       anotherA: { },
       anotherB: 'meh',
-    }, {
+    }, null, {
       anotherA: 1234,
       anotherB: 431,
-    }],
+    }, null],
   });
 
   const equalNonStrict = (a, b, desc) => {
@@ -1802,13 +1802,13 @@ Tinytest.add('minimongo - fetch with projection, subarrays', test => {
   testForProjection({ 'setA.fieldA': 1, 'setB.anotherB': 1, _id: 0 },
     {
       setA: [{ fieldA: 42 }, { fieldA: 'the good' }],
-      setB: [{ anotherB: 'meh' }, { anotherB: 431 }],
+      setB: [null, { anotherB: 'meh' }, null, { anotherB: 431 }, null],
     });
 
   testForProjection({ 'setA.fieldA': 0, 'setB.anotherA': 0, _id: 0 },
     {
       setA: [{fieldB: 33}, {fieldB: 'the bad', fieldC: 'the ugly'}],
-      setB: [{ anotherB: 'meh' }, { anotherB: 431 }],
+      setB: [null, { anotherB: 'meh' }, null, { anotherB: 431 }, null],
     });
 
   c.remove({});


### PR DESCRIPTION
This fixes a null reference exception, if an array contains null values while compiling a fields projection.
