### PR TITLE
Remove false positive warning on oplog entry

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -46,6 +46,8 @@
 
 #### Independent Releases
 
+* `mongo@1.14.6` at 2022-02-18
+  - Remove false-positive warning for supported operation a.0.b:{}
 * `mongo@1.14.5` at 2022-02-16
   - Fix multiple array operators bug and add support for debug messages
   - Fix isArrayOperator function regexp false-positive

--- a/packages/mongo/oplog_v2_converter.js
+++ b/packages/mongo/oplog_v2_converter.js
@@ -86,11 +86,13 @@ const nestedOplogEntryParsers = (oplogEntry, prefixKey = '') => {
         );
       }
     } else {
-      // we are looking at a "sSomething" that is actually a nested object set
+      // we are looking at something that we expected to be "sSomething" but is null after removing s
+      // this happens on "a": true which is a simply ack that comes embeded
+      // we dont need to call recursion on this case, only ignore it
       if (!actualKeyNameWithoutSPrefix || actualKeyNameWithoutSPrefix === '') {
-        logOplogEntryError(oplogEntry, prefixKey, key);
         return null;
       }
+      // we are looking at a "sSomething" that is actually a nested object set
       logConverterCalls(oplogEntry, prefixKey, key);
       sFieldsOperators.push(
         nestedOplogEntryParsers(

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -197,4 +197,15 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
       },
     })
   );
+  test.equal(
+    JSON.stringify(
+      oplogV2V1Converter({
+        $v: 2,
+        diff: {
+          sarray: { a: true, s2: { u: { a: 'something' } } },
+        },
+      })
+    ),
+    JSON.stringify({ $v: 2, $set: { 'array.2.a': 'something' } })
+  );
 });

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.14.5'
+  version: '1.14.6'
 });
 
 Npm.depends({


### PR DESCRIPTION
Remove false-positive warning for supported operation a.0.b:{} and add more test cases