### PR TITLE
Update babel runtime and skelets

### DIFF
--- a/History.md
+++ b/History.md
@@ -14,8 +14,22 @@
 
 * `meteor-tool@2.3.1`
   - Node.js updated to 14.17.2
+  - `@babel/runtime` dependency updated to v7.14.6 across the tool and testing apps
+  - Skeletons dependencies updated
+  - Apollo skeleton removed `apollo-boost` dependency which is no longer needed
 
 #### Independent Releases
+
+* `less@3.0.2`
+  - Updated `@babel/runtime` to v7.14.6
+  - Updated `less` to v3.11.3
+  
+* `standard-minifiers-css@1.7.3`
+  - Updated `@babel/runtime` to v7.14.6
+
+* `standard-minifiers-js@2.6.1`
+  - Updated `@babel/runtime` to v7.14.6
+  
 
 ## v2.3, 2021-06-24
 

--- a/History.md
+++ b/History.md
@@ -21,6 +21,9 @@
 
 #### Independent Releases
 
+* `webapp@1.11.1`
+  - Remove `posix` from npm shrinkwrap, to fix a bug it causes on Windows.
+
 * `less@3.0.2`
   - Updated `@babel/runtime` to v7.14.6
   - Updated `less` to v3.11.3

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.17.1.1
+BUNDLE_VERSION=14.17.1.3
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/non-core/less/.npm/plugin/compileLessBatch/npm-shrinkwrap.json
+++ b/packages/non-core/less/.npm/plugin/compileLessBatch/npm-shrinkwrap.json
@@ -2,14 +2,14 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q=="
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg=="
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw=="
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="
     },
     "asap": {
       "version": "2.0.6",
@@ -37,9 +37,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -82,9 +82,9 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk="
     },
     "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A=="
     },
     "extend": {
       "version": "3.0.2",
@@ -97,9 +97,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -122,9 +122,9 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -132,9 +132,9 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g=="
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -182,9 +182,14 @@
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI="
     },
     "less": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/less/-/less-3.11.1.tgz",
