### PR TITLE
Add prepositions to changeAuthorized verbs

### DIFF
--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -781,9 +781,9 @@ export function changeAuthorized(site, action, username) {
   }
 
   const verbs = {
-    add: "added",
-    remove: "removed",
-    transfer: "transferred"
+    add: "added to",
+    remove: "removed from",
+    transfer: "transferred to"
   };
   Console.info(`${site}: ${verbs[action]} ${username}`);
   return 0;


### PR DESCRIPTION
Today when I transfer an app to our Galaxy organization, the message reads:
```
cool-app.meteorapp.com: transferred organization-name
```

I've corrected the grammar to:
```
cool-app.meteorapp.com: transferred to organization-name
```

With similar changes for `added` and `removed`.