### PR TITLE
Update skeleton dependencies

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,3 +1,11 @@
+## v2.7.2, UNRELEASED
+
+#### Highlights
+
+#### Meteor Version Release
+
+* Skeleton dependencies updated
+
 ## v2.7.1, 2022-03-31
 
 #### Highlights

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -8,11 +8,11 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@apollo/client": "^3.4.16",
-    "@babel/runtime": "^7.15.4",
-    "apollo-server-express": "^3.4.0",
-    "express": "^4.17.1",
-    "graphql": "^15.6.1",
+    "@apollo/client": "^3.5.10",
+    "@babel/runtime": "^7.17.9",
+    "apollo-server-express": "^3.6.7",
+    "express": "^4.17.3",
+    "graphql": "^15.8.0",
     "meteor-node-stubs": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/tools/static-assets/skel-bare/package.json
+++ b/tools/static-assets/skel-bare/package.json
@@ -5,7 +5,7 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
+    "@babel/runtime": "^7.17.9",
     "meteor-node-stubs": "^1.2.1"
   }
 }

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
+    "@babel/runtime": "^7.17.9",
     "jquery": "^3.6.0",
     "meteor-node-stubs": "^1.2.1"
   },

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -6,7 +6,7 @@
     "test": "meteor test --once --driver-package meteortesting:mocha"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
+    "@babel/runtime": "^7.17.9",
     "jquery": "^3.6.0",
     "meteor-node-stubs": "^1.2.1"
   },

--- a/tools/static-assets/skel-minimal/package.json
+++ b/tools/static-assets/skel-minimal/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
+    "@babel/runtime": "^7.17.9",
     "meteor-node-stubs": "^1.2.1"
   },
   "meteor": {

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
+    "@babel/runtime": "^7.17.9",
     "meteor-node-stubs": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
+    "@babel/runtime": "^7.17.9",
     "meteor-node-stubs": "^1.2.1",
     "svelte": "^3.46.4"
   },

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -8,17 +8,17 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
+    "@babel/runtime": "^7.17.9",
     "meteor-node-stubs": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@types/meteor": "^1.4.81",
+    "@types/meteor": "^1.4.87",
     "@types/mocha": "^8.2.3",
-    "@types/react": "^17.0.30",
-    "@types/react-dom": "^17.0.9",
-    "typescript": "^4.5.4"
+    "@types/react": "^17.0.43",
+    "@types/react-dom": "^17.0.14",
+    "typescript": "^4.6.3"
   },
   "meteor": {
     "mainModule": {

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -8,7 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
+    "@babel/runtime": "^7.17.9",
     "meteor-node-stubs": "^1.2.1",
     "vue": "^2.6.14",
     "vue-meteor-tracker": "^2.0.0-beta.5"


### PR DESCRIPTION
Update skeleton dependencies to latest, with the exception of Vue and Svelte packages which I remember there are some restrictions.