### PR TITLE
Update mongodb to 3.6.10

### DIFF
--- a/History.md
+++ b/History.md
@@ -23,6 +23,9 @@
 * `less@4.0.0`
   - Updated `less` to v4.1.1
   - Fixed tests
+
+* `npm-mongo@3.9.1`
+  - `mongodb@3.6.10`
   
 ## v2.3.4, 2021-08-03
 

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: "3.9.0",
+  version: "3.9.1",
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "3.6.6"
+  mongodb: "3.6.10"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
While looking for stuff around #11568 I went ahead and updated `npm-mongo` with the latest `mongodb` in the 3.6 series.
