### PR TITLE
Prevent hot.accept from overriding hot.decline

### DIFF
--- a/npm-packages/meteor-installer/README.md
+++ b/npm-packages/meteor-installer/README.md
@@ -23,6 +23,7 @@ npm install -g meteor
 | 2.4.1       | 2.4                     |
 | 2.5.0       | 2.5                     |
 | 2.5.1       | 2.5.1                   |
+| 2.5.2       | 2.5.1                   |
 
 ### Important note
 

--- a/npm-packages/meteor-installer/config.js
+++ b/npm-packages/meteor-installer/config.js
@@ -17,7 +17,7 @@ let rootPath;
 if (isWindows()) {
   rootPath = localAppData;
 } else if (isRoot() && sudoUser) {
-  rootPath = `/home/${sudoUser}`;
+  rootPath = isMac() ? `/Users/${sudoUser}` : `/home/${sudoUser}`;
 } else {
   if (isRoot()) {
     console.info(

--- a/npm-packages/meteor-installer/package.json
+++ b/npm-packages/meteor-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Install Meteor",
   "main": "install.js",
   "scripts": {

--- a/packages/hot-module-replacement/hot-api.js
+++ b/packages/hot-module-replacement/hot-api.js
@@ -34,11 +34,17 @@ Object.defineProperty(meteorInstall.Module.prototype, "hot", {
         if (arguments.length > 0) {
           console.warn('hot.accept does not support any arguments.');
         }
+
+        if (hotState._hotAccepts === false) {
+          return;
+        }
+
         hotState._hotAccepts = true;
       },
       /**
         * @summary Disable updating this module or its dependencies with HMR.
-        * Hot code push will be used instead.
+        * Hot code push will be used instead. Can not be overridden by calling
+        * module.hot.accept later.
         * @locus Client
         * @memberOf module.hot
         * @instance


### PR DESCRIPTION
Currently, when both `module.hot.accept` and `module.hot.decline` are called for a module, the last one wins for if the module is updated with HMR.

There are several issues with this:
1. `module.hot.decline` is called when it is known the module can not be updated with HMR. Usually the code that calls`hot.accept` isn't completely accurate and it doesn't make sense for it to override `hot.decline`.
2. In most apps, `module.hot.accept` is only called by hmr integrations (`zodern:melte`, `react-fast-refresh`, `blaze-hot`, `vuejs:vue3`, etc.), after the module was run. If a developer simply adds `module.hot.decline()` to a module, it is likely to be overridden by the HMR integration, making it difficult to disable HMR for a module.
3. The HMR implementations in other bundlers that have a working `hot.decline` do not allow hot.accept to override hot.decline.

This is a breaking change. I'm not sure if the change is worth it, but `hot.decline` is rarely used so the effect should be minimal.