### PR TITLE
Add platforms options to meteor build:

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1017,7 +1017,7 @@ var buildCommand = function (options) {
 
   let selectedPlatforms;
   if (options.platforms) {
-    const platformsArray = options.platforms.trim().split(/\s*,\s*/);
+    const platformsArray = options.platforms.split(",");
 
     platformsArray.forEach((plat) => {
       if (!excludableWebArchs.concat(['android', 'ios']).includes(plat)) {

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -425,6 +425,8 @@ Options:
                       downgraded to versions that are potentially incompatible
                       with the current versions, if required to satisfy all
                       package version constraints.
+  --platforms         Builds only the specified platforms (when available).
+
 
 
 >>> lint


### PR DESCRIPTION
This commit adds the "--platforms" flag to meteor build command. This allows the user to specify which platforms he want to build. For example, if we pass only android to it, we will build only android and web.cordova.

I think this is pretty useful when we want to build a specific mobile app. For example, I want to build only for android and not for iOS (but I may still build for iOS on another time, so removing and adding the platform is more work to do).

Usage example: `meteor build . --platforms=android`.

Note: if no platforms flag is used, it will do the build like it always did. 

Related to issue #63 (https://github.com/meteor/meteor-feature-requests/issues/63)

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
