### PR TITLE
Remove throw on _id exclusion inside mongo collection finds

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -343,13 +343,6 @@ Object.assign(Mongo.Collection.prototype, {
         )
       );
 
-      const { projection } = newOptions;
-
-      // this error: "Cannot do exclusion on field _id in inclusion projection"
-      // happens on MongoDB CLI but doesn't happen in the Node.js Driver for MongoDB 5.0+
-      if (projection && projection._id != null && !projection._id) {
-        throw new Error(`Cannot do exclusion on field _id in inclusion projection, collectionName=${self._name}`);
-      }
 
       return {
         transform: self._transform,

--- a/packages/mongo/observe_changes_tests.js
+++ b/packages/mongo/observe_changes_tests.js
@@ -48,9 +48,10 @@ _.each ([{added: 'added', forceOrdered: true},
 
     handle.stop();
 
-    test.throws(function () {
-      c.find({}, {fields: {noodles: 1, _id: false}})
-    }, undefined, 'bad cursor excluding _id from projection');
+   const badCursor = c.find({}, {fields: {noodles: 1, _id: false}});
+   test.throws(function () {
+     badCursor.observeChanges(logger);
+   });
 
     onComplete();
     });


### PR DESCRIPTION
Remove throw-on _id exclusion inside mongo collection finds.

Revert changed test that was done during the development of the new mongo driver. 