### PR TITLE
Pass lazy css resources to minifier in development

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1120,8 +1120,7 @@ class Target {
       // Takes a CssOutputResource and returns a string of minified CSS,
       // or null to indicate no minification occurred.
       minifyCssResource: (resource) => {
-        if (! minifiersByExt.css ||
-            minifyMode === "development") {
+        if (! minifiersByExt.css) {
           // Indicates the caller should use the original resource.data
           // without minification.
           return null;

--- a/tools/tests/apps/custom-minifier/body.html
+++ b/tools/tests/apps/custom-minifier/body.html
@@ -1,4 +1,5 @@
 <body>
   <div class="production_css">Text for prod</div>
   <div class="development_css">Text for devel</div>
+  <div class="minified_lazy">Text for imported</div>
 </body>

--- a/tools/tests/apps/custom-minifier/code.js
+++ b/tools/tests/apps/custom-minifier/code.js
@@ -1,6 +1,8 @@
 if (Meteor.isClient) {
+  require('./imports/imported.css');
+
   Meteor.startup(function () {
-    ['production_css', 'development_css'].forEach(cls => {
+    ['production_css', 'development_css', 'minified_lazy'].forEach(cls => {
       var color = getComputedStyle(document.querySelectorAll('.' + cls)[0]).color;
       Meteor.call('print', cls + ': ' + color);
     });

--- a/tools/tests/apps/custom-minifier/imports/imported.css
+++ b/tools/tests/apps/custom-minifier/imports/imported.css
@@ -1,0 +1,3 @@
+.lazy-resource {
+  color: rgb(0, 256, 0);
+}

--- a/tools/tests/apps/custom-minifier/packages/custom-minifier/plugin/minify.js
+++ b/tools/tests/apps/custom-minifier/packages/custom-minifier/plugin/minify.js
@@ -29,6 +29,7 @@ CustomMinifier.prototype.processFilesForBundle = function (files, options) {
         data: contents
       });
     } else {
+      contents = contents.replace(/lazy-resource/g, 'minified_lazy');
       file.addStylesheet({
         data: contents
       });
@@ -37,5 +38,3 @@ CustomMinifier.prototype.processFilesForBundle = function (files, options) {
     Plugin.nudge();
   });
 };
-
-

--- a/tools/tests/custom-minifier.js
+++ b/tools/tests/custom-minifier.js
@@ -22,6 +22,7 @@ selftest.define('custom minifier - devel vs prod', function (options) {
 
     run.match('production_css: rgb(255, 0, 0)');
     run.match('development_css: rgb(0, 0, 0)');
+    run.match('minified_lazy: rgb(0, 255, 0)');
     run.match('Message (client): production_js');
 
     run.stop();
@@ -43,6 +44,7 @@ selftest.define('custom minifier - devel vs prod', function (options) {
 
     run.match('production_css: rgb(0, 0, 0)');
     run.match('development_css: rgb(255, 0, 0)');
+    run.match('minified_lazy: rgb(0, 255, 0)');
     run.match('Message (client): development_js');
 
     run.stop();


### PR DESCRIPTION
This makes it consistent with non-lazy resources. Lazy css resources are those in `imports` and any other css files that are not eagerly loaded.

This makes it possible for minifiers that run postcss plugins to do so with these files in development instead of only in production builds.