### PR TITLE
Fix reading packages installed before Meteor 1.2

### DIFF
--- a/packages/hot-module-replacement/server.js
+++ b/packages/hot-module-replacement/server.js
@@ -1,4 +1,3 @@
-// METEOR_PARENT_PID 
 if (process.env.METEOR_HMR_SECRET) {
   __meteor_runtime_config__._hmrSecret = process.env.METEOR_HMR_SECRET;
 } else if (process.env.METEOR_PARENT_PID) {

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -1432,6 +1432,9 @@ export function readBufferWithLengthAndOffset(
       if (count !== length) {
         throw new Error("couldn't read entire resource");
       }
+    } catch (err: any) {
+      err.message = `Error while reading ${filename}: ` + err.message;
+      throw err;
     } finally {
       close(fd);
     }

--- a/tools/isobuild/unibuild.js
+++ b/tools/isobuild/unibuild.js
@@ -120,10 +120,6 @@ export class Unibuild {
     _.each(unibuildJson.resources, function (resource) {
       rejectBadPath(resource.file);
 
-      if (resource.type === 'head') {
-        console.dir(resource);
-      }
-
       const data = files.readBufferWithLengthAndOffset(
         files.pathJoin(unibuildBasePath, resource.file),
         resource.length,

--- a/tools/isobuild/unibuild.js
+++ b/tools/isobuild/unibuild.js
@@ -120,6 +120,10 @@ export class Unibuild {
     _.each(unibuildJson.resources, function (resource) {
       rejectBadPath(resource.file);
 
+      if (resource.type === 'head') {
+        console.dir(resource);
+      }
+
       const data = files.readBufferWithLengthAndOffset(
         files.pathJoin(unibuildBasePath, resource.file),
         resource.length,
@@ -153,7 +157,10 @@ export class Unibuild {
           usesDefaultSourceProcessor: true,
           legacyPrelink: {
             packageVariables: unibuildJson.packageVariables || []
-          }
+          },
+          // Only published packages still use prelink resources,
+          // so there is no need to mark this file to be watched
+          _dataUsed: false
         };
 
         if (resource.sourceMap) {

--- a/tools/packaging/tropohouse.js
+++ b/tools/packaging/tropohouse.js
@@ -29,9 +29,6 @@ var defaultWarehouseDir = function () {
 
   var warehouseBase = files.inCheckout()
      ? files.getCurrentToolsDir() : files.getHomeDir();
-  // XXX This will be `.meteor` soon, once we've written the code to make the
-  // tropohouse and warehouse live together in harmony (eg, allowing tropohouse
-  // tools to springboard to warehouse tools).
   return files.pathJoin(warehouseBase, ".meteor");
 };
 


### PR DESCRIPTION
This fixes a crash from #11474 when reading a package that was downloaded with a Meteor version before Meteor 1.2. Should fix #11959.

Also improves the error message in https://github.com/meteor/meteor/issues/11918.