### PR TITLE
Add enableCallback option for appcache

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -7,6 +7,7 @@ import path from 'path';
 
 let _disableSizeCheck = false;
 let disabledBrowsers = {};
+let enableCallback = null;
 
 Meteor.AppCache = {
   config: options => {
@@ -20,6 +21,9 @@ Meteor.AppCache = {
         value.forEach(urlPrefix =>
           RoutePolicy.declare(urlPrefix, 'static-online')
         );
+      }
+      else if (option === 'enableCallback') {
+        enableCallback = value;
       }
       // option to suppress warnings for tests.
       else if (option === '_disableSizeCheck') {
@@ -37,7 +41,13 @@ Meteor.AppCache = {
   }
 };
 
-const browserDisabled = request => disabledBrowsers[request.browser.name];
+const browserDisabled = request => {
+  if (enableCallback) {
+    return !enableCallback(request);
+  }
+
+  return disabledBrowsers[request.browser.name];
+}
 
 // Cache of previously computed app.manifest files.
 const manifestCache = new Map;


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

Sometimes `browsers` is not enough when deciding to enable/disable the appcache feature.

This PR adds `enableCallback` as a more versatile option to control the appcache feature on a per-request basis.

### Use case example 1

```js
// Enable offline mode using a value from database
Meteor.AppCache.config({
    enableCallback: () => {
        return getSettingsFromDb("public.appcache_enabled");
    },
});
```

### Use case example 2

```js
// Enable offline mode only when client sends a valid certificate
Meteor.AppCache.config({
    enableCallback: req => {
        const validation = validateClientCert({
            clientCertPayload: req.headers["x-client-cert"],
            url: req.url.href,
        });

        return validation.passed;
    },
});
```
