### PR TITLE
Add hash to runtime config file url

### DIFF
--- a/packages/boilerplate-generator/template-web.browser.js
+++ b/packages/boilerplate-generator/template-web.browser.js
@@ -42,6 +42,7 @@ export const headTemplate = ({
 // Template function for rendering the boilerplate html for browsers
 export const closeTemplate = ({
   meteorRuntimeConfig,
+  meteorRuntimeHash,
   rootUrlPathPrefix,
   inlineScriptsAllowed,
   js,
@@ -54,8 +55,9 @@ export const closeTemplate = ({
     ? template('  <script type="text/javascript">__meteor_runtime_config__ = JSON.parse(decodeURIComponent(<%= conf %>))</script>')({
       conf: meteorRuntimeConfig,
     })
-    : template('  <script type="text/javascript" src="<%- src %>/meteor_runtime_config.js"></script>')({
+    : template('  <script type="text/javascript" src="<%- src %>/meteor_runtime_config.js?hash=<%- hash %>"></script>')({
       src: rootUrlPathPrefix,
+      hash: meteorRuntimeHash,
     }),
   '',
 

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -317,9 +317,11 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
                                                         additionalOptions) {
   additionalOptions = additionalOptions || {};
 
-  var runtimeConfig = _.extend(
-    _.clone(__meteor_runtime_config__),
-    additionalOptions.runtimeConfigOverrides || {}
+  const meteorRuntimeConfig = JSON.stringify(
+    encodeURIComponent(JSON.stringify({
+      ...__meteor_runtime_config__,
+      ...(additionalOptions.runtimeConfigOverrides || {})
+    }))
   );
 
   return new Boilerplate(arch, manifest, _.extend({
@@ -342,8 +344,8 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
       // end up inside a <script> tag so we need to be careful to not include
       // "</script>", but normal {{spacebars}} escaping escapes too much! See
       // https://github.com/meteor/meteor/issues/3730
-      meteorRuntimeConfig: JSON.stringify(
-        encodeURIComponent(JSON.stringify(runtimeConfig))),
+      meteorRuntimeConfig,
+      meteorRuntimeHash: sha1(meteorRuntimeConfig),
       rootUrlPathPrefix: __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '',
       bundledJsCssUrlRewriteHook: bundledJsCssUrlRewriteHook,
       sriMode: sriMode,


### PR DESCRIPTION
Although Meteor doesn't send cache headers to the runtime config file, a reverse proxy might still cache it.
Some reverse proxies will treat this case similar to cache-control: private.
So adding the hash can prevent reverse proxies from serving stale versions.
Furthermore, by adding the hash, it can actually be cached correctly by reverse proxies.

For more context: #10733