### PR TITLE
#459 MongoDB

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1437,6 +1437,7 @@ main.registerCommand({
     'deploy-polling-timeout': { type: Number },
     'no-wait': { type: Boolean },
     'cache-build': { type: Boolean },
+    mongo: { type: Boolean }
   },
   allowUnrecognizedOptions: true,
   requiresApp: function (options) {
@@ -1517,6 +1518,7 @@ function deployCommand(options, { rawOptions }) {
     projectContext: projectContext,
     site: site,
     settingsFile: options.settings,
+    mongo: options.mongo,
     buildOptions: buildOptions,
     rawOptions,
     deployPollingTimeoutMs,

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -520,6 +520,10 @@ Options:
                   waiting for the deploy to conclude.
   --cache-build   Reuses the build already created if the git commit hash is the
                   same
+  --mongo         If this flag is true and it's not provided a mongo url in the settings
+                  ('galaxy.meteor.com'.env.MONGO_URL), when deploying, Galaxy will create
+                  a database to your app in its shared cluster and will insert the URL in
+                  your app's settings for you.
 
 >>> authorized
 View or change authorized users and organizations for a site.

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -617,7 +617,12 @@ export async function bundleAndDeploy(options) {
       method: 'POST',
       operation: 'deploy',
       site: site,
-      qs: Object.assign({}, options.rawOptions, settings !== null ? {settings: settings} : {}),
+      qs: Object.assign(
+        {},
+        options.rawOptions,
+        settings !== null ? {settings: settings} : {},
+        { mongo: options.mongo }
+      ),
       bodyStream: createTarGzStream(pathJoin(buildDir, 'bundle')),
       expectPayload: ['url'],
       preflightPassword: preflight.preflightPassword,


### PR DESCRIPTION
Adding a new flag that will allow Galaxy to create a database for apps, that do not have a MONGO_URL in their settings when deploying.