### PR TITLE
Adds support to override mongo options via Meteor settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.11.1"
+  - "12.16.1"
 cache:
   directories:
     - ".meteor"

--- a/History.md
+++ b/History.md
@@ -23,6 +23,10 @@
 
 ### Changes
 
+* Adds support to override MongoDB options via Meteor settings. Code PR 
+[#10976](https://github.com/meteor/meteor/pull/10976), Docs PR 
+[#662](https://github.com/meteor/docs/pull/662)
+
 * The `meteor-babel` npm package has been updated to version 7.9.0.
 
 * The `typescript` npm package has been updated to version 3.8.3.

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.10.2-beta.0'
+  version: '1.10.2-beta.1'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '1.10.1'
+  version: '1.10.2-beta.0'
 });
 
 Package.includeTool();

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.10.0-beta1102.0'
+  version: '1.10.0-beta1102.1'
 });
 
 Npm.depends({

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.9.1'
+  version: '1.10.0-beta1102.0'
 });
 
 Npm.depends({

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.10.2-beta.0",
+  "version": "1.10.2-beta.1",
   "recommended": false,
   "official": false,
   "description": "Meteor"

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "1.10-rc.5",
+  "version": "1.10.2-beta.0",
   "recommended": false,
   "official": false,
   "description": "Meteor"

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -369,6 +369,9 @@ var loadServerBundles = Profile("Load server bundles", function () {
         var filePath = path.join(serverDir, fileInfo.assets[assetPath]);
         return files.convertToOSPath(filePath);
       },
+      getServerDir: function() {
+        return serverDir;
+      }
     };
 
     var wrapParts = ["(function(Npm,Assets"];


### PR DESCRIPTION
In some MongoDB host providers like ScaleGrid and IBM Cloud some developers are getting this error because of certificate:

```
MongoNetworkError: failed to connect to server [sg-meteorappdb-32194.servers.mongodirector.com:27017] on first connect [Error: self signed certificate
```

We can fix the error passing additional options to the Mongo connection but right now Meteor only offers this ability via code in a package and also it's not easy to reference the certificate file inside the project.

This PR provides:
a) ability to set Mongo options using Meteor.settings.overrideMongoOptions;
b) simple way to reference files inside the `private` folder in the root.

Read the docs PR to see how this can be used https://github.com/meteor/docs/pull/662

More info:
- Issues about the limitation of `Mongo.setConnectionOptions` usage https://github.com/meteor/meteor/issues/7455 https://github.com/meteor/meteor/issues/6958
- Forums [discussion](https://forums.meteor.com/t/meteor-with-the-new-mongodb-3-2-1-compose-io/17763/3)