### PR TITLE
tools/deploy: provide more context for version-status errors

### DIFF
--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -428,12 +428,13 @@ async function pollForDeploy(pollingState, versionId, site) {
     // keep polling as per usual – this may have just been a whiff from Galaxy.
     // We do the retry here because we might hit an error if we try to parse the
     // result of the version-status call below.
-    Console.warn(versionStatusResult.errorMessage || 'Unexpected error from Galaxy');
     pollingState.errors++;
+    const errorMessage = versionStatusResult.errorMessage || 'Unexpected error from Galaxy';
     if (pollingState.errors >= pollingState.maxErrors) {
-      Console.error(versionStatusResult.errorMessage);
+      Console.error(`Error checking deploy status; giving up: ${errorMessage}`);
       return 1;
     } else if (new Date() < deadline) {
+      Console.warn(`Error checking deploy status; will retry: ${errorMessage}`);
       await sleepForMilliseconds(pollIntervalMs);
       return await pollForDeploy(pollingState, versionId, site);
     }


### PR DESCRIPTION
Also only print the error once on failure.

