### PR TITLE
Allows the oauth server package to parse post body data

### DIFF
--- a/packages/oauth/.npm/package/.gitignore
+++ b/packages/oauth/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/oauth/.npm/package/README
+++ b/packages/oauth/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/oauth/.npm/package/npm-shrinkwrap.json
+++ b/packages/oauth/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,115 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw=="
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg=="
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    }
+  }
+}

--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -1,4 +1,4 @@
-import url from 'url';
+import bodyParser from 'body-parser';
 
 OAuth = {};
 OAuthTest = {};
@@ -136,6 +136,8 @@ OAuth._checkRedirectUrlOrigin = redirectUrl => {
 };
 
 const middleware = (req, res, next) => {
+  let requestData;
+
   // Make sure to catch any exceptions because otherwise we'd crash
   // the runner
   try {
@@ -158,7 +160,14 @@ const middleware = (req, res, next) => {
     const handler = OAuth._requestHandlers[service.version];
     if (!handler)
       throw new Error(`Unexpected OAuth version ${service.version}`);
-    handler(service, req.query, res);
+
+    if (req.method === 'GET') {
+      requestData = req.query;
+    } else {
+      requestData = req.body;
+    }
+
+    handler(service, requestData, res);
   } catch (err) {
     // if we got thrown an error, save it off, it will get passed to
     // the appropriate login call (if any) and reported there.
@@ -167,9 +176,9 @@ const middleware = (req, res, next) => {
     // is still open at this point, ignoring the 'close' or 'redirect'
     // we were passed. But then the developer wouldn't be able to
     // style the error or react to it in any way.
-    if (req.query.state && err instanceof Error) {
+    if (requestData?.state && err instanceof Error) {
       try { // catch any exceptions to avoid crashing runner
-        OAuth._storePendingCredential(OAuth._credentialTokenFromQuery(req.query), err);
+        OAuth._storePendingCredential(OAuth._credentialTokenFromQuery(requestData), err);
       } catch (err) {
         // Ignore the error and just give up. If we failed to store the
         // error, then the login will just fail with a generic error.
@@ -184,8 +193,8 @@ const middleware = (req, res, next) => {
     // Catch errors because any exception here will crash the runner.
     try {
       OAuth._endOfLoginResponse(res, {
-        query: req.query,
-        loginStyle: OAuth._loginStyleFromQuery(req.query),
+        query: requestData,
+        loginStyle: OAuth._loginStyleFromQuery(requestData),
         error: err
       });
     } catch (err) {
@@ -196,6 +205,8 @@ const middleware = (req, res, next) => {
 };
 
 // Listen to incoming OAuth http requests
+WebApp.connectHandlers.use('/_oauth', bodyParser.json());
+WebApp.connectHandlers.use('/_oauth', bodyParser.urlencoded({ extended: false }));
 WebApp.connectHandlers.use(middleware);
 
 OAuthTest.middleware = middleware;

--- a/packages/oauth/package.js
+++ b/packages/oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth-based services",
-  version: "1.2.8"
+  version: "1.2.9"
 });
 
 Package.onUse(api => {

--- a/packages/oauth/package.js
+++ b/packages/oauth/package.js
@@ -47,6 +47,9 @@ Package.onUse(api => {
   api.addFiles('deprecated.js', ['client', 'server']);
 });
 
+Npm.depends({
+  'body-parser': '1.19.0',
+});
 
 Package.onTest(api => {
   api.use('tinytest');

--- a/packages/oauth1/package.js
+++ b/packages/oauth1/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth1-based login services",
-  version: "1.2.2",
+  version: "1.2.3",
 });
 
 Package.onUse(api => {

--- a/packages/oauth2/oauth2_tests.js
+++ b/packages/oauth2/oauth2_tests.js
@@ -1,6 +1,6 @@
 import http from 'http';
 
-const testPendingCredential = function (test) {
+const testPendingCredential = function (test, method) {
   const foobookId = Random.id();
   const foobookOption1 = Random.id();
   const credentialToken = Random.id();
@@ -21,13 +21,23 @@ const testPendingCredential = function (test) {
     });
 
     // simulate logging in using foobook
-    const req = {method: "POST",
-               url: `/_oauth/${serviceName}`,
-               query: {
-                 state: OAuth._generateState('popup', credentialToken),
-                 close: 1,
-                 only_credential_secret_for_test: 1
-               }};
+    const req = {
+      method,
+      url: `/_oauth/${serviceName}`
+    };
+
+    const payload = {
+      state: OAuth._generateState('popup', credentialToken),
+      close: 1,
+      only_credential_secret_for_test: 1
+    };
+
+    if (method === 'GET') {
+      req.query = payload;
+    } else {
+      req.body = payload;
+    }
+
     const res = new http.ServerResponse(req);
     const write = res.write;
     const end = res.end;
@@ -64,13 +74,15 @@ const testPendingCredential = function (test) {
 
 Tinytest.add("oauth2 - pendingCredential is stored and can be retrieved (without oauth encryption)", test => {
   OAuthEncryption.loadKey(null);
-  testPendingCredential(test);
+  testPendingCredential(test, "GET");
+  testPendingCredential(test, "POST");
 });
 
 Tinytest.add("oauth2 - pendingCredential is stored and can be retrieved (with oauth encryption)", test => {
   try {
     OAuthEncryption.loadKey(Buffer.from([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]).toString("base64"));
-    testPendingCredential(test);
+    testPendingCredential(test, "GET");
+    testPendingCredential(test, "POST");
   } finally {
     OAuthEncryption.loadKey(null);
   }

--- a/packages/oauth2/package.js
+++ b/packages/oauth2/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth2-based login services",
-  version: "1.2.1",
+  version: "1.2.2",
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
This builds on work done by rooch84 in pull request #10501 and issue #10491 
That PR seems to have lost momentum and I am ready help with it as it's needed for sign in with apple oauth.

I have fixed the tests and made some small changes to take care of some bugs.
Tests are passing but i have some console warnings that I need help rectifying:
```
W20191029-15:10:41.469(1)? (STDERR) (node:79991) UnhandledPromiseRejectionWarning: TypeError: req.on is not a function
W20191029-15:10:41.537(1)? (STDERR)     at Promise (packages/oauth/oauth_server.js:146:8)
W20191029-15:10:41.538(1)? (STDERR)     at new Promise (<anonymous>)
W20191029-15:10:41.538(1)? (STDERR)     at parseRequestData (packages/oauth/oauth_server.js:142:33)
W20191029-15:10:41.538(1)? (STDERR)     at Promise.asyncApply (packages/oauth/oauth_server.js:188:5)
W20191029-15:10:41.538(1)? (STDERR)     at /Users/kim/git/bigowl/meteor/packages/promise/.npm/package/node_modules/meteor-promise/fiber_pool.js:43:40
```
