### PR TITLE
installer: Add a flag to skip modifying exec path

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -38,6 +38,16 @@ If you only use sudo because of a distribution default permission system, [check
 
 In some cases you can get this error `npm WARN checkPermissions Missing write access to /usr/local/lib/node_modules` because your Node.js installation was performed with wrong permissions. An easy way to fix this is to install Node.js using [nvm](https://github.com/nvm-sh/nvm) and forcing it to be used in your terminal. You can force it in the current session of your terminal by running `nvm use 14`.
 
+<h2 id="path-management">PATH management</h2>
+
+By default, the Meteor installer adds its install path (by default, `~/.meteor/`) to your PATH by updating either your `.bashrc`, `.bash_profile`, or `.zshrc` as appropriate. To disable this behavior, install Meteor by running:
+
+```bash
+npm install -g meteor --ignore-meteor-setup-exec-path
+```
+
+(or by setting the environment variable `npm_config_ignore_meteor_setup_exec_path=true`)
+
 <h2 id="old-versions-m1">Old Versions on Apple M1</h2>
 
 For Apple M1 computers, you can append Rosetta prefix as following, if you need to run older versions of Meteor (before 2.5.1):

--- a/npm-packages/meteor-installer/README.md
+++ b/npm-packages/meteor-installer/README.md
@@ -27,3 +27,13 @@ npm install -g meteor
 ### Important note
 
 This npm package is not Meteor itself, this npm package is just an installer. You should not include it as a dependency in your project. If you do your deploy is going to be broken.
+
+### Path management
+
+By default, the Meteor installer adds its install path (by default, `~/.meteor/`) to your PATH by updating either your `.bashrc`, `.bash_profile`, or `.zshrc` as appropriate. To disable this behavior, install Meteor by running:
+
+```bash
+npm install -g meteor --ignore-meteor-setup-exec-path
+```
+
+(or by setting the environment variable `npm_config_ignore_meteor_setup_exec_path=true`)

--- a/npm-packages/meteor-installer/config.js
+++ b/npm-packages/meteor-installer/config.js
@@ -31,6 +31,10 @@ if (isWindows() && !localAppData) {
   throw new Error('LOCALAPPDATA env var is not set.');
 }
 
+const shouldSetupExecPath = () => {
+  return !process.env.npm_config_ignore_meteor_setup_exec_path;
+}
+
 const meteorLocalFolder = '.meteor';
 const meteorPath = path.resolve(rootPath, meteorLocalFolder);
 
@@ -45,5 +49,6 @@ module.exports = {
   isWindows,
   isMac,
   isRoot,
-  isSudo
+  isSudo,
+  shouldSetupExecPath,
 };

--- a/npm-packages/meteor-installer/install.js
+++ b/npm-packages/meteor-installer/install.js
@@ -19,6 +19,7 @@ const {
   isSudo,
   isMac,
   METEOR_LATEST_VERSION,
+  shouldSetupExecPath,
 } = require('./config.js');
 const { uninstall } = require('./uninstall');
 const {
@@ -246,7 +247,10 @@ async function extract() {
 }
 async function setup() {
   fs.unlinkSync(startedPath);
-  await setupExecPath();
+  if (shouldSetupExecPath()) {
+    await setupExecPath();
+  }
+  await fixOwnership();
   showGettingStarted();
 }
 async function setupExecPath() {
@@ -267,8 +271,9 @@ async function setupExecPath() {
     await appendPathToFile('.bashrc');
     await appendPathToFile('.bash_profile');
   }
-
-  if (isSudo()) {
+}
+async function fixOwnership() {
+  if (!isWindows() && isSudo()) {
     // if we identified sudo is being used, we need to change the ownership of the meteorpath folder
     child_process.execSync(`chown -R ${sudoUser} "${meteorPath}"`);
   }


### PR DESCRIPTION
The Meteor installer currently modifies the dotfiles of the user running it unconditionally. This makes sense as default behavior, but isn't always optimal. (For instance, I setup my dotfiles before installing meteor, and those dotfiles have the PATH modification already).

This change adds a flag to disable that behavior. I opted for an npm-managed argument, since that felt the most fluid of an interface to me. It's also accessible through a handful of means - you can use `npm install -g meteor --no-meteor-setup-exec-path`, but you can also pass it through the environment (`npm_config_meteor_setup_exec_path=false npm install -g meteor`). I used [this post](https://kgrz.io/how-npm-install-passes-cli-args.html) as a reference on how these arguments work, although the behavior of environment variables has changed a bit since that was written.

I didn't add any documentation yet. I assume that we'll want some, but I'm not sure where to put it, so pointers would be appreciated. (Easiest would probably be stuffing it in the installer README?)

I did run a handful of tests to make sure this worked the way I thought it did. First, here's a standard install:

```
evan@mathias meteor-installer (installer-optional-setup-path) % npm run-script -g install

> meteor@2.5.1 install
> node cli.js install
[...]
evan@mathias meteor-installer (installer-optional-setup-path) % tail -n 1 ~/.zshrc
export PATH=/Users/evan/.meteor:$PATH
```

Here's passing the argument through argv:

```
evan@mathias meteor-installer (installer-optional-setup-path) % npm run-script -g install --no-meteor-setup-exec-path

> meteor@2.5.1 install
> node cli.js install
[...]
evan@mathias meteor-installer (installer-optional-setup-path) % tail -n 1 ~/.zshrc
autoload -Uz compinit && compinit
```

And here's passing it through an environment variable (note that `--no-blah` in arguments gets canonicalized to `blah=''` in the env):

```
evan@mathias meteor-installer (installer-optional-setup-path) % npm_config_meteor_setup_exec_path=false npm run-script -g install

> meteor@2.5.1 install
> node cli.js install
[...]
evan@mathias meteor-installer (installer-optional-setup-path) % tail -n 1 ~/.zshrc
autoload -Uz compinit && compinit
```