### PR TITLE
Fix caching compiler file cache

### DIFF
--- a/History.md
+++ b/History.md
@@ -250,7 +250,7 @@ N/A
   See [this comment](https://github.com/meteor/meteor/pull/10522#issuecomment-535535056)
   by [@SimonSimCity](https://github.com/SimonSimCity).
 
-* Plugin.fs methods are now always sync and no longer accept a callback.
+* `Plugin.fs` methods are now always sync and no longer accept a callback.
 
 ### Migration Steps
 

--- a/History.md
+++ b/History.md
@@ -250,6 +250,8 @@ N/A
   See [this comment](https://github.com/meteor/meteor/pull/10522#issuecomment-535535056)
   by [@SimonSimCity](https://github.com/SimonSimCity).
 
+* Plugin.fs methods are now always sync and no longer accept a callback.
+
 ### Migration Steps
 
 * Be sure to update the `@babel/runtime` npm package to its latest version

--- a/packages/caching-compiler/multi-file-caching-compiler.js
+++ b/packages/caching-compiler/multi-file-caching-compiler.js
@@ -253,6 +253,6 @@ extends CachingCompilerBase {
     const cacheContents =
       JSON.stringify(cacheEntry.cacheKeys) + '\n' +
       this.stringifyCompileResult(cacheEntry.compileResult);
-    this._writeFileAsync(cacheFilename, cacheContents);
+    this._writeFile(cacheFilename, cacheContents);
   }
 }


### PR DESCRIPTION
Starting in Meteor 1.8.2, Plugin.fs methods no longer accept a callback and are always the sync version. The caching compiler passed a callback that was never called and caused the cache files to never be renamed to their correct name.
