### PR TITLE
Add `autoupdate-development` package

### DIFF
--- a/packages/autoupdate-development/client.js
+++ b/packages/autoupdate-development/client.js
@@ -1,0 +1,11 @@
+import { ssePath } from "./common.js";
+
+const eventSource = new EventSource(ssePath);
+
+eventSource.addEventListener("message", ({ data }) => {
+  if (data !== __meteor_runtime_config__.clientHash) {
+    window.location.reload();
+  }
+});
+
+window.addEventListener("beforeunload", () => eventSource.close());

--- a/packages/autoupdate-development/common.js
+++ b/packages/autoupdate-development/common.js
@@ -1,0 +1,1 @@
+export const ssePath = "/__meteor__/webapp/autoupdate-development";

--- a/packages/autoupdate-development/package.js
+++ b/packages/autoupdate-development/package.js
@@ -1,0 +1,17 @@
+Package.describe({
+  name: "autoupdate-development",
+  summary: "Development-only autoupdate for clients",
+  version: "1.0.0",
+  debugOnly: true
+});
+
+Package.onUse((api) => {
+  api.use([
+    "ecmascript",
+    "random",
+    "webapp"
+  ]);
+
+  api.mainModule("client.js", "client");
+  api.mainModule("server.js", "server");
+});

--- a/packages/autoupdate-development/server.js
+++ b/packages/autoupdate-development/server.js
@@ -1,0 +1,65 @@
+import { WebApp, WebAppInternals } from "meteor/webapp";
+import { Random } from "meteor/random";
+import { ssePath } from "./common.js";
+
+const responses = new Map();
+let clientHash;
+
+function sendClientHash(res) {
+  res.write(`data: ${clientHash}\n\n`);
+  res.flush();
+}
+
+function updateClientHash() {
+  clientHash = __meteor_runtime_config__.clientHash = WebApp.clientHash();
+}
+
+WebApp.connectHandlers.use(ssePath, (req, res) => {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache"
+  });
+
+  const clientId = Random.id();
+
+  responses.set(clientId, res);
+  sendClientHash(res);
+
+  // Send a heartbeat message (zero-length comment) every ten seconds to keep
+  // the connection alive.
+  const interval = setInterval(() => {
+    res.write(":\n\n");
+    res.flush();
+  }, 10000);
+
+  function close() {
+    clearInterval(interval);
+    responses.delete(clientId);
+  }
+
+  req.on("end", close);
+  req.on("close", close);
+});
+
+process.on(
+  "message",
+  Meteor.bindEnvironment(function (message) {
+    if (message?.topic === "client-refresh") {
+      updateClientHash();
+
+      // Load the new client bundle.
+      WebAppInternals.reloadClientPrograms();
+      WebAppInternals.generateBoilerplate();
+
+      responses.forEach(sendClientHash);
+    }
+  })
+);
+
+Meteor.startup(updateClientHash);
+
+// If the Meteor tool terminates the server (e.g., after a server code change),
+// signal to all clients that no more data will be sent.
+process.on("SIGTERM", function () {
+  responses.forEach((res) => res.end());
+});

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -641,9 +641,11 @@ _.extend(AppRunner.prototype, {
     serverWatchSet.merge(settingsWatchSet);
 
     // We only can refresh the client without restarting the server if the
-    // client contains the 'autoupdate' package.
-    var canRefreshClient = self.projectContext.packageMap &&
-          self.projectContext.packageMap.getInfo('autoupdate');
+    // client contains the 'autoupdate' or 'autoupdate-development' package.
+    var canRefreshClient =
+      self.projectContext.packageMap &&
+      (self.projectContext.packageMap.getInfo('autoupdate') ||
+        self.projectContext.packageMap.getInfo('autoupdate-development'));
 
     if (! canRefreshClient) {
       // Restart server on client changes if we can't refresh the client.

--- a/tools/static-assets/skel-minimal/.meteor/packages
+++ b/tools/static-assets/skel-minimal/.meteor/packages
@@ -14,3 +14,4 @@ typescript              # Enable TypeScript syntax in .ts and .tsx modules
 shell-server            # Server-side component of the `meteor shell` command
 webapp                  # Serves a Meteor app over HTTP
 server-render           # Support for server-side rendering
+autoupdate-development  # Development-only autoupdate for clients


### PR DESCRIPTION
Inspired by #11034 (`autoupdate-polling`), this PR adds an even more lightweight autoupdate package based on server-sent events. In contrast to `autoupdate-polling`, this package is only intended for development, not for production.

cc @delki8