### PR TITLE
Add note about legacy bundle

### DIFF
--- a/tools/isobuild/package-api.js
+++ b/tools/isobuild/package-api.js
@@ -309,8 +309,12 @@ export class PackageAPI {
    * @param {String|String[]} filenames Paths to the source files.
    * @param {String|String[]} [architecture] If you only want to use the file
    * on the server (or the client), you can pass this argument
-   * (e.g., 'server', 'client', 'web.browser', 'web.cordova') to specify
-   * what architecture the file is used with. You can specify multiple
+   * (e.g., 'server', 'legacy', 'client', 'web.browser', 'web.cordova') to specify
+   * what architecture the file is used with. You can call api.addFiles(files, "legacy")
+   * in your package.js configuration file to add extra files to the legacy bundle,
+   * or api.addFiles(files, "client") to add files to all client bundles,
+   * or api.addFiles(files, "web.browser") to add files only to the modern bundle.
+   * You can specify multiple
    * architectures by passing in an array, for example
    * `['web.cordova', 'os.linux']`. By default, the file will be loaded on both
    * server and client.


### PR DESCRIPTION
In [v1.7, 2018-05-28](https://docs.meteor.com/changelog.html#changes-24) there's a mentioning of `legacy` option that can be passed to `addFiles` but the official docs has no records of it.

>For the most part, the modern/legacy system will transparently determine how your code is compiled, bundled, and delivered—and yes, it works with every existing part of Meteor, including dynamic import() and even the old appcache package. However, if you're writing dynamic code that depends on modern features, you can use the boolean Meteor.isModern flag to detect the status of the current environment (Node 8 is modern, too, of course). If you're writing a Meteor package, you can call api.addFiles(files, "legacy") in your package.js configuration file to add extra files to the legacy bundle, or api.addFiles(files, "client") to add files to all client bundles, or api.addFiles(files, "web.browser") to add files only to the modern bundle, and the same rules apply to api.mainModule. Just be sure to call setMinimumBrowserVersions (in server startup code) to enforce your assumptions about ECMAScript feature support.