### PR TITLE
Use double-ended-deque directly now that npm issue resolved

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.17.3.2
+BUNDLE_VERSION=14.17.3.3
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/packages/meteor/.npm/package/npm-shrinkwrap.json
+++ b/packages/meteor/.npm/package/npm-shrinkwrap.json
@@ -1,17 +1,10 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "meteor-deque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/meteor-deque/-/meteor-deque-2.1.0.tgz",
-      "integrity": "sha1-VZCvQksH7d1gJuIGzHquVnRHBDk=",
-      "dependencies": {
-        "double-ended-queue": {
-          "version": "2.1.0-0",
-          "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-          "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
-        }
-      }
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     }
   }
 }

--- a/packages/meteor/fiber_helpers.js
+++ b/packages/meteor/fiber_helpers.js
@@ -13,7 +13,7 @@ Meteor._noYieldsAllowed = function (f) {
   }
 };
 
-Meteor._DoubleEndedQueue = Npm.require('meteor-deque');
+Meteor._DoubleEndedQueue = Npm.require('double-ended-queue');
 
 // Meteor._SynchronousQueue is a queue which runs task functions serially.
 // Tasks are assumed to be synchronous: ie, it's assumed that they are

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.9.3'
+  version: '1.10.0-beta240.1'
 });
 
 Package.registerBuildPlugin({
@@ -11,7 +11,7 @@ Package.registerBuildPlugin({
 });
 
 Npm.depends({
-  "meteor-deque": "2.1.0"
+  "double-ended-queue": "2.1.0-0"
 });
 
 Package.onUse(function (api) {
@@ -40,7 +40,7 @@ Package.onUse(function (api) {
   api.addFiles('debug.js', ['client', 'server']);
   api.addFiles('string_utils.js', ['client', 'server']);
   api.addFiles('test_environment.js', ['client', 'server']);
-  
+
   // dynamic variables, bindEnvironment
   // XXX move into a separate package?
   api.addFiles('dynamics_browser.js', 'client');

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -85,7 +85,7 @@ OplogHandle = function (oplogUrl, dbName) {
   self._startTailing();
 };
 
-_.extend(OplogHandle.prototype, {
+Object.assign(OplogHandle.prototype, {
   stop: function () {
     var self = this;
     if (self._stopped)


### PR DESCRIPTION
The original issue for which we have used our own `meteor-deque` npm package has been long resolved:
https://github.com/npm/read-installed/issues/40

So I have moved to used the target package directly.