### PR TITLE
Handled invalid dates in Minimongo Matcher (fixes #12063).

### DIFF
--- a/packages/minimongo/matcher.js
+++ b/packages/minimongo/matcher.js
@@ -262,8 +262,8 @@ LocalCollection._f = {
     if (ta === 9) { // Date
       // Convert to millis.
       ta = tb = 1;
-      a = a.getTime();
-      b = b.getTime();
+      a = isNaN(a) ? 0 : a.getTime();
+      b = isNaN(b) ? 0 : b.getTime();
     }
 
     if (ta === 1) { // double

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -439,8 +439,16 @@ Tinytest.add('minimongo - selector_compiler', test => {
   // dates
   const date1 = new Date;
   const date2 = new Date(date1.getTime() + 1000);
+  const date3 = new Date('');
   match({a: date1}, {a: date1});
   nomatch({a: date1}, {a: date2});
+  match({a: date3}, {a: date3});
+  nomatch({a: date1}, {a: date3});
+  nomatch({a: date3}, {a: date1});
+  match({a: {$gt: date3}}, {a: date1});
+  match({a: {$gte: date3}}, {a: date1});
+  nomatch({a: {$lt: date3}}, {a: date1});
+  nomatch({a: {$lte: date3}}, {a: date1});
 
 
   // arrays


### PR DESCRIPTION
As reported in #12063, Minimongo doesn't handle the inequality operators (e.g., `$gt`) on invalid date objects (e.g., `new Date('')`) correctly, resulting in a broken connection. I couldn't figure out why the connection breaks (yet...?), but I implemented handling of the invalid date objects to fix it in the first place.

It's not stated in the MongoDB docs, but by checking the `explain` result, it looks like invalid dates are handled just like `new Date(0)`, and that's what I did. Here's how I checked it:
```ts
// db.example.find({createdAt: {$gt: new Date('')}}).explain().queryPlanner
{
    "namespace" : "meteor.example",
    "indexFilterSet" : false,
    "parsedQuery" : {
        "createdAt" : {
            "$gt" : ISODate("1970-01-01T00:00:00.000Z")
        }
    },
    "queryHash" : "77E9ED6B",
    "planCacheKey" : "0CF3FA65",
    "maxIndexedOrSolutionsReached" : false,
    "maxIndexedAndSolutionsReached" : false,
    "maxScansToExplodeReached" : false,
    "winningPlan" : {
        "stage" : "COLLSCAN",
        "filter" : {
            "createdAt" : {
                "$gt" : ISODate("1970-01-01T00:00:00.000Z")
            }
        },
        "direction" : "forward"
    },
    "rejectedPlans" : []
}
```