### PR TITLE
Fixing prefetching errors with dynamic-import #11157

### DIFF
--- a/packages/dynamic-import/client.js
+++ b/packages/dynamic-import/client.js
@@ -1,6 +1,7 @@
 var Module = module.constructor;
 var cache = require("./cache.js");
 var meteorInstall = require("meteor/modules").meteorInstall;
+var dynamicVersions = require("./dynamic-versions.js");
 
 var dynamicImportSettings = Meteor.settings
     && Meteor.settings.public
@@ -23,7 +24,6 @@ Module.prototype.dynamicImport = function (id) {
 meteorInstall.fetch = function (ids) {
   var tree = Object.create(null);
   var versions = Object.create(null);
-  var dynamicVersions = require("./dynamic-versions.js");
   var missing;
 
   function addSource(id, source) {


### PR DESCRIPTION
Fix for #11157 
The fix contains two commits, the first fixes the problem that prefetching of dynamic imports only occurs when an import is executed during initial load of the page.
The second commit fixes a failed prefetch when dynamic imports from packages are used because of replacing : with _ in package names.