### PR TITLE
Rollback to core-js@3.15.2

### DIFF
--- a/packages/ecmascript-runtime-client/package.js
+++ b/packages/ecmascript-runtime-client/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: "ecmascript-runtime-client",
-  version: "0.12.0",
+  version: "0.12.1",
   summary: "Polyfills for new ECMAScript 2015 APIs like Map and Set",
   git: "https://github.com/meteor/meteor/tree/devel/packages/ecmascript-runtime-client",
   documentation: "README.md"
 });
 
 Npm.depends({
-  "core-js": "3.16.0"
+  "core-js": "3.15.2"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
This fixes #11662

- [x] rollback to `core-js@3.15.2`
- [x] set version to `ecmascript-runtime-client@0.12.1`
