### PR TITLE
Update source-map to 0.7.3

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=12.13.0.1
+BUNDLE_VERSION=12.13.0.2
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -132,7 +132,10 @@ fi
 # the script take precedence over $NODE_PATH; it used to be that users would
 # screw up their meteor installs by have a ~/node_modules
 
+# --no-wasm-code-gc is currently necessary as a workaround for
+# https://github.com/nodejs/node/issues/29767
 exec "$DEV_BUNDLE/bin/node" \
      --max-old-space-size=4096 \
+     --no-wasm-code-gc \
      ${TOOL_NODE_FLAGS} \
      "$METEOR" "$@"

--- a/meteor.bat
+++ b/meteor.bat
@@ -47,6 +47,7 @@ SET NODE_PATH=%~dp0\dev_bundle\lib\node_modules
 SET BABEL_CACHE_DIR=%~dp0\.babel-cache
 
 "%~dp0\dev_bundle\bin\node.exe" ^
+  --no-wasm-code-gc ^
   %TOOL_NODE_FLAGS% ^
   "%~dp0\tools\index.js" %*
 

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -39,7 +39,7 @@ var packageJson = {
     // Fork of kexec@3.0.0 with my Node.js 12 compatibility PR
     // https://github.com/jprichardson/node-kexec/pull/37 applied.
     kexec: "https://github.com/meteor/node-kexec/tarball/f29f54037c7db6ad29e1781463b182e5929215a0",
-    "source-map": "0.5.7",
+    "source-map": "0.7.3",
     chalk: "0.5.1",
     sqlite3: "4.1.0",
     "http-proxy": "1.16.2",

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -1164,8 +1164,10 @@ export function runJavaScript(code: string, {
     const header = "(function(" + keys.join(',') + "){";
     chunks.push(header);
     if (sourceMap) {
+      const sourcemapConsumer = Promise.await(new sourcemap.SourceMapConsumer(sourceMap));
       chunks.push(sourcemap.SourceNode.fromStringWithSourceMap(
-        code, new sourcemap.SourceMapConsumer(sourceMap)));
+        code, sourcemapConsumer));
+      sourcemapConsumer.destroy();
     } else {
       chunks.push(code);
     }
@@ -1234,8 +1236,9 @@ export function runJavaScript(code: string, {
 
         if (parsedSourceMap) {
           // XXX this duplicates code in computeGlobalReferences
-          var consumer2 = new sourcemap.SourceMapConsumer(parsedSourceMap);
+          var consumer2 = Promise.await(new sourcemap.SourceMapConsumer(parsedSourceMap));
           var original = consumer2.originalPositionFor(parseError.loc);
+          consumer2.destroy();
           if (original.source) {
             err.file = original.source;
             err.line = original.line;

--- a/tools/index.d.ts
+++ b/tools/index.d.ts
@@ -10,7 +10,13 @@ declare global {
     // This is an incomplete list of methods added to Promise.prototype by the
     // meteor-promise npm package. TODO Eventually these declarations should be
     // moved into that package.
-    await: () => T;
+    await(): T;
+  }
+
+  // Promise.await(x) is a shorthand provided by meteor-promise for
+  // Promise.resolve(x).await().
+  interface PromiseConstructor {
+    await<T>(arg: T | PromiseLike<T>): T;
   }
 
   interface Function {

--- a/tools/isobuild/import-scanner.ts
+++ b/tools/isobuild/import-scanner.ts
@@ -693,12 +693,13 @@ export default class ImportScanner {
 
     function getChunk(file: File) {
       const consumer = file.sourceMap &&
-        new SourceMapConsumer(file.sourceMap);
+        Promise.await(new SourceMapConsumer(file.sourceMap));
       const node = consumer &&
         SourceNode.fromStringWithSourceMap(
           scanner.getDataString(file),
           consumer
         );
+      consumer.destroy();
       return node || scanner.getDataString(file);
     }
 

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -657,7 +657,7 @@ _.extend(File.prototype, {
         column: e.column
       };
       if (self.sourceMap) {
-        var parsed = new sourcemap.SourceMapConsumer(self.sourceMap);
+        var parsed = Promise.await(new sourcemap.SourceMapConsumer(self.sourceMap));
         var original = parsed.originalPositionFor(
           {line: e.lineNumber, column: e.column - 1});
         if (original.source) {
@@ -665,6 +665,7 @@ _.extend(File.prototype, {
           errorOptions.line = original.line;
           errorOptions.column = original.column + 1;
         }
+        parsed.destroy();
       }
 
       buildmessage.error(e.message, errorOptions);
@@ -779,10 +780,12 @@ const getPrelinkedOutputCached = require("optimism").wrap(
       let chunk = result.code;
 
       if (result.map) {
+        const sourcemapConsumer = Promise.await(new sourcemap.SourceMapConsumer(result.map));
         chunk = sourcemap.SourceNode.fromStringWithSourceMap(
           result.code,
-          new sourcemap.SourceMapConsumer(result.map),
+          sourcemapConsumer,
         );
+        sourcemapConsumer.destroy();
       }
 
       chunks.push(chunk);

--- a/tools/tests/old.js
+++ b/tools/tests/old.js
@@ -27,7 +27,7 @@ var runOldTest = function (filename, extraEnv) {
   var run = new Run(files.convertToStandardPath(process.execPath), {
     // 'args' are treated as-is, so need to be converted before passing into
     // 'Run'
-    args: [files.convertToOSPath(files.pathResolve(
+    args: ['--no-wasm-code-gc', files.convertToOSPath(files.pathResolve(
       files.convertToStandardPath(__dirname), 'old', filename))],
     env: maybeFixRelease(_.extend({
       METEOR_TOOL_PATH: s.execPath


### PR DESCRIPTION
source-map 0.7.0+ has a much faster Rust WASM implementation.
Because this needs to be loaded, the constructor is now asynchronous.
The consumer should also be destroyed after it's no longer needed.

https://github.com/meteor/meteor/commit/1cf59867b2f74f5be1a3e6f1eb13ea4ae10540db paved the way for this.

Should hopefully help with: https://github.com/meteor/meteor/issues/9568 , but didn't ran any benchmarks yet.