### PR TITLE
Adding HMR to the Svelte skeleton

### DIFF
--- a/tools/static-assets/skel-svelte/.meteor/packages
+++ b/tools/static-assets/skel-svelte/.meteor/packages
@@ -19,5 +19,6 @@ shell-server            # Server-side component of the `meteor shell` command
 autopublish             # Publish all data to the clients (for prototyping)
 insecure                # Allow all DB writes from clients (for prototyping)
 static-html             # Define static page content in .html files
-svelte:compiler         # Meteor package to allow us to create files with the .svelte extension
+zodern:melte            # Meteor package to allow us to create files with the .svelte extension
 rdb:svelte-meteor-data  # Meteor package which allows us to consume Meteor's reactive data sources inside of our Svelte components
+hot-module-replacement  # Update client in development without reloading the page

--- a/tools/static-assets/skel-svelte/imports/ui/App.svelte
+++ b/tools/static-assets/skel-svelte/imports/ui/App.svelte
@@ -14,7 +14,7 @@
 
   <h2>Learn Meteor!</h2>
   <ul>
-    <li><a href="https://www.meteor.com/tutorials/svelte/" target="_blank">Do the Tutorial</a></li>
+    <li><a href="https://svelte-tutorial.meteor.com/" target="_blank">Do the Tutorial</a></li>
     <li><a href="http://guide.meteor.com" target="_blank">Follow the Guide</a></li>
     <li><a href="https://docs.meteor.com" target="_blank">Read the Docs</a></li>
     <li><a href="https://forums.meteor.com" target="_blank">Discussions</a></li>


### PR DESCRIPTION
In the new version of the Svelte tutorial (https://svelte-tutorial.meteor.com/), we made it visualizing that the programmer just needs to run the command to create a new app with Svelte and this app already has the HMR package installed.