### PR TITLE
Release 2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ run_save_node_bin: &run_save_node_bin
 build_machine_environment: &build_machine_environment
   # Specify that we want an actual machine (ala Circle 1.0), not a Docker image.
   docker:
-    - image: meteor/circleci:android-28-node-12
+    - image: meteor/circleci:android-30-node-14
   environment:
     # This multiplier scales the waitSecs for selftests.
     TIMEOUT_SCALE_FACTOR: 8

--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -42,7 +42,7 @@ export const Autoupdate = {};
 
 // Stores acceptable client versions.
 const clientVersions =
-  Autoupdate._clientVersions = // Used by a self-test.
+  Autoupdate._clientVersions = // Used by a self-test and hot-module-replacement
   new ClientVersions();
 
 Meteor.connection.registerStore(

--- a/packages/autoupdate/autoupdate_cordova.js
+++ b/packages/autoupdate/autoupdate_cordova.js
@@ -10,6 +10,9 @@ export const Autoupdate = {};
 // Stores acceptable client versions.
 const clientVersions = new ClientVersions();
 
+// Used by hot-module-replacement
+Autoupdate._clientVersions = clientVersions;
+
 Meteor.connection.registerStore(
   "meteor_autoupdate_clientVersions",
   clientVersions.createStore()

--- a/packages/autoupdate/autoupdate_server.js
+++ b/packages/autoupdate/autoupdate_server.js
@@ -79,7 +79,8 @@ function updateVersions(shouldReloadClientProgram) {
       versionNonRefreshable: AUTOUPDATE_VERSION ||
         WebApp.calculateClientHashNonRefreshable(arch),
       versionReplaceable: AUTOUPDATE_VERSION ||
-        WebApp.calculateClientHashReplaceable(arch)
+        WebApp.calculateClientHashReplaceable(arch),
+      versionHmr: WebApp.clientPrograms[arch].hmrVersion
     };
   });
 

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Update the client when new client code is available",
-  version: '1.7.0'
+  version: '1.8.0-beta250.0'
 });
 
 Package.onUse(function (api) {

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.15.3',
+  version: '0.16.0-beta250.0',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md'
 });

