### PR TITLE
callback-hook add forEach iterator to follow the JS standard

### DIFF
--- a/packages/callback-hook/hook.js
+++ b/packages/callback-hook/hook.js
@@ -94,7 +94,7 @@ export class Hook {
   // The iteration is stopped if the iterator function returns a falsy
   // value or throws an exception.
   //
-  each(iterator) {
+  forEach(iterator) {
     // Invoking bindEnvironment'd callbacks outside of a Fiber in Node doesn't
     // run them to completion (and exceptions thrown from onException are not
     // propagated), so we need to be in a Fiber.
@@ -111,6 +111,10 @@ export class Hook {
         }
       }
     }
+  }
+
+  each(iterator) {
+    return this.forEach(iterator);
   }
 }
 

--- a/packages/callback-hook/hook.js
+++ b/packages/callback-hook/hook.js
@@ -113,6 +113,10 @@ export class Hook {
     }
   }
 
+  /**
+   * @deprecated use forEach
+   * @param iterator
+   */
   each(iterator) {
     return this.forEach(iterator);
   }

--- a/packages/callback-hook/hook_tests.js
+++ b/packages/callback-hook/hook_tests.js
@@ -7,7 +7,7 @@ Tinytest.add("callback-hook - binds to registrar's env by default", function (te
     });
   });
   envVar.withValue("invoker's value", function() {
-    hook.each(function(callback) {
+    hook.forEach(function(callback) {
       callback();
     });
   });
@@ -33,7 +33,7 @@ Tinytest.add("callback-hook - exceptions unhandled with {bindEnvironment: false}
   hook.register(function() {
     throw new Error("Test error");
   });
-  hook.each(function(callback) {
+  hook.forEach(function(callback) {
     test.throws(callback, "Test error");
   });
 });


### PR DESCRIPTION
Add `forEach` to the `callback-hook` so that it follows the naming standard for ES when it comes to looping. Retains `each` iterator for backward compatibility.