### PR TITLE
#371 cold-start

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1437,6 +1437,7 @@ main.registerCommand({
     'deploy-polling-timeout': { type: Number },
     'no-wait': { type: Boolean },
     'cache-build': { type: Boolean },
+    free: { type: Boolean }
   },
   allowUnrecognizedOptions: true,
   requiresApp: function (options) {
@@ -1517,6 +1518,7 @@ function deployCommand(options, { rawOptions }) {
     projectContext: projectContext,
     site: site,
     settingsFile: options.settings,
+    free: options.free,
     buildOptions: buildOptions,
     rawOptions,
     deployPollingTimeoutMs,

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -520,6 +520,8 @@ Options:
                   waiting for the deploy to conclude.
   --cache-build   Reuses the build already created if the git commit hash is the
                   same
+  --free          When deploying an app for the first time, you can pass this option
+                  to deploy your app in the Galaxy's free mode.
 
 >>> authorized
 View or change authorized users and organizations for a site.

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -617,7 +617,12 @@ export async function bundleAndDeploy(options) {
       method: 'POST',
       operation: 'deploy',
       site: site,
-      qs: Object.assign({}, options.rawOptions, settings !== null ? {settings: settings} : {}),
+      qs: Object.assign(
+        {},
+        options.rawOptions,
+        settings !== null ? {settings: settings} : {},
+        { free: options.free },
+      ),
       bodyStream: createTarGzStream(pathJoin(buildDir, 'bundle')),
       expectPayload: ['url'],
       preflightPassword: preflight.preflightPassword,


### PR DESCRIPTION
Inserting a new flag that will allow the users to deploy their apps directly in the Galaxy's free mode.