### PR TITLE
Add delay in oauth secret retrieval if it fails first time

### DIFF
--- a/packages/oauth/pending_credentials.js
+++ b/packages/oauth/pending_credentials.js
@@ -71,6 +71,7 @@ OAuth._storePendingCredential = (key, credential, credentialSecret = null) => {
 //
 OAuth._retrievePendingCredential = (key, credentialSecret = null) => {
   check(key, String);
+  check(credentialSecret, Match.Maybe(String));
 
   const pendingCredential = OAuth._pendingCredentials.findOne({
     key,


### PR DESCRIPTION
Now, this one is was a tough one to nail down. Last week I got an email from Facebook that my OAuth was not working. After some testing I have noticed few interesting behaviors.
In the past occasionally I had to click the login with Facebook button twice before I got logged in. Often when I was already logged into Facebook. Now this behavior had escalated that no matter how many times I clicked, the popup would blink and nothing would happen. When I started to trace what was going on, I have notice a long list of login secrets in my local storage. After more investigation I have found out that in `end_of_popup_response.js` in oauth package that `window.opener` was never available. I do believe this is due to the tightening of browser security. So the code went for the backup, setting local storage. All good, but then when `Accounts.oauth.tryLoginAfterPopupClosed` calls `OAuth._retrieveCredentialSecret`, the `_retrieveCredentialSecret` function fails to retrieve any from local storage, yet when I looked into my local storage they were all there. So after much trial and error I have added a timeout if the first attempt fails. I set it to 500ms for test and that seemed to work. I was again able to use OAuth logins without problem. The only thing that sometimes appears is that the OAuth window fails to close, but that is a minor thing.

I'm keeping this in a draft for a while to get a discussion on this issue and to see if anyone else has run into this issue. I have checked my app multiple times and I don't see anything that should interfere, but it is still possible so I would like to see if others have experience this in some form. Either way I think this could be a good backup to include none the less.