### PR TITLE
Fix flatten object issue when internal object value is an array on oplog converter

### DIFF
--- a/packages/mongo/oplog_v2_converter.js
+++ b/packages/mongo/oplog_v2_converter.js
@@ -99,8 +99,6 @@ function flattenObject(ob) {
       let objectKeys = Object.keys(flatObject);
       if(objectKeys.length === 0) { return ob; }
       for (const x of objectKeys) {
-        if (!flatObject.hasOwnProperty(x)) continue;
-
         toReturn[i + '.' + x] = flatObject[x];
       }
     } else {

--- a/packages/mongo/oplog_v2_converter.js
+++ b/packages/mongo/oplog_v2_converter.js
@@ -94,10 +94,11 @@ function flattenObject(ob) {
   for (const i in ob) {
     if (!ob.hasOwnProperty(i)) continue;
 
-    if (typeof ob[i] == 'object' && ob[i] !== null) {
+    if (!Array.isArray(ob[i]) && typeof ob[i] == 'object' && ob[i] !== null) {
       const flatObject = flattenObject(ob[i]);
-      if(Object.keys(flatObject).length === 0) { return ob; }
-      for (const x in flatObject) {
+      let objectKeys = Object.keys(flatObject);
+      if(objectKeys.length === 0) { return ob; }
+      for (const x of objectKeys) {
         if (!flatObject.hasOwnProperty(x)) continue;
 
         toReturn[i + '.' + x] = flatObject[x];

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -98,6 +98,12 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
     JSON.stringify({ $v: 2, $set: { 'services.resume.loginTokens': [] } })
   );
 
+  const entry91 = { "$v" : 2, "diff" : { "i" : { "tShirt" : { "sizes" : [ "small", "medium", "large" ] } } } };
+  test.equal(
+    JSON.stringify(oplogV2V1Converter(entry91)),
+    JSON.stringify({ $v: 2, $set: { "tShirt.sizes" : [ "small", "medium", "large" ] } })
+  );
+
   const entry10 = {
     $v: 2,
     $set: {

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.14.1'
+  version: '1.14.2'
 });
 
 Npm.depends({


### PR DESCRIPTION
Fix flatten object issue when internal object value is an array - fix #11887

Preserve object.keys call for performance reasons