### PR TITLE
Permit users to set uname info

### DIFF
--- a/meteor
+++ b/meteor
@@ -4,7 +4,12 @@ BUNDLE_VERSION=14.19.1.0
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.
-UNAME=$(uname)
+# Use of : "${ARCH:=$(uname)}" assignment permits users to set their
+# architecture manually; this is useful for multi-arch systems whose
+# uname executables may sometimes return different architectures in
+# different contexts.
+#   Ex: ARCH=arm64 meteor ARGS...;
+UNAME="$(uname)"
 if [ "$UNAME" != "Linux" -a "$UNAME" != "Darwin" ] ; then
     echo "Sorry, this OS is not supported."
     exit 1
@@ -12,7 +17,7 @@ fi
 
 if [ "$UNAME" = "Darwin" ] ; then
     if [ "arm64" == "$(uname -m)" ]; then
-      ARCH="arm64"
+      : "${ARCH:=arm64}"
     else
       if [ "i386" != "$(uname -p)" -o "1" != "$(sysctl -n hw.cpu64bit_capable 2>/dev/null || echo 0)" ] ; then
 
@@ -21,10 +26,10 @@ if [ "$UNAME" = "Darwin" ] ; then
           echo "Only 64-bit and arm64 processors are supported at this time."
           exit 1
       fi
-      ARCH="x86_64"
+      : "${ARCH:=x86_64}"
     fi
 elif [ "$UNAME" = "Linux" ] ; then
-    ARCH="$(uname -m)"
+    : "${ARCH:=$(uname -m)}"
     if [ "$ARCH" != "x86_64" ] ; then
         echo "Unsupported architecture: $ARCH"
         echo "Meteor only supports x86_64"


### PR DESCRIPTION
This allows users on multi-arch systems to explicitly indicate their execution architecture.

Overriding `ARCH` is necessary for systems which run without a `uname` binary extended to "lie" about the system's architecture in different contexts. For example on a multi-arch build system `meteor` may be running in an execution mode which differs from the host execution mode; currently you either have to modify `meteor` or patch `uname` to "lie" in order to get the desired `ARCH`.

This change allows users to run multi-arch without a patched `meteor` launcher or `uname` binary.
  Ex:
```
PATH="/usr/local/opt/gnu-coreutils/bin${PATH+:$PATH}" ARCH=x86_64;
export PATH ARCH;
/usr/bin/arch -x86_64 ~/.meteor/packages/meteor-tool/2.5.6/mt-os.osx.x86_64/meteor ARGS...;
```
For context `gnu-coreutils`'s `uname` is agnostic to the effects of `arch -x86_64` and would output `arm64` in this case when we actually want `x86_64`.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
