### PR TITLE
New api getMinimumBrowserVersions

### DIFF
--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -120,9 +120,12 @@ function getCaller(calleeName) {
   return caller;
 }
 
+function getMinimumBrowserVersions() { return minimumVersions; }
+
 Object.assign(exports, {
   isModern,
   setMinimumBrowserVersions,
+  getMinimumBrowserVersions,
   calculateHashOfMinimumVersions() {
     const { createHash } = require('crypto');
     return createHash('sha1')


### PR DESCRIPTION
I have a need to access the `minimumBrowserVersions`.

I could not find an api that was able to read this information.

The PR is quite simple, just expose the `minimumBrowserVersions` with a new API `getMinimumBrowserVersions`.

Thanks!