### PR TITLE
Replace lolex with @sinonjs/fake-timers

### DIFF
--- a/packages/ddp-client/.npm/package/npm-shrinkwrap.json
+++ b/packages/ddp-client/.npm/package/npm-shrinkwrap.json
@@ -1,10 +1,20 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "lolex": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ=="
+    },
+    "@sinonjs/fake-timers": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.0.5.tgz",
+      "integrity": "sha512-fUt6b15bjV/VW93UP5opNXJxdwZSbK1EdiwnhN7XrQrcpaOhMJpZ/CjwFpM3THpxwA+YviBUJKSuEqKlCK5alw=="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     }
   }
 }

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -5,7 +5,7 @@ Package.describe({
 });
 
 Npm.depends({
-  lolex: '2.3.2'
+  '@sinonjs/fake-timers': '7.0.5'
 });
 
 Package.onUse((api) => {

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -1,4 +1,4 @@
-import lolex from 'lolex';
+import FakeTimers from '@sinonjs/fake-timers';
 import { DDP } from '../common/namespace.js';
 import { Connection } from '../common/livedata_connection.js';
 
@@ -114,7 +114,7 @@ Tinytest.add('livedata stub - receive data', function(test) {
 Tinytest.add('livedata stub - buffering data', function(test) {
   // Install special setTimeout that allows tick-by-tick control in tests using sinonjs 'lolex'
   // This needs to be before the connection is instantiated.
-  const clock = lolex.install();
+  const clock = FakeTimers.install();
   const tick = timeout => clock.tick(timeout);
 
   const stream = new StubStream();


### PR DESCRIPTION
lolex is deprecated.
![Screenshot_2021-05-11_12-24-01](https://user-images.githubusercontent.com/6644545/117800789-cf025b80-b253-11eb-80ea-2a1239b16fb8.png)
