### PR TITLE
Add migration for npm installer when command issues

### DIFF
--- a/History.md
+++ b/History.md
@@ -32,6 +32,11 @@
 
 1. Replace all usage of `collection._ensureIndex` with `collection.createIndex`. You only need to rename the method as the functionality is the same.
 2. If you are using a [well known service](https://nodemailer.com/smtp/well-known/) for the email package switch to using `Meteor.settings.pacakges.email` settings instead of `MAIL_URL` env variable. Alternatively you can utilize the new `Email.customTransport` function to override the default package behavior and use your own. [Read the email docs](https://docs.meteor.com/api/email.html) for implementation details.
+3. If you install new universal NPM installer on an existing Unix/Mac system you might need add the following line to your bash profile `~/.bash_profile` file:
+```
+#meteor
+export PATH=$PATH:$HOME/.meteor
+```
 
 #### Meteor Version Release
 


### PR DESCRIPTION
On some systems installing the new NPM installer makes the command missing as described on the forums:
https://forums.meteor.com/t/meteor-2-4-is-out/56670/3?u=storyteller

So I have added a step to migration for those that come across this.