### PR TITLE
Add beforeExternalLoginHook

### DIFF
--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "A user account system",
-  version: "1.6.0",
+  version: "1.7.0",
 });
 
 Package.onUse(api => {

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -20,7 +20,7 @@ const reportError = (error, callback) => {
 /**
  * @summary Log the user in with a password.
  * @locus Client
- * @param {Object | String} user
+ * @param {Object | String} selector
  *   Either a string interpreted as a username or an email; or an object with a
  *   single key: `email`, `username` or `id`. Username or email match in a case
  *   insensitive manner.


### PR DESCRIPTION
Add hook that allows to run check before user is created/logged via external service.

Draft PR so that we can discuss this and I still need to do testing on this.

Why this hook:
This hook fires after you get information from third-party on login and Meteor finds if there is a corresponding user. You will then get the service name, the data from the service and the corresponding user (if any) in the hook so that you can make determination if you want to allow the user to progress with login/user creation.
For example I plan to use this in an integration where I want to check that the user is logging in with the proper Google account.
Another example with Google includes that I want only people from certain domain(s) to be able to login, so I will use this hook to check that.
Yet another example would analytics.

The difference with `validateNewUser` hook is that this happens only on third-party logins before user creation and provides you with the details of the login method (which makes it easier to check if that is something you are potentially looking for). Potentially we could expand this hook to take an object that would be added to the user document.