### PR TITLE
Added `firefoxMobile` as an alias for `firefox` in modern-broswers

### DIFF
--- a/History.md
+++ b/History.md
@@ -24,6 +24,9 @@
 * `ecmascript-runtime-client@0.12.1`
   - Revert `core-js` to v3.15.2 due to issues in legacy build with arrays, [see issue for more details](https://github.com/meteor/meteor/issues/11662)
 
+* `modern-browsers@0.1.7`
+  - Added `firefoxMobile` as an alias for `firefox`
+
 ## v2.4, 2021-09-15
 
 #### Highlights

--- a/packages/ecmascript/README.md
+++ b/packages/ecmascript/README.md
@@ -249,7 +249,7 @@ Here is a list of the Babel transformers that are currently enabled:
 
 The ECMAScript 2015 standard library has grown to include new APIs and
 data structures, some of which can be implemented ("polyfilled") using
-JavaScript that runs in all engines and browsers today. Here are three new
+JavaScript that runs in all engines and browsers today. Here are four new
 constructors that are guaranteed to be available when the `ecmascript`
 package is installed:
 

--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -6,9 +6,9 @@ const hasOwn = Object.prototype.hasOwnProperty;
 const browserAliases = {
   chrome: [
     // chromeMobile*, per https://github.com/meteor/meteor/pull/9793,
-    "chromeMobile",
-    "chromeMobileIOS",
-    "chromeMobileWebView",
+    'chromeMobile',
+    'chromeMobileIOS',
+    'chromeMobileWebView',
 
     // The major version number of Chromium and Headless Chrome track with the
     // releases of Chrome Dev, Canary and Stable, so we should be okay to
@@ -18,19 +18,21 @@ const browserAliases = {
     // Chromium is particularly important to list here since, unlike macOS
     // builds, Linux builds list Chromium in the userAgent along with Chrome:
     //   e.g. Chromium/70.0.3538.77 Chrome/70.0.3538.77
-    "chromium",
-    "headlesschrome",
+    'chromium',
+    'headlesschrome',
   ],
 
   // If a call to setMinimumBrowserVersions specifies Edge 12 as a minimum
   // version, that means no version of Internet Explorer pre-Edge should
   // be classified as modern. This edge:["ie"] alias effectively enforces
   // that logic, because there is no IE12. #9818 #9839
-  edge: ["ie"],
+  edge: ['ie'],
+
+  firefox: ['firefox', 'firefoxMobile'],
 
   // The webapp package converts browser names to camel case, so
   // mobile_safari and mobileSafari should be synonymous.
-  mobile_safari: ["mobileSafari", "mobileSafariUI", "mobileSafariUI/WKWebView"],
+  mobile_safari: ['mobileSafari', 'mobileSafariUI', 'mobileSafariUI/WKWebView'],
 };
 
 // Expand the given minimum versions by reusing chrome versions for
@@ -49,7 +51,7 @@ function applyAliases(versions) {
     if (hasOwn.call(lowerCaseVersions, original)) {
       aliases.forEach(alias => {
         alias = alias.toLowerCase();
-        if (! hasOwn.call(lowerCaseVersions, alias)) {
+        if (!hasOwn.call(lowerCaseVersions, alias)) {
           lowerCaseVersions[alias] = lowerCaseVersions[original];
         }
       });
@@ -66,17 +68,17 @@ function applyAliases(versions) {
 // webapp via request.browser, return true if that browser qualifies as
 // "modern" according to all requested version constraints.
 function isModern(browser) {
-  const lowerCaseName = browser &&
-    typeof browser.name === "string" &&
-    browser.name.toLowerCase();
+  const lowerCaseName =
+    browser && typeof browser.name === 'string' && browser.name.toLowerCase();
 
-  return !!lowerCaseName &&
+  return (
+    !!lowerCaseName &&
     hasOwn.call(minimumVersions, lowerCaseName) &&
-    greaterThanOrEqualTo([
-      ~~browser.major,
-      ~~browser.minor,
-      ~~browser.patch,
-    ], minimumVersions[lowerCaseName].version);
+    greaterThanOrEqualTo(
+      [~~browser.major, ~~browser.minor, ~~browser.patch],
+      minimumVersions[lowerCaseName].version
+    )
+  );
 }
 
 // Any package that depends on the modern-browsers package can call this
@@ -90,22 +92,24 @@ function setMinimumBrowserVersions(versions, source) {
   Object.keys(lowerCaseVersions).forEach(lowerCaseName => {
     const version = lowerCaseVersions[lowerCaseName];
 
-    if (hasOwn.call(minimumVersions, lowerCaseName) &&
-        ! greaterThan(version, minimumVersions[lowerCaseName].version)) {
+    if (
+      hasOwn.call(minimumVersions, lowerCaseName) &&
+      !greaterThan(version, minimumVersions[lowerCaseName].version)
+    ) {
       return;
     }
 
     minimumVersions[lowerCaseName] = {
       version: copy(version),
-      source: source || getCaller("setMinimumBrowserVersions")
+      source: source || getCaller('setMinimumBrowserVersions'),
     };
   });
 }
 
 function getCaller(calleeName) {
-  const error = new Error;
+  const error = new Error();
   Error.captureStackTrace(error);
-  const lines = error.stack.split("\n");
+  const lines = error.stack.split('\n');
   let caller;
   lines.some((line, i) => {
     if (line.indexOf(calleeName) >= 0) {
@@ -113,6 +117,7 @@ function getCaller(calleeName) {
       return true;
     }
   });
+  console.log(caller);
   return caller;
 }
 
@@ -120,17 +125,17 @@ Object.assign(exports, {
   isModern,
   setMinimumBrowserVersions,
   calculateHashOfMinimumVersions() {
-    const { createHash } = require("crypto");
-    return createHash("sha1").update(
-      JSON.stringify(minimumVersions)
-    ).digest("hex");
-  }
+    const { createHash } = require('crypto');
+    return createHash('sha1')
+      .update(JSON.stringify(minimumVersions))
+      .digest('hex');
+  },
 });
 
 // For making defensive copies of [major, minor, ...] version arrays, so
 // they don't change unexpectedly.
 function copy(version) {
-  if (typeof version === "number") {
+  if (typeof version === 'number') {
     return version;
   }
 
@@ -142,17 +147,17 @@ function copy(version) {
 }
 
 function greaterThanOrEqualTo(a, b) {
-  return ! greaterThan(b, a);
+  return !greaterThan(b, a);
 }
 
 function greaterThan(a, b) {
-  const as = (typeof a === "number") ? [a] : a;
-  const bs = (typeof b === "number") ? [b] : b;
+  const as = typeof a === 'number' ? [a] : a;
+  const bs = typeof b === 'number' ? [b] : b;
   const maxLen = Math.max(as.length, bs.length);
 
   for (let i = 0; i < maxLen; ++i) {
-    a = (i < as.length) ? as[i] : 0;
-    b = (i < bs.length) ? bs[i] : 0;
+    a = i < as.length ? as[i] : 0;
+    b = i < bs.length ? bs[i] : 0;
 
     if (a > b) {
       return true;
@@ -167,49 +172,61 @@ function greaterThan(a, b) {
 }
 
 function makeSource(feature) {
-  return module.id + " (" + feature + ")";
+  return module.id + ' (' + feature + ')';
 }
 
-setMinimumBrowserVersions({
-  chrome: 49,
-  edge: 12,
-  firefox: 45,
-  mobileSafari: [9, 2],
-  opera: 36,
-  safari: 9,
-  // Electron 1.0.0+ matches Chromium 49, per
-  // https://github.com/Kilian/electron-to-chromium/blob/master/full-versions.js
-  electron: 1,
-}, makeSource("classes"));
+setMinimumBrowserVersions(
+  {
+    chrome: 49,
+    edge: 12,
+    firefox: 45,
+    mobileSafari: [9, 2],
+    opera: 36,
+    safari: 9,
+    // Electron 1.0.0+ matches Chromium 49, per
+    // https://github.com/Kilian/electron-to-chromium/blob/master/full-versions.js
+    electron: 1,
+  },
+  makeSource('classes')
+);
 
-setMinimumBrowserVersions({
-  chrome: 39,
-  edge: 13,
-  firefox: 26,
-  mobileSafari: 10,
-  opera: 26,
-  safari: 10,
-  // Disallow any version of PhantomJS.
-  phantomjs: Infinity,
-  electron: [0, 20],
-}, makeSource("generator functions"));
+setMinimumBrowserVersions(
+  {
+    chrome: 39,
+    edge: 13,
+    firefox: 26,
+    mobileSafari: 10,
+    opera: 26,
+    safari: 10,
+    // Disallow any version of PhantomJS.
+    phantomjs: Infinity,
+    electron: [0, 20],
+  },
+  makeSource('generator functions')
+);
 
-setMinimumBrowserVersions({
-  chrome: 41,
-  edge: 13,
-  firefox: 34,
-  mobileSafari: [9, 2],
-  opera: 29,
-  safari: [9, 1],
-  electron: [0, 24],
-}, makeSource("template literals"));
+setMinimumBrowserVersions(
+  {
+    chrome: 41,
+    edge: 13,
+    firefox: 34,
+    mobileSafari: [9, 2],
+    opera: 29,
+    safari: [9, 1],
+    electron: [0, 24],
+  },
+  makeSource('template literals')
+);
 
-setMinimumBrowserVersions({
-  chrome: 38,
-  edge: 12,
-  firefox: 36,
-  mobileSafari: 9,
-  opera: 25,
-  safari: 9,
-  electron: [0, 20],
-}, makeSource("symbols"));
+setMinimumBrowserVersions(
+  {
+    chrome: 38,
+    edge: 12,
+    firefox: 36,
+    mobileSafari: 9,
+    opera: 25,
+    safari: 9,
+    electron: [0, 20],
+  },
+  makeSource('symbols')
+);

--- a/packages/modern-browsers/package.js
+++ b/packages/modern-browsers/package.js
@@ -1,19 +1,20 @@
 Package.describe({
-  name: "modern-browsers",
-  version: "0.1.6",
-  summary: "API for defining the boundary between modern and legacy " +
-    "JavaScript clients",
-  documentation: "README.md"
+  name: 'modern-browsers',
+  version: '0.1.7',
+  summary:
+    'API for defining the boundary between modern and legacy ' +
+    'JavaScript clients',
+  documentation: 'README.md',
 });
 
 Package.onUse(function(api) {
-  api.use("modules");
-  api.mainModule("modern.js", "server");
+  api.use('modules');
+  api.mainModule('modern.js', 'server');
 });
 
 Package.onTest(function(api) {
-  api.use("ecmascript");
-  api.use("tinytest");
-  api.use("modern-browsers");
-  api.mainModule("modern-tests.js", "server");
+  api.use('ecmascript');
+  api.use('tinytest');
+  api.use('modern-browsers');
+  api.mainModule('modern-tests.js', 'server');
 });


### PR DESCRIPTION
Fixes #11668 

Adding `firefoxMobile` as an alias for `firefox` will properly load polyfills for the mobile browser.