### PR TITLE
Remove noEmit option from tsconfig.json in TypeScript project skeleton

### DIFF
--- a/tools/static-assets/skel-typescript/tsconfig.json
+++ b/tools/static-assets/skel-typescript/tsconfig.json
@@ -8,7 +8,6 @@
     "checkJs": false,
     "jsx": "preserve",
     "incremental": true,
-    "noEmit": true,
 
     /* Strict Type-Checking Options */
     "strict": true,


### PR DESCRIPTION
Addresses #11135 

Remove the `noEmit` option due to conflicts with the `incremental` option.
