### PR TITLE
Fix resolving npm deps of local packages when on different drive

### DIFF
--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -284,6 +284,15 @@ export function getSettings(
   return str;
 }
 
+// Returns true if the first path is a parent of the second path
+export function containsPath(path1: string, path2: string) {
+  const relPath = pathRelative(path1, path2);
+
+  // On Windows, if the two paths are on different drives the relative
+  // path starts with /
+  return !(relPath.startsWith("..") || relPath.startsWith("/"));
+}
+
 // Try to find the prettiest way to present a path to the
 // user. Presently, the main thing it does is replace $HOME with ~.
 export function prettyPath(p: string) {

--- a/tools/isobuild/resolver.ts
+++ b/tools/isobuild/resolver.ts
@@ -7,12 +7,12 @@ import {
 import { matches as archMatches, isLegacyArch } from "../utils/archinfo";
 import {
   pathJoin,
-  pathRelative,
   pathNormalize,
   pathDirname,
   pathBasename,
   convertToOSPath,
   convertToPosixPath,
+  containsPath,
 } from "../fs/files";
 import { Stats, BigIntStats } from "fs";
 import { wrap } from "optimism";
@@ -300,8 +300,7 @@ export default class Resolver {
     }
 
     let sourceRoot: string | undefined;
-    const relParentPath = pathRelative(this.sourceRoot, absParentPath);
-    if (! relParentPath.startsWith("..")) {
+    if (containsPath(this.sourceRoot, absParentPath)) {
       // If the file is contained by this.sourceRoot, then it's safe to
       // use this.sourceRoot as the limiting ancestor directory in the
       // while loop below, but we're still going to check whether the file
@@ -312,7 +311,7 @@ export default class Resolver {
     }
 
     this.nodeModulesPaths.some(path => {
-      if (! pathRelative(path, absParentPath).startsWith("..")) {
+      if (containsPath(path, absParentPath)) {
         // If the file is inside an external node_modules directory,
         // consider the rootDir to be the parent directory of that
         // node_modules directory, rather than this.sourceRoot.


### PR DESCRIPTION
When building a local package for an app on Windows, if the package is on a different drive than the app, Meteor might resolve npm dependencies to a path that is not available when the app runs. This fixes it so the resolver works the same as when the app and package are on the same drive.