### PR TITLE
add Decimal support to minimongo

### DIFF
--- a/packages/minimongo/matcher.js
+++ b/packages/minimongo/matcher.js
@@ -1,10 +1,28 @@
-import { Decimal } from 'meteor/mongo-decimal'
 import LocalCollection from './local_collection.js';
 import {
   compileDocumentSelector,
   hasOwn,
   nothingMatcher,
 } from './common.js';
+
+let Decimal = Package['mongo-decimal']?.Decimal;
+
+// Due to {weak: true} Decimal dependency on client
+// declare minimal Decimal functionality
+if (!Decimal) {
+  class Decimal {
+    constructor(value) {
+      this.value = value.toString();
+    }
+    minus(value) {
+      let _value = Number(this.value) - Number(value);
+      return new Decimal(_value);
+    }
+    toNumber() {
+      return Number(this.value);
+    }
+  }
+}
 
 // The minimongo selector compiler!
 

--- a/packages/minimongo/matcher.js
+++ b/packages/minimongo/matcher.js
@@ -5,24 +5,7 @@ import {
   nothingMatcher,
 } from './common.js';
 
-let Decimal = Package['mongo-decimal']?.Decimal;
-
-// Due to {weak: true} Decimal dependency on client
-// declare minimal Decimal functionality
-if (!Decimal) {
-  class Decimal {
-    constructor(value) {
-      this.value = value.toString();
-    }
-    minus(value) {
-      let _value = Number(this.value) - Number(value);
-      return new Decimal(_value);
-    }
-    toNumber() {
-      return Number(this.value);
-    }
-  }
-}
+const Decimal = Package['mongo-decimal']?.Decimal || class DecimalStub {}
 
 // The minimongo selector compiler!
 

--- a/packages/minimongo/matcher.js
+++ b/packages/minimongo/matcher.js
@@ -1,3 +1,4 @@
+import { Decimal } from 'meteor/mongo-decimal'
 import LocalCollection from './local_collection.js';
 import {
   compileDocumentSelector,
@@ -170,6 +171,10 @@ LocalCollection._f = {
       return 7;
     }
 
+    if (v instanceof Decimal) {
+      return 1;
+    }
+
     // object
     return 3;
 
@@ -260,8 +265,13 @@ LocalCollection._f = {
       b = b.getTime();
     }
 
-    if (ta === 1) // double
-      return a - b;
+    if (ta === 1) { // double
+      if (a instanceof Decimal) {
+        return a.minus(b).toNumber();
+      } else {
+        return a - b;
+      }
+    }
 
     if (tb === 2) // string
       return a < b ? -1 : a === b ? 0 : 1;

--- a/packages/minimongo/package.js
+++ b/packages/minimongo/package.js
@@ -24,6 +24,10 @@ Package.onUse(api => {
     'tracker'
   ]);
 
+  // Make weak use of Decimal type on client
+  api.use('mongo-decimal', 'client', {weak: true});
+  api.use('mongo-decimal', 'server');
+
   api.mainModule('minimongo_client.js', 'client');
   api.mainModule('minimongo_server.js', 'server');
 });


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

Minimongo now has no support for Decimal.js so there is issue when using is.
If we try to use meteor/mongo-decimal package it works normal on server side, but not on client, especially sorting cause it not implementing there.