### PR TITLE
Sourcemaps are now being loaded based on the ROOT_URL

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2828,7 +2828,7 @@ function addSourceMappingURL(data, url, targetPath) {
 
   parts.push(
     newLineBuffer,
-    Buffer.from("//# sourceMappingURL=" + url, "utf8"),
+    Buffer.from("//# sourceMappingURL=" + (process.env.ROOT_URL || "") + url, "utf8"),
     newLineBuffer // trailing newline
   );
 


### PR DESCRIPTION
PR submitted to approach #10671.

Up until now SourceMaps have always been loading based on the webpage we are currently on which, for use cases allowed by ROOT_URL, may not always happen - the webserver may differ from the current domain of the webpage.

Just a quick note: it's not the first time I request a change to Meteor that [doesn't fit other users' use cases](https://github.com/meteor/meteor/commit/a646bdbbd4b988f1f25c86159972fb1b70c13ce9). I'm submitting this PR as requested but as I stated in the original issue, I'm not aware of the possible repercussion this change may have for other users.