### PR TITLE
Enable TypeScript compilation of .ts modules in meteor/tools.

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=8.15.1.6
+BUNDLE_VERSION=8.15.1.7
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,7 +14,7 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/c5043daa1b768594e01d76275e3854fc19f038f9",
     "node-gyp": "3.7.0",
     "node-pre-gyp": "0.10.3",
-    "meteor-babel": "7.4.3",
+    "meteor-babel": "7.4.4",
     "meteor-promise": "0.8.7",
     reify: "0.17.3",
     fibers: "3.1.1",
@@ -23,7 +23,6 @@ var packageJson = {
     // For backwards compatibility with isopackets that still depend on
     // babel-runtime rather than @babel/runtime.
     "babel-runtime": "7.0.0-beta.3",
-    tslib: "1.9.3",
     // Not yet upgrading Underscore from 1.5.2 to 1.7.0 (which should be done
     // in the package too) because we should consider using lodash instead
     // (and there are backwards-incompatible changes either way).

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -14,7 +14,7 @@ import LRU from 'lru-cache';
 import {sourceMapLength} from '../utils/utils.js';
 import {Console} from '../console/console.js';
 import ImportScanner from './import-scanner.js';
-import {cssToCommonJS} from "./css-modules.js";
+import {cssToCommonJS} from "./css-modules";
 import Resolver from "./resolver.js";
 import {
   optimisticStatOrNull,

--- a/tools/isobuild/css-modules.ts
+++ b/tools/isobuild/css-modules.ts
@@ -1,4 +1,4 @@
-export function cssToCommonJS(css) {
+export function cssToCommonJS(css: string) {
   return [
     'module.exports = require("meteor/modules").addStyles(',
     "  " + JSON.stringify(css),

--- a/tools/isobuild/import-scanner.js
+++ b/tools/isobuild/import-scanner.js
@@ -7,7 +7,7 @@ import {
 import {sha1} from "../fs/watch.js";
 import {matches as archMatches} from "../utils/archinfo.js";
 import {findImportedModuleIdentifiers} from "./js-analyze.js";
-import {cssToCommonJS} from "./css-modules.js";
+import {cssToCommonJS} from "./css-modules";
 import buildmessage from "../utils/buildmessage.js";
 import LRU from "lru-cache";
 import {Profile} from "../tool-env/profile.js";

--- a/tools/tool-env/install-babel.js
+++ b/tools/tool-env/install-babel.js
@@ -10,7 +10,8 @@ function babelRegister() {
   const meteorPath = path.dirname(toolsPath);
   const cacheDir = path.join(meteorPath, ".babel-cache");
   const babelOptions = meteorBabel.getDefaultOptions({
-    nodeMajorVersion: parseInt(process.versions.node)
+    nodeMajorVersion: parseInt(process.versions.node),
+    typescript: true
   });
 
   // Make sure that source maps are included in the generated code for

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es2018",
+    "module": "es2015",
+    "lib": ["esnext"],
+    "allowJs": true,
+    "checkJs": false,
+    "incremental": true,
+    "noEmit": true,
+
+    /* Strict Type-Checking Options */
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+
+    /* Additional Checks */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": false,
+    "noFallthroughCasesInSwitch": false,
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",
+    "types": ["node"],
+    "esModuleInterop": true,
+    "preserveSymlinks": true,
+  }
+}


### PR DESCRIPTION
These changes pave the way for incrementally converting the implementation of Meteor's command-line tool to TypeScript, which should have profound benefits for self-documentation via types, as well as substantially improving navigability and approachability for community contributors.

Just imagine being able to auto-complete the fields of the various `File`-like classes currently floating around the codebase, instead of having to track down their implementations every time. TypeScript was designed with large projects like Meteor in mind, and it seems increasingly irresponsible to forgo the benefits of a type system by relying on the expertise of a few core contributors who know the codebase inside and out. I am one of those few people, and I am very excited to have the assistance of a type system, so I can only imagine how transformative and empowering it will be for everyone else.

If you've ever wanted to get involved in core Meteor development, picking a few `meteor/tools` modules to convert to TypeScript is a great way to get to know that part of the codebase, while also making things easier for everyone else who interacts with that code in the future.

> **Note:** Although I've included this PR in the [Meteor 1.8.2 milestone](https://github.com/meteor/meteor/milestone/66), converting the entire `meteor/tools` codebase to TypeScript is _not_ a blocker for the 1.8.2 release. This will be an ongoing, incremental project that we may not ever declare "finished," and that's okay!

Because we already compile `meteor/tools` using Babel, it makes the most sense to use [Babel's `@babel/preset-typescript`](https://babeljs.io/docs/en/next/babel-preset-typescript.html) to compile `.ts` files.

Using Babel also means we get to keep all of our current advanced compilation strategies, such as using [Reify](https://www.npmjs.com/package/reify) to compile module syntax.

Since we're using Babel, the `meteor/tools/tsconfig.json` file exists mostly for the benefit of external tools like VSCode, rather than as a source of truth for compilation behavior.

Despite our existing convention of including explicit `.js` file extensions when importing modules, TypeScript and VSCode strongly encourage omitting the file extension, so the import can be resolved to a `.ts` file in development or a `.js` file when compiled. Although I find this ambiguity somewhat unfortunate, it makes sense to follow community norms, at least until Node.js begins supporting `.ts` modules by default (if that day ever comes).