### PR TITLE
accounts-password use isEnroll

### DIFF
--- a/History.md
+++ b/History.md
@@ -56,6 +56,9 @@
 * `ddp-server@2.4.1`
   - Fix a bug where `testMessageOnConnect` has always been sent
 
+* `accounts-password@2.0.1`
+  - Fix use of `isEnroll` in reset password
+
 ## v2.3.5, 2021-08-12
 
 #### Highlights

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -5,12 +5,12 @@ Package.describe({
   // 2.2.x in the future. The version was also bumped to 2.0.0 temporarily
   // during the Meteor 1.5.1 release process, so versions 2.0.0-beta.2
   // through -beta.5 and -rc.0 have already been published.
-  version: "2.0.0"
+  version: "2.0.1"
 });
 
 Npm.depends({
   'bcrypt': '5.0.1'
-})
+});
 
 Package.onUse(api => {
 

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -526,7 +526,7 @@ Accounts.generateResetToken = (userId, email, reason, extraTokenData) => {
 
   if (extraTokenData) {
     Object.assign(tokenRecord, extraTokenData);
-  } 
+  }
   // if this method is called from the enroll account work-flow then
   // store the token record in 'services.password.enroll' db field
   // else store the token record in in 'services.password.reset' db field
@@ -722,7 +722,7 @@ Meteor.methods({resetPassword: function (...args) {
           emails: 1,
         }}
       );
-     
+
       let isEnroll = false;
       // if token is in services.password.reset db field implies
       // this method is was not called from enroll account workflow
@@ -746,9 +746,9 @@ Meteor.methods({resetPassword: function (...args) {
       } else {
         tokenRecord = user.services.password.reset;
       }
-      const { when, reason, email } = tokenRecord;
+      const { when, email } = tokenRecord;
       let tokenLifetimeMs = Accounts._getPasswordResetTokenLifetimeMs();
-      if (reason === "enroll") {
+      if (isEnroll) {
         tokenLifetimeMs = Accounts._getPasswordEnrollTokenLifetimeMs();
       }
       const currentTimeMs = Date.now();
@@ -760,7 +760,7 @@ Meteor.methods({resetPassword: function (...args) {
           error: new Meteor.Error(403, "Token has invalid email address")
         };
 
-      const hashed = hashPassword(newPassword);     
+      const hashed = hashPassword(newPassword);
 
       // NOTE: We're about to invalidate tokens on the user, who we might be
       // logged in as. Make sure to avoid logging ourselves out if this
@@ -778,7 +778,7 @@ Meteor.methods({resetPassword: function (...args) {
         // - Verifying their email, since they got the password reset via email.
         let affectedRecords = {};
         // if reason is enroll then check services.password.enroll.token field for affected records
-        if(reason === 'enroll') {
+        if(isEnroll) {
           affectedRecords = Meteor.users.update(
             {
               _id: user._id,

--- a/tools/tests/apps/custom-minifier/packages/custom-minifier/plugin/minify.js
+++ b/tools/tests/apps/custom-minifier/packages/custom-minifier/plugin/minify.js
@@ -14,7 +14,7 @@ Plugin.registerMinifier({
 
 function CustomMinifier(type) {
   this.type = type;
-};
+}
 
 CustomMinifier.prototype.processFilesForBundle = function (files, options) {
   var self = this;


### PR DESCRIPTION
Fix #11600 properly use `isEnroll` in accounts-password when determining reset password token location instead of the old way.