### PR TITLE
Fixed: Apollo Skeleton - Apollo Client needs a cache to be setup

### DIFF
--- a/tools/static-assets/skel-apollo/imports/ui/App.jsx
+++ b/tools/static-assets/skel-apollo/imports/ui/App.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { ApolloProvider, ApolloClient } from '@apollo/client';
+import { ApolloProvider, ApolloClient, InMemoryCache } from '@apollo/client';
 import { Hello } from './Hello.jsx';
 import { Info } from './Info.jsx';
 
 const client = new ApolloClient({
   uri: '/graphql',
+  cache: new InMemoryCache(),
   /* Uncomment this for accounts use
   request: operation =>
     operation.setContext(() => ({


### PR DESCRIPTION
Addressing and fixing issue #11145

Configured the client to use the InMemoryCache
