### PR TITLE
Improved `oplogV2V1Converter` implementation.

### DIFF
--- a/packages/mongo/oplog_v2_converter.js
+++ b/packages/mongo/oplog_v2_converter.js
@@ -1,174 +1,122 @@
-// we are mapping the new oplog format on mongo 5
-// to what we know better, $set and $unset format
-// new oplog format ex:
-// {
-//  '$v': 2,
-//  diff: { u: { key1: 2022-01-06T18:23:16.131Z, key2: [ObjectID] } }
-// }
+// Converter of the new MongoDB Oplog format (>=5.0) to the one that Meteor
+// handles well, i.e., `$set` and `$unset`. The new format is completely new,
+// and looks as follows:
+//
+//   { $v: 2, diff: Diff }
+//
+// where `Diff` is a recursive structure:
+//
+//   {
+//     // Nested updates (sometimes also represented with an s-field).
+//     // Example: `{ $set: { 'foo.bar': 1 } }`.
+//     i: { <key>: <value>, ... },
+//
+//     // Top-level updates.
+//     // Example: `{ $set: { foo: { bar: 1 } } }`.
+//     u: { <key>: <value>, ... },
+//
+//     // Unsets.
+//     // Example: `{ $unset: { foo: '' } }`.
+//     d: { <key>: false, ... },
+//
+//     // Array operations.
+//     // Example: `{ $push: { foo: 'bar' } }`.
+//     s<key>: { a: true, u<index>: <value>, ... },
+//     ...
+//
+//     // Nested operations (sometimes also represented in the `i` field).
+//     // Example: `{ $set: { 'foo.bar': 1 } }`.
+//     s<key>: Diff,
+//     ...
+//   }
+//
+// (all fields are optional).
 
