### PR TITLE
Support Apple M1 on linux

### DIFF
--- a/meteor
+++ b/meteor
@@ -25,9 +25,9 @@ if [ "$UNAME" = "Darwin" ] ; then
     fi
 elif [ "$UNAME" = "Linux" ] ; then
     ARCH="$(uname -m)"
-    if [ "$ARCH" != "x86_64" ] ; then
+    if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "aarch64" ]; then
         echo "Unsupported architecture: $ARCH"
-        echo "Meteor only supports x86_64"
+        echo "Meteor only supports x86_64 and aarch64"
         exit 1
     fi
 fi

--- a/scripts/build-dev-bundle-common.sh
+++ b/scripts/build-dev-bundle-common.sh
@@ -13,7 +13,7 @@ NPM_VERSION=6.14.15
 
 if [ "$UNAME" == "Linux" ] ; then
     NODE_BUILD_NUMBER=
-    if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" ] ; then
+    if [ "$ARCH" != "i686" -a "$ARCH" != "x86_64" -a "$ARCH" != "aarch64" ] ; then
         echo "Unsupported architecture: $ARCH"
         echo "Meteor only supports i686 and x86_64 for now."
         exit 1
@@ -65,6 +65,9 @@ then
     elif [ "$ARCH" == "x86_64" ]
     then
         NODE_TGZ="node-v${NODE_VERSION}-linux-x64.tar.gz"
+    elif [ "$ARCH" == "aarch64" ]
+    then
+        NODE_TGZ="node-v${NODE_VERSION}-linux-arm64.tar.gz"
     else
         echo "Unknown architecture: $UNAME $ARCH"
         exit 1

--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -64,15 +64,17 @@ fi
 case $OS in
     macos) MONGO_BASE_URL="https://fastdl.mongodb.org/osx" ;;
     linux)
-        [ $ARCH = "i686" ] &&
+        [ $ARCH = "i686" -o $ARCH = "aarch64" ] &&
             MONGO_BASE_URL="https://fastdl.mongodb.org/linux" ||
             MONGO_BASE_URL="https://github.com/meteor/mongodb-builder/releases/download/v${MONGO_VERSION}"
         ;;
 esac
 
 
-if [ $OS = "macos" ] && [ "$(uname -m)" = "arm64" ] ; then
+if [ $OS = "macos" ] && [ "$ARCH" = "arm64" ] ; then
   MONGO_NAME="mongodb-${OS}-x86_64-${MONGO_VERSION}"
+elif [ $OS = "linux" ] && [ "$ARCH" = "aarch64" ] ; then
+  MONGO_NAME="mongodb-linux-aarch64-ubuntu2004-${MONGO_VERSION}"
 else
   MONGO_NAME="mongodb-${OS}-${ARCH}-${MONGO_VERSION}"
 fi

--- a/tools/utils/archinfo.ts
+++ b/tools/utils/archinfo.ts
@@ -131,6 +131,7 @@ export const VALID_ARCHITECTURES: Record<string, boolean> = {
   "os.osx.x86_64": true,
   "os.osx.arm64": true,
   "os.linux.x86_64": true,
+  "os.linux.aarch64": true,
   "os.windows.x86_64": true,
 };
 
@@ -173,6 +174,8 @@ export function host() {
       const machine = run('uname', '-m');
       if (["x86_64", "amd64", "ia64"].includes(machine)) {
         _host = "os.linux.x86_64";
+      } else if(machine === "aarch64") {
+        _host = "os.linux.aarch64";
       } else {
         throw new Error(`Unsupported architecture: ${machine}`);
       }


### PR DESCRIPTION
Hi,

Super excited about the Apple M1 on macOS support added in 2.5.1; 

However, when we started setting up an Ubuntu guest VM, we found that meteor doesn't run under linux on the same CPU architecture.

We were able to get meteor running from a checkout, by just making a dev bundle using the linux-aarch64 versions of each dependency.

There are some things unfinished, to get it to run outside a checkout;

1. We need to build a custom version of mongodb without openssl/curl 
2. We need to update the release build system etc. which is out of scope of meteor/meteor

