### PR TITLE
Log error stack on exception in publication

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1738,7 +1738,7 @@ var wrapInternalException = function (exception, context) {
   // Tests can set the '_expectedByTest' flag on an exception so it won't go to
   // the server log.
   if (!exception._expectedByTest) {
-    Meteor._debug("Exception " + context, exception);
+    Meteor._debug("Exception " + context, exception.stack);
     if (exception.sanitizedError) {
       Meteor._debug("Sanitized and reported to the client as:", exception.sanitizedError);
       Meteor._debug();


### PR DESCRIPTION
When an exception is thrown in a publication, it is very useful to see the entire stack trace rather than just the name of the error (#10782). #9678 refactored the debug messages and unfortunately made the server-side error messages less detailes. This PR tries to address the issue  by reverting some of the changes made by #9678,  specifically https://github.com/meteor/meteor/pull/9678/files#diff-7e48a19069e07781db2a50282a8bfdd7R1737

There is perhaps an opportinuty to print more details in other places, e.g. when exceptions are thrown in method calls, etc. #9678 added a todo that stack traces should be formatted nicely but that seems to have not been addressed. IMO it's better to print badly formatted stack traces than nothing at all. I'd be happy to do that if people are happy
