### PR TITLE
Update core-js to version 3.6.5

### DIFF
--- a/packages/ecmascript-runtime-client/package.js
+++ b/packages/ecmascript-runtime-client/package.js
@@ -7,7 +7,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "core-js": "3.2.1"
+  "core-js": "3.6.5"
 });
 
 Package.onUse(function(api) {

--- a/packages/ecmascript-runtime-server/package.js
+++ b/packages/ecmascript-runtime-server/package.js
@@ -7,7 +7,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "core-js": "3.2.1"
+  "core-js": "3.6.5"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Updates the `core-js` library to the latest version `3.6.5` in `ecmascript-runtime-client` and `ecmascript-runtime-server`.


> #### Motivation
>
> During our tests with legacy browsers we noticed some issues with Svelte & older browsers, mainly IE11 and iOS {10,11}. I found some related closed issues in `core-js`.
>
>These problems were resolved by updating the `core-js` version .