### PR TITLE
Use symbolic links for transpiling chalk and make it not throw parse errors with IE11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 os: linux
 dist: xenial
 node_js:
-  - "14.17.5"
+  - "14.17.6"
 cache:
   directories:
     - ".meteor"

--- a/packages/logging/.npm/package/.gitignore
+++ b/packages/logging/.npm/package/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/packages/logging/.npm/package/README
+++ b/packages/logging/.npm/package/README
@@ -1,7 +1,0 @@
-This directory and the files immediately inside it are automatically generated
-when you change this package's NPM dependencies. Commit the files in this
-directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
-so that others run the same versions of sub-dependencies.
-
-You should NOT check in the node_modules directory that Meteor automatically
-creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/packages/logging/chalk
+++ b/packages/logging/chalk
@@ -1,0 +1,1 @@
+node_modules/chalk/

--- a/packages/logging/package-lock.json
+++ b/packages/logging/package-lock.json
@@ -1,20 +1,33 @@
 {
+  "name": "logging",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
     },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
     },
     "color-name": {
       "version": "1.1.4",
@@ -29,7 +42,10 @@
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
     }
   }
 }

--- a/packages/logging/package.js
+++ b/packages/logging/package.js
@@ -3,9 +3,6 @@ Package.describe({
   version: '1.3.0-rc240.5'
 });
 
-Npm.depends({
-  'chalk': '4.1.1'
-});
 
 Npm.strip({
   'es5-ext': ['test/']

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "logging",
+  "version": "1.0.0",
+  "description": "[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/logging) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/logging) ***",
+  "dependencies": {
+    "chalk": "^4.1.2"
+  }
+}


### PR DESCRIPTION
This commit creates a package.json for using the node_modules folder, and it does link the chalk dependency to the root of the package so meteor transpiles it.

The error was happening because IE11 doesn't support ecmascript 2019 features, and thus needs to be served a legacy bundle. Chalk wasn't being transpiled.