### PR TITLE
Avoid unnecessary Buffer allocations in minifyJs.

### DIFF
--- a/tools/tests/apps/custom-minifier/.meteor/packages
+++ b/tools/tests/apps/custom-minifier/.meteor/packages
@@ -1,4 +1,4 @@
 meteor-base
 custom-minifier
-blaze-html-templates
 ecmascript
+static-html

--- a/tools/tests/apps/custom-minifier/package.json
+++ b/tools/tests/apps/custom-minifier/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "custom-minifier",
+  "private": true,
+  "scripts": {
+    "start": "meteor run",
+    "test": "meteor test --once --driver-package meteortesting:mocha",
+    "test-app": "TEST_WATCH=1 meteor test --full-app --driver-package meteortesting:mocha",
+    "visualize": "meteor --production --extra-packages bundle-visualizer"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.6.0",
+    "meteor-node-stubs": "^1.0.0"
+  },
+  "meteor": {
+    "mainModule": "code.js"
+  }
+}


### PR DESCRIPTION
Allocating a new `Buffer` just to provide a named function wrapper for every dynamic file (to play nicely with the assumptions of JS minifiers) is surprisingly expensive (1s+ for a large application, even without `--production`), and it happens on every rebuild. There's no reason we can't make dynamic files parse as programs rather than expressions… especially if the alternative is modifying the code to add the function name later!

[Previously](https://github.com/meteor/meteor/commit/a2e950dfd3b473598d6a279672f6d838b87f0a35#diff-0a9bda8218ed5e15d66c3e1d105f04ccR588-R593), [previously](https://github.com/meteor/meteor/commit/5ff0f4f98702f059684d4fef04c234bbd62e2675), [more recently](https://github.com/meteor/meteor/pull/10454).