### PR TITLE
Fixed handling objects in `oplogV2V1Converter` (fixes #12098).

### DIFF
--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -208,4 +208,36 @@ Tinytest.add('oplog - v2/v1 conversion', function(test) {
     ),
     JSON.stringify({ $v: 2, $set: { 'array.2.a': 'something' } })
   );
+
+  // https://github.com/meteor/meteor/issues/12098
+  test.equal(
+    JSON.stringify(oplogV2V1Converter({
+      $v: 2,
+      diff: { u: { params: { d: 5 } } },
+    })),
+    JSON.stringify({
+      $v: 2,
+      $set: { params: { d: 5 } },
+    })
+  );
+  test.equal(
+    JSON.stringify(oplogV2V1Converter({
+      $v: 2,
+      diff: { u: { params: { a: 5, d: 5 } } },
+    })),
+    JSON.stringify({
+      $v: 2,
+      $set: { params: { a: 5, d: 5 } },
+    })
+  );
+  test.equal(
+    JSON.stringify(oplogV2V1Converter({
+      $v: 2,
+      diff: { u: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } } },
+    })),
+    JSON.stringify({
+      $v: 2,
+      $set: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } },
+    })
+  );
 });


### PR DESCRIPTION
As I wrote in https://github.com/meteor/meteor/issues/12098#issuecomment-1198122133: it was a problem with handling the `u` section of new oplog messages. I fixed it and added tests for that.

Once this is done, I'd like to file another PR with a cleaner implementation of the converter, as I'm honestly surprised by the sheer number of unnecessary object copies it does right now.