### PR TITLE
Reduce watchers and stats

### DIFF
--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -5,7 +5,7 @@
 ///
 
 import assert from "assert";
-import fs, { PathLike, Stats } from "fs";
+import fs, { PathLike, Stats, Dirent } from "fs";
 import path from "path";
 import os from "os";
 import { spawn, execFile } from "child_process";
@@ -1746,6 +1746,14 @@ wrapFsFunc<[string], string[]>("readdir", fs.readdirSync, [0], {
   modifyReturnValue(entries: string[]) {
     return entries.map(entry => convertToStandardPath(entry));
   },
+});
+
+export const readdirWithTypes = wrapFsFunc<[string], Dirent[]>("readdirWithTypes", (dir) => {
+    return fs.readdirSync(dir, {
+      withFileTypes: true
+    });
+  }, [0], {
+  cached: true
 });
 
 export const appendFile = wrapDestructiveFsFunc("appendFile", fs.appendFileSync);

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -35,6 +35,14 @@ var NO_WATCHER_POLLING_INTERVAL =
 // file watchers, but it's to our advantage if they survive restarts.
 const WATCHER_CLEANUP_DELAY_MS = 30000;
 
+// Pathwatcher complains (using console.error, ugh) if you try to watch
+// two files with the same stat.ino number but different paths on linux, so we have
+// to deduplicate files by ino.
+const DEDUPLICATE_BY_INO = process.platform !== "win32";
+
+const entriesByIno = new Map;
+
+
 export type SafeWatcher = {
   close: () => void;
 }
@@ -48,11 +56,6 @@ interface Entry extends SafeWatcher {
 }
 
 const entries: Record<string, Entry | null> = Object.create(null);
-
-// Pathwatcher complains (using console.error, ugh) if you try to watch
-// two files with the same stat.ino number but different paths, so we have
-// to deduplicate files by ino.
-const entriesByIno = new Map;
 
 // Set of paths for which a change event has been fired, watched with
 // watchLibrary.watch if available. This could be an LRU cache, but in
@@ -86,10 +89,19 @@ function acquireWatcher(absPath: string, callback: EntryCallback) {
 }
 
 function startNewWatcher(absPath: string): Entry {
-  const stat = statOrNull(absPath);
-  if (stat && stat.ino > 0 && entriesByIno.has(stat.ino)) {
-    const entry = entriesByIno.get(stat.ino);
-    if (entries[absPath] === entry) {
+  let stat: Stats | null;
+
+  if (DEDUPLICATE_BY_INO) {
+    stat = statOrNull(absPath);
+    if (stat && stat.ino > 0 && entriesByIno.has(stat.ino)) {
+      const entry = entriesByIno.get(stat.ino);
+      if (entries[absPath] === entry) {
+        return entry;
+      }
+    }
+  } else {
+    let entry = entries[absPath];
+    if (entry) {
       return entry;
     }
   }

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -89,7 +89,7 @@ function acquireWatcher(absPath: string, callback: EntryCallback) {
 }
 
 function startNewWatcher(absPath: string): Entry {
-  let stat: Stats | null;
+  let stat: Stats | null = null;
 
   if (DEDUPLICATE_BY_INO) {
     stat = statOrNull(absPath);

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -1714,7 +1714,7 @@ export class PackageSourceBatch {
     if (cacheFilename) {
       let diskCached = null;
       try {
-        diskCached = optimisticReadJsonOrNull(cacheFilename);
+        diskCached = files.readJSONOrNull(cacheFilename);
       } catch (e) {
         // Ignore JSON parse errors; pretend there was no cache.
         if (!(e instanceof SyntaxError)) {


### PR DESCRIPTION
Since Meteor 1.8.2, it stats and watches most files and folders in the app and node_modules folders. It only does this to check which are folders. This PR changes it to use readdir's `withFileTypes` option, which removes the need to watch many of the files. This has very low overhead compared to `readdir` without the option.

Also, Meteor was using optimistic functions to read from the linker and reify file caches, which resulted in the files being watched, and the entries stored in two memory caches. This PR changes it to use a single memory cache, and not watch the files.

To work around a bug in Pathwatcher on Linux, Meteor would stat each file before watching it to deduplicate watchers by the file inode. Since Node can provide the same `ino` value for different files on Windows, and this bug is specific to linux, this PR disables deduplicating on Windows, avoiding the extra stats.

These changes reduce Meteor's cpu usage when not building, though it is still higher than Meteor 1.8.1. Tests done before changing the caches showed stats reduced from 56,362 to 23,253, and watched files reduced from 47,194 to 18,005. The changes to the linker cache reduced memory usage by 40% in one app I tested.