### PR TITLE
[fix #10157] Make sure onLogin callbacks are called during startup

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -441,16 +441,14 @@ export class AccountsClient extends AccountsCommon {
   // at registration time if already logged in
   // this can happen when new AccountsClient is created
   // before callbacks are registered see #10157
-  _startupCallback(callbackId) {
+  _startupCallback(callback) {
     // Are we already logged in?
     if (this.connection._userId) {
-      // Then go ahead and call the callback that we just registered.
-      const cb = this._onLoginHook.callbacks[callbackId];
       // If already logged in before handler is registered, it's safe to
-      // assume type is a 'resume', and execute the callback at the end of
-      // the queue so that Meteor.startup can complete before any embedded
-      // onLogin callbacks would execute.
-      Meteor.setTimeout(() => cb({ type: 'resume' }), 0);
+      // assume type is a 'resume', so we execute the callback at the end
+      // of the queue so that Meteor.startup can complete before any
+      // embedded onLogin callbacks would execute.
+      Meteor.setTimeout(() => callback({ type: 'resume' }), 0);
     }
   }
 

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -196,7 +196,10 @@ export class AccountsCommon {
    *                        as user details, connection information, etc.
    */
   onLogin(func) {
-    return this._onLoginHook.register(func);
+    let ret = this._onLoginHook.register(func);
+    // call the just registered callback if already logged in
+    this._startupCallback(this._onLoginHook.nextCallbackId - 1);
+    return ret;
   }
 
   /**
@@ -285,6 +288,9 @@ export class AccountsCommon {
     }
     return new Date() > (new Date(when) - minLifetimeMs);
   }
+
+  // noop on the server overridden on the client
+  _startupCallback(callbackId) {}
 }
 
 // Note that Accounts is defined separately in accounts_client.js and

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -198,7 +198,7 @@ export class AccountsCommon {
   onLogin(func) {
     let ret = this._onLoginHook.register(func);
     // call the just registered callback if already logged in
-    this._startupCallback(this._onLoginHook.nextCallbackId - 1);
+    this._startupCallback(ret.callback);
     return ret;
   }
 
@@ -289,8 +289,8 @@ export class AccountsCommon {
     return new Date() > (new Date(when) - minLifetimeMs);
   }
 
-  // noop on the server overridden on the client
-  _startupCallback(callbackId) {}
+  // No-op on the server, overridden on the client.
+  _startupCallback(callback) {}
 }
 
 // Note that Accounts is defined separately in accounts_client.js and

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "A user account system",
-  version: "1.4.4",
+  version: "1.4.5",
 });
 
 Package.onUse(api => {

--- a/packages/callback-hook/hook.js
+++ b/packages/callback-hook/hook.js
@@ -77,6 +77,7 @@ export class Hook {
     this.callbacks[id] = callback;
 
     return {
+      callback,
       stop: () => {
         delete this.callbacks[id];
       }

--- a/packages/callback-hook/package.js
+++ b/packages/callback-hook/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Register callbacks on a hook",
-  version: '1.1.0'
+  version: '1.2.0'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
This repairs a timing issue. #10157 

Essentially, the user is logged in before any `onLogin` callbacks can be set up.  To remedy the problem:

I added a new internal function.
### `AccountsCommon#_startupCallback` internal function
- `_startupCallback` is [called](https://github.com/brucejo75/meteor/blob/accounts_call_onLogin_callbacks_startup/packages/accounts-base/accounts_common.js#L198-L203) is called right after an `onLogin` callback is registered.
- On the client [`_startupCallback`](https://github.com/brucejo75/meteor/blob/accounts_call_onLogin_callbacks_startup/packages/accounts-base/accounts_client.js#L440-L455) checks if the user is logged in (non reactively), if true then the newly registered `callback` is scheduled to execute at the back of the event loop.  This makes sure that all necessary`Meteor.startup` callbacks complete before the `onLogin` callback executes if the `onLogin` is called within a `Meteor.startup`.
- On the server the function is a [noop](https://github.com/brucejo75/meteor/blob/accounts_call_onLogin_callbacks_startup/packages/accounts-base/accounts_common.js#L292-L293).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
