### PR TITLE
Fix calling pathBasename twice during loadOrderSort

### DIFF
--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -79,6 +79,9 @@ var loadOrderSort = function (sourceProcessorSet, arch) {
   });
 
   return function (a, b) {
+    const aBasename = files.pathBasename(a);
+    const bBasename = files.pathBasename(b);
+
     // XXX MODERATELY SIZED HACK --
     // push template files ahead of everything else. this is
     // important because the user wants to be able to say
@@ -87,15 +90,15 @@ var loadOrderSort = function (sourceProcessorSet, arch) {
     // before the corresponding .html file.
     //
     // maybe all of the templates should go in one file?
-    var isTemplate_a = isTemplate(files.pathBasename(a));
-    var isTemplate_b = isTemplate(files.pathBasename(b));
+    var isTemplate_a = isTemplate(aBasename);
+    var isTemplate_b = isTemplate(bBasename);
     if (isTemplate_a !== isTemplate_b) {
       return (isTemplate_a ? -1 : 1);
     }
 
     // main.* loaded last
-    var ismain_a = (files.pathBasename(a).indexOf('main.') === 0);
-    var ismain_b = (files.pathBasename(b).indexOf('main.') === 0);
+    var ismain_a = (aBasename.indexOf('main.') === 0);
+    var ismain_b = (bBasename.indexOf('main.') === 0);
     if (ismain_a !== ismain_b) {
       return (ismain_a ? 1 : -1);
     }


### PR DESCRIPTION
For a medium sized app on Windows, these are some times from sorting files in 3 architectures during full rebuilds:
Before: 153ms, 140, 358, 391, 219, 177

After removing duplicate `files.pathBasename`: 84ms, 58, 73, 49, 114, 88

In the future, an additional optimization we could consider is using `path.posix.basename` instead of `files.pathBasename`. `files.pathBasename` converts paths to the os style path, then uses the `basename` function for the os. This conversion is probably unnecessary since all paths should be in posix format and are relative.

With posix basename: 57ms, 38, 25, 30, 40, 70, 43