### PR TITLE
Allow setting nonce in browser-policy-content (fixes 11031)

### DIFF
--- a/packages/browser-policy-content/browser-policy-content.js
+++ b/packages/browser-policy-content/browser-policy-content.js
@@ -106,7 +106,7 @@ var addSourceForDirective = function (directive, src) {
     var toAdd = [];
 
     //Only add single quotes to CSP2 script digests
-    if (/^(sha(256|384|512)-)/i.test(src)) {
+    if (/^(sha(256|384|512)|nonce)-/i.test(src)) {
       toAdd.push("'" + src + "'");
     } else {
       src = src.toLowerCase();

--- a/packages/browser-policy/browser-policy-test.js
+++ b/packages/browser-policy/browser-policy-test.js
@@ -143,6 +143,30 @@ Tinytest.add("browser-policy - csp", function (test) {
                         "default-src 'none'; frame-src https://foo.com; " + 
                         "object-src http://foo.com https://foo.com; " + 
                         "frame-ancestors https://foo.com;"));
+
+  // CSP2 options: nonce
+  BrowserPolicy.content.disallowAll();
+  BrowserPolicy.content.allowScriptOrigin('nonce-2gB8y5CrknnK2dgQk');
+  test.isTrue(cspsEqual(BrowserPolicy.content._constructCsp(),
+                        "default-src 'none'; script-src 'nonce-2gB8y5CrknnK2dgQk';"));
+
+  // CSP2 options: sha256
+  BrowserPolicy.content.disallowAll();
+  BrowserPolicy.content.allowScriptOrigin('sha256-KFQx9ysdKgqbAPoY7');
+  test.isTrue(cspsEqual(BrowserPolicy.content._constructCsp(),
+                        "default-src 'none'; script-src 'sha256-KFQx9ysdKgqbAPoY7';"));
+
+  // CSP2 options: sha384
+  BrowserPolicy.content.disallowAll();
+  BrowserPolicy.content.allowScriptOrigin('sha384-mChdKgyBF83ewvbTy');
+  test.isTrue(cspsEqual(BrowserPolicy.content._constructCsp(),
+                        "default-src 'none'; script-src 'sha384-mChdKgyBF83ewvbTy';"));
+
+  // CSP2 options: sha512
+  BrowserPolicy.content.disallowAll();
+  BrowserPolicy.content.allowScriptOrigin('sha512-A8x946bPwaak2LToB');
+  test.isTrue(cspsEqual(BrowserPolicy.content._constructCsp(),
+                        "default-src 'none'; script-src 'sha512-A8x946bPwaak2LToB';"));
 });
 
 Tinytest.add("browser-policy - x-frame-options", function (test) {


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
Fixes https://github.com/meteor/meteor/issues/11031

In short, this didn't work, now it works: 
```js
BrowserPolicy.content.allowScriptOrigin(`nonce-${nonce}`);`
```

To try it out, run this minimal example project: https://github.com/namenotrequired/meteor-csp-nonce-example - the page shows either `The nonce was set successfully` or `The nonce was NOT set`

Edit: I also added tests for both the new `nonce` and the pre-existing `sha` options