### PR TITLE
refactor: lazy import for markdown package

### DIFF
--- a/packages/deprecated/markdown/README.md
+++ b/packages/deprecated/markdown/README.md
@@ -1,5 +1,7 @@
 # markdown
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/markdown) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/markdown)
+[Source code of released version](https://github.com/jirikrepl/meteor/tree/master/packages/deprecated/markdown) | [Source code of development version](https://github.com/jirikrepl/meteor/tree/devel/packages/deprecated/markdown)
 ***
 
-This is an internal Meteor package.
+This is an internal Meteor package. 
+
+[How to use it at Meteor Docs](https://docs.meteor.com/packages/markdown.html)

--- a/packages/deprecated/markdown/README.md
+++ b/packages/deprecated/markdown/README.md
@@ -1,5 +1,5 @@
 # markdown
-[Source code of released version](https://github.com/jirikrepl/meteor/tree/master/packages/deprecated/markdown) | [Source code of development version](https://github.com/jirikrepl/meteor/tree/devel/packages/deprecated/markdown)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/markdown) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/markdown)
 ***
 
 This is an internal Meteor package. 

--- a/packages/deprecated/markdown/package.js
+++ b/packages/deprecated/markdown/package.js
@@ -6,11 +6,9 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.addFiles("showdown.js");
-  api.export('Showdown');
-
+  api.use('ecmascript');
   api.use("templating@1.3.1", "client", {weak: true});
-  api.addFiles('template-integration.js', 'client');
+  api.mainModule('template-integration.js', 'client', { lazy: true });
 });
 
 Package.onTest(function (api) {

--- a/packages/deprecated/markdown/package.js
+++ b/packages/deprecated/markdown/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use('ecmascript');
-  api.use("templating@1.3.1", "client", {weak: true});
+  api.use("templating@1.4.0", "client", {weak: true});
   api.mainModule('template-integration.js', 'client', { lazy: true });
 });
 

--- a/packages/deprecated/markdown/showdown.js
+++ b/packages/deprecated/markdown/showdown.js
@@ -65,7 +65,7 @@
 // Showdown namespace
 //
 // METEOR CHANGE: remove "var" so that this isn't file-local.
-Showdown = { extensions: {} };
+export const Showdown = { extensions: {} };
 
 //
 // forEach
@@ -121,7 +121,7 @@ var g_output_modifiers = [];
 if (typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefined') {
 	var fs = require('fs');
 
-	if (fs) {
+	if (fs && fs.readdirSync) {
 		// Search extensions folder
 		var extensions = fs.readdirSync((__dirname || '.')+'/extensions').filter(function(file){
 			return ~file.indexOf('.js');

--- a/packages/deprecated/markdown/template-integration.js
+++ b/packages/deprecated/markdown/template-integration.js
@@ -1,3 +1,5 @@
+import { Showdown } from './showdown';
+
 if (Package.templating) {
   var Template = Package.templating.Template;
   var Blaze = Package.blaze.Blaze; // implied by `templating`


### PR DESCRIPTION
this is breaking change but it saves 9kb in the initial bundle

markdown pacakge is using lazy imports and will not be added to the initial bundle.

to use `{{#markdown}}...{{/markdown}}` import it first with:

`import 'meteor/markdown';`

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor-feature-requests/issues
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
