### PR TITLE
Fix flatten object issue when the object is empty on oplog converter

### DIFF
--- a/packages/mongo/oplog_v2_converter.js
+++ b/packages/mongo/oplog_v2_converter.js
@@ -57,7 +57,6 @@ const nestedOplogEntryParsers = (
   const setObjectSource = { ...i, ...u };
   const $set = Object.keys(setObjectSource).reduce((acc, key) => {
     const prefixedKey = `${prefixKey}${key}`;
-
     return {
       ...acc,
       ...(!Array.isArray(setObjectSource[key]) && typeof setObjectSource[key] === 'object'
@@ -97,6 +96,7 @@ function flattenObject(ob) {
 
     if (typeof ob[i] == 'object' && ob[i] !== null) {
       const flatObject = flattenObject(ob[i]);
+      if(Object.keys(flatObject).length === 0) { return ob; }
       for (const x in flatObject) {
         if (!flatObject.hasOwnProperty(x)) continue;
 

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -1,6 +1,6 @@
 import { oplogV2V1Converter } from './oplog_v2_converter';
 
-Tinytest.add('oplog - v2/v1 conversion', function(test) {
+Tinytest.only('oplog - v2/v1 conversion', function(test) {
   const entry1 = {
     $v: 2,
     diff: { scustom: { sEJSON$value: { u: { EJSONtail: 'd' } } } },
@@ -48,6 +48,16 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
   test.equal(
     JSON.stringify(oplogV2V1Converter(entry5)),
     JSON.stringify({ $v: 2, $set: { 'a.b': 2 } })
+  );
+
+  //set a new nested field inside an object
+  const entry51 =  { "$v" : 2, "diff" : { "u" : { "count" : 1 }, "i" : { "nested" : { "state" : {  } } } } };
+  // the correct format for this test, inspecting the mongodb oplog, should be "nested" : { "state" : {  } } }
+  // but this is not a case in which we cant flatten the object without collateral, so we are considering
+  // "nested.state" : {  } to be valid too
+  test.equal(
+    JSON.stringify(oplogV2V1Converter(entry51)),
+    JSON.stringify( { "$v" : 2, "$set" : { "nested.state": {  }, "count" : 1 } })
   );
 
   //set an existing nested field inside an object

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -53,7 +53,7 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
   //set a new nested field inside an object
   const entry51 =  { "$v" : 2, "diff" : { "u" : { "count" : 1 }, "i" : { "nested" : { "state" : {  } } } } };
   // the correct format for this test, inspecting the mongodb oplog, should be "nested" : { "state" : {  } } }
-  // but this is not a case in which we cant flatten the object without collateral, so we are considering
+  // but this is a case in which we can flatten the object without collateral, so we are considering
   // "nested.state" : {  } to be valid too
   test.equal(
     JSON.stringify(oplogV2V1Converter(entry51)),

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -1,6 +1,6 @@
 import { oplogV2V1Converter } from './oplog_v2_converter';
 
-Tinytest.only('oplog - v2/v1 conversion', function(test) {
+Tinytest.add('oplog - v2/v1 conversion', function(test) {
   const entry1 = {
     $v: 2,
     diff: { scustom: { sEJSON$value: { u: { EJSONtail: 'd' } } } },


### PR DESCRIPTION
Fix flatten object issue when the object is empty on oplog converter
Fix #11884