### PR TITLE
Reduce stats and watched files

### DIFF
--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -1628,7 +1628,7 @@ function wrapFsFunc<TArgs extends any[], TResult>(
     let result;
     Profile.time(`files.${fnName} - uncached`, () => {
       result = fn.apply(fs, args);
-    })
+    });
 
     if (options && options.dirty) {
       options.dirty(...args);
@@ -1650,7 +1650,7 @@ const withCacheSlot = new Slot<Record<string, any>>();
 export const withCache =  Profile('files.withCache', function withCache<R>(fn: () => R): R {
   const cache = withCacheSlot.getValue();
   return cache ? fn() : withCacheSlot.withValue(Object.create(null), fn);
-})
+});
 
 export const dependOnPath = dep<string>();
 
@@ -1735,7 +1735,6 @@ export const rename = isWindowsLikeFilesystem() ? function (from: string, to: st
   }).await();
 } : wrappedRename;
 
-// Warning: doesn't convert slashes in the second 'cache' arg
 export const realpath =
 wrapFsFunc<[string], string>("realpath", fs.realpathSync, [0], {
   cached: true,
@@ -1747,7 +1746,7 @@ wrapFsFunc<[string, { encoding: 'utf-8' | null, withFileTypes: true }], string[]
   cached: true,
   modifyReturnValue(entries: string[] | fs.Dirent[]) {
     if (entries.length === 0 || typeof entries[0] === 'object') {
-      return entries
+      return entries;
     }
 
     return (entries as string[]).map(entry => convertToStandardPath(entry));

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -91,14 +91,14 @@ function acquireWatcher(absPath: string, callback: EntryCallback) {
 function startNewWatcher(absPath: string): Entry {
   const stat = !isWindows && statOrNull(absPath);
 
-  if (stat && stat.ino > 0 && entriesByIno.has(stat.ino)) {
-    const entry = entriesByIno.get(stat.ino);
-    if (entries[absPath] === entry) {
-      return entry;
-    }
-  } else if (isWindows && !stat) {
+  if (isWindows) {
     const entry = entries[absPath];
     if (entry) {
+      return entry;
+    }
+  } else if (stat && stat.ino > 0 && entriesByIno.has(stat.ino)) {
+    const entry = entriesByIno.get(stat.ino);
+    if (entries[absPath] === entry) {
       return entry;
     }
   }

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -300,6 +300,8 @@ Profile("meteorNpm.rebuildIfNonPortable", function (nodeModulesDir) {
         return scan(path, true);
       }
 
+      // We want to handle symlinks to
+      // directories as directories
       if (item.isSymbolicLink()) {
         item = files.stat(path);
       }
@@ -476,7 +478,6 @@ const portableCache = Object.create(null);
 const portableVersion = 2;
 
 const isPortable = Profile("meteorNpm.isPortable", (dir, isDirectory) => {
-  isDirectory = isDirectory || optimisticLStat(dir).isDirectory();
   if (! isDirectory) {
     // Non-directory files are portable unless they end with .node.
     return ! dir.endsWith(".node");
@@ -578,7 +579,7 @@ meteorNpm.dependenciesArePortable = function (nodeModulesDir) {
 
   // Only check/write .meteor-portable files in each of the top-level
   // package directories.
-  return isPortable(nodeModulesDir);
+  return isPortable(nodeModulesDir, optimisticLStat(nodeModulesDir).isDirectory());
 };
 
 var makeNewPackageNpmDir = function (newPackageNpmDir) {


### PR DESCRIPTION
In many places Meteor uses `readdir` to get a list of items in a folder, and then uses `stat` to check if the item is a directory, file, or symlink. Node now has an option for `readdir` which provides that information. There is very minimal overhead since Node already has the information when reading the directory, but normally it doesn't use it.

Almost always the type is the same as using `lstat`, but there are some rare situations where it is instead the same type as using `stat`. I tried to only updated the places where it isn't important which one it is.

In a medium sized app, this reduced the uncached stats from 56,362 to 23,253 when running Meteor from a git checkout.

To improve performance of other aspects of building, Meteor 1.8.2 removed some checks to prevent watching files in node_modules for `optimisticStatOrNull` and `optimisticLStatOrNull`, and started calling `optimisticStatOrNull` instead of `statOrNull` for most files in the app, including files in `node_modules`. Removing those calls to `optimisticStatOrNull` reduces the number of unique files watched from 47,194 to 18,005 for a medium sized app, which is a similar number to Meteor 1.8.1.

Also, Meteor stats each path it watches to get the file's Inode number to work around a bug. The bug doesn't happen on Windows. Also, due to how Node calculates the `ino` value on Windows, there are occasionally duplicate values for different files which could cause Meteor to not watch both files. For both reasons I disabled this on Windows. The other option is to use the `bigint` option which fixes the duplicate values, but this would have a minor performance impact.