### PR TITLE
Use fibers 5.0.1 version

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.18.3.0
+BUNDLE_VERSION=14.18.3.1
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -10,7 +10,7 @@ var packageJson = {
   dependencies: {
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-tool-package.js.
-    fibers: "https://github.com/meteor/node-fibers/archive/refs/tags/5.0.0-1.tar.gz",
+    fibers: "5.0.1",
     "meteor-promise": "0.9.0",
     promise: "8.1.0",
     "@meteorjs/reify": "0.23.0",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -19,7 +19,7 @@ var packageJson = {
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",
-    fibers: "https://github.com/meteor/node-fibers/archive/refs/tags/5.0.0-1.tar.gz",
+    fibers: "5.0.1",
     "@meteorjs/reify": "0.23.0",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
     "@babel/runtime": "7.15.3",


### PR DESCRIPTION
Fix https://github.com/meteor/meteor/issues/11791 by reusing the same binaries shipped with 5.0.0, as our changes haven't touched the other distributed binary for now.

For any upcoming changes we will generate new binaries.