### PR TITLE
Disable native file watcher for more commands

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -23,7 +23,6 @@ var packageMapModule = require('../packaging/package-map.js');
 var packageClient = require('../packaging/package-client.js');
 var tropohouse = require('../packaging/tropohouse.js');
 
-import { disableNativeWatcher } from '../fs/safe-watcher';
 import {
   ensureDevBundleDependencies,
   newPluginId,

--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -29,6 +29,7 @@ import {
   newPluginId,
   splitPluginsAndPackages,
 } from '../cordova/index.js';
+import { disableNativeWatcher } from '../fs/safe-watcher';
 import { updateMeteorToolSymlink } from "../packaging/updater.js";
 
 // For each release (or package), we store a meta-record with its name,
@@ -1160,6 +1161,8 @@ main.registerCommand({
   },
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: true })
 }, function (options) {
+  disableNativeWatcher();
+
   var projectContext = new projectContextModule.ProjectContext({
     projectDir: options.appDir,
     allowIncompatibleUpdate: options['allow-incompatible-update']
@@ -1771,6 +1774,8 @@ main.registerCommand({
   maxArgs: Infinity,
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: true })
 }, function (options) {
+  disableNativeWatcher();
+
   // If you are specifying packages individually, you probably don't want to
   // update the release.
   if (options.args.length > 0) {
@@ -2133,6 +2138,8 @@ main.registerCommand({
   requiresApp: true,
   catalogRefresh: new catalog.Refresh.OnceAtStart({ ignoreErrors: true })
 }, function (options) {
+  disableNativeWatcher();
+
   var projectContext = new projectContextModule.ProjectContext({
     projectDir: options.appDir,
     allowIncompatibleUpdate: options["allow-incompatible-update"]
@@ -2341,6 +2348,8 @@ main.registerCommand({
   requiresApp: true,
   catalogRefresh: new catalog.Refresh.Never()
 }, function (options) {
+  disableNativeWatcher();
+
   var projectContext = new projectContextModule.ProjectContext({
     projectDir: options.appDir,
     allowIncompatibleUpdate: options["allow-incompatible-update"]

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -941,6 +941,7 @@ main.registerCommand({
   name: "build",
   ...buildCommands,
 }, async function (options) {
+  disableNativeWatcher();
   return Profile.run(
     "meteor build",
     () => Promise.await(buildCommand(options))


### PR DESCRIPTION
Disables it for:

- `meteor update`
- `meteor add`
- `meteor remove`
- `meteor build`