### PR TITLE
Be able to provide extra info to Meteor Developer OAuth in the URL

### DIFF
--- a/packages/meteor-developer-oauth/meteor_developer_client.js
+++ b/packages/meteor-developer-oauth/meteor_developer_client.js
@@ -27,7 +27,7 @@ const requestCredential = (options, credentialRequestCompleteCallback) => {
         "/oauth2/authorize?" +
         `state=${OAuth._stateParam(loginStyle, credentialToken, options && options.redirectUrl)}` +
         "&response_type=code&" +
-        `client_id=${config.clientId}`;
+        `client_id=${config.clientId}${options && options.details ? `&details=${options && options.details}` : ''}`;
 
   /**
    * @deprecated in 1.3.0

--- a/packages/meteor-developer-oauth/package.js
+++ b/packages/meteor-developer-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Meteor developer accounts OAuth flow',
-  version: '1.2.1'
+  version: '1.2.2'
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
We need to have more control over what we send to our authentication system, so we are adding a new param for this.