### PR TITLE
Updated less package

### DIFF
--- a/packages/non-core/less/.npm/plugin/compileLessBatch/npm-shrinkwrap.json
+++ b/packages/non-core/less/.npm/plugin/compileLessBatch/npm-shrinkwrap.json
@@ -7,19 +7,14 @@
       "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA=="
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU="
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw=="
     },
     "asap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-      "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -42,9 +37,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -56,15 +51,15 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -102,14 +97,14 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -117,9 +112,9 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -127,9 +122,9 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
     },
     "graceful-fs": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-      "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -137,9 +132,9 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -147,9 +142,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE="
     },
     "image-size": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
-      "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw="
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -172,9 +167,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -187,8 +182,9 @@
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI="
     },
     "less": {
-      "version": "https://github.com/meteor/less.js/tarball/8130849eb3d7f0ecf0ca8d0af7c4207b0442e3f6",
-      "integrity": "sha512-514pMpzrABW11ploVaRcbHLf3MhollYYCJj9SyJmNT1O8ZeLCiIeqZ2SjZUM1uudohPlHgTRwmCZouzIJFJ7Jw=="
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.11.1.tgz",
+      "integrity": "sha512-tlWX341RECuTOvoDIvtFqXsKj072hm3+9ymRBe76/mD6O5ZZecnlAOVDlWAleF2+aohFrxNidXhv2773f6kY7g=="
     },
     "mime": {
       "version": "1.6.0",
@@ -196,29 +192,24 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A=="
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ=="
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
-    },
-    "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -231,9 +222,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "promise": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-      "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
     },
     "prr": {
       "version": "1.0.1",
@@ -241,14 +232,14 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -261,14 +252,14 @@
       "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg=="
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw=="
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -276,19 +267,24 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg="
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg=="
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g=="
+    },
+    "tslib": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -300,10 +296,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ=="
+    },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "verror": {
       "version": "1.10.0",

--- a/packages/non-core/less/README.md
+++ b/packages/non-core/less/README.md
@@ -1,9 +1,17 @@
 # Less
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/less) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/less)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/non-core/less) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/non-core/less)
 ***
 
 The Less package provides a compiler build plugin for the Meteor build tool. It
 handles the compilation of `*.less` files to CSS.
+
+## Changelog
+
+### 3.0.0
+
+- Updated less to 3.11.1.
+- Import files without ending as less files, according to less import rules.
+- Add `javascriptEnabled` option to less, to be backwards compatible to previous version of this package.
 
 ## Usage
 

--- a/packages/non-core/less/package.js
+++ b/packages/non-core/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '2.8.0',
+  version: '3.0.0',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });
@@ -13,8 +13,7 @@ Package.registerBuildPlugin({
   ],
   npmDependencies: {
     "@babel/runtime": "7.0.0",
-    // Fork of 2.5.0, deleted large unused files in dist directory.
-    "less": "https://github.com/meteor/less.js/tarball/8130849eb3d7f0ecf0ca8d0af7c4207b0442e3f6"
+    "less": "3.11.1"
   }
 });
 

