### PR TITLE
chore(docs): add `loggingOut` api to accounts page

### DIFF
--- a/docs/source/api/accounts.md
+++ b/docs/source/api/accounts.md
@@ -146,6 +146,8 @@ Meteor.users.deny({ update: () => true });
 For example, [the `accounts-ui` package](#accountsui) uses this to display an
 animation while the login request is being processed.
 
+{% apibox "Meteor.loggingOut" %}
+
 {% apibox "Meteor.logout" %}
 
 {% apibox "Meteor.logoutOtherClients" %}


### PR DESCRIPTION
The `loggingOut` data source is available and described equally as well as `loggingIn` in the [project file](https://github.com/meteor/meteor/blob/devel/packages/accounts-base/accounts_client.js#L60-L66) but is not described in [Meteor's online API docs](https://docs.meteor.com/api/accounts.html#Meteor-loggingIn).