### PR TITLE
Add chromeMobileWebView alias

### DIFF
--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -8,6 +8,7 @@ const browserAliases = {
     // chromeMobile*, per https://github.com/meteor/meteor/pull/9793,
     "chromeMobile",
     "chromeMobileIOS",
+    "chromeMobileWebView",
 
     // The major version number of Chromium and Headless Chrome track with the
     // releases of Chrome Dev, Canary and Stable, so we should be okay to


### PR DESCRIPTION
Capacitor (and possibly others) are identified as chromeMobileWebView. This is identical (also in numbering) to e.g. chromeMobile and can therefore be used as alias.

Fixes https://github.com/meteor/meteor/issues/10794
