### PR TITLE
Support the "module" field of package.json for client code.

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,6 +13,13 @@ N/A
 
 * The `meteor-babel` npm package has been updated to version 7.4.3.
 
+* When bundling client code, the Meteor module system now prefers the
+  `"module"` field in `package.json`, if defined. Additionally, npm
+  packages with a `"module"` entry point will now be compiled
+  automatically by `meteor-babel`, like application code, without any
+  special symlinking tricks.
+  [PR #10541](https://github.com/meteor/meteor/pull/10541)
+
 ## v1.8.1, 2019-04-03
 
 ### Breaking changes

--- a/packages/modules-runtime/client.js
+++ b/packages/modules-runtime/client.js
@@ -1,7 +1,8 @@
 meteorInstall = makeInstaller({
   // On the client, make package resolution prefer the "browser" field of
-  // package.json files to the "main" field.
+  // package.json over the "module" field over the "main" field.
   browser: true,
+  mainFields: ["browser", "module", "main"],
 
   fallback: function(id, parentId, error) {
     if (id && id.startsWith('meteor/')) {

--- a/packages/modules-runtime/package.js
+++ b/packages/modules-runtime/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules-runtime",
-  version: "0.10.3",
+  version: "0.11.0",
   summary: "CommonJS module system",
   git: "https://github.com/benjamn/install",
   documentation: "README.md"

--- a/tools/fs/optimistic.js
+++ b/tools/fs/optimistic.js
@@ -275,6 +275,21 @@ export const optimisticReadMeteorIgnore = wrap(dir => {
   return null;
 });
 
+export const optimisticLookupPackageJson = wrap((absRootDir, relDir) => {
+  const absPkgJsonPath = pathJoin(absRootDir, relDir, "package.json");
+  const pkgJson = optimisticReadJsonOrNull(absPkgJsonPath);
+  if (pkgJson) {
+    return pkgJson;
+  }
+
+  const relParentDir = pathDirname(relDir);
+  if (relParentDir === relDir) {
+    return null;
+  }
+
+  return optimisticLookupPackageJson(absRootDir, relParentDir);
+});
+
 const optimisticIsSymbolicLink = wrap(path => {
   try {
     return lstat(path).isSymbolicLink();

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -299,6 +299,7 @@ _.extend(Module.prototype, {
           }
 
           tryMain("browser");
+          tryMain("module");
           tryMain("main");
 
           stubArray.push(stub);

--- a/tools/isobuild/resolver.js
+++ b/tools/isobuild/resolver.js
@@ -83,6 +83,12 @@ export default class Resolver {
 
     this._cacheMethod("_findPkgJsonSubsetForPath");
     this._cacheMethod("_getPkgJsonSubsetForDir");
+
+    if (archMatches(this.targetArch, "web")) {
+      this.mainFields = ["browser", "module", "main"];
+    } else {
+      this.mainFields = ["main"];
+    }
   }
 
   _cacheMethod(name) {
@@ -366,11 +372,7 @@ export default class Resolver {
       }
     }
 
-    if (archMatches(this.targetArch, "web")) {
-      tryMain("browser");
-    }
-
-    tryMain("main");
+    this.mainFields.forEach(tryMain);
 
     return {
       path: pkgJsonPath,

--- a/tools/tests/apps/modules/package-lock.json
+++ b/tools/tests/apps/modules/package-lock.json
@@ -186,6 +186,14 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@wry/context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.0.tgz",
+      "integrity": "sha512-rVjwzFjVYXJ8pWJ8ZRCHv6meOebQvfTlvnUYUNX93Ce0KNeMTqCkf0GiOJc6BNVB96s7qfvwoLN3nUgDnSFOOg==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "acorn": {
       "version": "file:imports/links/acorn"
     },
@@ -1498,6 +1506,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/tools/tests/apps/modules/package.json
+++ b/tools/tests/apps/modules/package.json
@@ -8,6 +8,7 @@
     "@babel/plugin-proposal-do-expressions": "^7.0.0-beta.56",
     "@babel/plugin-proposal-optional-chaining": "^7.0.0-beta.56",
     "@babel/runtime": "^7.1.2",
+    "@wry/context": "^0.4.0",
     "acorn": "file:imports/links/acorn",
     "aws-sdk": "^2.2.41",
     "cli-color": "^0.2.3",

--- a/tools/tests/apps/modules/tests.js
+++ b/tools/tests/apps/modules/tests.js
@@ -344,6 +344,20 @@ describe("local node_modules", () => {
     // module layout, so we shouldn't let this change without notice.
     assert.strictEqual(pkg.version, "0.2.3");
   });
+
+  it('should prefer "module" field of package.json on client', () => {
+    assert.strictEqual(
+      require.resolve("@wry/context"),
+      "/node_modules/@wry/context/lib/" + (
+        Meteor.isClient ? "context.esm.js" : "context.js"
+      ),
+    );
+
+    assert.strictEqual(
+      typeof require("@wry/context").Slot,
+      "function",
+    );
+  });
 });
 
 describe("Meteor packages", () => {


### PR DESCRIPTION
Like Node.js, Meteor's module system currently pays attention only to the `"main"` field of `package.json` files (and also `"browser"` on the client) when resolving package entry points. This behavior effectively limits Meteor to using the CommonJS version of any npm packages, even though many packages have both a CommonJS and an ECMAScript module (ESM) entry point.

This PR enables support for the `"module"` field for client code. The implementation required a few small adjustments: in particular, we now compile `.js` files within `node_modules` if they are contained by a package that has a `"module"` entry point (only if the `ImportScanner` decides the module is actually used), and our module resolution logic now prefers the `"module"` entry point both during build (`resover.js`) and at runtime (`modules-runtime`).

Why is this important? Supporting ESM syntax everywhere is the future of JavaScript, first and foremost. Also, wherever ESM syntax is used, it's important for Meteor to have a chance to compile it, since we have an advanced module compiler called [Reify](https://blog.meteor.com/reify-meteors-evolving-javascript-module-compiler-70425fa45d81).

Supporting `"module"` in `package.json` for server code is not advisable because Node.js will be adopting the [`"type": "module"` convention](https://medium.com/@nodejs/announcing-a-new-experimental-modules-1be8d2d6c2ff) instead, and in the meantime we need to maintain consistency with Node's module resolution rules, which only currently pay attention to `"main"`.