### PR TITLE
Convert tools/console/progress.js to TypeScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -32,7 +32,7 @@ tools/http-helpers.js
 tools/inspector.js
 tools/index.js
 tools/mongo-exit-codes.ts
-tools/processes.js
+tools/processes.ts
 tools/progress.ts
 tools/project-context.js
 tools/runners/run-log.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -32,8 +32,8 @@ tools/http-helpers.js
 tools/inspector.js
 tools/index.js
 tools/mongo-exit-codes.ts
-tools/processes.ts
-tools/progress.js
+tools/processes.js
+tools/progress.ts
 tools/project-context.js
 tools/runners/run-log.js
 tools/fs/safe-pathwatcher.js

--- a/tools/console/README.md
+++ b/tools/console/README.md
@@ -1,6 +1,6 @@
 This folder contains libs for printing output in response to CLI commands.
 
-`progress.js` defines the lib for printing a progress-bar, so the long
+`progress.ts` defines the lib for printing a progress-bar, so the long
 operations don't look like hanging.
 
 `console.js` exposes the `Console` singleton that should be used through-out the

--- a/tools/console/progress.ts
+++ b/tools/console/progress.ts
@@ -73,7 +73,7 @@ class Progress {
   // don't descend into fork-join jobs; we know these execute concurrently,
   // so we assume the top-level task has the title
   // i.e. "Downloading packages", not "downloading supercool-1.0"
-  getCurrentProgress() {
+  getCurrentProgress(): Progress | null {
     var self = this;
 
     var isRoot = !self.parent;
@@ -103,6 +103,7 @@ class Progress {
         // pick one to display, somewhat arbitrarily
         return active[active.length - 1];
       }
+
       // No single active task, return self
       return self;
     }
@@ -217,7 +218,7 @@ class Progress {
   }
 
   // Called by a child when its state changes
-  _reportChildState(child, state) {
+  _reportChildState(_child: Progress, _state: ProgressState) {
     this._updateTotalState();
     this._notifyState();
   }

--- a/tools/console/progress.ts
+++ b/tools/console/progress.ts
@@ -1,11 +1,18 @@
 
+type ProgressWatcher = (state: ProgressState) => void;
+
+type ProgressOptions = {
+  parent?: Progress,
+  watchers?: ProgressWatcher[],
+  title?: string,
+  forkJoin?: boolean,
+};
+
 type ProgressState = {
   done: boolean,
   current: number,
   end?: number,
 };
-
-type ProgressWatcher = (state: ProgressState) => void;
 
 /// utility functions for computing progress of complex tasks
 ///
@@ -17,7 +24,7 @@ type ProgressWatcher = (state: ProgressState) => void;
 /// If end is not set, we'll display a spinner instead of a progress bar
 ///
 class Progress {
-  private title: string | null;
+  private title: string | null | void;
   private isDone: boolean;
   private forkJoin?: boolean;
 
@@ -29,9 +36,7 @@ class Progress {
 
   private allTasks: Progress[];
 
-  constructor(options) {
-    options = options || {};
-
+  constructor(options: ProgressOptions = {}) {
     this.parent = options.parent;
     this.watchers = options.watchers || [];
   
@@ -116,7 +121,7 @@ class Progress {
   }
 
   // Creates a subtask that must be completed as part of this (bigger) task
-  addChildTask(options) {
+  addChildTask(options: ProgressOptions = {}) {
     var self = this;
     options = {
       parent: self,

--- a/tools/utils/buildmessage.js
+++ b/tools/utils/buildmessage.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var files = require('../fs/files');
 var parseStack = require('./parse-stack.js');
 var fiberHelpers = require('./fiber-helpers.js');
-var Progress = require('../console/progress.js').Progress;
+var Progress = require('../console/progress').Progress;
 
 var debugBuild = !!process.env.METEOR_DEBUG_BUILD;
 
@@ -13,7 +13,7 @@ var debugBuild = !!process.env.METEOR_DEBUG_BUILD;
 // relative to that path.
 //
 // Jobs are used both for error handling (via buildmessage.capture) and to set
-// the progress bar title (via progress.js).
+// the progress bar title (via progress.ts).
 //
 // Job titles should begin with a lower-case letter (unless they begin with a
 // proper noun), so that they look correct in error messages which say "While


### PR DESCRIPTION
Converts the "progress" class to TypeScript! This conversion is a little bigger because I refactored the class to use `class` syntax and private members.