### PR TITLE
Throwing an error when the login tokens are not generated well calling requestLoginTokenForUser

### DIFF
--- a/packages/accounts-passwordless/passwordless_server.js
+++ b/packages/accounts-passwordless/passwordless_server.js
@@ -189,6 +189,11 @@ Meteor.methods({
         return { email, sequence };
       })
       .filter(Boolean);
+
+    if (!tokens.length) {
+      Accounts._handleError(`Login tokens could not be generated`);
+    }
+
     Meteor.users.update(user._id, {
       $set: {
         'services.passwordless': {


### PR DESCRIPTION
As reported here https://github.com/meteor/meteor/issues/12040, it was pointed out that if there is a user with an email `abC@g.com` in the DB, but the email `abc@g.com` is provided in the selector of the function requestLoginTokenForUser, it will fail silently because no token will be sent. Now, if no tokens are generated, an error will be thrown.