### PR TITLE
Fixes Cordova build fails on the second time uninstalling plugins

### DIFF
--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -607,7 +607,7 @@ to Cordova project`, cordova_lib.plugin.bind(undefined, 'add', [target],
         commandOptions);
 
       this.runCommands(`removing plugin ${plugin} \
-  from Cordova project`, cordova_lib.plugin.bind(undefined, 'rm', [plugin],
+  from Cordova project`, cordova_lib.plugin.bind(undefined, 'rm --force', [plugin],
         commandOptionsPlugin));
     });
   }


### PR DESCRIPTION
After a change on `cordova-plugins` file `meteor run ios-device` was failing as explained here #11021

I was not able to reproduce without changing the `cordova-plugins` file but I hope this fix fixes all the cases.

Now I'm using remove force instead of just remove to uninstall Cordova plugins.

If the force mode causes other problems we could only force in the second try but as some users are experiencing this very often I prefer first to always use force mode.