### PR TITLE
Convert tools/utils/mongo-exit-codes.js to TypeScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -31,7 +31,7 @@ tools/func-utils.js
 tools/http-helpers.js
 tools/inspector.js
 tools/index.js
-tools/mongo-exit-codes.js
+tools/mongo-exit-codes.ts
 tools/processes.js
 tools/progress.js
 tools/project-context.js

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -1,6 +1,7 @@
+import { MongoExitCodes } from '../utils/mongo-exit-codes';
+
 var files = require('../fs/files');
 var utils = require('../utils/utils.js');
-var mongoExitCodes = require('../utils/mongo-exit-codes.js');
 var fiberHelpers = require('../utils/fiber-helpers.js');
 var runLog = require('./run-log.js');
 var child_process = require('child_process');
@@ -917,7 +918,7 @@ _.extend(MRp, {
 
     // Too many restarts, too quicky. It's dead. Print friendly
     // diagnostics and give up.
-    var explanation = mongoExitCodes.Codes[code];
+    var explanation = MongoExitCodes[code];
     var message = "Can't start Mongo server.";
 
     if (explanation && explanation.symbol === 'EXIT_UNCAUGHT' &&
@@ -928,7 +929,7 @@ _.extend(MRp, {
       message += "\n" + explanation.longText;
     }
 
-    if (explanation === mongoExitCodes.EXIT_NET_ERROR) {
+    if (explanation && explanation.symbol === 'EXIT_NET_ERROR') {
       message += "\n\n" +
 "Check for other processes listening on port " + self.port + "\n" +
 "or other Meteor instances running in the same project.";

--- a/tools/utils/mongo-exit-codes.ts
+++ b/tools/utils/mongo-exit-codes.ts
@@ -4,10 +4,7 @@
 
 // Explanations have been rewritten, not copied, for license reasons.
 
-
-var _ = require('underscore');
-
-exports.Codes = {
+export const MongoExitCodes = {
   0 : { code: 0,
         symbol: "EXIT_CLEAN",
         longText: "MongoDB exited cleanly"
@@ -68,6 +65,4 @@ exports.Codes = {
         }
 };
 
-_.each(exports.Codes, function (value) {
-  exports[value.symbol] = value;
-});
+export type MongoExitCode = keyof typeof MongoExitCodes;


### PR DESCRIPTION
[no issue]

Another very very small TypeScript conversion along the lines of #10614. This time I just side-stepped the issue of "how do I install types for a package like underscore?" by removing underscore from this module, because it really doesn't seem to be necessary as far as I can tell.

Also exported a new (currently unused) type, `MongoExitCode`, that I think may be helpful when typing `tools/runners/run-mongo`, which I was experimenting with in another branch.