### PR TITLE
Try other web.* arches if preferred arch was excluded.

### DIFF
--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor'
-import { isModern } from "meteor/modern-browsers";
 import { WebApp } from "meteor/webapp";
 import crypto from 'crypto';
 import fs from 'fs';
@@ -88,12 +87,12 @@ WebApp.connectHandlers.use((req, res, next) => {
   }
 
   const cacheInfo = {
-    modern: isModern(request.browser),
+    // Provided by WebApp.categorizeRequest.
+    modern: request.modern,
   };
 
-  cacheInfo.arch = cacheInfo.modern
-    ? "web.browser"
-    : "web.browser.legacy";
+  // Also provided by WebApp.categorizeRequest.
+  cacheInfo.arch = request.arch;
 
   // The true hash of the client manifest for this arch, regardless of
   // AUTOUPDATE_VERSION or Autoupdate.autoupdateVersion.

--- a/packages/appcache/package.js
+++ b/packages/appcache/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Enable the application cache in the browser",
-  version: "1.2.6",
+  version: "1.2.7",
 });
 
 Package.onUse(api => {

--- a/packages/dynamic-import/package.js
+++ b/packages/dynamic-import/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "dynamic-import",
-  version: "0.5.1",
+  version: "0.5.2",
   summary: "Runtime support for Meteor 1.5 dynamic import(...) syntax",
   documentation: "README.md"
 });

--- a/packages/dynamic-import/server.js
+++ b/packages/dynamic-import/server.js
@@ -8,7 +8,6 @@ const {
 } = require("path");
 const { fetchURL } = require("./common.js");
 const { Meteor } = require("meteor/meteor");
-const { isModern } = require("meteor/modern-browsers");
 const hasOwn = Object.prototype.hasOwnProperty;
 
 require("./security.js");
