### PR TITLE
Fix form submit bugs in accounts-ui

### DIFF
--- a/packages/accounts-ui-unstyled/login_buttons_dropdown.js
+++ b/packages/accounts-ui-unstyled/login_buttons_dropdown.js
@@ -238,8 +238,10 @@ Template._loginButtonsLoggedOutDropdown.events({
   },
 
   'keypress #forgot-password-email': event => {
-    if (event.keyCode === 13)
+    if (event.keyCode === 13) {
+      event.preventDefault();
       forgotPassword();
+    }
   },
 
   'click #login-buttons-forgot-password': forgotPassword,

--- a/packages/accounts-ui-unstyled/login_buttons_dropdown.js
+++ b/packages/accounts-ui-unstyled/login_buttons_dropdown.js
@@ -335,10 +335,6 @@ Template._loginButtonsLoggedOutDropdown.events({
     if (password !== null)
       document.getElementById('login-password').value = password;
   },
-  'keypress #login-username, keypress #login-email, keypress #login-username-or-email, keypress #login-password, keypress #login-password-again': event => {
-    if (event.keyCode === 13)
-      loginOrSignup();
-  }
 });
 
 Template._loginButtonsLoggedOutDropdown.helpers({


### PR DESCRIPTION
In accounts-ui, when pressing Enter to submit,

- The login form would send the server two login requests (part of https://github.com/meteor/meteor/issues/10853; see the [reproduction repo](https://github.com/AndyCC25/meteor-login-bug))
- The "forgot password" form would not only send the email but also refresh the page

## Double login request

The first bug was because when we hit Enter on one of the form fields, the event handlers for both `click #login-buttons-password` and `keypress #login-password` run, and they both call `loginOrSignup();`. The `keypress` event listener wasn't needed, as the `login-buttons-password` is a `button`, and the [HTML spec](https://html.spec.whatwg.org/#implicit-submission) says:

> If the user agent supports letting the user submit a form implicitly ... then doing so ... must cause the user agent to fire a click event at that default button.

Solution: removed the event handler

## Page refresh

Pressing Enter would not only trigger the `keypress #forgot-password-email` event but also the form submit event. (Because no destination is specified, in effect this means the page is refreshed and a `?` appended to the URL.) According to the [HTML standard](https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2),

>  When there is only one single-line text input field in a form, the user agent should accept Enter in that field as a request to submit the form. 

This explains why the same bug does not happen for the `changePassword` form, which works exactly in the same way as the `forgotPassword` form except it has more than one input.

Solution: `event.preventDefault()`

## Tests?

There are currently no automated tests for these behaviors and I'm not sure how to add them.

I tested manually on Firefox, Chrome, Android and iOS.