### PR TITLE
2FA use userId instead of username

### DIFF
--- a/packages/accounts-2fa/2fa-server.js
+++ b/packages/accounts-2fa/2fa-server.js
@@ -131,7 +131,7 @@ Meteor.methods({
     }
 
     if (!selector) {
-      selector = { $or: [{ _id: userId }, { username: userId }] };
+      selector = { _id: userId };
     }
 
     return Accounts._is2faEnabledForUser(selector);

--- a/packages/accounts-2fa/package.js
+++ b/packages/accounts-2fa/package.js
@@ -12,11 +12,25 @@ Npm.depends({
 Package.onUse(function(api) {
   api.use(['accounts-base'], ['client', 'server']);
 
-  // Export Accounts (etc) to packages using this one.
+  // Export Accounts (etc.) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);
 
   api.use('ecmascript');
+  api.use('check', 'server');
 
   api.addFiles(['2fa-client.js'], 'client');
   api.addFiles(['2fa-server.js'], 'server');
+});
+
+Package.onTest(function(api) {
+  api.use([
+    'accounts-base',
+    'accounts-password',
+    'ecmascript',
+    'tinytest',
+    'random',
+    'accounts-2fa',
+  ]);
+
+  api.mainModule('server_tests.js', 'server');
 });

--- a/packages/accounts-2fa/server_tests.js
+++ b/packages/accounts-2fa/server_tests.js
@@ -1,0 +1,15 @@
+import { Accounts } from 'meteor/accounts-base';
+import { Random } from 'meteor/random';
+
+Tinytest.add('account - 2fa - has2faEnabled', test => {
+  // Create users
+  const userWithout2FA = Accounts.insertUserDoc({}, { emails: [{address: `${Random.id()}@meteorapp.com`, verified: true}] });
+  const userWith2FA = Accounts.insertUserDoc({}, { emails: [{address: `${Random.id()}@meteorapp.com`, verified: true}], services: { twoFactorAuthentication: { type: 'otp', secret: 'superSecret' } } });
+
+  test.equal(Accounts._is2faEnabledForUser(userWithout2FA), false);
+  test.equal(Accounts._is2faEnabledForUser(userWith2FA), true);
+
+  // cleanup
+  Accounts.users.remove(userWithout2FA);
+  Accounts.users.remove(userWith2FA);
+});

--- a/packages/accounts-base/accounts_client_tests.js
+++ b/packages/accounts-base/accounts_client_tests.js
@@ -10,7 +10,7 @@ const profile = {
   name: username,
   [excludeField]: excludeValue,
   [defaultExcludeField]: excludeValue,
-}
+};
 
 const logoutAndCreateUser = (test, done, nextTests) => {
   Meteor.logout(() => {

--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -114,7 +114,7 @@ export const Match = {
   _failIfArgumentsAreNotAllChecked(f, context, args, description) {
     const argChecker = new ArgumentChecker(args, description);
     const result = currentArgumentChecker.withValue(
-      argChecker, 
+      argChecker,
       () => f.apply(context, args)
     );
 
@@ -261,7 +261,7 @@ const testSubtree = (value, pattern) => {
     if (typeof value === 'number' && (value | 0) === value) {
       return false;
     }
-    
+
     return {
       message: `Expected Integer, got ${stringForErrorMessage(value)}`,
       path: '',
@@ -296,7 +296,7 @@ const testSubtree = (value, pattern) => {
         return result;
       }
     }
-    
+
     return false;
   }
 
@@ -310,7 +310,7 @@ const testSubtree = (value, pattern) => {
       if (!(err instanceof Match.Error)) {
         throw err;
       }
-      
+
       return {
         message: err.message,
         path: err.path


### PR DESCRIPTION
I have noticed that the 2FA implementation uses username as a the primary key to find user. That doesn't sound right as username is an optional parameter. As such I have switched it to use userId as the primary key and where feasible add backup of username.

I have also added `check` package to check for input and added a simple server side test for `_is2faEnabledForUser`. Nothing for client for now as I'm struggling with `has2faEnabled` which always returns undefined...