### PR TITLE
docs: fix example code in security guide

### DIFF
--- a/guide/source/security.md
+++ b/guide/source/security.md
@@ -652,8 +652,12 @@ const helpmentOptions = {
 // connection available.
 // Run your project with --production flag to simulate script-src hashing
 if (!usesHttps && Meteor.isDevelopment) {
-  delete opt.contentSecurityPolicy.directives.blockAllMixedContent
-  opt.contentSecurityPolicy.directives.scriptSrc = [self, unsafeEval, unsafeInline]
+  delete helpmentOptions.contentSecurityPolicy.blockAllMixedContent;
+  helpmentOptions.contentSecurityPolicy.directives.scriptSrc = [
+    self,
+    unsafeEval,
+    unsafeInline,
+  ];
 }
 
 // finally pass the options to helmet to make them apply


### PR DESCRIPTION
I think there is a small typo in guide related  to security

As you'll see, dev environment settings weren't consistent with helpmentOptions.

Let me know if I missed something.