### PR TITLE
Allow minifiers to get source path of file

### DIFF
--- a/docs/source/api/packagejs.md
+++ b/docs/source/api/packagejs.md
@@ -313,6 +313,8 @@ methods are available:
    uses the `hot-module-replacement` package. There are rare situations where `hmrAvailable`
    returns true, but when more information is available later in the build process Meteor
    decides the file can not be updated with HMR.
+ - `readAndWatchFileWithHash` - Accepts an absolute path, and returns { contents, hash }
+    Makes sure Meteor watches the file so any changes to it will trigger a rebuild
 
 Meteor implements a couple of compilers as Core packages, good examples would be
 the
@@ -385,9 +387,11 @@ unnecessary work and then we minify the files in production mode.
 
 Besides the common input files' methods, these methods are available:
 - `getPathInBundle` - returns a path of the processed file in the bundle.
+- `getSourcePath` - returns absolute path of the input file if available, or null.
 - `getSourceMap` - returns the source-map for the processed file if there is such.
 - `addJavaScript` - same as compilers
 - `addStylesheet` - same as compilers
+- `readAndWatchFileWithHash` - only available for css minifiers. Same as compilers.
 
 Right now, Meteor Core ships with the `standard-minifiers` package that can be
 replaced with a custom one. The

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -127,8 +127,7 @@ const mergeCss = Profile("mergeCss", async function (css, postcssConfig) {
         const result = await postcssConfig.postcss(
           postcssConfig.plugins
         ).process(content, {
-          // TODO: provide a better way to get the file's path
-          from: process.cwd() + file._source.url?.replace('/__cordova', ''),
+          from: file.getSourcePath(),
           parser: postcssConfig.options.parser
         });
 

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1126,11 +1126,17 @@ class Target {
           return null;
         }
 
+        let sourcePath;
+        if (resource.data && resource.sourceRoot && resource.sourcePath) {
+          sourcePath = files.pathJoin(resource.sourceRoot, resource.sourcePath);
+        }
+
         const file = new File({
           info: 'resource ' + resource.servePath,
           arch: target.arch,
           data: resource.data,
           hash: resource.hash,
+          sourcePath
         });
 
         file.setTargetPathFromRelPath(
@@ -1279,13 +1285,18 @@ class Target {
             return;
           }
 
+          let sourcePath;
+          if (resource.data && resource.sourceRoot && resource.sourcePath) {
+            sourcePath = files.pathJoin(resource.sourceRoot, resource.sourcePath);
+          }
           const f = new File({
             info: 'resource ' + resource.servePath,
             arch: this.arch,
             data: resource.data,
             hash: resource.hash,
             cacheable: false,
-            replaceable: resource.type === 'js' && sourceBatch.hmrAvailable
+            replaceable: resource.type === 'js' && sourceBatch.hmrAvailable,
+            sourcePath
           });
 
           const relPath = stripLeadingSlash(resource.servePath);

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -892,6 +892,7 @@ class OutputResource {
       sourcePath,
       targetPath,
       servePath,
+      sourceRoot: resourceSlot.packageSourceBatch.sourceRoot,
       // Remember the source hash so that changes to the source that
       // disappear after compilation can still contribute to the hash.
       // Bypassing SourceResource.hash getter so if the compiler plugin doesn't

--- a/tools/isobuild/minifier-plugin.js
+++ b/tools/isobuild/minifier-plugin.js
@@ -36,6 +36,9 @@ class InputFile extends buildPluginModule.InputFile {
   getArch() {
     return this._arch;
   }
+  getSourcePath() {
+    return this._source.sourcePath || null;
+  }
 
   error({message, sourcePath, line, column, func}) {
     const relPath = this.getPathInBundle();


### PR DESCRIPTION
Fixes  https://github.com/meteor/meteor/issues/11940.

Adds `file.getSourcePath()` to the minifier files to get the absolute path to the corresponding input file if there is one.
