### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/npm-eslint-plugin-meteor.yml
+++ b/.github/workflows/npm-eslint-plugin-meteor.yml
@@ -2,10 +2,10 @@ name: NPM eslint-plugin-meteor
 on:
   push:
     paths:
-      - 'npm-packages/eslint-plugin-meteor/**'
+      - "npm-packages/eslint-plugin-meteor/**"
   pull_request:
     paths:
-      - 'npm-packages/eslint-plugin-meteor/**'
+      - "npm-packages/eslint-plugin-meteor/**"
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,13 +14,13 @@ jobs:
         working-directory: npm-packages/eslint-plugin-meteor
     strategy:
       matrix:
-        node-version: [ 12.x, 14.x ]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - run: npm test
-

--- a/.github/workflows/npm-meteor-babel.yml
+++ b/.github/workflows/npm-meteor-babel.yml
@@ -2,10 +2,10 @@ name: NPM meteor-babel
 on:
   push:
     paths:
-      - 'npm-packages/meteor-babel/**'
+      - "npm-packages/meteor-babel/**"
   pull_request:
     paths:
-      - 'npm-packages/meteor-babel/**'
+      - "npm-packages/meteor-babel/**"
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,12 +14,13 @@ jobs:
         working-directory: npm-packages/meteor-babel
     strategy:
       matrix:
-        node-version: [ 12.x, 14.x ]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - run: npm run test

--- a/.github/workflows/npm-meteor-promise.yml
+++ b/.github/workflows/npm-meteor-promise.yml
@@ -2,10 +2,10 @@ name: NPM meteor-promise
 on:
   push:
     paths:
-      - 'npm-packages/meteor-promise/**'
+      - "npm-packages/meteor-promise/**"
   pull_request:
     paths:
-      - 'npm-packages/meteor-promise/**'
+      - "npm-packages/meteor-promise/**"
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,12 +14,13 @@ jobs:
         working-directory: npm-packages/meteor-promise
     strategy:
       matrix:
-        node-version: [ 12.x, 14.x ]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - run: npm run test


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
