### PR TITLE
Fix issue #11320.  WindowsLikeFilesystem true when release string includes case insensitive word microsoft

### DIFF
--- a/tools/static-assets/server/mini-files.ts
+++ b/tools/static-assets/server/mini-files.ts
@@ -14,7 +14,7 @@ import { release, EOL } from "os";
 // (Windows Subsystem for Linux) even if it otherwise looks like we're on Unix.
 // https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364
 export function isWindowsLikeFilesystem() {
-  return process.platform === "win32" || release().toLowerCase().indexOf("microsoft") >= 0;
+  return process.platform === "win32" || release().toLowerCase().includes("microsoft");
 }
 
 export function toPosixPath(p: string, partialPath: boolean = false) {

--- a/tools/static-assets/server/mini-files.ts
+++ b/tools/static-assets/server/mini-files.ts
@@ -14,7 +14,7 @@ import { release, EOL } from "os";
 // (Windows Subsystem for Linux) even if it otherwise looks like we're on Unix.
 // https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364
 export function isWindowsLikeFilesystem() {
-  return process.platform === "win32" || release().indexOf("Microsoft") >= 0;
+  return process.platform === "win32" || release().toLowerCase().indexOf("microsoft") >= 0;
 }
 
 export function toPosixPath(p: string, partialPath: boolean = false) {


### PR DESCRIPTION
Simple fix for #11320.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
