### PR TITLE
Update ecmascript-runtime-{client,server} to use core-js@3.1.4.

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,6 +13,9 @@ N/A
 
 * The `meteor-babel` npm package has been updated to version 7.4.3.
 
+* The `core-js` npm package used by `ecmascript-runtime-client` and
+  `ecmascript-runtime-server` has been updated to version 3.1.4.
+
 * When bundling client code, the Meteor module system now prefers the
   `"module"` field in `package.json`, if defined. Additionally, npm
   packages with a `"module"` entry point will now be compiled

--- a/packages/ecmascript-runtime-client/.npm/package/npm-shrinkwrap.json
+++ b/packages/ecmascript-runtime-client/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
     }
   }
 }

--- a/packages/ecmascript-runtime-client/legacy.js
+++ b/packages/ecmascript-runtime-client/legacy.js
@@ -1,7 +1,7 @@
 try {
-  Symbol = exports.Symbol = require("core-js/modules/es.symbol");
-  Map = exports.Map = require("core-js/modules/es.map");
-  Set = exports.Set = require("core-js/modules/es.set");
+  Symbol = exports.Symbol = require("core-js/es/symbol");
+  Map = exports.Map = require("core-js/es/map");
+  Set = exports.Set = require("core-js/es/set");
 
 } catch (e) {
   throw new Error([

--- a/packages/ecmascript-runtime-client/legacy.js
+++ b/packages/ecmascript-runtime-client/legacy.js
@@ -1,16 +1,7 @@
 try {
-  require("core-js/modules/es6.symbol");
-  require("core-js/modules/es6.map");
-  require("core-js/modules/es6.set");
-
-  var core = function () {
-    try {
-      return require("core-js/modules/_core");
-    } catch (e) {
-      // Older versions of core-js had a different file layout.
-      return require("core-js/modules/$.core");
-    }
-  }();
+  Symbol = exports.Symbol = require("core-js/modules/es.symbol");
+  Map = exports.Map = require("core-js/modules/es.map");
+  Set = exports.Set = require("core-js/modules/es.set");
 
 } catch (e) {
   throw new Error([
@@ -22,19 +13,15 @@ try {
   ].join("\n"));
 }
 
-Symbol = exports.Symbol = core.Symbol;
-Map = exports.Map = core.Map;
-Set = exports.Set = core.Set;
-
 // ECMAScript 2015 polyfills.
-require("core-js/es6/array");
-require("core-js/es6/function");
-require("core-js/es6/math");
-require("core-js/es6/object");
-require("core-js/es6/regexp");
-require("core-js/es6/string");
-require("core-js/es6/weak-map");
-require("core-js/es6/weak-set");
+require("core-js/es/array");
+require("core-js/es/function");
+require("core-js/es/math");
+require("core-js/es/object");
+require("core-js/es/regexp");
+require("core-js/es/string");
+require("core-js/es/weak-map");
+require("core-js/es/weak-set");
 
 // If the Reflect global namespace is missing or undefined, explicitly
 // initialize it as undefined, so that expressions like _typeof(Reflect)
@@ -43,26 +30,20 @@ if (typeof Reflect === "undefined") {
   global.Reflect = void 0;
 }
 
-// ECMAScript 2017 polyfills.
-require("core-js/es7/array");
-require("core-js/es7/object");
-require("core-js/modules/es7.string.pad-start");
-require("core-js/modules/es7.string.pad-end");
-
-// We want everything from the core-js/es6/number module except
-// es6.number.constructor.
-require('core-js/modules/es6.number.epsilon');
-require('core-js/modules/es6.number.is-finite');
-require('core-js/modules/es6.number.is-integer');
-require('core-js/modules/es6.number.is-nan');
-require('core-js/modules/es6.number.is-safe-integer');
-require('core-js/modules/es6.number.max-safe-integer');
-require('core-js/modules/es6.number.min-safe-integer');
-require('core-js/modules/es6.number.parse-float');
-require('core-js/modules/es6.number.parse-int');
+// We want everything from the core-js/es/number module except
+// es.number.constructor.
+require('core-js/modules/es.number.epsilon');
+require('core-js/modules/es.number.is-finite');
+require('core-js/modules/es.number.is-integer');
+require('core-js/modules/es.number.is-nan');
+require('core-js/modules/es.number.is-safe-integer');
+require('core-js/modules/es.number.max-safe-integer');
+require('core-js/modules/es.number.min-safe-integer');
+require('core-js/modules/es.number.parse-float');
+require('core-js/modules/es.number.parse-int');
 
 // Typed Arrays
-require('core-js/modules/es6.typed.uint8-array');
-require('core-js/modules/es6.typed.uint32-array');
+require('core-js/modules/es.typed-array.uint8-array');
+require('core-js/modules/es.typed-array.uint32-array');
 
 require("./modern.js");

--- a/packages/ecmascript-runtime-client/modern.js
+++ b/packages/ecmascript-runtime-client/modern.js
@@ -1,5 +1,5 @@
 try {
-  require("core-js/modules/es7.object.get-own-property-descriptors");
+  require("core-js/modules/es.object.get-own-property-descriptors");
 } catch (e) {
   throw new Error([
     "The core-js npm package could not be found in your node_modules ",
@@ -10,13 +10,14 @@ try {
   ].join("\n"));
 }
 
-require("core-js/modules/es6.object.is");
-require("core-js/modules/es6.function.name");
-require("core-js/modules/es6.number.is-finite");
-require("core-js/modules/es6.number.is-nan");
-require("core-js/modules/es7.array.flatten");
-require("core-js/modules/es7.array.flat-map");
-require("core-js/modules/es7.object.values");
-require("core-js/modules/es7.object.entries");
-require("core-js/modules/es7.string.pad-start");
-require("core-js/modules/es7.string.pad-end");
+require("core-js/modules/es.object.is");
+require("core-js/modules/es.function.name");
+require("core-js/modules/es.number.is-finite");
+require("core-js/modules/es.number.is-nan");
+require("core-js/modules/es.array.flat");
+require("core-js/modules/es.array.flat-map");
+require("core-js/modules/es.object.values");
+require("core-js/modules/es.object.entries");
+require("core-js/modules/es.string.pad-start");
+require("core-js/modules/es.string.pad-end");
+require("core-js/modules/es.symbol.async-iterator");

--- a/packages/ecmascript-runtime-client/package.js
+++ b/packages/ecmascript-runtime-client/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: "ecmascript-runtime-client",
-  version: "0.8.0",
+  version: "0.9.0",
   summary: "Polyfills for new ECMAScript 2015 APIs like Map and Set",
   git: "https://github.com/meteor/meteor/tree/devel/packages/ecmascript-runtime-client",
   documentation: "README.md"
 });
 
 Npm.depends({
-  "core-js": "2.5.7"
+  "core-js": "3.1.4"
 });
 
 Package.onUse(function(api) {

--- a/packages/ecmascript-runtime-server/.npm/package/npm-shrinkwrap.json
+++ b/packages/ecmascript-runtime-server/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
     }
   }
 }

--- a/packages/ecmascript-runtime-server/package.js
+++ b/packages/ecmascript-runtime-server/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: "ecmascript-runtime-server",
-  version: "0.7.1",
+  version: "0.8.0",
   summary: "Polyfills for new ECMAScript 2015 APIs like Map and Set",
   git: "https://github.com/meteor/meteor/tree/devel/packages/ecmascript-runtime-client",
   documentation: "README.md"
 });
 
 Npm.depends({
-  "core-js": "2.5.7"
+  "core-js": "3.1.4"
 });
 
 Package.onUse(function(api) {

--- a/packages/ecmascript-runtime-server/runtime.js
+++ b/packages/ecmascript-runtime-server/runtime.js
@@ -21,5 +21,6 @@
 // Note that the es6.reflect.* and es6.typed.* modules have been commented
 // out for bundle size reasons.
 
-require("core-js/modules/es7.string.pad-start");
-require("core-js/modules/es7.string.pad-end");
+require("core-js/modules/es.string.pad-start");
+require("core-js/modules/es.string.pad-end");
+require("core-js/modules/es.symbol.async-iterator");

--- a/packages/ecmascript-runtime/package.js
+++ b/packages/ecmascript-runtime/package.js
@@ -14,7 +14,7 @@ Package.onUse(function(api) {
 Package.onTest(function(api) {
   api.use("tinytest");
   api.use("check");
+  api.use("ecmascript");
   api.use("es5-shim");
-  api.use("ecmascript-runtime");
   api.addFiles("runtime-tests.js");
 });

--- a/packages/ecmascript-runtime/runtime-tests.js
+++ b/packages/ecmascript-runtime/runtime-tests.js
@@ -124,3 +124,30 @@ Tinytest.add("core-js - Function", function (test) {
   test.equal(Constructor[Symbol.hasInstance](new Constructor), true);
   test.equal(Constructor[Symbol.hasInstance]({}), false);
 });
+
+Tinytest.addAsync("async iterators", async test => {
+  class Range {
+    constructor(limit) {
+      this.limit = limit;
+    }
+
+    [Symbol.asyncIterator]() {
+      const promises = [];
+      for (let value = 1; value <= this.limit; ++value) {
+        promises.push(Promise.resolve({ value, done: false }));
+      }
+
+      return {
+        next() {
+          return promises.shift() || Promise.resolve({ done: true });
+        }
+      };
+    }
+  }
+
+  let sum = 0;
+  for await (const n of new Range(10)) {
+    sum += n;
+  }
+  test.equal(sum, (10 * 11) / 2);
+});


### PR DESCRIPTION
Also added a polyfill for `Symbol.asyncIterator` to server, modern, and legacy bundles, which should fix #9897.