### PR TITLE
Don't use ecmascript features - fixes #11264

### DIFF
--- a/packages/dynamic-import/dynamic-versions.js
+++ b/packages/dynamic-import/dynamic-versions.js
@@ -70,7 +70,7 @@ function precacheOnLoad(event) {
     Promise.all(modules.splice(0, amount).map(function (id) {
       return new Promise(function (resolve, reject) {
         module.prefetch(id).then(resolve).catch(
-          (err) => {
+          function (err) {
             // we probably have a : _ mismatch
             // what can get wrong if we do the replacement
             // 1. a package with a name like a_b:package will not resolve


### PR DESCRIPTION
The problem as described in #11264 was that the new code used an arrow function which is incompatible with IE.

I have tested the fix locally by copying the entire package into my "packages" directory with meteor 1.12 and running our app with IE and then it worked fine.