### PR TITLE
Fix issues with HMR and meteor build --debug

### DIFF
--- a/packages/hot-module-replacement/server.js
+++ b/packages/hot-module-replacement/server.js
@@ -1,5 +1,8 @@
-if (!process.env.METEOR_HMR_SECRET) {
-  console.log('Restart Meteor to enable hot module replacement.');
-} else {
+// METEOR_PARENT_PID 
+if (process.env.METEOR_HMR_SECRET) {
   __meteor_runtime_config__._hmrSecret = process.env.METEOR_HMR_SECRET;
+} else if (process.env.METEOR_PARENT_PID) {
+  // if METEOR_PARENT_PID isn't set, then the app isn't being run by the meteor
+  // tool and restarting won't enable HRM.
+  console.log('Restart Meteor to enable hot module replacement.');
 }

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -929,13 +929,7 @@ function runWebAppServer() {
       versionReplaceable: () =>
         WebAppHashing.calculateClientHash(
           manifest,
-          (_type, replaceable) => {
-            if (Meteor.isProduction && replaceable) {
-              throw new Error('Unexpected replaceable file in production');
-            }
-
-            return replaceable;
-          },
+          (_type, replaceable) => replaceable,
           configOverrides
         ),
       cordovaCompatibilityVersions: programJson.cordovaCompatibilityVersions,


### PR DESCRIPTION
1. Fixes crash when the app was built with the `--debug` option, and then run with NODE_ENV set to production. Some files are expected to be replaceable in this situation, so I removed the check that was causing the crash. Fixes https://forums.meteor.com/t/unexpected-replaceable-file-in-production/57534.
2. When running the app created from `meteor build --debug`, it would log `Restart Meteor to enable hot module replacement.`. Restarting the app wouldn't enable HMR since it isn't being run by the meteor tool, so it no longer shows the message.