### PR TITLE
Increase max size of IMPORT_SCANNER_CACHE

### DIFF
--- a/tools/isobuild/import-scanner.ts
+++ b/tools/isobuild/import-scanner.ts
@@ -291,7 +291,7 @@ function setImportedStatus(file: File, status: string | boolean) {
 // of ImportScanner (which do not persist across builds).
 const LRU = require("lru-cache");
 const IMPORT_SCANNER_CACHE = new LRU({
-  max: Math.pow(2, 22),
+  max: Math.pow(2, 23),
   length(ids: Record<string, ImportInfo>) {
     let total = 40; // size of key
     each(ids, (_info, id) => { total += id.length; });


### PR DESCRIPTION
Follow up to #11956 since it didn't increase the cache size enough for some apps.