### PR TITLE
Deliver siteUrl in google-config-ui as other config-ui packages

### DIFF
--- a/History.md
+++ b/History.md
@@ -21,6 +21,9 @@
 * `accounts-ui-unstyled@1.5.1`
   - Update compatibility range with `less` from 3.0.2 to 4.0.0
 
+* `google-config-ui@1.0.3`
+  - Deliver siteUrl in the same way as other config-ui packages
+
 ## v2.4, 2021-09-15
 
 #### Highlights

--- a/packages/google-config-ui/google_configure.html
+++ b/packages/google-config-ui/google_configure.html
@@ -22,7 +22,7 @@
      Set Authorized Javascript Origins to: <span class="url">{{siteUrl}}</span>
     </li>
     <li>
-      Set Authorized Redirect URI to: <span class="url">{{siteUrl}}/_oauth/google?close</span>
+      Set Authorized Redirect URI to: <span class="url">{{siteUrl}}_oauth/google?close</span>
     </li>
     <li>
       Finish by clicking "Create".

--- a/packages/google-config-ui/google_configure.js
+++ b/packages/google-config-ui/google_configure.js
@@ -1,14 +1,8 @@
 Template.configureLoginServiceDialogForGoogle.helpers({
-  siteUrl: () => {
-    let url = Meteor.absoluteUrl();
-    if (url.slice(-1) === "/") {
-      url = url.slice(0,-1)
-    }
-    return url;
-  }
+  siteUrl: () => Meteor.absoluteUrl(),
 });
 
 Template.configureLoginServiceDialogForGoogle.fields = () => [
-  {property: 'clientId', label: 'Client ID'},
-  {property: 'secret', label: 'Client secret'}
+  { property: 'clientId', label: 'Client ID' },
+  { property: 'secret', label: 'Client secret' },
 ];

--- a/packages/google-config-ui/package.js
+++ b/packages/google-config-ui/package.js
@@ -1,14 +1,12 @@
 Package.describe({
-  summary: "Blaze configuration templates for Google OAuth.",
-  version: "1.0.2",
+  summary: 'Blaze configuration templates for Google OAuth.',
+  version: '1.0.3',
 });
 
 Package.onUse(api => {
   api.use('ecmascript', 'client');
-  api.use('templating@1.4.0', 'client');
+  api.use('templating@1.4.1', 'client');
 
   api.addFiles('google_login_button.css', 'client');
-  api.addFiles(
-    ['google_configure.html', 'google_configure.js'],
-    'client');
+  api.addFiles(['google_configure.html', 'google_configure.js'], 'client');
 });


### PR DESCRIPTION
`google-config-ui` was needlessly deleting the trailing `/` instead of just removing it from the html like all the other config-ui packages do. This reduces complexity and standardizes with the other packages (and now linted/pretied as well).