### PR TITLE
Optionally make the UNIX socket path readable/writeable for all.

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -1105,7 +1105,11 @@ function runWebAppServer() {
     if (unixSocketPath) {
       // Start the HTTP server using a socket file.
       removeExistingSocketFile(unixSocketPath);
-      startHttpServer({ path: unixSocketPath });
+      startHttpServer({
+        path: unixSocketPath,
+        readableAll: (process.env.UNIX_SOCKET_PATH_READABLE_ALL === "true"),
+        writableAll: (process.env.UNIX_SOCKET_PATH_WRITABLE_ALL === "true"),
+      });
       registerSocketFileCleanup(unixSocketPath);
     } else {
       localPort = isNaN(Number(localPort)) ? localPort : Number(localPort);


### PR DESCRIPTION
Adding to #7392 and #8702, it'd be great to be able to use the new `readableAll` and `writableAll` options that were added in node v10 (see https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_server_listen_options_callback). This will make it much easier to allow deployment to environments that enforce the use of separate users / groups for the node.js process and e.g. a reverse proxy server in front of it. So here are my two cents to enable that.