### PR TITLE
Support node: imports

### DIFF
--- a/npm-packages/meteor-node-stubs/index.js
+++ b/npm-packages/meteor-node-stubs/index.js
@@ -6,11 +6,11 @@ Object.keys(map).forEach(function (id) {
     var aliasParts = module.id.split("/");
     aliasParts.pop();
     aliasParts.push("node_modules", map[id]);
-    exports[id] = meteorAliases[id + ".js"] =
+    exports[id] = meteorAliases[id + ".js"] = meteorAliases["node:" + id] =
       aliasParts.join("/");
   } else {
     exports[id] = map[id];
-    meteorAliases[id + ".js"] = function(){};
+    meteorAliases[id + ".js"] = meteorAliases["node:" + id] = function(){};
   }
 });
 

--- a/tools/isobuild/resolver.ts
+++ b/tools/isobuild/resolver.ts
@@ -31,6 +31,7 @@ nativeNames.forEach((id: string) => {
   // identifier will not be imported at runtime, but the modules it
   // depends on are necessary for the original import to succeed.
   nativeModulesMap[id] =  "meteor-node-stubs/deps/" + id;
+  nativeModulesMap[`node:${id}`] =  "meteor-node-stubs/deps/" + id;
 });
 
 export type ResolverOptions = {


### PR DESCRIPTION
Adds support for [`node:`](https://nodejs.org/api/esm.html#node-imports) imports.