### PR TITLE
UNIX_SOCKET_PERMISSIONS sets permissions on UNIX_SOCKET_FILE

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { readFileSync } from "fs";
+import { chmodSync } from "fs";
 import { createServer } from "http";
 import {
   join as pathJoin,
@@ -1190,6 +1191,18 @@ function runWebAppServer() {
       // Start the HTTP server using a socket file.
       removeExistingSocketFile(unixSocketPath);
       startHttpServer({ path: unixSocketPath });
+
+      let unixSocketPermissions = process.env.UNIX_SOCKET_PERMISSIONS;
+      if (unixSocketPermissions) {
+        unixSocketPermissions = unixSocketPermissions.trim();
+
+        if (/^[0-7]{3}$/.test(unixSocketPermissions)) {
+          chmodSync(unixSocketPath, parseInt(unixSocketPermissions,8));
+        } else {
+          throw new Error("Invalid UNIX_SOCKET_PERMISSIONS specified");
+        }
+      }
+
       registerSocketFileCleanup(unixSocketPath);
     } else {
       localPort = isNaN(Number(localPort)) ? localPort : Number(localPort);

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -1,6 +1,8 @@
 import assert from "assert";
-import { readFileSync } from "fs";
-import { chmodSync } from "fs";
+import {
+  readFileSync,
+  chmodSync
+} from "fs";
 import { createServer } from "http";
 import {
   join as pathJoin,


### PR DESCRIPTION
UNIX_SOCKET_PERMISSIONS takes an octal value. If an invalid value is specified, an exception is generated.

e.g. when the following env variables are set:

```
UNIX_SOCKET_FILE=/tmp/meteor.sock
UNIX_SOCKET_PERMISSIONS=660
```

After the Meteor app is started, the socket file `/tmp/meteor.sock` is created and will be given user & group read-write permissions.

When the Meteor app is running:

`ls -l /tmp/meteor.sock`

displays something like

`srw-rw---- 1 meteor meteor 0 May 24 09:25 /tmp/meteor.sock`

For us, the use case is to allow the Meteor app to run under a different user id to the Nginx web server. Instead, Nginx is made a member of the Meteor app's group and can now be given group permission to write to the Meteor app's socket file.