### PR TITLE
Fix typo in v2.4 notes: pacakges -> packages

### DIFF
--- a/History.md
+++ b/History.md
@@ -31,7 +31,7 @@
 #### Migration steps
 
 1. Replace all usage of `collection._ensureIndex` with `collection.createIndex`. You only need to rename the method as the functionality is the same.
-2. If you are using a [well known service](https://nodemailer.com/smtp/well-known/) for the email package switch to using `Meteor.settings.pacakges.email` settings instead of `MAIL_URL` env variable. Alternatively you can utilize the new `Email.customTransport` function to override the default package behavior and use your own. [Read the email docs](https://docs.meteor.com/api/email.html) for implementation details.
+2. If you are using a [well known service](https://nodemailer.com/smtp/well-known/) for the email package switch to using `Meteor.settings.packages.email` settings instead of `MAIL_URL` env variable. Alternatively you can utilize the new `Email.customTransport` function to override the default package behavior and use your own. [Read the email docs](https://docs.meteor.com/api/email.html) for implementation details.
 
 #### Meteor Version Release
 


### PR DESCRIPTION
While exploring the upgrade to the recently released v2.4 version, I noticed a small typo in the migration steps. Submitting a tiny fix (sorry if this isn't enough description; hoping it's okay for a one-word fix).