### PR TITLE
Fix recompiling npm packages for web arch

### DIFF
--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1749,9 +1749,16 @@ export class MeteorConfig {
       const get = arch => packageNamesByArch[arch] || (
         packageNamesByArch[arch] = new Set);
 
-      const addToWeb = name => {
-        ['web.browser', 'web.browser.legacy', 'web.cordova'].forEach(arch => {
-          get(arch).add(name);
+      const addPackage = (name, archs) => {
+        archs.forEach(arch => {
+          if (arch === 'web') {
+            addPackage(
+              name,
+              ['web.browser', 'web.browser.legacy', 'web.cordova']
+            );
+          } else {
+            get(arch).add(name);
+          }
         });
       };
 
@@ -1759,21 +1766,12 @@ export class MeteorConfig {
         const info = recompile[packageName];
         if (! info) return;
         if (info === true) {
-          addToWeb(packageName);
-          get("os").add(packageName);
+          addPackage(packageName, ['web', 'os']);
         } else if (typeof info === "string") {
-          mapWhereToArches(info).forEach(arch => {
-            get(arch).add(packageName);
-          });
+          addPackage(packageName, mapWhereToArches(info));
         } else if (Array.isArray(info)) {
           info.forEach(where => {
-            mapWhereToArches(where).forEach(arch => {
-              if (arch === 'web') {
-                addToWeb(packageName);
-              } else {
-                get(arch).add(packageName);
-              }
-            });
+            addPackage(packageName, mapWhereToArches(where));
           });
         }
       });

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1749,11 +1749,17 @@ export class MeteorConfig {
       const get = arch => packageNamesByArch[arch] || (
         packageNamesByArch[arch] = new Set);
 
+      const addToWeb = name => {
+        ['web.browser', 'web.browser.legacy', 'web.cordova'].forEach(arch => {
+          get(arch).add(name);
+        });
+      };
+
       Object.keys(recompile).forEach(packageName => {
         const info = recompile[packageName];
         if (! info) return;
         if (info === true) {
-          get("web").add(packageName);
+          addToWeb(packageName);
           get("os").add(packageName);
         } else if (typeof info === "string") {
           mapWhereToArches(info).forEach(arch => {
@@ -1762,7 +1768,11 @@ export class MeteorConfig {
         } else if (Array.isArray(info)) {
           info.forEach(where => {
             mapWhereToArches(where).forEach(arch => {
-              get(arch).add(packageName);
+              if (arch === 'web') {
+                addToWeb(packageName);
+              } else {
+                get(arch).add(packageName);
+              }
             });
           });
         }


### PR DESCRIPTION
Fixes Meteor not recompiling an npm package for the client when using these recompile settings:

```json
{
  "meteor": {
    "nodeModules": {
      "recompile": {
        "svelte": true,
        "package-1": "web",
        "package-2": "client",
        "package-3": ["client"]
      }
    }
  }
}
```