### PR TITLE
remove jquery and deprecated bootstrap dependency in test-in-browser

### DIFF
--- a/packages/test-in-browser/.npm/package/.gitignore
+++ b/packages/test-in-browser/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/test-in-browser/.npm/package/README
+++ b/packages/test-in-browser/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/test-in-browser/.npm/package/npm-shrinkwrap.json
+++ b/packages/test-in-browser/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,10 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "bootstrap": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+    }
+  }
+}

--- a/packages/test-in-browser/driver.css
+++ b/packages/test-in-browser/driver.css
@@ -1,6 +1,17 @@
 body {
-    padding-top: 60px;
-    padding-bottom: 40px;
+  height: 100vh;
+  width: 100vw;
+}
+
+.test-in-browser {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+}
+
+.test-results {
+  flex: 1;
+  overflow: auto;
 }
 
 #testProgressBar {

--- a/packages/test-in-browser/driver.css
+++ b/packages/test-in-browser/driver.css
@@ -4,8 +4,9 @@ body {
 }
 
 #testProgressBar {
-    margin-top: 10px;
-    position: relative;
+  flex: 1;
+  max-width: 400px;
+  position: relative;
 }
 
 .header {

--- a/packages/test-in-browser/driver.html
+++ b/packages/test-in-browser/driver.html
@@ -1,3 +1,4 @@
+
 <template name="testInBrowserBody">
   <div class="container-fluid">
   {{> navBars}}
@@ -8,74 +9,59 @@
 </template>
 
 <template name="navBars">
-  <div class="navbar navbar-fixed-top navbar-inverse">
-    <div class="navbar-inner">
-      <div class="row-fluid">
-        <div class="span3"><a class="brand" href="#">
-          &nbsp;
-          {{#if running}}
-            Testing in progress...
+  <nav class="navbar fixed-top navbar-dark bg-dark">
+    <a class="navbar-brand" href="#">
+        {{#if running}}
+          Testing in progress...
+        {{else}}
+          {{#if passed}}
+            All tests pass!
           {{else}}
-            {{#if passed}}
-              All tests pass!
-            {{else}}
-              There are failures.
-            {{/if}}
+            There are failures.
           {{/if}}
-        </a></div>
-        <div class="span2">
-          {{#unless running}}
-            <p class="navbar-text">{{total_test_time}} ms</p>
-          {{/unless}}
-        </div>
-        <div class="span6">
-          {{> progressBar}}
-        </div>
-        <div class="span1"></div>
-      </div>
-    </div>
-  </div>
+        {{/if}}
+    </a>
+    {{#unless running}}
+      <span class="navbar-text">{{total_test_time}} ms</span>
+    {{/unless}}
+    {{> progressBar}}
+  </nav>
   {{> groupNav}}
 </template>
 
 <template name="progressBar">
   <div id="testProgressBar" class="progress {{barOuterClass}}">
     <span class="in-progress">Passed {{passedCount}} of {{totalCount}}</span>
-    <div class="bar bar-danger" style="width: {{percentFail}}%;"></div>
-    <div class="bar {{barInnerClass}}" style="width: {{percentPass}}%;"></div>
+    <div class="progress-bar bg-danger" role="progressbar" style="width: {{percentFail}}%;" aria-valuenow="{{percentFail}}" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-bar {{barInnerClass}}" role="progressbar" style="width: {{percentPass}}%;" aria-valuenow="{{percentPass}}" aria-valuemin="0" aria-valuemax="100"></div>
   </div>
 </template>
 
 <template name="groupNav">
-  <div class="navbar navbar-fixed-bottom navbar-inverse">
-    <div class="navbar-inner">
-      <ul class="nav">
+  <nav class="navbar navbar-expand-sm fixed-bottom navbar-dark bg-dark">
+    <ul class="navbar-nav mr-auto">
       {{#each groupPaths}}
-        <li class="navbar-text">&nbsp;-&nbsp;</li>
-        <li><a class="group" href="#">{{name}}</a></li>
+        <li class="nav-item"><span class="nav-link">&nbsp;-&nbsp;</span></li>
+        <li class="nav-item"><a class="nav-link" href="#">{{name}}</a></li>
       {{/each}}
-      </ul>
-      <form class="navbar-form pull-right">
-        <span id="current-client-test"></span>
-        <a class="btn rerun">
-          {{#if rerunScheduled}}
-          <i class="icon-time"></i>
-          Rerun scheduled...
-          {{else}}
-          <i class="icon-repeat"></i>
-          Rerun
-          {{/if}}
-        </a>
-      </form>
-      &nbsp;
-    </div>
-  </div>
+    </ul>
+
+    <form class="navbar-form pull-right">
+      <span id="current-client-test"></span>
+      <button class="btn btn-primary rerun">
+        {{#if rerunScheduled}}
+        Rerun scheduled...
+        {{else}}
+        Rerun
+        {{/if}}
+      </button>
+    </form>
+  </nav>
 </template>
 
 <template name="uncaughtErrors">
   {{#if uncaughtErrors}}
-    <div class="row-fluid">
-      <div class="span12">
+    <div class="container-fluid">
         <div class="alert alert-danger">
           <p>
             <strong>WARNING:</strong> The following uncaught errors might be
@@ -86,7 +72,6 @@
               <li>{{this}}</li>
             {{/each}}
           </ul>
-        </div>
       </div>
     </div>
   {{/if}}
@@ -94,26 +79,24 @@
 
 <template name="failedTests">
   {{#if failedTests}}
-    <div class="row-fluid">
-      <div class="span12">
-        <ul class="failedTests">
-          {{#each failedTests}}
-            <li>{{this}}</li>
-          {{/each}}
-        </ul>
-      </div>
+    <div class="container-fluid">
+      <ul class="failedTests">
+        {{#each failedTests}}
+          <li>{{this}}</li>
+        {{/each}}
+      </ul>
     </div>
   {{/if}}
 </template>
 
 <template name="testTable">
-  <div class="row-fluid"><div class="span12">
+  <div class="container-fluid">
   <div class="test_table">
     {{#each testdata}}
       {{> test_group thisWithDep}}
     {{/each}}
   </div>
-  </div></div>
+  </div>
 </template>
 
 <template name="test_group">

--- a/packages/test-in-browser/driver.html
+++ b/packages/test-in-browser/driver.html
@@ -1,15 +1,18 @@
 
 <template name="testInBrowserBody">
-  <div class="container-fluid">
-  {{> navBars}}
-  {{> uncaughtErrors}}
-  {{> failedTests}}
-  {{> testTable}}
+  <div class="test-in-browser">
+  {{> navBar}}
+  <div class="test-results">
+    {{> uncaughtErrors}}
+    {{> failedTests}}
+    {{> testTable}}
+  </div>
+  {{> groupNav}}
   </div>
 </template>
 
-<template name="navBars">
-  <nav class="navbar fixed-top navbar-dark bg-dark">
+<template name="navBar">
+  <nav class="navbar navbar-dark bg-dark">
     <a class="navbar-brand" href="#">
         {{#if running}}
           Testing in progress...
@@ -26,7 +29,6 @@
     {{/unless}}
     {{> progressBar}}
   </nav>
-  {{> groupNav}}
 </template>
 
 <template name="progressBar">
@@ -38,7 +40,7 @@
 </template>
 
 <template name="groupNav">
-  <nav class="navbar navbar-expand-sm fixed-bottom navbar-dark bg-dark">
+  <nav class="navbar navbar-expand-sm navbar-dark bg-dark">
     <ul class="navbar-nav mr-auto">
       {{#each groupPaths}}
         <li class="nav-item"><span class="nav-link">&nbsp;-&nbsp;</span></li>

--- a/packages/test-in-browser/driver.js
+++ b/packages/test-in-browser/driver.js
@@ -2,6 +2,7 @@
 //// Setup
 ////
 
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 // dependency for the count of tests running/passed/failed, etc. drives
 // the navbar and the like.
@@ -309,12 +310,12 @@ Template.progressBar.helpers({
   },
   barOuterClass: function () {
     countDep.depend();
-    return running ? 'progress-striped' : '';
+    return running ? 'progress-bar-animated progress-bar-striped' : '';
   },
   barInnerClass: function () {
     countDep.depend();
     return (failedCount > 0 ?
-            'bar-warning' : 'bar-success');
+            'bg-warning' : 'bg-success');
   }
 });
 

--- a/packages/test-in-browser/driver.js
+++ b/packages/test-in-browser/driver.js
@@ -245,7 +245,7 @@ var _testStatus = function(t) {
 
 //// Template - navBars
 
-Template.navBars.helpers({
+Template.navBar.helpers({
   running: function() {
     countDep.depend();
     return running;

--- a/packages/test-in-browser/package.js
+++ b/packages/test-in-browser/package.js
@@ -4,17 +4,19 @@ Package.describe({
   documentation: null
 });
 
+Npm.depends({
+  'bootstrap': '4.3.1',
+});
+
 Package.onUse(function (api) {
   api.use('ecmascript');
   // XXX this should go away, and there should be a clean interface
   // that tinytest and the driver both implement?
   api.use('tinytest');
-  api.use('bootstrap@1.0.1');
   api.use('underscore');
 
   api.use('session');
   api.use('reload');
-  api.use('jquery@1.11.1');
 
   api.use(['webapp', 'blaze@2.1.8', 'templating@1.2.13', 'spacebars@1.0.12',
            'ddp', 'tracker'], 'client');
@@ -24,7 +26,7 @@ Package.onUse(function (api) {
   api.addFiles([
     'driver.html',
     'driver.js',
-    'driver.css'
+    'driver.css',
   ], "client");
 
   api.use("random", "server");


### PR DESCRIPTION
Another step towards #10498

The direct jquery dependency was not necessary as far as I can tell. There was a second indirect dependency through the deprecated bootstrap package from which we only need the css.
So I replaced that one with bootstrap 4 css from npm