### PR TITLE
Allow for METEOR_GIT_COMMIT_HASH in lieu of findGitCommitHash's execFile

### DIFF
--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -484,7 +484,7 @@ export class CordovaBuilder {
 
     const runtimeConfig = {
       meteorRelease: meteorRelease,
-      gitCommitHash: files.findGitCommitHash(applicationPath),
+      gitCommitHash: process.env.METEOR_GIT_COMMIT_HASH || files.findGitCommitHash(applicationPath),
       ROOT_URL: mobileServerUrl,
       // XXX propagate it from this.options?
       ROOT_URL_PATH_PREFIX: '',

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2931,7 +2931,7 @@ var writeSiteArchive = Profile("bundler writeSiteArchive", function (
       meteorRelease: releaseName,
       nodeVersion: process.versions.node,
       npmVersion: meteorNpm.npmVersion,
-      gitCommitHash: files.findGitCommitHash(sourceRoot),
+      gitCommitHash: process.env.METEOR_GIT_COMMIT_HASH || files.findGitCommitHash(sourceRoot),
     };
 
     // Tell the deploy server what version of the dependency kit we're using, so


### PR DESCRIPTION
Straight forward, we allow for overriding `gitCommitHash` in lieu of `findGitCommitHash`

Needed when build systems don't have access to `git` or `.git/`, but commit may be known.

This could also be used as a way to set custom version numbers, although something like `Meteor.appVersion` may be desired.

Cheers,
- Rob