### PR TITLE
add hook to allow custom user selection in Accounts.updateOrCreateUserFromExternalService

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -190,11 +190,11 @@ export class AccountsServer extends AccountsCommon {
    * @param {Function} func Called whenever a user is logged in via oauth and a
    * user is not found with the service id. Return the user or undefined. 
    */
-  selectCustomUserOnExternalLogin(func) {
-    if (this._selectCustomUserOnExternalLogin) {
-      throw new Error("Can only call selectCustomUserOnExternalLogin once");
+   setAdditionalFindUserOnExternalLogin(func) {
+    if (this._setAdditionalFindUserOnExternalLogin) {
+      throw new Error("Can only call setAdditionalFindUserOnExternalLogin once");
     }
-    this._selectCustomUserOnExternalLogin = func;
+    this._setAdditionalFindUserOnExternalLogin = func;
   }
 
   _validateLogin(connection, attempt) {
@@ -1271,8 +1271,8 @@ export class AccountsServer extends AccountsCommon {
 
     // Check to see if the developer has a custom way to find the user outside
     // of the general selectors above.
-    if (!user && this._selectCustomUserOnExternalLogin) {
-      user = this._selectCustomUserOnExternalLogin(serviceName, serviceData, options)
+    if (!user && this._setAdditionalFindUserOnExternalLogin) {
+      user = this._setAdditionalFindUserOnExternalLogin({serviceName, serviceData, options})
     }
 
     // Before continuing, run user hook to see if we should continue

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -670,14 +670,14 @@ Tinytest.add(
 );
 
 Tinytest.add(
-  'accounts - verify selectCustomUserOnExternalLogin hook can provide user',
+  'accounts - verify setAdditionalFindUserOnExternalLogin hook can provide user',
   test => {
       // create test user, without a google service
       const testEmail = "test@testdomain.com"
       const uid0 = Accounts.createUser({email: testEmail})
       
       // Verify that user is found from email and service merged
-      Accounts.selectCustomUserOnExternalLogin((serviceName, serviceData) => {
+      Accounts.setAdditionalFindUserOnExternalLogin(({serviceName, serviceData}) => {
         if (serviceName === "google") {
           return Accounts.findUserByEmail(serviceData.email)
         }

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -669,6 +669,38 @@ Tinytest.add(
     }
 );
 
+Tinytest.add(
+  'accounts - verify selectCustomUserOnExternalLogin hook can provide user',
+  test => {
+      // create test user, without a google service
+      const testEmail = "test@testdomain.com"
+      const uid0 = Accounts.createUser({email: testEmail})
+      
+      // Verify that user is found from email and service merged
+      Accounts.selectCustomUserOnExternalLogin((serviceName, serviceData) => {
+        if (serviceName === "google") {
+          return Accounts.findUserByEmail(serviceData.email)
+        }
+      })
+      
+      let googleId = Random.id();
+      const uid1 = Accounts.updateOrCreateUserFromExternalService(
+          'google',
+          { id: googleId, email: "oter@test.com"}, //testEmail },
+          { profile: { foo: 1 } },
+      ).userId;
+
+      test.Equal(uid0, uid1)
+
+      // Cleanup
+      if (uid1 !== uid0) {
+        Meteor.users.remove(uid0)
+      }
+      Meteor.users.remove(uid1);
+      Accounts.selectCustomUserOnExternalLogin = null;
+  }
+);
+
 if(Meteor.isServer) {
   Tinytest.add(
     'accounts - make sure that extra params to accounts urls are added',

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -686,11 +686,11 @@ Tinytest.add(
       let googleId = Random.id();
       const uid1 = Accounts.updateOrCreateUserFromExternalService(
           'google',
-          { id: googleId, email: "oter@test.com"}, //testEmail },
+          { id: googleId, email: testEmail },
           { profile: { foo: 1 } },
       ).userId;
 
-      test.Equal(uid0, uid1)
+      test.equal(uid0, uid1)
 
       // Cleanup
       if (uid1 !== uid0) {


### PR DESCRIPTION

## The problem
When using an external service, there are times when a developer wants to merge the account instead of creating a new user. Various packages and workarounds have been created and suggested to handle this:
* [merge-accounts](https://atmospherejs.com/rkstar/accounts-merge) - Creates two users and decides which to use. Old package.
* [delete user in `Accounts.createUser` hook, and return identical user to be created](https://forums.meteor.com/t/accounts-password-merge-with-accounts-google-2017-way/35590) - Has bad side effect of an error being thrown in the `insertUserDoc` and now no user exists.

## This solution
Provide another login hook, `selectCustomUserOnExternalLogin`, that takes a callback to allow the developer to decide how to determine if a user exists based on the `serviceData` provided by the external service.

### API
```javascript
Accounts.selectCustomUserOnExternalLogin(callback)
```
##### Arguments
Callback: function, Called with same arguments passed to `Accounts.updateOrCreateUserFromExternalService`: `serviceName`, `serviceData`, `options`.
##### Return
Should return the custom user, or undefined if no user found.

### Example
```javascript
Accounts.selectCustomUserOnExternalLogin((serviceName, serviceData) => {
  if (serviceName === "google") {
    return Accounts.findUserByEmail(serviceData.email)
  }
})
```

Or, developer could throw error ...
```javascript
Accounts.selectCustomUserOnExternalLogin((serviceName, serviceData) => {
  if (serviceName === "google") {
    const user = Accounts.findUserByEmail(serviceData.email)
    if (!user) throw new Error("The email is not registered")
    return user
  }
})
```

I think this PR fits the two main design requirements:
* It doesn't harm the experience of a new Meteor developer. The hook doesn't change any existing functionality, so there is nothing more required of new Meteor developers.
* It doesn't preclude an expert from doing what they want. In fact, it let's experts do more.