### PR TITLE
Set explicitly write concern to w:1 on mongo v5 when running locally

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -33,6 +33,7 @@ Read our [Migration Guide](https://guide.meteor.com/2.6-migration.html) for this
     - update/insert/remove behavior is maintained in the Meteor way, documented in our docs, but we are now using replaceOne/updateOne/updateMany internally. This is subject to changes in the API rewrite of MongoDB without Fibers AND if you are using rawCollection directly you have to review your methods otherwise you will see deprecation messages if you are still using the old mongodb style directly.
     - waitForStepDownOnNonCommandShutdown=false is not needed anymore when spawning the mongodb process
     - _synchronousCursor._dbCursor.operation is not an option anymore in the raw cursor from nodejs mongodb driver. If you want to access the options, use _synchronousCursor._dbCursor.(GETTERS) - for example, _synchronousCursor._dbCursor.readPreference.
+    - the default write preference for replica sets on mongo v5 is w:majority
 
 * `allow-deny@1.1.1`
     - Handle `MongoBulkWriteError` as `BulkWriteError` was already handled.

--- a/guide/source/2.6-migration.md
+++ b/guide/source/2.6-migration.md
@@ -59,6 +59,7 @@ Here is a list of the changes that we have made to Meteor core packages in order
   - update/insert/remove behavior is maintained in the Meteor way, documented in our docs, but we are now using replaceOne/updateOne/updateMany internally. This is subject to changes in the API rewrite of MongoDB without Fibers AND if you are using rawCollection directly you have to review your methods otherwise you will see deprecation messages if you are still using the old mongodb style directly.
   - waitForStepDownOnNonCommandShutdown=false is not needed anymore when spawning the mongodb process
   - _synchronousCursor._dbCursor.operation is not an option anymore in the raw cursor from nodejs mongodb driver. If you want to access the options, use _synchronousCursor._dbCursor.(GETTERS) - for example, _synchronousCursor._dbCursor.readPreference.
+  - the default write preference for replica sets on mongo v5 is w:majority
 
 It's worth mentioning that if you are using the built-in MongoDB that Meteor provides to run your app locally, you need to perform a `meteor reset` on your app to be able to use the version 2.6.
 


### PR DESCRIPTION
From mongoDB 5.0, w: majority is the default write concern for most MongoDB configurations
this causes writes to be acknowledged after the timeout on M1 macs
We are explicitly setting it to 1 when there is only 1 node, as we do simulate replica sets with only 1 node
when running locally or in test environments.
ref: https://docs.mongodb.com/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-majority-
