### PR TITLE
Modernize standard-minifier-css and update dependencies

### DIFF
--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.6.1',
+  version: '1.7.0',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });
@@ -8,12 +8,13 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "minifyStdCSS",
   use: [
-    'minifier-css'
+    'minifier-css',
+    'ecmascript'
   ],
   npmDependencies: {
-    "@babel/runtime": "7.6.0",
-    "source-map": "0.6.1",
-    "lru-cache": "5.1.1"
+    "@babel/runtime": "7.11.2",
+    "source-map": "0.7.3",
+    "lru-cache": "6.0.0"
   },
   sources: [
     'plugin/minify-css.js'


### PR DESCRIPTION
This modernizes the standard-minifier-css package. 
It should also have a performance improvement on css heavy projects because of the updated source-map package which now works with the wasm-based sourcemap consumer.