### PR TITLE
Update TypeScript to 4.2.4

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=12.22.1.3
+BUNDLE_VERSION=12.22.1.5
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.15.1',
+  version: '0.15.2',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/typescript/package.js
+++ b/packages/typescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "typescript",
-  version: "4.2.2",
+  version: "4.2.4",
   summary: "Compiler plugin that compiles TypeScript and ECMAScript in .ts and .tsx files",
   documentation: "README.md"
 });

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,7 +14,7 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "6.0.1",
     "node-pre-gyp": "0.14.0",
-    typescript: "4.2.2",
+    typescript: "4.2.4",
     "@meteorjs/babel": "7.11.0",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.


### PR DESCRIPTION
The version of @meteorjs/babel was already updated in https://github.com/meteor/meteor/pull/11411

TS version in @meteorjs/babel also was updated in https://github.com/meteor/babel/commit/f23cb8dd5e44b6e84efc455e53504556532d6635