### PR TITLE
Update tar library for faster extractions/compressions

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.18.2.3
+BUNDLE_VERSION=14.18.2.6
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.18.2.6
+BUNDLE_VERSION=14.18.2.7
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -35,7 +35,7 @@ var packageJson = {
     uuid: "3.4.0",
     "graceful-fs": "4.2.6",
     fstream: "https://github.com/meteor/fstream/tarball/cf4ea6c175355cec7bee38311e170d08c4078a5d",
-    tar: "2.2.2",
+    tar: "6.1.11",
     // Fork of kexec@3.0.0 with my Node.js 12 compatibility PR
     // https://github.com/jprichardson/node-kexec/pull/37 applied.
     // TODO: We should replace this with: https://github.com/jprichardson/node-kexec/pull/38

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -36,6 +36,7 @@ var packageJson = {
     "graceful-fs": "4.2.6",
     fstream: "https://github.com/meteor/fstream/tarball/cf4ea6c175355cec7bee38311e170d08c4078a5d",
     tar: "6.1.11",
+    'tar-fs': "2.1.1",
     // Fork of kexec@3.0.0 with my Node.js 12 compatibility PR
     // https://github.com/jprichardson/node-kexec/pull/37 applied.
     // TODO: We should replace this with: https://github.com/jprichardson/node-kexec/pull/38

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -6,7 +6,6 @@
 
 import assert from "assert";
 import fs, { PathLike, Stats, Dirent } from "fs";
-import path from "path";
 import os from "os";
 import { spawn, execFile } from "child_process";
 import { EventEmitter } from "events";

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -932,7 +932,7 @@ function tryExtractWithNpmTar(
         return header
       }
     }).on('error', reject)
-      .on('resolve', resolve);
+      .on('finish', resolve);
 
     // write the buffer to the (gunzip|untar) pipeline; these calls
     // cause the tar to be extracted to disk.


### PR DESCRIPTION
This PR updates the tar library for faster extractions/compressions.

We are now using tar-fs and tar-streams, as they are 10x faster working with tar streams compared to the version we had of tar.

https://www.npmjs.com/package/tar-fs#performance

Testing locally, I've been able to see a reduction of 30% on deploy time(in the upload bundle step) 