### PR TITLE
Update server-render npm dependies

### DIFF
--- a/packages/server-render/package.js
+++ b/packages/server-render/package.js
@@ -7,9 +7,9 @@ Package.describe({
 
 Npm.depends({
   "combined-stream2": "1.1.2",
-  "magic-string": "0.21.3",
-  "stream-to-string": "1.1.0",
-  "parse5": "3.0.2"
+  "magic-string": "0.25.7",
+  "stream-to-string": "1.2.0",
+  "parse5": "4.0.0"
 });
 
 Package.onUse(function(api) {

--- a/packages/server-render/server-register.js
+++ b/packages/server-render/server-register.js
@@ -2,7 +2,7 @@ import { WebAppInternals } from "meteor/webapp";
 import MagicString from "magic-string";
 import { SAXParser } from "parse5";
 import { create as createStream } from "combined-stream2";
-import { ServerSink, isReadable } from "./server-sink.js";
+import { ServerSink } from "./server-sink.js";
 import { onPageLoad } from "./server.js";
 
 WebAppInternals.registerBoilerplateDataCallback(
@@ -62,7 +62,7 @@ WebAppInternals.registerBoilerplateDataCallback(
               const end = magic.slice(lastStart);
               stream.append(Buffer.from(end, "utf8"));
             }
-          })
+          });
 
           data[property] = stream;
         }


### PR DESCRIPTION
Update server-render npm dependencies and small cleaning of the code. Supposedly this should help a bit with performance (when it comes to `magic-string` dependency: https://github.com/Rich-Harris/magic-string/blob/master/CHANGELOG.md).
