### PR TITLE
Fix win style paths being added to watch sets

### DIFF
--- a/tools/fs/watch.ts
+++ b/tools/fs/watch.ts
@@ -843,10 +843,6 @@ export function readAndWatchDirectory(
 // Calculating the sha hash can be expensive for large files.  By
 // returning the calculated hash along with the file contents, the
 // hash doesn't need to be calculated again for static files.
-//
-// We only calculate the hash if needed here, so callers must not
-// *rely* on the hash being returned; merely that if the hash is
-// present, it is the correct hash of the contents.
 export function readAndWatchFileWithHash(watchSet: WatchSet, absPath: string) {
   const result: {
     contents: string | Buffer | null;

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -304,7 +304,7 @@ class InputFile extends buildPluginModule.InputFile {
     const sourceBatch = this._resourceSlot.packageSourceBatch;
     return readAndWatchFileWithHash(
       sourceBatch.unibuild.watchSet,
-      files.convertToOSPath(path),
+      files.convertToPosixPath(path),
     );
   }
 


### PR DESCRIPTION
Watch sets should only have posix style paths, but on Windows there would be some that were not from build plugins calling `file.readAndWatchFileWithHash`. 