### PR TITLE
Update postcss from the minifier-css package

### DIFF
--- a/packages/minifier-css/package.js
+++ b/packages/minifier-css/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: 'CSS minifier',
-  version: '1.6.0'
+  version: '1.6.1'
 });
 
 Npm.depends({
-  postcss: '8.3.5',
+  postcss: '8.4.16',
   cssnano: '4.1.11'
 });
 


### PR DESCRIPTION
Update the `postcss` package from `8.3.5` to `8.4.16` from the `minifier-css` package.
This update will avoid issues with `Browserslist` and `caniuse-lite`.

https://github.com/postcss/postcss/releases