### PR TITLE
Make client 25kb smaller

### DIFF
--- a/packages/babel-runtime/package.js
+++ b/packages/babel-runtime/package.js
@@ -7,5 +7,5 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use("modules");
-  api.mainModule("babel-runtime.js");
+  api.mainModule("babel-runtime.js", "server");
 });


### PR DESCRIPTION
The `@babel/runtime`'s package.json file is over 25kb. It was being imported on both the server and client by the `babel-runtime` meteor package to show a message when it needs to be updated. This changes it to only show the message on the server so we don't have to import it on the client.

It is easier to miss messages shown on the server, so if we want, I could add back showing the message on the client, but do it in a different way that doesn't require importing the package.json file on the client. 
