### PR TITLE
Update terser from the minifier-js package

### DIFF
--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "JavaScript minifier",
-  version: "2.7.4"
+  version: "2.7.5"
 });
 
 Npm.depends({
-  terser: "5.12.1"
+  terser: "5.14.2"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Update the `terser` package from `5.12.1` to `5.14.2` from the `minifier-js` package.
This update is important due to security fixes and to take advantage of `terser` improvements.

https://github.com/terser/terser/blob/HEAD/CHANGELOG.md