### PR TITLE
Don't lose the query string when using a path prefix

### DIFF
--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.8.2'
+  version: '1.8.3'
 });
 
 Npm.depends({"basic-auth-connect": "1.0.0",

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -880,7 +880,7 @@ function runWebAppServer() {
       if (isPrefixOf(prefixParts, pathParts)) {
         request.url = "/" + pathParts.slice(prefixParts.length).join("/");
         if (search) {
-         request.url += search; 
+          request.url += search; 
         }
         return next();
       }

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -871,7 +871,7 @@ function runWebAppServer() {
   // Strip off the path prefix, if it exists.
   app.use(function (request, response, next) {
     const pathPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
-    const { pathname } = parseUrl(request.url);
+    const { pathname, search } = parseUrl(request.url);
 
     // check if the path in the url starts with the path prefix
     if (pathPrefix) {
@@ -879,6 +879,9 @@ function runWebAppServer() {
       const pathParts = getPathParts(pathname);
       if (isPrefixOf(prefixParts, pathParts)) {
         request.url = "/" + pathParts.slice(prefixParts.length).join("/");
+        if (search) {
+         request.url += search; 
+        }
         return next();
       }
     }


### PR DESCRIPTION
Fixes https://github.com/meteor/meteor/issues/10756
