### PR TITLE
Switch `google-oauth` to pass token in headers.

### DIFF
--- a/packages/github-oauth/github_server.js
+++ b/packages/github-oauth/github_server.js
@@ -62,8 +62,7 @@ const getIdentity = accessToken => {
   try {
     return HTTP.get(
       "https://api.github.com/user", {
-        headers: {"User-Agent": userAgent}, // http://developer.github.com/v3/#user-agent-required
-        params: {access_token: accessToken}
+        headers: {"User-Agent": userAgent, "Authorization": `token ${accessToken}`}, // http://developer.github.com/v3/#user-agent-required
       }).data;
   } catch (err) {
     throw Object.assign(
@@ -77,8 +76,7 @@ const getEmails = accessToken => {
   try {
     return HTTP.get(
       "https://api.github.com/user/emails", {
-        headers: {"User-Agent": userAgent}, // http://developer.github.com/v3/#user-agent-required
-        params: {access_token: accessToken}
+        headers: {"User-Agent": userAgent, "Authorization": `token ${accessToken}`}, // http://developer.github.com/v3/#user-agent-required
       }).data;
   } catch (err) {
     return [];

--- a/packages/github-oauth/package.js
+++ b/packages/github-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'GitHub OAuth flow',
-  version: '1.2.2'
+  version: '1.2.3'
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
Update OAuth API calls for authentication due to deprecation:
https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/
https://developer.github.com/v3/auth/#basic-authentication