### PR TITLE
Fix Windows dev_bundle extraction for running from checkout with spaces in path

### DIFF
--- a/scripts/windows/download-dev-bundle.ps1
+++ b/scripts/windows/download-dev-bundle.ps1
@@ -41,7 +41,7 @@ if (Test-Path $devbundle_zip) {
 
 Write-Host "Extracting $TARBALL to the dev_bundle directory"
 
-cmd /C "7z.exe x $devbundle_zip -so | 7z.exe x -aoa -si -ttar -o$CHECKOUT_DIR\dev_bundle_XXX" | out-null
+cmd /C "7z.exe x `"$devbundle_zip`" -so | 7z.exe x -aoa -si -ttar -o`"$CHECKOUT_DIR\dev_bundle_XXX`"" | out-null
 if ($LASTEXITCODE -ne 0) {
   Exit 1
 }


### PR DESCRIPTION
Fix for #10979 

I already described the issue, but just a quick summary: when running `meteor` from checkout from a directory which has a space in it, 7zip cannot find the dev_bundle tar to extract. This fixes this issue by surrounding the filepath with quotes.

Not sure I can provide any kind of automated test for this though, but for what it's worth, it works!

Note: I wasn't sure if I had to create an issue before opening a PR. Please let me know if this is the way to go in the future, or just a PR is good too!