### PR TITLE
Fix multiple array operators bug and add support for debug messages

### DIFF
--- a/packages/mongo/oplog_v2_converter.js
+++ b/packages/mongo/oplog_v2_converter.js
@@ -34,13 +34,16 @@ on mongo 4
  */
 
 const isArrayOperator = possibleArrayOperator => {
-  if (!Object.keys(possibleArrayOperator).length) return false;
+  if (!possibleArrayOperator || !Object.keys(possibleArrayOperator).length)
+    return false;
 
+  if (!possibleArrayOperator.a) {
+    return false;
+  }
   return !Object.keys(possibleArrayOperator).find(
-    key => key !== 'a' && !key.match(/u\d+/)
+      key => key !== 'a' && !key.match(/^u\d+/)
   );
 };
-
 function logOplogEntryError(oplogEntry, prefixKey, key) {
   console.log('---');
   console.log(

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -51,13 +51,16 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
   );
 
   //set a new nested field inside an object
-  const entry51 =  { "$v" : 2, "diff" : { "u" : { "count" : 1 }, "i" : { "nested" : { "state" : {  } } } } };
+  const entry51 = {
+    $v: 2,
+    diff: { u: { count: 1 }, i: { nested: { state: {} } } },
+  };
   // the correct format for this test, inspecting the mongodb oplog, should be "nested" : { "state" : {  } } }
   // but this is a case in which we can flatten the object without collateral, so we are considering
   // "nested.state" : {  } to be valid too
   test.equal(
     JSON.stringify(oplogV2V1Converter(entry51)),
-    JSON.stringify( { "$v" : 2, "$set" : { "nested.state": {  }, "count" : 1 } })
+    JSON.stringify({ $v: 2, $set: { 'nested.state': {}, count: 1 } })
   );
 
   //set an existing nested field inside an object
@@ -98,10 +101,30 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
     JSON.stringify({ $v: 2, $set: { 'services.resume.loginTokens': [] } })
   );
 
-  const entry91 = { "$v" : 2, "diff" : { "i" : { "tShirt" : { "sizes" : [ "small", "medium", "large" ] } } } };
+  const entry91 = {
+    $v: 2,
+    diff: { i: { tShirt: { sizes: ['small', 'medium', 'large'] } } },
+  };
   test.equal(
     JSON.stringify(oplogV2V1Converter(entry91)),
-    JSON.stringify({ $v: 2, $set: { "tShirt.sizes" : [ "small", "medium", "large" ] } })
+    JSON.stringify({
+      $v: 2,
+      $set: { 'tShirt.sizes': ['small', 'medium', 'large'] },
+    })
+  );
+
+  test.equal(
+    JSON.stringify(
+      oplogV2V1Converter({
+        $v: 2,
+        diff: { slist: { a: true, u3: 'i', u4: 'h' } },
+      })
+    ),
+    JSON.stringify({
+      $v: 2,
+      // oplog v1 outputs the whole list -> list: ['e', 'f', 'g', 'i', 'h', 'j']
+      "$set":{"list.3":"i", "list.4":"h"},
+    })
   );
 
   const entry10 = {
@@ -135,6 +158,20 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
           },
         ],
       },
+    })
+  );
+  test.equal(
+    JSON.stringify(
+      oplogV2V1Converter({
+        $v: 2,
+        diff: {
+          sobject: { u: { array: ['2', '2', '4', '3'] } },
+        },
+      })
+    ),
+    JSON.stringify({
+      $v: 2,
+      $set: { 'object.array': ['2', '2', '4', '3'] },
     })
   );
 });

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -123,7 +123,7 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
     JSON.stringify({
       $v: 2,
       // oplog v1 outputs the whole list -> list: ['e', 'f', 'g', 'i', 'h', 'j']
-      "$set":{"list.3":"i", "list.4":"h"},
+      $set: { 'list.3': 'i', 'list.4': 'h' },
     })
   );
 
@@ -172,6 +172,29 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
     JSON.stringify({
       $v: 2,
       $set: { 'object.array': ['2', '2', '4', '3'] },
+    })
+  );
+  test.equal(
+    JSON.stringify(
+      oplogV2V1Converter({
+        $v: 2,
+        diff: {
+          slayout: {
+            sjourneyStepIds: {
+              sj4aqp3tiK6xCPCYu8: {
+                a: true,
+                u2: 'zTkxivNrKuBi2iJ2m',
+              },
+            },
+          },
+        },
+      })
+    ),
+    JSON.stringify({
+      $v: 2,
+      $set: {
+        'layout.journeyStepIds.j4aqp3tiK6xCPCYu8.2': 'zTkxivNrKuBi2iJ2m',
+      },
     })
   );
 });


### PR DESCRIPTION
The format for oplog v2 might include multiple array type operations. This PR fixes the bug that was caused by only going over the first one.

This PR also adds support for debug messages, which will help debug issues with the new format.

Fixes https://github.com/meteor/meteor/issues/11914