### PR TITLE
Add an error message warning developers of oversized headers.

### DIFF
--- a/tools/runners/run-proxy.js
+++ b/tools/runners/run-proxy.js
@@ -95,6 +95,15 @@ _.extend(Proxy.prototype, {
     // client->proxy connection has an error, though this may change; see
     // discussion at https://github.com/nodejitsu/node-http-proxy/pull/488
     self.proxy.on('error', function (err, req, resOrSocket) {
+      if (err.code === 'HPE_HEADER_OVERFLOW') {
+        const logMessage = 'Error during proxy to server communication ' +
+          'due to the header size exceeding Node\'s currently ' +
+          'configured limit. This limit is configurable with a command ' +
+          'line option (https://nodejs.org/api/cli.html#cli_max_http_header_size_size ' +
+          'and https://docs.meteor.com/commandline.html#meteorrun).';
+        runLog.log(logMessage);
+      }
+
       if (resOrSocket instanceof http.ServerResponse) {
         if (!resOrSocket.headersSent) {
           // Return a 503, but only if we haven't already written headers (or

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -8,6 +8,7 @@ var files = require('../fs/files');
 var catalog = require('../packaging/catalog/catalog.js');
 var os = require('os');
 var isReachable = require("is-reachable");
+var httpHelpers = require('../utils/http-helpers.js');
 
 var DEFAULT_RELEASE_TRACK = catalog.DEFAULT_TRACK;
 
@@ -223,6 +224,35 @@ selftest.define("run errors", function () {
   f = new Future;
   server.close(f.resolver());
   f.wait();
+});
+
+selftest.define("handle requests with large headers", function() {
+  const sandbox = new Sandbox();
+  sandbox.createApp('myapp', 'standard-app');
+  sandbox.cd('myapp');
+  sandbox.append('.meteor/packages', 'browser-policy\n');
+
+  const browserPolicyCode = Array(1000).fill(null)
+    .map((_, index) => (
+      `BrowserPolicy.content.allowConnectOrigin('host${index}.com');`
+    ))
+    .join('\n');
+  sandbox.write('packageless.js', browserPolicyCode);
+
+  const run = sandbox.run();
+  run.waitSecs(5);
+  run.match('App running');
+
+  let errorMessage = null;
+  try {
+    httpHelpers.getUrl('http://localhost:3000');
+  } catch (error) {
+    errorMessage = error.message;
+  }
+
+  const errorMatchesExpected = /Unexpected error\./.test(errorMessage);
+  selftest.expectTrue(errorMatchesExpected);
+  run.match('due to the header size exceeding Node\'s currently');
 });
 
 selftest.define("update during run", ["checkout", 'custom-warehouse'], function () {

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -228,6 +228,8 @@ selftest.define("run errors", function () {
 
 selftest.define("handle requests with large headers", function() {
   const sandbox = new Sandbox();
+  sandbox.env.NODE_OPTIONS = '--max-http-header-size=8192';
+
   sandbox.createApp('myapp', 'standard-app');
   sandbox.cd('myapp');
   sandbox.append('.meteor/packages', 'browser-policy\n');


### PR DESCRIPTION
Currently if the headers exceed Node's set limit, the client will see a blank page with the text "Unexpected error." and nothing will be logged on the server. This PR adds a server-side log informing the developer of the cause and suggests using a node CLI option to increase the maximum allowable header size.

One scenario which leads to this error is if a project with many CSP rules upgrades from an older version of Meteor, prior to Node's reduction of the maximum allowable size from 80 KB to 8 KB (discussed here https://github.com/nodejs/node/issues/24692).

This issue as it affects Meteor has been discussed here https://forums.meteor.com/t/meteor-1-8-1-unexpected-error-too-many-csp-rules/48447.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
