### PR TITLE
Allow usage of http packages v1 and v2 in affected packages

### DIFF
--- a/History.md
+++ b/History.md
@@ -29,7 +29,28 @@
 
 * `accounts-base@2.0.1`
   - Create index on `services.password.enroll.when`
-  - Blaze weak dependency updated to v2.5.0 
+  - Blaze weak dependency updated to v2.5.0
+
+* `facebook-oauth@1.9.1`
+  - Allow usage of `http` package both v1 and v2 for backward compatibility
+
+* `github-oauth@1.3.1`
+  - Allow usage of `http` package both v1 and v2 for backward compatibility
+
+* `google-oauth@1.3.1`
+  - Allow usage of `http` package both v1 and v2 for backward compatibility
+
+* `meetup-oauth@1.1.1`
+  - Allow usage of `http` package both v1 and v2 for backward compatibility
+
+* `meteor-developer-oauth@1.3.1`
+  - Allow usage of `http` package both v1 and v2 for backward compatibility
+
+* `weibo-oauth@1.3.1`
+  - Allow usage of `http` package both v1 and v2 for backward compatibility
+
+* `oauth1@1.4.1`
+  - Allow usage of `http` package both v1 and v2 for backward compatibility
   
 ## v2.3.4, 2021-08-03
 

--- a/packages/facebook-oauth/package.js
+++ b/packages/facebook-oauth/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   summary: "Facebook OAuth flow",
-  version: "1.9.0"
+  version: "1.9.1"
 });
 
 Package.onUse(api => {
   api.use('ecmascript', ['client', 'server']);
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
-  api.use('http', ['server']);
+  api.use('http@1.4.4 || 2.0.0', ['server']);
   api.use('random', 'client');
   api.use('service-configuration', ['client', 'server']);
 

--- a/packages/github-oauth/package.js
+++ b/packages/github-oauth/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   summary: 'GitHub OAuth flow',
-  version: '1.3.0'
+  version: '1.3.1'
 });
 
 Package.onUse(api => {
   api.use('ecmascript', ['client', 'server']);
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
-  api.use('http', 'server');
+  api.use('http@1.4.4 || 2.0.0', 'server');
   api.use('random', 'client');
   api.use('service-configuration', ['client', 'server']);
 

--- a/packages/google-oauth/package.js
+++ b/packages/google-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Google OAuth flow",
-  version: "1.4.0",
+  version: "1.4.1",
 });
 
 Cordova.depends({
@@ -11,7 +11,7 @@ Package.onUse(api => {
   api.use("ecmascript");
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
-  api.use('http', ['server']);
+  api.use('http@1.4.4 || 2.0.0', ['server']);
   api.use('service-configuration');
   api.use('random', 'client');
 

--- a/packages/meetup-oauth/package.js
+++ b/packages/meetup-oauth/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   summary: 'Meetup OAuth flow',
-  version: '1.1.0'
+  version: '1.1.1'
 });
 
 Package.onUse(api => {
   api.use('ecmascript');
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
-  api.use('http', 'server');
+  api.use('http@1.4.4 || 2.0.0', 'server');
   api.use('random', 'client');
   api.use('service-configuration', ['client', 'server']);
 

--- a/packages/meteor-developer-oauth/package.js
+++ b/packages/meteor-developer-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Meteor developer accounts OAuth flow',
-  version: '1.3.0'
+  version: '1.3.1'
 });
 
 Package.onUse(api => {

--- a/packages/meteor-developer-oauth/package.js
+++ b/packages/meteor-developer-oauth/package.js
@@ -6,7 +6,7 @@ Package.describe({
 Package.onUse(api => {
   api.use('oauth2', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
-  api.use('http', ['server']);
+  api.use('http@1.4.4 || 2.0.0', ['server']);
   api.use(['ecmascript', 'service-configuration'], ['client', 'server']);
   api.use('random', 'client');
 

--- a/packages/oauth1/package.js
+++ b/packages/oauth1/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth1-based login services",
-  version: "1.4.0",
+  version: "1.4.1",
 });
 
 Package.onUse(api => {
@@ -10,7 +10,7 @@ Package.onUse(api => {
   api.use('oauth', ['client', 'server']);
   api.use([
     'check',
-    'http'
+    'http@1.4.4 || 2.0.0'
   ], 'server');
 
   api.use('mongo');

--- a/packages/weibo-oauth/package.js
+++ b/packages/weibo-oauth/package.js
@@ -1,12 +1,13 @@
 Package.describe({
   summary: "Weibo OAuth flow",
-  version: "1.3.0",
+  version: "1.3.1",
 });
 
 Package.onUse(api => {
   api.use('oauth1', ['client', 'server']);
   api.use('oauth', ['client', 'server']);
   api.use('random', 'client');
+  api.use('http@1.4.4 || 2.0.0', 'server');
   api.use(['service-configuration', 'ecmascript'], ['client', 'server']);
 
   api.addFiles('weibo_client.js', 'client');


### PR DESCRIPTION
Fix #11575 by allowing usage of both major versions of the deprecated `http` package until we can fully replace it with `fetch`.