### PR TITLE
Add missing dot in query parameter in accounts-google package

### DIFF
--- a/packages/accounts-google/google.js
+++ b/packages/accounts-google/google.js
@@ -50,7 +50,7 @@ if (Meteor.isClient) {
       Google.whitelistedFields.filter(
         field => field !== 'email' && field !== 'verified_email'
       ).map(
-        subfield => `services.google${subfield}`
+        subfield => `services.google.${subfield}`
       ),
   });
 }


### PR DESCRIPTION
A dot went missing in a query parameter (in this commit: bb17d4d). Stumbled upon this by accident and have not seen any similar issues or pull requests.