### PR TITLE
Reverse order of adding plugins/adding platforms on cordova build

### DIFF
--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -266,9 +266,9 @@ outdated platforms`);
     builder.writeConfigXmlAndCopyResources();
     builder.copyWWW(bundlePath);
 
-    this.ensurePlatformsAreSynchronized();
     this.ensurePluginsAreSynchronized(pluginVersions,
-      builder.pluginsConfiguration);
+        builder.pluginsConfiguration);
+    this.ensurePlatformsAreSynchronized();
 
     // Temporary workaround for Cordova iOS bug until
     // https://issues.apache.org/jira/browse/CB-10885 is fixed


### PR DESCRIPTION
Fix by first installing plugins, and then adding the Cordova platform android/ios, it will avoid errors due to plugins options declared in the config.xml.