### PR TITLE
[Feature] Be able to define default user fields published on login

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -42,7 +42,11 @@ export class AccountsServer extends AccountsCommon {
     // where _defaultPublishFields is destructured into lexical scope
     // for publish callbacks that need `this`
     this._defaultPublishFields = {
-      loggedInUser: ['profile', 'username', 'emails'],
+      projection: {
+        profile: 1,
+        username: 1,
+        emails: 1,
+      }
     };
 
     this._initServerPublications();
@@ -694,14 +698,8 @@ export class AccountsServer extends AccountsCommon {
       return ServiceConfiguration.configurations.find({}, {fields: {secret: 0}});
     }, {is_auto: true}); // not techincally autopublish, but stops the warning.
 
-    // ['profile', 'username'] -> {profile: 1, username: 1}
-    const toFieldSelector = fields => fields.reduce((prev, field) => (
-            { ...prev, [field]: 1 }),
-        {}
-    );
-
     // Use Meteor.startup to give other packages a chance to call
-    // addDefaultPublishFields.
+    // setDefaultPublishFields.
     Meteor.startup(() => {
       // Publish the current user's record to the client.
       this._server.publish(null, function () {
@@ -709,7 +707,7 @@ export class AccountsServer extends AccountsCommon {
           return users.find({
             _id: this.userId
           }, {
-            fields: toFieldSelector(_defaultPublishFields.loggedInUser),
+            fields: _defaultPublishFields.projection,
           });
         } else {
           return null;
@@ -720,6 +718,11 @@ export class AccountsServer extends AccountsCommon {
     // Use Meteor.startup to give other packages a chance to call
     // addAutopublishFields.
     Package.autopublish && Meteor.startup(() => {
+      // ['profile', 'username'] -> {profile: 1, username: 1}
+      const toFieldSelector = fields => fields.reduce((prev, field) => (
+          { ...prev, [field]: 1 }),
+        {}
+      );
       this._server.publish(null, function () {
         if (this.userId) {
           return users.find({ _id: this.userId }, {
@@ -758,12 +761,12 @@ export class AccountsServer extends AccountsCommon {
       this._autopublishFields.otherUsers, opts.forOtherUsers);
   };
 
-  // Add to the list of fields or subfields to be automatically
+  // Replaces the fields to be automatically
   // published when the user logs in
   //
-  // @param fields {Array.<string>} fields
-  addDefaultPublishFields(fields) {
-    this._defaultPublishFields.loggedInUser = [...new Set([...this._defaultPublishFields.loggedInUser, ...fields])];
+  // @param {MongoFieldSpecifier} fields Dictionary of fields to return or exclude.
+  setDefaultPublishFields(fields) {
+    this._defaultPublishFields.projection = fields;
   };
 
   ///


### PR DESCRIPTION
##### This removes the limitation described in https://docs.meteor.com/api/accounts.html

> By default, the current user’s username, emails and profile are published to the client. You can publish additional fields for the current user with:

```JS
// Server
Meteor.publish('userData', function () {
  if (this.userId) {
    return Meteor.users.find({ _id: this.userId }, {
      fields: { other: 1, things: 1 }
    });
  } else {
    this.ready();
  }
});

// Client
Meteor.subscribe('userData');
```

##### How to be used

```JS
Accounts.setDefaultPublishFields({username: 1, profile: 1, emails: 1, 'foo.bar': 1});
// or
Accounts.setDefaultPublishFields({'do.not.publish.this': -1});
```

**Since this replaces the default projection the user has to add `profile`, `username`, and `profile` to the projection to keep the old behavior.**

##### Motivation

I think that writing an additional subscription just for the sole purpose to fetch additional fields, is cumbersome and degrades the performance for no reason.

##### Background

In our scenario, a logged-in user has additional fields that are not part of `profile`. Those fields are needed to determine the state and the permissions of the user. In the UI, after the login has succeeded, the user will be redirected to the primary route for logged-in users - this then checks for the appropriate permission. At that point, the custom subscription used to fetch all the user data has not finished yet. As a result, the user will be redirected back to the "you are not logged in" page.

**tl;dr**
It helps with race conditions where fields are missing after login.