### PR TITLE
Fix mysterious Windows AppVeyor test stalls.

### DIFF
--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -35,6 +35,7 @@ import {
   convertToStandardLineEndings,
   convertToStandardPath,
   convertToWindowsPath,
+  isWindowsLikeFilesystem,
   pathBasename,
   pathDirname,
   pathJoin,
@@ -1690,7 +1691,7 @@ export function copyFile(from: string, to: string, flags = 0) {
 }
 
 const wrappedRename = wrapDestructiveFsFunc("rename", fs.renameSync, [0, 1]);
-export function rename(from: string, to: string) {
+export const rename = isWindowsLikeFilesystem() ? function (from: string, to: string) {
   // Retries are necessary only on Windows, because the rename call can
   // fail with EBUSY, which means the file is in use.
   const osTo = convertToOSPath(to);
@@ -1727,7 +1728,7 @@ export function rename(from: string, to: string) {
       throw error;
     }
   }).await();
-}
+} : wrappedRename;
 
 // Warning: doesn't convert slashes in the second 'cache' arg
 export const realpath =

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -35,7 +35,6 @@ import {
   convertToStandardLineEndings,
   convertToStandardPath,
   convertToWindowsPath,
-  isWindowsLikeFilesystem,
   pathBasename,
   pathDirname,
   pathJoin,
@@ -1691,7 +1690,7 @@ export function copyFile(from: string, to: string, flags = 0) {
 }
 
 const wrappedRename = wrapDestructiveFsFunc("rename", fs.renameSync, [0, 1]);
-export const rename = isWindowsLikeFilesystem() ? function (from: string, to: string) {
+export function rename(from: string, to: string) {
   // Retries are necessary only on Windows, because the rename call can
   // fail with EBUSY, which means the file is in use.
   const osTo = convertToOSPath(to);
@@ -1728,7 +1727,7 @@ export const rename = isWindowsLikeFilesystem() ? function (from: string, to: st
       throw error;
     }
   }).await();
-} : wrappedRename;
+}
 
 // Warning: doesn't convert slashes in the second 'cache' arg
 export const realpath =

--- a/tools/isobuild/import-scanner.ts
+++ b/tools/isobuild/import-scanner.ts
@@ -142,7 +142,9 @@ class DefaultHandlers {
           file.hash,
           this.bundleArch,
         );
-        process.nextTick(writeFileAtomically, cacheFileName, code);
+        Promise.resolve().then(
+          () => writeFileAtomically(cacheFileName, code),
+        );
         return code;
       }
     } else {

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -368,7 +368,7 @@ export default class Sandbox {
     // Allow user to set TOOL_NODE_FLAGS for self-test app.
     if (process.env.TOOL_NODE_FLAGS && ! process.env.SELF_TEST_TOOL_NODE_FLAGS)
       console.log('Consider setting SELF_TEST_TOOL_NODE_FLAGS to configure ' +
-                  'self-test test applicaion spawns');
+                  'self-test test application spawns');
     env.TOOL_NODE_FLAGS = process.env.SELF_TEST_TOOL_NODE_FLAGS || '';
 
     return env;


### PR DESCRIPTION
Windows tests have been timing out because the preparatory `meteor --get-ready` command stalls forever (using 0% CPU), so I'd like to gain some insight into how far it gets before it stalls.