### PR TITLE
Update accounts-ui less dependencies

### DIFF
--- a/History.md
+++ b/History.md
@@ -15,6 +15,12 @@
 * `standard-minifier-js@2.7.1`
   - Updated `@babel/runtime` to [v7.15.4](https://github.com/babel/babel/releases/tag/v7.15.4)
 
+* `accounts-ui@1.4.1`
+  - Update compatibility range with `less` from 3.0.2 to 4.0.0
+
+* `accounts-ui-unstyled@1.5.1`
+  - Update compatibility range with `less` from 3.0.2 to 4.0.0
+
 ## v2.4, 2021-09-15
 
 #### Highlights

--- a/packages/accounts-ui-unstyled/package.js
+++ b/packages/accounts-ui-unstyled/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Unstyled version of login widgets",
-  version: "1.5.0"
+  version: "1.5.1"
 });
 
 Package.onUse(function (api) {
@@ -42,7 +42,7 @@ Package.onUse(function (api) {
   // this package doesn't actually apply these styles; they need to be
   // `@import`ed from some non-import less file.  The accounts-ui package does
   // that for you, or you can do it in your app.
-  api.use('less');
+  api.use('less@3.0.2 || 4.0.0');
   api.addFiles('login_buttons.import.less');
 });
 

--- a/packages/accounts-ui-unstyled/package.js
+++ b/packages/accounts-ui-unstyled/package.js
@@ -9,7 +9,7 @@ Package.onUse(function (api) {
     'service-configuration',
     'accounts-base',
     'ecmascript',
-    'templating@1.4.0',
+    'templating@1.4.1',
     'session',
   ], 'client');
 

--- a/packages/accounts-ui/package.js
+++ b/packages/accounts-ui/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   summary: "Simple templates to add login widgets to an app",
-  version: "1.4.0",
+  version: "1.4.1",
 });
 
 Package.onUse(api => {
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);
   api.use('accounts-ui-unstyled', 'client');
-  api.use('less', 'client');
+  api.use('less@3.0.2 || 4.0.0', 'client');
 
   api.addFiles(['login_buttons.less'], 'client');
 });


### PR DESCRIPTION
While working on mobile-packages I have noticed that accounts-ui is not updated to work with the latest `less` package. This PR fixes that by providing compatibility span from v3.0.2 to v4.0.0 of less.