### PR TITLE
Allow .npm/package/node_modules to be compiled in Meteor packages.

### DIFF
--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -65,7 +65,7 @@ const hasOwn = Object.prototype.hasOwnProperty;
 // Cache the (slightly post-processed) results of linker.fullLink.
 const CACHE_SIZE = process.env.METEOR_LINKER_CACHE_SIZE || 1024*1024*100;
 const CACHE_DEBUG = !! process.env.METEOR_TEST_PRINT_LINKER_CACHE_DEBUG;
-const LINKER_CACHE_SALT = 22; // Increment this number to force relinking.
+const LINKER_CACHE_SALT = 23; // Increment this number to force relinking.
 const LINKER_CACHE = new LRU({
   max: CACHE_SIZE,
   // Cache is measured in bytes. We don't care about servePath.

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -34,7 +34,7 @@ var compiler = exports;
 // dependencies. (At least for now, packages only used in target creation (eg
 // minifiers) don't require you to update BUILT_BY, though you will need to quit
 // and rerun "meteor run".)
-compiler.BUILT_BY = 'meteor/32';
+compiler.BUILT_BY = 'meteor/33';
 
 // This is a list of all possible architectures that a build can target. (Client
 // is expanded into 'web.browser' and 'web.cordova')

--- a/tools/tests/apps/modules/packages/modules-test-package/.npm/package/npm-shrinkwrap.json
+++ b/tools/tests/apps/modules/packages/modules-test-package/.npm/package/npm-shrinkwrap.json
@@ -1,6 +1,11 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
+    "@wry/context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.0.tgz",
+      "integrity": "sha512-rVjwzFjVYXJ8pWJ8ZRCHv6meOebQvfTlvnUYUNX93Ce0KNeMTqCkf0GiOJc6BNVB96s7qfvwoLN3nUgDnSFOOg=="
+    },
     "assert": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",

--- a/tools/tests/apps/modules/packages/modules-test-package/common.js
+++ b/tools/tests/apps/modules/packages/modules-test-package/common.js
@@ -5,6 +5,16 @@ export const ModulesTestPackage = "loaded";
 import { parse } from "acorn";
 assert.strictEqual(typeof parse, "function");
 
+// Test that an npm package with a "module" entry point in its package.json
+// file can be imported.
+import { Slot } from "@wry/context";
+assert.strictEqual(typeof Slot, "function");
+const idPrefix = "/node_modules/meteor/modules-test-package/node_modules/@wry/context/lib/";
+assert.strictEqual(
+  require.resolve("@wry/context"),
+  idPrefix + (Meteor.isClient ? "context.esm.js" : "context.js"),
+);
+
 export function checkWhere(where) {
   const { where: serverWhere } = require("./server/where.js");
   const { where: clientWhere } = require("./client/where.js");

--- a/tools/tests/apps/modules/packages/modules-test-package/package.js
+++ b/tools/tests/apps/modules/packages/modules-test-package/package.js
@@ -6,6 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
+  "@wry/context": "0.4.0",
   "os-browserify": "0.2.0",
   "assert": "1.3.0",
   "cheerio": "0.22.0"

--- a/tools/tests/apps/modules/packages/modules-test-plugin/.npm/plugin/compile-arson/npm-shrinkwrap.json
+++ b/tools/tests/apps/modules/packages/modules-test-plugin/.npm/plugin/compile-arson/npm-shrinkwrap.json
@@ -17,19 +17,19 @@
       "integrity": "sha1-wM5mIMtfLB+xArIPZXQRVcq8REo="
     },
     "babel-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4="
     },
     "babel-types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc="
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "esutils": {
       "version": "2.0.2",
@@ -37,19 +37,29 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "ts-invariant": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.1.tgz",
+      "integrity": "sha512-fdL8AZinDiVKMsOI0cOWHLprS85LWy2p/eVSctVe6fpZF9BAvO59sQYMEWQ37yybBtlKU2zkmILYmy1jrOf6+g=="
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     }
   }
 }

--- a/tools/tests/apps/modules/packages/modules-test-plugin/package.js
+++ b/tools/tests/apps/modules/packages/modules-test-plugin/package.js
@@ -14,6 +14,7 @@ Package.registerBuildPlugin({
   npmDependencies: {
     // TODO Figure out what to do about the duplication between this list
     // and the Npm.depends list below.
+    "ts-invariant": "0.4.1",
     "babel-plugin-transform-class-properties": "6.9.0",
     "babel-plugin-transform-strict-mode": "6.8.0"
   }

--- a/tools/tests/apps/modules/packages/modules-test-plugin/plugin.js
+++ b/tools/tests/apps/modules/packages/modules-test-plugin/plugin.js
@@ -1,4 +1,14 @@
-import assert from "assert";
+import { invariant } from "ts-invariant";
+
+invariant(
+  typeof process.versions.node === "string",
+  "Meteor plugins should only run in Node.js",
+);
+
+invariant(
+  require.resolve("ts-invariant"),
+  "/node_modules/meteor/meteor-test-plugin/node_modules/ts-invariant/lib/invariant.js",
+);
 
 // This verifies that babel-plugin-transform-strict-mode is enabled.
 let expected;
@@ -7,8 +17,8 @@ try {
 } catch (e) {
   expected = e;
 }
-assert.ok(expected instanceof TypeError);
-assert.ok(/callee/.test(expected.message));
+invariant(expected instanceof TypeError);
+invariant(/callee/.test(expected.message), expected.message);
 
 Plugin.registerCompiler({
   extensions: ["arson"]
@@ -20,8 +30,8 @@ class ArsonCompiler {
   expectedName = "compile-arson";
 
   processFilesForTarget(inputFiles) {
-    assert.strictEqual(this.expectedName, "compile-arson");
-    assert.ok(inputFiles.length > 0);
+    invariant(this.expectedName === "compile-arson", this.expectedName);
+    invariant(inputFiles.length > 0);
 
     let vueCheckCount = 0;
 
@@ -47,14 +57,12 @@ class ArsonCompiler {
         const vueCompilerId = file.resolve("vue-template-compiler");
         // Make sure resolution does not use the "browser" field of
         // vue-template-compiler/package.json.
-        assert.strictEqual(
-          vueCompilerId.split("/").pop(),
-          "index.js"
-        );
+        const base = vueCompilerId.split("/").pop();
+        invariant(base === "index.js", base);
         ++vueCheckCount;
       }
     });
 
-    assert.ok(vueCheckCount > 0);
+    invariant(vueCheckCount > 0);
   }
 }


### PR DESCRIPTION
When I implemented support for the `"module"` entry point in `package.json` files for client code in #10541, I modified `PackageSource#_findSources` to include files found in `node_modules` that need to be compiled, but my implementation considered only "local" `node_modules` directories, like the one in the application root directory, while neglecting the private `.npm/package/node_modules` directories that many Meteor packages have.

This PR includes `.npm/**/node_modules` when `_findSources` is scanning a Meteor package, which should solve issues like #10544, where a Meteor package imports an npm package that was installed with `Npm.depends`, and that npm package has a `"module"` field in its `package.json` file, pointing to an ESM entry point module, but the ESM syntax was not appropriately compiled, leading to parse errors like `"Unexpected token export"`.

Before lazy compilation was introduced in Meteor 1.7 (#9983), including the `node_modules` directories of Meteor packages would likely have been a big problem for build performance, since there would be that many more modules to compile. It's still worth making sure this change doesn't regress build performance for other reasons, but I'm reasonably confident lazy compilation will save us here, unless there are just too many npm packages installed via `Npm.depends` that export ESM modules.