### PR TITLE
Convert eachline.js to eachline.ts

### DIFF
--- a/tools/cordova/run-targets.js
+++ b/tools/cordova/run-targets.js
@@ -132,7 +132,7 @@ export class AndroidRunTarget extends CordovaRunTarget {
   }
 
   async tailLogs(cordovaProject, target) {
-    const { transform } = require("../utils/eachline.js");
+    const { transform } = require("../utils/eachline");
 
     cordovaProject.runCommands(`tailing logs for ${this.displayName}`, async () => {
       await this.checkPlatformRequirementsAndSetEnv(cordovaProject);

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -15,7 +15,7 @@ var release = require('../packaging/release.js');
 import { pluginVersionsFromStarManifest } from '../cordova/index.js';
 import { CordovaBuilder } from '../cordova/builder.js';
 import { closeAllWatchers } from "../fs/safe-watcher";
-import { eachline } from "../utils/eachline.js";
+import { eachline } from "../utils/eachline";
 import { loadIsopackage } from '../tool-env/isopackets.js';
 
 const hasOwn = Object.prototype.hasOwnProperty;

--- a/tools/shell-client.js
+++ b/tools/shell-client.js
@@ -181,7 +181,7 @@ Cp.setUpSocket = function setUpSocket(sock, key) {
 
   sock.pipe(process.stdout);
 
-  require("./utils/eachline.js").eachline(sock, function (line) {
+  require("./utils/eachline").eachline(sock, function (line) {
     self.exitOnClose = line.indexOf(EXITING_MESSAGE) >= 0;
   });
 

--- a/tools/utils/eachline.ts
+++ b/tools/utils/eachline.ts
@@ -1,19 +1,22 @@
-import split from "split2";
-import pipe from "multipipe";
-import { Transform } from "stream";
+const split = require("split2");
+const pipe = require("multipipe");
 
-export function eachline(stream, callback) {
+import { Transform, Stream } from "stream";
+
+type LineTransformer = (line: string) => string | Promise<string>
+
+export function eachline(stream: Stream, callback: LineTransformer) {
   stream.pipe(transform(callback));
 }
 
-export function transform(callback) {
+export function transform(callback: LineTransformer) {
   const splitStream = split(/\r?\n/, null, {
     trailing: false
   });
 
   const transform = new Transform();
 
-  transform._transform = async function (chunk, encoding, done) {
+  transform._transform = async function (chunk, _encoding, done) {
     let line = chunk.toString("utf8");
     try {
       line = await callback(line);

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -532,7 +532,7 @@ exports.isValidVersion = function (version, {forCordova}) {
 
 exports.execFileSync = function (file, args, opts) {
   var child_process = require('child_process');
-  var { eachline } = require('./eachline.js');
+  var { eachline } = require('./eachline');
 
   opts = opts || {};
   if (! _.has(opts, 'maxBuffer')) {
@@ -573,7 +573,7 @@ exports.execFileSync = function (file, args, opts) {
 exports.execFileAsync = function (file, args, opts) {
   opts = opts || {};
   var child_process = require('child_process');
-  var { eachline } = require('./eachline.js');
+  var { eachline } = require('./eachline');
   var p = child_process.spawn(file, args, opts);
   var mapper = opts.lineMapper || _.identity;
 


### PR DESCRIPTION
[no issue]

Hi @benjamn! Michael Newman here, no relation.

Wanted to give Meteor TypeScript conversion a shot after attending [your excellent Meteor Night talk](https://slides.com/benjamn/reimplementing-meteor-in-typescript#), so here's my shot at one of the easy files to start with you mentioned in your presentation.

I had a few questions about getting started, since the codebase/tooling of this repo is pretty unfamiliar to me:
1. Is the correct way to check for TS errors in this project just to open the project in VSCode and see if it gets angry? (That's what I did and it seemed to work... okay.)
2. For whatever reason, TypeScript lets me get away with code like `const pipe = require("multipipe");`	but not `import pipe from "multipipe";`, because for the latter version it wants me to install the type defs for that package via NPM. I have no idea how to add new NPM dependencies to `meteor/tools` and I'm not sure whether it's advised/allowed even for TS types. What do you recommend we do in cases like that?
3. I submitted this into the `release-1.8.2` branch because that's where your "convert files.ts" PR was targeted, but I'm not sure if this was the right thing to do, since the Contributing guides seem to encourage submitting into `devel`. However, `devel` doesn't seem to have all of your TS-related changes from `release-1.8.2`.

Thank you for your talk and for your patience with my first Meteor PR!