### PR TITLE
Use true mongo binary types

### DIFF
--- a/packages/mongo/collection_tests.js
+++ b/packages/mongo/collection_tests.js
@@ -1,3 +1,6 @@
+
+var MongoDB = NpmModuleMongodb;
+
 Tinytest.add(
   'collection - call Mongo.Collection without new',
   function (test) {
@@ -200,6 +203,184 @@ Tinytest.add('collection - calling find with an invalid readPreference',
         // Trigger the creation of _synchronousCursor
         cursor.count();
       }, `Invalid read preference mode "${invalidReadPreference}"`);
+    }
+  }
+);
+
+Tinytest.add('collection - inserting a document with a binary should return a document with a binary',
+  function(test) {
+    if (Meteor.isServer) {
+      const collection = new Mongo.Collection('testBinary1');
+      const _id = Random.id();
+      collection.insert({
+        _id,
+        binary: new MongoDB.Binary(Buffer.from('hello world'), 6)
+      });
+
+      const doc = collection.findOne({ _id });
+      test.ok(
+        doc.binary instanceof MongoDB.Binary
+      );
+      test.equal(
+        doc.binary.buffer,
+        Buffer.from('hello world')
+      );
+    }
+  }
+);
+
+Tinytest.add('collection - inserting a document with a binary (sub type 0) should return a document with a uint8array',
+  function(test) {
+    if (Meteor.isServer) {
+      const collection = new Mongo.Collection('testBinary8');
+      const _id = Random.id();
+      collection.insert({
+        _id,
+        binary: new MongoDB.Binary(Buffer.from('hello world'), 0)
+      });
+
+      const doc = collection.findOne({ _id });
+      test.ok(
+        doc.binary instanceof Uint8Array
+      );
+      test.equal(
+        doc.binary,
+        new Uint8Array(Buffer.from('hello world'))
+      );
+    }
+  }
+);
+
+Tinytest.add('collection - updating a document with a binary should return a document with a binary',
+  function(test) {
+    if (Meteor.isServer) {
+      const collection = new Mongo.Collection('testBinary2');
+      const _id = Random.id();
+      collection.insert({
+        _id
+      });
+
+      collection.update({ _id }, { $set: { binary: new MongoDB.Binary(Buffer.from('hello world'), 6) } });
+
+      const doc = collection.findOne({ _id });
+      test.ok(
+        doc.binary instanceof MongoDB.Binary
+      );
+      test.equal(
+        doc.binary.buffer,
+        Buffer.from('hello world')
+      );
+    }
+  }
+);
+
+Tinytest.add('collection - updating a document with a binary (sub type 0) should return a document with a uint8array',
+  function(test) {
+    if (Meteor.isServer) {
+      const collection = new Mongo.Collection('testBinary7');
+      const _id = Random.id();
+      collection.insert({
+        _id
+      });
+
+      collection.update({ _id }, { $set: { binary: new MongoDB.Binary(Buffer.from('hello world'), 0) } });
+
+      const doc = collection.findOne({ _id });
+      test.ok(
+        doc.binary instanceof Uint8Array
+      );
+      test.equal(
+        doc.binary,
+        new Uint8Array(Buffer.from('hello world'))
+      );
+    }
+  }
+);
+
+Tinytest.add('collection - inserting a document with a uint8array should return a document with a uint8array',
+  function(test) {
+    if (Meteor.isServer) {
+      const collection = new Mongo.Collection('testBinary3');
+      const _id = Random.id();
+      collection.insert({
+        _id,
+        binary: new Uint8Array(Buffer.from('hello world'))
+      });
+
+      const doc = collection.findOne({ _id });
+      test.ok(
+        doc.binary instanceof Uint8Array
+      );
+      test.equal(
+        doc.binary,
+        new Uint8Array(Buffer.from('hello world'))
+      );
+    }
+  }
+);
+
+Tinytest.add('collection - updating a document with a uint8array should return a document with a uint8array',
+  function(test) {
+    if (Meteor.isServer) {
+      const collection = new Mongo.Collection('testBinary4');
+      const _id = Random.id();
+      collection.insert({
+        _id
+      });
+
+      collection.update(
+        { _id },
+        { $set: { binary: new Uint8Array(Buffer.from('hello world')) } }
+      )
+
+      const doc = collection.findOne({ _id });
+      test.ok(
+        doc.binary instanceof Uint8Array
+      );
+      test.equal(
+        doc.binary,
+        new Uint8Array(Buffer.from('hello world'))
+      );
+    }
+  }
+);
+
+Tinytest.add('collection - finding with a query with a uint8array field should return the correct document',
+  function(test) {
+    if (Meteor.isServer) {
+      const collection = new Mongo.Collection('testBinary5');
+      const _id = Random.id();
+      collection.insert({
+        _id,
+        binary: new Uint8Array(Buffer.from('hello world'))
+      });
+
+      const doc = collection.findOne({ binary: new Uint8Array(Buffer.from('hello world')) });
+      test.equal(
+        doc._id,
+        _id
+      );
+      collection.remove({});
+    }
+  }
+);
+
+Tinytest.add('collection - finding with a query with a binary field should return the correct document',
+  function(test) {
+    if (Meteor.isServer) {
+      const collection = new Mongo.Collection('testBinary6');
+      const _id = Random.id();
+      collection.insert({
+        _id,
+        binary: new MongoDB.Binary(Buffer.from('hello world'), 6)
+      });
+
+      const doc = collection.findOne({ binary: new MongoDB.Binary(Buffer.from('hello world'), 6) });
+      test.equal(
+        doc._id,
+        _id
+      );
+      collection.remove({});
     }
   }
 );

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -63,6 +63,10 @@ var unmakeMongoLegal = function (name) { return name.substr(5); };
 
 var replaceMongoAtomWithMeteor = function (document) {
   if (document instanceof MongoDB.Binary) {
+    // for backwards compatibility
+    if (document.sub_type !== 0) {
+      return document;
+    }
     var buffer = document.value(true);
     return new Uint8Array(buffer);
   }
@@ -91,6 +95,9 @@ var replaceMeteorAtomWithMongo = function (document) {
     // MongoDB.BSON only looks like it takes a Uint8Array (and doesn't actually
     // serialize it correctly).
     return new MongoDB.Binary(Buffer.from(document));
+  }
+  if (document instanceof Mongo.Binary) {
+     return document;
   }
   if (document instanceof Mongo.ObjectID) {
     return new MongoDB.ObjectID(document.toHexString());

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -96,7 +96,7 @@ var replaceMeteorAtomWithMongo = function (document) {
     // serialize it correctly).
     return new MongoDB.Binary(Buffer.from(document));
   }
-  if (document instanceof Mongo.Binary) {
+  if (document instanceof MongoDB.Binary) {
      return document;
   }
   if (document instanceof Mongo.ObjectID) {

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.15.0'
+  version: '1.14.4'
 });
 
 Npm.depends({
@@ -88,6 +88,7 @@ Package.onTest(function (api) {
   api.use('mongo');
   api.use('check');
   api.use('ecmascript');
+  api.use('npm-mongo', 'server');
   api.use(['tinytest', 'underscore', 'test-helpers', 'ejson', 'random',
            'ddp', 'base64']);
   // XXX test order dependency: the allow_tests "partial allow" test

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.14.4'
+  version: '1.15.0'
 });
 
 Npm.depends({


### PR DESCRIPTION
When implementing manual field level encryption with mongo, the decryption function expects a Binary data type with a `sub_type` of 6. Because meteor converts `Binary` to `Uint8Array` (and vice versa) we lose that. It isn't even possible to pass in a `Binary` - because mongo returns undefined.

This PR simple says to maintain the `Binary` type in most situations. The only situation it does not is when the `sub_type` is `0`. It does this for backwards compatibility (e.g., `sub_type` 0 is still returned as a `Uint8Array`)