### PR TITLE
METEOR_SETTINGS always accepted

### DIFF
--- a/History.md
+++ b/History.md
@@ -19,7 +19,7 @@
   - Apollo skeleton now uses [Apollo server v3](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v300) - [migration guide](https://www.apollographql.com/docs/apollo-server/migration/)
   - Upgraded `chalk` to v4.1.1
   - Typescript updated to [v4.3.5](https://github.com/Microsoft/TypeScript/releases/tag/v4.3.5)
-  - `METEOR_SETTINGS` will now be only ignored in development mode and passed on in every other circumstances
+  - `METEOR_SETTINGS` is now accepted an all modes
     
 * `webapp@1.12`
   - npm dependencies have been updated

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -172,17 +172,13 @@ Object.assign(AppProcess.prototype, {
     } else if (env.METEOR_SETTINGS && env.NODE_ENV === 'development') {
       // Warn the developer that we are not going to use their environment var.
       runLog.log(
-        "WARNING: The 'METEOR_SETTINGS' environment variable is ignored " +
-        "when running in development (as you are doing now).  Instead, use " +
-        "the '--settings settings.json' option to see reactive changes " +
+        "WARNING: The 'METEOR_SETTINGS' environment variable is set " +
+        "while running in development. This means that settings are not reactive. " +
+        "Use the '--settings settings.json' option to see reactive changes " +
         "when settings are changed.  For more information, see the " +
         "documentation for 'Meteor.settings': " +
         "https://docs.meteor.com/api/core.html#Meteor-settings" +
         "\n");
-
-      // To provide a consistent, reactive experience in development, do
-      // not use settings provided via the environment variable.
-      delete env.METEOR_SETTINGS;
     }
     if (self.testMetadata) {
       env.TEST_METADATA = JSON.stringify(self.testMetadata);


### PR DESCRIPTION
Do not delete `METEOR_SETTINGS`, but show a warning when used in development.