-      "integrity": "sha512-tlWX341RECuTOvoDIvtFqXsKj072hm3+9ymRBe76/mD6O5ZZecnlAOVDlWAleF2+aohFrxNidXhv2773f6kY7g=="
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.11.3.tgz",
+      "integrity": "sha512-VkZiTDdtNEzXA3LgjQiC3D7/ejleBPFVvq+aRI9mIj+Zhmif5TvFPM244bT4rzkvOCvJ9q4zAztok1M7Nygagw=="
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA=="
     },
     "mime": {
       "version": "1.6.0",
@@ -192,24 +197,14 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ=="
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "mkdirp": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw=="
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -220,6 +215,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "promise": {
       "version": "7.3.1",
@@ -247,9 +247,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "request": {
       "version": "2.88.2",
@@ -257,14 +257,19 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw=="
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -282,9 +287,9 @@
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g=="
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -297,9 +302,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="
     },
     "uuid": {
       "version": "3.4.0",

--- a/packages/non-core/less/package.js
+++ b/packages/non-core/less/package.js
@@ -9,7 +9,7 @@ Package.registerBuildPlugin({
   name: "compileLessBatch",
   use: [
     "caching-compiler@1.2.2",
-    "ecmascript@0.15.2",
+    "ecmascript@0.15.1",
   ],
   sources: [
     'plugin/compile-less.js'

--- a/packages/non-core/less/package.js
+++ b/packages/non-core/less/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'less',
-  version: '3.0.1',
+  version: '3.0.2',
   summary: 'Leaner CSS language',
   documentation: 'README.md'
 });
@@ -9,14 +9,14 @@ Package.registerBuildPlugin({
   name: "compileLessBatch",
   use: [
     "caching-compiler@1.2.2",
-    "ecmascript@0.14.3",
+    "ecmascript@0.15.2",
   ],
   sources: [
     'plugin/compile-less.js'
   ],
   npmDependencies: {
     "@babel/runtime": "7.14.6",
-    "less": "3.11.1"
+    "less": "3.11.3"
   }
 });
 

--- a/packages/non-core/less/package.js
+++ b/packages/non-core/less/package.js
@@ -15,7 +15,7 @@ Package.registerBuildPlugin({
     'plugin/compile-less.js'
   ],
   npmDependencies: {
-    "@babel/runtime": "7.9.2",
+    "@babel/runtime": "7.14.6",
     "less": "3.11.1"
   }
 });

--- a/packages/standard-minifier-css/.npm/plugin/minifyStdCSS/npm-shrinkwrap.json
+++ b/packages/standard-minifier-css/.npm/plugin/minifyStdCSS/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw=="
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.7.2',
+  version: '1.7.3',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });
@@ -22,6 +22,6 @@ Package.registerBuildPlugin({
 });
 
 Package.onUse(function(api) {
-  api.use('minifier-css@1.5.3');
+  api.use('minifier-css@1.5.4');
   api.use('isobuild:minifier-plugin@1.0.0');
 });

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -12,7 +12,7 @@ Package.registerBuildPlugin({
     'ecmascript'
   ],
   npmDependencies: {
-    "@babel/runtime": "7.11.2",
+    "@babel/runtime": "7.14.6",
     "source-map": "0.7.3",
     "lru-cache": "6.0.0"
   },

--- a/packages/standard-minifier-js/.npm/plugin/minifyStdJS/npm-shrinkwrap.json
+++ b/packages/standard-minifier-js/.npm/plugin/minifyStdJS/npm-shrinkwrap.json
@@ -2,14 +2,14 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-      "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw=="
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg=="
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     }
   }
 }

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '2.6.0',
+  version: '2.6.1',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md',
 });

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -13,7 +13,7 @@ Package.registerBuildPlugin({
     'ecmascript'
   ],
   npmDependencies: {
-    "@babel/runtime": "7.7.4"
+    "@babel/runtime": "7.14.6"
   },
   sources: [
     'plugin/minify-js.js',

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -22,7 +22,7 @@ var packageJson = {
     fibers: "5.0.0",
     reify: "0.20.12",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
-    "@babel/runtime": "7.14.0",
+    "@babel/runtime": "7.14.6",
     // For backwards compatibility with isopackets that still depend on
     // babel-runtime rather than @babel/runtime.
     "babel-runtime": "7.0.0-beta.3",

--- a/tools/static-assets/skel-apollo/imports/ui/Info.jsx
+++ b/tools/static-assets/skel-apollo/imports/ui/Info.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useQuery } from '@apollo/client';
-import { gql } from 'apollo-boost';
+import { useQuery, gql } from '@apollo/client';
 
 const GET_LINKS = gql`
     {

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -8,14 +8,13 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@apollo/client": "^3.3.19",
-    "@babel/runtime": "^7.14.0",
-    "apollo-boost": "^0.4.9",
-    "apollo-server-express": "^2.24.1",
-    "graphql": "^15.5.0",
+    "@apollo/client": "^3.3.20",
+    "@babel/runtime": "^7.14.6",
+    "apollo-server-express": "^2.25.2",
+    "graphql": "^15.5.1",
     "meteor-node-stubs": "^1.0.3",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "meteor": {
     "mainModule": {

--- a/tools/static-assets/skel-bare/package.json
+++ b/tools/static-assets/skel-bare/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "@babel/runtime": "^7.14.0",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3"
   }
 }

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.14.0",
+    "@babel/runtime": "^7.14.6",
     "jquery": "^3.6.0",
     "meteor-node-stubs": "^1.0.3"
   },

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -6,7 +6,7 @@
     "test": "meteor test --once --driver-package meteortesting:mocha"
   },
   "dependencies": {
-    "@babel/runtime": "^7.14.0",
+    "@babel/runtime": "^7.14.6",
     "jquery": "^3.6.0",
     "meteor-node-stubs": "^1.0.3"
   },

--- a/tools/static-assets/skel-minimal/package.json
+++ b/tools/static-assets/skel-minimal/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.14.0",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3"
   },
   "meteor": {

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.14.0",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.14.0",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3",
     "svelte": "^3.38.2"
   },

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.14.0",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.14.0",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3",
     "vue": "^2.6.12",
     "vue-meteor-tracker": "^2.0.0-beta.5"

--- a/tools/tests/apps/app-config/package.json
+++ b/tools/tests/apps/app-config/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3",
     "puppeteer": "^2.1.1"
   },

--- a/tools/tests/apps/app-prints-pid/package.json
+++ b/tools/tests/apps/app-prints-pid/package.json
@@ -2,8 +2,8 @@
   "name": "app-prints-pid",
   "private": true,
   "dependencies": {
-    "@babel/runtime": "^7.5.0",
-    "meteor-node-stubs": "^1.0.1"
+    "@babel/runtime": "^7.14.6",
+    "meteor-node-stubs": "^1.0.3"
   },
   "meteor": {
     "mainModule": {

--- a/tools/tests/apps/client-refresh/package.json
+++ b/tools/tests/apps/client-refresh/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3"
   },
   "meteor": {

--- a/tools/tests/apps/css-injection-test/package.json
+++ b/tools/tests/apps/css-injection-test/package.json
@@ -8,9 +8,9 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.3.4",
+    "@babel/runtime": "^7.14.6",
     "jquery": "^3.5.1",
-    "meteor-node-stubs": "^0.4.1"
+    "meteor-node-stubs": "^1.0.3"
   },
   "meteor": {
     "mainModule": "css-injection-test.js"

--- a/tools/tests/apps/custom-minifier/package.json
+++ b/tools/tests/apps/custom-minifier/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "jquery": "^3.6.0",
     "meteor-node-stubs": "^1.0.3"
   },

--- a/tools/tests/apps/dev-bundle-bin-commands/package.json
+++ b/tools/tests/apps/dev-bundle-bin-commands/package.json
@@ -7,7 +7,7 @@
     "exit-normally": "echo \"This script will exit normally\" && exit 0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.5.0",
-    "meteor-node-stubs": "^1.0.1"
+    "@babel/runtime": "^7.14.6",
+    "meteor-node-stubs": "^1.0.3"
   }
 }

--- a/tools/tests/apps/dynamic-import/package.json
+++ b/tools/tests/apps/dynamic-import/package.json
@@ -6,7 +6,7 @@
     "test": "TEST_BROWSER_DRIVER=puppeteer meteor test --full-app --driver-package meteortesting:mocha"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "acorn": "^7.4.1",
     "arson": "^0.2.6",
     "jquery": "^3.6.0",

--- a/tools/tests/apps/git-commit-hash/package.json
+++ b/tools/tests/apps/git-commit-hash/package.json
@@ -6,7 +6,7 @@
     "test": "TEST_BROWSER_DRIVER=puppeteer meteor test --once --full-app --driver-package meteortesting:mocha"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3",
     "puppeteer": "^2.1.1"
   },

--- a/tools/tests/apps/link-config-npm-package/package.json
+++ b/tools/tests/apps/link-config-npm-package/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "config": "file:../config-package",
     "meteor-node-stubs": "^1.0.3"
   },

--- a/tools/tests/apps/linked-external-npm-package/package.json
+++ b/tools/tests/apps/linked-external-npm-package/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "external-package": "file:../external-package",
     "meteor-node-stubs": "^1.0.3"
   },

--- a/tools/tests/apps/meteor-ignore/package.json
+++ b/tools/tests/apps/meteor-ignore/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3"
   }
 }

--- a/tools/tests/apps/modules/package.json
+++ b/tools/tests/apps/modules/package.json
@@ -4,9 +4,9 @@
   "description": "Test app exercising many aspects of the Meteor module system.",
   "private": true,
   "dependencies": {
-    "@babel/core": "^7.8.4",
+    "@babel/core": "^7.14.6",
     "@babel/plugin-proposal-do-expressions": "^7.8.3",
-    "@babel/runtime": "^7.8.4",
+    "@babel/runtime": "^7.14.6",
     "@polymer/lit-element": "0.7.1",
     "@wry/context": "^0.4.0",
     "acorn": "file:imports/links/acorn",

--- a/tools/tests/apps/package-tests/package.json
+++ b/tools/tests/apps/package-tests/package.json
@@ -5,6 +5,6 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17"
+    "@babel/runtime": "^7.14.6"
   }
 }

--- a/tools/tests/apps/shell/package.json
+++ b/tools/tests/apps/shell/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3"
   }
 }

--- a/tools/tests/apps/standard-app/package.json
+++ b/tools/tests/apps/standard-app/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.17",
+    "@babel/runtime": "^7.14.6",
     "meteor-node-stubs": "^1.0.3"
   },
   "meteor": {


### PR DESCRIPTION
* Updates babel runtime across the code base to use the same version.
* Update skeleton dependencies to be consistent (same React version, etc.).
* In Apollo skelet removed `apollo-boost` which is no longer needed.