### PR TITLE
Update Cordova to 9.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ run_save_node_bin: &run_save_node_bin
 build_machine_environment: &build_machine_environment
   # Specify that we want an actual machine (ala Circle 1.0), not a Docker image.
   docker:
-    - image: meteor/circleci:android-27-node-8
+    - image: meteor/circleci:android-28-node-8
   environment:
     # This multiplier scales the waitSecs for selftests.
     TIMEOUT_SCALE_FACTOR: 8

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -39,7 +39,20 @@ A proper service worker build target. Regular Web Workers can be built from a fu
 - Status: -
 - PRs: -
 
-Have a ultra-thin version of Meteor that does not depend in anyway to mongo. Allow completely shutting down DDP and dependencies on DDP. ([MFR #31](https://github.com/meteor/meteor-feature-requests/issues/31), [MFR #354](https://github.com/meteor/meteor-feature-requests/issues/354), [Issue #9960](https://github.com/meteor/meteor/issues/9960))
+[Meteor 1.7](https://github.com/meteor/meteor/blob/devel/History.md#v17-2018-05-28) introduced the `meteor create --minimal` command, which generates a new application without any unnecessary Meteor packages, like `mongo` and `ddp`.
+
+When minified and gzip-compressed, the JS bundle for this app weighs in at less than 20kB, which is much smaller than the default `meteor create` application. Nevertheless, there is still room for improvement, using techniques like bundle visualization (`meteor npm run visualize`) and converting static `import`s to dynamic `import()`s.
+
+Additionally, minimal Meteor applications do not include the `autoupdate` package by default, because it is not strictly necessary for building an application, and its dependencies (`ddp` in particular, but no longer `mongo` or `minimongo`, thanks to [PR #10238](https://github.com/meteor/meteor/pull/10238)) contribute an additional 30kB to the JS bundle. The drawback of not using `autoupdate` is that instantaneous client refreshes are disabled, which can slow down development, so it would be great to find a way of making `autoupdate` less expensive, or enable it only in development.
+
+In other words, we want minimal Meteor apps to be not only as tiny as possible, but also just as developer-friendly as a normal Meteor application.
+
+Related issues:
+* [MFR #31](https://github.com/meteor/meteor-feature-requests/issues/31)
+* [MFR #354](https://github.com/meteor/meteor-feature-requests/issues/354)
+* [Issue #9960](https://github.com/meteor/meteor/issues/9960)
+* [PR #8853](https://github.com/meteor/meteor/pull/8853)
+* [PR #10238](https://github.com/meteor/meteor/pull/10238)
 
 ### Page load performance improvements
 - Leaders: <you?>

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -89,7 +89,7 @@ Update Cordoba lib and its dependencies to latest (version 9)
 - Status: -
 - PRs: -
 
-Provide a skeleton with mobile native configurations already in place such as `mobile-config.js`, sample assets, Fastlane scripts, etc. Also improve docs and guide.
+Provide a skeleton with mobile native configurations already in place such as `mobile-config.js`, sample assets, Fastlane scripts, etc. Also improve docs and guide ([Forums post](https://forums.meteor.com/t/lets-create-the-ultimate-cordova-hot-code-push-faq-doc/50500)).
 
 ## DB
 ### Update MongoDB driver

--- a/packages/launch-screen/package.js
+++ b/packages/launch-screen/package.js
@@ -10,7 +10,7 @@ Package.describe({
 });
 
 Cordova.depends({
-  'cordova-plugin-splashscreen': '4.1.0'
+  'cordova-plugin-splashscreen': '5.0.3'
 });
 
 Package.onUse(function(api) {

--- a/packages/launch-screen/package.js
+++ b/packages/launch-screen/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // between such packages and the build tool.
   name: 'launch-screen',
   summary: 'Default and customizable launch screen on mobile.',
-  version: '1.1.1'
+  version: '1.1.2-beta.0'
 });
 
 Cordova.depends({

--- a/packages/mobile-experience/package.js
+++ b/packages/mobile-experience/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mobile-experience',
-  version: '1.0.5',
+  version: '1.0.6-beta.0',
   summary: 'Packages for a great mobile user experience',
   documentation: 'README.md'
 });

--- a/packages/mobile-status-bar/package.js
+++ b/packages/mobile-status-bar/package.js
@@ -1,6 +1,7 @@
 Package.describe({
+  name: 'mobile-status-bar',
   summary: "Good defaults for the mobile status bar",
-  version: "1.0.14"
+  version: "1.0.15-beta.0"
 });
 
 Cordova.depends({

--- a/packages/mobile-status-bar/package.js
+++ b/packages/mobile-status-bar/package.js
@@ -4,5 +4,5 @@ Package.describe({
 });
 
 Cordova.depends({
-  'cordova-plugin-statusbar': '2.3.0'
+  'cordova-plugin-statusbar': '2.4.3'
 });

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -20,7 +20,7 @@ Npm.strip({
 });
 
 Cordova.depends({
-  'cordova-plugin-whitelist': '1.3.3',
+  'cordova-plugin-whitelist': '1.3.4',
   'cordova-plugin-wkwebview-engine': '1.1.4',
   'cordova-plugin-meteor-webapp': '1.7.1-beta.1'
 });

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -22,7 +22,7 @@ Npm.strip({
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.3',
   'cordova-plugin-wkwebview-engine': '1.1.4',
-  'cordova-plugin-meteor-webapp': '1.7.1-beta.0'
+  'cordova-plugin-meteor-webapp': '1.7.1-beta.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -21,7 +21,7 @@ Npm.strip({
 
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.4',
-  'cordova-plugin-wkwebview-engine': '1.1.4',
+  'cordova-plugin-wkwebview-engine': '1.2.1',
   'cordova-plugin-meteor-webapp': '1.7.1-beta.1'
 });
 

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -22,7 +22,7 @@ Npm.strip({
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.3',
   'cordova-plugin-wkwebview-engine': '1.1.4',
-  'cordova-plugin-meteor-webapp': '1.7.0'
+  'cordova-plugin-meteor-webapp': '1.7.1-beta.0'
 });
 
 Package.onUse(function (api) {

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -14,14 +14,14 @@ export const CORDOVA_ARCH = "web.cordova";
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
-  'cordova-lib': '7.1.0',
-  'cordova-common': '2.1.1',
+  'cordova-lib': '9.0.1',
+  'cordova-common': '3.2.1',
   'cordova-registry-mapper': '1.1.15',
 };
 
 export const CORDOVA_PLATFORM_VERSIONS = {
-  'android': '7.1.4',
-  'ios': '4.5.5',
+  'android': '8.1.0',
+  'ios': '5.1.1',
 };
 
 const PLATFORM_TO_DISPLAY_NAME_MAP = {

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -305,18 +305,17 @@ ${displayNameForPlatform(platform)}`, async () => {
     options.push(isDevice ? '--device' : '--emulator');
 
     let env = this.defaultEnvWithPathsAdded(...extraPaths);
-
-    let command = files.convertToOSPath(files.pathJoin(
-      this.projectRoot, 'platforms', platform, 'cordova', 'run'));
+    const commandOptions = {
+      ...this.defaultOptions,
+      platforms: [platform],
+      device: isDevice,
+    };
 
     this.runCommands(`running Cordova app for platform \
-${displayNameForPlatform(platform)} with options ${options}`,
-    execFileAsync(command, options, {
-      env: env,
-      cwd: this.projectRoot,
-      stdio: Console.verbose ? 'inherit' : 'pipe',
-      waitForClose: false
-    }), null, null);
+${displayNameForPlatform(platform)} with options ${options}`, async () => {
+      await cordova_lib.run(commandOptions);
+    });
+
   }
 
   // Platforms

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -737,7 +737,7 @@ perform cordova plugins reinstall`);
     // cordova-plugin-whitelist@1.3.2 => { 'cordova-plugin-whitelist': '1.3.2' }
     // com.cordova.plugin@file://.cordova-plugins/plugin => { 'com.cordova.plugin': 'file://.cordova-plugins/plugin' }
     // @scope/plugin@1.0.0 => { 'com.cordova.plugin': 'scope/plugin' }
-    const installed = this.listInstalledPluginVersions();
+    const installed = this.listInstalledPluginVersions(true);
     const installedPluginsNames = Object.keys(installed);
     const installedPluginsVersions = Object.values(installed);
     const missingPlugins = {};


### PR DESCRIPTION
We want to update:
- [x] Lib from 7.1.0 to 9.0.1 [release notes](https://github.com/apache/cordova-lib/blob/master/RELEASENOTES.md)
- [x] Common from 2.1.1 to 3.2.1 [release notes](https://github.com/apache/cordova-common/blob/master/RELEASENOTES.md)
- [x] Android from 7.1.4 to 8.1.0 [release notes](https://github.com/apache/cordova-android/blob/master/RELEASENOTES.md)
- [x] iOS from 4.5.5 to 5.1.1 [release notes](https://github.com/apache/cordova-ios/blob/master/RELEASENOTES.md)
- [x] cordova-plugin-wkwebview-engine from 1.1.4 to 1.2.1 [release notes](https://github.com/apache/cordova-plugin-wkwebview-engine/blob/master/RELEASENOTES.md#121-jul-20-2019)
- [x] cordova-plugin-whitelist from 1.3.3 to 1.3.4 [release notes](https://github.com/apache/cordova-plugin-whitelist/blob/master/RELEASENOTES.md#134-jun-19-2019)
- [x] cordova-plugin-splashscreen (included by mobile-experience > launch-screen) from 4.1.0 to 5.0.3 [release notes](https://github.com/apache/cordova-plugin-splashscreen/blob/master/RELEASENOTES.md#503-may-09-2019)
- [x] cordova-plugin-statusbar (included by mobile-experience > mobile-status-bar) from 2.3.0 to 2.4.3 [release notes](https://github.com/apache/cordova-plugin-statusbar/blob/master/RELEASENOTES.md#243-jun-19-2019)

Related PRs (cordova-9 branch):
https://github.com/meteor/cordova-plugin-meteor-webapp/pull/88

Related issues #10809 #10626

Follow the list of known tasks:
- [x] (Fixed on 1.7.1-beta.0) Don't use context.requireCordovaModule to load non-Cordova modules ([error log](https://gist.github.com/filipenevola/5b80f7dfeecba52c0b747215fa93e283))
  - [x] Migrate context.requireCordovaModule to require on [cordova-plugin-meteor-webapp](https://github.com/meteor/cordova-plugin-meteor-webapp/)
- [x] docker images for CircleCI
  - [x] Android 28 / Node 8
  - [x] Android 28 / Node 12

Notes:
- To run on iOS the first time with `meteor run ios` I had to run this first `sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService` https://github.com/apache/cordova-ios/issues/652#issuecomment-514284852

Make sure the following is working after the update:
- [x] Create a new Meteor project and add iOS and Android platforms
  - [x] Run app on iOS simulator
  - [x] Run app on iOS device
  - [x] Run app on Android simulator
  - [x] Run app on Android device

Known issues to fix:
- [X] "Errors executing Cordova commands: While removing plugins"; when running for the second time - actually a plugin error : **https://github.com/jeduan/cordova-plugin-facebook4/issues/845**