### PR TITLE
Update standard-minifier-js dependencies

### DIFF
--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-js',
-  version: '2.8.0',
+  version: '2.8.1',
   summary: 'Standard javascript minifiers used with Meteor apps by default.',
   documentation: 'README.md',
 });
@@ -12,7 +12,7 @@ Package.registerBuildPlugin({
     'ecmascript'
   ],
   npmDependencies: {
-    "@babel/runtime": "7.15.4"
+    "@babel/runtime": "7.18.9",
   },
   sources: [
     'plugin/minify-js.js',


### PR DESCRIPTION
Update the `standard-minifier-js` package dependencies.
This update will avoid issues with `Browserslist` and `caniuse-lite`.