### PR TITLE
Simplify delayed watching of lazy modules.

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1146,6 +1146,13 @@ class Target {
       // that were used in these resources. Depend on them as well.
       // XXX assumes that this merges cleanly
       this.watchSet.merge(unibuild.pkg.pluginWatchSet);
+
+      const entry = jsOutputFilesMap.get(unibuild.pkg.name || null);
+      if (entry && entry.importScannerWatchSet) {
+        // Populated in PackageSourceBatch._watchOutputFiles, based on the
+        // ImportScanner's knowledge of which modules are really imported.
+        this.watchSet.merge(entry.importScannerWatchSet);
+      }
     });
 
     if (buildmessage.jobHasMessages()) {

--- a/tools/tests/apps/client-refresh/imports/node_modules/some-package/index.js
+++ b/tools/tests/apps/client-refresh/imports/node_modules/some-package/index.js
@@ -1,2 +1,1 @@
-import "some-package";
 console.log(module.id, 0);

--- a/tools/tests/client-refresh.js
+++ b/tools/tests/client-refresh.js
@@ -30,6 +30,21 @@ selftest.define("client refresh for application code", () => testHelper({
   },
 }));
 
+selftest.define("client refresh for non-npm node_modules", () => testHelper({
+  client: {
+    path: "client/main.js",
+    id: "/client/main.js",
+  },
+  server: {
+    path: "server/main.js",
+    id: "/server/main.js",
+  },
+  both: {
+    path: "imports/node_modules/some-package/index.js",
+    id: "/imports/node_modules/some-package/index.js",
+  },
+}));
+
 function testHelper(pathsAndIds) {
   const s = new selftest.Sandbox();
   s.createApp("myapp", "client-refresh");


### PR DESCRIPTION
Fixes #10736 by never modifying existing `unibuild.watchSet` information, with additional tests to enforce this subtle behavior.