### PR TITLE
Reduce one DB call on 2FA login

### DIFF
--- a/packages/accounts-2fa/2fa-server.js
+++ b/packages/accounts-2fa/2fa-server.js
@@ -4,6 +4,15 @@ import QRCode from 'qrcode-svg';
 import { Meteor } from 'meteor/meteor';
 import { check, Match } from 'meteor/check';
 
+Accounts._check2faEnabled = user => {
+  const { services: { twoFactorAuthentication } = {} } = user;
+  return !!(
+    twoFactorAuthentication &&
+    twoFactorAuthentication.secret &&
+    twoFactorAuthentication.type === 'otp'
+  );
+};
+
 Accounts._is2faEnabledForUser = selector => {
   if (!Meteor.isServer) {
     throw new Meteor.Error(
@@ -21,12 +30,7 @@ Accounts._is2faEnabledForUser = selector => {
   }
 
   const user = Meteor.users.findOne(selector) || {};
-  const { services: { twoFactorAuthentication } = {} } = user;
-  return !!(
-    twoFactorAuthentication &&
-    twoFactorAuthentication.secret &&
-    twoFactorAuthentication.type === 'otp'
-  );
+  return Accounts._check2faEnabled(user);
 };
 
 Accounts._generate2faToken = secret => twofactor.generateToken(secret);

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -193,8 +193,7 @@ Accounts.registerLoginHandler("password", options => {
   // First the login is validated, then the code situation is checked
   if (
     !result.error &&
-    Accounts._is2faEnabledForUser &&
-    Accounts._is2faEnabledForUser(options.user)
+    Accounts._check2faEnabled(user)
   ) {
     if (!options.code) {
       Accounts._handleError('2FA code must be informed', true, 'no-2fa-code');


### PR DESCRIPTION
I have noticed that in accounts-password, once we have the user object and we check for 2FA, we try to get the user again from DB. That looks like a needless DB round trip, so I have extracted the check for 2FA enabled into its own function and then used that in accounts-password to do the check with the user object we already have. This should save one trip to the DB.