### PR TITLE
Reordered fields in DDP method call.

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,8 @@
 
 * Updated `ddp-server@2.3.3` and `socket-stream-client@0.3.2` dependencies which removes Node's HTTP deprecation warning.
 
+* Released `ddp-client@2.4.1` re-ordering fields in DDP message for better client readability.
+
 ## v2.2, 2021-04-15
 
 #### Highlights

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -692,9 +692,9 @@ export class Connection {
     // wrote.
     const message = {
       msg: 'method',
+      id: methodId,
       method: name,
-      params: args,
-      id: methodId
+      params: args
     };
 
     // If an exception occurred in a stub, and we're ignoring it

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data client",
-  version: '2.4.0',
+  version: '2.4.1',
   documentation: null
 });
 


### PR DESCRIPTION
This PR implements my suggestion made in https://github.com/meteor/meteor-feature-requests/issues/427:

> While there's a couple of excellent tools to debug the DDP communication, I still tend to rely on the browser's _Network_ tab. In this case, I can't see the whole DDP messages but a short prefix instead. It's fine for all but one message: `method`.
> 
> For example, if I'd like to check whether a subscription is ready, the `id` of a subscription is the second key both in the `sub` and `ready` messages ([source](https://github.com/meteor/meteor/blob/46e00a875726dff078c59eaf7fdc7b956cf0a996/packages/ddp-client/common/livedata_connection.js#L1745-L1750), [source](https://github.com/meteor/meteor/blob/46e00a875726dff078c59eaf7fdc7b956cf0a996/packages/ddp-server/livedata_server.js#L330)). Similarly, [`added`](https://github.com/meteor/meteor/blob/46e00a875726dff078c59eaf7fdc7b956cf0a996/packages/ddp-server/livedata_server.js#L341)/[`changed`](https://github.com/meteor/meteor/blob/46e00a875726dff078c59eaf7fdc7b956cf0a996/packages/ddp-server/livedata_server.js#L350-L355)/[`removed`](https://github.com/meteor/meteor/blob/46e00a875726dff078c59eaf7fdc7b956cf0a996/packages/ddp-server/livedata_server.js#L362) maintain the order of `msg`, `collection`, `id` - the exact one we care about.
> 
> Now, let's get to methods. The `result` is fine ([source](https://github.com/meteor/meteor/blob/46e00a875726dff078c59eaf7fdc7b956cf0a996/packages/ddp-server/livedata_server.js#L732-L735), [source](https://github.com/meteor/meteor/blob/46e00a875726dff078c59eaf7fdc7b956cf0a996/packages/ddp-server/livedata_server.js#L669-L671)), but for some reason, `method` is not - [it sends the `id` last](https://github.com/meteor/meteor/blob/46e00a875726dff078c59eaf7fdc7b956cf0a996/packages/ddp-client/common/livedata_connection.js#L693-L698).
> 
> My proposal is to move the `id` sent in the `method` message to the second or third position:
> ```diff
>      const message = {
>        msg: 'method',
> +      id: methodId,
>        method: name,
> -      params: args,
> -      id: methodId
> +      params: args
>      };
> ```