--- a/packages/ecmascript/plugin.js
+++ b/packages/ecmascript/plugin.js
@@ -4,9 +4,9 @@ Plugin.registerCompiler({
   return new BabelCompiler({
     react: true
   }, (babelOptions, file) => {
-    if (file.hmrAvailable() && ReactFastRefresh.babelPlugin) {
+    if (file.hmrAvailable()) {
       babelOptions.plugins = babelOptions.plugins || [];
-      babelOptions.plugins.push(ReactFastRefresh.babelPlugin);
+      babelOptions.plugins.push(...ReactFastRefresh.getBabelPlugins());
     }
   });
 });

--- a/packages/hot-module-replacement/client.js
+++ b/packages/hot-module-replacement/client.js
@@ -1,25 +1,23 @@
 // TODO: add an api to Reify to update cached exports for a module
 const ReifyEntry = require('/node_modules/meteor/modules/node_modules/reify/lib/runtime/entry.js')
 
-const SOURCE_URL_PREFIX = "meteor://\u{1f4bb}app";
+const SOURCE_URL_PREFIX = "meteor://\ud83d\udcbbapp";
 
-// Due to the bundler and proxy running in the same node process
-// this could possibly be ran after the next build finished
-// TODO: the builder should inject a build timestamp in the bundle
-let lastUpdated = Date.now();
 let appliedChangeSets = [];
 let removeErrorMessage = null;
 
-let arch = __meteor_runtime_config__.isModern ? 'web.browser' : 'web.browser.legacy';
+const arch = Meteor.isCordova ? "web.cordova" :
+  Meteor.isModern ? "web.browser" : "web.browser.legacy";
+
+const initialVersions = __meteor_runtime_config__.autoupdate.versions[arch];
+let lastUpdated = initialVersions.versionHmr;
 const hmrSecret = __meteor_runtime_config__._hmrSecret;
-let supportedArch = arch === 'web.browser';
-const enabled = hmrSecret && supportedArch;
 
-if (!supportedArch) {
-  console.log(`HMR is not supported in ${arch}`);
-}
+// Cordova doesn't need the hmrSecret, though cordova is also unable to tell
+// if Meteor needs to be restarted to enable HMR;
+const enabled = Meteor.isCordova || !!hmrSecret;
 
-if (!hmrSecret) {
+if (!enabled) {
   console.log('Restart Meteor to enable HMR');
 }
 
@@ -28,7 +26,7 @@ const importedBy = Object.create(null);
 
 if (module._onRequire) {
   module._onRequire({
-    before(importedModule, parentId) {
+    before: function (importedModule, parentId) {
       if (parentId === module.id) {
         // While applying updates we import modules to re-run them.
         // Don't track those imports since we don't want them to affect
@@ -44,8 +42,9 @@ if (module._onRequire) {
   });
 }
 
-let pendingReload = () => Package['reload'].Reload._reload({ immediateMigration: true });
+let pendingReload;
 let mustReload = false;
+
 // Once an eager update fails, we stop processing future updates since they
 // might depend on the failed update. This gets reset when we re-try applying
 // the changes as non-eager updates.
@@ -61,7 +60,7 @@ function handleMessage(message) {
       console.log('HMR: Will enable HMR the next time the page is loaded');
       mustReload = true;
     } else {
-      console.log(`HMR: Register failed for unknown reason`, message);
+      console.log('HMR: Register failed for unknown reason', message);
     }
     return;
   } else if (message.type === 'app-state') {
@@ -79,7 +78,7 @@ function handleMessage(message) {
   }
 
   if (message.type !== 'changes') {
-    throw new Error(`Unknown HMR message type ${message.type}`);
+    throw new Error('Unknown HMR message type ' + message.type);
   }
 
   if (message.eager && !applyEagerUpdates) {
@@ -92,7 +91,7 @@ function handleMessage(message) {
     applyEagerUpdates = true;
   }
 
-  const hasUnreloadable = message.changeSets.find(changeSet => {
+  const hasUnreloadable = message.changeSets.find(function (changeSet) {
     return !changeSet.reloadable;
   });
 
@@ -110,7 +109,7 @@ function handleMessage(message) {
       return;
     }
 
-    console.log('HMR: Unable to do HMR. Falling back to hot code push.')
+    console.log('HMR: Unable to do HMR. Falling back to hot code push.');
     // Complete hot code push if we can not do hot module reload
     mustReload = true;
     return pendingReload();
@@ -119,9 +118,9 @@ function handleMessage(message) {
   // In case the user changed how a module works with HMR
   // in one of the earlier change sets, we want to apply each
   // change set one at a time in order.
-  const succeeded = message.changeSets.filter(changeSet => {
+  const succeeded = message.changeSets.filter(function (changeSet) {
     return !appliedChangeSets.includes(changeSet.id)
-  }).every(changeSet => {
+  }).every(function (changeSet) {
     const applied = applyChangeset(changeSet, message.eager);
 
     // We don't record if a module is unreplaceable
@@ -142,13 +141,14 @@ function handleMessage(message) {
   }
 
   if (!succeeded) {
+    console.log('HMR: Some changes can not be applied with HMR. Using hot code push.')
+    mustReload = true;
+
     if (pendingReload) {
-      console.log('HMR: Some changes can not be applied with HMR. Using hot code push.')
-      mustReload = true;
-      return pendingReload();
+      pendingReload();
     }
 
-    throw new Error('HMR failed and unable to fallback to hot code push?');
+    return;
   }
 
   if (message.changeSets.length > 0) {
@@ -201,7 +201,7 @@ function connect() {
     console.log('HMR: connected');
     socket.send(JSON.stringify({
       type: 'register',
-      arch,
+      arch: arch,
       secret: hmrSecret,
       appId: __meteor_runtime_config__.appId,
     }));
@@ -209,7 +209,7 @@ function connect() {
     const toSend = pendingMessages.slice();
     pendingMessages = [];
 
-    toSend.forEach(message => {
+    toSend.forEach(function (message) {
       send(message);
     });
   });
@@ -229,7 +229,7 @@ if (enabled) {
 function requestChanges() {
   send({
     type: 'request-changes',
-    arch,
+    arch: arch,
     after: lastUpdated
   });
 }
@@ -303,7 +303,7 @@ function checkModuleAcceptsUpdate(moduleId, checked) {
 
   // The module did not accept the update. If the update is accepted depends
   // on if the modules that imported this module accept the update.
-  importedBy[moduleId].forEach(depId => {
+  importedBy[moduleId].forEach(function (depId) {
     if (depId === '/' && importedBy[moduleId].size > 1) {
       // This module was eagerly required by Meteor.
       // Meteor won't know if the module can be updated
@@ -327,13 +327,13 @@ function checkModuleAcceptsUpdate(moduleId, checked) {
 }
 
 function addFiles(addedFiles) {
-  addedFiles.forEach(file => {
+  addedFiles.forEach(function (file) {
     const tree = {};
     const segments = file.path.split('/').slice(1);
     const fileName = segments.pop();
 
     let previous = tree;
-    segments.forEach(segment => {
+    segments.forEach(function (segment) {
       previous[segment] = previous[segment] || {}
       previous = previous[segment]
     });
@@ -354,7 +354,7 @@ module.constructor.prototype._reset = function (id) {
   const hotState = file.module._hotState;
 
   const hotData = {};
-  hotState._disposeHandlers.forEach(cb => {
+  hotState._disposeHandlers.forEach(function (cb) {
     cb(hotData);
   });
 
@@ -370,14 +370,14 @@ module.constructor.prototype._reset = function (id) {
   entry.getters = {};
   entry.setters = {};
   entry.module = null;
-  Object.keys(entry.namespace).forEach(key => {
+  Object.keys(entry.namespace).forEach(function (key) {
     if (key !== '__esModule') {
       delete entry.namespace[key];
     }
   });
 
   if (imported[moduleId]) {
-    imported[moduleId].forEach(depId => {
+    imported[moduleId].forEach(function (depId) {
       importedBy[depId].delete(moduleId);
     });
     imported[moduleId] = new Set();
@@ -412,14 +412,15 @@ module.constructor.prototype._replaceModule = function (id, contents) {
   }
 }
 
-function applyChangeset({
-  changedFiles,
-  addedFiles
-}) {
+function applyChangeset(options) {
+  const changedFiles = options.changedFiles;
+  const addedFiles = options.addedFiles;
+
   let canApply = true;
   let toRerun = new Set();
 
-  changedFiles.forEach(({ path }) => {
+  changedFiles.forEach(function (changed) {
+    const path = changed.path;
     const file = findFile(path);
 
     // Check if the file has been imported. If it hasn't been,
@@ -430,7 +431,7 @@ function applyChangeset({
 
       if (canApply) {
         canApply = accepts;
-        checked.forEach(moduleId => {
+        checked.forEach(function (moduleId) {
           toRerun.add(moduleId);
         });
       }
@@ -442,15 +443,15 @@ function applyChangeset({
   }
 
 
-  changedFiles.forEach(({ content, path }) => {
-    module._replaceModule(path, content);
+  changedFiles.forEach(function (changedFile) {
+    module._replaceModule(changedFile.path, changedFile.content);
   });
 
   if (addedFiles.length > 0) {
     addFiles(addedFiles);
   }
 
-  toRerun.forEach(moduleId => {
+  toRerun.forEach(function (moduleId) {
     const file = findFile(moduleId);
     // clear module caches and hot state
     file.module._reset();
@@ -458,7 +459,7 @@ function applyChangeset({
   });
 
   try {
-    toRerun.forEach(moduleId => {
+    toRerun.forEach(function (moduleId) {
       require(moduleId);
     });
   } catch (error) {
@@ -466,21 +467,20 @@ function applyChangeset({
   }
 
   const updateCount = changedFiles.length + addedFiles.length;
-  console.log(`HMR: updated ${updateCount} ${updateCount === 1 ? 'file' : 'files'}`);
+  console.log('HMR: updated ' + updateCount + ' ' + (updateCount === 1 ? 'file' : 'files'));
   return true;
 }
 
-const initialVersions = (__meteor_runtime_config__.autoupdate.versions || {})['web.browser'];
 let nonRefreshableVersion = initialVersions.versionNonRefreshable;
 let replaceableVersion = initialVersions.versionReplaceable;
 
-Meteor.startup(() => {
-  if (!supportedArch) {
+Meteor.startup(function () {
+  if (!enabled) {
     return;
   }
 
-  Package['autoupdate'].Autoupdate._clientVersions.watch((doc) => {
-    if (doc._id !== 'web.browser') {
+  Package['autoupdate'].Autoupdate._clientVersions.watch(function (doc) {
+    if (doc._id !== arch) {
       return;
     }
 
@@ -488,21 +488,27 @@ Meteor.startup(() => {
       nonRefreshableVersion = doc.versionNonRefreshable;
       console.log('HMR: Some changes can not be applied with HMR. Using hot code push.')
       mustReload = true;
-      pendingReload();
+      if (pendingReload) {
+        pendingReload();
+      }
     } else if (doc.versionReplaceable !== replaceableVersion) {
       replaceableVersion = doc.versionReplaceable;
-      if (enabled && !mustReload) {
-        requestChanges();
+      if (!mustReload) {
+        if (pendingReload) {
+          requestChanges();
+        }
       } else {
         mustReload = true;
-        pendingReload();
+        if (pendingReload) {
+          pendingReload();
+        }
       }
     }
   });
 
   // We disable hot code push for js until there were
   // changes that can not be applied through HMR.
-  Package['reload'].Reload._onMigrate((tryReload) => {
+  Package['reload'].Reload._onMigrate(function (tryReload) {
     if (mustReload) {
       return [true];
     }

--- a/packages/hot-module-replacement/hot-api.js
+++ b/packages/hot-module-replacement/hot-api.js
@@ -30,7 +30,7 @@ Object.defineProperty(meteorInstall.Module.prototype, "hot", {
        * @instance
        * @name accept
        */
-      accept() {
+      accept: function () {
         if (arguments.length > 0) {
           console.warn('hot.accept does not support any arguments.');
         }
@@ -44,7 +44,7 @@ Object.defineProperty(meteorInstall.Module.prototype, "hot", {
         * @instance
         * @name decline
         */
-      decline() {
+      decline: function () {
         if (arguments.length > 0) {
           throw new Error('hot.decline does not support any arguments.');
         }
@@ -59,7 +59,7 @@ Object.defineProperty(meteorInstall.Module.prototype, "hot", {
         * @name dispose
         * @param {module.hot.DisposeFunction} callback Called before replacing the old module.
         */
-      dispose(cb) {
+      dispose: function (cb) {
         hotState._disposeHandlers.push(cb);
       },
       /**
@@ -71,10 +71,10 @@ Object.defineProperty(meteorInstall.Module.prototype, "hot", {
         * @param {Object} callbacks Can have before and after methods, called before a module is required,
         * and after it finished being evaluated
         */
-      onRequire(callbacks) {
+      onRequire: function (callbacks) {
         return module._onRequire(callbacks);
       },
-      _canAcceptUpdate() {
+      _canAcceptUpdate: function () {
         return hotState._hotAccepts;
       },
       /**
@@ -88,5 +88,5 @@ Object.defineProperty(meteorInstall.Module.prototype, "hot", {
       data: hotState.data
     }
   },
-  set() { }
+  set: function () { }
 });

--- a/packages/hot-module-replacement/package.js
+++ b/packages/hot-module-replacement/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'hot-module-replacement',
-  version: '0.3.0',
+  version: '0.4.0-beta250.0',
   summary: 'Update code in development without reloading the page',
   documentation: 'README.md',
   debugOnly: true
@@ -12,7 +12,7 @@ Package.onUse(function (api) {
   api.use('hot-code-push', { unordered: true });
 
   // Provides polyfills needed by Meteor.absoluteUrl in legacy browsers
-  api.use('ecmascript-runtime-client', { weak: true });  
+  api.use('ecmascript-runtime-client', { weak: true });
 
   api.use('dev-error-overlay', { weak: true });
   api.imply('modules-runtime-hot@0.13.0');

--- a/packages/hot-module-replacement/package.js
+++ b/packages/hot-module-replacement/package.js
@@ -11,6 +11,9 @@ Package.onUse(function (api) {
   api.use('meteor');
   api.use('hot-code-push', { unordered: true });
 
+  // Provides polyfills needed by Meteor.absoluteUrl in legacy browsers
+  api.use('ecmascript-runtime-client', { weak: true });  
+
   api.use('dev-error-overlay', { weak: true });
   api.imply('modules-runtime-hot@0.13.0');
   api.addFiles([

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '2.4.0_1'
+  version: '2.5.0-beta.0'
 });
 
 Package.includeTool();

--- a/packages/modules-runtime-hot/legacy.js
+++ b/packages/modules-runtime-hot/legacy.js
@@ -1,0 +1,28 @@
+meteorInstall = makeInstaller({
+  // On the client, make package resolution prefer the "browser" field of
+  // package.json over the "module" field over the "main" field.
+  browser: true,
+
+  // The difference between legacy.js and modern.js is that this module
+  // prefers "main" over "module" (see issue #10658).
+  mainFields: ["browser", "main", "module"],
+
+  fallback: function (id, parentId, error) {
+    if (id && id.startsWith('meteor/')) {
+      var packageName = id.split('/', 2)[1];
+      throw new Error(
+        'Cannot find package "' + packageName + '". ' +
+        'Try "meteor add ' + packageName + '".'
+      );
+    }
+
+    throw error;
+  }
+});
+
+let Module = Package['modules-runtime'].meteorInstall.Module;
+meteorInstall.Module.prototype.link = Module.prototype.link;
+
+// This package should be running after modules-runtime but before modules.
+// We want modules to use our patched meteorInstall
+Package['modules-runtime'].meteorInstall = meteorInstall;

--- a/packages/modules-runtime-hot/package.js
+++ b/packages/modules-runtime-hot/package.js
@@ -14,6 +14,7 @@ Package.onUse(function (api) {
   });
 
   api.addFiles("modern.js", "modern");
+  api.addFiles("legacy.js", "legacy");
   api.export("meteorInstall", "client");
 });
 

--- a/packages/modules-runtime-hot/package.js
+++ b/packages/modules-runtime-hot/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules-runtime-hot",
-  version: "0.13.0",
+  version: "0.14.0-beta250.0",
   summary: "Patches modules-runtime to support Hot Module Replacement",
   git: "https://github.com/benjamn/install",
   documentation: "README.md"

--- a/packages/react-fast-refresh/client.js
+++ b/packages/react-fast-refresh/client.js
@@ -1,0 +1,37 @@
+let enabled = __meteor_runtime_config__ &&
+  __meteor_runtime_config__.reactFastRefreshEnabled;
+let hmrEnabled = !!module.hot;
+var setupModule;
+
+function init(module) {
+  if (!hmrEnabled) {
+    return;
+  }
+
+  setupModule = setupModule || require('./client-runtime.js');
+  setupModule(module);
+}
+
+if (
+  hmrEnabled &&
+  enabled
+) {
+  let inBefore = false;
+  module.hot.onRequire({
+    before(module) {
+      if (inBefore) {
+        // This is a module required while loading the react refresh runtime
+        // Do not initialize it to avoid an infinite loop 
+        return;
+      }
+
+      inBefore = true;
+      init(module);
+      inBefore = false;
+    }
+  });
+
+  window.___INIT_METEOR_FAST_REFRESH = function () {};
+} else {
+  window.___INIT_METEOR_FAST_REFRESH = init;
+}

--- a/packages/react-fast-refresh/package.js
+++ b/packages/react-fast-refresh/package.js
@@ -15,6 +15,6 @@ Package.onUse(function (api) {
   api.export('ReactFastRefresh');
   api.use('modules');
   api.addFiles('server.js', 'server');
-  api.addFiles('client-runtime.js', 'web.browser');
+  api.addFiles('client.js', 'client');
   api.use('hot-module-replacement', { weak: true });
 });

--- a/packages/react-fast-refresh/package.js
+++ b/packages/react-fast-refresh/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'react-fast-refresh',
-  version: '0.1.1',
+  version: '0.2.0-beta250.0',
   summary: 'Automatically update React components with HMR',
   documentation: 'README.md',
   devOnly: true

--- a/packages/react-fast-refresh/server.js
+++ b/packages/react-fast-refresh/server.js
@@ -1,20 +1,20 @@
-
 let enabled = !process.env.DISABLE_REACT_FAST_REFRESH;
 
 if (enabled) {
   try {
     // React fast refresh requires react 16.9.0 or newer
-    const semver = require('semver');
+    const semverGte = require('semver/functions/gte');
     const pkg = require('react/package.json');
 
     enabled = pkg && pkg.version &&
-      semver.gte(pkg.version, '16.9.0');
+      semverGte(pkg.version, '16.9.0');
   } catch (e) {
     // If the app doesn't directly depend on react, leave react-refresh
     // enabled in case a package or indirect dependency uses react.
   }
 }
 
+// Needed for compatibility when build plugins use ReactFastRefresh.babelPlugin
 if (typeof __meteor_runtime_config__ === 'object') {
   __meteor_runtime_config__.reactFastRefreshEnabled = enabled;
 }
@@ -23,6 +23,48 @@ const babelPlugin = enabled ?
   require('react-refresh/babel') :
   null;
 
+// Babel plugin that adds a call to global.___INIT_METEOR_FAST_REFRESH()
+// at the start of every file compiled with react-refresh to ensure the runtime
+// is enabled if it is used.
+function enableReactRefreshBabelPlugin(babel) {
+  const { types: t } = babel;
+
+  return {
+    name: "meteor-enable-react-fast-refresh",
+    post(state) {
+      // This is the path for the Program node
+      let path = state.path;
+      let method = t.identifier("___INIT_METEOR_FAST_REFRESH");
+      let call = t.callExpression(
+        t.memberExpression(t.identifier('global'), method),
+        [t.identifier("module")]
+      );
+      path.unshiftContainer("body", t.expressionStatement(call));
+    },
+  };
+}
+
+let deprecationWarned = false;
+
 ReactFastRefresh = {
-  babelPlugin,
+  get babelPlugin() {
+    if (!deprecationWarned) {
+      console.warn(
+        'ReactFastRefresh.babelPlugin is deprecated and is incompatible with HMR on Cordova. Use ReactFastRefresh.getBabelPlugins() instead.'
+      );
+      deprecationWarned = true;
+    }
+
+    return babelPlugin;
+  },
+  getBabelPlugins() {
+    if (!babelPlugin) {
+      return [];
+    }
+
+    return [
+      babelPlugin,
+      enableReactRefreshBabelPlugin,
+    ]
+  }
 };

--- a/packages/typescript/package.js
+++ b/packages/typescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "typescript",
-  version: "4.3.5",
+  version: "4.4.0-beta250.0",
   summary: "Compiler plugin that compiles TypeScript and ECMAScript in .ts and .tsx files",
   documentation: "README.md"
 });

--- a/packages/typescript/plugin.js
+++ b/packages/typescript/plugin.js
@@ -5,9 +5,9 @@ Plugin.registerCompiler({
     react: true,
     typescript: true,
   }, (babelOptions, file) => {
-    if (file.hmrAvailable() && ReactFastRefresh.babelPlugin) {
+    if (file.hmrAvailable()) {
       babelOptions.plugins = babelOptions.plugins || [];
-      babelOptions.plugins.push(ReactFastRefresh.babelPlugin);
+      babelOptions.plugins.push(...ReactFastRefresh.getBabelPlugins());
     }
   });
 });

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Serves a Meteor app over HTTP",
-  version: '1.12.0'
+  version: '1.13.0-beta250.0'
 });
 
 Npm.depends({"basic-auth-connect": "1.0.0",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -20,9 +20,9 @@ Npm.strip({
   useragent: ["test/"]
 });
 
+// whitelist plugin is now included in the core
 Cordova.depends({
-  'cordova-plugin-whitelist': '1.3.4',
-  'cordova-plugin-meteor-webapp': '1.9.1'
+  'cordova-plugin-meteor-webapp': '2.0.0-beta.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -912,6 +912,7 @@ function runWebAppServer() {
       ),
       cordovaCompatibilityVersions: programJson.cordovaCompatibilityVersions,
       PUBLIC_SETTINGS,
+      hmrVersion: programJson.hmrVersion,
     };
 
     // Expose program details as a string reachable via the following URL.

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "2.4-rc.6",
+  "version": "2.5-beta.0",
   "recommended": false,
   "official": false,
   "description": "Meteor experimental release"

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -408,6 +408,7 @@ function doRunCommand(options) {
     }
   }
   webArchs = filterWebArchs(webArchs, options['exclude-archs']);
+  const buildMode = options.production ? 'production' : 'development'
 
   let cordovaRunner;
   if (!_.isEmpty(runTargets)) {
@@ -419,7 +420,9 @@ function doRunCommand(options) {
         const cordovaProject = new CordovaProject(projectContext, {
           settingsFile: options.settings,
           mobileServerUrl: utils.formatUrl(parsedMobileServerUrl),
-          cordovaServerPort: parsedCordovaServerPort });
+          cordovaServerPort: parsedCordovaServerPort,
+          buildMode
+        });
         if (buildmessage.jobHasMessages()) return;
 
         cordovaRunner = new CordovaRunner(cordovaProject, runTargets);
@@ -442,7 +445,7 @@ function doRunCommand(options) {
     settingsFile: options.settings,
     buildOptions: {
       minifyMode: options.production ? 'production' : 'development',
-      buildMode: options.production ? 'production' : 'development',
+      buildMode,
       webArchs: webArchs
     },
     rootUrl: process.env.ROOT_URL,

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -13,15 +13,18 @@ export const CORDOVA_ARCH = "web.cordova";
 
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
+const CORDOVA_ANDROID_VERSION = "10.1.1";
+
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
   'cordova-lib': '10.0.0',
   'cordova-common': '4.0.2',
   'cordova-create': '2.0.0',
   'cordova-registry-mapper': '1.1.15',
+  'cordova-android': CORDOVA_ANDROID_VERSION,
 };
 
 export const CORDOVA_PLATFORM_VERSIONS = {
-  'android': '9.0.0',
+  'android': CORDOVA_ANDROID_VERSION,
   'ios': '6.2.0',
 };
 

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -178,7 +178,8 @@ outdated platforms`);
         templatePath,
         { mobileServerUrl: this.options.mobileServerUrl,
           cordovaServerPort: this.options.cordovaServerPort,
-          settingsFile: this.options.settingsFile }
+          settingsFile: this.options.settingsFile,
+          buildMode: this.options.buildMode }
       );
 
       builder.processControlFile();
@@ -254,7 +255,8 @@ outdated platforms`);
       this.projectRoot,
       { mobileServerUrl: this.options.mobileServerUrl,
         cordovaServerPort: this.options.cordovaServerPort,
-        settingsFile: this.options.settingsFile }
+        settingsFile: this.options.settingsFile,
+        buildMode: this.options.buildMode }
     );
 
     builder.processControlFile();

--- a/tools/cordova/run-targets.js
+++ b/tools/cordova/run-targets.js
@@ -118,15 +118,14 @@ export class AndroidRunTarget extends CordovaRunTarget {
     // Unfortunately, this is intertwined with checking requirements, so the
     // only way to get access to this functionality is to run check_reqs and
     // let it modify process.env
-    var check_reqs_path = files.pathJoin(
-      cordovaProject.projectRoot, 'platforms', this.platform,
-      'cordova', 'lib', 'check_reqs');
-    check_reqs_path = files.convertToOSPath(check_reqs_path);
-    let check_reqs = require(check_reqs_path);
+    // cordova-android 10 and beyond will not include the API files in the project
+    // so we need to load it from the dev bundle
+    const projectPath = files.pathJoin(
+        cordovaProject.projectRoot, 'platforms', this.platform);
+    const check_reqs = require("cordova-android/lib/check_reqs");
     // We can't use check_reqs.run() because that will print the values of
     // JAVA_HOME and ANDROID_HOME to stdout.
-    await Promise.all([check_reqs.check_java(),
-      check_reqs.check_android().then(check_reqs.check_android_target)]);
+    await check_reqs.check_all(projectPath);
   }
 
   async tailLogs(cordovaProject, target) {

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1699,7 +1699,7 @@ class ClientTarget extends Target {
   // Returns an object with the following keys:
   // - controlFile: the path (relative to 'builder') of the control file for
   // the target
-  write(builder, {minifyMode}) {
+  write(builder, {minifyMode, buildMode}) {
     builder.reserve("program.json");
 
     // Helper to iterate over all resources that we serve over HTTP.
@@ -1882,6 +1882,10 @@ class ClientTarget extends Target {
           return [platform, hash];
         }));
       program.cordovaCompatibilityVersions = cordovaCompatibilityVersions;
+    }
+
+    if (buildMode === 'development') {
+      program.hmrVersion = Date.now();
     }
 
     builder.writeJson('program.json', program);

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -1116,7 +1116,7 @@ export class PackageSourceBatch {
         "hot-module-replacement",
         self.unibuild.arch
       );
-    const supportedArch = self.unibuild.arch === 'web.browser';
+    const supportedArch = archinfo.matches(self.unibuild.arch, 'web');
 
     self.hmrAvailable = self.useMeteorInstall && isDevelopment
       && usesHMRPackage && supportedArch;

--- a/tools/runners/run-all.js
+++ b/tools/runners/run-all.js
@@ -34,6 +34,7 @@ class Runner {
     selenium,
     seleniumBrowser,
     noReleaseCheck,
+    cordovaServerPort,
     ...optionsForAppRunner
   }) {
     const self = this;
@@ -121,7 +122,8 @@ class Runner {
         proxy: self.proxy,
         hmrPath: HMRPath,
         secret: hmrSecret,
-        projectContext: self.projectContext
+        projectContext: self.projectContext,
+        cordovaServerPort 
       });
     }
 


### PR DESCRIPTION
The focus of this release is to upgrade the integration between Meteor and Cordova for Android apps.

As Google is going to require apps to be using API version 30 or above in October we are going to release this new version as soon as possible.

We recommend to everybody with Android apps to test our latest beta or RC asap.

All included items are listed [here](https://github.com/meteor/meteor/milestone/83).