### PR TITLE
Upgrading reify version

### DIFF
--- a/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-server-package.js
+++ b/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-server-package.js
@@ -13,7 +13,7 @@ var packageJson = {
     fibers: "https://github.com/meteor/node-fibers/archive/refs/tags/5.0.0.tar.gz",
     "meteor-promise": "0.9.0",
     promise: "8.1.0",
-    "@meteorjs/reify": "0.23.0",
+    "@meteorjs/reify": "0.24.0",
     "@babel/parser": "7.15.3",
     "@types/underscore": "1.11.2",
     underscore: "1.13.1",

--- a/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
+++ b/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
@@ -20,7 +20,7 @@ var packageJson = {
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",
     fibers: "https://github.com/meteor/node-fibers/archive/refs/tags/5.0.0.tar.gz",
-    "@meteorjs/reify": "0.23.0",
+    "@meteorjs/reify": "0.24.0",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
     "@babel/runtime": "7.15.3",
     // For backwards compatibility with isopackets that still depend on

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "@meteorjs/reify": "0.23.0",
+  "@meteorjs/reify": "0.24.0",
   "meteor-babel-helpers": "0.0.3"
 });
 

--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -13,7 +13,7 @@ var packageJson = {
     fibers: "5.0.1",
     "meteor-promise": "0.9.0",
     promise: "8.1.0",
-    "@meteorjs/reify": "0.23.0",
+    "@meteorjs/reify": "0.24.0",
     "@babel/parser": "7.15.3",
     "@types/underscore": "1.11.2",
     underscore: "1.13.1",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -20,7 +20,7 @@ var packageJson = {
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",
     fibers: "5.0.1",
-    "@meteorjs/reify": "0.23.0",
+    "@meteorjs/reify": "0.24.0",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
     "@babel/runtime": "7.15.3",
     // For backwards compatibility with isopackets that still depend on


### PR DESCRIPTION
This [PR](https://github.com/meteor/reify/pull/2) was open on the meteor/reify repository to fix this [issue](https://github.com/meteor/meteor/issues/12035), so we're upgrading the version on Meteor.