### PR TITLE
A small optimization when updating documents

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -176,7 +176,7 @@ Object.assign(Mongo.Collection.prototype, {
       // XXX better specify this interface (not in terms of a wire message)?
       update(msg) {
         var mongoId = MongoID.idParse(msg.id);
-        var doc = self._collection.findOne(mongoId);
+        var doc = self._collection._docs.get(mongoId);
 
         // Is this a "replace the whole doc" message coming from the quiescence
         // of method writes to an object? (Note that 'undefined' is a valid


### PR DESCRIPTION
I found a small optimization opportunity here. So at this point we:
* We do not need any projection or transformation.
* We do not modify returned `doc` in any way.

So there is no need to invoke full machinery of `findOne` (which internally creates a cursor object and copies the object every time using `EJSON.clone`).