### PR TITLE
docs: document options argument when calling DDP.connect

### DIFF
--- a/packages/ddp-client/common/namespace.js
+++ b/packages/ddp-client/common/namespace.js
@@ -58,6 +58,11 @@ DDP.randomStream = name => {
  * @summary Connect to the server of a different Meteor application to subscribe to its document sets and invoke its remote methods.
  * @locus Anywhere
  * @param {String} url The URL of another Meteor application.
+ * @param {Object} [options]
+ * @param {Boolean} options.reloadWithOutstanding is it OK to reload if there are outstanding methods?
+ * @param {Object} options.headers extra headers to send on the websockets connection, for server-to-server DDP only
+ * @param {Object} options._sockjsOptions Specifies options to pass through to the sockjs client
+ * @param {Function} options.onDDPNegotiationVersionFailure callback when version negotiation fails.
  */
 DDP.connect = (url, options) => {
   const ret = new Connection(url, options);


### PR DESCRIPTION
Document options argument when calling DDP.connect.

Fix issue: [DDP.connect options are not documented](https://github.com/meteor/meteor/issues/3837)