### PR TITLE
Reorder code to fix absoluteFilePath on windows fixes #11312

### DIFF
--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -360,12 +360,12 @@ var loadServerBundles = Profile("Load server bundles", function () {
         // Unicode normalize the asset path to prevent string mismatches when
         // using this string elsewhere.
         assetPath = files.unicodeNormalizePath(assetPath);
+        assetPath = files.convertToStandardPath(assetPath);
 
         if (! fileInfo.assets || ! hasOwn.call(fileInfo.assets, assetPath)) {
           throw new Error("Unknown asset: " + assetPath);
         }
 
-        assetPath = files.convertToStandardPath(assetPath);
         var filePath = path.join(serverDir, fileInfo.assets[assetPath]);
         return files.convertToOSPath(filePath);
       },


### PR DESCRIPTION
This pull request will reorder the operations when attempting to get the absolute file path of an asset. I have reordered the operations in this pull request so we will convert the asset path before checking if it exists. Before when you passed a windows files path to `getAbsoluteFilePath` (e.g. getAbsoluteFilePath(`tests\test`)) the array that holds the assets would be storing the path with a linux like separator (e.g. `test/test`). Since the separator does not match, the asset was not found. The `convertToStandartPath` function takes care of this by changing the assetPath to use the proper separator. This function was being called after the existence check, which was too late causing the code to throw the error on line 365.

@filipenevola sorry about the delay for getting the pr up on this.

Closes #11312
