### PR TITLE
feat: allow to pass METEOR_SETTINGS by env vars

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -307,6 +307,7 @@ var runCommandOptions = {
     production: { type: Boolean },
     'raw-logs': { type: Boolean },
     settings: { type: String, short: "s" },
+    'allow-settings-from-env': { type: Boolean },
     verbose: { type: Boolean, short: "v" },
     // With --once, meteor does not re-run the project if it crashes
     // and does not monitor for file changes. Intentionally
@@ -443,6 +444,7 @@ function doRunCommand(options) {
     cordovaServerPort: parsedCordovaServerPort,
     once: options.once,
     noReleaseCheck: options['no-release-check'] || process.env.METEOR_NO_RELEASE_CHECK,
+    allowSettingsFromEnv: options['allow-settings-from-env'],
     cordovaRunner: cordovaRunner
   });
 }

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -500,6 +500,7 @@ Options:
   --delete, -D    permanently delete this deployment
   --debug         deploy in debug mode (don't minify, etc)
   --settings, -s  set optional data for Meteor.settings
+  --allow-settings-from-env   Allow to pass settings from the environment-variable METEOR_SETTINGS
   --allow-incompatible-update   Allow packages in your project to be upgraded or
                   downgraded to versions that are potentially incompatible with
                   the current versions, if required to satisfy all package version

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -65,12 +65,13 @@ var AppProcess = function (options) {
   self.mongoUrl = options.mongoUrl;
   self.oplogUrl = options.oplogUrl;
   self.mobileServerUrl = options.mobileServerUrl;
-
+  
   self.onExit = options.onExit;
   self.onListen = options.onListen;
   self.nodeOptions = options.nodeOptions || [];
   self.inspect = options.inspect;
   self.settings = options.settings;
+  self.allowSettingsFromEnv = options.allowSettingsFromEnv;
   self.testMetadata = options.testMetadata;
   self.autoRestart = options.autoRestart;
 
@@ -172,7 +173,7 @@ _.extend(AppProcess.prototype, {
       env.METEOR_SETTINGS = self.settings;
     } else {
       // Warn the developer that we are not going to use their environment var.
-      if (env.METEOR_SETTINGS) {
+      if (env.METEOR_SETTINGS && !self.allowSettingsFromEnv) {
         runLog.log(
           "WARNING: The 'METEOR_SETTINGS' environment variable is ignored " +
           "when running in development (as you are doing now).  Instead, use " +
@@ -181,11 +182,10 @@ _.extend(AppProcess.prototype, {
           "documentation for 'Meteor.settings': " +
           "https://docs.meteor.com/api/core.html#Meteor-settings" +
           "\n");
+        // To provide a consistent, reactive experience in development, do
+        // not use settings provided via the environment variable.
+        delete env.METEOR_SETTINGS;
       }
-
-      // To provide a consistent, reactive experience in development, do
-      // not use settings provided via the environment variable.
-      delete env.METEOR_SETTINGS;
     }
     if (self.testMetadata) {
       env.TEST_METADATA = JSON.stringify(self.testMetadata);
@@ -356,6 +356,7 @@ var AppRunner = function (options) {
   self.mobileServerUrl = options.mobileServerUrl;
   self.cordovaRunner = options.cordovaRunner;
   self.settingsFile = options.settingsFile;
+  self.allowSettingsFromEnv = options.allowSettingsFromEnv;
   self.testMetadata = options.testMetadata;
   self.inspect = options.inspect;
   self.proxy = options.proxy;
@@ -727,6 +728,7 @@ _.extend(AppRunner.prototype, {
       },
       nodeOptions: getNodeOptionsFromEnvironment(),
       settings: settings,
+      allowSettingsFromEnv: self.allowSettingsFromEnv,
       testMetadata: self.testMetadata,
       autoRestart: self.autoRestart,
     });


### PR DESCRIPTION
solves https://github.com/meteor/meteor/issues/9907

meteor is doing a great job in following the "principle of least surprise", e.g. that changes in settings.json also trigger a restart automatically and therefore settings passed as an env var `METEOR_SETTINGS` will be ignored to guarantee this consistency.

However meteor-settings often contain secrets and environment specific values and therefore need to be managed the same way as other environment variables with special care, so that they do not leak into the git repository.

We therefore use a combination of [direnv](https://direnv.net) and a password store like [pass](https://www.passwordstore.org/) to manage and share these secrets among developers.

Unfortunatly, meteor prevents us to use the same technique also for meteor-settings, so this pull request tries to fix that by allowing to pass `METEOR_SETTINGS` as env var when you also pass an option `--allowSettingsFromEnv`

Personally, i would like to not have the flag allowSettingsFromEnv and delete the whole check there, because devs who pass the `METEOR_SETTINGS` env var usually know what they are doing. But that's debateable.

