### PR TITLE
Remove redundant dynamic-import from socket-stream-client

### DIFF
--- a/packages/socket-stream-client/browser.js
+++ b/packages/socket-stream-client/browser.js
@@ -189,16 +189,7 @@ export class ClientStream extends StreamClientCommon {
     };
 
     this.socket.onclose = () => {
-      Promise.resolve(
-        // If the socket is closing because there was an error, and we
-        // didn't load SockJS before, try loading it dynamically before
-        // retrying the connection.
-        this.lastError &&
-        ! hasSockJS &&
-        import("./sockjs-0.3.4.js")
-      ).done(() => {
-        this._lostConnection();
-      });
+      this._lostConnection();
     };
 
     this.socket.onerror = error => {

--- a/packages/socket-stream-client/package.js
+++ b/packages/socket-stream-client/package.js
@@ -14,7 +14,6 @@ Package.onUse(function(api) {
   api.use("ecmascript");
   api.use("modern-browsers");
   api.use("retry"); // TODO Try to remove this.
-  api.use("dynamic-import");
 
   api.addFiles("sockjs-0.3.4.js", "legacy");
   api.mainModule("browser.js", "client", { lazy: true });


### PR DESCRIPTION
Currently it's very difficult to remove `dynamic-import` from a Meteor app (#10704) because of strict dependencies from `ecmascript` and `socket-stream-client` (aka `ddp`).

This also means it's very difficult to disable `unsafe-eval` in CSP as `dynamic-import` sets `BrowserPolicy.allowEval()`.

Looking at `socket-stream-client`, the only dynamic import is rendered redundant by #9985 and so this PR cleans up the `import` call and dependency.

Maybe the optimization that #9985 reverts will come back, in which case it would be nice if SockJs could be conditionally bundled or `import()`ed based on whether the `dynamic-import` package is installed