### PR TITLE
Throwing error when no mail URL is set but the app is running in a 

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -55,13 +55,13 @@ Read our [Migration Guide](https://guide.meteor.com/2.6.1-migration.html) for th
 * `ejson@1.1.2`
   - Fixing error were EJSON.equals fail to compare object and array if first param is object and second is array. [PR](https://github.com/meteor/meteor/pull/11866), [Issue](https://github.com/meteor/meteor/issues/11864).
 
+* `email@2.2.1`
+  - Throwing error when trying to send email in a production environment but without a mail URL set. [PR](https://github.com/meteor/meteor/pull/11891), [Issue](https://github.com/meteor/meteor/issues/11709).
+
 #### Independent Releases
 
 * `mongo@1.14.1` at 2022-02-04
   - Fix flatten object issue when the object is empty on oplog converter. [PR](https://github.com/meteor/meteor/pull/11885), [Issue](https://github.com/meteor/meteor/issues/11884).
-
-* `email@2.2.1`
-  - Modernizes the code.
 
 ## v2.6, 2022-02-01
 

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -257,7 +257,7 @@ Email.send = function(options) {
     // This check is mostly necessary when using the flag --production when running locally.
     // And it works as a reminder to properly set the mail URL when running locally.
     throw new Error(
-      'You do not provided a mail URL. You can provide it by using the environment variable MAIL_URL or using your settings. You can read more about it here: https://docs.meteor.com/api/email.html.'
+      'You have not provided a mail URL. You can provide it by using the environment variable MAIL_URL or your settings. You can read more about it here: https://docs.meteor.com/api/email.html.'
     );
   }
 

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -251,11 +251,11 @@ Email.send = function(options) {
   }
 
   const mailUrlEnv = process.env.MAIL_URL;
-  const mailUrlUrlSettings = Meteor.settings.packages?.email;
-  if (Meteor.isProduction || mailUrlEnv || mailUrlUrlSettings) {
+  const mailUrlSettings = Meteor.settings.packages?.email;
+  if (Meteor.isProduction || mailUrlEnv || mailUrlSettings) {
     // This check is mostly necessary when using the flag --production when running locally.
     // And it works as a reminder to properly set the mail URL when running locally.
-    if (!mailUrlEnv && !mailUrlUrlSettings) {
+    if (!mailUrlEnv && !mailUrlSettings) {
       throw new Error(
         'You do not provided a mail URL. You can provide it by using the environment variable MAIL_URL or using your settings. You can read more about it here: https://docs.meteor.com/api/email.html.'
       );

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -252,15 +252,16 @@ Email.send = function(options) {
 
   const mailUrlEnv = process.env.MAIL_URL;
   const mailUrlSettings = Meteor.settings.packages?.email;
-  if (Meteor.isProduction || mailUrlEnv || mailUrlSettings) {
+
+  if (Meteor.isProduction && !mailUrlEnv && !mailUrlSettings) {
     // This check is mostly necessary when using the flag --production when running locally.
     // And it works as a reminder to properly set the mail URL when running locally.
-    if (!mailUrlEnv && !mailUrlSettings) {
-      throw new Error(
-        'You do not provided a mail URL. You can provide it by using the environment variable MAIL_URL or using your settings. You can read more about it here: https://docs.meteor.com/api/email.html.'
-      );
-    }
+    throw new Error(
+      'You do not provided a mail URL. You can provide it by using the environment variable MAIL_URL or using your settings. You can read more about it here: https://docs.meteor.com/api/email.html.'
+    );
+  }
 
+  if (mailUrlEnv || mailUrlSettings) {
     const transport = getTransport();
     smtpSend(transport, options);
     return;


### PR DESCRIPTION
Based on the issue [#11709](https://github.com/meteor/meteor/issues/11709), I could reproduce it by not setting a MAIL_URL and running my app with --production.

Now, an error will be thrown when the app runs in a production environment but doesn't have a mail URL set, as a reminder.

Also, making sure there are no [settings](https://github.com/meteor/meteor/compare/release-2.6.1...feature/check-if-mail-url-is-set?expand=1#diff-81b3d1c2cbdddcb39f637030fdb2c2fe5e3190c2b3e0b638c68199f793aa7e5aR66) when calling the function [knownHostsTransport](https://github.com/meteor/meteor/compare/release-2.6.1...feature/check-if-mail-url-is-set?expand=1#diff-81b3d1c2cbdddcb39f637030fdb2c2fe5e3190c2b3e0b638c68199f793aa7e5aR63). Before, this function was being called from [here](https://github.com/meteor/meteor/blob/34596ca59213a4938f651b71261b3159e61b0e86/packages/email/email.js#L131) with the settings as an empty object, therefore never entering on this [`if`](https://github.com/meteor/meteor/compare/release-2.6.1...feature/check-if-mail-url-is-set?expand=1#diff-81b3d1c2cbdddcb39f637030fdb2c2fe5e3190c2b3e0b638c68199f793aa7e5aL65).
