### PR TITLE
Remove underscore from routepolicy

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,9 @@
 
 * `minifier-js@2.6.1`
   - Terser updated to [4.8.0](https://github.com/terser/terser/blob/master/CHANGELOG.md#v480)
+    
+* `routepolicy@1.1.1`
+  - Removed `underscore` dependency since it was not used in the package
   
 ## v2.3.2, 2021-07-13
 

--- a/packages/routepolicy/package.js
+++ b/packages/routepolicy/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "route policy declarations",
-  version: '1.1.0'
+  version: '1.1.1'
 });
 
 Package.onUse(function (api) {
-  api.use(['underscore', 'ecmascript'], 'server');
+  api.use('ecmascript', 'server');
   // Resolve circular dependency with webapp. We can only use WebApp via
   // Package.webapp and only after initial load.
   api.use('webapp', 'server', {unordered: true});


### PR DESCRIPTION
I have noticed that underscore was not used in `routepolicy` package so I have removed it from the dependencies.