@@ -112,27 +111,19 @@ function middleware(request, response) {
 }
 
 function getPlatform(request) {
-  const { identifyBrowser } = Package.webapp.WebAppInternals;
-  const browser = identifyBrowser(request.headers["user-agent"]);
-  let platform = isModern(browser)
-    ? "web.browser"
-    : "web.browser.legacy";
-
   // If the __dynamicImport request includes a secret key, and it matches
   // dynamicImportInfo[platform].key, use platform instead of the default
   // platform, web.browser.
   const secretKey = request.query.key;
-
   if (typeof secretKey === "string") {
-    Object.keys(dynamicImportInfo).some(p => {
+    for (const p of Object.keys(dynamicImportInfo)) {
       if (secretKey === dynamicImportInfo[p].key) {
-        platform = p;
-        return true;
+        return p;
       }
-    });
+    }
   }
 
-  return platform;
+  return Package.webapp.WebApp.categorizeRequest(request).arch;
 }
 
 function readTree(tree, platform) {

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.9.0'
+  version: '1.9.1'
 });
 
 Npm.depends({"basic-auth-connect": "1.0.0",

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -130,10 +130,63 @@ var identifyBrowser = function (userAgentString) {
 WebAppInternals.identifyBrowser = identifyBrowser;
 
 WebApp.categorizeRequest = function (req) {
-  return _.extend({
-    browser: identifyBrowser(req.headers['user-agent']),
-    url: parseUrl(req.url, true)
-  }, _.pick(req, 'dynamicHead', 'dynamicBody', 'headers', 'cookies'));
+  if (req.browser && req.arch && typeof req.modern === "boolean") {
+    // Already categorized.
+    return req;
+  }
+
+  const browser = identifyBrowser(req.headers["user-agent"]);
+  const modern = isModern(browser);
+  const path = typeof req.pathname === "string"
+   ? req.pathname
+   : parseRequest(req).pathname;
+
+  const categorized = {
+    browser,
+    modern,
+    path,
+    arch: WebApp.defaultArch,
+    url: parseUrl(req.url, true),
+    dynamicHead: req.dynamicHead,
+    dynamicBody: req.dynamicBody,
+    headers: req.headers,
+    cookies: req.cookies,
+  };
+
+  const pathParts = path.split("/");
+  const archKey = pathParts[1];
+
+  if (archKey.startsWith("__")) {
+    const archCleaned = "web." + archKey.slice(2);
+    if (hasOwn.call(WebApp.clientPrograms, archCleaned)) {
+      pathParts.splice(1, 1); // Remove the archKey part.
+      return Object.assign(categorized, {
+        arch: archCleaned,
+        path: pathParts.join("/"),
+      });
+    }
+  }
+
+  // TODO Perhaps one day we could infer Cordova clients here, so that we
+  // wouldn't have to use prefixed "/__cordova/..." URLs.
+  const preferredArchOrder = isModern(browser)
+    ? ["web.browser", "web.browser.legacy"]
+    : ["web.browser.legacy", "web.browser"];
+
+  for (const arch of preferredArchOrder) {
+    // If our preferred arch is not available, it's better to use another
+    // client arch that is available than to guarantee the site won't work
+    // by returning an unknown arch. For example, if web.browser.legacy is
+    // excluded using the --exclude-archs command-line option, legacy
+    // clients are better off receiving web.browser (which might actually
+    // work) than receiving an HTTP 404 response. If none of the archs in
+    // preferredArchOrder are defined, only then should we send a 404.
+    if (hasOwn.call(WebApp.clientPrograms, arch)) {
+      return Object.assign(categorized, { arch });
+    }
+  }
+
+  return categorized;
 };
 
 // HTML attribute hooks: functions to be called to determine any attributes to
@@ -399,10 +452,7 @@ WebAppInternals.staticFilesMiddleware = async function (
     return;
   }
 
-  const { arch, path } = getArchAndPath(
-    pathname,
-    identifyBrowser(req.headers["user-agent"]),
-  );
+  const { arch, path } = WebApp.categorizeRequest(req);
 
   if (! hasOwn.call(WebApp.clientPrograms, arch)) {
     // We could come here in case we run with some architectures excluded
@@ -525,7 +575,7 @@ function getStaticFileInfo(staticFilesByArch, originalPath, path, arch) {
       return finalize(originalPath);
     }
 
-    // If getArchAndPath returned an alternate path, try that instead.
+    // If categorizeRequest returned an alternate path, try that instead.
     if (path !== originalPath &&
         hasOwn.call(staticFiles, path)) {
       return finalize(path);
@@ -533,46 +583,6 @@ function getStaticFileInfo(staticFilesByArch, originalPath, path, arch) {
   });
 
   return info;
-}
-
-function getArchAndPath(path, browser) {
-  const pathParts = path.split("/");
-  const archKey = pathParts[1];
-
-  if (archKey.startsWith("__")) {
-    const archCleaned = "web." + archKey.slice(2);
-    if (hasOwn.call(WebApp.clientPrograms, archCleaned)) {
-      pathParts.splice(1, 1); // Remove the archKey part.
-      return {
-        arch: archCleaned,
-        path: pathParts.join("/"),
-      };
-    }
-  }
-
-  // TODO Perhaps one day we could infer Cordova clients here, so that we
-  // wouldn't have to use prefixed "/__cordova/..." URLs.
-  const preferredArchOrder = isModern(browser)
-    ? ["web.browser", "web.browser.legacy"]
-    : ["web.browser.legacy", "web.browser"];
-
-  for (const arch of preferredArchOrder) {
-    // If our preferred arch is not available, it's better to use another
-    // client arch that is available than to guarantee the site won't work
-    // by returning an unknown arch. For example, if web.browser.legacy is
-    // excluded using the --exclude-archs command-line option, legacy
-    // clients are better off receiving web.browser (which might actually
-    // work) than receiving an HTTP 404 response. If none of the archs in
-    // preferredArchOrder are defined, only then should we send a 404.
-    if (hasOwn.call(WebApp.clientPrograms, arch)) {
-      return { arch, path };
-    }
-  }
-
-  return {
-    arch: WebApp.defaultArch,
-    path,
-  };
 }
 
 // Parse the passed in port value. Return the port as-is if it's a String
@@ -895,7 +905,7 @@ function runWebAppServer() {
       if (isPrefixOf(prefixParts, pathParts)) {
         request.url = "/" + pathParts.slice(prefixParts.length).join("/");
         if (search) {
-          request.url += search; 
+          request.url += search;
         }
         return next();
       }
@@ -1000,10 +1010,8 @@ function runWebAppServer() {
         return;
       }
 
-      const { arch } = getArchAndPath(
-        parseRequest(req).pathname,
-        request.browser,
-      );
+      const { arch } = request;
+      assert.strictEqual(typeof arch, "string", { arch });
 
       if (! hasOwn.call(WebApp.clientPrograms, arch)) {
         // We could come here in case we run with some architectures excluded


### PR DESCRIPTION
Follow-up to #10824.

If the preferred arch is not available (most likely because it was deliberately excluded), it's better to use another client arch that is available than to guarantee the site won't work by returning an unknown arch.

For example, if `web.browser.legacy` is excluded using the `--exclude-archs` option (introduced by #10824), legacy clients are better served by receiving `web.browser` (which might actually work) than receiving an HTTP 404 response.

If none of the arches in `preferredArchOrder` are defined, only then should we send a 404.

I encountered this issue when `meteor npx wait-on http://localhost:3000` stopped working after I specified `--exclude-archs web.browser.legacy`, because the `wait-on` tool does not provide a `user-agent` header, so it gets classified as a legacy client, so it receives an HTTP 404 response, which does not satisfy the condition it was waiting for (any 2xx response).