### PR TITLE
Allow to exclude web architectures in development mode

### DIFF
--- a/History.md
+++ b/History.md
@@ -21,6 +21,15 @@ N/A
   * cordova-plugin-splashscreen (included by mobile-experience > launch-screen) from 4.1.0 to 5.0.3 [release notes](https://github.com/apache/cordova-plugin-splashscreen/blob/master/RELEASENOTES.md#503-may-09-2019)
   * cordova-plugin-statusbar (included by mobile-experience > mobile-status-bar) from 2.3.0 to 2.4.3 [release notes](https://github.com/apache/cordova-plugin-statusbar/blob/master/RELEASENOTES.md#243-jun-19-2019)
 
+* You can now pass an `--exclude-archs` option to the `meteor run` and
+  `meteor test` commands to temporarily disable building certain web
+  architectures. For example, `meteor run --exclude-archs web.browser.legacy`.
+  Multiple architectures should be separated by commas. This option can be
+  used to improve (re)build times if you're not actively testing the
+  excluded architectures during development.
+  [Feature #333](https://github.com/meteor/meteor-feature-requests/issues/333),
+  [PR #10824](https://github.com/meteor/meteor/pull/10824)
+
 ## v1.9, 2020-01-09
 
 ### Breaking changes
@@ -102,13 +111,6 @@ N/A
 * The `meteor-babel` npm package has been updated to version 7.7.5.
 
 * The `typescript` npm package has been updated to version 3.7.3.
-
-* You can now use the `--exclude-archs` CLI argument for the run and test 
-  commands to temporarily disable building certain web architectures.
-  For example: `meteor run --exclude-archs web.browser.legacy`.
-  You can pass multiple architectures comma seperated.
-  This can be used to improve rebuild times if you're not actively testing
-  those architectures during development.
 
 ## v1.8.2, 2019-11-14
 

--- a/History.md
+++ b/History.md
@@ -103,6 +103,13 @@ N/A
 
 * The `typescript` npm package has been updated to version 3.7.3.
 
+* You can now use the `--exclude-archs` CLI argument for the run and test 
+  commands to temporarily disable building certain web architectures.
+  For example: `meteor run --exclude-archs web.browser.legacy`.
+  You can pass multiple architectures comma seperated.
+  This can be used to improve rebuild times if you're not actively testing
+  those architectures during development.
+
 ## v1.8.2, 2019-11-14
 
 ### Breaking changes

--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -251,10 +251,12 @@ function eachResource({
 }
 
 function sizeCheck() {
-  const sizes = [ // Check size of each known architecture independently.
+  const RESOURCE_SIZE_LIMIT = 5 * 1024 * 1024; // 5MB
+  const largeSizes = [ // Check size of each known architecture independently.
     "web.browser",
     "web.browser.legacy",
-  ].reduce((filt, arch) => {
+  ].filter((arch) => !!WebApp.clientPrograms[arch])
+  .map((arch) => {
     let totalSize = 0;
 
     WebApp.clientPrograms[arch].manifest.forEach(resource => {
@@ -265,22 +267,21 @@ function sizeCheck() {
       }
     });
 
-    if (totalSize > 5 * 1024 * 1024) {
-      filt.push({
-        arch,
-        size: totalSize
-      });
+    return {
+      arch,
+      size: totalSize,
     }
-    return filt;
-  }, []);
-  if (sizes.length > 0) {
+  })
+  .filter(({ size }) => size > RESOURCE_SIZE_LIMIT);
+
+  if (largeSizes.length > 0) {
     Meteor._debug([
       "** You are using the appcache package, but the size of",
       "** one or more of your cached resources is larger than",
       "** the recommended maximum size of 5MB which may break",
       "** your app in some browsers!",
       "** ",
-      ...sizes.map(data => `** ${data.arch}: ${(data.size / 1024 / 1024).toFixed(1)}MB`),
+      ...largeSizes.map(data => `** ${data.arch}: ${(data.size / 1024 / 1024).toFixed(1)}MB`),
       "** ",
       "** See http://docs.meteor.com/#appcache for more",
       "** information and fixes."

--- a/packages/appcache/package.js
+++ b/packages/appcache/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Enable the application cache in the browser",
-  version: "1.2.3",
+  version: "1.2.4",
 });
 
 Package.onUse(api => {

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.8.0'
+  version: '1.8.1'
 });
 
 Npm.depends({"basic-auth-connect": "1.0.0",

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -402,6 +402,12 @@ WebAppInternals.staticFilesMiddleware = async function (
     identifyBrowser(req.headers["user-agent"]),
   );
 
+  if (! hasOwn.call(WebApp.clientPrograms, arch)) {
+    // We could come here in case we run with some architectures excluded
+    next();
+    return;
+  }
+
   // If pauseClient(arch) has been called, program.paused will be a
   // Promise that will be resolved when the program is unpaused.
   const program = WebApp.clientPrograms[arch];
@@ -984,6 +990,19 @@ function runWebAppServer() {
         parseRequest(req).pathname,
         request.browser,
       );
+
+      if (! hasOwn.call(WebApp.clientPrograms, arch)) {
+        // We could come here in case we run with some architectures excluded
+        headers['Cache-Control'] = 'no-cache';
+        res.writeHead(404, headers);
+        if (Meteor.isDevelopment) {
+          res.end(`No client program found for the ${arch} architecture.`);
+        } else {
+          // Safety net, but this branch should not be possible.
+          res.end("404 Not Found");
+        }
+        return;
+      }
 
       // If pauseClient(arch) has been called, program.paused will be a
       // Promise that will be resolved when the program is unpaused.

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -103,6 +103,9 @@ Options:
                    version constraints.
   --extra-packages Run with additional packages (comma separated, for example:
                    --extra-packages "package-name1, package-name2@1.2.3")
+  --exclude-archs  Don't create bundles for certain web architectures
+                  (comma separated, for example:
+                   --exclude-archs "web.browser.legacy, web.cordova")
 
 >>> debug
 Run the project with server-side debugging enabled.
@@ -713,6 +716,9 @@ Options:
   --driver-package  Name of the optional test driver package to use to run
                     tests and display results. For example:
                     --driver-package practicalmeteor:mocha
+  --exclude-archs   Don't create test bundles for certain web architectures
+                    (comma separated, for example:
+                    --exclude-archs "web.browser.legacy, web.cordova")
 
 >>> self-test
 Run tests of the 'meteor' tool.


### PR DESCRIPTION
This commit implements an `--exclude-archs` arg to the run command which allows you to pass a comma-seperated list of architectures to exclude.

Motivation:
Improve rebuild speeds, by allowing to leave out certain web architectures during development.

Meteor rebuild speeds, although greatly improved in recent versions, is still a common point of frustration as seen in the issues (https://github.com/meteor/meteor/issues/10800) and on the forum (https://forums.meteor.com/t/2x-to-3x-longer-build-time-also-on-testing-since-1-8-2-update/51028/3)

One reason for slow rebuilds is high memory pressure (https://github.com/meteor/meteor/issues/9568).
The web.browser.legacy architecture is currently always being build while most of us will only test this every once in a while.
So while we don't need it most of times during development it does add to the high memory usage.
Furthermore, even though these builds are delayed, long-running synchronous tasks have the potential to block the server startup (https://github.com/meteor/meteor/issues/10261).
This last issue can be partially, but not fully, improved by https://github.com/meteor/meteor/pull/10427
Therefore a commonly requested feature has been to disable the legacy build (https://github.com/meteor/meteor-feature-requests/issues/333)

However, we may also temporarily disable cordova builds and we may even want to disable just the web.browser build if we're just debugging a bug in the legacy build.
Therefore I chose to create the more generic `--exclude-archs` option.