### PR TITLE
Initial implementation of DDP resumption

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -102,6 +102,10 @@ export class Connection {
     }
 
     self._lastSessionId = null;
+    // how many messages we've received (excluding ping/pong).
+    // when we try to reconnect to the server, it will check this against the number of messages it sent.
+    // if there is a mismatch, our info is out of date and we need a clean session.
+    self._receivedCount = 0;
     self._versionSuggestion = null; // The last proposed DDP version.
     self._version = null; // The DDP version agreed on by client and server.
     self._stores = Object.create(null); // name -> object with methods
@@ -897,11 +901,12 @@ export class Connection {
    * @locus Client
    */
   disconnect(...args) {
+    this._send({ msg: 'disconnect' });
     return this._stream.disconnect(...args);
   }
 
   close() {
-    return this._stream.disconnect({ _permanent: true });
+    return this.disconnect({ _permanent: true });
   }
 
   ///
@@ -972,6 +977,8 @@ export class Connection {
       // this possible, at which point we'll probably need more code here.
       return;
     }
+
+    self._receivedCount = 1;
 
     // Server doesn't have our data any more. Re-sync a new session.
 
@@ -1629,7 +1636,9 @@ export class Connection {
         Meteor._debug('discarding invalid livedata message', msg);
       return;
     }
-
+    if (!['ping', 'pong'].includes(msg.msg)) {
+      this._receivedCount++;
+    }
     if (msg.msg === 'connected') {
       this._version = this._versionSuggestion;
       this._livedata_connected(msg);
@@ -1669,7 +1678,10 @@ export class Connection {
     // NOTE: reset is called even on the first connection, so this is
     // the only place we send this message.
     const msg = { msg: 'connect' };
-    if (this._lastSessionId) msg.session = this._lastSessionId;
+    if (this._lastSessionId) {
+      msg.session = this._lastSessionId;
+      msg.receivedCount = this._receivedCount;
+    }
     msg.version = this._versionSuggestion || this._supportedDDPVersions[0];
     this._versionSuggestion = msg.version;
     msg.support = this._supportedDDPVersions;


### PR DESCRIPTION
Recently we've noticed that a lot of CPU (and in some cases memory) issues can be tracked down to the problem of transient disconnects, and the effort it takes to re-setup a DDP connection clean. This is particularly egregious if the cause of the disconnects is at the load balancer level (e.g., a reconfiguration causing NGINX to drop existing connections all at the same time).

In the majority of cases these disconnects last milliseconds, but can take upwards of 30 seconds to re-subscribe to all data that the client previously had access to (aside: particularly in the case of using a sub manager to cache subscriptions). 

It would of course be ideal if these disconnects never happened - but being that we live in an imperfect world... It would be much better if in the case of a transient disconnect, the cost were much lower.

To that end, this PR is an initial implementation of DDP session resumption (resuming?) based on the following:

1. All inflight methods will still be requested.
2. All active subscriptions will still be re-ran
3. Resumption will only occur if the server being connected to has a session with the same `id` AND the number of messages sent by the server matches the number of messages received by the client (excluding ping/pong - e.g., `result`,  `updated`, `nosub`, `ready`, `added`, `removed`, `changed`) - we don't need to consider messages sent from client -> server due to (1) and (2).
4. In the case of a persistent disconnect (e.g., triggered by code on client or server, or navigating away) the session should terminate immediately
5. In the case of a (potentially) transient disconnect - the memory and CPU overhead to maintain the session should be low.



This implementation modifies the following to accomplish this:
1. track a `sentCount` on the server and `receivedCount` on the client.
2. transmit a `{ msg: "disconnect" }` before disconnecting on an explicit disconnect.
3. Upon a non-graceful disconnect (without seeing a `disconnect` message) maintain a list of messages that should be sent upon reconnect 
4. Defer the removal of a session for `DISCONNECT_GRACE_PERIOD` ms or until `MAX_QUEUE_LENGTH` is reached
5. On reconnect, perform a lookup on `msg.session` and, if found, check the `receivedCount === sentCount`.
6. On unsuccessful "resume" (or a resume never comes) - cleanup the session as normal.

Potential limitations/vulnerabilities:
1. session hijacking - currently resuming a session with a valid sessionId will grant you the same access from a new machine without logging in. I'm looking into a solution for this - though if an attacker can get a valid session ID, they can probably get the valid resume token too.

NOTE: This implementation was ported over from a custom copy of DDP server/client packages in an application. It's been tested there but it's possible that in applying the changes here I messed something up. Currently I'm interested in if there are any pitfalls in this approach, if none are obvious to the community I'll work on implementing tests.