### PR TITLE
Bump standard-minifier-css version to use the latest version of minifier-css package

### DIFF
--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.6.0',
+  version: '1.6.1',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });


### PR DESCRIPTION
I did update minifier-css package to remove a warning about 'caniuse-lite'.

But standard-minifier-css uses minifier-css, so we should update the version of standard-minifier-css.

I tested it locally by cloning standard-minifier-css to project's packages folder and increase its version to 1.6.1. The warning disappeared.