### PR TITLE
Fix type of tools/node_modules symlink on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tools/node_modules  symlink=dir


### PR DESCRIPTION
Hopefully this is the last step needed to fix #10930.