### PR TITLE
Feature: Add login handler for Facebook

### DIFF
--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -1,5 +1,6 @@
 Facebook = {};
 import crypto from 'crypto';
+import { Accounts } from 'meteor/accounts-base';
 
 const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '10.0';
 
@@ -24,6 +25,14 @@ Facebook.handleAuthFromAccessToken = (accessToken, expiresAt) => {
     options: {profile: {name: identity.name}}
   };
 };
+
+Accounts.registerLoginHandler(request => {
+  if (request.facebookSignIn !== true) {
+    return;
+  }
+  const facebookData = Facebook.handleAuthFromAccessToken(request.accessToken, (+new Date) + (1000 * request.expirationTime));
+  return Accounts.updateOrCreateUserFromExternalService('facebook', facebookData.serviceData, facebookData.options);
+});
 
 OAuth.registerService('facebook', 2, null, query => {
   const response = getTokenResponse(query);


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

Hello, I am using Meteor as a back-end for a **React Native App**. I have configured **OAuth** with **Facebook** and **Google** successfully (based on these articles for [Facebook](https://medium.com/differential/react-native-meteor-oauth-with-facebook-3d1346d7cdb7) and [Google](https://spencer-carli.medium.com/meteor-google-oauth-from-react-native-e30d146dfad6)).

Currently, the package of **accounts-google** already includes a **login handler** for Google, whereas **accounts-facebook** doesn't include it. So, I did this PR to add this login handler for the Facebook package to make **easier** the process about **Login with Facebook** using Meteor and React Native. Actually, this is part of a [feature](https://github.com/TheRealNate/meteor-react-native/issues/36) from **react-native-meteor** package.

Discussion is already [here](https://github.com/meteor/meteor/discussions/11599).

Tested on Android and iOS.
