### PR TITLE
WebApp option to always return content

### DIFF
--- a/History.md
+++ b/History.md
@@ -54,6 +54,7 @@
   - Update `cordova-plugin-meteor-webapp` to v2
   - Removed dependency on `cordova-plugin-whitelist` as it is now included in core
   - Cordova Meteor plugin is now using AndroidX
+  - Added new settings option `Meteor.settings.packages.webapp.alwaysReturnContent` that will always return content on requests like `POST`, essentially enabling behavior prior to Meteor 2.3.1.
 
 #### Independent Releases
 

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -1,35 +1,28 @@
-import assert from "assert";
-import {
-  readFileSync,
-  chmodSync,
-  chownSync
-} from "fs";
-import { createServer } from "http";
-import { userInfo } from "os";
-import {
-  join as pathJoin,
-  dirname as pathDirname,
-} from "path";
-import { parse as parseUrl } from "url";
-import { createHash } from "crypto";
-import { connect } from "./connect.js";
-import compress from "compression";
-import cookieParser from "cookie-parser";
-import qs from "qs";
-import parseRequest from "parseurl";
-import basicAuth from "basic-auth-connect";
-import { lookup as lookupUserAgent } from "useragent";
-import { isModern } from "meteor/modern-browsers";
-import send from "send";
+import assert from 'assert';
+import { readFileSync, chmodSync, chownSync } from 'fs';
+import { createServer } from 'http';
+import { userInfo } from 'os';
+import { join as pathJoin, dirname as pathDirname } from 'path';
+import { parse as parseUrl } from 'url';
+import { createHash } from 'crypto';
+import { connect } from './connect.js';
+import compress from 'compression';
+import cookieParser from 'cookie-parser';
+import qs from 'qs';
+import parseRequest from 'parseurl';
+import basicAuth from 'basic-auth-connect';
+import { lookup as lookupUserAgent } from 'useragent';
+import { isModern } from 'meteor/modern-browsers';
+import send from 'send';
 import {
   removeExistingSocketFile,
   registerSocketFileCleanup,
 } from './socket_file.js';
-import cluster from "cluster";
-import whomst from "@vlasky/whomst";
+import cluster from 'cluster';
+import whomst from '@vlasky/whomst';
 
-var SHORT_SOCKET_TIMEOUT = 5*1000;
-var LONG_SOCKET_TIMEOUT = 120*1000;
+var SHORT_SOCKET_TIMEOUT = 5 * 1000;
+var LONG_SOCKET_TIMEOUT = 120 * 1000;
 
 export const WebApp = {};
 export const WebAppInternals = {};
@@ -43,7 +36,7 @@ WebAppInternals.NpmModules = {
   connect: {
     version: Npm.require('connect/package.json').version,
     module: connect,
-  }
+  },
 };
 
 // Though we might prefer to use web.browser (modern) as the default
@@ -56,13 +49,12 @@ WebApp.clientPrograms = {};
 // XXX maps archs to program path on filesystem
 var archPath = {};
 
