### PR TITLE
Replace lru-cache with lru-native2

### DIFF
--- a/packages/caching-compiler/caching-compiler.js
+++ b/packages/caching-compiler/caching-compiler.js
@@ -1,8 +1,8 @@
+import { createHash } from 'crypto';
+import assert from 'assert';
+import LRUCache from 'lru-native2';
 const fs = Plugin.fs;
 const path = Plugin.path;
-const createHash = Npm.require('crypto').createHash;
-const assert = Npm.require('assert');
-const LRU = Npm.require('lru-cache');
 
 // Base class for CachingCompiler and MultiFileCachingCompiler.
 CachingCompilerBase = class CachingCompilerBase {
@@ -161,7 +161,6 @@ CachingCompilerBase = class CachingCompilerBase {
 
     case 'function':
       assert.ok(false, 'cannot hash function objects');
-      break;
 
     default:
       hash.update('' + val);
@@ -251,7 +250,7 @@ CachingCompiler = class CachingCompiler extends CachingCompilerBase {
     super({compilerName, defaultCacheSize, maxParallelism});
 
     // Maps from a hashed cache key to a compileResult.
-    this._cache = new LRU({
+    this._cache = new LRUCache({
       max: this._cacheSize,
       length: (value) => this.compileResultSize(value),
     });

--- a/packages/caching-compiler/caching-compiler.js
+++ b/packages/caching-compiler/caching-compiler.js
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto';
 import assert from 'assert';
-import LRUCache from 'lru-native2';
+import LRU from 'lru-native2';
 const fs = Plugin.fs;
 const path = Plugin.path;
 
@@ -250,7 +250,7 @@ CachingCompiler = class CachingCompiler extends CachingCompilerBase {
     super({compilerName, defaultCacheSize, maxParallelism});
 
     // Maps from a hashed cache key to a compileResult.
-    this._cache = new LRUCache({
+    this._cache = new LRU({
       max: this._cacheSize,
       length: (value) => this.compileResultSize(value),
     });

--- a/packages/caching-compiler/multi-file-caching-compiler.js
+++ b/packages/caching-compiler/multi-file-caching-compiler.js
@@ -1,5 +1,5 @@
+import LRUCache from 'lru-native2'
 const path = Plugin.path;
-const LRU = Npm.require('lru-cache');
 
 // MultiFileCachingCompiler is like CachingCompiler, but for implementing
 // languages which allow files to reference each other, such as CSS
@@ -23,7 +23,7 @@ extends CachingCompilerBase {
     // Maps from cache key to { compileResult, cacheKeys }, where
     // cacheKeys is an object mapping from absolute import path to hashed
     // cacheKey for each file referenced by this file (including itself).
-    this._cache = new LRU({
+    this._cache = new LRUCache({
       max: this._cacheSize,
       // We ignore the size of cacheKeys here.
       length: (value) => this.compileResultSize(value.compileResult),

--- a/packages/caching-compiler/multi-file-caching-compiler.js
+++ b/packages/caching-compiler/multi-file-caching-compiler.js
@@ -1,4 +1,4 @@
-import LRUCache from 'lru-native2'
+import LRU from 'lru-native2'
 const path = Plugin.path;
 
 // MultiFileCachingCompiler is like CachingCompiler, but for implementing
@@ -23,7 +23,7 @@ extends CachingCompilerBase {
     // Maps from cache key to { compileResult, cacheKeys }, where
     // cacheKeys is an object mapping from absolute import path to hashed
     // cacheKey for each file referenced by this file (including itself).
-    this._cache = new LRUCache({
+    this._cache = new LRU({
       max: this._cacheSize,
       // We ignore the size of cacheKeys here.
       length: (value) => this.compileResultSize(value.compileResult),

--- a/packages/caching-compiler/package.js
+++ b/packages/caching-compiler/package.js
@@ -5,6 +5,10 @@ Package.describe({
   documentation: 'README.md'
 });
 
+Npm.depends({
+  "lru-native2": "1.2.5"
+});
+
 Package.onUse(function(api) {
   api.use(['ecmascript', 'random']);
   api.addFiles(['caching-compiler.js'], 'server');

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -14,7 +14,7 @@ Package.registerBuildPlugin({
   npmDependencies: {
     "@babel/runtime": "7.15.3",
     "source-map": "0.7.3",
-    "lru-cache": "6.0.0"
+    "lru-native2": "1.2.5"
   },
   sources: [
     'plugin/minify-css.js'

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -1,6 +1,6 @@
 import sourcemap from "source-map";
 import { createHash } from "crypto";
-import LRU from "lru-cache";
+import LRU from "lru-native2";
 
 Plugin.registerMinifier({
   extensions: ["css"],

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -62,7 +62,7 @@ var packageJson = {
     // version constraint imposed by optimism/package.json.
     optimism: "0.16.1",
     "@wry/context": "0.6.0",
-    'lru-cache': '4.1.5',
+    'lru-native2': '1.2.5',
     "anser": "2.0.1",
     'xmlbuilder2': '1.8.1',
     "ws": "7.4.5"

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -14,7 +14,7 @@ import {
   sha1,
   readAndWatchFileWithHash,
 } from  '../fs/watch';
-import LRU from 'lru-cache';
+import LRU from 'lru-native2';
 import {sourceMapLength} from '../utils/utils.js';
 import {Console} from '../console/console.js';
 import ImportScanner from './import-scanner';

--- a/tools/isobuild/import-scanner.ts
+++ b/tools/isobuild/import-scanner.ts
@@ -289,7 +289,7 @@ function setImportedStatus(file: File, status: string | boolean) {
 // The cache can be global because findImportedModuleIdentifiers
 // is a pure function, and that way it applies across instances
 // of ImportScanner (which do not persist across builds).
-const LRU = require("lru-cache");
+const LRU = require("lru-native2");
 const IMPORT_SCANNER_CACHE = new LRU({
   max: 1024*1024,
   length(ids: Record<string, ImportInfo>) {

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -1,6 +1,6 @@
 import { parse } from '@meteorjs/babel';
 import { analyze as analyzeScope } from 'escope';
-import LRU from "lru-cache";
+import LRU from "lru-native2";
 
 import Visitor from "reify/lib/visitor.js";
 import { findPossibleIndexes } from "reify/lib/utils.js";

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -4,7 +4,7 @@ var buildmessage = require('../utils/buildmessage.js');
 var watch = require('../fs/watch');
 var Profile = require('../tool-env/profile').Profile;
 import assert from 'assert';
-import LRU from 'lru-cache';
+import LRU from 'lru-native2';
 import { sourceMapLength } from '../utils/utils.js';
 import files from '../fs/files';
 import { findAssignedGlobals } from './js-analyze.js';


### PR DESCRIPTION
This PR replaces [lru-cache](https://github.com/isaacs/node-lru-cache) which is no longer maintained with [lru-native2](https://github.com/adzerk/node-lru-native). Both retain the same API so there's not any significant changes. 

I also thought about modernizing the code of caching-compiler especially the [Promise.await](https://github.com/meteor/meteor/blob/devel/packages/caching-compiler/caching-compiler.js#L305) which relies on fibers afaik but thought to ask you first. What do you think?