### PR TITLE
Add isomorphic URL api with BC

### DIFF
--- a/packages/url/.npm/package/.gitignore
+++ b/packages/url/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/url/.npm/package/README
+++ b/packages/url/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/url/.npm/package/npm-shrinkwrap.json
+++ b/packages/url/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,10 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "url-polyfill": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.3.tgz",
+      "integrity": "sha512-xIAXc0DyXJCd767sSeRu4eqisyYhR0z0sohWArCn+WPwIatD39xGrc09l+tluIUi6jGkpGa8Gz8TKwkKYxMQvQ=="
+    }
+  }
+}

--- a/packages/url/.npm/package/npm-shrinkwrap.json
+++ b/packages/url/.npm/package/npm-shrinkwrap.json
@@ -1,10 +1,10 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "url-polyfill": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.3.tgz",
-      "integrity": "sha512-xIAXc0DyXJCd767sSeRu4eqisyYhR0z0sohWArCn+WPwIatD39xGrc09l+tluIUi6jGkpGa8Gz8TKwkKYxMQvQ=="
+    "core-js": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+      "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
     }
   }
 }

--- a/packages/url/bc/url_client.js
+++ b/packages/url/bc/url_client.js
@@ -1,7 +1,6 @@
 var common = require("./url_common.js");
-var URL = exports.URL = common.URL;
 
