### PR TITLE
Disable native file watching during meteor create

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -17,6 +17,7 @@ var release = require('../packaging/release.js');
 
 const { Profile } = require("../tool-env/profile");
 
+import { disableNativeWatcher } from '../fs/safe-watcher';
 import { ensureDevBundleDependencies } from '../cordova/index.js';
 import { CordovaRunner } from '../cordova/runner.js';
 import { iOSRunTarget, AndroidRunTarget } from '../cordova/run-targets.js';
@@ -533,6 +534,7 @@ main.registerCommand({
   },
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
+  disableNativeWatcher();
 
   // Creating a package is much easier than creating an app, so if that's what
   // we are doing, do that first. (For example, we don't springboard to the


### PR DESCRIPTION
This should fix Meteor getting stuck when creating the first app after it is installed on Windows. This is a temporary fix until we replace the library we use for using native file watchers.