### PR TITLE
Realpath performance

### DIFF
--- a/tools/fs/optimistic.ts
+++ b/tools/fs/optimistic.ts
@@ -16,6 +16,7 @@ import {
   readdir,
   dependOnPath,
   findAppDir,
+  realpath,
 } from "./files";
 
 // When in doubt, the optimistic caching system can be completely disabled
@@ -272,6 +273,24 @@ export const optimisticLStatOrNull = makeCheapPathFunction(
     }
   },
 );
+
+export const optimisticRealpath = makeOptimistic('realpath', realpath);
+export const optimisticRealpathOrNull = makeOptimistic('realpathOrNull', (
+  path: string,
+  options?: Parameters<typeof optimisticRealpath>[1],
+) => {
+  try {
+    return realpath(path, options)
+  } catch (e) {
+    if (e.code !== "ENOENT") {
+      throw e;
+    }
+  }
+
+  dependOnParentDirectory(path);
+
+  return null;
+});
 
 export const optimisticReadFile = makeOptimistic("readFile", readFile);
 export const optimisticReaddir = makeOptimistic("readdir", readdir);

--- a/tools/fs/optimistic.ts
+++ b/tools/fs/optimistic.ts
@@ -16,7 +16,6 @@ import {
   readdir,
   dependOnPath,
   findAppDir,
-  realpath,
 } from "./files";
 
 // When in doubt, the optimistic caching system can be completely disabled

--- a/tools/fs/optimistic.ts
+++ b/tools/fs/optimistic.ts
@@ -274,24 +274,6 @@ export const optimisticLStatOrNull = makeCheapPathFunction(
   },
 );
 
-export const optimisticRealpath = makeOptimistic('realpath', realpath);
-export const optimisticRealpathOrNull = makeOptimistic('realpathOrNull', (
-  path: string,
-  options?: Parameters<typeof optimisticRealpath>[1],
-) => {
-  try {
-    return realpath(path, options)
-  } catch (e) {
-    if (e.code !== "ENOENT") {
-      throw e;
-    }
-  }
-
-  dependOnParentDirectory(path);
-
-  return null;
-});
-
 export const optimisticReadFile = makeOptimistic("readFile", readFile);
 export const optimisticReaddir = makeOptimistic("readdir", readdir);
 export const optimisticHashOrNull = makeOptimistic("hashOrNull", (

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -11,6 +11,7 @@ import {
   optimisticStatOrNull,
   optimisticLStatOrNull,
   optimisticHashOrNull,
+  optimisticRealpath,
 } from "../fs/optimistic";
 
 // Builder is in charge of writing "bundles" to disk, which are
@@ -540,7 +541,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       // as well as node_modules/meteor and the parent directories of any
       // scoped npm packages.
       this._ensureAllNonPackageDirectories(
-        files.realpath(options.from),
+        optimisticRealpath(options.from),
         options.to
       );
     }
@@ -637,7 +638,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       });
     }
 
-    const rootDir = files.realpath(from);
+    const rootDir = optimisticRealpath(from);
 
     const walk = (absFrom, relTo) => {
       if (symlink && ! (relTo in this.usedAsFile)) {
@@ -671,7 +672,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
           }
 
           try {
-            var real = files.realpath(thisAbsFrom);
+            var real = optimisticRealpath(thisAbsFrom);
           } catch (e) {
             if (e.code !== "ENOENT" &&
                 e.code !== "ELOOP") {

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 import {WatchSet, readAndWatchFile, sha1} from '../fs/watch';
 import files, {
-  symlinkWithOverwrite,
+  symlinkWithOverwrite, realpath,
 } from '../fs/files';
 import NpmDiscards from './npm-discards.js';
 import {Profile} from '../tool-env/profile';
@@ -11,7 +11,6 @@ import {
   optimisticStatOrNull,
   optimisticLStatOrNull,
   optimisticHashOrNull,
-  optimisticRealpath,
 } from "../fs/optimistic";
 
 // Builder is in charge of writing "bundles" to disk, which are
@@ -541,7 +540,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       // as well as node_modules/meteor and the parent directories of any
       // scoped npm packages.
       this._ensureAllNonPackageDirectories(
-        optimisticRealpath(options.from),
+        realpath(options.from),
         options.to
       );
     }
@@ -638,7 +637,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       });
     }
 
