### PR TITLE
Support the new "projection" field inside the decision of using oplog for a published cursor or not

### DIFF
--- a/packages/mongo/oplog_observe_driver.js
+++ b/packages/mongo/oplog_observe_driver.js
@@ -984,9 +984,10 @@ OplogObserveDriver.cursorSupported = function (cursorDescription, matcher) {
 
   // If a fields projection option is given check if it is supported by
   // minimongo (some operators are not supported).
-  if (options.fields) {
+  const fields = options.fields || options.projection;
+  if (fields) {
     try {
-      LocalCollection._checkSupportedProjection(options.fields);
+      LocalCollection._checkSupportedProjection(fields);
     } catch (e) {
       if (e.name === "MinimongoError") {
         return false;


### PR DESCRIPTION
Also support the new "projection" field inside the decision of using oplog for a published cursor or not

It was spawning errors as the decision was true for unsupported cursor fields

Fixes this comment: https://github.com/meteor/meteor/issues/11855#issuecomment-1035120781
