### PR TITLE
Pass on the real postcss error message if processing fails

### DIFF
--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -81,7 +81,7 @@ class CssToolsMinifier {
     const { error, postcssConfig } = await loadPostCss();
 
     if (error) {
-      files[0].error(postcssInfo.error);
+      files[0].error(error);
       return;
     }
 


### PR DESCRIPTION
When setting up the new postcss support in standard-minifier-js along with tailwind, I was getting this error: `postcssInfo is not defined`. Eventually I figured out that it is an error in this file, where postcssInfo is undefined. This change passes along the *actual* error message, which is much more helpful – in my case I had neglected to `npm install -D tailwindcss`, which was an easy fix.