### PR TITLE
Avoid use of forEach in Base64 encode method

### DIFF
--- a/packages/base64/base64.js
+++ b/packages/base64/base64.js
@@ -32,19 +32,19 @@ const encode = array => {
   let c = null;
   let d = null;
 
-  array.forEach((elm, i) => {
+  for (let i = 0; i < array.length; i++) {
     switch (i % 3) {
       case 0:
-        a = (elm >> 2) & 0x3F;
-        b = (elm & 0x03) << 4;
+        a = (array[i] >> 2) & 0x3F;
+        b = (array[i] & 0x03) << 4;
         break;
       case 1:
-        b = b | (elm >> 4) & 0xF;
-        c = (elm & 0xF) << 2;
+        b = b | (array[i] >> 4) & 0xF;
+        c = (array[i] & 0xF) << 2;
         break;
       case 2:
-        c = c | (elm >> 6) & 0x03;
-        d = elm & 0x3F;
+        c = c | (array[i] >> 6) & 0x03;
+        d = array[i] & 0x3F;
         answer.push(getChar(a));
         answer.push(getChar(b));
         answer.push(getChar(c));
@@ -55,7 +55,7 @@ const encode = array => {
         d = null;
         break;
     }
-  });
+  }
 
   if (a != null) {
     answer.push(getChar(a));
@@ -65,7 +65,7 @@ const encode = array => {
     } else {
       answer.push(getChar(c));
     }
-    
+
     if (d == null) {
       answer.push('=');
     }
@@ -102,7 +102,7 @@ const decode = str => {
       len--;
     }
   }
-  
+
   const arr = newBinary(len);
 
   let one = null;
@@ -147,7 +147,7 @@ const decode = str => {
         break;
     }
   }
-  
+
   return arr;
 };
 

--- a/packages/base64/package.js
+++ b/packages/base64/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Base64 encoding and decoding",
-  version: '1.0.11',
+  version: '1.0.12',
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
Fixes #10628

For strings we convert to Uint8Array, which does not support forEach on any version of IE, and is not polyfilled by default.

If a polyfill solution is preferable, we can close this and fix it that way.