### PR TITLE
Fix react-fast-refresh for IE11

### DIFF
--- a/packages/react-fast-refresh/client-runtime.js
+++ b/packages/react-fast-refresh/client-runtime.js
@@ -6,7 +6,7 @@ if (enabled && process.env.NODE_ENV !== 'production' && module.hot) {
   let timeout = null;
   function scheduleRefresh() {
     if (!timeout) {
-      timeout = setTimeout(() => {
+      timeout = setTimeout(function() {
         timeout = null;
         runtime.performReactRefresh();
       }, 0);
@@ -69,11 +69,13 @@ if (enabled && process.env.NODE_ENV !== 'production' && module.hot) {
 
   runtime.injectIntoGlobalHook(window);
 
-  window.$RefreshReg$ = () => { };
-  window.$RefreshSig$ = () => type => type;
+  window.$RefreshReg$ = function() { };
+  window.$RefreshSig$ = function() {
+    return function(type) { return type; };
+  };
 
   module.hot.onRequire({
-    before(module) {
+    before: function(module) {
       if (module.loaded) {
         // The module was already executed
         return;
@@ -83,18 +85,18 @@ if (enabled && process.env.NODE_ENV !== 'production' && module.hot) {
       var prevRefreshSig = window.$RefreshSig$;
 
       window.RefreshRuntime = runtime;
-      window.$RefreshReg$ = (type, _id) => {
+      window.$RefreshReg$ = function(type, _id) {
         const fullId = module.id + ' ' + _id;
         RefreshRuntime.register(type, fullId);
       }
       window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
 
       return {
-        prevRefreshReg,
-        prevRefreshSig
+        prevRefreshReg: prevRefreshReg,
+        prevRefreshSig: prevRefreshSig
       };
     },
-    after(module, beforeData) {
+    after: function(module, beforeData) {
       // TODO: handle modules with errors
       if (!beforeData) {
         return;

--- a/packages/react-fast-refresh/package.js
+++ b/packages/react-fast-refresh/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'react-fast-refresh',
-  version: '0.1.0',
+  version: '0.1.1',
   summary: 'Automatically update React components with HMR',
   documentation: 'README.md',
   devOnly: true


### PR DESCRIPTION
Fix #11418 by replacing arrow functions in `react-fast-refresh` by traditional anonymous functions.

A side note: shouldn't we move `react-fast-refresh` to react-pacakages repo?