### PR TITLE
Meteor Babel 7.11.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 ## v2.2.1, UNRELEASED
 
+* `meteor-babel` has been update to v7.11.0 and renamed to `@meteorjs/babel`. This update includes a fix for Samsung Internet v6.2+ to be considered modern browser and addition of [logical assingment operators](https://github.com/tc39/proposal-logical-assignment) via `babel-presets-meteor`. 
+
 #### Independent Releases
 
 * Updated `ddp-server@2.3.3` and `socket-stream-client@0.3.2` dependencies which removes Node's HTTP deprecation warning.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=12.22.1.2
+BUNDLE_VERSION=12.22.1.3
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/babel-compiler/README.md
+++ b/packages/babel-compiler/README.md
@@ -20,7 +20,7 @@ Meteor's Babel support consists of the following core packages:
 
 The `babel-compiler` package exports the `Babel` symbol, which exposes
 functionality provided by the
-[`meteor-babel`](https://www.npmjs.com/package/meteor-babel) NPM package,
+[`@meteorjs/babel`](https://www.npmjs.com/package/@meteorjs/babel) NPM package,
 which is in turn implmented using the
 [`babel-core`](https://www.npmjs.com/package/babel-core) NPM package.
 Note that you can only use the `babel-compiler` package on the server.

--- a/packages/babel-compiler/babel.js
+++ b/packages/babel-compiler/babel.js
@@ -1,6 +1,6 @@
 var meteorBabel = null;
 function getMeteorBabel() {
-  return meteorBabel || (meteorBabel = Npm.require("meteor-babel"));
+  return meteorBabel || (meteorBabel = Npm.require("@meteorjs/babel"));
 }
 
 /**
@@ -46,6 +46,6 @@ Babel = {
   },
 
   getMinimumModernBrowserVersions: function () {
-    return Npm.require("meteor-babel/modern-versions.js").get();
+    return Npm.require("@meteorjs/babel/modern-versions.js").get();
   }
 };

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,11 +6,11 @@ Package.describe({
   // isn't possible because you can't publish a non-recommended
   // release with package versions that don't have a pre-release
   // identifier at the end (eg, -dev)
-  version: '7.6.1'
+  version: '7.6.2'
 });
 
 Npm.depends({
-  'meteor-babel': '7.10.7',
+  '@meteorjs/babel': '7.10.7',
   'json5': '2.1.1'
 });
 

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -10,7 +10,7 @@ Package.describe({
 });
 
 Npm.depends({
-  '@meteorjs/babel': '7.10.7',
+  '@meteorjs/babel': '7.11.0',
   'json5': '2.1.1'
 });
 

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -15,7 +15,7 @@ var packageJson = {
     "node-gyp": "6.0.1",
     "node-pre-gyp": "0.14.0",
     typescript: "4.2.2",
-    "meteor-babel": "7.10.7",
+    "@meteorjs/babel": "7.11.0",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.8.7",

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -1236,7 +1236,7 @@ export function runJavaScript(code: string, {
       // node to run the code and parse its output. We instead run an
       // entirely different JS parser, from the Babel project, but
       // which at least has a nice API for reporting errors.
-      const { parse } = require('meteor-babel');
+      const { parse } = require('@meteorjs/babel');
       try {
         parse(wrapped, { strictMode: false });
       } catch (parseError) {

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -363,7 +363,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       return;
     }
 
-    const babel = require("meteor-babel");
+    const babel = require("@meteorjs/babel");
     const commonBabelOptions = babel.getDefaultOptions({
       nodeMajorVersion: parseInt(process.versions.node),
       typescript: true

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -1,4 +1,4 @@
-import { parse } from 'meteor-babel';
+import { parse } from '@meteorjs/babel';
 import { analyze as analyzeScope } from 'escope';
 import LRU from "lru-cache";
 

--- a/tools/tool-env/install-babel.js
+++ b/tools/tool-env/install-babel.js
@@ -18,7 +18,7 @@ function babelRegister() {
   // meteor/tools modules.
   babelOptions.sourceMaps = "inline";
 
-  require('meteor-babel/register')
+  require('@meteorjs/babel/register')
     .setCacheDirectory(cacheDir)
     .setSourceMapRootPath(meteorPath)
     .allowDirectory(toolsPath)

--- a/tools/tool-env/install-babel.js
+++ b/tools/tool-env/install-babel.js
@@ -4,7 +4,7 @@
 "use strict";
 
 function babelRegister() {
-  const meteorBabel = require("meteor-babel");
+  const meteorBabel = require("@meteorjs/babel");
   const path = require("path");
   const toolsPath = path.dirname(__dirname);
   const meteorPath = path.dirname(toolsPath);

--- a/tools/tool-env/source-map-retriever-stack.js
+++ b/tools/tool-env/source-map-retriever-stack.js
@@ -75,5 +75,5 @@ Error.METEOR_prepareStackTrace = Error.prepareStackTrace;
 push(sourceMapSupport.retrieveSourceMap);
 
 /* eslint-disable max-len */
-push(require('meteor-babel/register').retrieveSourceMap); // #RemoveInProd this line is removed in isopack.js
+push(require('@meteorjs/babel/register').retrieveSourceMap); // #RemoveInProd this line is removed in isopack.js
 /* eslint-enable max-len */


### PR DESCRIPTION
`meteor-babel` has been update to v7.11.0 and renamed to `@meteorjs/babel`. This update includes a fix for Samsung Internet v6.2+ to be considered modern browser and addition of [logical assingment operators](https://github.com/tc39/proposal-logical-assignment) via `babel-presets-meteor`.