### PR TITLE
[Refactoring] tools/run-updater

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -67,7 +67,6 @@ tools/runners/run-app.js
 tools/runners/run-mongo.js
 tools/runners/run-proxy.js
 tools/runners/run-selenium.js
-tools/runners/run-updater.js
 
 tools/packaging/package-client.js
 tools/packaging/package-map.js

--- a/npm-packages/eslint-plugin-meteor/.eslintignore
+++ b/npm-packages/eslint-plugin-meteor/.eslintignore
@@ -67,7 +67,6 @@ tools/runners/run-app.js
 tools/runners/run-mongo.js
 tools/runners/run-proxy.js
 tools/runners/run-selenium.js
-tools/runners/run-updater.js
 
 tools/packaging/package-client.js
 tools/packaging/package-map.js

--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -10,7 +10,6 @@ var compiler = require('../isobuild/compiler.js');
 var catalog = require('../packaging/catalog/catalog.js');
 var catalogRemote = require('../packaging/catalog/catalog-remote.js');
 var isopack = require('../isobuild/isopack.js');
-var updater = require('../packaging/updater.js');
 var Console = require('../console/console.js').Console;
 var projectContextModule = require('../project-context.js');
 var colonConverter = require('../utils/colon-converter.js');

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -1,9 +1,6 @@
 // Note that this file is required before we install our Babel hooks in
 // ../tool-env/install-babel.js, so we can't use ES2015+ syntax here.
 
-var fs = require("fs");
-var path = require("path");
-
 // The dev_bundle/bin command has to come immediately after the meteor
 // command, as in `meteor npm` or `meteor node`, because we don't want to
 // require("./main.js") for these commands.

--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -1,13 +1,9 @@
 import _ from 'underscore';
-import util from 'util';
 import url from 'url';
-import path from 'path';
 import { Console } from '../console/console.js';
 import buildmessage from '../utils/buildmessage.js';
 import files from '../fs/files';
 import { optimisticReadJsonOrNull } from "../fs/optimistic";
-import bundler from '../isobuild/bundler.js';
-import archinfo from '../utils/archinfo';
 import release from '../packaging/release.js';
 import { loadIsopackage } from '../tool-env/isopackets.js';
 import utils from '../utils/utils.js';

--- a/tools/cordova/run-targets.js
+++ b/tools/cordova/run-targets.js
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import child_process from 'child_process';
 
 import { loadIsopackage } from '../tool-env/isopackets.js';
 import { Console } from '../console/console.js';

--- a/tools/cordova/runner.js
+++ b/tools/cordova/runner.js
@@ -4,8 +4,6 @@ import runLog from '../runners/run-log.js';
 import { Console } from '../console/console.js';
 import main from '../cli/main.js';
 
