### PR TITLE
Bump accounts-password version

### DIFF
--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -5,7 +5,7 @@ Package.describe({
   // 2.2.x in the future. The version was also bumped to 2.0.0 temporarily
   // during the Meteor 1.5.1 release process, so versions 2.0.0-beta.2
   // through -beta.5 and -rc.0 have already been published.
-  version: "1.5.1"
+  version: "1.5.2"
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
Should be republished, since the published 1.5.1 is outdated and still contains underscore. https://github.com/meteor/meteor/issues/10788
