### PR TITLE
Catch broken symlinks in isobuild #11241

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -491,7 +491,13 @@ export class NodeModulesDirectory {
         if (fileStatus && fileStatus.isSymbolicLink()) {
           // If node_modules/.bin/command is a symlink, determine the
           // answer by calling isWithinProdPackage(real).
-          return isWithinProdPackage(files.realpathOrNull(path));
+          // guard against broken symlinks (#11241)
+          const realpath = files.realpathOrNull(path);
+          if (realpath) {
+            return isWithinProdPackage(realpath);
+          } else {
+            throw new Error(`Broken symbolic link encountered at ${path}`);
+          }
         }
 
         // If node_modules/.bin/command is not a symlink, then it's hard

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -493,11 +493,10 @@ export class NodeModulesDirectory {
           // answer by calling isWithinProdPackage(real).
           // guard against broken symlinks (#11241)
           const realpath = files.realpathOrNull(path);
-          if (realpath) {
-            return isWithinProdPackage(realpath);
-          } else {
+          if (!realpath) {
             throw new Error(`Broken symbolic link encountered at ${path}`);
           }
+          return isWithinProdPackage(realpath);
         }
 
         // If node_modules/.bin/command is not a symlink, then it's hard


### PR DESCRIPTION
Change isWithinProdPackage() in isobuild/bundler.js to check for broken symlinks and throw a useful error. Fixes #11241.

