### PR TITLE
Should be retry run test for Travis CI when falling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ cache:
   directories:
     - ".meteor"
     - ".babel-cache"
-script: TEST_PACKAGES_EXCLUDE="less" phantom=false ./packages/test-in-console/run.sh
+script:
+  - export TEST_PACKAGES_EXCLUDE="less"
+  - export phantom=false
+  - travis_retry ./packages/test-in-console/run.sh
 sudo: false
 env:
   - CXX=g++-4.8


### PR DESCRIPTION
I think we should retry run test for Travis CI when failing by timeout or network, max times to retry is 3 times. Read more about `travis_retry` at [here](https://docs.travis-ci.com/user/common-build-problems/#travis_retry)