### PR TITLE
Reflect removal of npmRequestOptions in documentation and comments

### DIFF
--- a/History.md
+++ b/History.md
@@ -139,7 +139,7 @@
   - This package is now deprecated
 
 * `http@2.0.0`
-  - Internally http has been replaced by [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), should still work as previous version, but edge cases might be different. This is to aid you in transition to fetch.
+  - Internally http has been replaced by [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), should still work as previous version, but edge cases might be different. This is to aid you in transition to fetch. Note that this means that the `npmRequestOptions` parameter to `HTTP.call` has been removed, as `request` is no longer used internally.
 
 * `socket-stream-client@0.4.0`
   - Remove IE8 checks

--- a/packages/deprecated/http/httpcall_client.js
+++ b/packages/deprecated/http/httpcall_client.js
@@ -18,7 +18,6 @@ var hasOwn = Object.prototype.hasOwnProperty;
  * @param {Object} options.headers Dictionary of strings, headers to add to the HTTP request.
  * @param {Number} options.timeout Maximum time in milliseconds to wait for the request before failing.  There is no timeout by default.
  * @param {Boolean} options.followRedirects If `true`, transparently follow HTTP redirects. Cannot be set to `false` on the client. Default `true`.
- * @param {Object} options.npmRequestOptions On the server, `HTTP.call` is implemented by using the [npm `request` module](https://www.npmjs.com/package/request). Any options in this object will be passed directly to the `request` invocation.
  * @param {Function} options.beforeSend On the client, this will be called before the request is sent to allow for more direct manipulation of the underlying XMLHttpRequest object, which will be passed as the first argument. If the callback returns `false`, the request will be not be sent.
  * @param {Function} [asyncCallback] Optional callback.  If passed, the method runs asynchronously, instead of synchronously, and calls asyncCallback.  On the client, this callback is required.
  */
@@ -59,9 +58,6 @@ HTTP.call = function(method, url, options, callback) {
   if (options.followRedirects === false)
     throw new Error("Option followRedirects:false not supported on client.");
 
-  if (hasOwn.call(options, 'npmRequestOptions')) {
-    throw new Error("Option npmRequestOptions not supported on client.");
-  }
 
   var username, password;
   if (options.auth) {

--- a/packages/deprecated/http/httpcall_server.js
+++ b/packages/deprecated/http/httpcall_server.js
@@ -112,9 +112,6 @@ function _call (method, url, options, callback) {
 
   ////////// Kickoff! //////////
 
-  // Allow users to override any request option with the npmRequestOptions
-  // option.
-
   const requestOptions = {
     method: method,
     caching: caching,


### PR DESCRIPTION
This updates the documentation and code to reflect the removal of the `npmRequestOptions` parameter to `HTTP.call`.