### PR TITLE
[wip] Improve error page

### DIFF
--- a/packages/build-events/event-handler.js
+++ b/packages/build-events/event-handler.js
@@ -1,0 +1,11 @@
+const source = new EventSource("/__meteor__/build-events");
+
+source.addEventListener("message", ({ data }) => {
+  if (data === "error" || data === "success") {
+    window.location.reload();
+  }
+});
+
+window.addEventListener("beforeunload", () => {
+  source.close();
+});

--- a/packages/build-events/package.js
+++ b/packages/build-events/package.js
@@ -1,0 +1,8 @@
+Package.describe({
+  version: "1.0.0",
+  debugOnly: true
+});
+
+Package.onUse((api) => {
+  api.addFiles("event-handler.js", "client");
+});

--- a/packages/meteor-base/package.js
+++ b/packages/meteor-base/package.js
@@ -28,6 +28,7 @@ Package.onUse(function(api) {
     'es5-shim',
 
     // Push code changes to the client and automatically reload the page
-    'hot-code-push'
+    'hot-code-push',
+    'build-events'
   ]);
 });

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -54,7 +54,8 @@ var packageJson = {
     multipipe: "2.0.1",
     pathwatcher: "7.1.1",
     optimism: "0.6.3",
-    'lru-cache': '4.1.3'
+    'lru-cache': '4.1.3',
+    anser: "1.4.8"
   }
 };
 

--- a/tools/runners/error-page/build-error-page.js
+++ b/tools/runners/error-page/build-error-page.js
@@ -1,0 +1,35 @@
+const Anser = require("anser");
+const fs = require("fs");
+const path = require("path");
+
+function readFile(name) {
+  return fs.readFileSync(path.join(__dirname, name), "utf8");
+}
+
+// Taken from packages/blaze/preamble.js.
+function escapeEntities(string) {
+  const escapeMap = {
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#x27;",
+    "`": "&#x60;",
+    "&": "&amp;"
+  };
+
+  const escapeChar = (char) => {
+    return escapeMap[char];
+  };
+
+  return string.replace(/[<>"'`&]/g, escapeChar);
+}
+
+module.exports = function buildErrorPage(log) {
+  const htmlLog = Anser.ansiToHtml(
+    escapeEntities(log.map((item) => item.message).join("\n"))
+  );
+
+  return readFile("template.html")
+    .replace("{{log}}", htmlLog)
+    .replace("{{script}}", readFile("event-handler.js"));
+};

--- a/tools/runners/error-page/event-handler.js
+++ b/tools/runners/error-page/event-handler.js
@@ -1,0 +1,1 @@
+../../../packages/build-events/event-handler.js

--- a/tools/runners/error-page/template.html
+++ b/tools/runners/error-page/template.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Application crashing</title>
+
+    <style>
+      body {
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+      }
+
+      h1 {
+        margin: 0;
+        font-family: sans-serif;
+        font-size: 1.3em;
+        padding: 20px;
+        background: #eee;
+      }
+
+      pre {
+        flex: 1;
+        overflow: auto;
+        margin: 0;
+        padding: 20px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Your application is crashing.</h1>
+    <pre>{{log}}</pre>
+    <script>{{script}}</script>
+  </body>
+</html>


### PR DESCRIPTION
This PR improves how the Meteor Tool handles server crashes and build failures:

* If an error occurs, clients automatically load the error page.
* No more `Uncaught SyntaxError: Unexpected token < in JSON at position 1` in the console!
* Clients automatically reload the page after rebuilds.
* Code frames are displayed with colors instead of ANSI escape codes.
* The error page works better on mobile devices.

[**Video comparison of the current and the new version**](https://streamable.com/5q7wr)

# Technical Details

The `autoupdate` package, which is responsible for notifying clients of changes, is used in both development and production. Therefore, it's part of the app and not the build tool. However, since the app server is terminated in case of a crash or build failure, `autoupdate` cannot be used to reload the error page (see the following diagram).

![diagram](https://user-images.githubusercontent.com/1312807/54785546-cd661b80-4c26-11e9-82f8-c9e1858ae0a6.png)

To solve this problem, the *proxy* opens an SSE endpoint (`/__meteor__/build-events`) that the app client and error page use to get notified of build events, which means that there are now two reload mechanisms: one for errors (via SSE) and one for regular rebuilds (via WebSocket/DDP). However, it might make sense to use SSE for regular rebuilds as well in the future.

# Future Work

Apps that need `autoupdate`/`hot-code-push` only in development (some Apollo apps, for example) still have these packages and large dependencies (including `socket-stream-client` and `ddp-client`) in their production bundles. This results in up to 90 kB of unused code as well as an unused WebSocket for each client. I've already reduced the size of `autoupdate` in #10238 by removing the `mongo` dependency but that's still a lot of overhead.

However, I think it's possible to support both use cases in a backwards-compatible way. If `autoupdate` is included in the app, the Meteor Tool can use the current WebSocket/DDP-based reload for regular rebuilds. If the package is not included, it can let the proxy send a reload message to clients via SSE. That way, apps that use `autoupdate` work exactly as they do now, whereas more lightweight apps don't need any additional packages for development-only reloads.
