### PR TITLE
Create index on `services.password.enroll.when`

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1610,4 +1610,5 @@ const setupUsersCollection = users => {
   users._ensureIndex("services.resume.loginTokens.when", { sparse: true });
   // For expiring password tokens
   users._ensureIndex('services.password.reset.when', { sparse: true });
+  users._ensureIndex('services.password.enroll.when', { sparse: true });
 };


### PR DESCRIPTION
Due to the changes a few months ago bringing in a concept of enroll.reason and enroll.when, the queries need a new index. Adding the same.