### PR TITLE
2FA return secret as well

### DIFF
--- a/docs/source/packages/accounts-2fa.md
+++ b/docs/source/packages/accounts-2fa.md
@@ -15,8 +15,8 @@ The first step, in order to enable 2FA, is to generate a QR code so that the use
 
 {% apibox "Accounts.generate2faActivationQrCode" "module":"accounts-base" %}
 
-Receives an `appName` which is the name of your app that will show up when the user scans the QR code. Also, a callback called with a QR code in SVG format on success or a single `Error` argument
-on failure.
+Receives an `appName` which is the name of your app that will show up when the user scans the QR code. Also, a callback called with a QR code in SVG format and QR secret on success 
+or a single `Error` argument on failure.
 
 On success, this function will also add an object to the logged user's services object containing the QR secret:
 

--- a/packages/accounts-2fa/2fa-server.js
+++ b/packages/accounts-2fa/2fa-server.js
@@ -71,7 +71,7 @@ Meteor.methods({
       }
     );
 
-    return svg;
+    return { svg, secret };
   },
   enableUser2fa(code) {
     const user = Meteor.user();


### PR DESCRIPTION
As I have stated in release 2.7 PR, returning the secret on 2FA creation is desired as it can be dysplayed as a backup to the QR code and allows the OTP to be used with clients such as KeePassXC which require manual imput of the secret.