### PR TITLE
Update email dependencies

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,9 @@
     instead of `dns.lookup()` which might be breaking on some environments.
     See [nodemailer changelog](https://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md) for more information.
 
+### Changes
+
+* `email` package now exposes `hookSend` that runs before emails are send.
 
 ## v1.10.2, 2020-04-21
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+## vNEXT, unreleased
+
+### Changes
+
+* `email` package dependencies have been update and package version has been bumped to 1.3.0
+
 
 ## v1.10.2, 2020-04-21
 

--- a/History.md
+++ b/History.md
@@ -1,8 +1,11 @@
 ## vNEXT, unreleased
 
-### Changes
+### Breaking changes
 
-* `email` package dependencies have been update and package version has been bumped to 1.3.0
+* `email` package dependencies have been update and package version has been bumped to 2.0.0
+    There is a potential breaking change as the underlying package started to use `dns.resolve()`
+    instead of `dns.lookup()` which might be breaking on some environments.
+    See [nodemailer changelog](https://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md) for more information.
 
 
 ## v1.10.2, 2020-04-21

--- a/packages/accounts-password/email_tests_setup.js
+++ b/packages/accounts-password/email_tests_setup.js
@@ -20,7 +20,7 @@ Accounts.emailTemplates.headers = {
   'My-Custom-Header' : 'Cool'
 };
 
-EmailTest.hookSend(options => {
+Email.hookSend(options => {
   const { to } = options;
   if (!to || !to.toUpperCase().includes('INTERCEPT')) {
     return true; // go ahead and send

--- a/packages/email/.npm/package/npm-shrinkwrap.json
+++ b/packages/email/.npm/package/npm-shrinkwrap.json
@@ -1,15 +1,15 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "node4mailer": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/node4mailer/-/node4mailer-4.0.3.tgz",
-      "integrity": "sha1-jwx6ZzdSehKFMBhaFMLoeZiaiRA="
+    "nodemailer": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.6.tgz",
+      "integrity": "sha512-/kJ+FYVEm2HuUlw87hjSqTss+GU35D4giOpdSfGp7DO+5h6RlJj7R94YaYHOkoxu1CSaM0d3WRBtCzwXrY6MKA=="
     },
     "stream-buffers": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.5.tgz",
-      "integrity": "sha1-+TBTnTzwjXSKNArWE5+Vss60jwU="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ=="
     }
   }
 }

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -118,9 +118,9 @@ EmailTest.hookSend = function (f) {
  * If the `MAIL_URL` environment variable is set, actually sends the email.
  * Otherwise, prints the contents of the email to standard out.
  *
- * Note that this package is based on **mailcomposer 4**, so make sure to refer to
- * [the documentation](https://github.com/nodemailer/mailcomposer/blob/v4.0.1/README.md)
- * for that version when using the `attachments` or `mailComposer` options.
+ * Note that this package is based on **nodemailer**, so make sure to refer to
+ * [the documentation](http://nodemailer.com/)
+ * when using the `attachments` or `mailComposer` options.
  *
  * @locus Server
  * @param {Object} options
@@ -136,7 +136,7 @@ EmailTest.hookSend = function (f) {
  * @param {String} [options.icalEvent] iCalendar event attachment
  * @param {Object} [options.headers] Dictionary of custom headers - e.g. `{ "header name": "header value" }`. To set an object under a header name, use `JSON.stringify` - e.g. `{ "header name": JSON.stringify({ tracking: { level: 'full' } }) }`.
  * @param {Object[]} [options.attachments] Array of attachment objects, as
- * described in the [mailcomposer documentation](https://github.com/nodemailer/mailcomposer/blob/v4.0.1/README.md#attachments).
+ * described in the [nodemailer documentation](https://nodemailer.com/message/attachments/).
  * @param {MailComposer} [options.mailComposer] A [MailComposer](https://nodemailer.com/extras/mailcomposer/#e-mail-message-fields)
  * object representing the message to be sent.  Overrides all other options.
  * You can create a `MailComposer` object via

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -100,7 +100,7 @@ var smtpSend = function (transport, mail) {
 
 var sendHooks = [];
 /**
- * Mock out email sending (eg, during a test.)
+ * Hook that runs before email is send.
  *
  * @param f {function} receives the arguments to Email.send and should return true to go
  * ahead and send the email (or at least, try subsequent hooks), or

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -1,6 +1,6 @@
 var Future = Npm.require('fibers/future');
 var urlModule = Npm.require('url');
-var nodemailer = Npm.require('node4mailer');
+var nodemailer = Npm.require('nodemailer');
 
 Email = {};
 EmailTest = {};
@@ -8,12 +8,12 @@ EmailTest = {};
 EmailInternals = {
   NpmModules: {
     mailcomposer: {
-      version: Npm.require('node4mailer/package.json').version,
-      module: Npm.require('node4mailer/lib/mail-composer')
+      version: Npm.require('nodemailer/package.json').version,
+      module: Npm.require('nodemailer/lib/mail-composer')
     },
     nodemailer: {
-      version: Npm.require('node4mailer/package.json').version,
-      module: Npm.require('node4mailer')
+      version: Npm.require('nodemailer/package.json').version,
+      module: Npm.require('nodemailer')
     }
   }
 };

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -98,15 +98,15 @@ var smtpSend = function (transport, mail) {
   transport._syncSendMail(mail);
 };
 
+var sendHooks = [];
 /**
- * Mock out email sending (eg, during a test.) This is private for now.
+ * Mock out email sending (eg, during a test.)
  *
- * f receives the arguments to Email.send and should return true to go
+ * @param f {function} receives the arguments to Email.send and should return true to go
  * ahead and send the email (or at least, try subsequent hooks), or
  * false to skip sending.
  */
-var sendHooks = [];
-EmailTest.hookSend = function (f) {
+Email.hookSend = function (f) {
   sendHooks.push(f);
 };
 

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.3.0"
+  version: "2.0.0"
 });
 
 Npm.depends({

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   summary: "Send email messages",
-  version: "1.2.3"
+  version: "1.3.0"
 });
 
 Npm.depends({
-  node4mailer: "4.0.3",
-  "stream-buffers": "0.2.5"
+  nodemailer: "6.4.6",
+  "stream-buffers": "3.0.2"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Updated dependencies of the `email` package and bumped the version to 1.3. The tests ran fine (though more testing is always encouraged). From the [changelog](https://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md) the biggest change is dropping support for Node bellow v6 (we had here a special version that supported Node v4) and various fixes and improvements.

TODO:
- [x] Update doc