### PR TITLE
Build in place on Windows during full rebuilds

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2844,20 +2844,18 @@ var writeTargetToPath = Profile(
     previousBuilder = null,
     buildMode,
     minifyMode,
+    forceInPlaceBuild
   }) {
     var builder = new Builder({
       outputPath: files.pathJoin(outputPath, 'programs', name),
       previousBuilder,
-      // We do not force an in-place build for individual targets like
-      // .meteor/local/build/programs/web.browser.legacy, because they
-      // tend to be written atomically, and it's important on Windows to
-      // avoid overwriting files that might be open currently in the build
-      // or server process.
-      // Server builds do use an in-place build since the server is always stopped
-      // during the build.
-      // If client in-place builds were safer on Windows, they
-      // would be much quicker than from-scratch rebuilds.
-      forceInPlaceBuild: name === 'server',
+      // We do not force an in-place build for individual targets
+      // like .meteor/local/build/programs/web.browser.legacy, because they tend
+      // to be written atomically, and it's important on Windows to avoid
+      // overwriting files that might be open currently in the server
+      // process. There are some exceptions when we know the server process
+      // is not using the files, such as during a full build when it is stopped.
+      forceInPlaceBuild: forceInPlaceBuild,
     });
 
     var targetBuild = target.write(builder, {
@@ -2910,6 +2908,7 @@ var writeSiteArchive = Profile("bundler writeSiteArchive", function (
     buildMode,
     minifyMode,
     sourceRoot,
+    forceInPlaceBuild,
   }) {
 
   const builders = {};
@@ -3004,7 +3003,8 @@ Find out more about Meteor at meteor.com.
         releaseName,
         previousBuilder: previousBuilders[name] || null,
         buildMode,
-        minifyMode
+        minifyMode,
+        forceInPlaceBuild
       });
 
       builders[name] = targetBuilder;
@@ -3083,6 +3083,10 @@ Find out more about Meteor at meteor.com.
  * - hasCachedBundle: true if we already have a cached bundle stored in
  *   /build. When true, we only build the new client targets in the bundle.
  *
+ *  - forceInPlaceBuild On Windows, in place builds are disabled by default
+ *    since they are only safe when the output files from the previous build
+ *    are not being used. This can be set to true when it is safe.
+ *
  * Returns an object with keys:
  * - errors: A buildmessage.MessageSet, or falsy if bundling succeeded.
  * - serverWatchSet: Information about server files and paths that were
@@ -3117,6 +3121,7 @@ function bundle({
   previousBuilders = Object.create(null),
   hasCachedBundle,
   allowDelayedClientBuilds = false,
+  forceInPlaceBuild,
 }) {
   buildOptions = buildOptions || {};
 
@@ -3271,6 +3276,7 @@ function bundle({
       builtBy,
       releaseName,
       minifyMode,
+      forceInPlaceBuild,
     };
 
     function writeClientTarget(target) {

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -579,6 +579,10 @@ _.extend(AppRunner.prototype, {
           // Permit delayed bundling of client architectures if the
           // console is interactive.
           allowDelayedClientBuilds: ! Console.isHeadless(),
+
+          // None of the targets are used during full rebuilds
+          // so we can safely build in place on Windows
+          forceInPlaceBuild: !cachedServerWatchSet
         });
       });
 


### PR DESCRIPTION
One optimization Meteor uses during builds is build in place. When enabled, Meteor re-uses files from the previous build and only updates the files that changed. On Windows, this was disabled since there could be issues if the meteor tool updates a file the server is accessing. I enabled it for building the server in #10399 since the server is always stopped before a full rebuild is started. Since there hasn't been any issues, this PR enables it for the client architectures during full rebuilds.

Before, writing the client target would take between 600 and 950ms during rebuilds of a medium sized app on Windows.
After, it is between 70 and 215ms.

Building in place is still disabled for client only builds. Meteor 1.8 added the ability for the webapp to be paused during delayed builds. It might be possible to use this to make it safer to use in place builds, but it won't completely prevent issues.