### PR TITLE
[WIP] Refactoring: Update TypeScript to 4.5

### DIFF
--- a/History.md
+++ b/History.md
@@ -8,6 +8,18 @@
 
 #### Meteor Version Release
 
+* `@meteorjs/babel@7.16.0`
+  - Upgrade TypeScript to `4.5.4`
+
+* `babel-compiler@7.9.0`
+  - Upgrade TypeScript to `4.5.4`
+
+* `ecmascript@0.16.2`
+  - Upgrade TypeScript to `4.5.4`
+
+* `typescript@4.5.4`
+  - Upgrade TypeScript to `4.5.4` [PR](https://github.com/meteor/meteor/pull/11846)
+
 #### Independent Releases
 
 * `oauth@2.1.1`

--- a/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
+++ b/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
@@ -14,8 +14,8 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "8.0.0",
     "node-pre-gyp": "0.15.0",
-    typescript: "4.3.5",
-    "@meteorjs/babel": "7.15.0",
+    typescript: "4.5.4",
+    "@meteorjs/babel": "7.16.0",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",

--- a/npm-packages/meteor-babel/package-lock.json
+++ b/npm-packages/meteor-babel/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/babel",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-packages/meteor-babel/package-lock.json
+++ b/npm-packages/meteor-babel/package-lock.json
@@ -2438,9 +2438,9 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/npm-packages/meteor-babel/package.json
+++ b/npm-packages/meteor-babel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meteorjs/babel",
   "author": "Meteor <dev@meteor.com>",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "license": "MIT",
   "description": "Babel wrapper package for use with Meteor",
   "keywords": [
@@ -47,7 +47,7 @@
     "lodash": "^4.17.21",
     "meteor-babel-helpers": "0.0.3",
     "@meteorjs/reify": "0.23.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.5.4"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "7.14.5",

--- a/npm-packages/meteor-babel/package.json
+++ b/npm-packages/meteor-babel/package.json
@@ -41,12 +41,12 @@
     "@babel/template": "^7.14.5",
     "@babel/traverse": "^7.15.0",
     "@babel/types": "^7.15.0",
+    "@meteorjs/reify": "0.23.0",
     "babel-preset-meteor": "^7.10.0",
     "babel-preset-minify": "^0.5.1",
     "convert-source-map": "^1.6.0",
     "lodash": "^4.17.21",
     "meteor-babel-helpers": "0.0.3",
-    "@meteorjs/reify": "0.23.0",
     "typescript": "^4.5.4"
   },
   "devDependencies": {

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   name: "babel-compiler",
   summary: "Parser/transpiler for ECMAScript 2015+ syntax",
-  version: '7.8.0'
+  version: '7.9.0'
 });
 
 Npm.depends({
-  '@meteorjs/babel': '7.15.0',
+  '@meteorjs/babel': '7.16.0',
   'json5': '2.1.1'
 });
 

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '0.16.1',
+  version: '0.16.2',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md',
 });

--- a/packages/typescript/package.js
+++ b/packages/typescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'typescript',
-  version: '4.4.1',
+  version: '4.5.4',
   summary:
     'Compiler plugin that compiles TypeScript and ECMAScript in .ts and .tsx files',
   documentation: 'README.md',

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,8 +14,8 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "8.0.0",
     "node-pre-gyp": "0.15.0",
-    typescript: "4.3.5",
-    "@meteorjs/babel": "7.15.0",
+    typescript: "4.5.4",
+    "@meteorjs/babel": "7.16.0",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -18,7 +18,7 @@
     "@types/mocha": "^8.2.3",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.5.4"
   },
   "meteor": {
     "mainModule": {


### PR DESCRIPTION
The latest version of TypeScript: `4.5.4`

Updated packages:

- `@meteorjs/babel@7.16.0`
- `babel-compiler@7.9.0`
- `ecmascript@0.16.2`
- `typescript@4.5.4`

Announcing 4.4: https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/
**Breaking changes:** https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#breaking-changes

Some items from changelog:
- `static` Blocks in Classes: https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#static-blocks
- More-Compliant Indirect Calls for Imported Functions: https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#more-compliant-indirect-calls-for-imported-functions


Announcing 4.5: https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/
**Breaking changes:** https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#breaking-changes

Some items from changelog:

- Disabling Import Elision: https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#preserve-value-imports
- `type` Modifiers on Import Names: https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names

TODO:

- [x] update all relevant places
- [ ] publish `@meteorjs/babel` to npm
- [ ] check tests
- [ ] merge and release