--- a/packages/non-core/less/plugin/compile-less.js
+++ b/packages/non-core/less/plugin/compile-less.js
@@ -62,6 +62,8 @@ class LessCompiler extends MultiFileCachingCompiler {
     return less.render(inputFile.getContentsAsBuffer().toString('utf8'), {
       filename: this.getAbsoluteImportPath(inputFile),
       plugins: [importPlugin],
+      // Enabled as it was default true before less v3.0.0
+      javascriptEnabled: true,
       // Generate a source map, and include the source files in the
       // sourcesContent field. (Note that source files which don't
       // themselves produce text (eg, are entirely variable definitions)
@@ -81,11 +83,11 @@ class LessCompiler extends MultiFileCachingCompiler {
       };
 
       const referencedImportPaths = [];
-      output.imports.forEach((path) => {
+      output.imports.forEach((outputPath) => {
         // Some files that show up in output.imports are not actually files; for
         // example @import url("...");
-        if (allFiles.has(path)) {
-          referencedImportPaths.push(path);
+        if (allFiles.has(outputPath)) {
+          referencedImportPaths.push(outputPath);
         }
       });
 
@@ -109,22 +111,18 @@ class LessCompiler extends MultiFileCachingCompiler {
   addCompileResult(inputFile, compileResult) {
     inputFile.addStylesheet({
       data: compileResult.css,
-      path: inputFile.getPathInPackage() + '.css',
+      path: `${inputFile.getPathInPackage()}.css`,
       sourceMap: compileResult.sourceMap
     });
   }
 }
 
-class MeteorImportLessPlugin {
-  constructor(allFiles) {
-    this.allFiles = allFiles;
-    this.minVersion = [2, 5, 0];
-  }
+function MeteorImportLessPlugin(allFiles) {
+  this.minVersion = [3, 6, 0];
 
-  install(less, pluginManager) {
-    pluginManager.addFileManager(
-      new MeteorImportLessFileManager(this.allFiles));
-  }
+  this.install = (l, pluginManager) => {
+    pluginManager.addFileManager(new MeteorImportLessFileManager(allFiles));
+  };
 }
 
 class MeteorImportLessFileManager extends less.AbstractFileManager {
@@ -138,20 +136,17 @@ class MeteorImportLessFileManager extends less.AbstractFileManager {
     // We shouldn't process files that start with `//` or a protocol because
     // those are not relative to the app at all; they are probably native
     // CSS imports
-    if (! filename.match(/^(https?:)?\/\//)) {
-      return true;
-    }
-
-    return false;
+    return !filename.match(/^(https?:)?\/\//);
   }
 
-  loadFile(filename, currentDirectory, options, environment, cb) {
+  loadFile(filename, currentDirectory) {
     const packageMatch = currentDirectory.match(/^(\{[^}]*\})/);
-    if (! packageMatch) {
+    if (!packageMatch) {
       // shouldn't happen.  all filenames less ever sees should involve this {}
       // thing!
-      cb(new Error('file without Meteor context? ' + currentDirectory));
-      return;
+      return new Promise((r, reject) => {
+        reject(new Error(`file without Meteor context? ${currentDirectory}`));
+      });
     }
     const currentPackagePrefix = packageMatch[1];
 
@@ -164,15 +159,25 @@ class MeteorImportLessFileManager extends less.AbstractFileManager {
     } else {
       resolvedFilename = path.join(currentDirectory, filename);
     }
+    // Import rule from less:
+    // If it does not have an extension, .less will be appended and it will be included as a imported Less file.
+    if (
+      !this.allFiles.has(resolvedFilename) &&
+      this.allFiles.has(`${resolvedFilename}.less`)
+    ) {
+      resolvedFilename = `${resolvedFilename}.less`;
+    }
 
     if (!this.allFiles.has(resolvedFilename)) {
-      cb({type: 'File', message: 'Unknown import: ' + filename});
-      return;
+      return new Promise((r, reject) => {
+        reject(new Error(`Unknown import: ${filename}`));
+      });
     }
-    cb(null, {
-      contents: this.allFiles.get(resolvedFilename)
-        .getContentsAsBuffer().toString('utf8'),
-      filename: resolvedFilename
+    return new Promise((resolve) => {
+      resolve({
+        contents: this.allFiles.get(resolvedFilename).getContentsAsBuffer().toString('utf8'),
+        filename: resolvedFilename,
+      });
     });
   }
 }
@@ -180,12 +185,12 @@ class MeteorImportLessFileManager extends less.AbstractFileManager {
 function decodeFilePath (filePath) {
   const match = filePath.match(/^{(.*)}\/(.*)$/);
   if (! match)
-    throw new Error('Failed to decode Less path: ' + filePath);
+    throw new Error(`Failed to decode Less path: ${filePath}`);
 
   if (match[1] === '') {
     // app
     return match[2];
   }
 
-  return 'packages/' + match[1] + '/' + match[2];
+  return `packages/${match[1]}/${match[2]}`;
 }


### PR DESCRIPTION
This pull request updates less to the current version 3.11.1 from 2.5.0. Closing #10992.

I added the `javascriptEnabled` flag to less to maintain backwards compatbility, as this was the default behavior before 3.0.0 of less.

In addition I configured the file loader in a way that it loads files as less if they have no ending provided, accoriding to the documentation of less: http://lesscss.org/features/#import-atrules-feature-file-extensions

The main changes in the code were:

- Rewrite the `loadFile` function as this requires to return a promise.
- In addition I refactored the code to use template string syntax.
