### PR TITLE
Update terser to 5.8

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,12 @@
 * `modern-browsers@0.1.6`
   - Added `mobileSafariUI` as an alias for Mobile Safari
 
+* `minifier-js@2.7.1`
+  - Updated `terser` to [v5.8.0](https://github.com/terser/terser/blob/master/CHANGELOG.md#v580) to fix various bugs
+
+* `standard-minifier-js@2.7.1`
+  - Updated `@babel/runtime` to [v7.15.4](https://github.com/babel/babel/releases/tag/v7.15.4)
+
 ## v2.4, 2021-09-15
 
 #### Highlights

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "commander": {
       "version": "2.20.3",
@@ -12,19 +12,26 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw=="
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw=="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
+      "integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A=="
     }
   }
 }

--- a/packages/minifier-js/minifier-tests.js
+++ b/packages/minifier-js/minifier-tests.js
@@ -7,17 +7,17 @@ Tinytest.add('minifier-js - verify how terser handles an empty string', (test) =
 Tinytest.add('minifier-js - verify terser is able to minify valid javascript', (test) => {
   let result = meteorJsMinify('function add(first,second){return first + second; }\n');
   test.equal(result.code, 'function add(n,d){return n+d}');
-  test.equal(result.minifier, 'terser');  
+  test.equal(result.minifier, 'terser');
 });
 
 Tinytest.add('minifier-js - verify error handling is done as expected', (test) => {
-  test.throws( () => meteorJsMinify('let name = {;\n'), undefined );    
+  test.throws( () => meteorJsMinify('let name = {;\n'), undefined );
 });
 
 Tinytest.add('minifier-js - verify tersers error object has the fields we use for reporting errors to users', (test) => {
   let result;
   try {
-    result = meteorJsMinify('let name = {;\n');    
+    result = meteorJsMinify('let name = {;\n');
   }
   catch (err) {
     test.isNotUndefined(err.name);

--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -36,7 +36,6 @@ export const meteorJsMinify = function (source) {
   try {
     terserResult = terserJsMinify(source, options);
   } catch (e) {
-    // the terser api doesnt throw exceptions, so we throw one ourselves
     throw e;
   }
 

--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -1,15 +1,26 @@
 let terser;
 
-const meteorJsMinify = function (source) {
+const terserMinify = async (source, options, callback) => {
+  terser = terser || Npm.require("terser");
+  try {
+    const result = await terser.minify(source, options);
+    return callback(null, result);
+  } catch (e) {
+    return callback(e);
+  }
+};
+
+export const meteorJsMinify = function (source) {
   const result = {};
   const NODE_ENV = process.env.NODE_ENV || "development";
-  terser = terser || Npm.require("terser");
+
 
   const options = {
     compress: {
       drop_debugger: false,  // remove debugger; statements
       unused: false,         // drop unreferenced functions and variables
       dead_code: true,       // remove unreachable code
+      typeofs: false,        // set to false due to known issues in IE10
       global_defs: {
         "process.env.NODE_ENV": NODE_ENV
       }
@@ -20,10 +31,14 @@ const meteorJsMinify = function (source) {
     safari10: true,          // set this option to true to work around the Safari 10/11 await bug
   };
 
-  const terserResult = terser.minify(source, options);
-
-  // the terser api doesnt throw exceptions, so we throw one ourselves
-  if (terserResult.error) throw terserResult.error;
+  const terserJsMinify = Meteor.wrapAsync(terserMinify);
+  let terserResult;
+  try {
+    terserResult = terserJsMinify(source, options);
+  } catch (e) {
+    // the terser api doesnt throw exceptions, so we throw one ourselves
+    throw e;
+  }
 
   // this is kept to maintain backwards compatability
   result.code = terserResult.code;
@@ -31,5 +46,3 @@ const meteorJsMinify = function (source) {
 
   return result;
 };
-
-export { meteorJsMinify };

--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -4,9 +4,11 @@ const terserMinify = async (source, options, callback) => {
   terser = terser || Npm.require("terser");
   try {
     const result = await terser.minify(source, options);
-    return callback(null, result);
+    callback(null, result);
+    return result;
   } catch (e) {
-    return callback(e);
+    callback(e);
+    return e;
   }
 };
 

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "2.7.0"
+  version: "2.7.1"
 });
 
 Npm.depends({

--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Npm.depends({
-  terser: "4.8.0"
+  terser: "5.8.0"
 });
 
 Package.onUse(function (api) {

--- a/packages/standard-minifier-js/.npm/plugin/minifyStdJS/npm-shrinkwrap.json
+++ b/packages/standard-minifier-js/.npm/plugin/minifyStdJS/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA=="
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw=="
     },
     "regenerator-runtime": {
       "version": "0.13.9",

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '2.7.0',
+  version: '2.7.1',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md',
 });
@@ -12,7 +12,7 @@ Package.registerBuildPlugin({
     'ecmascript'
   ],
   npmDependencies: {
-    "@babel/runtime": "7.15.3"
+    "@babel/runtime": "7.15.4"
   },
   sources: [
     'plugin/minify-js.js',


### PR DESCRIPTION
Updates terser to the latest version, which in our case is one major version bump.

From breaking side it means this:
* BREAKING: minify() is now async and rejects a promise instead of returning an error.
* BREAKING: Internal AST is no longer exposed, so that it can be improved without releasing breaking changes.
* BREAKING: Lowest supported node version is 10
* BREAKING: There are no more warnings being emitted

Here are some highlights from new features:
* Optional chaining syntax is now supported.
* `source-map` library has been updated, bringing memory usage and CPU time improvements when reading input source maps (the SourceMapConsumer is now WASM based).
* Accept `{get = "default val"}` and `{set = "default val"}` in destructuring arguments.
* Performance improvements
* Many bug fixes

Full changelog: https://github.com/terser/terser/blob/master/CHANGELOG.md

This also fixes few bugs we were getting.

Currently I believe that the code could be improved. Also we have to decide how this should be released. Since it fixes bugs on our end there is an argument to release it as patch, but it is also a big update so argument could be made for major or feature release (feature probably best given how much issues major release presents).