### PR TITLE
[Release-2.4] fix updated flag to be true for all hook subscribers

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -382,10 +382,10 @@ function getBoilerplateAsync(request, arch) {
       encodedCurrentConfig: boilerplate.baseData.meteorRuntimeConfig,
       updated: runtimeConfig.isUpdatedByArch[arch]
     });
-    runtimeConfig.isUpdatedByArch[arch] = false;
     if(!meteorRuntimeConfig) return;
     boilerplate.baseData = Object.assign({}, boilerplate.baseData, {meteorRuntimeConfig});
   });
+  runtimeConfig.isUpdatedByArch[arch] = false;
   const data = Object.assign({}, boilerplate.baseData, {
     htmlAttributes: getHtmlAttributes(request),
   }, _.pick(request, "dynamicHead", "dynamicBody"));


### PR DESCRIPTION
This fixes an issue in #11506 where the `WebApp.addRuntimeConfigHook` callback receives an `update` flag.

The `update` flag was only ever `true` for the first subscriber to the hook.

To fix the issue, I moved the reset of the updated flag out of the hook callback loop.
