### PR TITLE
Avoid bailing out with module.useNode() for ESM modules.

### DIFF
--- a/packages/modules-runtime/server.js
+++ b/packages/modules-runtime/server.js
@@ -71,6 +71,10 @@ Module.prototype.useNode = function () {
     return false;
   }
 
+  // See tools/static-assets/server/npm-require.js for the implementation
+  // of npmRequire. Note that this strategy fails when importing ESM
+  // modules (typically, a .js file in a package with "type": "module" in
+  // its package.json), as of Node 12.16.0 (Meteor 1.9.1).
   this.exports = npmRequire(this.id);
 
   return true;

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -34,7 +34,7 @@ import {
   optimisticHashOrNull,
   optimisticStatOrNull,
   optimisticReadMeteorIgnore,
-  optimisticLookupPackageJson,
+  optimisticLookupPackageJsonArray,
 } from "../fs/optimistic";
 
 // XXX: This is a medium-term hack, to avoid having the user set a package name
@@ -1287,8 +1287,16 @@ _.extend(PackageSource.prototype, {
 
       let readOptions = sourceReadOptions;
       if (inNodeModules) {
-        const pkgJson = optimisticLookupPackageJson(self.sourceRoot, dir);
-        if (pkgJson && nodeModulesToRecompile.has(pkgJson.name)) {
+        // This is an array because (in some rare cases) an npm package
+        // may have nested package.json files with additional properties.
+        const pkgJsonArray = optimisticLookupPackageJsonArray(self.sourceRoot, dir);
+
+        // If a package.json file with a "name" property is found, it will
+        // always be the first in the array.
+        const pkgJson = pkgJsonArray[0];
+
+        if (pkgJson && pkgJson.name &&
+            nodeModulesToRecompile.has(pkgJson.name)) {
           // Avoid caching node_modules code recompiled by Meteor.
           cacheKey = false;
         } else {


### PR DESCRIPTION
On the server, Meteor attempts to avoid bundling `node_modules` code by replacing entry point modules with a stub that calls [`module.useNode()`](https://github.com/meteor/meteor/blob/fca6c62d432eff1afd4a67280b7c90af23399511/packages/modules-runtime/server.js#L48). This trick allows evaluating server `node_modules` natively in Node.js, faithfully preserving all Node-specific behaviors, such as `module.id` being an absolute file system path, the `__dirname` and `__filename` variables, the ability to import binary `.node` modules, and so on. This bailout has been in place since Meteor 1.3 (when the module system was first introduced), and it has worked remarkably well.

However, starting in Node.js 12.16.0 (Meteor 1.9.1+), modules evaluated natively by Node are considered ECMAScript modules (ESM) if the closest `package.json` file has `"type": "module"` (or has an `.mjs` file extension). This poses a problem for the `module.useNode()` trick, because ESM modules cannot be imported synchronously using `require` (which is currently how `module.useNode()` works).

To work around this new error, this commit checks `package.json` for `"type": "module"` in `ImportScanner#shouldUseNode` to determine whether it's safe to use the `module.useNode()` trick. This leads to including ESM modules in the server bundle, rather than relying on Node to execute them directly from the file system.

The good news is that ESM modules don't have access to nearly as many Node/CommonJS-specific quirks: no `module`, `require`, or `exports` variables; no `__dirname`, no `__filename`; no ability to import JSON or other non-ESM file types (at least right now). So it seems somewhat less important for ESM code (compared to CommonJS code) to bail out into native Node.js execution using `module.useNode()`. In other words, bundling server code should not affect its execution in nearly as many cases, if that code is ESM rather than legacy CommonJS.

If this good news turns out to be overly optimistic, we can consider using a different kind of bailout stub that's capable of importing ESM, perhaps using dynamic `import()`. For now, making sure we avoid bailing out for ESM code found in `@babel/runtime/helpers/esm/*` is the priority.