### PR TITLE
Rebase PR #10810 (Cordova 9) against current devel branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ run_save_node_bin: &run_save_node_bin
 build_machine_environment: &build_machine_environment
   # Specify that we want an actual machine (ala Circle 1.0), not a Docker image.
   docker:
-    - image: meteor/circleci:android-27-node-12
+    - image: meteor/circleci:android-28-node-12
   environment:
     # This multiplier scales the waitSecs for selftests.
     TIMEOUT_SCALE_FACTOR: 8
@@ -656,7 +656,7 @@ jobs:
   Docs:
     docker:
       # This Node version should match that in the meteor/docs CircleCI config.
-      - image: meteor/circleci:android-27-node-12
+      - image: meteor/circleci:android-28-node-12
     environment:
       CHECKOUT_METEOR_DOCS: /home/circleci/test_docs
     steps:

--- a/History.md
+++ b/History.md
@@ -1,3 +1,26 @@
+## v1.10, TBD
+
+### Breaking changes
+
+* Cordova was updated from version 7 to 9 then we recommend that you test 
+your features that are taking advantage of Cordova plugins to be sure they are 
+still working as expected. 
+
+### Migration Steps
+N/A
+
+### Changes
+
+* Cordova was updated from version 7 to 9
+  * cordova-lib from 7.1.0 to 9.0.1 [release notes](https://github.com/apache/cordova-lib/blob/master/RELEASENOTES.md)
+  * cordova-common from 2.1.1 to 3.2.1 [release notes](https://github.com/apache/cordova-common/blob/master/RELEASENOTES.md)
+  * cordova-android from 7.1.4 to 8.1.0 [release notes](https://github.com/apache/cordova-android/blob/master/RELEASENOTES.md)
+  * cordova-ios from 4.5.5 to 5.1.1 [release notes](https://github.com/apache/cordova-ios/blob/master/RELEASENOTES.md)
+  * cordova-plugin-wkwebview-engine from 1.1.4 to 1.2.1 [release notes](https://github.com/apache/cordova-plugin-wkwebview-engine/blob/master/RELEASENOTES.md#121-jul-20-2019)
+  * cordova-plugin-whitelist from 1.3.3 to 1.3.4 [release notes](https://github.com/apache/cordova-plugin-whitelist/blob/master/RELEASENOTES.md#134-jun-19-2019)
+  * cordova-plugin-splashscreen (included by mobile-experience > launch-screen) from 4.1.0 to 5.0.3 [release notes](https://github.com/apache/cordova-plugin-splashscreen/blob/master/RELEASENOTES.md#503-may-09-2019)
+  * cordova-plugin-statusbar (included by mobile-experience > mobile-status-bar) from 2.3.0 to 2.4.3 [release notes](https://github.com/apache/cordova-plugin-statusbar/blob/master/RELEASENOTES.md#243-jun-19-2019)
+
 ## v1.9, 2020-01-09
 
 ### Breaking changes

--- a/packages/launch-screen/package.js
+++ b/packages/launch-screen/package.js
@@ -10,7 +10,7 @@ Package.describe({
 });
 
 Cordova.depends({
-  'cordova-plugin-splashscreen': '4.1.0'
+  'cordova-plugin-splashscreen': '5.0.3'
 });
 
 Package.onUse(function(api) {

--- a/packages/launch-screen/package.js
+++ b/packages/launch-screen/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // between such packages and the build tool.
   name: 'launch-screen',
   summary: 'Default and customizable launch screen on mobile.',
-  version: '1.1.1'
+  version: '1.1.2-beta.0'
 });
 
 Cordova.depends({

--- a/packages/launch-screen/package.js
+++ b/packages/launch-screen/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // between such packages and the build tool.
   name: 'launch-screen',
   summary: 'Default and customizable launch screen on mobile.',
-  version: '1.1.2-beta.0'
+  version: '1.2.0'
 });
 
 Cordova.depends({

--- a/packages/mobile-experience/package.js
+++ b/packages/mobile-experience/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mobile-experience',
-  version: '1.0.5',
+  version: '1.0.6-beta.0',
   summary: 'Packages for a great mobile user experience',
   documentation: 'README.md'
 });

--- a/packages/mobile-experience/package.js
+++ b/packages/mobile-experience/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mobile-experience',
-  version: '1.0.6-beta.0',
+  version: '1.1.0',
   summary: 'Packages for a great mobile user experience',
   documentation: 'README.md'
 });

--- a/packages/mobile-status-bar/package.js
+++ b/packages/mobile-status-bar/package.js
@@ -1,6 +1,7 @@
 Package.describe({
+  name: 'mobile-status-bar',
   summary: "Good defaults for the mobile status bar",
-  version: "1.0.14"
+  version: "1.0.15-beta.0"
 });
 
 Cordova.depends({

--- a/packages/mobile-status-bar/package.js
+++ b/packages/mobile-status-bar/package.js
@@ -4,5 +4,5 @@ Package.describe({
 });
 
 Cordova.depends({
-  'cordova-plugin-statusbar': '2.3.0'
+  'cordova-plugin-statusbar': '2.4.3'
 });

--- a/packages/mobile-status-bar/package.js
+++ b/packages/mobile-status-bar/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'mobile-status-bar',
   summary: "Good defaults for the mobile status bar",
-  version: "1.0.15-beta.0"
+  version: "1.1.0"
 });
 
 Cordova.depends({

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -20,7 +20,7 @@ Npm.strip({
 });
 
 Cordova.depends({
-  'cordova-plugin-whitelist': '1.3.3',
+  'cordova-plugin-whitelist': '1.3.4',
   'cordova-plugin-wkwebview-engine': '1.1.4',
   'cordova-plugin-meteor-webapp': '1.7.1-beta.1'
 });

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -22,7 +22,7 @@ Npm.strip({
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.3',
   'cordova-plugin-wkwebview-engine': '1.1.4',
-  'cordova-plugin-meteor-webapp': '1.7.1-beta.0'
+  'cordova-plugin-meteor-webapp': '1.7.1-beta.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -21,7 +21,7 @@ Npm.strip({
 
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.4',
-  'cordova-plugin-wkwebview-engine': '1.1.4',
+  'cordova-plugin-wkwebview-engine': '1.2.1',
   'cordova-plugin-meteor-webapp': '1.7.1-beta.1'
 });
 

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -22,7 +22,7 @@ Npm.strip({
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.3',
   'cordova-plugin-wkwebview-engine': '1.1.4',
-  'cordova-plugin-meteor-webapp': '1.7.0'
+  'cordova-plugin-meteor-webapp': '1.7.1-beta.0'
 });
 
 Package.onUse(function (api) {

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -22,7 +22,7 @@ Npm.strip({
 Cordova.depends({
   'cordova-plugin-whitelist': '1.3.4',
   'cordova-plugin-wkwebview-engine': '1.2.1',
-  'cordova-plugin-meteor-webapp': '1.7.1-beta.1'
+  'cordova-plugin-meteor-webapp': '1.7.1'
 });
 
 Package.onUse(function (api) {

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -14,14 +14,14 @@ export const CORDOVA_ARCH = "web.cordova";
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
-  'cordova-lib': '7.1.0',
-  'cordova-common': '2.1.1',
+  'cordova-lib': '9.0.1',
+  'cordova-common': '3.2.1',
   'cordova-registry-mapper': '1.1.15',
 };
 
 export const CORDOVA_PLATFORM_VERSIONS = {
-  'android': '7.1.4',
-  'ios': '4.5.5',
+  'android': '8.1.0',
+  'ios': '5.1.1',
 };
 
 const PLATFORM_TO_DISPLAY_NAME_MAP = {

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -305,18 +305,17 @@ ${displayNameForPlatform(platform)}`, async () => {
     options.push(isDevice ? '--device' : '--emulator');
 
     let env = this.defaultEnvWithPathsAdded(...extraPaths);
-
-    let command = files.convertToOSPath(files.pathJoin(
-      this.projectRoot, 'platforms', platform, 'cordova', 'run'));
+    const commandOptions = {
+      ...this.defaultOptions,
+      platforms: [platform],
+      device: isDevice,
+    };
 
     this.runCommands(`running Cordova app for platform \
-${displayNameForPlatform(platform)} with options ${options}`,
-    execFileAsync(command, options, {
-      env: env,
-      cwd: this.projectRoot,
-      stdio: Console.verbose ? 'inherit' : 'pipe',
-      waitForClose: false
-    }), null, null);
+${displayNameForPlatform(platform)} with options ${options}`, async () => {
+      await cordova_lib.run(commandOptions);
+    });
+
   }
 
   // Platforms

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -737,7 +737,7 @@ perform cordova plugins reinstall`);
     // cordova-plugin-whitelist@1.3.2 => { 'cordova-plugin-whitelist': '1.3.2' }
     // com.cordova.plugin@file://.cordova-plugins/plugin => { 'com.cordova.plugin': 'file://.cordova-plugins/plugin' }
     // @scope/plugin@1.0.0 => { 'com.cordova.plugin': 'scope/plugin' }
-    const installed = this.listInstalledPluginVersions();
+    const installed = this.listInstalledPluginVersions(true);
     const installedPluginsNames = Object.keys(installed);
     const installedPluginsVersions = Object.values(installed);
     const missingPlugins = {};


### PR DESCRIPTION
Since #10810 was merged into `release-1.8.4`, which contains [a lot of extraneous changes](https://github.com/meteor/meteor/pull/10837), I wanted to try recreating just the Cordova-related parts, so that we can merge them cleanly into `devel`.