### PR TITLE
Improving 2.6 migration guide

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -85,13 +85,13 @@ Read our [Migration Guide](https://guide.meteor.com/2.6-migration.html) for this
 #### Meteor Version Release
 
 * `mongo@1.14.0`
+    - `applySkipLimit` option for count() on find cursors is no longer supported. Read more about it [here](https://guide.meteor.com/2.6-migration.html), in the `Cursor.count()` section.
     - internal result of operations inside Node.js MongoDB driver have changed. If you are depending on rawCollection results (not only the effect inside the DB), please review the expected format as we have done [here](https://github.com/meteor/meteor/blob/155ae639ee590bae66237fc1c29295072ec92aef/packages/mongo/mongo_driver.js#L658)
     - useUnifiedTopology is not an option anymore, it defaults to true.
     - native parser is not an option anymore, it defaults to false in the mongo connection.
     - poolSize not an option anymore, we are using max/minPoolSize for the same behavior on mongo connection.
     - fields option is deprecated, we are maintaining a translation layer to "projection" field (now prefered) until the next minor version, where we will start showing alerts.
     - _ensureIndex is now showing a deprecation message
-    - applySkipLimit option for count() on find cursors is no longer supported.
     - we are maintaining a translation layer for the new oplog format, so if you read or rely on any behavior of it please read our oplog_v2_converter.js code
     - update/insert/remove behavior is maintained in the Meteor way, documented in our docs, but we are now using replaceOne/updateOne/updateMany internally. This is subject to changes in the API rewrite of MongoDB without Fibers AND if you are using rawCollection directly you have to review your methods otherwise you will see deprecation messages if you are still using the old mongodb style directly.
     - waitForStepDownOnNonCommandShutdown=false is not needed anymore when spawning the mongodb process

--- a/guide/source/2.6-migration.md
+++ b/guide/source/2.6-migration.md
@@ -45,6 +45,27 @@ For this specific case, we have written the fix in this [PR](https://github.com/
 
 If you are a user looking for errors that are showing in a custom package, please open an issue in the package owner repository so the maintainer can make the due changes.
 
+#### Cursor.count()
+
+`applySkipLimit` option for count() on find cursors is no longer supported. By default, this option will always be true. So, for example, let's say you have a collection with 50 documents and execute a `find` with a limit of 25:
+
+```js
+const cursor = collection.find({}, { limit: 25 });
+```
+
+When you call `cursor.fetch()`, the result will be 25 documents, and `cursor.count()` will be 25. Whereas, in the previous version, `cursor.count()` would result in 50, in this case, and you would need to provide the option `applySkipLimit` to get the result 25.
+
+Now, you'll need to create a new cursor, but this time not providing a limit, in order to get the number of all documents in your collection:
+
+```js
+const cursorWithLimit = collection.find({}, { limit: 25 });
+const cursorWithNoLimit = collection.find({});
+// cursorWithLimit.fetch() => returns 25 documents
+// cursorWithNoLimit.count() => returns 50
+```
+
+Remember that a `find` is a wrapper for the query, so creating two or more cursors in a row is totally fine and not slower at all.
+
 #### Changes
 
 Here is a list of the changes that we have made to Meteor core packages in order to make it compatible with MongoDB Node.js Driver 4.3.x, most of them are not going to affect you but we recommend that you test your application well before upgrading to the latest version of Meteor as we have made many changes on how Meteor interact with MongoDB.
@@ -54,7 +75,6 @@ Here is a list of the changes that we have made to Meteor core packages in order
   - poolSize not an option anymore, we are using max/minPoolSize for the same behavior on mongo connection.
   - fields option is deprecated, we are maintaining a translation layer to "projection" field (now prefered) until the next minor version, where we will start showing alerts.
   - _ensureIndex is now showing a deprecation message
-  - applySkipLimit option for count() on find cursors is no longer supported.
   - we are maintaining a translation layer for the new oplog format, so if you read or rely on any behavior of it please read our oplog_v2_converter.js code
   - update/insert/remove behavior is maintained in the Meteor way, documented in our docs, but we are now using replaceOne/updateOne/updateMany internally. This is subject to changes in the API rewrite of MongoDB without Fibers AND if you are using rawCollection directly you have to review your methods otherwise you will see deprecation messages if you are still using the old mongodb style directly.
   - waitForStepDownOnNonCommandShutdown=false is not needed anymore when spawning the mongodb process


### PR DESCRIPTION
Based on the issue [#11921](https://github.com/meteor/meteor/issues/11921), we felt the necessity to make clear that the option applySkipLimit is no longer supported and present a solution in case someone is in the same situation.