### PR TITLE
Add upgrader to add jquery dependency for blaze-users

### DIFF
--- a/tools/tests/apps/client-refresh/.meteor/.finished-upgraders
+++ b/tools/tests/apps/client-refresh/.meteor/.finished-upgraders
@@ -16,3 +16,4 @@ notices-for-facebook-graph-api-2
 1.4.3-split-account-service-packages
 1.5-add-dynamic-import-package
 1.7-split-underscore-from-meteor-base
+1.8.3-split-jquery-from-blaze

--- a/tools/tests/apps/compiler-plugin-static-html-error/.meteor/.finished-upgraders
+++ b/tools/tests/apps/compiler-plugin-static-html-error/.meteor/.finished-upgraders
@@ -16,3 +16,4 @@ notices-for-facebook-graph-api-2
 1.4.3-split-account-service-packages
 1.5-add-dynamic-import-package
 1.7-split-underscore-from-meteor-base
+1.8.3-split-jquery-from-blaze

--- a/tools/tests/apps/compiler-plugin-static-html/.meteor/.finished-upgraders
+++ b/tools/tests/apps/compiler-plugin-static-html/.meteor/.finished-upgraders
@@ -16,3 +16,4 @@ notices-for-facebook-graph-api-2
 1.4.3-split-account-service-packages
 1.5-add-dynamic-import-package
 1.7-split-underscore-from-meteor-base
+1.8.3-split-jquery-from-blaze

--- a/tools/tests/apps/dynamic-import/.meteor/.finished-upgraders
+++ b/tools/tests/apps/dynamic-import/.meteor/.finished-upgraders
@@ -16,3 +16,4 @@ notices-for-facebook-graph-api-2
 1.4.3-split-account-service-packages
 1.5-add-dynamic-import-package
 1.7-split-underscore-from-meteor-base
+1.8.3-split-jquery-from-blaze

--- a/tools/tests/apps/git-commit-hash/.meteor/.finished-upgraders
+++ b/tools/tests/apps/git-commit-hash/.meteor/.finished-upgraders
@@ -16,3 +16,4 @@ notices-for-facebook-graph-api-2
 1.4.3-split-account-service-packages
 1.5-add-dynamic-import-package
 1.7-split-underscore-from-meteor-base
+1.8.3-split-jquery-from-blaze

--- a/tools/tests/apps/linked-external-npm-package/.meteor/.finished-upgraders
+++ b/tools/tests/apps/linked-external-npm-package/.meteor/.finished-upgraders
@@ -16,3 +16,4 @@ notices-for-facebook-graph-api-2
 1.4.3-split-account-service-packages
 1.5-add-dynamic-import-package
 1.7-split-underscore-from-meteor-base
+1.8.3-split-jquery-from-blaze

--- a/tools/tests/apps/modules/.meteor/.finished-upgraders
+++ b/tools/tests/apps/modules/.meteor/.finished-upgraders
@@ -17,3 +17,4 @@ notices-for-facebook-graph-api-2
 1.4.3-split-account-service-packages
 1.5-add-dynamic-import-package
 1.7-split-underscore-from-meteor-base
+1.8.3-split-jquery-from-blaze

--- a/tools/tests/apps/standard-app/.meteor/.finished-upgraders
+++ b/tools/tests/apps/standard-app/.meteor/.finished-upgraders
@@ -16,3 +16,4 @@ notices-for-facebook-graph-api-2
 1.4.3-split-account-service-packages
 1.5-add-dynamic-import-package
 1.7-split-underscore-from-meteor-base
+1.8.3-split-jquery-from-blaze

--- a/tools/upgraders.js
+++ b/tools/upgraders.js
@@ -308,6 +308,25 @@ safely remove it using 'meteor remove underscore'.`,
       packagesFile.addPackages([`underscore`]);
       packagesFile.writeIfModified();
     }
+  },
+
+  '1.8.3-split-jquery-from-blaze': function (projectContext) {
+    const packagesFile = projectContext.projectConstraintsFile;
+    if (! packagesFile.getConstraint(`jquery`) &&
+      packagesFile.getConstraint(`blaze-html-templates`)) {
+
+      maybePrintNoticeHeader();
+      Console.info(
+`The jquery package has become a weak dependency of the blaze package. \
+Since you will most likely need jquery as the commonly used blaze backend \
+and it was not listed in your .meteor/packages files, it has \
+been added automatically. If your app is not using jquery, then you can \
+safely remove it using 'meteor remove jquery'.`,
+        Console.options({ bulletPoint: "1.8.3: " })
+      );
+      packagesFile.addPackages([`jquery`]);
+      packagesFile.writeIfModified();
+    }
   }
 
   ////////////


### PR DESCRIPTION
While jquery is now a theoretical weak dependency of blaze, in reality everyone uses the jquery dombackend of blaze. So try to limit the complaints about apps being broken. (they will still need to have it as an NPM dependency, but at least the `jquery` package gives a clear error message if this isn't the case)