### PR TITLE
Add note about fail

### DIFF
--- a/packages/tinytest/README.md
+++ b/packages/tinytest/README.md
@@ -317,6 +317,24 @@ Call this to fail the test with an exception that occurs inside asynchronous cal
 - the test doesn't call its callback (onComplete function).
 - the test function doesn't directly raise an exception.
 
+### fail
+
+`test.fail(doc);`
+
+Can be used to output a detailed message about a failure with path and value.
+
+Example call:
+```js
+test.fail({
+          type: 'match-error-path',
+          message: "The path of Match.Error doesn't match.",
+          pattern: JSON.stringify(pattern),
+          value: JSON.stringify(value),
+          path: err.path,
+          expectedPath,
+        });
+```        
+
 #### expect_fail
 
 `test.expect_fail();`


### PR DESCRIPTION
Was reading into [`check`](https://github.com/meteor/meteor/blob/devel/packages/check/match_test.js#L347) package and wanted to know more about [`fail`](https://github.com/meteor/meteor/blob/devel/packages/tinytest/tinytest.js#L35) method but there wasn't any notes about it so I added one. 