-var bundledJsCssUrlRewriteHook = function (url) {
-  var bundledPrefix =
-     __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
+var bundledJsCssUrlRewriteHook = function(url) {
+  var bundledPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
   return bundledPrefix + url;
 };
 
-var sha1 = function (contents) {
+var sha1 = function(contents) {
   var hash = createHash('sha1');
   hash.update(contents);
   return hash.digest('hex');
@@ -112,41 +104,41 @@ function shouldCompress(req, res) {
 // Real routing / server side rendering will probably refactor this
 // heavily.
 
-
 // e.g. "Mobile Safari" => "mobileSafari"
-var camelCase = function (name) {
+var camelCase = function(name) {
   var parts = name.split(' ');
   parts[0] = parts[0].toLowerCase();
-  for (var i = 1;  i < parts.length;  ++i) {
+  for (var i = 1; i < parts.length; ++i) {
     parts[i] = parts[i].charAt(0).toUpperCase() + parts[i].substr(1);
   }
   return parts.join('');
 };
 
-var identifyBrowser = function (userAgentString) {
+var identifyBrowser = function(userAgentString) {
   var userAgent = lookupUserAgent(userAgentString);
   return {
     name: camelCase(userAgent.family),
     major: +userAgent.major,
     minor: +userAgent.minor,
-    patch: +userAgent.patch
+    patch: +userAgent.patch,
   };
 };
 
 // XXX Refactor as part of implementing real routing.
 WebAppInternals.identifyBrowser = identifyBrowser;
 
-WebApp.categorizeRequest = function (req) {
-  if (req.browser && req.arch && typeof req.modern === "boolean") {
+WebApp.categorizeRequest = function(req) {
+  if (req.browser && req.arch && typeof req.modern === 'boolean') {
     // Already categorized.
     return req;
   }
 
-  const browser = identifyBrowser(req.headers["user-agent"]);
+  const browser = identifyBrowser(req.headers['user-agent']);
   const modern = isModern(browser);
-  const path = typeof req.pathname === "string"
-   ? req.pathname
-   : parseRequest(req).pathname;
+  const path =
+    typeof req.pathname === 'string'
+      ? req.pathname
+      : parseRequest(req).pathname;
 
   const categorized = {
     browser,
@@ -160,16 +152,16 @@ WebApp.categorizeRequest = function (req) {
     cookies: req.cookies,
   };
 
-  const pathParts = path.split("/");
+  const pathParts = path.split('/');
   const archKey = pathParts[1];
 
-  if (archKey.startsWith("__")) {
-    const archCleaned = "web." + archKey.slice(2);
+  if (archKey.startsWith('__')) {
+    const archCleaned = 'web.' + archKey.slice(2);
     if (hasOwn.call(WebApp.clientPrograms, archCleaned)) {
       pathParts.splice(1, 1); // Remove the archKey part.
       return Object.assign(categorized, {
         arch: archCleaned,
-        path: pathParts.join("/"),
+        path: pathParts.join('/'),
       });
     }
   }
@@ -177,8 +169,8 @@ WebApp.categorizeRequest = function (req) {
   // TODO Perhaps one day we could infer Cordova clients here, so that we
   // wouldn't have to use prefixed "/__cordova/..." URLs.
   const preferredArchOrder = isModern(browser)
-    ? ["web.browser", "web.browser.legacy"]
-    : ["web.browser.legacy", "web.browser"];
+    ? ['web.browser', 'web.browser.legacy']
+    : ['web.browser.legacy', 'web.browser'];
 
   for (const arch of preferredArchOrder) {
     // If our preferred arch is not available, it's better to use another
@@ -200,26 +192,24 @@ WebApp.categorizeRequest = function (req) {
 // be added to the '<html>' tag. Each function is passed a 'request' object (see
 // #BrowserIdentification) and should return null or object.
 var htmlAttributeHooks = [];
-var getHtmlAttributes = function (request) {
-  var combinedAttributes  = {};
-  _.each(htmlAttributeHooks || [], function (hook) {
+var getHtmlAttributes = function(request) {
+  var combinedAttributes = {};
+  _.each(htmlAttributeHooks || [], function(hook) {
     var attributes = hook(request);
-    if (attributes === null)
-      return;
+    if (attributes === null) return;
     if (typeof attributes !== 'object')
-      throw Error("HTML attribute hook must return null or object");
+      throw Error('HTML attribute hook must return null or object');
     _.extend(combinedAttributes, attributes);
   });
   return combinedAttributes;
 };
-WebApp.addHtmlAttributeHook = function (hook) {
+WebApp.addHtmlAttributeHook = function(hook) {
   htmlAttributeHooks.push(hook);
 };
 
 // Serve app HTML for this URL?
-var appUrl = function (url) {
-  if (url === '/favicon.ico' || url === '/robots.txt')
-    return false;
+var appUrl = function(url) {
+  if (url === '/favicon.ico' || url === '/robots.txt') return false;
 
   // NOTE: app.manifest is not a web standard like favicon.ico and
   // robots.txt. It is a file name we have chosen to use for HTML5
@@ -227,17 +217,14 @@ var appUrl = function (url) {
   // then removing it from poisoning an app permanently. Eventually,
   // once we have server side routing, this won't be needed as
   // unknown URLs with return a 404 automatically.
-  if (url === '/app.manifest')
-    return false;
+  if (url === '/app.manifest') return false;
 
   // Avoid serving app HTML for declared routes such as /sockjs/.
-  if (RoutePolicy.classify(url))
-    return false;
+  if (RoutePolicy.classify(url)) return false;
 
   // we currently return app HTML on all URLs by default
   return true;
 };
-
 
 // We need to calculate the client hash after all packages have loaded
 // to give them a chance to populate __meteor_runtime_config__.
@@ -256,36 +243,32 @@ var appUrl = function (url) {
 // pre-listen" hook to allow it to insert the auto update version at
 // the right moment.
 
-Meteor.startup(function () {
+Meteor.startup(function() {
   function getter(key) {
-    return function (arch) {
+    return function(arch) {
       arch = arch || WebApp.defaultArch;
       const program = WebApp.clientPrograms[arch];
       const value = program && program[key];
       // If this is the first time we have calculated this hash,
       // program[key] will be a thunk (lazy function with no parameters)
       // that we should call to do the actual computation.
-      return typeof value === "function"
-        ? program[key] = value()
-        : value;
+      return typeof value === 'function' ? (program[key] = value()) : value;
     };
   }
 
-  WebApp.calculateClientHash = WebApp.clientHash = getter("version");
-  WebApp.calculateClientHashRefreshable = getter("versionRefreshable");
-  WebApp.calculateClientHashNonRefreshable = getter("versionNonRefreshable");
-  WebApp.calculateClientHashReplaceable = getter("versionReplaceable");
-  WebApp.getRefreshableAssets = getter("refreshableAssets");
+  WebApp.calculateClientHash = WebApp.clientHash = getter('version');
+  WebApp.calculateClientHashRefreshable = getter('versionRefreshable');
+  WebApp.calculateClientHashNonRefreshable = getter('versionNonRefreshable');
+  WebApp.calculateClientHashReplaceable = getter('versionReplaceable');
+  WebApp.getRefreshableAssets = getter('refreshableAssets');
 });
-
-
 
 // When we have a request pending, we want the socket timeout to be long, to
 // give ourselves a while to serve it, and to allow sockjs long polls to
 // complete.  On the other hand, we want to close idle sockets relatively
 // quickly, so that we can shut down relatively promptly but cleanly, without
 // cutting off anyone's response.
-WebApp._timeoutAdjustmentRequestCallback = function (req, res) {
+WebApp._timeoutAdjustmentRequestCallback = function(req, res) {
   // this is really just req.socket.setTimeout(LONG_SOCKET_TIMEOUT);
   req.setTimeout(LONG_SOCKET_TIMEOUT);
   // Insert our new finish listener to run BEFORE the existing one which removes
@@ -296,12 +279,13 @@ WebApp._timeoutAdjustmentRequestCallback = function (req, res) {
   // But it has switched back to 'finish' in Node v4:
   // https://github.com/nodejs/node/pull/1411
   res.removeAllListeners('finish');
-  res.on('finish', function () {
+  res.on('finish', function() {
     res.setTimeout(SHORT_SOCKET_TIMEOUT);
   });
-  _.each(finishListeners, function (l) { res.on('finish', l); });
+  _.each(finishListeners, function(l) {
+    res.on('finish', l);
+  });
 };
-
 
 // Will be updated by main before we listen.
 // Map from client arch to boilerplate object.
@@ -318,10 +302,10 @@ var boilerplateByArch = {};
 // changes affecting the boilerplate. Passing null deletes the callback.
 // Any previous callback registered for this key will be returned.
 const boilerplateDataCallbacks = Object.create(null);
-WebAppInternals.registerBoilerplateDataCallback = function (key, callback) {
+WebAppInternals.registerBoilerplateDataCallback = function(key, callback) {
   const previousCallback = boilerplateDataCallbacks[key];
 
-  if (typeof callback === "function") {
+  if (typeof callback === 'function') {
     boilerplateDataCallbacks[key] = callback;
   } else {
     assert.strictEqual(callback, null);
@@ -351,10 +335,10 @@ function getBoilerplate(request, arch) {
  * @locus Server
  * @param {Object} rtimeConfig
  * @returns {String}
-*/
-WebApp.encodeRuntimeConfig = function (rtimeConfig) {
+ */
+WebApp.encodeRuntimeConfig = function(rtimeConfig) {
   return JSON.stringify(encodeURIComponent(JSON.stringify(rtimeConfig)));
-}
+};
 
 /**
  * @summary Takes an encoded runtime string and returns
@@ -362,19 +346,19 @@ WebApp.encodeRuntimeConfig = function (rtimeConfig) {
  * @locus Server
  * @param {String} rtimeConfigString
  * @returns {Object}
-*/
-WebApp.decodeRuntimeConfig = function (rtimeConfigStr) {
+ */
+WebApp.decodeRuntimeConfig = function(rtimeConfigStr) {
   return JSON.parse(decodeURIComponent(JSON.parse(rtimeConfigStr)));
-}
+};
 
- const runtimeConfig = {
+const runtimeConfig = {
   // hooks will contain the callback functions
   // set by the caller to addRuntimeConfigHook
   hooks: new Hook(),
   // updateHooks will contain the callback functions
   // set by the caller to addUpdatedNotifyHook
   updateHooks: new Hook(),
-  // isUpdatedByArch is an object containing fields for each arch 
+  // isUpdatedByArch is an object containing fields for each arch
   // that this server supports.
   // - Each field will be true when the server updates the runtimeConfig for that arch.
   // - When the hook callback is called the update field in the callback object will be
@@ -382,7 +366,7 @@ WebApp.decodeRuntimeConfig = function (rtimeConfigStr) {
   // = isUpdatedyByArch[arch] is reset to false after the callback.
   // This enables the caller to cache data efficiently so they do not need to
   // decode & update data on every callback when the runtimeConfig is not changing.
-  isUpdatedByArch: {}
+  isUpdatedByArch: {},
 };
 
 /**
@@ -390,17 +374,17 @@ WebApp.decodeRuntimeConfig = function (rtimeConfigStr) {
  * @locus Server
  * @isprototype true
  * @summary Callback for `addRuntimeConfigHook`.
- * 
+ *
  * If the handler returns a _falsy_ value the hook will not
  * modify the runtime configuration.
- * 
+ *
  * If the handler returns a _String_ the hook will substitute
  * the string for the encoded configuration string.
- * 
+ *
  * **Warning:** the hook does not check the return value at all it is
  * the responsibility of the caller to get the formatting correct using
  * the helper functions.
- * 
+ *
  * `addRuntimeConfigHookCallback` takes only one `Object` argument
  * with the following fields:
  * @param {Object} options
@@ -421,7 +405,7 @@ WebApp.decodeRuntimeConfig = function (rtimeConfigStr) {
 /**
  * @summary Hook that calls back when the meteor runtime configuration,
  * `__meteor_runtime_config__` is being sent to any client.
- * 
+ *
  * **returns**: <small>_Object_</small> `{ stop: function, callback: function }`
  * - `stop` <small>_Function_</small> Call `stop()` to stop getting callbacks.
  * - `callback` <small>_Function_</small> The passed in `callback`.
@@ -431,41 +415,50 @@ WebApp.decodeRuntimeConfig = function (rtimeConfigStr) {
  * @returns {Object} {{ stop: function, callback: function }}
  * Call the returned `stop()` to stop getting callbacks.
  * The passed in `callback` is returned also.
-*/
-WebApp.addRuntimeConfigHook = function (callback) {
+ */
+WebApp.addRuntimeConfigHook = function(callback) {
   return runtimeConfig.hooks.register(callback);
-}
+};
 
 function getBoilerplateAsync(request, arch) {
   let boilerplate = boilerplateByArch[arch];
-  runtimeConfig.hooks.forEach((hook) => {
+  runtimeConfig.hooks.forEach(hook => {
     const meteorRuntimeConfig = hook({
       arch,
       request,
       encodedCurrentConfig: boilerplate.baseData.meteorRuntimeConfig,
-      updated: runtimeConfig.isUpdatedByArch[arch]
+      updated: runtimeConfig.isUpdatedByArch[arch],
     });
-    if(!meteorRuntimeConfig) return;
-    boilerplate.baseData = Object.assign({}, boilerplate.baseData, {meteorRuntimeConfig});
+    if (!meteorRuntimeConfig) return;
+    boilerplate.baseData = Object.assign({}, boilerplate.baseData, {
+      meteorRuntimeConfig,
+    });
   });
   runtimeConfig.isUpdatedByArch[arch] = false;
-  const data = Object.assign({}, boilerplate.baseData, {
-    htmlAttributes: getHtmlAttributes(request),
-  }, _.pick(request, "dynamicHead", "dynamicBody"));
+  const data = Object.assign(
+    {},
+    boilerplate.baseData,
+    {
+      htmlAttributes: getHtmlAttributes(request),
+    },
+    _.pick(request, 'dynamicHead', 'dynamicBody')
+  );
 
   let madeChanges = false;
   let promise = Promise.resolve();
 
   Object.keys(boilerplateDataCallbacks).forEach(key => {
-    promise = promise.then(() => {
-      const callback = boilerplateDataCallbacks[key];
-      return callback(request, data, arch);
-    }).then(result => {
-      // Callbacks should return false if they did not make any changes.
-      if (result !== false) {
-        madeChanges = true;
-      }
-    });
+    promise = promise
+      .then(() => {
+        const callback = boilerplateDataCallbacks[key];
+        return callback(request, data, arch);
+      })
+      .then(result => {
+        // Callbacks should return false if they did not make any changes.
+        if (result !== false) {
+          madeChanges = true;
+        }
+      });
   });
 
   return promise.then(() => ({
@@ -489,67 +482,76 @@ function getBoilerplateAsync(request, arch) {
  * object for this `arch`.
  */
 
-
 /**
  * @summary Hook that runs when the meteor runtime configuration
  * is updated.  Typically the configuration only changes during development mode.
  * @locus Server
- * @param {addUpdatedNotifyHookCallback} handler 
+ * @param {addUpdatedNotifyHookCallback} handler
  * The `handler` is called on every change to an `arch` runtime configuration.
  * See `addUpdatedNotifyHookCallback`.
  * @returns {Object} {{ stop: function, callback: function }}
-*/
+ */
 WebApp.addUpdatedNotifyHook = function(handler) {
   return runtimeConfig.updateHooks.register(handler);
-}
+};
 
-WebAppInternals.generateBoilerplateInstance = function (arch,
-                                                        manifest,
-                                                        additionalOptions) {
+WebAppInternals.generateBoilerplateInstance = function(
+  arch,
+  manifest,
+  additionalOptions
+) {
   additionalOptions = additionalOptions || {};
 
   runtimeConfig.isUpdatedByArch[arch] = true;
   const rtimeConfig = {
     ...__meteor_runtime_config__,
-    ...(additionalOptions.runtimeConfigOverrides || {})
+    ...(additionalOptions.runtimeConfigOverrides || {}),
   };
-  runtimeConfig.updateHooks.forEach((cb) => {
-    cb({arch, manifest, runtimeConfig: rtimeConfig});
+  runtimeConfig.updateHooks.forEach(cb => {
+    cb({ arch, manifest, runtimeConfig: rtimeConfig });
   });
 
   const meteorRuntimeConfig = JSON.stringify(
     encodeURIComponent(JSON.stringify(rtimeConfig))
   );
 
-  return new Boilerplate(arch, manifest, _.extend({
-    pathMapper(itemPath) {
-      return pathJoin(archPath[arch], itemPath);
-    },
-    baseDataExtension: {
-      additionalStaticJs: _.map(
-        additionalStaticJs || [],
-        function (contents, pathname) {
-          return {
-            pathname: pathname,
-            contents: contents
-          };
-        }
-      ),
-      // Convert to a JSON string, then get rid of most weird characters, then
-      // wrap in double quotes. (The outermost JSON.stringify really ought to
-      // just be "wrap in double quotes" but we use it to be safe.) This might
-      // end up inside a <script> tag so we need to be careful to not include
-      // "</script>", but normal {{spacebars}} escaping escapes too much! See
-      // https://github.com/meteor/meteor/issues/3730
-      meteorRuntimeConfig,
-      meteorRuntimeHash: sha1(meteorRuntimeConfig),
-      rootUrlPathPrefix: __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '',
-      bundledJsCssUrlRewriteHook: bundledJsCssUrlRewriteHook,
-      sriMode: sriMode,
-      inlineScriptsAllowed: WebAppInternals.inlineScriptsAllowed(),
-      inline: additionalOptions.inline
-    }
-  }, additionalOptions));
+  return new Boilerplate(
+    arch,
+    manifest,
+    Object.assign(
+      {
+        pathMapper(itemPath) {
+          return pathJoin(archPath[arch], itemPath);
+        },
+        baseDataExtension: {
+          additionalStaticJs: _.map(additionalStaticJs || [], function(
+            contents,
+            pathname
+          ) {
+            return {
+              pathname: pathname,
+              contents: contents,
+            };
+          }),
+          // Convert to a JSON string, then get rid of most weird characters, then
+          // wrap in double quotes. (The outermost JSON.stringify really ought to
+          // just be "wrap in double quotes" but we use it to be safe.) This might
+          // end up inside a <script> tag so we need to be careful to not include
+          // "</script>", but normal {{spacebars}} escaping escapes too much! See
+          // https://github.com/meteor/meteor/issues/3730
+          meteorRuntimeConfig,
+          meteorRuntimeHash: sha1(meteorRuntimeConfig),
+          rootUrlPathPrefix:
+            __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '',
+          bundledJsCssUrlRewriteHook: bundledJsCssUrlRewriteHook,
+          sriMode: sriMode,
+          inlineScriptsAllowed: WebAppInternals.inlineScriptsAllowed(),
+          inline: additionalOptions.inline,
+        },
+      },
+      additionalOptions
+    )
+  );
 };
 
 // A mapping from url path to architecture (e.g. "web.browser") to static
@@ -564,11 +566,11 @@ WebAppInternals.generateBoilerplateInstance = function (arch,
 
 // Serve static files from the manifest or added with
 // `addStaticJs`. Exported for tests.
-WebAppInternals.staticFilesMiddleware = async function (
+WebAppInternals.staticFilesMiddleware = async function(
   staticFilesByArch,
   req,
   res,
-  next,
+  next
 ) {
   var pathname = parseRequest(req).pathname;
   try {
@@ -578,8 +580,12 @@ WebAppInternals.staticFilesMiddleware = async function (
     return;
   }
 
-  var serveStaticJs = function (s) {
-    if (req.method === 'GET' || req.method === 'HEAD') {
+  var serveStaticJs = function(s) {
+    if (
+      req.method === 'GET' ||
+      req.method === 'HEAD' ||
+      Meteor.settings.packages?.webapp?.alwaysReturnContent
+    ) {
       res.writeHead(200, {
         'Content-type': 'application/javascript; charset=UTF-8',
         'Content-Length': Buffer.byteLength(s),
@@ -589,22 +595,24 @@ WebAppInternals.staticFilesMiddleware = async function (
     } else {
       const status = req.method === 'OPTIONS' ? 200 : 405;
       res.writeHead(status, {
-        'Allow': 'OPTIONS, GET, HEAD',
+        Allow: 'OPTIONS, GET, HEAD',
         'Content-Length': '0',
       });
       res.end();
     }
   };
 
-  if (_.has(additionalStaticJs, pathname) &&
-              ! WebAppInternals.inlineScriptsAllowed()) {
+  if (
+    _.has(additionalStaticJs, pathname) &&
+    !WebAppInternals.inlineScriptsAllowed()
+  ) {
     serveStaticJs(additionalStaticJs[pathname]);
     return;
   }
 
   const { arch, path } = WebApp.categorizeRequest(req);
 
-  if (! hasOwn.call(WebApp.clientPrograms, arch)) {
+  if (!hasOwn.call(WebApp.clientPrograms, arch)) {
     // We could come here in case we run with some architectures excluded
     next();
     return;
@@ -615,24 +623,32 @@ WebAppInternals.staticFilesMiddleware = async function (
   const program = WebApp.clientPrograms[arch];
   await program.paused;
 
-  if (path === "/meteor_runtime_config.js" &&
-      ! WebAppInternals.inlineScriptsAllowed()) {
-    serveStaticJs(`__meteor_runtime_config__ = ${program.meteorRuntimeConfig};`);
+  if (
+    path === '/meteor_runtime_config.js' &&
+    !WebAppInternals.inlineScriptsAllowed()
+  ) {
+    serveStaticJs(
+      `__meteor_runtime_config__ = ${program.meteorRuntimeConfig};`
+    );
     return;
   }
 
   const info = getStaticFileInfo(staticFilesByArch, pathname, path, arch);
-  if (! info) {
+  if (!info) {
     next();
     return;
   }
   // "send" will handle HEAD & GET requests
-  if (req.method !== 'HEAD' && req.method !== 'GET') {
+  if (
+    req.method !== 'HEAD' &&
+    req.method !== 'GET' &&
+    !Meteor.settings.packages?.webapp?.alwaysReturnContent
+  ) {
     const status = req.method === 'OPTIONS' ? 200 : 405;
     res.writeHead(status, {
-      'Allow': 'OPTIONS, GET, HEAD',
+      Allow: 'OPTIONS, GET, HEAD',
       'Content-Length': '0',
-    })
+    });
     res.end();
     return;
   }
@@ -644,16 +660,14 @@ WebAppInternals.staticFilesMiddleware = async function (
   // Cacheable files are files that should never change. Typically
   // named by their hash (eg meteor bundled js and css files).
   // We cache them ~forever (1yr).
-  const maxAge = info.cacheable
-    ? 1000 * 60 * 60 * 24 * 365
-    : 0;
+  const maxAge = info.cacheable ? 1000 * 60 * 60 * 24 * 365 : 0;
 
   if (info.cacheable) {
     // Since we use req.headers["user-agent"] to determine whether the
     // client should receive modern or legacy resources, tell the client
     // to invalidate cached resources when/if its user agent string
     // changes in the future.
-    res.setHeader("Vary", "User-Agent");
+    res.setHeader('Vary', 'User-Agent');
   }
 
   // Set the X-SourceMap header, which current Chrome, FireFox, and Safari
@@ -663,18 +677,18 @@ WebAppInternals.staticFilesMiddleware = async function (
   // You may also need to enable source maps in Chrome: open dev tools, click
   // the gear in the bottom right corner, and select "enable source maps".
   if (info.sourceMapUrl) {
-    res.setHeader('X-SourceMap',
-                  __meteor_runtime_config__.ROOT_URL_PATH_PREFIX +
-                  info.sourceMapUrl);
+    res.setHeader(
+      'X-SourceMap',
+      __meteor_runtime_config__.ROOT_URL_PATH_PREFIX + info.sourceMapUrl
+    );
   }
 
-  if (info.type === "js" ||
-      info.type === "dynamic js") {
-    res.setHeader("Content-Type", "application/javascript; charset=UTF-8");
-  } else if (info.type === "css") {
-    res.setHeader("Content-Type", "text/css; charset=UTF-8");
-  } else if (info.type === "json") {
-    res.setHeader("Content-Type", "application/json; charset=UTF-8");
+  if (info.type === 'js' || info.type === 'dynamic js') {
+    res.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
+  } else if (info.type === 'css') {
+    res.setHeader('Content-Type', 'text/css; charset=UTF-8');
+  } else if (info.type === 'json') {
+    res.setHeader('Content-Type', 'application/json; charset=UTF-8');
   }
 
   if (info.hash) {
@@ -689,21 +703,24 @@ WebAppInternals.staticFilesMiddleware = async function (
     send(req, info.absolutePath, {
       maxage: maxAge,
       dotfiles: 'allow', // if we specified a dotfile in the manifest, serve it
-      lastModified: false // don't set last-modified based on the file date
-    }).on('error', function (err) {
-      Log.error("Error serving static file " + err);
-      res.writeHead(500);
-      res.end();
-    }).on('directory', function () {
-      Log.error("Unexpected directory " + info.absolutePath);
-      res.writeHead(500);
-      res.end();
-    }).pipe(res);
+      lastModified: false, // don't set last-modified based on the file date
+    })
+      .on('error', function(err) {
+        Log.error('Error serving static file ' + err);
+        res.writeHead(500);
+        res.end();
+      })
+      .on('directory', function() {
+        Log.error('Unexpected directory ' + info.absolutePath);
+        res.writeHead(500);
+        res.end();
+      })
+      .pipe(res);
   }
 };
 
 function getStaticFileInfo(staticFilesByArch, originalPath, path, arch) {
-  if (! hasOwn.call(WebApp.clientPrograms, arch)) {
+  if (!hasOwn.call(WebApp.clientPrograms, arch)) {
     return null;
   }
 
@@ -724,7 +741,7 @@ function getStaticFileInfo(staticFilesByArch, originalPath, path, arch) {
       info = staticFiles[path];
       // Sometimes we register a lazy function instead of actual data in
       // the staticFiles manifest.
-      if (typeof info === "function") {
+      if (typeof info === 'function') {
         info = staticFiles[path] = info();
       }
       return info;
@@ -737,8 +754,7 @@ function getStaticFileInfo(staticFilesByArch, originalPath, path, arch) {
     }
 
     // If categorizeRequest returned an alternate path, try that instead.
-    if (path !== originalPath &&
-        hasOwn.call(staticFiles, path)) {
+    if (path !== originalPath && hasOwn.call(staticFiles, path)) {
       return finalize(path);
     }
   });
@@ -758,15 +774,15 @@ WebAppInternals.parsePort = port => {
     parsedPort = port;
   }
   return parsedPort;
-}
+};
 
-import { onMessage } from "meteor/inter-process-messaging";
+import { onMessage } from 'meteor/inter-process-messaging';
 
-onMessage("webapp-pause-client", async ({ arch }) => {
+onMessage('webapp-pause-client', async ({ arch }) => {
   WebAppInternals.pauseClient(arch);
 });
 
-onMessage("webapp-reload-client", async ({ arch }) => {
+onMessage('webapp-reload-client', async ({ arch }) => {
   WebAppInternals.generateClientProgram(arch);
 });
 
@@ -774,17 +790,17 @@ function runWebAppServer() {
   var shuttingDown = false;
   var syncQueue = new Meteor._SynchronousQueue();
 
-  var getItemPathname = function (itemUrl) {
+  var getItemPathname = function(itemUrl) {
     return decodeURIComponent(parseUrl(itemUrl).pathname);
   };
 
-  WebAppInternals.reloadClientPrograms = function () {
+  WebAppInternals.reloadClientPrograms = function() {
     syncQueue.runTask(function() {
       const staticFilesByArch = Object.create(null);
 
       const { configJson } = __meteor_bootstrap__;
-      const clientArchs = configJson.clientArchs ||
-        Object.keys(configJson.clientPaths);
+      const clientArchs =
+        configJson.clientArchs || Object.keys(configJson.clientPaths);
 
       try {
         clientArchs.forEach(arch => {
@@ -792,7 +808,7 @@ function runWebAppServer() {
         });
         WebAppInternals.staticFilesByArch = staticFilesByArch;
       } catch (e) {
-        Log.error("Error reloading the client program: " + e.stack);
+        Log.error('Error reloading the client program: ' + e.stack);
         process.exit(1);
       }
     });
@@ -800,15 +816,15 @@ function runWebAppServer() {
 
   // Pause any incoming requests and make them wait for the program to be
   // unpaused the next time generateClientProgram(arch) is called.
-  WebAppInternals.pauseClient = function (arch) {
+  WebAppInternals.pauseClient = function(arch) {
     syncQueue.runTask(() => {
       const program = WebApp.clientPrograms[arch];
       const { unpause } = program;
       program.paused = new Promise(resolve => {
-        if (typeof unpause === "function") {
+        if (typeof unpause === 'function') {
           // If there happens to be an existing program.unpause function,
           // compose it with the resolve function.
-          program.unpause = function () {
+          program.unpause = function() {
             unpause();
             resolve();
           };
@@ -819,52 +835,54 @@ function runWebAppServer() {
     });
   };
 
-  WebAppInternals.generateClientProgram = function (arch) {
+  WebAppInternals.generateClientProgram = function(arch) {
     syncQueue.runTask(() => generateClientProgram(arch));
   };
 
   function generateClientProgram(
     arch,
-    staticFilesByArch = WebAppInternals.staticFilesByArch,
+    staticFilesByArch = WebAppInternals.staticFilesByArch
   ) {
     const clientDir = pathJoin(
       pathDirname(__meteor_bootstrap__.serverDir),
-      arch,
+      arch
     );
 
     // read the control for the client we'll be serving up
-    const programJsonPath = pathJoin(clientDir, "program.json");
+    const programJsonPath = pathJoin(clientDir, 'program.json');
 
     let programJson;
     try {
       programJson = JSON.parse(readFileSync(programJsonPath));
     } catch (e) {
-      if (e.code === "ENOENT") return;
+      if (e.code === 'ENOENT') return;
       throw e;
     }
 
-    if (programJson.format !== "web-program-pre1") {
-      throw new Error("Unsupported format for client assets: " +
-                      JSON.stringify(programJson.format));
+    if (programJson.format !== 'web-program-pre1') {
+      throw new Error(
+        'Unsupported format for client assets: ' +
+          JSON.stringify(programJson.format)
+      );
     }
 
-    if (! programJsonPath || ! clientDir || ! programJson) {
-      throw new Error("Client config file not parsed.");
+    if (!programJsonPath || !clientDir || !programJson) {
+      throw new Error('Client config file not parsed.');
     }
 
     archPath[arch] = clientDir;
-    const staticFiles = staticFilesByArch[arch] = Object.create(null);
+    const staticFiles = (staticFilesByArch[arch] = Object.create(null));
 
     const { manifest } = programJson;
     manifest.forEach(item => {
-      if (item.url && item.where === "client") {
+      if (item.url && item.where === 'client') {
         staticFiles[getItemPathname(item.url)] = {
           absolutePath: pathJoin(clientDir, item.path),
           cacheable: item.cacheable,
           hash: item.hash,
           // Link from source to its map
           sourceMapUrl: item.sourceMapUrl,
-          type: item.type
+          type: item.type,
         };
 
         if (item.sourceMap) {
@@ -872,7 +890,7 @@ function runWebAppServer() {
           // all source maps are cacheable.
           staticFiles[getItemPathname(item.sourceMapUrl)] = {
             absolutePath: pathJoin(clientDir, item.sourceMap),
-            cacheable: true
+            cacheable: true,
           };
         }
       }
@@ -884,8 +902,8 @@ function runWebAppServer() {
     };
 
     const oldProgram = WebApp.clientPrograms[arch];
-    const newProgram = WebApp.clientPrograms[arch] = {
-      format: "web-program-pre1",
+    const newProgram = (WebApp.clientPrograms[arch] = {
+      format: 'web-program-pre1',
       manifest: manifest,
       // Use arrow functions so that these versions can be lazily
       // calculated later, and so that they will not be included in the
@@ -894,36 +912,45 @@ function runWebAppServer() {
       // Note: these version calculations must be kept in agreement with
       // CordovaBuilder#appendVersion in tools/cordova/builder.js, or hot
       // code push will reload Cordova apps unnecessarily.
-      version: () => WebAppHashing.calculateClientHash(
-        manifest, null, configOverrides),
-      versionRefreshable: () => WebAppHashing.calculateClientHash(
-        manifest, type => type === "css", configOverrides),
-      versionNonRefreshable: () => WebAppHashing.calculateClientHash(
-        manifest, (type, replaceable) => type !== "css" && !replaceable, configOverrides),
-      versionReplaceable: () => WebAppHashing.calculateClientHash(
-        manifest, (_type, replaceable) => {
-          if (Meteor.isProduction && replaceable) {
-            throw new Error('Unexpected replaceable file in production');
-          }
+      version: () =>
+        WebAppHashing.calculateClientHash(manifest, null, configOverrides),
+      versionRefreshable: () =>
+        WebAppHashing.calculateClientHash(
+          manifest,
+          type => type === 'css',
+          configOverrides
+        ),
+      versionNonRefreshable: () =>
+        WebAppHashing.calculateClientHash(
+          manifest,
+          (type, replaceable) => type !== 'css' && !replaceable,
+          configOverrides
+        ),
+      versionReplaceable: () =>
+        WebAppHashing.calculateClientHash(
+          manifest,
+          (_type, replaceable) => {
+            if (Meteor.isProduction && replaceable) {
+              throw new Error('Unexpected replaceable file in production');
+            }
 
-          return replaceable
-        },
-        configOverrides
-      ),
+            return replaceable;
+          },
+          configOverrides
+        ),
       cordovaCompatibilityVersions: programJson.cordovaCompatibilityVersions,
       PUBLIC_SETTINGS,
       hmrVersion: programJson.hmrVersion,
-    };
+    });
 
     // Expose program details as a string reachable via the following URL.
-    const manifestUrlPrefix = "/__" + arch.replace(/^web\./, "");
-    const manifestUrl = manifestUrlPrefix + getItemPathname("/manifest.json");
+    const manifestUrlPrefix = '/__' + arch.replace(/^web\./, '');
+    const manifestUrl = manifestUrlPrefix + getItemPathname('/manifest.json');
 
     staticFiles[manifestUrl] = () => {
       if (Package.autoupdate) {
         const {
-          AUTOUPDATE_VERSION =
-            Package.autoupdate.Autoupdate.autoupdateVersion
+          AUTOUPDATE_VERSION = Package.autoupdate.Autoupdate.autoupdateVersion,
         } = process.env;
 
         if (AUTOUPDATE_VERSION) {
@@ -931,7 +958,7 @@ function runWebAppServer() {
         }
       }
 
-      if (typeof newProgram.version === "function") {
+      if (typeof newProgram.version === 'function') {
         newProgram.version = newProgram.version();
       }
 
@@ -939,7 +966,7 @@ function runWebAppServer() {
         content: JSON.stringify(newProgram),
         cacheable: false,
         hash: newProgram.version,
-        type: "json"
+        type: 'json',
       };
     };
 
@@ -947,11 +974,10 @@ function runWebAppServer() {
 
     // If there are any requests waiting on oldProgram.paused, let them
     // continue now (using the new program).
-    if (oldProgram &&
-        oldProgram.paused) {
+    if (oldProgram && oldProgram.paused) {
       oldProgram.unpause();
     }
-  };
+  }
 
   const defaultOptionsForArch = {
     'web.cordova': {
@@ -966,46 +992,45 @@ function runWebAppServer() {
         // redirects. (Plus it's undesirable to have clients
         // connecting to http://example.meteor.com when force-ssl is
         // in use.)
-        DDP_DEFAULT_CONNECTION_URL: process.env.MOBILE_DDP_URL ||
-          Meteor.absoluteUrl(),
-        ROOT_URL: process.env.MOBILE_ROOT_URL ||
-          Meteor.absoluteUrl()
-      }
+        DDP_DEFAULT_CONNECTION_URL:
+          process.env.MOBILE_DDP_URL || Meteor.absoluteUrl(),
+        ROOT_URL: process.env.MOBILE_ROOT_URL || Meteor.absoluteUrl(),
+      },
     },
 
-    "web.browser": {
+    'web.browser': {
       runtimeConfigOverrides: {
         isModern: true,
-      }
+      },
     },
 
-    "web.browser.legacy": {
+    'web.browser.legacy': {
       runtimeConfigOverrides: {
         isModern: false,
-      }
+      },
     },
   };
 
-  WebAppInternals.generateBoilerplate = function () {
+  WebAppInternals.generateBoilerplate = function() {
     // This boilerplate will be served to the mobile devices when used with
     // Meteor/Cordova for the Hot-Code Push and since the file will be served by
     // the device's server, it is important to set the DDP url to the actual
     // Meteor server accepting DDP connections and not the device's file server.
     syncQueue.runTask(function() {
-      Object.keys(WebApp.clientPrograms)
-        .forEach(generateBoilerplateForArch);
+      Object.keys(WebApp.clientPrograms).forEach(generateBoilerplateForArch);
     });
   };
 
   function generateBoilerplateForArch(arch) {
     const program = WebApp.clientPrograms[arch];
     const additionalOptions = defaultOptionsForArch[arch] || {};
-    const { baseData } = boilerplateByArch[arch] =
-      WebAppInternals.generateBoilerplateInstance(
-        arch,
-        program.manifest,
-        additionalOptions,
-      );
+    const { baseData } = (boilerplateByArch[
+      arch
+    ] = WebAppInternals.generateBoilerplateInstance(
+      arch,
+      program.manifest,
+      additionalOptions
+    ));
     // We need the runtime config with overrides for meteor_runtime_config.js:
     program.meteorRuntimeConfig = JSON.stringify({
       ...__meteor_runtime_config__,
@@ -1027,7 +1052,7 @@ function runWebAppServer() {
   app.use(rawConnectHandlers);
 
   // Auto-compress any json, javascript, or text.
-  app.use(compress({filter: shouldCompress}));
+  app.use(compress({ filter: shouldCompress }));
 
   // parse cookies into an object
   app.use(cookieParser());
@@ -1040,7 +1065,7 @@ function runWebAppServer() {
       return;
     }
     res.writeHead(400);
-    res.write("Not a proxy");
+    res.write('Not a proxy');
     res.end();
   });
 
@@ -1049,24 +1074,26 @@ function runWebAppServer() {
   //
   // Do this before the next middleware destroys req.url if a path prefix
   // is set to close #10111.
-  app.use(function (request, response, next) {
+  app.use(function(request, response, next) {
     request.query = qs.parse(parseUrl(request.url).query);
     next();
   });
 
   function getPathParts(path) {
-    const parts = path.split("/");
-    while (parts[0] === "") parts.shift();
+    const parts = path.split('/');
+    while (parts[0] === '') parts.shift();
     return parts;
   }
 
   function isPrefixOf(prefix, array) {
-    return prefix.length <= array.length &&
-      prefix.every((part, i) => part === array[i]);
+    return (
+      prefix.length <= array.length &&
+      prefix.every((part, i) => part === array[i])
+    );
   }
 
   // Strip off the path prefix, if it exists.
-  app.use(function (request, response, next) {
+  app.use(function(request, response, next) {
     const pathPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
     const { pathname, search } = parseUrl(request.url);
 
@@ -1075,7 +1102,7 @@ function runWebAppServer() {
       const prefixParts = getPathParts(pathPrefix);
       const pathParts = getPathParts(pathname);
       if (isPrefixOf(prefixParts, pathParts)) {
-        request.url = "/" + pathParts.slice(prefixParts.length).join("/");
+        request.url = '/' + pathParts.slice(prefixParts.length).join('/');
         if (search) {
           request.url += search;
         }
@@ -1083,14 +1110,13 @@ function runWebAppServer() {
       }
     }
 
-    if (pathname === "/favicon.ico" ||
-        pathname === "/robots.txt") {
+    if (pathname === '/favicon.ico' || pathname === '/robots.txt') {
       return next();
     }
 
     if (pathPrefix) {
       response.writeHead(404);
-      response.write("Unknown path");
+      response.write('Unknown path');
       response.end();
       return;
     }
@@ -1100,17 +1126,18 @@ function runWebAppServer() {
 
   // Serve static files from the manifest.
   // This is inspired by the 'static' middleware.
-  app.use(function (req, res, next) {
+  app.use(function(req, res, next) {
     WebAppInternals.staticFilesMiddleware(
       WebAppInternals.staticFilesByArch,
-      req, res, next
+      req,
+      res,
+      next
     );
   });
 
   // Core Meteor packages like dynamic-import can add handlers before
   // other handlers added by package and application code.
-  app.use(WebAppInternals.meteorInternalHandlers = connect());
-
+  app.use((WebAppInternals.meteorInternalHandlers = connect()));
 
   /**
    * @name connectHandlersCallback(req, res, next)
@@ -1130,7 +1157,7 @@ function runWebAppServer() {
    * @param {Function} next
    * Calling this function will pass on the handling of
    * this request to the next relevant handler.
-   * 
+   *
    */
 
   /**
@@ -1141,13 +1168,13 @@ function runWebAppServer() {
    * @param {String} [path]
    * This handler will only be called on paths that match
    * this string. The match has to border on a `/` or a `.`.
-   * 
+   *
    * For example, `/hello` will match `/hello/world` and
    * `/hello.world`, but not `/hello_world`.
    * @param {connectHandlersCallback} handler
    * A handler function that will be called on HTTP requests.
    * See `connectHandlersCallback`
-   * 
+   *
    */
   // Packages and apps can add handlers to this via WebApp.connectHandlers.
   // They are inserted before our default handler.
@@ -1158,29 +1185,32 @@ function runWebAppServer() {
   // connect knows it is an error handler because it has 4 arguments instead of
   // 3. go figure.  (It is not smart enough to find such a thing if it's hidden
   // inside packageAndAppHandlers.)
-  app.use(function (err, req, res, next) {
+  app.use(function(err, req, res, next) {
     if (!err || !suppressConnectErrors || !req.headers['x-suppress-error']) {
       next(err);
       return;
     }
     res.writeHead(err.status, { 'Content-Type': 'text/plain' });
-    res.end("An error message");
+    res.end('An error message');
   });
 
-  app.use(async function (req, res, next) {
-    if (! appUrl(req.url)) {
+  app.use(async function(req, res, next) {
+    if (!appUrl(req.url)) {
       return next();
-
-    } else if (req.method !== 'HEAD' && req.method !== 'GET') {
+    } else if (
+      req.method !== 'HEAD' &&
+      req.method !== 'GET' &&
+      !Meteor.settings.packages?.webapp?.alwaysReturnContent
+    ) {
       const status = req.method === 'OPTIONS' ? 200 : 405;
       res.writeHead(status, {
-        'Allow': 'OPTIONS, GET, HEAD',
+        Allow: 'OPTIONS, GET, HEAD',
         'Content-Length': '0',
-      })
+      });
       res.end();
     } else {
       var headers = {
-        'Content-Type': 'text/html; charset=utf-8'
+        'Content-Type': 'text/html; charset=utf-8',
       };
 
       if (shuttingDown) {
@@ -1200,7 +1230,7 @@ function runWebAppServer() {
         headers['Content-Type'] = 'text/css; charset=utf-8';
         headers['Cache-Control'] = 'no-cache';
         res.writeHead(200, headers);
-        res.write(".meteor-css-not-found-error { width: 0px;}");
+        res.write('.meteor-css-not-found-error { width: 0px;}');
         res.end();
         return;
       }
@@ -1212,7 +1242,7 @@ function runWebAppServer() {
         // already!)
         headers['Cache-Control'] = 'no-cache';
         res.writeHead(404, headers);
-        res.end("404 Not Found");
+        res.end('404 Not Found');
         return;
       }
 
@@ -1223,14 +1253,14 @@ function runWebAppServer() {
         // So similar to the situation above, we serve an uncached 404.
         headers['Cache-Control'] = 'no-cache';
         res.writeHead(404, headers);
-        res.end("404 Not Found");
+        res.end('404 Not Found');
         return;
       }
 
       const { arch } = request;
-      assert.strictEqual(typeof arch, "string", { arch });
+      assert.strictEqual(typeof arch, 'string', { arch });
 
-      if (! hasOwn.call(WebApp.clientPrograms, arch)) {
+      if (!hasOwn.call(WebApp.clientPrograms, arch)) {
         // We could come here in case we run with some architectures excluded
         headers['Cache-Control'] = 'no-cache';
         res.writeHead(404, headers);
@@ -1238,7 +1268,7 @@ function runWebAppServer() {
           res.end(`No client program found for the ${arch} architecture.`);
         } else {
           // Safety net, but this branch should not be possible.
-          res.end("404 Not Found");
+          res.end('404 Not Found');
         }
         return;
       }
@@ -1247,40 +1277,36 @@ function runWebAppServer() {
       // Promise that will be resolved when the program is unpaused.
       await WebApp.clientPrograms[arch].paused;
 
-      return getBoilerplateAsync(request, arch).then(({
-        stream,
-        statusCode,
-        headers: newHeaders,
-      }) => {
-        if (!statusCode) {
-          statusCode = res.statusCode ? res.statusCode : 200;
-        }
+      return getBoilerplateAsync(request, arch)
+        .then(({ stream, statusCode, headers: newHeaders }) => {
+          if (!statusCode) {
+            statusCode = res.statusCode ? res.statusCode : 200;
+          }
 
-        if (newHeaders) {
-          Object.assign(headers, newHeaders);
-        }
+          if (newHeaders) {
+            Object.assign(headers, newHeaders);
+          }
 
-        res.writeHead(statusCode, headers);
+          res.writeHead(statusCode, headers);
 
-        stream.pipe(res, {
-          // End the response when the stream ends.
-          end: true,
+          stream.pipe(res, {
+            // End the response when the stream ends.
+            end: true,
+          });
+        })
+        .catch(error => {
+          Log.error('Error running template: ' + error.stack);
+          res.writeHead(500, headers);
+          res.end();
         });
-
-      }).catch(error => {
-        Log.error("Error running template: " + error.stack);
-        res.writeHead(500, headers);
-        res.end();
-      });
     }
   });
 
   // Return 404 by default, if no other handlers serve this URL.
-  app.use(function (req, res) {
+  app.use(function(req, res) {
     res.writeHead(404);
     res.end();
   });
-
 
   var httpServer = createServer(app);
   var onListeningCallbacks = [];
@@ -1324,18 +1350,16 @@ function runWebAppServer() {
     httpServer: httpServer,
     connectApp: app,
     // For testing.
-    suppressConnectErrors: function () {
+    suppressConnectErrors: function() {
       suppressConnectErrors = true;
     },
-    onListening: function (f) {
-      if (onListeningCallbacks)
-        onListeningCallbacks.push(f);
-      else
-        f();
+    onListening: function(f) {
+      if (onListeningCallbacks) onListeningCallbacks.push(f);
+      else f();
     },
     // This can be overridden by users who want to modify how listening works
     // (eg, to run a proxy like Apollo Engine Proxy in front of the server).
-    startListening: function (httpServer, listenOptions, cb) {
+    startListening: function(httpServer, listenOptions, cb) {
       httpServer.listen(listenOptions, cb);
     },
   });
@@ -1347,17 +1371,26 @@ function runWebAppServer() {
     WebAppInternals.generateBoilerplate();
 
     const startHttpServer = listenOptions => {
-      WebApp.startListening(httpServer, listenOptions, Meteor.bindEnvironment(() => {
-        if (process.env.METEOR_PRINT_ON_LISTEN) {
-          console.log("LISTENING");
-        }
-        const callbacks = onListeningCallbacks;
-        onListeningCallbacks = null;
-        callbacks.forEach(callback => { callback(); });
-      }, e => {
-        console.error("Error listening:", e);
-        console.error(e && e.stack);
-      }));
+      WebApp.startListening(
+        httpServer,
+        listenOptions,
+        Meteor.bindEnvironment(
+          () => {
+            if (process.env.METEOR_PRINT_ON_LISTEN) {
+              console.log('LISTENING');
+            }
+            const callbacks = onListeningCallbacks;
+            onListeningCallbacks = null;
+            callbacks.forEach(callback => {
+              callback();
+            });
+          },
+          e => {
+            console.error('Error listening:', e);
+            console.error(e && e.stack);
+          }
+        )
+      );
     };
 
     let localPort = process.env.PORT || 0;
@@ -1365,28 +1398,30 @@ function runWebAppServer() {
 
     if (unixSocketPath) {
       if (cluster.isWorker) {
-        const workerName = cluster.worker.process.env.name || cluster.worker.id
-        unixSocketPath += "." + workerName + ".sock";
+        const workerName = cluster.worker.process.env.name || cluster.worker.id;
+        unixSocketPath += '.' + workerName + '.sock';
       }
       // Start the HTTP server using a socket file.
       removeExistingSocketFile(unixSocketPath);
       startHttpServer({ path: unixSocketPath });
 
-      const unixSocketPermissions = (process.env.UNIX_SOCKET_PERMISSIONS || "").trim();
+      const unixSocketPermissions = (
+        process.env.UNIX_SOCKET_PERMISSIONS || ''
+      ).trim();
       if (unixSocketPermissions) {
         if (/^[0-7]{3}$/.test(unixSocketPermissions)) {
           chmodSync(unixSocketPath, parseInt(unixSocketPermissions, 8));
         } else {
-          throw new Error("Invalid UNIX_SOCKET_PERMISSIONS specified");
+          throw new Error('Invalid UNIX_SOCKET_PERMISSIONS specified');
         }
       }
 
-      const unixSocketGroup = (process.env.UNIX_SOCKET_GROUP || "").trim();
+      const unixSocketGroup = (process.env.UNIX_SOCKET_GROUP || '').trim();
       if (unixSocketGroup) {
         //whomst automatically handles both group names and numerical gids
         const unixSocketGroupInfo = whomst.sync.group(unixSocketGroup);
         if (unixSocketGroupInfo === null) {
-          throw new Error("Invalid UNIX_SOCKET_GROUP name specified");
+          throw new Error('Invalid UNIX_SOCKET_GROUP name specified');
         }
         chownSync(unixSocketPath, userInfo().uid, unixSocketGroupInfo.gid);
       }
@@ -1397,28 +1432,28 @@ function runWebAppServer() {
       if (/\\\\?.+\\pipe\\?.+/.test(localPort)) {
         // Start the HTTP server using Windows Server style named pipe.
         startHttpServer({ path: localPort });
-      } else if (typeof localPort === "number") {
+      } else if (typeof localPort === 'number') {
         // Start the HTTP server using TCP.
         startHttpServer({
           port: localPort,
-          host: process.env.BIND_IP || "0.0.0.0"
+          host: process.env.BIND_IP || '0.0.0.0',
         });
       } else {
-        throw new Error("Invalid PORT specified");
+        throw new Error('Invalid PORT specified');
       }
     }
 
-    return "DAEMON";
+    return 'DAEMON';
   };
 }
 
 var inlineScriptsAllowed = true;
 
-WebAppInternals.inlineScriptsAllowed = function () {
+WebAppInternals.inlineScriptsAllowed = function() {
   return inlineScriptsAllowed;
 };
 
-WebAppInternals.setInlineScriptsAllowed = function (value) {
+WebAppInternals.setInlineScriptsAllowed = function(value) {
   inlineScriptsAllowed = value;
   WebAppInternals.generateBoilerplate();
 };
@@ -1430,16 +1465,15 @@ WebAppInternals.enableSubresourceIntegrity = function(use_credentials = false) {
   WebAppInternals.generateBoilerplate();
 };
 
-WebAppInternals.setBundledJsCssUrlRewriteHook = function (hookFn) {
+WebAppInternals.setBundledJsCssUrlRewriteHook = function(hookFn) {
   bundledJsCssUrlRewriteHook = hookFn;
   WebAppInternals.generateBoilerplate();
 };
 
-WebAppInternals.setBundledJsCssPrefix = function (prefix) {
+WebAppInternals.setBundledJsCssPrefix = function(prefix) {
   var self = this;
-  self.setBundledJsCssUrlRewriteHook(
-    function (url) {
-      return prefix + url;
+  self.setBundledJsCssUrlRewriteHook(function(url) {
+    return prefix + url;
   });
 };
 
@@ -1448,8 +1482,8 @@ WebAppInternals.setBundledJsCssPrefix = function (prefix) {
 // unless inline scripts have been disabled, in which case it will be
 // served under `/<sha1 of contents>`.
 var additionalStaticJs = {};
-WebAppInternals.addStaticJs = function (contents) {
-  additionalStaticJs["/" + sha1(contents) + ".js"] = contents;
+WebAppInternals.addStaticJs = function(contents) {
+  additionalStaticJs['/' + sha1(contents) + '.js'] = contents;
 };
 
 // Exported for tests


### PR DESCRIPTION
Adds a new settings option `Meteor.settings.packages.webapp.alwaysReturnContent` to allow bypass changes done in #11224 and revert to the old behavior as per special use cases in #11685 
`packages/webapp/webapp_server.js` was linted, so look for comments for the actual changes.

Tested on reproduction in #11685