### PR TITLE
createIndex for collections

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,9 @@
 * `meteor-tool@2.4`
   - `meteor show` now reports if a package is deprecated
 
+* `mongo@1.13.0`
+  - Add `createIndex` as a collection function. This is a new name for `_ensureIndex` which MongoDB has deprecated and removed in MongoDB 5.0. Use of `_ensureIndex` will show a deprecation warning on development.
+
 #### Independent Releases
 
 * `minifier-js@2.6.1`
@@ -19,9 +22,6 @@
 * `callback-hook@1.3.1`
   - Modernized the code
   - Fixed a variable assignment bug in `dontBindEnvironment` function
-  
-* `mongo@1.12.1`
-  - Add `_createIndex` as a collection function. This is a new name for `_ensureIndex` which MongoDB has deprecated and removed in MongoDB 5.0.
   
 ## v2.3.2, 2021-07-13
 

--- a/History.md
+++ b/History.md
@@ -6,7 +6,7 @@
   - `meteor show` now reports if a package is deprecated
 
 * `mongo@1.13.0`
-  - Add `createIndex` as a collection function. This is a new name for `_ensureIndex` which MongoDB has deprecated and removed in MongoDB 5.0. Use of `_ensureIndex` will show a deprecation warning on development.
+  - Add `createIndex` as a collection function (in MongoDB since MongoDB v3). This is a new name for `_ensureIndex` which MongoDB has deprecated and removed in MongoDB 5.0. Use of `_ensureIndex` will show a deprecation warning on development.
 
 #### Independent Releases
 

--- a/History.md
+++ b/History.md
@@ -16,6 +16,9 @@
 * `email@2.1.1`
   - Updated `nodemailer` to v6.6.3
   
+* `mongo@1.12.1`
+  - Add `_createIndex` as a collection function. This is a new name for `_ensureIndex` which MongoDB has deprecated and removed in MongoDB 5.0.
+  
 ## v2.3.2, 2021-07-13
 
 #### Meteor Version Release

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1596,18 +1596,18 @@ const setupUsersCollection = users => {
   });
 
   /// DEFAULT INDEXES ON USERS
