### PR TITLE
Fix spurious Babel ES6 default export error, once and for all.

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=12.14.1.1
+BUNDLE_VERSION=12.14.1.2
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -649,9 +649,9 @@
       "integrity": "sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g=="
     },
     "meteor-babel": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-7.8.0.tgz",
-      "integrity": "sha512-Gq9Dak4JK0+awaeaYcEhr9rpu2u1zJmvhy8VZRXTd8SsZxAmXy3Hkv5G6Nu6dHlOW3ewSBXDPwIavaS8LZPmUQ=="
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/meteor-babel/-/meteor-babel-7.8.1.tgz",
+      "integrity": "sha512-0pA7paVbvyHsB0CJFzpEW5Jxiss+07aa1umGRME1jI7pIDX+oKSM9bJsrWxchrfBEpdiERkzlop89aSTgtQzVg=="
     },
     "meteor-babel-helpers": {
       "version": "0.0.3",

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -10,7 +10,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'meteor-babel': '7.8.0',
+  'meteor-babel': '7.8.1',
   'json5': '2.1.1'
 });
 

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -15,7 +15,7 @@ var packageJson = {
     "node-gyp": "6.0.1",
     "node-pre-gyp": "0.14.0",
     typescript: "3.7.4",
-    "meteor-babel": "7.8.0",
+    "meteor-babel": "7.8.1",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.8.7",

--- a/tools/tool-env/install-babel.js
+++ b/tools/tool-env/install-babel.js
@@ -20,9 +20,19 @@ function babelRegister() {
 
   require('meteor-babel/register')
     .setCacheDirectory(cacheDir)
-    .allowDirectory(toolsPath)
     .setSourceMapRootPath(meteorPath)
-    .setBabelOptions(babelOptions);
+    .allowDirectory(toolsPath)
+    .setBabelOptions(babelOptions)
+    // Exclude files that are imported before we configure
+    // meteor-babel/register (including this very file).
+    .excludeFile(path.join(toolsPath, "index.js"))
+    .excludeFile(path.join(__dirname, "install-promise.js"))
+    .excludeFile(path.join(__dirname, "wrap-fibers.js"))
+    .excludeFile(path.join(toolsPath, "cli", "dev-bundle-bin-commands.js"))
+    .excludeFile(path.join(toolsPath, "cli", "dev-bundle-bin-helpers.js"))
+    .excludeFile(path.join(toolsPath, "cli", "flush-buffers-on-exit-in-windows.js"))
+    .excludeFile(path.join(toolsPath, "cli", "convert-to-os-path.js"))
+    .excludeFile(__filename);
 }
 
 babelRegister(); // #RemoveInProd this line is removed in isopack.js


### PR DESCRIPTION
Modules that are evaluated before `meteor-babel/register` is configured should not be transformed by `meteor-babel`, even if they are imported again later, after `meteor-babel/register` has been configured.

If my analysis is correct, this change should prevent the dreaded
```
Error: [BABEL] /tools/index.js: Must export a default export when using ES6 modules. (While processing: "base$0$0")
```
error, as seen most recently in https://travis-ci.org/meteor/meteor/builds/638030190 and https://circleci.com/gh/meteor/meteor/40863.