-import { displayNameForPlatform, prepareProjectForBuild } from './index.js';
-
 export class CordovaRunner {
   constructor(cordovaProject, runTargets) {
     this.cordovaProject = cordovaProject;

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -149,7 +149,6 @@
 // wait until later.
 
 var assert = require('assert');
-var util = require('util');
 var Fiber = require('fibers');
 var _ = require('underscore');
 
@@ -160,7 +159,6 @@ var compilerPluginModule = require('./compiler-plugin.js');
 import { JsFile, CssFile } from './minifier-plugin.js';
 var meteorNpm = require('./meteor-npm.js');
 import { addToTree, File as LinkerFile } from "./linker.js";
-
 var files = require('../fs/files');
 var archinfo = require('../utils/archinfo');
 var buildmessage = require('../utils/buildmessage.js');

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -5,7 +5,6 @@ var colonConverter = require('../utils/colon-converter.js');
 var files = require('../fs/files');
 var compiler = require('./compiler.js');
 var linker = require('./linker.js');
-var util = require('util');
 var _ = require('underscore');
 var Profile = require('../tool-env/profile').Profile;
 import assert from "assert";
@@ -22,7 +21,6 @@ import {cssToCommonJS} from "./css-modules";
 import Resolver from "./resolver";
 import {
   optimisticStatOrNull,
-  optimisticReadJsonOrNull,
   optimisticHashOrNull,
 } from "../fs/optimistic";
 

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -7,7 +7,6 @@ var isopackModule = require('./isopack.js');
 var watch = require('../fs/watch');
 var colonConverter = require('../utils/colon-converter.js');
 var Profile = require('../tool-env/profile').Profile;
-var archinfo = require('../utils/archinfo');
 import { requestGarbageCollection } from "../utils/gc.js";
 
 export class IsopackCache {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -7,16 +7,13 @@ var assert = require('assert');
 var cleanup = require('../tool-env/cleanup.js');
 var fs = require('fs');
 var files = require('../fs/files');
-var os = require('os');
 var _ = require('underscore');
-var httpHelpers = require('../utils/http-helpers.js');
 var buildmessage = require('../utils/buildmessage.js');
 var utils = require('../utils/utils.js');
 var runLog = require('../runners/run-log.js');
 var Profile = require('../tool-env/profile').Profile;
 import { parse } from "semver";
 import { version as npmVersion } from 'npm';
-import { execFileAsync } from "../utils/processes";
 import {
   get as getRebuildArgs
 } from "../static-assets/server/npm-rebuild-args.js";

--- a/tools/isobuild/minifier-plugin.js
+++ b/tools/isobuild/minifier-plugin.js
@@ -1,8 +1,5 @@
 import buildmessage from '../utils/buildmessage.js';
 import {
-  readAndWatchFileWithHash,
-} from '../fs/watch';
-import {
   optimisticReadFile,
   optimisticHashOrNull,
 } from "../fs/optimistic";

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -1,15 +1,9 @@
 var _ = require('underscore');
-var sourcemap = require('source-map');
-
 var files = require('../fs/files');
 var utils = require('../utils/utils.js');
 var watch = require('../fs/watch');
 var buildmessage = require('../utils/buildmessage.js');
-var meteorNpm = require('./meteor-npm.js');
-import Builder from './builder.js';
 var archinfo = require('../utils/archinfo');
-var catalog = require('../packaging/catalog/catalog.js');
-var packageVersionParser = require('../packaging/package-version-parser.js');
 var compiler = require('./compiler.js');
 var Profile = require('../tool-env/profile').Profile;
 

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -20,7 +20,6 @@ import {
   doInteractivePasswordLogin,
   loggedInUsername,
   isLoggedIn,
-  maybePrintRegistrationLink,
 } from './auth.js';
 import { recordPackages } from './stats.js';
 import { Console } from '../console/console.js';

--- a/tools/runners/run-all.js
+++ b/tools/runners/run-all.js
@@ -14,7 +14,7 @@ const Selenium = require('./run-selenium.js').Selenium;
 const AppRunner = require('./run-app.js').AppRunner;
 const MongoRunner = require('./run-mongo.js').MongoRunner;
 const HMRServer = require('./run-hmr').HMRServer;
-const Updater = require('./run-updater.js').Updater;
+const Updater = require('./run-updater').Updater;
 
 class Runner {
   constructor({
@@ -123,7 +123,7 @@ class Runner {
         hmrPath: HMRPath,
         secret: hmrSecret,
         projectContext: self.projectContext,
-        cordovaServerPort 
+        cordovaServerPort
       });
     }
 

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -15,8 +15,6 @@ import { closeAllWatchers } from "../fs/safe-watcher";
 import { eachline } from "../utils/eachline";
 import { loadIsopackage } from '../tool-env/isopackets.js';
 
-const hasOwn = Object.prototype.hasOwnProperty;
-
 // Parse out s as if it were a bash command line.
 var bashParse = function (s) {
   if (s.search("\"") !== -1 || s.search("'") !== -1) {

--- a/tools/runners/run-hmr.js
+++ b/tools/runners/run-hmr.js
@@ -1,7 +1,6 @@
 import WS from 'ws';
 import runLog from './run-log.js';
 import crypto from 'crypto';
-import { AssertionError } from 'assert';
 import Anser from "anser";
 import { CordovaBuilder } from '../cordova/builder.js';
 

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -1,11 +1,9 @@
 import { MongoExitCodes } from '../utils/mongo-exit-codes';
-
 var files = require('../fs/files');
 var utils = require('../utils/utils.js');
 var fiberHelpers = require('../utils/fiber-helpers.js');
 var runLog = require('./run-log.js');
 var child_process = require('child_process');
-
 var _ = require('underscore');
 import { loadIsopackage } from '../tool-env/isopackets.js';
 var Console = require('../console/console.js').Console;

--- a/tools/runners/run-updater.js
+++ b/tools/runners/run-updater.js
@@ -1,5 +1,3 @@
-var Fiber = require('fibers');
-var fiberHelpers = require('../utils/fiber-helpers.js');
 var Console = require('../console/console.js').Console;
 
 var Updater = function () {

--- a/tools/runners/run-updater.js
+++ b/tools/runners/run-updater.js
@@ -1,60 +1,52 @@
-var Console = require('../console/console.js').Console;
+import { Console } from '../console/console';
 
-var Updater = function () {
-  var self = this;
-  self.timer = null;
-};
+const CHECK_UPDATE_INTERVAL = 3 * 60 * 60 * 1000; // every 3 hours
 
 // XXX make it take a runLog?
 // XXX need to deal with updater writing messages (bypassing old
 // stdout interception.. maybe it should be global after all..)
-Object.assign(Updater.prototype, {
-  start: function () {
-    var self = this;
+export class Updater {
+  constructor() {
+    this.timer = null;
+  }
 
-    if (self.timer) {
-      throw new Error("already running?");
+  start() {
+    if (this.timer) {
+      throw new Error('already running?');
     }
 
+    const self = this;
     // Check every 3 hours. (Should not share buildmessage state with
     // the main fiber.)
     async function check() {
       self._check();
     }
 
-    self.timer = setInterval(check, 3 * 60 * 60 * 1000);
+    this.timer = setInterval(check, CHECK_UPDATE_INTERVAL);
 
     // Also start a check now, but don't block on it. (This should
     // not share buildmessage state with the main fiber.)
     check();
-  },
+  }
 
-  _check: function () {
-    var self = this;
-    var updater = require('../packaging/updater.js');
+  _check() {
+    const updater = require('../packaging/updater');
     try {
-      updater.tryToDownloadUpdate({showBanner: true});
+      updater.tryToDownloadUpdate({ showBanner: true });
     } catch (e) {
       // oh well, this was the background. Only show errors if we are in debug
       // mode.
-      Console.debug("Error inside updater.");
+      Console.debug('Error inside updater.');
       Console.debug(e.stack);
-      return;
     }
-  },
-
-  // Returns immediately. However if an update check is currently
-  // running it will complete in the background. Idempotent.
-  stop: function () {
-    var self = this;
-
-    if (self.timer) {
-      return;
-    }
-    clearInterval(self.timer);
-    self.timer = null;
   }
-});
 
+  // Returns immediately. However, if an update check is currently
+  // running it will complete in the background. Idempotent.
+  stop() {
+    if (!this.timer) return;
 
-exports.Updater = Updater;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+}

--- a/tools/tests/assets.js
+++ b/tools/tests/assets.js
@@ -12,7 +12,7 @@ function startRun(sandbox) {
   run.tellMongo(MONGO_LISTENING);
   run.match("MongoDB");
   return run;
-};
+}
 
 // Test that an app can properly read assets with unicode based filenames
 selftest.define("assets - unicode asset names are allowed", () => {

--- a/tools/tests/colon-converter-tests.js
+++ b/tools/tests/colon-converter-tests.js
@@ -1,7 +1,6 @@
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 var files = require('../fs/files');
-var testUtils = require('../tool-testing/test-utils.js');
 var utils = require('../utils/utils.js');
 var _ = require('underscore');
 var tropohouse = require('../packaging/tropohouse.js');

--- a/tools/tests/command-line.js
+++ b/tools/tests/command-line.js
@@ -2,7 +2,6 @@ var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 var archinfo = require('../utils/archinfo');
 var release = require('../packaging/release.js');
-var _ = require('underscore');
 var files = require('../fs/files');
 var utils = require('../utils/utils.js');
 var runMongo = require('../runners/run-mongo.js');

--- a/tools/tests/compiler-plugins.js
+++ b/tools/tests/compiler-plugins.js
@@ -2,7 +2,6 @@ var _ = require('underscore');
 var selftest = require('../tool-testing/selftest.js');
 var files = require('../fs/files');
 import { getUrl } from '../utils/http-helpers.js';
-import { sleepMs } from '../utils/utils.js';
 import { host } from '../utils/archinfo';
 const osArch = host();
 
@@ -19,7 +18,7 @@ function startRun(sandbox) {
   run.matchBeforeExit("Started MongoDB");
   run.waitSecs(15);
   return run;
-};
+}
 
 // Tests the actual cache logic used by coffeescript.
 selftest.define("compiler plugin caching - coffee", () => {

--- a/tools/tests/constraint-solver.js
+++ b/tools/tests/constraint-solver.js
@@ -1,7 +1,5 @@
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
-var files = require('../fs/files');
-var _= require('underscore');
 
 // Runs all of the constraint-solver tests, including ones that tie up the CPU
 // for too long to safely run in the normal test-packages run.

--- a/tools/tests/cordova-append-config.js
+++ b/tools/tests/cordova-append-config.js
@@ -1,6 +1,5 @@
 var files = require('../fs/files');
 var selftest = require('../tool-testing/selftest.js');
-var testUtils = require('../tool-testing/test-utils.js');
 var Sandbox = selftest.Sandbox;
 
 var cleanUpBuild = function (s) {

--- a/tools/tests/cordova-hcp.js
+++ b/tools/tests/cordova-hcp.js
@@ -1,9 +1,7 @@
-var _ = require('underscore');
 var selftest = require('../tool-testing/selftest.js');
 var httpHelpers = require('../utils/http-helpers.js');
 var Sandbox = selftest.Sandbox;
 var testUtils = require('../tool-testing/test-utils.js');
-var config = require('../meteor-services/config.js');
 
 // This is not an end-to-end test for Cordova hot code push, but this test
 // is for the issue that we observed where the value of the

--- a/tools/tests/cordova-platforms.js
+++ b/tools/tests/cordova-platforms.js
@@ -1,6 +1,5 @@
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
-var files = require('../fs/files');
 
 selftest.define("add cordova platforms", ["cordova"], function () {
   var s = new Sandbox();

--- a/tools/tests/cordova-run.js
+++ b/tools/tests/cordova-run.js
@@ -1,6 +1,6 @@
 import selftest from '../tool-testing/selftest.js';
 import utils from '../utils/utils.js';
-import { parseServerOptionsForRunCommand, parseRunTargets } from '../cli/commands.js';
+import { parseServerOptionsForRunCommand } from '../cli/commands.js';
 
 selftest.define('get mobile server argument for meteor run', ['cordova'], function () {
   // meteor run -p 3000

--- a/tools/tests/dynamic-import.js
+++ b/tools/tests/dynamic-import.js
@@ -1,6 +1,5 @@
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
-const { mkdtemp } = require("../fs/files");
 
 const offlineStorageQuotaKB = 10000;
 
@@ -31,7 +30,7 @@ function run(isProduction) {
     "--full-app",
     "--driver-package", "meteortesting:mocha"
   ];
-  
+
   // For meteortesting:mocha to work we must set test broswer driver
   // See https://github.com/meteortesting/meteor-mocha
   sandbox.set("TEST_BROWSER_DRIVER", "puppeteer");

--- a/tools/tests/linter-plugins.js
+++ b/tools/tests/linter-plugins.js
@@ -1,5 +1,4 @@
 var selftest = require('../tool-testing/selftest.js');
-var files = require('../fs/files');
 
 var Sandbox = selftest.Sandbox;
 

--- a/tools/tests/mongo.js
+++ b/tools/tests/mongo.js
@@ -1,10 +1,5 @@
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
-var utils = require('../utils/utils.js');
-var net = require('net');
-var Future = require('fibers/future');
-var _ = require('underscore');
-var files = require('../fs/files');
 
 // Tests that observeChanges continues to work even over a mongo failover.
 selftest.define("mongo failover", ["slow"], function () {

--- a/tools/tests/package-tests.js
+++ b/tools/tests/package-tests.js
@@ -3,10 +3,7 @@ var _= require('underscore');
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 var files = require('../fs/files');
-var testUtils = require('../tool-testing/test-utils.js');
 var utils = require('../utils/utils.js');
-var packageClient = require('../packaging/package-client.js');
-var catalog = require('../packaging/catalog/catalog.js');
 
 var username = "test";
 

--- a/tools/tests/parse-stack-test.js
+++ b/tools/tests/parse-stack-test.js
@@ -1,8 +1,6 @@
 import selftest from '../tool-testing/selftest.js';
 import { parse, markBottom } from '../utils/parse-stack';
 import _ from 'underscore';
-import Fiber from 'fibers';
-import Future from 'fibers/future';
 import files from '../fs/files';
 
 selftest.define("parse-stack - parse stack traces without fibers", () => {

--- a/tools/tests/source-maps.js
+++ b/tools/tests/source-maps.js
@@ -1,7 +1,6 @@
 var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 var files = require('../fs/files');
-var catalog = require('../packaging/catalog/catalog.js');
 
 function matchPath (text, doubleBS) {
   if (process.platform === 'win32') {

--- a/tools/tests/static-html.js
+++ b/tools/tests/static-html.js
@@ -1,8 +1,5 @@
-var _ = require('underscore');
 var selftest = require('../tool-testing/selftest.js');
-var files = require('../fs/files');
 import { getUrl } from '../utils/http-helpers.js';
-import { sleepMs } from '../utils/utils.js';
 
 var Sandbox = selftest.Sandbox;
 

--- a/tools/tool-env/isopackets.js
+++ b/tools/tool-env/isopackets.js
@@ -11,7 +11,6 @@ var files = require('../fs/files');
 var config = require('../meteor-services/config.js');
 var watch = require('../fs/watch');
 var Console = require('../console/console.js').Console;
-var fiberHelpers = require('../utils/fiber-helpers.js');
 var packageMapModule = require('../packaging/package-map.js');
 var archinfo = require('../utils/archinfo');
 var Profile = require('./profile').Profile;

--- a/tools/tool-testing/clients/browserstack/index.js
+++ b/tools/tool-testing/clients/browserstack/index.js
@@ -1,18 +1,12 @@
-import { execFile } from 'child_process';
 import Client from '../../client.js';
 import configuredClients from "./clients.js";
 import { enterJob } from '../../../utils/buildmessage.js';
-import { getUrlWithResuming } from '../../../utils/http-helpers.js';
 import { execFileSync } from '../../../utils/processes';
 import { ensureDependencies } from '../../../cli/dev-bundle-helpers.js';
 import {
   mkdtemp,
   pathJoin,
-  chmod,
-  statOrNull,
   readFile,
-  createWriteStream,
-  getDevBundle,
 } from '../../../fs/files';
 
 const NPM_DEPENDENCIES = {

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -4,12 +4,10 @@ import { createHash } from 'crypto';
 import {
   markBottom as parseStackMarkBottom,
   markTop as parseStackMarkTop,
-  parse as parseStackParse,
 } from '../utils/parse-stack';
 import { Console } from '../console/console.js';
 import { loadIsopackage } from '../tool-env/isopackets.js';
 import TestFailure from './test-failure.js';
-import { setRunningTest } from './run.js';
 import Run from './run.js';
 
 // These are accessed through selftest directly on many tests.

--- a/tools/upgraders.js
+++ b/tools/upgraders.js
@@ -3,7 +3,6 @@
 var _ = require('underscore');
 var files = require('./fs/files');
 var Console = require('./console/console.js').Console;
-import main from './cli/main.js';
 import buildmessage from './utils/buildmessage.js';
 import { convertPluginVersions } from './cordova/index.js';
 


### PR DESCRIPTION
Should be merged after #12072 because this PR based on it.

- convert `Updater` to es6 class
- remove `run-updater.js` from `.eslintignore`
- fix a small bug