### PR TITLE
Review contributing docs and organizing labels

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 * ❓ Questions?
-          Use Stack Overflow (http://stackoverflow.com/questions/tagged/meteor), start a discussion on the Meteor forums (https://forums.meteor.com/) or post a message on (Community Slack)[https://join.slack.com/t/meteor-community/shared_invite/enQtODA0NTU2Nzk5MTA3LWY5NGMxMWRjZDgzYWMyMTEyYTQ3MTcwZmU2YjM5MTY3MjJkZjQ0NWRjOGZlYmIxZjFlYTA5Mjg4OTk3ODRiOTc]
+          Start a discussion on the Meteor forums (https://forums.meteor.com/) or post a message on (Community Slack)[https://join.slack.com/t/meteor-community/shared_invite/enQtODA0NTU2Nzk5MTA3LWY5NGMxMWRjZDgzYWMyMTEyYTQ3MTcwZmU2YjM5MTY3MjJkZjQ0NWRjOGZlYmIxZjFlYTA5Mjg4OTk3ODRiOTc]
 * 💡 Feature requests?
           Visit the feature request repository (https://github.com/meteor/meteor-feature-requests).
 * ❗️ Bug?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ isn't a security risk, please file a report in
 > will page the security team.
 
 A Meteor app has many moving parts, and it's often difficult to
-reproduce a bug based on just a few lines of code.  So your report
-should include a link to a repository with a reproduction.  By making it as easy as possible
+reproduce a bug based on just a few lines of code. So your report
+should include a link to a repository with a reproduction. By making it as easy as possible
 for others to reproduce your bug, you make it easier for your bug to be
 fixed. 
 
@@ -214,7 +214,7 @@ For more information about how to work with Meteor core, take a look at the [Dev
 
 ### Proposing your change
 
-You'll have the best chance of getting a change into core if you can build consensus in the community for it. Start by creating a well specified feature request as a Github issue, in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests) repository.
+You'll have the best chance of getting a change into core if you can build consensus in the community for it or if it is listed in the [roadmap](https://github.com/meteor/meteor/blob/devel/Roadmap.md). Start by creating a well specified feature request as a Github issue, in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests) repository.
 
 Help drive discussion and advocate for your feature on the Github ticket (and perhaps the forums). The higher the demand for the feature and the greater the clarity of it's specification will determine the likelihood of a core contributor prioritizing your feature by flagging it with the `pull-requests-encouraged` label.
 
@@ -229,7 +229,7 @@ Once you've come up with a good design, go ahead and submit a pull request (PR).
  * Sign the CLA (the bot will ask you do to this in the PR).
 
  * Base all your work off of the **devel** branch. The **devel** branch
-   is where active development happens.  **We do not merge pull requests
+   is where active development happens. **We do not merge pull requests
    directly into master.**
 
  * Name your branch to match the feature/bug fix that you are
@@ -243,12 +243,30 @@ Once you've come up with a good design, go ahead and submit a pull request (PR).
    [code contributions](DEVELOPMENT.md#code-style)
    and
    [commit messages](DEVELOPMENT.md#commit-messages)
+   
+ * Bump the version of the changed package accordingly
+    * If your changes are ok to be released without a whole new Meteor version bump just the patch, for example, 2.4.5 will become 2.4.6.
+    * If your changes need a new Meteor version because they are affecting many parts or they depend on changes in the meteor-tool bump the minor, for example, 2.4.5 will become 2.5.0.
+    * If your change is a major rewrite then bump the major, for example, 2.4.5 will become 3.0.0.
+    * If you bump anything that is not the patch you will need to wait a new Meteor version to have your changes available. This is how Meteor core packages work.
 
  * Be sure your author field in git is properly filled out with your full name
  and email address so we can credit you.
 
-### Need help with your pull request?
+ * You can submit PRs that are not ready yet, submit them as Draft on GitHub and explain what is left and also if you need help.
 
-If you need help with a pull request, you should start by asking questions in the issue which it pertains to.  If you feel that your pull request is almost ready or needs feedback which can only be demonstrated with code, go ahead and open a pull-request with as much progress as possible.  By including a "[Work in Progress]" note in the subject, project contributors will know you need help!
+#### Keeping PRs up-to-date
 
-Submitting a pull request is no guarantee it will be accepted, but contributors will do their best to help move your pull request toward release.
+We should add new labels when the stage is evolving. This is specially important on PRs.
+
+##### Stages
+_[Stage:Confirmed, Stage:In discussion, Stage:Ready, Stage:Needs reproduction, Stage:In development, Stage:Pending tests, Stage:Waiting feedback]_
+
+- `Confirmed`: We want to fix or implement it
+- `Ready`: We've decided how to solve or implement it
+- `In discussion`: We are still discussing how to solve or implement it
+- `Needs reproduction`: We can't reproduce so it's blocked
+- `In development`: We are already working on it
+- `Pending tests`: Tests are not passing, stuck or we need new tests
+- `Waiting feedback`: It's implemented but we need feedback that it is working as expected
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,19 +27,17 @@ Are you new here? Please check our issues `good-for-first-contribution`: [core](
 
 We curate specific issues that would make great pull requests for community contributors by applying the `pull-requests-encouraged` label ([bugs](https://github.com/meteor/meteor/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged) / [feature requests](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aopen+is%3Aissue+label%3Apull-requests-encouraged)).
 
-Issues which *also* have the `confirmed` label ([bugs](https://github.com/meteor/meteor/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) / [feature requests](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed)) are considered to have their details clear enough to begin working on.
+Issues which *also* have the `Stage:Confirmed` label ([bugs](https://github.com/meteor/meteor/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed) / [feature requests](https://github.com/meteor/meteor-feature-requests/issues?q=is%3Aissue%20is%3Aopen%20label%3Apull-requests-encouraged%20label%3Aconfirmed)) are considered to have their details clear enough to begin working on.
 
-Any issue which does not have the `confirmed` label still requires discussion on implementation details but input and positive commentary is welcome!  Any pull request opened on an issue which is not `confirmed` is still welcome, however the pull-request is more likely to be sent back for reworking than a `confirmed` issue.  If in doubt about the best way to implement something, please create additional conversation on the issue. You can also reach Filipe Névola (Meteor Developer Evangelist) and he will help you to find something interesting to work on.
-
-Please note that `pull-requests-encouraged` issues with low activity will often be closed without being implemented. These issues are tagged with an additional [`not-implemented`](https://github.com/meteor/meteor/issues?utf8=✓&q=label%3Apull-requests-encouraged+label%3Anot-implemented) label, and can still be considered good candidates to work on. If you're interested in working on a closed and `not-implemented` issue, please let us know by posting on that issue.
+Any issue which does not have the `Stage:Confirmed` label still requires discussion on implementation details but input and positive commentary is welcome!  Any pull request opened on an issue which is not `Stage:Confirmed` is still welcome, however the pull-request is more likely to be sent back for reworking than a `Stage:Confirmed` issue.  If in doubt about the best way to implement something, please create additional conversation on the issue. You can also reach Filipe Névola (Meteor Developer Evangelist, @FilipeNevola) and he will help you to find something interesting to work on.
 
 ### Project roles
 
-We’ve just begun to create more defined project roles for Meteor. Here are descriptions of the existing project roles, along with the current contributors taking on those roles today.
+Here are descriptions of the existing project roles, along with the current contributors taking on those roles today.
 
 #### Issue Triager
 
-Issue Triagers are members of the community that meet with us weekly to help triage Meteor’s open issues and bug reports. Once you’ve begun triaging issues regularly on your own, we will invite you to join our dedicated Slack channel to participate in these regular coordination sessions.
+Issue Triagers are members of the community that help every week with  Meteor’s open issues and bug reports.
 
 Current Issue Triagers:
 - [meteor](https://github.com/meteor/meteor)
@@ -56,37 +54,24 @@ Current Reviewers:
 - [meteor](https://github.com/meteor/meteor)
   - [@klaussner](https://github.com/klaussner)
   - [@zodern](https://github.com/zodern)
-  - [@benjamn](https://github.com/benjamn)
-  - [@abernix](https://github.com/abernix)
-  - [@hwillson](https://github.com/hwillson)
+  - [@StorytellerCZ](https://github.com/StorytellerCZ)
+  - [@sebakerckhof](https://github.com/sebakerckhof)
   - [@filipenevola](https://github.com/filipenevola)
+  - [@renanccastro](https://github.com/renanccastro)
 
 - [docs](https://github.com/meteor/docs) / [guide](https://github.com/meteor/guide)
   - [@lorensr](https://github.com/lorensr)
   - [@filipenevola](https://github.com/filipenevola)
+  - [@renanccastro](https://github.com/renanccastro)
 
 #### Core Committer
 
 The contributors with commit access to meteor/meteor are employees of Meteor Software Ltd or community members who have distinguished themselves in other contribution areas. If you want to become a core committer please start writing PRs.
 
 Current Core Committers:
-- [@benjamn](https://github.com/benjamn)
 - [@filipenevola](https://github.com/filipenevola)
-
-#### Documentation Maintainer
-
-Documentation Maintainers are regular documentation contributors that have been given the ability to merge docs changes on [meteor/docs](https://github.com/meteor/docs).
-
-Current Documentation Maintainers:
-- [@abernix](https://github.com/abernix)
-- [@lorensr](https://github.com/lorensr)
-
-#### Community Package Maintainer:
-
-Community package maintainers are community members who maintain packages outside of Meteor core. This requires code to be extracted from meteor/meteor, and entails a high level of responsibility. For this reason, community maintainers generally (and currently) must first become an advanced contributor to Meteor core and have 4-5 non-trivial pull requests merged that went through the proper contribution work-flow. At that point, core contributors may make the case for breaking out a particular core package, and assist in the technical process around doing so.
-
-Current Community Package Maintainers:
-- [@mitar](https://github.com/mitar) for [Blaze](https://github.com/meteor/blaze)
+- [@renanccastro](https://github.com/renanccastro)
+- [@denihs](https://github.com/denihs)
 
 #### Developer Evangelist
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -163,6 +163,13 @@ In a similar way to the method of specifying which tests TO run, there is a way 
 
 Simply remove the `--list` flag to actually run the matching tests.
 
+#### Avoiding retries
+
+On CI we want to retry the tests to avoid false failures but in development can take some time if you retry every time a test is failing. So to avoid retries use:
+
+    ./meteor self-test --retries 0
+
+
 #### More reading
 
 For even more details on how to run Meteor Tool "self tests", please refer to the [Testing section of the Meteor Tool README](https://github.com/meteor/meteor/blob/master/tools/README.md#testing).
@@ -183,7 +190,7 @@ Since Meteor is a free, open-source project, you can run tests in the context of
 
 To enable CircleCI for your development:
 
-1. Make sure you have an account with [CircleCI](https://circleci.com)
+0. Make sure you have an account with [CircleCI](https://circleci.com)
 0. Make sure you have [forked](https://help.github.com/articles/fork-a-repo/) [Meteor](https://github.com/meteor/meteor) into your own GitHub account.
 0. Go to the [Add Projects](https://circleci.com/add-projects) page on CircleCI.
 0. On the left, click on your GitHub username.
@@ -202,7 +209,7 @@ To enable CircleCI for your development:
 
 ## Commit messages
 
-Good commit messages are very important and you should make sure to explain what is changing and why.  The commit message should include:
+Good commit messages are very important and you should make sure to explain what is changing and why. The commit message should include:
 
 * A short and helpful commit title (maximum 80 characters).
 * A commit description which clearly explains the change if it's not super-obvious by the title.  Some description always helps!

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,6 +65,7 @@ When `meteor` is run from a checkout, a `dev_bundle` is automatically downloaded
 * Node.js version
 * npm version
 * MongoDB version
+* TypeScript version
 * Packages [used by `meteor-tool`](scripts/dev-bundle-tool-package.js)
 * Packages [used by the server bundle](scripts/dev-bundle-server-package.js)
 

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -13,7 +13,7 @@ We would love to have more contributors who are willing to help out with triagin
   - [Impact](#impact)
 - [Issues ready to claim](#issues-ready-to-claim)
 
-## Issue lifecycle
+## Lifecycle
 
 All issues follow the flow outlined below. Your job as an issue maintainer is to work with the requester and others within the community towards the goal of having an issue either become 'claimable' or closed. Read on for more details on the process.
 
@@ -21,55 +21,33 @@ All issues follow the flow outlined below. Your job as an issue maintainer is to
 
 The first step is in determining whether the issue is a bug, help question or feature request. Read on for more details.
 
-We have [Stale bot](https://github.com/probot/stale) watching this repository with these [settings](https://github.com/meteor/meteor/blob/devel/.github/stale.yml) and closing stale issues. Issues marked as `confirmed`, `pinned` or `security` are never considered stale.
+We have [Stale bot](https://github.com/probot/stale) watching this repository with these [settings](https://github.com/meteor/meteor/blob/devel/.github/stale.yml) and closing stale issues (40 days without activities). Issues marked as `Stage:Confirmed` or `pinned` are never considered stale.
 
 ### Bugs
 
 1. Duplicates should be closed and marked as such.
 2. Add the `bug` label and `Project:*` labels that apply (a best guess on the `Project:` is fine; sometimes it's hard to tell exactly which project the issue falls under).
 3. Bugs should have a high-quality reproduction as described [here](CONTRIBUTING.md#reporting-bug). You may need to help the reporter reduce their bug to a minimal reproduction. Leave the issue open.
-4. A reproduction should be confirmed by at least one person other than the original reporter. Run the reproduction and validate that the bug exists; then make a note of your findings on the issue. If a reproduction is supplied but doesn't work, add the `can't-reproduce` label and make a comment describing what happened.
-5. Finally, once you've confirmed the reproduction add the `confirmed` label and [classify](#classification) the issue (removing the `can't-reproduce` label if it exists).
-
-#### Bug issue lifespan
-
-To help keep issues in this repository under control, and make sure the most important problems are visible to maintainers, unresolved issues (lacking recent activity) should be closed after a certain amount of time has elapsed. 
-
-##### Issues labelled with `pull-requests-encouraged`
-
-- Open `pull-requests-encouraged` issues should be closed after one month of inactivity, unless someone has clearly identified that they are interested in working on the issue.
-- When closing, the `not-implemented` label should be added.
-- A message similar to the following should be included:
-
-> While we think resolving this issue would be a great addition to the Meteor project, we're going to close it for now due to inactivity. If anyone comes across this issue in the future, and is interested in working on resolving it, please let us know by posting here and we'll consider re-opening this issue. Thanks!
-
-##### Issues labelled with `bug` and `confirmed`
-
-- Open `bug` + `confirmed` issues should be closed after two months of inactivity, unless someone has clearly identified that they are interested in working on the issue.
-- Triagers should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. This means helping clearly identify where the problem is, pointing towards parts of the codebase that someone might want to look into, documenting what a potential solution looks like, etc.
-
-##### All other issues 
-
-- All open issues that can’t be labelled as `bug` + `confirmed` and/or `pull-requests-encouraged`, should be closed after one month of inactivity.
-- Triagers should do everything possible to help get `bug` + `confirmed` issues to `pull-requests-encouraged`. 
+4. A reproduction should be confirmed by at least one person other than the original reporter. Run the reproduction and validate that the bug exists; then make a note of your findings on the issue. If a reproduction is supplied but doesn't work, make a comment describing what happened.
+5. Finally, once you've confirmed the reproduction add the `Stage:Confirmed` label and [classify](#classification) the issue.
 
 ### Help questions
 
-[Stack Overflow](http://stackoverflow.com/questions/tagged/meteor) and our [forums](https://forums.meteor.com/c/help) are the place to ask for help on using the framework. Close issues that are help requests and politely refer the author to the above locations.
+Our [forums](https://forums.meteor.com/c/help) or Community Slack are the place to ask for help on using the framework. Close issues that are help requests and politely refer the author to the above locations.
 
 ### Feature requests
 
 1. For reasons described [here](CONTRIBUTING.md#feature-requests), we would prefer features to be built as separate packages. If the feature can clearly be built as a package, explain this to the requester and close the issue.
 > - If the feature could be built as a package and serves a particular need, encourage the user to contribute it themselves.
->- If the underlying issue could be better solved by existing technology, encourage them to seek help in the [forums](https://forums.meteor.com/c/help) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/meteor).
+>- If the underlying issue could be better solved by existing technology, encourage them to seek help in the [forums](https://forums.meteor.com/c/help).
 2. If you haven't closed the issue, add `Project:*` labels that apply (a best guess on the `Project:` is fine, sometimes it's hard to tell exactly which project the issue falls under).
 3. If it's not possible to build the feature as a package (as you identified in step 1), explore whether creating hooks in core would make it possible to do so. If it would, redefine the issue as a request to create those hooks.
 4. Work with the requester and others in the community to build a clear specification for the feature and update the issue description accordingly.
-5. Finally, add the `confirmed` label and [classify](#classification) the issue.
+5. Finally, add the `Stage:Confirmed` label and [classify](#classification) the issue.
 
 Core contributors may add the `pull-requests-encouraged` label to feature requests. This indicates the feature is aligned with the project roadmap and a high-quality pull request will almost certainly be merged.
 
-<h2 id="classification">Classification</h2>
+## Classification
 
 Assign a classification (via GH labels) that enables the community to determine how to prioritize which issues to work on. The classification is based on *Severity x Impact* .
 
@@ -89,10 +67,15 @@ This is a somewhat subjective label and is interpreted in conjunction with Githu
 - `Impact:some` issues would impact users using a feature that is commonly but not universally used.
 - `Impact:most` issues would impact more or less every user of the framework.
 
+### Is it ready?
+
+- If the desired fixed or solution is already clear add the label `Stage:Ready`.
+- If discussions are still necessary add the label `Stage:In discussion` and start the discussion.
+
 ## Issues ready to claim
 
 This state indicates that bugs/feature requests have reached the level of quality
-required for a contributor to begin writing code against (you can easily filter for [bugs](https://github.com/meteor/meteor/labels/confirmed) or [feature requests](https://github.com/meteor/meteor-feature-requests/labels/confirmed) that are ready to claim, by using the `confirmed` label).
+required for a contributor to begin writing code against (you can easily filter for [Ready](https://github.com/meteor/meteor/labels/Stage:Ready))
 
 Although this should have already been done by this stage, ensure the issue is
 correctly labeled and the title/description have been updated to reflect an

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Building an application with Meteor?
 
 * Deploy on Galaxy hosting: https://www.meteor.com/hosting
 * Announcement list: sign up at https://www.meteor.com/
-* Having problems? Ask for help at: https://stackoverflow.com/questions/tagged/meteor
 * Discussion forums: https://forums.meteor.com/
 * Join the Meteor community Slack by clicking this [invite link](https://join.slack.com/t/meteor-community/shared_invite/enQtODA0NTU2Nzk5MTA3LWY5NGMxMWRjZDgzYWMyMTEyYTQ3MTcwZmU2YjM5MTY3MjJkZjQ0NWRjOGZlYmIxZjFlYTA5Mjg4OTk3ODRiOTc).
  


### PR DESCRIPTION
The idea of this change is to update the contributing docs and also organize the labels in a way that we can see better the current stage of each PR.