### PR TITLE
Add WebApp.addUpdatedNotifyHook

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -412,17 +412,32 @@ function getBoilerplateAsync(request, arch) {
   }));
 }
 
+// Notification hook whenever the runtime configuration is updated
+// hook will pass an object with the following fields:
+// - arch
+// - manifest
+// - runtimeConfig
+WebApp.addUpdatedNotifyHook = function(hook) {
+  if(typeof hook !== 'function') throw new Error('WebApp.addUpdatedNotifyHook must be a function');
+  runtimeConfig.updateHooks.push(hook);
+}
+
 WebAppInternals.generateBoilerplateInstance = function (arch,
                                                         manifest,
                                                         additionalOptions) {
   additionalOptions = additionalOptions || {};
 
   runtimeConfig.isUpdatedByArch[arch] = true;
+  const rtimeConfig = {
+    ...__meteor_runtime_config__,
+    ...(additionalOptions.runtimeConfigOverrides || {})
+  };
+  runtimeConfig.updateHooks.forEach((cb) => {
+    cb({arch, manifest, runtimeConfig: rtimeConfig});
+  });
+
   const meteorRuntimeConfig = JSON.stringify(
-    encodeURIComponent(JSON.stringify({
-      ...__meteor_runtime_config__,
-      ...(additionalOptions.runtimeConfigOverrides || {})
-    }))
+    encodeURIComponent(JSON.stringify(rtimeConfig))
   );
 
   return new Boilerplate(arch, manifest, _.extend({

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -357,6 +357,9 @@ WebApp.decodeRuntimeConfig = function (rtimeConfig) {
   // hooks will contain the callback functions
   // set by the caller to addRuntimeConfigHook
   hooks: [],
+  // updateHooks will contain the callback functions
+  // set by the caller to addUpdatedConfigHook
+  updateHooks: [],
   // isUpdatedByArch is an object containing fields for each arch 
   // that this server supports.
   // - Each field will be true when the server updates the runtimeConfig for that arch.


### PR DESCRIPTION
Add another hook to the `webapp` package.

### `WebApp.addUpdatedNotifyHook`
This function will add a hook to notify the caller whenever meteor has updated its code.  This hook would mostly be used in development to enable the caller to perform actions whenever meteor has updated itself.

@filipenevola, @StorytellerCZ,
This is a hook that I require to enable `autoupdate` when I am developing with a meteor server shared among multiple client applications.  Super useful during development.

Hoping we can sneak this into 2.4 while I was updating `webapp` anyway.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
