### PR TITLE
Convert `func-utils.js` to typescript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -27,7 +27,6 @@ tools/deploy.js
 tools/fiber-helpers.js
 tools/fs/files.js
 tools/fs/mini-files.js
-tools/func-utils.js
 tools/http-helpers.js
 tools/inspector.js
 tools/index.js

--- a/tools/fs/watch.ts
+++ b/tools/fs/watch.ts
@@ -2,7 +2,7 @@ import { Stats, FSWatcher } from "fs";
 import * as files from "./files";
 import * as safeWatcher from "./safe-watcher";
 import { createHash } from "crypto";
-import { coalesce } from "../utils/func-utils.js";
+import { coalesce } from "../utils/func-utils";
 import { Profile } from "../tool-env/profile";
 import {
   optimisticHashOrNull,
@@ -520,7 +520,7 @@ export class Watcher {
     // additional calls if they happen within that window of time, so that
     // a rapid succession of calls will tend to trigger only one inspection
     // of the file system.
-    return coalesce(WATCH_COALESCE_MS, () => {
+    return coalesce<WatchSet>(WATCH_COALESCE_MS, () => {
       if (this.stopped) {
         return;
       }

--- a/tools/index.d.ts
+++ b/tools/index.d.ts
@@ -12,4 +12,9 @@ declare global {
     // moved into that package.
     await: () => T;
   }
+
+  interface Function {
+    // func-utils.ts makes usage of this feature
+    displayName?: string;
+  }
 }

--- a/tools/utils/func-utils.ts
+++ b/tools/utils/func-utils.ts
@@ -1,13 +1,16 @@
+type EmptyFunction = () => void;
+type AnyFunction = (...args: any[]) => any;
+
 // Return a function that coalesceses calls to fn that occur within delay
 // milliseconds of each other, and prevents overlapping invocations of fn
 // by postponing the next invocation until after fn's fiber finishes.
-exports.coalesce = function(delayMs, callback, context) {
+export function coalesce<T> (delayMs: number, callback : EmptyFunction, context?: T) : EmptyFunction {
   var pending = false;
   var inProgress = 0;
 
-  delayMs = delayMs || 100;
+  const actualDelayMs = delayMs || 100;
 
-  function coalescingWrapper() {
+  function coalescingWrapper(this: T) {
     var self = context || this;
 
     if (inProgress) {
@@ -23,7 +26,7 @@ exports.coalesce = function(delayMs, callback, context) {
     }
 
     new Promise(
-      resolve => setTimeout(resolve, delayMs)
+      resolve => setTimeout(resolve, actualDelayMs)
     ).then(function thenCallback() {
       // Now that the timeout has fired, set inProgress to 1 so that
       // (until the callback is complete and we set inProgress to 0 again)
@@ -48,7 +51,7 @@ exports.coalesce = function(delayMs, callback, context) {
   return wrap(coalescingWrapper, callback);
 };
 
-function wrap(wrapper, wrapped) {
+function wrap<T extends AnyFunction, W extends AnyFunction>(wrapper: T, wrapped: W) {
   // Allow the wrapper to be used as a constructor function, just in case
   // the wrapped function was meant to be used as a constructor.
   wrapper.prototype = wrapped.prototype;

--- a/tools/utils/func-utils.ts
+++ b/tools/utils/func-utils.ts
@@ -5,13 +5,13 @@ type AnyFunction = (...args: any[]) => any;
 // milliseconds of each other, and prevents overlapping invocations of fn
 // by postponing the next invocation until after fn's fiber finishes.
 export function coalesce<ContextT> (delayMs: number, callback : EmptyFunction, context?: ContextT) : EmptyFunction {
-  var pending = false;
-  var inProgress = 0;
+  let pending = false;
+  let inProgress = 0;
 
   const actualDelayMs = delayMs || 100;
 
   function coalescingWrapper(this: ContextT) {
-    var self = context || this;
+    const self = context || this;
 
     if (inProgress) {
       // Indicate that coalescingWrapper should be called again after the
@@ -57,7 +57,7 @@ function wrap<WrapperT extends AnyFunction, WrappedT extends AnyFunction>(wrappe
   wrapper.prototype = wrapped.prototype;
 
   // https://medium.com/@cramforce/on-the-awesomeness-of-fn-displayname-9511933a714a
-  var name = wrapped.displayName || wrapped.name;
+  const name = wrapped.displayName || wrapped.name;
   if (name) {
     wrapper.displayName = name;
   }

--- a/tools/utils/func-utils.ts
+++ b/tools/utils/func-utils.ts
@@ -4,13 +4,13 @@ type AnyFunction = (...args: any[]) => any;
 // Return a function that coalesceses calls to fn that occur within delay
 // milliseconds of each other, and prevents overlapping invocations of fn
 // by postponing the next invocation until after fn's fiber finishes.
-export function coalesce<T> (delayMs: number, callback : EmptyFunction, context?: T) : EmptyFunction {
+export function coalesce<ContextT> (delayMs: number, callback : EmptyFunction, context?: ContextT) : EmptyFunction {
   var pending = false;
   var inProgress = 0;
 
   const actualDelayMs = delayMs || 100;
 
-  function coalescingWrapper(this: T) {
+  function coalescingWrapper(this: ContextT) {
     var self = context || this;
 
     if (inProgress) {
@@ -51,7 +51,7 @@ export function coalesce<T> (delayMs: number, callback : EmptyFunction, context?
   return wrap(coalescingWrapper, callback);
 };
 
-function wrap<T extends AnyFunction, W extends AnyFunction>(wrapper: T, wrapped: W) {
+function wrap<WrapperT extends AnyFunction, WrappedT extends AnyFunction>(wrapper: WrapperT, wrapped: WrappedT): WrapperT {
   // Allow the wrapper to be used as a constructor function, just in case
   // the wrapped function was meant to be used as a constructor.
   wrapper.prototype = wrapped.prototype;

--- a/tools/utils/func-utils.ts
+++ b/tools/utils/func-utils.ts
@@ -4,13 +4,17 @@ type AnyFunction = (...args: any[]) => any;
 // Return a function that coalesceses calls to fn that occur within delay
 // milliseconds of each other, and prevents overlapping invocations of fn
 // by postponing the next invocation until after fn's fiber finishes.
-export function coalesce<ContextT> (delayMs: number, callback : EmptyFunction, context?: ContextT) : EmptyFunction {
+export function coalesce<TContext>(
+  delayMs: number,
+  callback: EmptyFunction,
+  context?: TContext,
+): EmptyFunction {
   let pending = false;
   let inProgress = 0;
 
   const actualDelayMs = delayMs || 100;
 
-  function coalescingWrapper(this: ContextT) {
+  function coalescingWrapper(this: TContext) {
     const self = context || this;
 
     if (inProgress) {
@@ -51,7 +55,10 @@ export function coalesce<ContextT> (delayMs: number, callback : EmptyFunction, c
   return wrap(coalescingWrapper, callback);
 };
 
-function wrap<WrapperT extends AnyFunction, WrappedT extends AnyFunction>(wrapper: WrapperT, wrapped: WrappedT): WrapperT {
+function wrap<
+  TWrapper extends AnyFunction,
+  TWrapped extends AnyFunction,
+>(wrapper: TWrapper, wrapped: TWrapped): TWrapper {
   // Allow the wrapper to be used as a constructor function, just in case
   // the wrapped function was meant to be used as a constructor.
   wrapper.prototype = wrapped.prototype;


### PR DESCRIPTION
This is part of the ongoing transformation to typescript.
The pull should be accepted only after adding a `@types/underscore` to the node_modules, as mentioned [in pull request 10624](https://github.com/meteor/meteor/pull/10624#discussion_r302651681). Currently I've installed the types locally.

Also, I've added some ad-hoc types e.g. `EmptyFunction` and `AnyFunction`. After the transformation will mature we can use a library for stuff like this or have a centralised way where these type shuld be defined.

The global `Function` interface was ammended to include the `displayName` property.