### PR TITLE
Logging v1.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -17,9 +17,10 @@
     - `postcss@8.3.5`
     - `cssnano@4.1.11`
   
-* `logging@2.0.0`
+* `logging@1.3.0`
   - Switch from `cli-color` to `chalk` to have the same dependency as meteor-tool
   - Fix detecting eval
+  - Copy over code from `Meteor._debug` to `Log.debug` which will be deprecated in the future
 
 #### Independent Releases
 

--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
   - `meteor show` now reports if a package is deprecated
   - `reify` update to v0.22.0 which bring optimizations for imports, [read more](https://github.com/benjamn/reify/pull/246)
   - Apollo skeleton now uses [Apollo server v3](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v300) - [migration guide](https://www.apollographql.com/docs/apollo-server/migration/)
+  - Upgraded `chalk` to v4.1.1
     
 * `webapp@1.12`
   - npm dependencies have been updated
@@ -15,6 +16,10 @@
   - Updated dependencies
     - `postcss@8.3.5`
     - `cssnano@4.1.11`
+  
+* `logging@2.0.0`
+  - Switch from `cli-color` to `chalk` to have the same dependency as meteor-tool
+  - Fix detecting eval
 
 #### Independent Releases
 

--- a/packages/logging/.npm/package/npm-shrinkwrap.json
+++ b/packages/logging/.npm/package/npm-shrinkwrap.json
@@ -1,87 +1,35 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="
     },
-    "cli-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.0.tgz",
-      "integrity": "sha512-a0VZ8LeraW0jTuCkuAGMNufareGHhyZU9z8OGsW0gXd1hZGi1SRuNRXdbGkraBBKnhyUhyebFWnRbp+dIn0f0A=="
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg=="
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA=="
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="
     },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q=="
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c="
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA=="
-    },
-    "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA=="
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk="
-    },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dependencies": {
-        "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
-        }
-      }
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
-    },
-    "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM="
-    },
-    "memoizee": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
-      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg=="
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-    },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ=="
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="
     }
   }
 }

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -2,4 +2,4 @@
 [Source code of released version](https://github.com/meteor/meteor/tree/master/packages/logging) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/logging)
 ***
 
-This is an internal Meteor package.
+Read more about this package in the [documentation](https://docs.meteor.com/packages/logging.html).

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -100,16 +100,14 @@ Log._getCallerDetails = () => {
 
   const stack = getStack();
 
-  if (!stack) {
-    return {};
-  }
+  if (!stack) return {};
 
   // looking for the first line outside the logging package (or an
   // eval if we find that first)
   let line;
   const lines = stack.split('\n').slice(1);
   for (line of lines) {
-    if (line.match(/^\s*at eval \(eval/)) {
+    if (line.match(/^\s*(at eval \(eval)|(eval:)/)) {
       return {file: "eval"};
     }
 
@@ -303,7 +301,7 @@ Log.format = (obj, options = {}) => {
 
   const prettify = function (line, color) {
     return (options.color && Meteor.isServer && color) ?
-      require('cli-color')[color](line) : line;
+      require('chalk')[color](line) : line;
   };
 
   return prettify(metaPrefix, platformColor(options.metaColor || META_COLOR)) +

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -80,10 +80,18 @@ const logInBrowser = obj => {
   if ((typeof console !== 'undefined') && console[level]) {
     console[level](str);
   } else {
-    // XXX Uses of Meteor._debug should probably be replaced by Log.debug or
-    //     Log.info, and we should have another name for "do your best to
-    //     call call console.log".
-    Meteor._debug(str);
+    // IE doesn't have console.log.apply, it's not a real Object.
+    // http://stackoverflow.com/questions/5538972/console-log-apply-not-working-in-ie9
+    // http://patik.com/blog/complete-cross-browser-console-log/
+    if (typeof console.log.apply === "function") {
+      // Most browsers
+      console.log.apply(console, [str]);
+
+    } else if (typeof Function.prototype.bind === "function") {
+      // IE9
+      const log = Function.prototype.bind.call(console.log, console);
+      log.apply(console, [str]);
+    }
   }
 };
 

--- a/packages/logging/package.js
+++ b/packages/logging/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: 'Logging facility.',
-  version: '1.2.0'
+  version: '2.0.0'
 });
 
 Npm.depends({
-  'cli-color': '2.0.0'
+  'chalk': '4.1.1'
 });
 
 Npm.strip({

--- a/packages/logging/package.js
+++ b/packages/logging/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Logging facility.',
-  version: '2.0.0'
+  version: '1.3.0-beta240.1'
 });
 
 Npm.depends({

--- a/packages/meteor/debug.js
+++ b/packages/meteor/debug.js
@@ -46,9 +46,6 @@ Meteor._debug = function (/* arguments */) {
         // IE9
         var log = Function.prototype.bind.call(console.log, console);
         log.apply(console, arguments);
-      } else {
-        // IE8
-        Function.prototype.call.call(console.log, console, Array.prototype.slice.call(arguments));
       }
     }
   }

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -41,7 +41,7 @@ var packageJson = {
     // TODO: We should replace this with: https://github.com/jprichardson/node-kexec/pull/38
     kexec: "https://github.com/meteor/node-kexec/tarball/f29f54037c7db6ad29e1781463b182e5929215a0",
     "source-map": "0.7.3",
-    chalk: "0.5.1",
+    chalk: "4.1.1",
     sqlite3: "5.0.2",
     "http-proxy": "1.18.1",
     "is-reachable": "3.1.0",

--- a/tools/console/console.js
+++ b/tools/console/console.js
@@ -58,7 +58,6 @@
 import { createInterface } from "readline";
 import { format as utilFormat }  from "util";
 import { getRootProgress } from "../utils/buildmessage.js";
-// XXX: Are we happy with chalk (and its sub-dependencies)?
 import chalk from "chalk";
 import { onExit as cleanupOnExit } from "../tool-env/cleanup.js";
 import wordwrap from "wordwrap";

--- a/tools/cordova/run-targets.js
+++ b/tools/cordova/run-targets.js
@@ -1,9 +1,7 @@
-import _ from 'underscore';
 import chalk from 'chalk';
 import child_process from 'child_process';
 
 import { loadIsopackage } from '../tool-env/isopackets.js';
-import runLog from '../runners/run-log.js';
 import { Console } from '../console/console.js';
 import files from '../fs/files';
 import { execFileSync, execFileAsync } from '../utils/processes';


### PR DESCRIPTION
The next version of Meteor logging.

### Changes
- [x] Docs for v1
- [x] Use `chalk` as meteor-tool uses it as well.
- [ ] Customizable colors for messages levels
- [ ] Hook to send report to third-party
- [ ] Update docs for v2
- [x] Move code from `Meteor._debug` into the package
- [ ] Replace the usage of `Meteor._debug`
- [ ] Deprecate `Meteor._debug`, but leave it still available as some packages use it

### Additional ideas
- [ ] Logging levels (add `Log.systemDebug`) that would allow to set in development up to what granularity dev wants to see logs.