### PR TITLE
Make sure source map consumer exists before destroying it.

### DIFF
--- a/tools/isobuild/import-scanner.ts
+++ b/tools/isobuild/import-scanner.ts
@@ -692,15 +692,17 @@ export default class ImportScanner {
     checkProperty("bare");
 
     function getChunk(file: File) {
-      const consumer = file.sourceMap &&
-        Promise.await(new SourceMapConsumer(file.sourceMap));
-      const node = consumer &&
-        SourceNode.fromStringWithSourceMap(
+      if (file.sourceMap) {
+        const consumer = Promise.await(new SourceMapConsumer(file.sourceMap));
+        const node = SourceNode.fromStringWithSourceMap(
           scanner.getDataString(file),
           consumer
         );
-      consumer.destroy();
-      return node || scanner.getDataString(file);
+        consumer.destroy();
+        return node;
+      } else {
+        return scanner.getDataString(file);
+      }
     }
 
     const {


### PR DESCRIPTION
[This line](https://github.com/meteor/meteor/pull/10798/files#diff-33c7061de8ece159a7cb510c847d2babR702) (added in #10798) causes a `TypeError: Cannot read property 'destroy' of null` if the file doesn't have a source map.