### PR TITLE
Fixes: TypeError: this._encodeParams is not a function #11092

### DIFF
--- a/packages/url/bc/url_common.js
+++ b/packages/url/bc/url_common.js
@@ -12,7 +12,7 @@ var _encodeParams = function (params, prefix) {
       var k = prefix ? prefix + '[' + (isParamsArray ? '' : p) + ']' : p;
       var v = params[p];
       if (typeof v === 'object') {
-        str.push(this._encodeParams(v, k));
+        str.push(_encodeParams(v, k));
       } else {
         var encodedKey =
           encodeString(k).replace('%5B', '[').replace('%5D', ']');


### PR DESCRIPTION
Fixes: TypeError: this._encodeParams is not a function #11092

I can't explain why behaviour changed, but this resolves the issue, I was able to reproduce it following @WayneUong comment (https://github.com/meteor/meteor/issues/11092#issuecomment-645814564) using a minimal app of:

```
meteor-base
http
ecmascript
standard-minifier-css
standard-minifier-js
```