-  users._ensureIndex('username', { unique: true, sparse: true });
-  users._ensureIndex('emails.address', { unique: true, sparse: true });
-  users._ensureIndex('services.resume.loginTokens.hashedToken',
+  users.createIndex('username', { unique: true, sparse: true });
+  users.createIndex('emails.address', { unique: true, sparse: true });
+  users.createIndex('services.resume.loginTokens.hashedToken',
     { unique: true, sparse: true });
-  users._ensureIndex('services.resume.loginTokens.token',
+  users.createIndex('services.resume.loginTokens.token',
     { unique: true, sparse: true });
   // For taking care of logoutOtherClients calls that crashed before the
   // tokens were deleted.
-  users._ensureIndex('services.resume.haveLoginTokensToDelete',
+  users.createIndex('services.resume.haveLoginTokensToDelete',
     { sparse: true });
   // For expiring login tokens
-  users._ensureIndex("services.resume.loginTokens.when", { sparse: true });
+  users.createIndex("services.resume.loginTokens.when", { sparse: true });
   // For expiring password tokens
-  users._ensureIndex('services.password.reset.when', { sparse: true });
+  users.createIndex('services.password.reset.when', { sparse: true });
 };

--- a/packages/accounts-oauth/oauth_common.js
+++ b/packages/accounts-oauth/oauth_common.js
@@ -15,7 +15,7 @@ Accounts.oauth.registerService = name => {
     // so this should be a unique index. You might want to add indexes for other
     // fields returned by your service (eg services.github.login) but you can do
     // that in your app.
-    Meteor.users._ensureIndex(`services.${name}.id`, {unique: true, sparse: true});
+    Meteor.users.createIndex(`services.${name}.id`, {unique: true, sparse: true});
   }
 };
 

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -526,7 +526,7 @@ Accounts.generateResetToken = (userId, email, reason, extraTokenData) => {
 
   if (extraTokenData) {
     Object.assign(tokenRecord, extraTokenData);
-  } 
+  }
   // if this method is called from the enroll account work-flow then
   // store the token record in 'services.password.enroll' db field
   // else store the token record in in 'services.password.reset' db field
@@ -722,7 +722,7 @@ Meteor.methods({resetPassword: function (...args) {
           emails: 1,
         }}
       );
-     
+
       let isEnroll = false;
       // if token is in services.password.reset db field implies
       // this method is was not called from enroll account workflow
@@ -760,7 +760,7 @@ Meteor.methods({resetPassword: function (...args) {
           error: new Meteor.Error(403, "Token has invalid email address")
         };
 
-      const hashed = hashPassword(newPassword);     
+      const hashed = hashPassword(newPassword);
 
       // NOTE: We're about to invalidate tokens on the user, who we might be
       // logged in as. Make sure to avoid logging ourselves out if this
@@ -1158,9 +1158,9 @@ Accounts.createUser = (options, callback) => {
 ///
 /// PASSWORD-SPECIFIC INDEXES ON USERS
 ///
-Meteor.users._ensureIndex('services.email.verificationTokens.token',
+Meteor.users.createIndex('services.email.verificationTokens.token',
                           { unique: true, sparse: true });
-Meteor.users._ensureIndex('services.password.reset.token',
+Meteor.users.createIndex('services.password.reset.token',
                           { unique: true, sparse: true });
-Meteor.users._ensureIndex('services.password.enroll.token',
+Meteor.users.createIndex('services.password.enroll.token',
                           { unique: true, sparse: true });

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -674,7 +674,7 @@ Object.assign(Mongo.Collection.prototype, {
     if (self._collection.createIndex) {
       import { Log } from 'meteor/logging';
 
-      Log.debug(`_ensureIndex has been deprecated, please use the new 'createIndex' instead, index name: ${options.name}`)
+      Log.debug(`_ensureIndex has been deprecated, please use the new 'createIndex' instead, index name: ${options?.name}`)
       self._collection.createIndex(index, options);
     } else {
       self._collection._ensureIndex(index, options);

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -671,14 +671,21 @@ Object.assign(Mongo.Collection.prototype, {
     var self = this;
     if (!self._collection._ensureIndex)
       throw new Error("Can only call _ensureIndex on server collections");
-    self._collection._ensureIndex(index, options);
+    if (self._collection.createIndex) {
+      import { Log } from 'logging';
+
+      Log.debug('_ensureIndex has been deprecated, please use the new `createIndex` instead')
+      self._collection.createIndex(index, options);
+    } else {
+      self._collection._ensureIndex(index, options);
+    }
   },
 
-  _createIndex(index, options) {
+  createIndex(index, options) {
     var self = this;
-    if (!self._collection._createIndex)
-      throw new Error("Can only call _createIndex on server collections");
-    self._collection._createIndex(index, options);
+    if (!self._collection.createIndex)
+      throw new Error("Can only call createIndex on server collections");
+    self._collection.createIndex(index, options);
   },
 
   _dropIndex(index) {

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -674,6 +674,13 @@ Object.assign(Mongo.Collection.prototype, {
     self._collection._ensureIndex(index, options);
   },
 
+  _createIndex(index, options) {
+    var self = this;
+    if (!self._collection._createIndex)
+      throw new Error("Can only call _createIndex on server collections");
+    self._collection._createIndex(index, options);
+  },
+
   _dropIndex(index) {
     var self = this;
     if (!self._collection._dropIndex)

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -672,15 +672,27 @@ Object.assign(Mongo.Collection.prototype, {
     if (!self._collection._ensureIndex)
       throw new Error("Can only call _ensureIndex on server collections");
     if (self._collection.createIndex) {
-      import { Log } from 'logging';
+      import { Log } from 'meteor/logging';
 
-      Log.debug('_ensureIndex has been deprecated, please use the new `createIndex` instead')
+      Log.debug(`_ensureIndex has been deprecated, please use the new 'createIndex' instead, index name: ${options.name}`)
       self._collection.createIndex(index, options);
     } else {
       self._collection._ensureIndex(index, options);
     }
   },
 
+  /**
+   * @summary Creates the specified index on the collection.
+   * @locus server
+   * @method createIndex
+   * @memberof Mongo.Collection
+   * @instance
+   * @param {Object} index A document that contains the field and value pairs where the field is the index key and the value describes the type of index for that field. For an ascending index on a field, specify a value of `1`; for descending index, specify a value of `-1`. Use `text` for text indexes.
+   * @param {Object} [options] All options are listed in [MongoDB documentation](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#std-label-ensureIndex-options)
+   * @param {String} options.name Name of the index
+   * @param {Boolean} options.unique Define that the index values must be unique, more at [MongoDB documentation](https://docs.mongodb.com/manual/core/index-unique/)
+   * @param {Boolean} options.sparse Define that the index is sparse, more at [MongoDB documentation](https://docs.mongodb.com/manual/core/index-sparse/)
+   */
   createIndex(index, options) {
     var self = this;
     if (!self._collection.createIndex)

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -829,7 +829,7 @@ MongoConnection.prototype.findOne = function (collection_name, selector,
 
 // We'll actually design an index API later. For now, we just pass through to
 // Mongo's, but make it synchronous.
-MongoConnection.prototype._ensureIndex = function (collectionName, index,
+MongoConnection.prototype._createIndex = function (collectionName, index,
                                                    options) {
   var self = this;
 
@@ -840,6 +840,9 @@ MongoConnection.prototype._ensureIndex = function (collectionName, index,
   var indexName = collection.ensureIndex(index, options, future.resolver());
   future.wait();
 };
+
+MongoCollection.prototype._ensureIndex = MongoConnection.prototype._createIndex;
+
 MongoConnection.prototype._dropIndex = function (collectionName, index) {
   var self = this;
 

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -829,7 +829,7 @@ MongoConnection.prototype.findOne = function (collection_name, selector,
 
 // We'll actually design an index API later. For now, we just pass through to
 // Mongo's, but make it synchronous.
-MongoConnection.prototype._createIndex = function (collectionName, index,
+MongoConnection.prototype.createIndex = function (collectionName, index,
                                                    options) {
   var self = this;
 
@@ -841,7 +841,7 @@ MongoConnection.prototype._createIndex = function (collectionName, index,
   future.wait();
 };
 
-MongoConnection.prototype._ensureIndex = MongoConnection.prototype._createIndex;
+MongoConnection.prototype._ensureIndex = MongoConnection.prototype.createIndex;
 
 MongoConnection.prototype._dropIndex = function (collectionName, index) {
   var self = this;

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -837,7 +837,7 @@ MongoConnection.prototype._createIndex = function (collectionName, index,
   // so we don't interact with the write fence.
   var collection = self.rawCollection(collectionName);
   var future = new Future;
-  var indexName = collection.ensureIndex(index, options, future.resolver());
+  var indexName = collection.createIndex(index, options, future.resolver());
   future.wait();
 };
 

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -841,7 +841,7 @@ MongoConnection.prototype._createIndex = function (collectionName, index,
   future.wait();
 };
 
-MongoCollection.prototype._ensureIndex = MongoConnection.prototype._createIndex;
+MongoConnection.prototype._ensureIndex = MongoConnection.prototype._createIndex;
 
 MongoConnection.prototype._dropIndex = function (collectionName, index) {
   var self = this;

--- a/packages/mongo/oplog_tests.js
+++ b/packages/mongo/oplog_tests.js
@@ -59,7 +59,7 @@ process.env.MONGO_OPLOG_URL && testAsyncMulti(
       var self = this;
       self.collectionName = Random.id();
       self.collection = new Mongo.Collection(self.collectionName);
-      self.collection._ensureIndex({species: 1});
+      self.collection._createIndex({species: 1});
 
       // Fill collection with lots of irrelevant objects (red cats) and some
       // relevant ones (blue dogs).

--- a/packages/mongo/oplog_tests.js
+++ b/packages/mongo/oplog_tests.js
@@ -59,7 +59,7 @@ process.env.MONGO_OPLOG_URL && testAsyncMulti(
       var self = this;
       self.collectionName = Random.id();
       self.collection = new Mongo.Collection(self.collectionName);
-      self.collection._createIndex({species: 1});
+      self.collection.createIndex({species: 1});
 
       // Fill collection with lots of irrelevant objects (red cats) and some
       // relevant ones (blue dogs).

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.12.0'
+  version: '1.12.0-beta240.2'
 });
 
 Npm.depends({
@@ -35,6 +35,7 @@ Package.onUse(function (api) {
     'check',
     'ecmascript',
     'mongo-dev-server',
+    'logging'
   ]);
 
   // Make weak use of Decimal type on client

--- a/packages/mongo/remote_collection_driver.js
+++ b/packages/mongo/remote_collection_driver.js
@@ -4,14 +4,13 @@ MongoInternals.RemoteCollectionDriver = function (
   self.mongo = new MongoConnection(mongo_url, options);
 };
 
-_.extend(MongoInternals.RemoteCollectionDriver.prototype, {
+Object.assign(MongoInternals.RemoteCollectionDriver.prototype, {
   open: function (name) {
     var self = this;
     var ret = {};
-    _.each(
-      ['find', 'findOne', 'insert', 'update', 'upsert',
-       'remove', '_ensureIndex', '_dropIndex', '_createCappedCollection',
-       'dropCollection', 'rawCollection'],
+    ['find', 'findOne', 'insert', 'update', 'upsert',
+      'remove', '_ensureIndex', '_createIndex', '_dropIndex', '_createCappedCollection',
+      'dropCollection', 'rawCollection'].forEach(
       function (m) {
         ret[m] = _.bind(self.mongo[m], self.mongo, name);
       });

--- a/packages/mongo/remote_collection_driver.js
+++ b/packages/mongo/remote_collection_driver.js
@@ -9,7 +9,7 @@ Object.assign(MongoInternals.RemoteCollectionDriver.prototype, {
     var self = this;
     var ret = {};
     ['find', 'findOne', 'insert', 'update', 'upsert',
-      'remove', '_ensureIndex', '_createIndex', '_dropIndex', '_createCappedCollection',
+      'remove', '_ensureIndex', 'createIndex', '_dropIndex', '_createCappedCollection',
       'dropCollection', 'rawCollection'].forEach(
       function (m) {
         ret[m] = _.bind(self.mongo[m], self.mongo, name);

--- a/packages/oauth/pending_credentials.js
+++ b/packages/oauth/pending_credentials.js
@@ -16,9 +16,9 @@ OAuth._pendingCredentials = new Mongo.Collection(
     _preventAutopublish: true
   });
 
-OAuth._pendingCredentials._ensureIndex('key', { unique: true });
-OAuth._pendingCredentials._ensureIndex('credentialSecret');
-OAuth._pendingCredentials._ensureIndex('createdAt');
+OAuth._pendingCredentials.createIndex('key', { unique: true });
+OAuth._pendingCredentials.createIndex('credentialSecret');
+OAuth._pendingCredentials.createIndex('createdAt');
 
 
 

--- a/packages/oauth1/oauth1_pending_request_tokens.js
+++ b/packages/oauth1/oauth1_pending_request_tokens.js
@@ -25,8 +25,8 @@ OAuth._pendingRequestTokens = new Mongo.Collection(
     _preventAutopublish: true
   });
 
-OAuth._pendingRequestTokens._ensureIndex('key', { unique: true });
-OAuth._pendingRequestTokens._ensureIndex('createdAt');
+OAuth._pendingRequestTokens.createIndex('key', { unique: true });
+OAuth._pendingRequestTokens.createIndex('createdAt');
 
 
 

--- a/packages/service-configuration/service_configuration_server.js
+++ b/packages/service-configuration/service_configuration_server.js
@@ -3,7 +3,7 @@
 // otherwise lead to an inconsistent database state (when there are multiple
 // configurations for a single service, which configuration is correct?)
 try {
-    ServiceConfiguration.configurations._ensureIndex(
+    ServiceConfiguration.configurations.createIndex(
         { "service": 1 },
         { unique: true }
     );
@@ -14,7 +14,7 @@ try {
         "each service should have exactly one configuration, Meteor " +
         "automatically creates a MongoDB index with a unique constraint on the " +
         " meteor_accounts_loginServiceConfiguration collection. The " +
-        "_ensureIndex command which creates that index is failing.\n\n" +
+        "createIndex command which creates that index is failing.\n\n" +
         "Meteor versions before 1.0.4 did not create this index. If you recently " +
         "upgraded and are seeing this error message for the first time, please " +
         "check your meteor_accounts_loginServiceConfiguration collection for " +
@@ -22,7 +22,7 @@ try {
         "configuration entries until there is no more than one configuration " +
         "entry per service.\n\n" +
         "If the meteor_accounts_loginServiceConfiguration collection looks " +
-        "fine, the _ensureIndex command is failing for some other reason.\n\n" +
+        "fine, the createIndex command is failing for some other reason.\n\n" +
         "For more information on this history of this issue, please see " +
         "https://github.com/meteor/meteor/pull/3514.\n"
     );


### PR DESCRIPTION
Add `_createIndex` as a collection function. This is a new name for `_ensureIndex` which MongoDB has deprecated and removed in MongoDB 5.0. This gives people the opportunity to start using the new MongoDB API, while we maintain backward compatibility.