-function logConverterCalls(oplogEntry, prefixKey, key) {
-  if (!process.env.OPLOG_CONVERTER_DEBUG) {
-    return;
-  }
-  console.log('Calling nestedOplogEntryParsers with the following values: ');
-  console.log(
-    `Oplog entry: ${JSON.stringify(
-      oplogEntry
-    )}, prefixKey: ${prefixKey}, key: ${key}`
-  );
+function join(prefix, key) {
+  return prefix ? `${prefix}.${key}` : key;
 }
 
-/*
-the structure of an entry is:
+const arrayOperatorKeyRegex = /^(a|u\d+)$/;
 
-
--> entry: i, u, d + sFields.
--> sFields: i, u, d + sFields
--> sFields: arrayOperator -> { a: true, u0: 2 }
--> i,u,d: { key: value }
--> value: {key: value}
-
-i is nested $set
-u is flat $set
-d is $unset
-on mongo 4
- */
-
-const isArrayOperator = possibleArrayOperator => {
-  if (!possibleArrayOperator || !Object.keys(possibleArrayOperator).length)
-    return false;
-
-  if (!possibleArrayOperator.a) {
-    return false;
-  }
-  return !Object.keys(possibleArrayOperator).find(
-      key => key !== 'a' && !key.match(/^u\d+/)
-  );
-};
-function logOplogEntryError(oplogEntry, prefixKey, key) {
-  console.log('---');
-  console.log(
-    'WARNING: Unsupported oplog operation, please fill an issue with this message at github.com/meteor/meteor'
-  );
-  console.log(
-    `Oplog entry: ${JSON.stringify(
-      oplogEntry
-    )}, prefixKey: ${prefixKey}, key: ${key}`
-  );
-  console.log('---');
+function isArrayOperatorKey(field) {
+  return arrayOperatorKeyRegex.test(field);
 }
 
-const nestedOplogEntryParsers = (oplogEntry, prefixKey = '') => {
-  const { i, u, d = {}, ...sFields } = oplogEntry;
-  logConverterCalls(oplogEntry, prefixKey, 'ENTRY_POINT');
-  const sFieldsOperators = [];
-  Object.entries(sFields).forEach(([key, value]) => {
-    const actualKeyNameWithoutSPrefix = key.substring(1);
-    if (isArrayOperator(value || {})) {
-      const { a, ...uPosition } = value;
-      if (uPosition) {
-        for (const [positionKey, newArrayIndexValue] of Object.entries(
-          uPosition
-        )) {
-          sFieldsOperators.push({
-            [newArrayIndexValue === null ? '$unset' : '$set']: {
-              [`${prefixKey}${actualKeyNameWithoutSPrefix}.${positionKey.substring(
-                1
-              )}`]: newArrayIndexValue === null ? true : newArrayIndexValue,
-            },
-          });
-        }
-      } else {
-        logOplogEntryError(oplogEntry, prefixKey, key);
-        throw new Error(
-          `Unsupported oplog array entry, please review the input: ${JSON.stringify(
-            value
-          )}`
-        );
-      }
+function isArrayOperator(operator) {
+  return operator.a === true && Object.keys(operator).every(isArrayOperatorKey);
+}
+
+function flattenObjectInto(target, source, prefix) {
+  if (Array.isArray(source) || typeof source !== 'object' || source === null) {
+    target[prefix] = source;
+  } else {
+    const entries = Object.entries(source);
+    if (entries.length) {
+      entries.forEach(([key, value]) => {
+        flattenObjectInto(target, value, join(prefix, key));
+      });
     } else {
-      // we are looking at something that we expected to be "sSomething" but is null after removing s
-      // this happens on "a": true which is a simply ack that comes embeded
-      // we dont need to call recursion on this case, only ignore it
-      if (!actualKeyNameWithoutSPrefix || actualKeyNameWithoutSPrefix === '') {
-        return null;
+      target[prefix] = source;
+    }
+  }
+}
+
+function convertOplogDiff(oplogEntry, diff, prefix) {
+  if (process.env.OPLOG_CONVERTER_DEBUG) {
+    console.log(`convertOplogDiff(${JSON.stringify(oplogEntry)}, ${JSON.stringify(diff)}, ${JSON.stringify(prefix)})`);
+  }
+
+  Object.entries(diff).forEach(([diffKey, value]) => {
+    if (diffKey === 'd') {
+      // Handle `$unset`s.
+      oplogEntry.$unset ??= {};
+      Object.keys(value).forEach(key => {
+        oplogEntry.$unset[join(prefix, key)] = true;
+      });
+    } else if (diffKey === 'i') {
+      // Handle (potentially) nested `$set`s.
+      oplogEntry.$set ??= {};
+      flattenObjectInto(oplogEntry.$set, value, prefix);
+    } else if (diffKey === 'u') {
+      // Handle flat `$set`s.
+      oplogEntry.$set ??= {};
+      Object.entries(value).forEach(([key, value]) => {
+        oplogEntry.$set[join(prefix, key)] = value;
+      });
+    } else {
+      // Handle s-fields.
+      const key = diffKey.slice(1);
+      if (isArrayOperator(value)) {
+        // Array operator.
+        Object.entries(value).forEach(([position, value]) => {
+          if (position === 'a') {
+            return;
+          }
+
+          const positionKey = join(join(prefix, key), position.slice(1));
+          if (value === null) {
+            oplogEntry.$unset ??= {};
+            oplogEntry.$unset[positionKey] = true;
+          } else {
+            oplogEntry.$set ??= {};
+            oplogEntry.$set[positionKey] = value;
+          }
+        });
+      } else if (key) {
+        // Nested object.
+        convertOplogDiff(oplogEntry, value, join(prefix, key));
       }
-      // we are looking at a "sSomething" that is actually a nested object set
-      logConverterCalls(oplogEntry, prefixKey, key);
-      sFieldsOperators.push(
-        nestedOplogEntryParsers(
-          value,
-          `${prefixKey}${actualKeyNameWithoutSPrefix}.`
-        )
-      );
     }
   });
-  const $unset = Object.keys(d).reduce((acc, key) => {
-    return { ...acc, [`${prefixKey}${key}`]: true };
-  }, {});
+}
 
-  const $set = {};
-
-  // Handle potentially nested keys.
-  if (i) {
-    Object.entries(i).forEach(([key, value]) => {
-      const prefixedKey = `${prefixKey}${key}`;
-      if (!Array.isArray(value) && typeof value === 'object') {
-        Object.assign($set, flattenObject({ [prefixedKey]: value }));
-      } else {
-        $set[prefixedKey] = value;
-      }
-    });
+export function oplogV2V1Converter(oplogEntry) {
+  // Pass-through v1 and (probably) invalid entries.
+  if (oplogEntry.$v !== 2 || !oplogEntry.diff) {
+    return oplogEntry;
   }
 
-  // Handle flat keys.
-  if (u) {
-    Object.entries(u).forEach(([key, value]) => {
-      const prefixedKey = `${prefixKey}${key}`;
-      $set[prefixedKey] = value;
-    });
-  }
-
-  const c = [...sFieldsOperators, { $unset, $set }];
-  const { $set: s, $unset: un } = c.reduce(
-    (acc, { $set: set = {}, $unset: unset = {} }) => {
-      return {
-        $set: { ...acc.$set, ...set },
-        $unset: { ...acc.$unset, ...unset },
-      };
-    },
-    {}
-  );
-  return {
-    ...(Object.keys(s).length ? { $set: s } : {}),
-    ...(Object.keys(un).length ? { $unset: un } : {}),
-  };
-};
-
-export const oplogV2V1Converter = v2OplogEntry => {
-  if (v2OplogEntry.$v !== 2 || !v2OplogEntry.diff) return v2OplogEntry;
-  logConverterCalls(v2OplogEntry, 'INITIAL_CALL', 'INITIAL_CALL');
-  return { $v: 2, ...nestedOplogEntryParsers(v2OplogEntry.diff || {}) };
-};
-
-function flattenObject(ob) {
-  const toReturn = {};
-
-  for (const i in ob) {
-    if (!ob.hasOwnProperty(i)) continue;
-
-    if (!Array.isArray(ob[i]) && typeof ob[i] == 'object' && ob[i] !== null) {
-      const flatObject = flattenObject(ob[i]);
-      let objectKeys = Object.keys(flatObject);
-      if (objectKeys.length === 0) {
-        return ob;
-      }
-      for (const x of objectKeys) {
-        toReturn[i + '.' + x] = flatObject[x];
-      }
-    } else {
-      toReturn[i] = ob[i];
-    }
-  }
-  return toReturn;
+  const convertedOplogEntry = { $v: 2 };
+  convertOplogDiff(convertedOplogEntry, oplogEntry.diff, '');
+  return convertedOplogEntry;
 }

--- a/packages/mongo/oplog_v2_converter.js
+++ b/packages/mongo/oplog_v2_converter.js
@@ -61,8 +61,10 @@ function flattenObjectInto(target, source, prefix) {
   }
 }
 
+const logDebugMessages = !!process.env.OPLOG_CONVERTER_DEBUG;
+
 function convertOplogDiff(oplogEntry, diff, prefix) {
-  if (process.env.OPLOG_CONVERTER_DEBUG) {
+  if (logDebugMessages) {
     console.log(`convertOplogDiff(${JSON.stringify(oplogEntry)}, ${JSON.stringify(diff)}, ${JSON.stringify(prefix)})`);
   }
 

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -1,243 +1,86 @@
 import { oplogV2V1Converter } from './oplog_v2_converter';
 
-Tinytest.add('oplog - v2/v1 conversion', function(test) {
-  const entry1 = {
-    $v: 2,
-    diff: { scustom: { sEJSON$value: { u: { EJSONtail: 'd' } } } },
-  };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry1)),
-    JSON.stringify({
-      $v: 2,
-      $set: { 'custom.EJSON$value.EJSONtail': 'd' },
-    })
-  );
+const cases = [
+  [
+    { $v: 2, diff: { scustom: { sEJSON$value: { u: { EJSONtail: 'd' } } } } },
+    { $v: 2, $set: { 'custom.EJSON$value.EJSONtail': 'd' } },
+  ],
+  [
+    { $v: 2, diff: { u: { d: '2', oi: 'asdas' } } },
+    { $v: 2, $set: { d: '2', oi: 'asdas' } },
+  ],
+  [
+    { $v: 2, diff: { sasd: { a: true, u0: 2 } } },
+    { $v: 2, $set: { 'asd.0': 2 } },
+  ],
+  [
+    { $v: 2, diff: { sasd: { a: true, u0: null } } },
+    { $v: 2, $unset: { 'asd.0': true } },
+  ],
+  [
+    { $v: 2, diff: { i: { a: { b: 2 } } } },
+    { $v: 2, $set: { 'a.b': 2 } },
+  ],
+  [
+    { $v: 2, diff: { u: { count: 1 }, i: { nested: { state: {} } } } },
+    { $v: 2, $set: { 'nested.state': {}, count: 1 } },
+  ],
+  [
+    { $v: 2, diff: { sa: { i: { b: 3, c: 1 } } } },
+    { $v: 2, $set: { 'a.b': 3, 'a.c': 1 } },
+  ],
+  [
+    { $v: 2, diff: { sa: { d: { b: false } } } },
+    { $v: 2, $unset: { 'a.b': true } },
+  ],
+  [
+    { $v: 2, diff: { u: { c: 'bar' }, sb: { a: true, u0: 2 } } },
+    { $v: 2, $set: { 'b.0': 2, c: 'bar' } },
+  ],
+  [
+    { $v: 2, diff: { sservices: { sresume: { u: { loginTokens: [] } } } } },
+    { $v: 2, $set: { 'services.resume.loginTokens': [] } },
+  ],
+  [
+    { $v: 2, diff: { i: { tShirt: { sizes: ['small', 'medium', 'large'] } } } },
+    { $v: 2, $set: { 'tShirt.sizes': ['small', 'medium', 'large'] } },
+  ],
+  [
+    { $v: 2, diff: { slist: { a: true, u3: 'i', u4: 'h' } } },
+    { $v: 2, $set: { 'list.3': 'i', 'list.4': 'h' } },
+  ],
+  [
+    { $v: 2, $set: { 'services.resume.loginTokens': [ { when: '2022-01-06T23:58:35.704Z', hashedToken: 'RlalW6ZSvPPJLH6sW3B1b+vrUnPy+Ox5oMv3O3S7jwg=' }, { when: '2022-01-06T23:58:35.704Z', hashedToken: 'DWG0Qw/+nZ48wAIhKR2r9H41wLpth9BM+Br6aZsl2bU=' }, ], }, },
+    { $v: 2, $set: { 'services.resume.loginTokens': [ { when: '2022-01-06T23:58:35.704Z', hashedToken: 'RlalW6ZSvPPJLH6sW3B1b+vrUnPy+Ox5oMv3O3S7jwg=' }, { when: '2022-01-06T23:58:35.704Z', hashedToken: 'DWG0Qw/+nZ48wAIhKR2r9H41wLpth9BM+Br6aZsl2bU=' }, ], }, },
+  ],
+  [
+    { $v: 2, diff: { sobject: { u: { array: ['2', '2', '4', '3'] } } } },
+    { $v: 2, $set: { 'object.array': ['2', '2', '4', '3'] } },
+  ],
+  [
+    { $v: 2, diff: { slayout: { sjourneyStepIds: { sj4aqp3tiK6xCPCYu8: { a: true, u2: 'zTkxivNrKuBi2iJ2m' } } } } },
+    { $v: 2, $set: { 'layout.journeyStepIds.j4aqp3tiK6xCPCYu8.2': 'zTkxivNrKuBi2iJ2m' } },
+  ],
+  [
+    { $v: 2, diff: { sarray: { a: true, s2: { u: { a: 'something' } } } } },
+    { $v: 2, $set: { 'array.2.a': 'something' } },
+  ],
+  [
+    { $v: 2, diff: { u: { params: { d: 5 } } } },
+    { $v: 2, $set: { params: { d: 5 } } },
+  ],
+  [
+    { $v: 2, diff: { u: { params: { a: 5, d: 5 } } } },
+    { $v: 2, $set: { params: { a: 5, d: 5 } } },
+  ],
+  [
+    { $v: 2, diff: { u: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } } } },
+    { $v: 2, $set: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } } },
+  ],
+];
 
-  const entry2 = {
-    $v: 2,
-    diff: { u: { d: '2', oi: 'asdas' } },
-  };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry2)),
-    JSON.stringify({
-      $v: 2,
-      $set: { d: '2', oi: 'asdas' },
-    })
-  );
-
-  //set inside an array
-  const entry3 = { $v: 2, diff: { sasd: { a: true, u0: 2 } } };
-
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry3)),
-    JSON.stringify({ $v: 2, $set: { 'asd.0': 2 } })
-  );
-
-  //unset inside an array
-  const entry4 = { $v: 2, diff: { sasd: { a: true, u0: null } } };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry4)),
-    JSON.stringify({ $v: 2, $unset: { 'asd.0': true } })
-  );
-
-  //set a new nested field inside an object
-  const entry5 = {
-    $v: 2,
-    diff: { i: { a: { b: 2 } } },
-  };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry5)),
-    JSON.stringify({ $v: 2, $set: { 'a.b': 2 } })
-  );
-
-  //set a new nested field inside an object
-  const entry51 = {
-    $v: 2,
-    diff: { u: { count: 1 }, i: { nested: { state: {} } } },
-  };
-  // the correct format for this test, inspecting the mongodb oplog, should be "nested" : { "state" : {  } } }
-  // but this is a case in which we can flatten the object without collateral, so we are considering
-  // "nested.state" : {  } to be valid too
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry51)),
-    JSON.stringify({ $v: 2, $set: { 'nested.state': {}, count: 1 } })
-  );
-
-  //set an existing nested field inside an object
-  const entry6 = {
-    $v: 2,
-    diff: { sa: { i: { b: 3, c: 1 } } },
-  };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry6)),
-    JSON.stringify({
-      $v: 2,
-      $set: { 'a.b': 3, 'a.c': 1 },
-    })
-  );
-
-  //unset an existing nested field inside an object
-  const entry7 = {
-    $v: 2,
-    diff: { sa: { d: { b: false } } },
-  };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry7)),
-    JSON.stringify({ $v: 2, $unset: { 'a.b': true } })
-  );
-
-  const entry8 = { $v: 2, diff: { u: { c: 'bar' }, sb: { a: true, u0: 2 } } };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry8)),
-    JSON.stringify({ $v: 2, $set: { 'b.0': 2, c: 'bar' } })
-  );
-
-  const entry9 = {
-    $v: 2,
-    diff: { sservices: { sresume: { u: { loginTokens: [] } } } },
-  };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry9)),
-    JSON.stringify({ $v: 2, $set: { 'services.resume.loginTokens': [] } })
-  );
-
-  const entry91 = {
-    $v: 2,
-    diff: { i: { tShirt: { sizes: ['small', 'medium', 'large'] } } },
-  };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry91)),
-    JSON.stringify({
-      $v: 2,
-      $set: { 'tShirt.sizes': ['small', 'medium', 'large'] },
-    })
-  );
-
-  test.equal(
-    JSON.stringify(
-      oplogV2V1Converter({
-        $v: 2,
-        diff: { slist: { a: true, u3: 'i', u4: 'h' } },
-      })
-    ),
-    JSON.stringify({
-      $v: 2,
-      // oplog v1 outputs the whole list -> list: ['e', 'f', 'g', 'i', 'h', 'j']
-      $set: { 'list.3': 'i', 'list.4': 'h' },
-    })
-  );
-
-  const entry10 = {
-    $v: 2,
-    $set: {
-      'services.resume.loginTokens': [
-        {
-          when: '2022-01-06T23:58:35.704Z',
-          hashedToken: 'RlalW6ZSvPPJLH6sW3B1b+vrUnPy+Ox5oMv3O3S7jwg=',
-        },
-        {
-          when: '2022-01-06T23:58:35.704Z',
-          hashedToken: 'DWG0Qw/+nZ48wAIhKR2r9H41wLpth9BM+Br6aZsl2bU=',
-        },
-      ],
-    },
-  };
-  test.equal(
-    JSON.stringify(oplogV2V1Converter(entry10)),
-    JSON.stringify({
-      $v: 2,
-      $set: {
-        'services.resume.loginTokens': [
-          {
-            when: '2022-01-06T23:58:35.704Z',
-            hashedToken: 'RlalW6ZSvPPJLH6sW3B1b+vrUnPy+Ox5oMv3O3S7jwg=',
-          },
-          {
-            when: '2022-01-06T23:58:35.704Z',
-            hashedToken: 'DWG0Qw/+nZ48wAIhKR2r9H41wLpth9BM+Br6aZsl2bU=',
-          },
-        ],
-      },
-    })
-  );
-  test.equal(
-    JSON.stringify(
-      oplogV2V1Converter({
-        $v: 2,
-        diff: {
-          sobject: { u: { array: ['2', '2', '4', '3'] } },
-        },
-      })
-    ),
-    JSON.stringify({
-      $v: 2,
-      $set: { 'object.array': ['2', '2', '4', '3'] },
-    })
-  );
-  test.equal(
-    JSON.stringify(
-      oplogV2V1Converter({
-        $v: 2,
-        diff: {
-          slayout: {
-            sjourneyStepIds: {
-              sj4aqp3tiK6xCPCYu8: {
-                a: true,
-                u2: 'zTkxivNrKuBi2iJ2m',
-              },
-            },
-          },
-        },
-      })
-    ),
-    JSON.stringify({
-      $v: 2,
-      $set: {
-        'layout.journeyStepIds.j4aqp3tiK6xCPCYu8.2': 'zTkxivNrKuBi2iJ2m',
-      },
-    })
-  );
-  test.equal(
-    JSON.stringify(
-      oplogV2V1Converter({
-        $v: 2,
-        diff: {
-          sarray: { a: true, s2: { u: { a: 'something' } } },
-        },
-      })
-    ),
-    JSON.stringify({ $v: 2, $set: { 'array.2.a': 'something' } })
-  );
-
-  // https://github.com/meteor/meteor/issues/12098
-  test.equal(
-    JSON.stringify(oplogV2V1Converter({
-      $v: 2,
-      diff: { u: { params: { d: 5 } } },
-    })),
-    JSON.stringify({
-      $v: 2,
-      $set: { params: { d: 5 } },
-    })
-  );
-  test.equal(
-    JSON.stringify(oplogV2V1Converter({
-      $v: 2,
-      diff: { u: { params: { a: 5, d: 5 } } },
-    })),
-    JSON.stringify({
-      $v: 2,
-      $set: { params: { a: 5, d: 5 } },
-    })
-  );
-  test.equal(
-    JSON.stringify(oplogV2V1Converter({
-      $v: 2,
-      diff: { u: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } } },
-    })),
-    JSON.stringify({
-      $v: 2,
-      $set: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } },
-    })
-  );
+Tinytest.add('oplog - v2/v1 conversion', function (test) {
+  cases.forEach(([input, output]) => {
+    test.equal(oplogV2V1Converter(input), output);
+  });
 });


### PR DESCRIPTION
As I mentioned in #12107, I find the current implementation of the `oplogV2V1Converter` inefficient but also hard to understand. In this PR, I simplified it and made it more performant by skipping a lot of unnecessary object copies.

Additionally, I adjusted the tests, so it's easier to add more, as well as reduced logs to one per call to make it easier to debug. (The error message that was there before was no longer reachable.)