### PR TITLE
Fix some npm modules being imported as an empty object

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -77,6 +77,9 @@ Read our [Migration Guide](https://guide.meteor.com/2.7-migration.html) for this
 * `google-oauth@1.4.2`
   - Migrate from `http` to `fetch`
 
+* `modules-runtime@0.13.0`
+  - Fix some npm modules being imported as an empty object. [PR](https://github.com/meteor/meteor/pull/11954), [Issue 1](https://github.com/meteor/meteor/issues/11900), [Issue 2](https://github.com/meteor/meteor/issues/11853).
+
 #### Independent Releases
 
 ## v2.6.1, 2022-02-18

--- a/packages/modules-runtime/package.js
+++ b/packages/modules-runtime/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules-runtime",
-  version: "0.12.0",
+  version: "0.13.0-rc270.0",
   summary: "CommonJS module system",
   git: "https://github.com/benjamn/install",
   documentation: "README.md"

--- a/packages/modules-runtime/server.js
+++ b/packages/modules-runtime/server.js
@@ -51,20 +51,6 @@ Module.prototype.useNode = function () {
     throw new Error('npmRequire must be defined to use useNode');
   }
 
-  var parts = this.id.split("/");
-  var start = 0;
-  if (parts[start] === "") ++start;
-  if (parts[start] === "node_modules" &&
-      parts[start + 1] === "meteor") {
-    start += 2;
-  }
-
-  if (parts.indexOf("node_modules", start) < 0) {
-    // Don't try to use Node for modules that aren't in node_modules
-    // directories.
-    throw new Error('useNode can not be used to import modules outside of node_modules');
-  }
-
   // See tools/static-assets/server/npm-require.js for the implementation
   // of npmRequire. Note that this strategy fails when importing ESM
   // modules (typically, a .js file in a package with "type": "module" in

--- a/packages/modules-runtime/server.js
+++ b/packages/modules-runtime/server.js
@@ -48,7 +48,7 @@ var Module = meteorInstall.Module;
 Module.prototype.useNode = function () {
   if (typeof npmRequire !== "function") {
     // Can't use Node if npmRequire is not defined.
-    return false;
+    throw new Error('npmRequire must be defined to use useNode');
   }
 
   var parts = this.id.split("/");
@@ -62,7 +62,7 @@ Module.prototype.useNode = function () {
   if (parts.indexOf("node_modules", start) < 0) {
     // Don't try to use Node for modules that aren't in node_modules
     // directories.
-    return false;
+    throw new Error('useNode can not be used to import modules outside of node_modules');
   }
 
   // See tools/static-assets/server/npm-require.js for the implementation
@@ -70,6 +70,4 @@ Module.prototype.useNode = function () {
   // modules (typically, a .js file in a package with "type": "module" in
   // its package.json), as of Node 12.16.0 (Meteor 1.9.1).
   this.exports = npmRequire(this.id);
-
-  return true;
 };

--- a/packages/modules-runtime/server.js
+++ b/packages/modules-runtime/server.js
@@ -65,12 +65,6 @@ Module.prototype.useNode = function () {
     return false;
   }
 
-  try {
-    npmRequire.resolve(this.id);
-  } catch (e) {
-    return false;
-  }
-
   // See tools/static-assets/server/npm-require.js for the implementation
   // of npmRequire. Note that this strategy fails when importing ESM
   // modules (typically, a .js file in a package with "type": "module" in

--- a/packages/modules-runtime/server.js
+++ b/packages/modules-runtime/server.js
@@ -51,6 +51,15 @@ Module.prototype.useNode = function () {
     throw new Error('npmRequire must be defined to use useNode');
   }
 
+  try {
+    npmRequire.resolve(this.id);
+  } catch (e) {
+    throw new Error(
+      `Cannot find module "${this.id}". ` +
+      `Try installing the npm package or make sure it is not a devDependency.`
+    );
+  }
+
   // See tools/static-assets/server/npm-require.js for the implementation
   // of npmRequire. Note that this strategy fails when importing ESM
   // modules (typically, a .js file in a package with "type": "module" in


### PR DESCRIPTION
The `install` npm package used to call `module.useNode` to check how to require a module, and then handle throwing an error itself if the module wasn't found. However, now Meteor does most of that work when building the app, and in some cases an error is never thrown if a module was found during the build, but not when running the app.

This PR updates `module.useNode` so it matches how it is now used.

Fixes https://github.com/meteor/meteor/issues/11900.