### PR TITLE
Drops support for Win 32-bit

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,7 +5,15 @@
 * Cordova has been updated from version 7 to 9. We recommend that you test
   your features that are taking advantage of Cordova plugins to be sure
   they are still working as expected.
+  
+* Because MongoDB since 3.4 no longer supports 32-bit Windows, Meteor 1.10 has also
+  dropped support for 32-bit Windows. In other words, Meteor 1.10 supports
+  64-bit Mac, Windows 64-bit, and Linux 64-bit.
 
+### Migration Steps
+N/A
+
+### Changes
 * The version of MongoDB used by Meteor in development has been updated
   from 4.0.6 to 4.2.1, and the `mongodb` driver package has been updated
   from 3.2.7 to 3.4.0, thanks to [@klaussner](https://github.com/klaussner).

--- a/History.md
+++ b/History.md
@@ -6,8 +6,8 @@
   your features that are taking advantage of Cordova plugins to be sure
   they are still working as expected.
   
-* Because MongoDB since 3.4 no longer supports 32-bit Windows, Meteor 1.10 has also
-  dropped support for 32-bit Windows. In other words, Meteor 1.10 supports
+* Because MongoDB since 3.4 no longer supports 32-bit Windows, Meteor 1.10 has 
+  also dropped support for 32-bit Windows. In other words, Meteor 1.10 supports
   64-bit Mac, Windows 64-bit, and Linux 64-bit.
 
 ### Migration Steps

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=12.16.1.3
+BUNDLE_VERSION=12.16.1.4
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/admin/copy-dev-bundle-from-jenkins.sh
+++ b/scripts/admin/copy-dev-bundle-from-jenkins.sh
@@ -39,7 +39,7 @@ echo Found build $DIRNAME
 trap "echo Found surprising number of tarballs." EXIT
 # Check to make sure the proper number of each kind of file is there.
 aws s3 ls s3://com.meteor.jenkins/$DIRNAME/ | \
-  perl -nle 'if (/\.tar\.gz/) { ++$TAR } else { die "something weird" }  END { exit !($TAR == 4) }'
+  perl -nle 'if (/\.tar\.gz/) { ++$TAR } else { die "something weird" }  END { exit !($TAR == 3) }'
 
 trap - EXIT
 

--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -72,9 +72,6 @@ Function Add-7ZipTool {
   $webclient.DownloadFile("http://www.7-zip.org/a/7z1604-extra.7z", $extraArchive)
 
   $pathToExtract = 'x64/7za.exe'
-  if ($PLATFORM -eq "windows_x86") {
-    $pathToExtract = '7za.exe'
-  }
 
   Write-Host 'Placing 7za.exe from extra.7z in \bin...' -ForegroundColor Magenta
   & "$system7zip" e $extraArchive -o"$dirTemp" $pathToExtract | Out-Null
@@ -118,11 +115,7 @@ Function Add-NodeAndNpm {
     $nodeUrlBase = 'https://nodejs.org/dist'
   }
 
-  if ($PLATFORM -eq "windows_x86") {
-    $nodeArchitecture = 'win-x86'
-  } else {
-    $nodeArchitecture = 'win-x64'
-  }
+  $nodeArchitecture = 'win-x64'
 
   # Various variables which are used as part of directory paths and
   # inside Node release and header archives.
@@ -231,7 +224,6 @@ Function Add-Mongo {
   # Mongo >= 3.4 no longer supports 32-bit (x86) architectures, so we package
   # the latest 3.2 version of Mongo for those builds and >= 3.4 for x64.
   $mongo_filenames = @{
-    windows_x86 = "mongodb-win32-i386-${MONGO_VERSION_32BIT}"
     windows_x64 = "mongodb-win32-x86_64-2012plus-${MONGO_VERSION_64BIT}"
   }
 

--- a/tools/cli/dev-bundle.js
+++ b/tools/cli/dev-bundle.js
@@ -189,10 +189,7 @@ function makeStatTest(method) {
 
 function getHostArch() {
   if (process.platform === "win32") {
-    if (process.arch === "x64") {
-      return "os.windows.x86_64";
-    }
-    return "os.windows.x86_32";
+    return "os.windows.x86_64";
   }
 
   if (process.platform === "linux") {

--- a/tools/utils/archinfo.ts
+++ b/tools/utils/archinfo.ts
@@ -64,7 +64,6 @@ const utils = require('./utils');
  *   hardware is virtually extinct. Meteor has never supported it and
  *   nobody has asked for it.
  *
- * os.windows.x86_32
  * os.windows.x86_64
  *   Once, on the far side of yesterday, there was not a 64-bit
  *   build of Meteor for Windows, due to the belief that Node didn't
@@ -76,6 +75,7 @@ const utils = require('./utils');
  *   platforms show clear performance benefits over their 32-bit
  *   siblings (e.g. 7-zip, et.al), so Meteor should also try to offer
  *   that same benefit by building and offering a 64-bit version.
+ *   Meteor no longer supports Windows 32-bit.
  *
  * To be (more but far from completely) precise, the ABI for os.*
  * architectures includes a CPU type, a mode in which the code will be
@@ -131,7 +131,6 @@ export const VALID_ARCHITECTURES: Record<string, boolean> = {
   "os.osx.x86_64": true,
   "os.linux.x86_64": true,
   "os.windows.x86_64": true,
-  "os.windows.x86_32": true,
 };
 
 // Returns the fully qualified arch of this host -- something like
@@ -170,12 +169,8 @@ export function host() {
       } else {
         throw new Error(`Unsupported architecture: ${machine}`);
       }
-    } else if (platform === "win32") {
-      if (process.arch === "x64") {
-        _host = "os.windows.x86_64";
-      } else {
-        _host = "os.windows.x86_32";
-      }
+    } else if (platform === "win32" && process.arch === "x64") {
+      _host = "os.windows.x86_64";
     } else {
       throw new Error(`Unsupported operating system: ${platform}`);
     }


### PR DESCRIPTION
Because MongoDB since 3.4 no longer supports 32-bit Windows, Meteor 1.10 has also dropped support for 32-bit Windows. In other words, Meteor 1.10 supports 64-bit Mac, Windows 64-bit, and Linux 64-bit.