### PR TITLE
Fix: Rare exception while invoking method 'tinytest/clearResults' 

### DIFF
--- a/packages/tinytest/tinytest_server.js
+++ b/packages/tinytest/tinytest_server.js
@@ -78,11 +78,16 @@ Meteor.methods({
   'tinytest/clearResults'(runId) {
     check(runId, String);
 
-    handlesForRun.get(runId).forEach(handle => {
-      // XXX this doesn't actually notify the client that it has been
-      // unsubscribed.
-      handle.stop();
-    });
+    const handles = handlesForRun.get(runId);
+    // Fix: Exception while invoking method 'tinytest/clearResults' TypeError: Cannot read property 'forEach' of undefined
+    // Second call of the method will always run without exception
+    if (typeof handles !== 'undefined') {
+      handles.forEach(handle => {
+        // XXX this doesn't actually notify the client that it has been
+        // unsubscribed.
+        handle.stop();
+      });
+    }
 
     handlesForRun.delete(runId);
     reportsForRun.delete(runId);

--- a/packages/tinytest/tinytest_server.js
+++ b/packages/tinytest/tinytest_server.js
@@ -78,15 +78,13 @@ Meteor.methods({
   'tinytest/clearResults'(runId) {
     check(runId, String);
 
-    const handles = handlesForRun.get(runId);
-    // Fix: Exception while invoking method 'tinytest/clearResults' TypeError: Cannot read property 'forEach' of undefined
-    // Second call of the method will always run without exception
-    if (typeof handles !== 'undefined') {
-      handles.forEach(handle => {
-        // XXX this doesn't actually notify the client that it has been
-        // unsubscribed.
-        handle.stop();
-      });
+    if (handlesForRun.has(runId)) {
+      handlesForRun.get(runId).forEach(handle => {
+          // XXX this doesn't actually notify the client that it has been
+          // unsubscribed.
+          handle.stop();
+        });
+      }
     }
 
     handlesForRun.delete(runId);


### PR DESCRIPTION
from command `meteor test-packages`.

Probably the `tinytest/clearResults` method called twice on client, but instead of debugging all tests of Meteor on the client side we make a small fix on the server side.

Best wishes,
Sergey.