### PR TITLE
Fix moving css imports after comments to top of merged css

### DIFF
--- a/packages/minifier-css/minifier-tests.js
+++ b/packages/minifier-css/minifier-tests.js
@@ -104,3 +104,48 @@ Tinytest.add(
     test.equal(stringifiedAsts.map.sources[0], 'test.css');
   }
 );
+
+Tinytest.add(
+  "minifier-css - hoist imports from merged CSS AST's",
+  (test) => {
+    const css1 = '@import "custom.css"; body { color: "red"; }';
+    const css2 = '@import "other.css"; body { color: "blue"; }';
+    const cssAst1 = CssTools.parseCss(css1, {from: "test.css"});
+    const cssAst2 = CssTools.parseCss(css2, {from: "test2.css"});
+    const mergedAst = CssTools.mergeCssAsts([cssAst1, cssAst2]);
+    const stringifiedAsts = CssTools.stringifyCss(mergedAst, {
+      sourcemap: true,
+      inputSourcemaps: false
+    });
+    test.equal(mergedAst.nodes.length, 4);
+    test.equal(mergedAst.nodes[0].name, 'import');
+    test.equal(mergedAst.nodes[1].name, 'import');
+    test.equal(mergedAst.nodes[2].type, 'rule');
+    test.equal(mergedAst.nodes[3].type, 'rule');
+    test.equal(stringifiedAsts.map.sources.length, 2);
+    test.equal(stringifiedAsts.map.sources[0], 'test.css');
+  }
+);
+
+Tinytest.add(
+  "minifier-css - hoist imports after comments from merged CSS AST's",
+  (test) => {
+    const css1 = '@import "custom.css"; body { color: "red"; }';
+    const css2 = '/* comment */ @import "other.css"; body { color: "blue"; }';
+    const cssAst1 = CssTools.parseCss(css1, {from: "test.css"});
+    const cssAst2 = CssTools.parseCss(css2, {from: "test2.css"});
+    const mergedAst = CssTools.mergeCssAsts([cssAst1, cssAst2]);
+    const stringifiedAsts = CssTools.stringifyCss(mergedAst, {
+      sourcemap: true,
+      inputSourcemaps: false
+    });
+    test.equal(mergedAst.nodes.length, 5);
+    test.equal(mergedAst.nodes[0].name, 'import');
+    test.equal(mergedAst.nodes[1].type, 'comment');
+    test.equal(mergedAst.nodes[2].name, 'import');
+    test.equal(mergedAst.nodes[3].type, 'rule');
+    test.equal(mergedAst.nodes[4].type, 'rule');
+    test.equal(stringifiedAsts.map.sources.length, 2);
+    test.equal(stringifiedAsts.map.sources[0], 'test.css');
+  }
+);

--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -96,8 +96,13 @@ const CssTools = {
       if (! Array.isArray(rules)) {
         rules = [rules];
       }
-      return node =>
-        exclude ? !rules.includes(node.name) : rules.includes(node.name);
+      return node => {
+        // PostCSS AtRule nodes have `type: 'atrule'` and a descriptive name,
+        // e.g. 'import' or 'charset', while Comment nodes have type only.
+        const nodeMatchesRule = rules.includes(node.name || node.type);
+
+        return exclude ? !nodeMatchesRule : nodeMatchesRule;
+      }
     };
 
     // Simple concatenation of CSS files would break @import rules


### PR DESCRIPTION
`minifier-css`'s check for imports to hoist unexpectedly stops on any comments and subsequent imports are not moved to the top of the merged css.

The `rulesPredicate(['import', 'comment'])` check for nodes to hoist is comparing to `node.name`, which is not present for PostCSS's Comment nodes. It should probably be looking for `type: 'comment'` instead.

Proposing a minimal fix to check `name` when present, i.e. for [AtRules](https://api.postcss.org/at-rule.es6.html#line39), and [`type`](https://api.postcss.org/node.es6.html#line423) otherwise for comments. Includes a basic test for import hoisting as there didn't appear to be one, as well as one for the broken case.

Possibly fixes #11096, as it resolved our issue that presented similarly, but need further info/confirmation that they are reporting the same scenario.