-URL._constructUrl = function (url, query, params) {
+exports._constructUrl = function (url, query, params) {
   var query_match = /^(.*?)(\?.*)?$/.exec(url);
   return common.buildUrl(
     query_match[1],
@@ -10,3 +9,5 @@ URL._constructUrl = function (url, query, params) {
     params
   );
 };
+
+exports._encodeParams = common._encodeParams;

--- a/packages/url/bc/url_common.js
+++ b/packages/url/bc/url_common.js
@@ -1,12 +1,10 @@
-var URL = exports.URL = {};
-
 function encodeString(str) {
   return encodeURIComponent(str).replace(/\*/g, '%2A');
 }
 
 // Encode URL parameters into a query string, handling nested objects and
 // arrays properly.
-URL._encodeParams = function (params, prefix) {
+var _encodeParams = function (params, prefix) {
   var str = [];
   var isParamsArray = Array.isArray(params);
   for (var p in params) {
@@ -25,6 +23,8 @@ URL._encodeParams = function (params, prefix) {
   return str.join('&').replace(/%20/g, '+');
 };
 
+exports._encodeParams = _encodeParams;
+
 exports.buildUrl = function(before_qmark, from_qmark, opt_query, opt_params) {
   var url_without_query = before_qmark;
   var query = from_qmark ? from_qmark.slice(1) : null;
@@ -34,7 +34,7 @@ exports.buildUrl = function(before_qmark, from_qmark, opt_query, opt_params) {
 
   if (opt_params) {
     query = query || "";
-    var prms = URL._encodeParams(opt_params);
+    var prms = _encodeParams(opt_params);
     if (query && prms)
       query += '&';
     query += prms;

--- a/packages/url/bc/url_server.js
+++ b/packages/url/bc/url_server.js
@@ -1,8 +1,7 @@
 var url_util = require('url');
 var common = require("./url_common.js");
-var URL = exports.URL = common.URL;
 
-URL._constructUrl = function (url, query, params) {
+exports._constructUrl = function (url, query, params) {
   var url_parts = url_util.parse(url);
   return common.buildUrl(
     url_parts.protocol + "//" + url_parts.host + url_parts.pathname,
@@ -11,3 +10,5 @@ URL._constructUrl = function (url, query, params) {
     params
   );
 };
+
+exports._encodeParams = common._encodeParams;

--- a/packages/url/bc/url_tests.js
+++ b/packages/url/bc/url_tests.js
@@ -1,3 +1,5 @@
+import { Tinytest } from "meteor/tinytest";
+
 Tinytest.add('url - serializes params to query correctly', function (test) {
   var hash = {
     filter: {

--- a/packages/url/legacy.js
+++ b/packages/url/legacy.js
@@ -1,0 +1,7 @@
+require("url-polyfill");
+
+exports.URL = global.URL;
+exports.URLSearchParams = global.URLSearchParams;
+
+// backwards compatability
+Object.assign(exports.URL, require('./bc/url_client'));

--- a/packages/url/legacy.js
+++ b/packages/url/legacy.js
@@ -1,7 +1,14 @@
-require("url-polyfill");
-
-exports.URL = global.URL;
-exports.URLSearchParams = global.URLSearchParams;
+try {
+  require("core-js/proposals/url");
+} catch (e) {
+  throw new Error([
+    "The core-js npm package could not be found in your node_modules ",
+    "directory. Please run the following command to install it:",
+    "",
+    "  meteor npm install --save core-js",
+    ""
+  ].join("\n"));
+}
 
 // backwards compatability
-Object.assign(exports.URL, require('./bc/url_client'));
+require('./modern.js');

--- a/packages/url/modern.js
+++ b/packages/url/modern.js
@@ -1,0 +1,5 @@
+exports.URL = global.URL;
+exports.URLSearchParams = global.URLSearchParams;
+
+// backwards compatability
+Object.assign(exports.URL, require('./bc/url_client'));

--- a/packages/url/modern.js
+++ b/packages/url/modern.js
@@ -1,5 +1,8 @@
-exports.URL = global.URL;
-exports.URLSearchParams = global.URLSearchParams;
+URL = global.URL;
+URLSearchParams = global.URLSearchParams;
+
+exports.URL = URL;
+exports.URLSearchParams = URLSearchParams;
 
 // backwards compatability
-Object.assign(exports.URL, require('./bc/url_client'));
+Object.assign(URL, require('./bc/url_client'));

--- a/packages/url/package.js
+++ b/packages/url/package.js
@@ -1,18 +1,29 @@
 Package.describe({
-  summary: "Utility code for constructing URLs",
-  version: "1.2.0"
+  name: "url",
+  version: "1.2.0",
+  summary: "Isomorphic modern/legacy/Node polyfill for WHATWG URL/URLSearchParams",
+  documentation: "README.md"
+});
+
+Npm.depends({
+  "url-polyfill": "1.1.3",
 });
 
 Package.onUse(function(api) {
-  api.use('modules');
-  api.mainModule('url_client.js', 'client');
-  api.mainModule('url_server.js', 'server');
-  api.export('URL');
+  api.use("modules");
+  api.use("modern-browsers");
+
+  api.mainModule("modern.js", "web.browser");
+  api.mainModule("legacy.js", "legacy");
+  api.mainModule("server.js", "server");
+
+  api.export("URL");
+  api.export("URLSearchParams");
 });
 
-Package.onTest(function (api) {
-  api.use(['tinytest', 'url']);
-  api.addFiles('url_tests.js');
+Package.onTest(function(api) {
+  api.use("ecmascript");
+  api.use("tinytest");
+  api.use("url");
+  api.mainModule("tests/main.js");
 });
-
-// More tests can be found in the http package

--- a/packages/url/package.js
+++ b/packages/url/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "url-polyfill": "1.1.3",
+  "core-js": "3.5.0"
 });
 
 Package.onUse(function(api) {

--- a/packages/url/server.js
+++ b/packages/url/server.js
@@ -1,0 +1,25 @@
+const { URL, URLSearchParams } = require('url');
+
+exports.URL = URL;
+exports.URLSearchParams = URLSearchParams;
+
+const { setMinimumBrowserVersions } = require("meteor/modern-browsers");
+
+// https://caniuse.com/#feat=url
+setMinimumBrowserVersions({
+   // Since there is no IE12, this effectively excludes Internet Explorer
+  // (pre-Edge) from the modern classification. #9818 #9839
+  ie: 12,
+  chrome: 32,
+  edge: 12,
+  firefox: 26,
+  mobile_safari: 8,
+  opera: 36,
+  safari: [7, 1],
+  phantomjs: Infinity,
+  // https://github.com/Kilian/electron-to-chromium/blob/master/full-versions.js
+  electron: [0, 20],
+}, module.id);
+
+// backwards compatability
+Object.assign(exports.URL, require('./bc/url_server'));

--- a/packages/url/tests/main.js
+++ b/packages/url/tests/main.js
@@ -1,0 +1,9 @@
+import { Tinytest } from "meteor/tinytest";
+
+Tinytest.add("url - sanity", function (test) {
+  test.equal(typeof URL, "function");
+  test.equal(typeof URLSearchParams, "function");
+});
+
+// backwards compatability
+require('../bc/url_tests');


### PR DESCRIPTION
Similar to the recent fetch package, this would add an isomorphic way to use the WHATWG URL api in legacy browsers (I needed this mainly for IE11).

Unfortunately there was already a url package exporting `URL`. So for BC reasons I have to add those old methods to the global URL function.