### PR TITLE
Add @types/semver@5.4.0 to both dev-bundle-tools-package.js and dev-bundle-server-package.js

### DIFF
--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -18,6 +18,7 @@ var packageJson = {
     "@types/underscore": "1.9.2",
     underscore: "1.9.1",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
+    "@types/semver": "5.4.0",
     semver: "5.4.1"
   },
   // These are only used in dev mode (by shell.js) so end-users can avoid

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -29,6 +29,7 @@ var packageJson = {
     "@types/underscore": "1.9.2",
     underscore: "1.9.1",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
+    "@types/semver": "5.4.0",
     semver: "5.4.1",
     request: "2.88.0",
     uuid: "3.3.2",

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -14,6 +14,7 @@ var buildmessage = require('../utils/buildmessage.js');
 var utils = require('../utils/utils.js');
 var runLog = require('../runners/run-log.js');
 var Profile = require('../tool-env/profile').Profile;
+import { parse } from "semver";
 import { version as npmVersion } from 'npm';
 import { execFileAsync } from "../utils/processes.js";
 import {
@@ -239,8 +240,6 @@ function recordLastRebuildVersions(pkgDir) {
 // Returns true iff isSubtreeOf(currentVersions, versions), allowing
 // valid semantic versions to differ in their patch versions.
 function versionsAreCompatible(versions) {
-  import { parse } from "semver";
-
   return isSubtreeOf(currentVersions, versions, (a, b) => {
     // Technically already handled by isSubtreeOf, but doesn't hurt.
     if (a === b) {


### PR DESCRIPTION
`@types/semver` is important because multiple files that should be transformed to TypeScript require it (e.g. `utils/utils.js`).
Regarding the versioning mismatch. There shouldn't be any problems since the only difference between 5.4.0 and 5.4.1 is the addition of a `try...catch` statement in commit [semver/7be83d15dcff73f6](https://github.com/npm/node-semver/commit/7be83d15dcff73f6df11b82507e0b9980e183bc2), so the interface wasn't changed.
