### PR TITLE
Fix sending test metadata

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -1624,7 +1624,6 @@ export class Connection {
     if (msg === null || !msg.msg) {
       if(!msg || !msg.testMessageOnConnect) {
         if (Object.keys(msg).length === 1 && msg.server_id) return;
-        console.dir(msg)
         Meteor._debug('discarding invalid livedata message', msg);
       }
       return;

--- a/packages/ddp-server/stream_server.js
+++ b/packages/ddp-server/stream_server.js
@@ -119,7 +119,7 @@ StreamServer = function () {
 
     // only to send a message after connection on tests, useful for
     // socket-stream-client/server-tests.js
-    if (process.env.TEST_METADATA) {
+    if (process.env.TEST_METADATA && process.env.TEST_METADATA !== "{}") {
       socket.send(JSON.stringify({ testMessageOnConnect: true }));
     }
 


### PR DESCRIPTION
TEST_METADATA is by default `"{}"`, so the check if to send it is always true, even though it was intended to be false when the env var is not set.
Thanks to @zodern for pairing up on this one.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
