### PR TITLE
Release 2.3.6

### DIFF
--- a/History.md
+++ b/History.md
@@ -65,6 +65,17 @@
 * `mdg:reload-on-resume@1.0.5`
   - Fixed API to work with Meteor 2.3+
 
+## v2.3.6, 2021-09-01
+
+#### Highlights
+
+* Updated Node.js per [August 31st security release](https://nodejs.org/en/blog/vulnerability/aug-2021-security-releases2/)
+
+#### Meteor Version Release
+
+* `meteor-tool@2.3.6`
+  - Node.js updated to [v14.17.6](https://nodejs.org/en/blog/release/v14.17.6/)
+
 ## v2.3.5, 2021-08-12
 
 #### Highlights

--- a/History.md
+++ b/History.md
@@ -5,17 +5,28 @@
 * `meteor-tool@2.4`
   - `meteor show` now reports if a package is deprecated
 
+## v2.3.6, 2021-09-02
+
+#### Highlights
+
+* Updated Node.js per [August 31st security release](https://nodejs.org/en/blog/vulnerability/aug-2021-security-releases2/)
+
+#### Meteor Version Release
+
+* `meteor-tool@2.3.6`
+  - Node.js updated to [v14.17.6](https://nodejs.org/en/blog/release/v14.17.6/)
+
 #### Independent Releases
 
 * `minifier-js@2.6.1`
   - Terser updated to [4.8.0](https://github.com/terser/terser/blob/master/CHANGELOG.md#v480)
-    
+
 * `routepolicy@1.1.1`
   - Removed `underscore` dependency since it was not used in the package
-  
+
 * `email@2.1.1`
   - Updated `nodemailer` to v6.6.3
-  
+
 * `callback-hook@1.3.1`
   - Modernized the code
   - Fixed a variable assignment bug in `dontBindEnvironment` function
@@ -64,17 +75,6 @@
 
 * `mdg:reload-on-resume@1.0.5`
   - Fixed API to work with Meteor 2.3+
-
-## v2.3.6, 2021-09-01
-
-#### Highlights
-
-* Updated Node.js per [August 31st security release](https://nodejs.org/en/blog/vulnerability/aug-2021-security-releases2/)
-
-#### Meteor Version Release
-
-* `meteor-tool@2.3.6`
-  - Node.js updated to [v14.17.6](https://nodejs.org/en/blog/release/v14.17.6/)
 
 ## v2.3.5, 2021-08-12
 

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.17.5.0
+BUNDLE_VERSION=14.17.6.0
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/npm-packages/meteor-installer/README.md
+++ b/npm-packages/meteor-installer/README.md
@@ -35,4 +35,5 @@ If you use a node version manager that uses a separate global `node_modules` fol
 | 2.3.4       | 2.3.4                   |
 | 2.3.5       | 2.3.5                   |
 | 2.3.6       | 2.3.5                   |
+| 2.3.7       | 2.3.6                   |
 

--- a/npm-packages/meteor-installer/config.js
+++ b/npm-packages/meteor-installer/config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const os = require('os');
 
-const METEOR_LATEST_VERSION = '2.3.5';
+const METEOR_LATEST_VERSION = '2.3.6';
 const sudoUser = process.env.SUDO_USER || '';
 function isRoot() {
   return process.getuid && process.getuid() === 0;

--- a/npm-packages/meteor-installer/package.json
+++ b/npm-packages/meteor-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "Install Meteor on Windows",
   "main": "install.js",
   "scripts": {

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '2.3.6-rc.0'
+  version: '2.3.6'
 });
 
 Package.includeTool();

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '2.3.5'
+  version: '2.3.6-rc.0'
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "2.3.5-rc.0",
+  "version": "2.3.6-rc.0",
   "recommended": false,
   "official": false,
   "description": "Meteor"

--- a/scripts/admin/meteor-release-official.json
+++ b/scripts/admin/meteor-release-official.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "recommended": false,
   "official": true,
   "description": "The Official Meteor Distribution"

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -5,10 +5,10 @@ set -u
 
 UNAME=$(uname)
 ARCH=$(uname -m)
-NODE_VERSION=14.17.5
+NODE_VERSION=14.17.6
 MONGO_VERSION_64BIT=4.4.4
 MONGO_VERSION_32BIT=3.2.22
-NPM_VERSION=6.14.13
+NPM_VERSION=6.14.15
 
 # If we built Node from source on Jenkins, this is the build number.
 NODE_BUILD_NUMBER=

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -10,7 +10,7 @@ var packageJson = {
   dependencies: {
     // Explicit dependency because we are replacing it with a bundled version
     // and we want to make sure there are no dependencies on a higher version
-    npm: "6.14.13",
+    npm: "6.14.15",
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "8.0.0",
     "node-pre-gyp": "0.15.0",


### PR DESCRIPTION
Updated Node.js per [August 31st security release](https://nodejs.org/en/blog/vulnerability/aug-2021-security-releases2/).

You can test this release as usual:
```bash
meteor update --release 2.3.6-rc.0
```