### PR TITLE
Revert "Allow cache keys to be shared between archs"

### DIFF
--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1260,10 +1260,9 @@ _.extend(PackageSource.prototype, {
 
     const baseCacheKey = JSON.stringify({
       isApp,
+      arch,
       sourceRoot: self.sourceRoot,
       excludes: anyLevelExcludes,
-      names: sourceReadOptions.names,
-      include: sourceReadOptions.include
     }, (key, value) => {
       if (_.isRegExp(value)) {
         return [value.source, value.flags];


### PR DESCRIPTION
This reverts commit e763d959 that was added in #10839. 

When investigating #11215 , a [git bisect](https://github.com/meteor/meteor/issues/11215#issuecomment-729273230) showed that this commit was responsible for the regression.

This commit is breaking the recompilation of npm modules for legacy browsers. This is important for us that support browsers like the old MS Edge.

This may not be the best way to resolve the issue, but just trying to give it some oxygen.