### PR TITLE
Add 'variables' as an extension for the less compiler to act on

### DIFF
--- a/packages/non-core/less/plugin/compile-less.js
+++ b/packages/non-core/less/plugin/compile-less.js
@@ -4,7 +4,7 @@ const less = Npm.require('less');
 Plugin.registerCompiler({
   // *.lessimport has been deprecated since 0.7.1, but it still works. We
   // *recommend *.import.less or the imports subdirectory instead.
-  extensions: ['less', 'lessimport'],
+  extensions: ['less', 'lessimport', 'variables'],
   archMatching: 'web'
 }, () => new LessCompiler());
 


### PR DESCRIPTION
In some projects, it's common to define `site.variables` or `theme.variables` less files. However, these do not appear to get picked up correctly by the less compiler (even though they are imported from `.less` files), so I added `variables` as a file extension for the less compiler to act on. So far, it seems like it works 😅
I suppose it would be even more ideal to have some config in the `package.json` for this, because some projects, like Semantic UI, use less files called `theme.config` and so on as well.

Feel free to close this if it's not relevant. I just wanted to make sure there was some record of this issue!

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
