### PR TITLE
Fix #11827 custom user fields not publishing

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -55,6 +55,9 @@ Read our [Migration Guide](https://guide.meteor.com/2.6.1-migration.html) for th
 * `ejson@1.1.2`
   - Fixing error were EJSON.equals fail to compare object and array if first param is object and second is array. [PR](https://github.com/meteor/meteor/pull/11866), [Issue](https://github.com/meteor/meteor/issues/11864).
 
+* `accounts-base@2.2.2`
+  - Fix an issue where an extra field defined in `defaultFieldSelector` would not get published to the client
+
 #### Independent Releases
 
 * `mongo@1.14.1` at 2022-02-04

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -765,13 +765,22 @@ export class AccountsServer extends AccountsCommon {
     // Use Meteor.startup to give other packages a chance to call
     // setDefaultPublishFields.
     Meteor.startup(() => {
+      // Merge custom fields selector and default publish fields so that the client
+      // gets all the necessary fields to run properly
+      const customFields = this._addDefaultFieldSelector().fields;
+      const keys = Object.keys(customFields || {});
+      // If the custom fields are negative, then ignore them and only send the necessary fields
+      const fields = keys.length > 0 && customFields[keys[0]] ? {
+        ...this._addDefaultFieldSelector().fields,
+        ..._defaultPublishFields.projection
+      } : _defaultPublishFields.projection
       // Publish the current user's record to the client.
       this._server.publish(null, function () {
         if (this.userId) {
           return users.find({
             _id: this.userId
           }, {
-            fields: _defaultPublishFields.projection,
+            fields,
           });
         } else {
           return null;

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -767,8 +767,8 @@ export class AccountsServer extends AccountsCommon {
     Meteor.startup(() => {
       // Merge custom fields selector and default publish fields so that the client
       // gets all the necessary fields to run properly
-      const customFields = this._addDefaultFieldSelector().fields;
-      const keys = Object.keys(customFields || {});
+      const customFields = this._addDefaultFieldSelector().fields || {};
+      const keys = Object.keys(customFields);
       // If the custom fields are negative, then ignore them and only send the necessary fields
       const fields = keys.length > 0 && customFields[keys[0]] ? {
         ...this._addDefaultFieldSelector().fields,

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -13,7 +13,7 @@ Meteor.methods({
 // *are* validated, but Accounts._options is global state which makes this hard
 // (impossible?)
 Tinytest.add(
-  'accounts - config validates keys', 
+  'accounts - config validates keys',
   test => test.throws(() => Accounts.config({foo: "bar"}))
 );
 
@@ -202,7 +202,7 @@ Tinytest.add('accounts - insertUserDoc username', test => {
 
   // run the hook again. now the user exists, so it throws an error.
   test.throws(
-    () => Accounts.insertUserDoc({profile: {name: 'Foo Bar'}}, userIn), 
+    () => Accounts.insertUserDoc({profile: {name: 'Foo Bar'}}, userIn),
     'Username already exists.'
   );
 
@@ -238,13 +238,13 @@ Tinytest.add('accounts - insertUserDoc email', test => {
   );
 
   // now with only one of them.
-  test.throws(() => 
-    Accounts.insertUserDoc({}, {emails: [{address: email1}]}), 
+  test.throws(() =>
+    Accounts.insertUserDoc({}, {emails: [{address: email1}]}),
     'Email already exists.'
   );
 
-  test.throws(() => 
-    Accounts.insertUserDoc({}, {emails: [{address: email2}]}), 
+  test.throws(() =>
+    Accounts.insertUserDoc({}, {emails: [{address: email2}]}),
     'Email already exists.'
   );
 
@@ -452,14 +452,14 @@ Tinytest.add(
       test.equal(Meteor.userId(), validateAttemptExpectedUserId, "validateLoginAttempt");
       return true;
     });
-    const onLoginStopper = Accounts.onLogin(attempt => 
+    const onLoginStopper = Accounts.onLogin(attempt =>
       test.equal(Meteor.userId(), onLoginExpectedUserId, "onLogin")
     );
     const onLogoutStopper = Accounts.onLogout(logoutContext => {
       test.equal(logoutContext.user._id, onLogoutExpectedUserId, "onLogout");
       test.instanceOf(logoutContext.connection, Object);
     });
-    const onLoginFailureStopper = Accounts.onLoginFailure(attempt => 
+    const onLoginFailureStopper = Accounts.onLoginFailure(attempt =>
       test.equal(Meteor.userId(), onLoginFailureExpectedUserId, "onLoginFailure")
     );
 
@@ -552,7 +552,8 @@ Tinytest.add(
   'accounts - Meteor.user() obeys options.defaultFieldSelector',
   test => {
     const ignoreFieldName = "bigArray";
-    const userId = Accounts.insertUserDoc({}, { username: Random.id(), [ignoreFieldName]: [1] });
+    const customField = "customField";
+    const userId = Accounts.insertUserDoc({}, { username: Random.id(), [ignoreFieldName]: [1], [customField]: 'test' });
     const stampedToken = Accounts._generateStampedLoginToken();
     Accounts._insertLoginToken(userId, stampedToken);
     const options = Accounts._options;
@@ -588,6 +589,15 @@ Tinytest.add(
     user = Meteor.user({fields: {}});
     test.isNotUndefined(user[ignoreFieldName], 'full selector');
     test.isNotUndefined(user.username, 'full selector username');
+
+    Accounts._options = {};
+
+    // Test that a custom field gets retrieved properly
+    Accounts.config({defaultFieldSelector: {[customField]: 1}});
+    user = Meteor.user()
+    test.isNotUndefined(user[customField]);
+    test.isUndefined(user.username);
+    test.isUndefined(user[ignoreFieldName]);
 
     Accounts._options = options;
     Accounts.userId = origAccountsUserId;
@@ -702,14 +712,14 @@ Tinytest.add(
       // create test user, without a google service
       const testEmail = "test@testdomain.com"
       const uid0 = Accounts.createUser({email: testEmail})
-      
+
       // Verify that user is found from email and service merged
       Accounts.setAdditionalFindUserOnExternalLogin(({serviceName, serviceData}) => {
         if (serviceName === "google") {
           return Accounts.findUserByEmail(serviceData.email)
         }
       })
-      
+
       let googleId = Random.id();
       const uid1 = Accounts.updateOrCreateUserFromExternalService(
           'google',


### PR DESCRIPTION
Fixes an issue where field defined in `Accounts.config.defaultFieldSelector` to be selected is not published to the client. Also added tests, but I'm not entirely certain about them.

The problem seem to have occurred that originally the `defaultFieldSelector` was to primarily prevent getting needless data retrieved, then there was a limitation of user data published to the client (and to ensure that people accidentally don't stop publishing fields that are needed for Meteor accounts to work), but it seems like this field was not taken into account and the functionality stayed only on client. The selection restrictions get applied both on client and server, but they don't make it to the publication till this PR.
This PR merges the required fields for publication and the desired fields. If the fields are restrictive then it publishes only the required fields.