### PR TITLE
fix: rename setPublicationStrategy and getPublicationStrategy arguments.

### DIFF
--- a/docs/source/api/pubsub.md
+++ b/docs/source/api/pubsub.md
@@ -303,7 +303,7 @@ You can use the following methods to set or get the publication strategy for pub
 
 {% apibox "setPublicationStrategy" %}
 
-For publication `foo`, you can set `NO_MERGE` strategy as shown:
+For the `foo` collection, you can set the `NO_MERGE` strategy as shown:
 
 ```js
 import { DDPServer } from "meteor/ddp-server";

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1517,7 +1517,7 @@ Object.assign(Server.prototype, {
   },
 
   /**
-   * @summary Set publication strategy for the given publication. Publications strategies are available from `DDPServer.publicationStrategies`. You call this method from `Meteor.server`, like `Meteor.server.setPublicationStrategy()`
+   * @summary Set publication strategy for the given collection. Publications strategies are available from `DDPServer.publicationStrategies`. You call this method from `Meteor.server`, like `Meteor.server.setPublicationStrategy()`
    * @locus Server
    * @alias setPublicationStrategy
    * @param collectionName {String}
@@ -1534,7 +1534,7 @@ Object.assign(Server.prototype, {
   },
 
   /**
-   * @summary Gets the publication strategy for the requested publication. You call this method from `Meteor.server`, like `Meteor.server.getPublicationStrategy()`
+   * @summary Gets the publication strategy for the requested collection. You call this method from `Meteor.server`, like `Meteor.server.getPublicationStrategy()`
    * @locus Server
    * @alias getPublicationStrategy
    * @param collectionName {String}

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1520,30 +1520,30 @@ Object.assign(Server.prototype, {
    * @summary Set publication strategy for the given publication. Publications strategies are available from `DDPServer.publicationStrategies`. You call this method from `Meteor.server`, like `Meteor.server.setPublicationStrategy()`
    * @locus Server
    * @alias setPublicationStrategy
-   * @param publicationName {String}
+   * @param collectionName {String}
    * @param strategy {{useCollectionView: boolean, doAccountingForCollection: boolean}}
    * @memberOf Meteor.server
    * @importFromPackage meteor
    */
-  setPublicationStrategy(publicationName, strategy) {
+  setPublicationStrategy(collectionName, strategy) {
     if (!Object.values(publicationStrategies).includes(strategy)) {
       throw new Error(`Invalid merge strategy: ${strategy} 
-        for collection ${publicationName}`);
+        for collection ${collectionName}`);
     }
-    this._publicationStrategies[publicationName] = strategy;
+    this._publicationStrategies[collectionName] = strategy;
   },
 
   /**
    * @summary Gets the publication strategy for the requested publication. You call this method from `Meteor.server`, like `Meteor.server.getPublicationStrategy()`
    * @locus Server
    * @alias getPublicationStrategy
-   * @param publicationName {String}
+   * @param collectionName {String}
    * @memberOf Meteor.server
    * @importFromPackage meteor
    * @return {{useCollectionView: boolean, doAccountingForCollection: boolean}}
    */
-  getPublicationStrategy(publicationName) {
-    return this._publicationStrategies[publicationName]
+  getPublicationStrategy(collectionName) {
+    return this._publicationStrategies[collectionName]
       || this.options.defaultPublicationStrategy;
   },
 


### PR DESCRIPTION
Rename setPublicationStrategy and getPublicationStrategy arguments.

Fix issue: [Bad naming for setPublicationStrategy variable (documentation fix probably) #12022](https://github.com/meteor/meteor/issues/12022)