### PR TITLE
Ignore oplog entries from other dbs instead of throwing an error.

### DIFF
--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -289,8 +289,6 @@ _.extend(OplogHandle.prototype, {
         if (typeof doc.ns === "string" &&
             doc.ns.startsWith(self._dbName + ".")) {
           trigger.collection = doc.ns.slice(self._dbName.length + 1);
-        } else {
-          throw new Error("Unexpected ns");
         }
 
         // Is it a special command and the collection name is hidden

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.6.2'
+  version: '1.6.3'
 });
 
 Npm.depends({


### PR DESCRIPTION
This is my first pull request to meteor, so I am sorry if I forgot something.

The changes targets issue: https://github.com/meteor/meteor/issues/10602

Instead of throwing an error if there is an oplog entire from another db on the same mongo instance it is now simply ignored.

I also pushed the minor version of the package.js file, I am not sure if there are required any further changes.
