### PR TITLE
Document changes to the URL package

### DIFF
--- a/History.md
+++ b/History.md
@@ -44,6 +44,12 @@
 * The version of MongoDB used by Meteor in development has been updated from
   4.2.1 to 4.2.5.
   [PR #11020](https://github.com/meteor/meteor/pull/11020)
+  
+* The `url` package now provides an isomorphic implentation of the [WHATWG `url()`
+  API](https://url.spec.whatwg.org/).
+  While remaining backwards compatible, you can now also import `URL` and `URLSearchParams` from `meteor/url`.
+  These will work for both modern and legacy browsers as well as node.
+  
 
 ## v1.10.1, 2020-03-12
 
@@ -240,7 +246,7 @@ N/A
   fields. [Issue #10469](https://github.com/meteor/meteor/issues/10469)
 
 * Lots of internal calls to `Meteor.user()` without field specifiers in `accounts-base` and
-  `accounts-password` packages have been optimized with explicit field selectors to only fetch
+  `accounts-password` packages have been optimized with explicit field selectors to only 
   the fields needed by the functions they are in.
   [Issue #10469](https://github.com/meteor/meteor/issues/10469)
 


### PR DESCRIPTION
Only just noticed https://github.com/meteor/meteor/pull/10518 got merged. Think it's good to explain in the changelog.