### PR TITLE
Update node to 12.18.4 & npm to 6.14.8

### DIFF
--- a/History.md
+++ b/History.md
@@ -12,6 +12,10 @@ N/A
 
 * `--apollo` skeleton was missing client cache setup [PR #11146](https://github.com/meteor/meteor/pull/11146)
 
+* Node.js has been updated to version [12.18.4](https://nodejs.org/en/blog/release/v12.18.4/), this is a [security release](https://nodejs.org/en/blog/vulnerability/september-2020-security-releases/)
+
+* Updated npm to version 6.14.8
+
 ## v1.11, 2020-08-18
 
 ### Breaking changes

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -5,10 +5,10 @@ set -u
 
 UNAME=$(uname)
 ARCH=$(uname -m)
-NODE_VERSION=12.18.3
+NODE_VERSION=12.18.4
 MONGO_VERSION_64BIT=4.2.8
 MONGO_VERSION_32BIT=3.2.22
-NPM_VERSION=6.14.6
+NPM_VERSION=6.14.8
 
 # If we built Node from source on Jenkins, this is the build number.
 NODE_BUILD_NUMBER=


### PR DESCRIPTION
* Node.js has been updated to version [12.18.4](https://nodejs.org/en/blog/release/v12.18.4/), this is a [security release](https://nodejs.org/en/blog/vulnerability/september-2020-security-releases/)

* Updated npm to version 6.14.8

@filipenevola might be worth to have a patch release of Meteor together with some other small fixes.