### PR TITLE
Proposed fix for issue #10803

### DIFF
--- a/tools/shell-client.ts
+++ b/tools/shell-client.ts
@@ -180,7 +180,7 @@ class Client {
 
     eachline(sock, (line: string) => {
       this.exitOnClose = line.indexOf(EXITING_MESSAGE) >= 0;
-      return line;
+      return undefined as unknown as string;
     });
 
     sock.on("connect", onConnect);


### PR DESCRIPTION
This is a proposed fix for issue #10803.

It has been observed that when the "shell-client.js" module got converted to TypeScript, producing the new "shell-client.ts" module, the callback passed to the "eachline()" function was modified to return the received data line. This, however, caused a side effect, which eventually made the meteor shell to hang.

This fix reverts that modification and eliminates that side effect.