-    const rootDir = optimisticRealpath(from);
+    const rootDir = realpath(from);
 
     const walk = (absFrom, relTo) => {
       if (symlink && ! (relTo in this.usedAsFile)) {
@@ -662,7 +661,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
           return;
         }
 
-        // Returns files.realpath(thisAbsFrom), iff it is external to
+        // Returns files.realpath(thisAbsFrom), if it is external to
         // rootDir, using caching because this function might be called
         // more than once.
         let cachedExternalPath;
@@ -672,7 +671,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
           }
 
           try {
-            var real = optimisticRealpath(thisAbsFrom);
+            var real = realpath(thisAbsFrom);
           } catch (e) {
             if (e.code !== "ENOENT" &&
                 e.code !== "ELOOP") {

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -173,7 +173,7 @@ import { loadIsopackage } from '../tool-env/isopackets.js';
 import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 import { gzipSync } from "zlib";
 import { PackageRegistry } from "../../packages/meteor/define-package.js";
-import { optimisticRealpathOrNull } from '../fs/optimistic';
+import { optimisticLStatOrNull } from '../fs/optimistic';
 
 const SOURCE_URL_PREFIX = "meteor://\u{1f4bb}app";
 
@@ -487,12 +487,11 @@ export class NodeModulesDirectory {
           return true;
         }
 
-        const real = optimisticRealpathOrNull(path);
-        if (typeof real === "string" &&
-            real !== path) {
+        const fileStatus = optimisticLStatOrNull(path);
+        if (fileStatus && fileStatus.isSymbolicLink()) {
           // If node_modules/.bin/command is a symlink, determine the
           // answer by calling isWithinProdPackage(real).
-          return isWithinProdPackage(real);
+          return isWithinProdPackage(files.realpathOrNull(path));
         }
 
         // If node_modules/.bin/command is not a symlink, then it's hard

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -173,6 +173,7 @@ import { loadIsopackage } from '../tool-env/isopackets.js';
 import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 import { gzipSync } from "zlib";
 import { PackageRegistry } from "../../packages/meteor/define-package.js";
+import { optimisticRealpathOrNull } from '../fs/optimistic';
 
 const SOURCE_URL_PREFIX = "meteor://\u{1f4bb}app";
 
@@ -486,7 +487,7 @@ export class NodeModulesDirectory {
           return true;
         }
 
-        const real = files.realpathOrNull(path);
+        const real = optimisticRealpathOrNull(path);
         if (typeof real === "string" &&
             real !== path) {
           // If node_modules/.bin/command is a symlink, determine the

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -225,7 +225,7 @@ class SymlinkLoopChecker {
 
     if (files.lstat(absPath).isSymbolicLink()) {
       const result = files.realpath(absPath);
-      this._cache.set(relPath, result);
+      this._cache.set(relDir, result);
 
       return result;
   }


### PR DESCRIPTION
With a smaller app on Windows, these changes reduces time spent by realpath from ~200 - 300 ms to 40ms on rebuilds, and saves ~750ms on the initial build. `realpath` works by using many lstat calls, which are slower on Windows than mac/linux.

When creating the list of files for each architecture, Meteor uses a symlink loop checker which would call `realpath` for each folder. It will now call `lstat` once for each folder and then call `realpath` for folders that are symlinks.

Meteor would also call realpath for each file in `node_modules/.bin` to check if it is a symlink. Since npm copies files into .bin instead of using symlinks on Windows, Meteor will now use lstat first, and then call `realpath` if it is a symlink. This does slightly increase the work done on linux/osx, but the additional lstat call is already cached from earlier in the build process.

The remaining use during rebuilds is calling `realpath` for each node_modules folder that is copied into the built app. I left this as is since it isn't clear why this is done and only adds ~20ms in the apps I profiled.