### PR TITLE
Fix checking for a rerender timeout

### DIFF
--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -336,7 +336,7 @@ class ProgressDisplayFull {
       this._progressBarRenderer.start = startTime;
     }
 
-    if (!this._renderTimeout && this._lastWrittenTime) {
+    if (!this._rerenderTimeout && this._lastWrittenTime) {
       this._rerenderTimeout = setTimeout(() => {
         this._rerenderTimeout = null;
         this._render()


### PR DESCRIPTION
Fixes a typo that caused ProgressDisplayFull to sometimes render after it was replaced with a different progress display.