### PR TITLE
Remove deprecated MongoDB connection options.

### DIFF
--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -134,11 +134,6 @@ MongoConnection = function (url, options) {
   self._onFailoverHook = new Hook;
 
   var mongoOptions = Object.assign({
-    // Reconnect on error.
-    autoReconnect: true,
-    // Try to reconnect forever, instead of stopping after 30 tries (the
-    // default), with each attempt separated by 1000ms.
-    reconnectTries: Infinity,
     ignoreUndefined: true,
     // Required to silence deprecation warnings with mongodb@3.2.1.
     useUnifiedTopology: true,


### PR DESCRIPTION
The `autoReconnect` and `reconnectTries` options are incompatible with the unified topology (http://bit.ly/2D8WfT6), which should reconnect automatically and without additional configuration.