### PR TITLE
Type definitions for core packages

### DIFF
--- a/packages/ejson/ejson.d.ts
+++ b/packages/ejson/ejson.d.ts
@@ -1,0 +1,71 @@
+export interface EJSONableCustomType {
+  clone?(): EJSONableCustomType;
+  equals?(other: Object): boolean;
+  toJSONValue(): JSONable;
+  typeName(): string;
+}
+
+export type EJSONableProperty =
+  | number
+  | string
+  | boolean
+  | Object
+  | number[]
+  | string[]
+  | Object[]
+  | Date
+  | Uint8Array
+  | EJSONableCustomType
+  | undefined
+  | null;
+
+export interface EJSONable {
+  [key: string]: EJSONableProperty;
+}
+
+export interface JSONable {
+  [key: string]:
+    | number
+    | string
+    | boolean
+    | Object
+    | number[]
+    | string[]
+    | Object[]
+    | undefined
+    | null;
+}
+
+export interface EJSON extends EJSONable {}
+
+export namespace EJSON {
+  function addType(
+    name: string,
+    factory: (val: JSONable) => EJSONableCustomType
+  ): void;
+
+  function clone<T>(val: T): T;
+
+  function equals(
+    a: EJSON,
+    b: EJSON,
+    options?: { keyOrderSensitive?: boolean | undefined }
+  ): boolean;
+
+  function fromJSONValue(val: JSONable): any;
+
+  function isBinary(x: Object): x is Uint8Array;
+  function newBinary(size: number): Uint8Array;
+
+  function parse(str: string): EJSON;
+
+  function stringify(
+    val: EJSON,
+    options?: {
+      indent?: boolean | number | string | undefined;
+      canonical?: boolean | undefined;
+    }
+  ): string;
+
+  function toJSONValue(val: EJSON): JSONable;
+}

--- a/packages/ejson/package-types.json
+++ b/packages/ejson/package-types.json
@@ -1,0 +1,3 @@
+{
+  "typesEntry": "ejson.d.ts"
+}

--- a/packages/ejson/package.js
+++ b/packages/ejson/package.js
@@ -5,7 +5,7 @@ Package.describe({
 
 Package.onUse(function onUse(api) {
   api.use(['ecmascript', 'base64']);
-  api.addAssets('ejson.d.ts', ['client', 'server']);
+  api.addAssets('ejson.d.ts', 'server');
   api.mainModule('ejson.js');
   api.export('EJSON');
 });

--- a/packages/ejson/package.js
+++ b/packages/ejson/package.js
@@ -5,6 +5,7 @@ Package.describe({
 
 Package.onUse(function onUse(api) {
   api.use(['ecmascript', 'base64']);
+  api.addAssets('ejson.d.ts', ['client', 'server']);
   api.mainModule('ejson.js');
   api.export('EJSON');
 });

--- a/packages/fetch/fetch.d.ts
+++ b/packages/fetch/fetch.d.ts
@@ -1,0 +1,4 @@
+export declare function fetch(): typeof globalThis.fetch;
+export declare var Headers: typeof globalThis.Headers;
+export declare var Request: typeof globalThis.Request;
+export declare var Response: typeof globalThis.Response;

--- a/packages/fetch/package-types.json
+++ b/packages/fetch/package-types.json
@@ -1,0 +1,3 @@
+{
+  "typesEntry": "fetch.d.ts"
+}

--- a/packages/fetch/package.js
+++ b/packages/fetch/package.js
@@ -19,6 +19,7 @@ Package.onUse(function(api) {
   api.mainModule("legacy.js", "legacy");
   api.mainModule("server.js", "server");
 
+  api.addAssets("fetch.d.ts", ["client", "server"]);
   // The other exports (Headers, Request, Response) can be imported
   // explicitly from the "meteor/fetch" package.
   api.export("fetch");

--- a/packages/fetch/package.js
+++ b/packages/fetch/package.js
@@ -19,7 +19,7 @@ Package.onUse(function(api) {
   api.mainModule("legacy.js", "legacy");
   api.mainModule("server.js", "server");
 
-  api.addAssets("fetch.d.ts", ["client", "server"]);
+  api.addAssets("fetch.d.ts", "server");
   // The other exports (Headers, Request, Response) can be imported
   // explicitly from the "meteor/fetch" package.
   api.export("fetch");


### PR DESCRIPTION
### Description

This is one of several PRs that move type definitions from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/meteor) into packages. It will enable using `zodern:types` for core packages' types.

It contains types for two packages: `ejson` and `fetch`. Types for other packages will be added later in different pull requests. There are two reasons for that:

1. To test the current solution of using `zodern:types` package on the production.
2. Several type definitions from DefinitelyTyped will go into different repositories for example [react-packages](https://github.com/meteor/react-packages) or [blaze](https://github.com/meteor/blaze). It will be easier to test this solution first and add other packages later than to make changes in several repositories.

### About this approach

Users can test implemented types with [zodern:types](https://github.com/zodern/meteor-types#meteor-apps) package. It needs to be installed on their Meteor project. However, a user has to remove previously used `@types/meteor` from the project because types will be redeclared.