### PR TITLE
fix hmr: btoa unicode support

### DIFF
--- a/packages/hot-module-replacement/client.js
+++ b/packages/hot-module-replacement/client.js
@@ -179,8 +179,21 @@ function walkTree(pathParts, tree) {
   return walkTree(pathParts, _module);
 }
 
+// Save default browser functions
+const btoa = window.btoa
+const atob = window.atob
+
+// Replace with unicode support
+window.btoa = function utoa(data) {
+  return btoa(unescape(encodeURIComponent(data)));
+}
+
+window.atob = function atou(data) {
+  return decodeURIComponent(escape(atob(b64)));
+}
+
 function createInlineSourceMap(map) {
-  return "//# sourceMappingURL=data:application/json;base64," + btoa(JSON.stringify(map));
+  return "//# sourceMappingURL=data:application/json;base64," + window.btoa(JSON.stringify(map));
 }
 
 function createModuleContent (code, map) {

--- a/packages/hot-module-replacement/client.js
+++ b/packages/hot-module-replacement/client.js
@@ -179,21 +179,13 @@ function walkTree(pathParts, tree) {
   return walkTree(pathParts, _module);
 }
 
-// Save default browser functions
-const btoa = window.btoa
-const atob = window.atob
-
-// Replace with unicode support
-window.btoa = function utoa(data) {
+// btoa with unicode support
+function utoa(data) {
   return btoa(unescape(encodeURIComponent(data)));
 }
 
-window.atob = function atou(data) {
-  return decodeURIComponent(escape(atob(b64)));
-}
-
 function createInlineSourceMap(map) {
-  return "//# sourceMappingURL=data:application/json;base64," + window.btoa(JSON.stringify(map));
+  return "//# sourceMappingURL=data:application/json;base64," + utoa(JSON.stringify(map));
 }
 
 function createModuleContent (code, map) {


### PR DESCRIPTION
When module that need to replaced have unicode symbols hrm client package throws error:

<img width="1680" alt="Снимок экрана 2020-10-29 в 14 54 08" src="https://user-images.githubusercontent.com/3257268/97548671-9eff1380-19f9-11eb-8930-a91edce30039.png">

This break replacement and to see your changes you need to reload full page.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
