### PR TITLE
Ensure the pathname of the rootUrl is used in the mobile URL

### DIFF
--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import util from 'util';
+import url from 'url';
 import path from 'path';
 import { Console } from '../console/console.js';
 import buildmessage from '../utils/buildmessage.js';
@@ -487,12 +488,14 @@ export class CordovaBuilder {
 
     const mobileServerUrl = this.options.mobileServerUrl;
 
+    const parsedUrl = url.parse(mobileServerUrl);
+
     const runtimeConfig = {
       meteorRelease: meteorRelease,
       gitCommitHash: process.env.METEOR_GIT_COMMIT_HASH || files.findGitCommitHash(applicationPath),
       ROOT_URL: mobileServerUrl,
       // XXX propagate it from this.options?
-      ROOT_URL_PATH_PREFIX: '',
+      ROOT_URL_PATH_PREFIX: parsedUrl.pathname.replace(/\/$/,"") || '',
       DDP_DEFAULT_CONNECTION_URL: mobileServerUrl,
       autoupdate: {
         versions: {

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -44,12 +44,15 @@ exports.parseUrl = function (str, defaults) {
   // for consistency remove colon at the end of protocol
   parsed.protocol = parsed.protocol.replace(/\:$/, '');
 
-  return {
-    pathname: parsed.pathname === '/' || parsed.pathname === '' ? undefined : parsed.pathname,
+  var ret = {
     protocol: hasScheme ? parsed.protocol : defaultProtocol,
     hostname: parsed.hostname || defaultHostname,
     port: parsed.port || defaultPort
   };
+  if (parsed.pathname !== '/' && parsed.pathname) {
+    ret.pathname = parsed.pathname;
+  }
+  return ret;
 };
 
 // 'options' is an object with 'hostname', 'port', and 'protocol' keys, such as

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -45,6 +45,7 @@ exports.parseUrl = function (str, defaults) {
   parsed.protocol = parsed.protocol.replace(/\:$/, '');
 
   return {
+    pathname: parsed.pathname,
     protocol: hasScheme ? parsed.protocol : defaultProtocol,
     hostname: parsed.hostname || defaultHostname,
     port: parsed.port || defaultPort

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -45,7 +45,7 @@ exports.parseUrl = function (str, defaults) {
   parsed.protocol = parsed.protocol.replace(/\:$/, '');
 
   return {
-    pathname: parsed.pathname,
+    pathname: parsed.pathname === '/' || parsed.pathname === '' ? undefined : parsed.pathname,
     protocol: hasScheme ? parsed.protocol : defaultProtocol,
     hostname: parsed.hostname || defaultHostname,
     port: parsed.port || defaultPort


### PR DESCRIPTION
This has been an annoyance for nearly 3 years - as documented here: https://github.com/meteor/meteor/issues/8883 finally getting around to submitting a PR. If you have a non `/` ROOT_URL, the suffix is stripped off when building for cordova, so your app never connects. E.g., `https://mydomain.com/admin`. 

This package ensures that both the parseUrl function and the cordova `generateBootstrapPage` function respect the suffix of ROOT_URL. I've been making this fix to every version of meteor on every build machine for almost 3 years. Some of my projects use a `/suffix` url and some don't.
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
