### PR TITLE
Include Meteor.isSever constant in roadmap

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -25,7 +25,7 @@ Since Node.js 12 is scheduled to become the LTS version on October 1st, 2019, Me
 - Status: -
 - PRs: -
 
-Implement tree shaking / dead code elimination, which involves pruning the dependency tree while scanning imports in the `ImportScanner`. We believe it should be possible to treat values like `Meteor.isProduction` as constants during this process, and eliminate those branches if their conditions are false.
+Implement tree shaking / dead code elimination, which involves pruning the dependency tree while scanning imports in the `ImportScanner`. We believe it should be possible to treat values like `Meteor.isProduction` and `Meteor.isServer` as constants during this process, and eliminate those branches if their conditions are false.
 
 ### Service worker build target
 - Leaders: <you?>

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -25,7 +25,7 @@ Since Node.js 12 is scheduled to become the LTS version on October 1st, 2019, Me
 - Status: -
 - PRs: -
 
-Implement tree shaking / dead code elimination, which involves pruning the dependency tree while scanning imports in the `ImportScanner`. We believe it should be possible to treat values like `Meteor.isProduction` and `Meteor.isServer` as constants during this process, and eliminate those branches if their conditions are false.
+Implement tree shaking / dead code elimination, which involves pruning the dependency tree while scanning imports in the `ImportScanner`. We believe it should be possible to treat values like `Meteor.isProduction` and `Meteor.isServer` as constants during this process, and eliminate those branches if their conditions are false (as in https://github.com/meteor/meteor/pull/10056).
 
 ### Service worker build target
 - Leaders: <you?>


### PR DESCRIPTION
I (and presumably others) often have code shared between client and server, with some blocked off by `if(Meteor.isServer)` and (more rarely) `if(!Meteor.isServer)`. It would be great if this constant is also handled in the tree shaking, and I imagine it's about as easy as `Meteor.isProduction` (but slightly different so worth mentioning).

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
