### PR TITLE
Fix running self tests on m1

### DIFF
--- a/tools/tool-testing/clients/puppeteer/index.js
+++ b/tools/tool-testing/clients/puppeteer/index.js
@@ -3,7 +3,7 @@ import { enterJob } from '../../../utils/buildmessage.js';
 import { ensureDependencies } from '../../../cli/dev-bundle-helpers.js';
 
 const NPM_DEPENDENCIES = {
-  puppeteer: '8.0.0'
+  puppeteer: '13.2.0'
 };
 
 export default class PuppeteerClient extends Client {


### PR DESCRIPTION
It was using an old version of puppeteer that didn't support m1.