### PR TITLE
Convert dev-bundle.js to TypeScript

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -38,6 +38,7 @@ var packageJson = {
     kexec: "3.0.0",
     "source-map": "0.5.7",
     chalk: "0.5.1",
+    "@types/sqlite3": "3.1.5",
     sqlite3: "3.1.8",
     netroute: "1.0.2",
     "http-proxy": "1.16.2",

--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -7,7 +7,7 @@ var extensions = isWindows ? [".cmd", ".exe"] : [""];
 var hasOwn = Object.prototype.hasOwnProperty;
 
 function getDevBundle() {
-  return require("./dev-bundle.js");
+  return require("./dev-bundle");
 }
 exports.getDevBundle = getDevBundle;
 

--- a/tools/cli/dev-bundle.ts
+++ b/tools/cli/dev-bundle.ts
@@ -18,7 +18,7 @@ function getDevBundleDir() {
   // file of the current app, if possible.
 
   const releaseFile = find(
-    (process as any).cwd(),
+    process.cwd(),
     makeStatTest("isFile"),
     ".meteor", "release"
   );
@@ -190,21 +190,21 @@ function makeStatTest(method: StatMethod) {
 }
 
 function getHostArch() {
-  if ((process as any).platform === "win32") {
-    if ((process as any).arch === "x64") {
+  if (process.platform === "win32") {
+    if (process.arch === "x64") {
       return "os.windows.x86_64";
     }
     return "os.windows.x86_32";
   }
 
-  if ((process as any).platform === "linux") {
-    if ((process as any).arch === "x64") {
+  if (process.platform === "linux") {
+    if (process.arch === "x64") {
       return "os.linux.x86_64";
     }
     return "os.linux.x86_32";
   }
 
-  if ((process as any).platform === "darwin") {
+  if (process.platform === "darwin") {
     return "os.osx.x86_64";
   }
 }

--- a/tools/cli/dev-bundle.ts
+++ b/tools/cli/dev-bundle.ts
@@ -111,12 +111,12 @@ function getDevBundleForRelease(release: string) {
     db.get(
       "SELECT content FROM releaseVersions WHERE track=? AND version=?",
       [track, version],
-      function (error: Error, data) {
+      function (error: Error | null, data: any) {
         error ? reject(error) : resolve(data);
       }
     );
 
-  }).then(function (data) {
+  }).then(function (data: any) {
     if (data) {
       const tool = JSON.parse(data.content).tool;
       const devBundleDir = path.join(
@@ -140,7 +140,9 @@ function getDevBundleForRelease(release: string) {
   });
 }
 
-function statOrNull(path: string, statMethod?: (() => void) | string) {
+type StatMethod = "isDirectory" | "isFile";
+
+function statOrNull(path: string, statMethod?: StatMethod) {
   let stat;
   try {
     stat = fs.statSync(path);
@@ -163,7 +165,7 @@ function statOrNull(path: string, statMethod?: (() => void) | string) {
   return null;
 }
 
-function find(dir: string, predicate: (input: string) => boolean, ...joinArgs: string[]) {
+function find(dir: string, predicate: (input: string) => fs.Stats | null, ...joinArgs: string[]) {
   joinArgs.unshift('');
 
   while (true) {
@@ -181,7 +183,7 @@ function find(dir: string, predicate: (input: string) => boolean, ...joinArgs: s
   return null;
 }
 
-function makeStatTest(method: string) {
+function makeStatTest(method: StatMethod) {
   return function (file: string) {
     return statOrNull(file, method);
   };
@@ -207,6 +209,4 @@ function getHostArch() {
   }
 }
 
-module.exports = getDevBundleDir().catch(function (error) {
-  return defaultDevBundlePromise;
-});
+module.exports = getDevBundleDir().catch(() => defaultDevBundlePromise);

--- a/tools/cli/dev-bundle.ts
+++ b/tools/cli/dev-bundle.ts
@@ -5,11 +5,11 @@
 // but that's unavoidable if we don't want to install Babel and load all
 // the rest of the code every time we run `meteor npm` or `meteor node`.
 
-var fs = require("fs");
-var path = require("path");
-var links = require("./dev-bundle-links.js");
-var rootDir = path.resolve(__dirname, "..", "..");
-var defaultDevBundlePromise =
+import fs from "fs";
+import path from "path";
+import links from "./dev-bundle-links.js";
+const rootDir = path.resolve(__dirname, "..", "..");
+const defaultDevBundlePromise =
   Promise.resolve(path.join(rootDir, "dev_bundle"));
 
 function getDevBundleDir() {
@@ -17,8 +17,8 @@ function getDevBundleDir() {
   // checkout, because it's always better to respect the .meteor/release
   // file of the current app, if possible.
 
-  var releaseFile = find(
-    process.cwd(),
+  const releaseFile = find(
+    (process as any).cwd(),
     makeStatTest("isFile"),
     ".meteor", "release"
   );
@@ -27,7 +27,7 @@ function getDevBundleDir() {
     return defaultDevBundlePromise;
   }
 
-  var localDir = path.join(path.dirname(releaseFile), "local");
+  const localDir = path.join(path.dirname(releaseFile), "local");
   if (! statOrNull(localDir, "isDirectory")) {
     try {
       fs.mkdirSync(localDir);
@@ -36,15 +36,15 @@ function getDevBundleDir() {
     }
   }
 
-  var devBundleLink = path.join(localDir, "dev_bundle");
-  var devBundleStat = statOrNull(devBundleLink);
+  const devBundleLink = path.join(localDir, "dev_bundle");
+  const devBundleStat = statOrNull(devBundleLink);
   if (devBundleStat) {
     return new Promise(function (resolve) {
       resolve(links.readLink(devBundleLink));
     });
   }
 
-  var release = fs.readFileSync(
+  const release = fs.readFileSync(
     releaseFile, "utf8"
   ).replace(/^\s+|\s+$/g, "");
 
@@ -64,16 +64,16 @@ function getDevBundleDir() {
   });
 }
 
-function getDevBundleForRelease(release) {
-  var parts = release.split("@");
+function getDevBundleForRelease(release: string) {
+  const parts = release.split("@");
   if (parts.length < 2) {
     return null;
   }
 
-  var track = parts[0];
-  var version = parts.slice(1).join("@");
+  const track = parts[0];
+  const version = parts.slice(1).join("@");
 
-  var packageMetadataDir = find(
+  const packageMetadataDir = find(
     rootDir,
     makeStatTest("isDirectory"),
     ".meteor", "package-metadata"
@@ -83,50 +83,50 @@ function getDevBundleForRelease(release) {
     return null;
   }
 
-  var meteorToolDir = path.resolve(
+  const meteorToolDir = path.resolve(
     packageMetadataDir,
     "..", "packages", "meteor-tool"
   );
 
-  var meteorToolStat = statOrNull(meteorToolDir, "isDirectory");
+  const meteorToolStat = statOrNull(meteorToolDir, "isDirectory");
   if (! meteorToolStat) {
     return null;
   }
 
-  var dbPath = path.join(
+  const dbPath = path.join(
     packageMetadataDir,
     "v2.0.1",
     "packages.data.db"
   );
 
-  var dbStat = statOrNull(dbPath, "isFile");
+  const dbStat = statOrNull(dbPath, "isFile");
   if (! dbStat) {
     return null;
   }
 
-  var sqlite3 = require("sqlite3");
-  var db = new sqlite3.Database(dbPath);
+  const sqlite3 = require("sqlite3");
+  const db = new sqlite3.Database(dbPath);
 
   return new Promise(function (resolve, reject) {
     db.get(
       "SELECT content FROM releaseVersions WHERE track=? AND version=?",
       [track, version],
-      function (error, data) {
+      function (error: Error, data) {
         error ? reject(error) : resolve(data);
       }
     );
 
   }).then(function (data) {
     if (data) {
-      var tool = JSON.parse(data.content).tool;
-      var devBundleDir = path.join(
+      const tool = JSON.parse(data.content).tool;
+      const devBundleDir = path.join(
         meteorToolDir,
         tool.split("@").slice(1).join("@"),
         "mt-" + getHostArch(),
         "dev_bundle"
       );
 
-      var devBundleStat = statOrNull(devBundleDir, "isDirectory");
+      const devBundleStat = statOrNull(devBundleDir, "isDirectory");
       if (devBundleStat) {
         return devBundleDir;
       }
@@ -140,9 +140,10 @@ function getDevBundleForRelease(release) {
   });
 }
 
-function statOrNull(path, statMethod) {
+function statOrNull(path: string, statMethod?: (() => void) | string) {
+  let stat;
   try {
-    var stat = fs.statSync(path);
+    stat = fs.statSync(path);
   } catch (e) {
     if (e.code !== "ENOENT") {
       throw e;
@@ -162,18 +163,17 @@ function statOrNull(path, statMethod) {
   return null;
 }
 
-function find(dir, predicate) {
-  var joinArgs = Array.prototype.slice.call(arguments, 2);
-  joinArgs.unshift(null);
+function find(dir: string, predicate: (input: string) => boolean, ...joinArgs: string[]) {
+  joinArgs.unshift('');
 
   while (true) {
     joinArgs[0] = dir;
-    var joined = path.join.apply(path, joinArgs);
+    const joined = path.join.apply(path, joinArgs);
     if (predicate(joined)) {
       return joined;
     }
 
-    var parentDir = path.dirname(dir);
+    const parentDir = path.dirname(dir);
     if (parentDir === dir) break;
     dir = parentDir;
   }
@@ -181,28 +181,28 @@ function find(dir, predicate) {
   return null;
 }
 
-function makeStatTest(method) {
-  return function (file) {
+function makeStatTest(method: string) {
+  return function (file: string) {
     return statOrNull(file, method);
   };
 }
 
 function getHostArch() {
-  if (process.platform === "win32") {
-    if (process.arch === "x64") {
+  if ((process as any).platform === "win32") {
+    if ((process as any).arch === "x64") {
       return "os.windows.x86_64";
     }
     return "os.windows.x86_32";
   }
 
-  if (process.platform === "linux") {
-    if (process.arch === "x64") {
+  if ((process as any).platform === "linux") {
+    if ((process as any).arch === "x64") {
       return "os.linux.x86_64";
     }
     return "os.linux.x86_32";
   }
 
-  if (process.platform === "darwin") {
+  if ((process as any).platform === "darwin") {
     return "os.osx.x86_64";
   }
 }


### PR DESCRIPTION
I did this before reading the comment at the top of the file 😅 :

https://github.com/meteor/meteor/blob/5c32331591f268f2acdac5a1a7481eb9e65dc3d4/tools/cli/dev-bundle.js#L1-L2

As well, the tests don't run, so guess the TypeScript compiler is also not running here?

So I'm not sure if we should even be converting this, but I'm making a PR since I already did it.

There is one use of the `any` type: the `data` parameter in the sqlite3 callback. This is the same type as in `@types/sqlite3`:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/bb36642c70f366af454e1bf67471fbfdf0b9bdc8/types/sqlite3/index.d.ts#L65