### PR TITLE
Browserstack tests should run only on browserstack-check branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1009,18 +1009,33 @@ workflows:
           requires:
             - Get Ready
       - Test Browserstack 1:
+          filters:
+            branches:
+              only: browserstack-check
           requires:
             - Get Ready
       - Test Browserstack 2:
+          filters:
+            branches:
+              only: browserstack-check
           requires:
             - Get Ready
       - Test Browserstack 3:
+          filters:
+            branches:
+              only: browserstack-check
           requires:
             - Get Ready
       - Test Browserstack 4:
+          filters:
+            branches:
+              only: browserstack-check
           requires:
             - Get Ready
       - Test Browserstack 5:
+          filters:
+            branches:
+              only: browserstack-check
           requires:
             - Get Ready
       - Clean Up:


### PR DESCRIPTION
These tests are flaky and also we are going to run them only before releases in a specific branch.

It's already covered in our release process to wait for these tests to pass before a final release.