### PR TITLE
Fix/ sending test metadata

### DIFF
--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '2.4.0',
+  version: '2.4.1',
   documentation: null
 });
 

--- a/packages/ddp-server/stream_server.js
+++ b/packages/ddp-server/stream_server.js
@@ -119,7 +119,7 @@ StreamServer = function () {
 
     // only to send a message after connection on tests, useful for
     // socket-stream-client/server-tests.js
-    if (process.env.TEST_METADATA) {
+    if (process.env.TEST_METADATA && process.env.TEST_METADATA !== "{}") {
       socket.send(JSON.stringify({ testMessageOnConnect: true }));
     }
 


### PR DESCRIPTION
TEST_METADATA is by default `"{}"`, so the check if to send it is always true, even though it was intended to be false when the env var is not set.
Thanks to @zodern for pairing up on this one.
In regards to #11513 this fixes particular case that @zodern was seeing, it might not apply to other cases. Again, get the latest releases to stop seeing those messages or you can safely disregard them.