### PR TITLE
Updated MongoDB driver to 4.9

### DIFF
--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@types/node": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg=="
+      "version": "18.7.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
+      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
     },
     "@types/webidl-conversions": {
       "version": "6.1.1",
@@ -22,9 +22,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bson": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
-      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -52,9 +52,9 @@
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "mongodb": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.0.tgz",
-      "integrity": "sha512-a0eVzm1e1kxwnzJV1wZXIS54KegM2y6wXTXOGTSAxr/E2YOUkl/zGBHNSI4z+6z+YQtVdzDqy1nJ4n5MxYJRnQ=="
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.0.tgz",
+      "integrity": "sha512-tJJEFJz7OQTQPZeVHZJIeSOjMRqc5eSyXTt86vSQENEErpkiG7279tM/GT5AVZ7TgXNh9HQxoa2ZkbrANz5GQw=="
     },
     "mongodb-connection-string-url": {
       "version": "2.5.3",

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: "4.8.0-beta280.5",
+  version: "4.9.0-beta280.5",
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "4.8.0"
+  mongodb: "4.9.0"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
In this pull request, I updated the MongoDB driver to version [4.9](https://github.com/mongodb/node-mongodb-native/releases/tag/v4.9.0). As @fredmaiaarantes pointed out, it includes a fix for https://github.com/mongodb/node-mongodb-native/pull/3337, which may be important for some Meteor apps (most likely the ones which heavily rely on oplog and are not using `cultofcoders:redis-oplog`).