### PR TITLE
Correct 'undefind' typo in deprecated markdown package

### DIFF
--- a/packages/deprecated/markdown/showdown.js
+++ b/packages/deprecated/markdown/showdown.js
@@ -118,7 +118,7 @@ var g_output_modifiers = [];
 // Automatic Extension Loading (node only):
 //
 
-if (typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefined') {
 	var fs = require('fs');
 
 	if (fs) {


### PR DESCRIPTION
This corrects 'undefind' to 'undefined' in line 121 of packages/deprecated/markdown/showdown.js