### PR TITLE
Fixes bug #10468: ddp-server guards against null argument in sockjs connection handler

### DIFF
--- a/packages/ddp-server/stream_server.js
+++ b/packages/ddp-server/stream_server.js
@@ -86,6 +86,12 @@ StreamServer = function () {
   self._redirectWebsocketEndpoint();
 
   self.server.on('connection', function (socket) {
+    // sockjs sometimes passes us null instead of a socket object
+    // so we need to guard against that. see:
+    // https://github.com/sockjs/sockjs-node/issues/121
+    // https://github.com/meteor/meteor/issues/10468
+    if (!socket) return;
+
     // We want to make sure that if a client connects to us and does the initial
     // Websocket handshake but never gets to the DDP handshake, that we
     // eventually kill the socket.  Once the DDP handshake happens, DDP


### PR DESCRIPTION
Defensive code to handle a scenario in which the sockjs `on('connection')` handler is passed `null` instead of a socket object.

This issue has popped up a couple of times in the past few years but doesn't look like it will be resolved in sockjs-node:
https://github.com/sockjs/sockjs-node/issues/121

And appears to be happening in recent versions of Meteor (1.8 and 1.9):
https://github.com/meteor/meteor/issues/10468


I couldn't really determine a way to write a test for this, apologies in advance.  