### PR TITLE
Adding the HMR to Blaze skeleton

### DIFF
--- a/tools/static-assets/skel-blaze/.meteor/packages
+++ b/tools/static-assets/skel-blaze/.meteor/packages
@@ -21,3 +21,6 @@ shell-server            # Server-side component of the `meteor shell` command
 
 autopublish             # Publish all data to the clients (for prototyping)
 insecure                # Allow all DB writes from clients (for prototyping)
+
+hot-module-replacement  # Update code in development without reloading the page
+blaze-hot               # Update files using Blaze's API with HMR

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -561,6 +561,8 @@ const ROOT_PACKAGES_TO_BUILD_IN_SANDBOX = [
   'mobile-experience',
   'mongo',
   'blaze-html-templates',
+  'blaze-hot',
+  'hot-module-replacement',
   "jquery", // necessary when using Blaze
   'session',
   'tracker',


### PR DESCRIPTION
Now, our Blaze skeleton by default will have [HMR](https://github.com/meteor/blaze/pull/313).


