### PR TITLE
Change passwordless loginWithToken method name to passwordlessLoginWithToken

### DIFF
--- a/docs/source/packages/accounts-passwordless.md
+++ b/docs/source/packages/accounts-passwordless.md
@@ -10,7 +10,7 @@ The first step to in the passwordless process is for the user to sign-up or requ
 
 If the user is signing up you can pass in the `userData` object like in [Accounts.createUser](/api/passwords.html#Accounts-createUser).
 
-{% apibox "Meteor.loginWithToken" %}
+{% apibox "Meteor.passwordlessLoginWithToken" %}
 The second step in the passwordless flow. Like all the other `loginWith` functions call this method to login the user with the token they have inputted.
 
 {% apibox "Accounts.sendLoginTokenEmail" %}

--- a/packages/accounts-passwordless/package.js
+++ b/packages/accounts-passwordless/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'No-password login/sign-up support for accounts',
-  version: '1.0.0',
+  version: '2.0.0',
 });
 
 Package.onUse(api => {

--- a/packages/accounts-passwordless/passwordless_client.js
+++ b/packages/accounts-passwordless/passwordless_client.js
@@ -41,7 +41,7 @@ const transformSelector = selector => {
  *   on failure.
  * @importFromPackage meteor
  */
-Meteor.loginWithToken = (selector, token, callback) => {
+Meteor.passwordlessLoginWithToken = (selector, token, callback) => {
   Accounts.callLoginMethod({
     methodArguments: [
       {
@@ -91,7 +91,7 @@ const checkToken = ({ selector, token }) => {
   const userId = Tracker.nonreactive(Meteor.userId);
 
   if (!userId) {
-    Meteor.loginWithToken(selector, token, () => {
+    Meteor.passwordlessLoginWithToken(selector, token, () => {
       // Make it look clean by removing the authToken from the URL
       if (window.history) {
         const url = window.location.href.split('?')[0];


### PR DESCRIPTION
Fixes issue #11763.

This PR changes the passwordless `Meteor.loginWithToken` method name to `Meteor.passwordlessLoginWithToken`.
