### PR TITLE
Update faye-websocket dependency

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,8 +1,8 @@
 ## v2.2.1, UNRELEASED
 
-### Fixes
+#### Independent Releases
 
-* Updated `ddp-server` and `socker-stream-client` dependencies which removes Node's HTTP deprecation warning.
+* Updated `ddp-server@2.3.3` and `socker-stream-client@0.3.2` dependencies which removes Node's HTTP deprecation warning.
 
 ## v2.2, 2021-04-15
 

--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@
 
 #### Independent Releases
 
-* Updated `ddp-server@2.3.3` and `socker-stream-client@0.3.2` dependencies which removes Node's HTTP deprecation warning.
+* Updated `ddp-server@2.3.3` and `socket-stream-client@0.3.2` dependencies which removes Node's HTTP deprecation warning.
 
 ## v2.2, 2021-04-15
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+## v2.2.1, UNRELEASED
+
+### Fixes
+
+* Updated `ddp-server` and `socker-stream-client` dependencies which removes Node's HTTP deprecation warning.
+
 ## v2.2, 2021-04-15
 
 #### Highlights

--- a/packages/ddp-server/.npm/package/npm-shrinkwrap.json
+++ b/packages/ddp-server/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,14 @@
   "lockfileVersion": 1,
   "dependencies": {
     "faye-websocket": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA=="
+    },
+    "http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg=="
     },
     "permessage-deflate": {
       "version": "0.1.7",
@@ -17,9 +22,9 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "sockjs": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
-      "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA=="
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+      "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw=="
     },
     "uuid": {
       "version": "3.4.0",
@@ -27,9 +32,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "websocket-driver": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg=="
     },
     "websocket-extensions": {
       "version": "0.1.4",

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '2.3.2',
+  version: '2.3.3',
   documentation: null
 });
 
 Npm.depends({
   "permessage-deflate": "0.1.7",
-  sockjs: "0.3.20"
+  sockjs: "0.3.21"
 });
 
 Package.onUse(function (api) {

--- a/packages/socket-stream-client/.npm/package/npm-shrinkwrap.json
+++ b/packages/socket-stream-client/.npm/package/npm-shrinkwrap.json
@@ -2,29 +2,34 @@
   "lockfileVersion": 1,
   "dependencies": {
     "faye-websocket": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA=="
     },
     "http-parser-js": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
-      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg=="
     },
     "permessage-deflate": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.6.tgz",
-      "integrity": "sha1-WB8c7fvUQPrEfQd3vohjM4a5kt4="
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.7.tgz",
+      "integrity": "sha512-EUNi/RIsyJ1P1u9QHFwMOUWMYetqlE22ZgGbad7YP856WF4BFF0B7DuNy6vEGsgNNud6c/SkdWzkne71hH8MjA=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg=="
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     }
   }
 }

--- a/packages/socket-stream-client/package.js
+++ b/packages/socket-stream-client/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: "socket-stream-client",
-  version: "0.3.1",
+  version: "0.3.2",
   summary: "Provides the ClientStream abstraction used by ddp-client",
   documentation: "README.md"
 });
 
 Npm.depends({
-  "faye-websocket": "0.11.1",
-  "permessage-deflate": "0.1.6"
+  "faye-websocket": "0.11.3",
+  "permessage-deflate": "0.1.7"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Update `faye-websocket` and related dependencies. This will remove Node's HTTP parser deprecation message.