### PR TITLE
Allow android-webview-video-poster (fixes #8965)

### DIFF
--- a/packages/boilerplate-generator/template-web.cordova.js
+++ b/packages/boilerplate-generator/template-web.cordova.js
@@ -29,7 +29,7 @@ export const headTemplate = ({
     '  <meta name="format-detection" content="telephone=no">',
     '  <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, viewport-fit=cover">',
     '  <meta name="msapplication-tap-highlight" content="no">',
-    '  <meta http-equiv="Content-Security-Policy" content="default-src * gap: data: blob: \'unsafe-inline\' \'unsafe-eval\' ws: wss:;">',
+    '  <meta http-equiv="Content-Security-Policy" content="default-src * android-webview-video-poster: gap: data: blob: \'unsafe-inline\' \'unsafe-eval\' ws: wss:;">',
 
   (headSections.length === 1)
     ? [cssBundle, headSections[0]].join('\n')


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
This fixes https://github.com/meteor/meteor/issues/8965, also discussed in the [forums](https://forums.meteor.com/t/correct-way-of-setting-content-security-policy-for-a-meteor-cordova-app/43985).

The issue was closed with a [workaround](https://github.com/meteor/meteor/issues/8965#issuecomment-370465644) which [turned out not to work](https://forums.meteor.com/t/correct-way-of-setting-content-security-policy-for-a-meteor-cordova-app/43985/7), forcing some people to maintain local versions of the `boilerplate-generator` package.

As the fix is simple and has no apparent drawbacks, I'd like to suggest we include it in Meteor by default.