### PR TITLE
[Facebook OAuth] Use Facebook API v12

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -60,6 +60,9 @@ Read our [Migration Guide](https://guide.meteor.com/2.6.1-migration.html) for th
 * `accounts-base@2.2.2`
   - Fix an issue where an extra field defined in `defaultFieldSelector` would not get published to the client
 
+* `facebook-oauth@1.11.0`
+  - Updated Facebook API to version 12.0
+
 #### Independent Releases
 
 * `mongo@1.14.1` at 2022-02-04

--- a/packages/facebook-oauth/facebook_client.js
+++ b/packages/facebook-oauth/facebook_client.js
@@ -30,7 +30,7 @@ Facebook.requestCredential = (options, credentialRequestCompleteCallback) => {
 
   const loginStyle = OAuth._loginStyle('facebook', config, options);
 
-  const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '10.0';
+  const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '12.0';
 
   let loginUrl =
       `https://www.facebook.com/v${API_VERSION}/dialog/oauth?client_id=${config.appId}` +

--- a/packages/facebook-oauth/facebook_client.js
+++ b/packages/facebook-oauth/facebook_client.js
@@ -30,7 +30,7 @@ Facebook.requestCredential = (options, credentialRequestCompleteCallback) => {
 
   const loginStyle = OAuth._loginStyle('facebook', config, options);
 
-  const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '12.0';
+  const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '10.0';
 
   let loginUrl =
       `https://www.facebook.com/v${API_VERSION}/dialog/oauth?client_id=${config.appId}` +

--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -2,7 +2,7 @@ Facebook = {};
 import crypto from 'crypto';
 import { Accounts } from 'meteor/accounts-base';
 
-const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '12.0';
+const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '10.0';
 
 Facebook.handleAuthFromAccessToken = (accessToken, expiresAt) => {
   // include basic fields from facebook

--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -2,7 +2,7 @@ Facebook = {};
 import crypto from 'crypto';
 import { Accounts } from 'meteor/accounts-base';
 
-const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '10.0';
+const API_VERSION = Meteor.settings?.public?.packages?.['facebook-oauth']?.apiVersion || '12.0';
 
 Facebook.handleAuthFromAccessToken = (accessToken, expiresAt) => {
   // include basic fields from facebook

--- a/packages/facebook-oauth/package.js
+++ b/packages/facebook-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Facebook OAuth flow",
-  version: "1.10.0"
+  version: "1.11.0"
 });
 
 Package.onUse(api => {

--- a/packages/facebook-oauth/package.js
+++ b/packages/facebook-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Facebook OAuth flow",
-  version: "1.11.0"
+  version: "1.11.0-beta261.3"
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
Update Facebook API to v12. No changes to OAuth has been made, so just bumping the number is enough. Since this is also not anything that needs to be done and the v10 of the API will be supported till June 8th, 2023 I have put it as a feature upgrade to be included in the next feature release of Meteor.
* [v11 changelog](https://developers.facebook.com/docs/graph-api/changelog/version11.0)
* [v12 changelog](https://developers.facebook.com/docs/graph-api/changelog/version12.0)