### PR TITLE
Adds nodeModulesToRecompile to the cacheKey

### DIFF
--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1263,7 +1263,9 @@ _.extend(PackageSource.prototype, {
       sourceRoot: self.sourceRoot,
       excludes: anyLevelExcludes,
       names: sourceReadOptions.names,
-      include: sourceReadOptions.include
+      include: sourceReadOptions.include,
+      // stringify does not work on Set
+      nodeModulesToRecompile: [...nodeModulesToRecompile],
     }, (key, value) => {
       if (_.isRegExp(value)) {
         return [value.source, value.flags];


### PR DESCRIPTION
I'm proposing this solution, adding the nodeModulesToRecompile to the cache key as suggested by @zodern instead of this #11247 to solve the issue #11215