### PR TITLE
Fixes #11583 Do not add ROOT_URL to sourceMappingURL for base64 encoded urls

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2834,7 +2834,8 @@ var writeFile = Profile("bundler writeFile", function (file, builder, options) {
   }
 
   if (options && options.sourceMapUrl) {
-    data = addSourceMappingURL(data, options.sourceMapUrl);
+    const url = (process.env.ROOT_URL || "") + options.sourceMapUrl;
+    data = addSourceMappingURL(data, url);
   } else if (!options || !options.leaveSourceMapUrls) {
     // If we do not have an options.sourceMapUrl to append, then we still
     // want to remove any existing //# sourceMappingURL comments.
@@ -2890,7 +2891,7 @@ function addSourceMappingURL(data, url, targetPath) {
 
   parts.push(
     newLineBuffer,
-    Buffer.from("//# sourceMappingURL=" + (process.env.ROOT_URL || "") + url, "utf8"),
+    Buffer.from("//# sourceMappingURL=" + url, "utf8"),
     newLineBuffer // trailing newline
   );
 


### PR DESCRIPTION
This PR fixes issue https://github.com/meteor/meteor/issues/11583.

The ROOT_URL should NOT be added for base64 encoded source Mapping URLs

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
