### PR TITLE
Feat user accounts base async

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -798,6 +798,11 @@ if (Package.blaze) {
    */
   Template.registerHelper('currentUser', () => Meteor.user());
 
+  // TODO: the code above needs to be changed to Meteor.userAsync() when we have
+  // a way to make it reactive using async.
+  // Template.registerHelper('currentUserAsync',
+  //  async () => await Meteor.userAsync());
+
   /**
    * @global
    * @name  loggingIn

--- a/packages/accounts-base/accounts_client_tests.js
+++ b/packages/accounts-base/accounts_client_tests.js
@@ -95,6 +95,20 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
+  'accounts async - Meteor.loggingIn() is false after login has completed',
+  (test, done) => {
+    logoutAndCreateUser(test, done, () => {
+      // Login then verify loggingIn is false after login has completed
+      Meteor.loginWithPassword(username, password, async () => {
+        test.isTrue(await Meteor.userAsync());
+        test.isFalse(Meteor.loggingIn());
+        removeTestUser(done);
+      });
+    });
+  }
+);
+
+Tinytest.addAsync(
   'accounts - Meteor.loggingOut() is true right after a logout call',
   (test, done) => {
     logoutAndCreateUser(test, done, () => {
@@ -150,7 +164,7 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
-  'accounts - Meteor.user obeys explicit and default field selectors',
+  'accounts - Meteor.user() obeys explicit and default field selectors',
   (test, done) => {
     logoutAndCreateUser(test, done, () => {
       Meteor.loginWithPassword(username, password, () => {
@@ -178,6 +192,37 @@ Tinytest.addAsync(
   }
 );
 
+Tinytest.addAsync(
+  'accounts async - Meteor.userAsync() obeys explicit and default field selectors',
+  (test, done) => {
+    logoutAndCreateUser(test, done, () => {
+      Meteor.loginWithPassword(username, password, () => {
+        // by default, all fields should be returned
+        Meteor.userAsync().then(user => {
+          test.equal( user.profile[excludeField], excludeValue);
+        });
+
+        // this time we want to exclude the default fields
+        const options = Accounts._options;
+        Accounts._options = {};
+        Accounts.config({defaultFieldSelector: {['profile.'+defaultExcludeField]: 0}});
+        Meteor.userAsync().then(async user => {
+          test.isUndefined(user.profile[defaultExcludeField]);
+          test.equal(user.profile[excludeField], excludeValue);
+          test.equal(user.profile.name, username);
+        })
+        // this time we only want certain fields...
+        Meteor.userAsync({fields: {'profile.name': 1}}).then(user => {
+          test.isUndefined(user.profile[excludeField]);
+          test.isUndefined(user.profile[defaultExcludeField]);
+          test.equal(user.profile.name, username);
+        });
+        Accounts._options = options;
+        removeTestUser(done);
+      });
+    });
+  }
+);
 
 Tinytest.addAsync(
   'accounts-2fa - Meteor.loginWithPasswordAnd2faCode() fails when token is not provided',

--- a/packages/accounts-base/accounts_client_tests.js
+++ b/packages/accounts-base/accounts_client_tests.js
@@ -100,8 +100,8 @@ Tinytest.addAsync(
     logoutAndCreateUser(test, done, () => {
       // Login then verify loggingIn is false after login has completed
       Meteor.loginWithPassword(username, password, async () => {
-        test.isTrue(await Meteor.userAsync());
         test.isFalse(Meteor.loggingIn());
+        test.isTrue(await Meteor.userAsync());
         removeTestUser(done);
       });
     });
@@ -196,27 +196,28 @@ Tinytest.addAsync(
   'accounts async - Meteor.userAsync() obeys explicit and default field selectors',
   (test, done) => {
     logoutAndCreateUser(test, done, () => {
-      Meteor.loginWithPassword(username, password, () => {
+      Meteor.loginWithPassword(username, password, async () => {
         // by default, all fields should be returned
-        Meteor.userAsync().then(user => {
-          test.equal( user.profile[excludeField], excludeValue);
-        });
+        let user;
+        user = await Meteor.userAsync();
+        test.equal(user.profile[excludeField], excludeValue);
 
         // this time we want to exclude the default fields
         const options = Accounts._options;
         Accounts._options = {};
-        Accounts.config({defaultFieldSelector: {['profile.'+defaultExcludeField]: 0}});
-        Meteor.userAsync().then(async user => {
-          test.isUndefined(user.profile[defaultExcludeField]);
-          test.equal(user.profile[excludeField], excludeValue);
-          test.equal(user.profile.name, username);
-        })
+        Accounts.config({ defaultFieldSelector: { ['profile.' + defaultExcludeField]: 0 } });
+
+        user = await Meteor.userAsync();
+        test.isUndefined(user.profile[defaultExcludeField]);
+        test.equal(user.profile[excludeField], excludeValue);
+        test.equal(user.profile.name, username);
+
         // this time we only want certain fields...
-        Meteor.userAsync({fields: {'profile.name': 1}}).then(user => {
-          test.isUndefined(user.profile[excludeField]);
-          test.isUndefined(user.profile[defaultExcludeField]);
-          test.equal(user.profile.name, username);
-        });
+
+        user = await Meteor.userAsync({ fields: { 'profile.name': 1 } });
+        test.isUndefined(user.profile[excludeField]);
+        test.isUndefined(user.profile[defaultExcludeField]);
+        test.equal(user.profile.name, username);
         Accounts._options = options;
         removeTestUser(done);
       });

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -170,6 +170,18 @@ export class AccountsCommon {
       : null;
   }
 
+  /**
+   * @summary Get the current user record, or `null` if no user is logged in.
+   * @locus Anywhere
+   * @param {Object} [options]
+   * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
+   */
+  async userAsync(options) {
+    const userId = this.userId();
+    return userId
+      ? await this.users.findOneAsync(userId, this._addDefaultFieldSelector(options))
+      : null;
+  }
   // Set up config for the accounts system. Call this on both the client
   // and the server.
   //
@@ -417,6 +429,15 @@ Meteor.userId = () => Accounts.userId();
  * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
  */
 Meteor.user = options => Accounts.user(options);
+
+/**
+ * @summary Get the current user record, or `null` if no user is logged in. A reactive data source.
+ * @locus Anywhere but publish functions
+ * @importFromPackage meteor
+ * @param {Object} [options]
+ * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
+ */
+Meteor.userAsync = options => Accounts.userAsync(options);
 
 // how long (in days) until a login token expires
 const DEFAULT_LOGIN_EXPIRATION_DAYS = 90;

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -179,7 +179,7 @@ export class AccountsCommon {
   async userAsync(options) {
     const userId = this.userId();
     return userId
-      ? await this.users.findOneAsync(userId, this._addDefaultFieldSelector(options))
+      ? this.users.findOneAsync(userId, this._addDefaultFieldSelector(options))
       : null;
   }
   // Set up config for the accounts system. Call this on both the client

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -629,7 +629,7 @@ Tinytest.addAsync(
     Accounts.config({ defaultFieldSelector: { [ignoreFieldName]: 0 } });
     user = await Meteor.userAsync();
     test.isUndefined(user[ignoreFieldName], 'excluded');
-    user = Meteor.user({});
+    user = await Meteor.userAsync({});
     test.isUndefined(user[ignoreFieldName], 'excluded {}');
 
     // test the field can still be retrieved if required

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -7,12 +7,18 @@ const reportError = (error, callback) => {
    }
 };
 
+const reportErrorAsync = async (error, callback) => {
+  if (callback) {
+    await callback(error);
+  } else {
+    throw error;
+  }
+};
 
 const internalLoginWithPassword = ({ selector, password, code, callback }) => {
   if (typeof selector === 'string')
     if (!selector.includes('@')) selector = { username: selector };
     else selector = { email: selector };
-
   Accounts.callLoginMethod({
     methodArguments: [
       {
@@ -22,10 +28,11 @@ const internalLoginWithPassword = ({ selector, password, code, callback }) => {
       },
     ],
     userCallback: async (error, result) => {
+      const isAsync = callback && callback.constructor.name === 'AsyncFunction';
       if (error) {
-        reportError(error, callback);
+        if (isAsync) await reportErrorAsync(error, callback);
+        else reportError(error, callback);
       } else {
-        const isAsync = callback && callback.constructor.name === 'AsyncFunction';
         if (isAsync) callback && await callback();
         else callback && callback();
       }

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -21,11 +21,13 @@ const internalLoginWithPassword = ({ selector, password, code, callback }) => {
         code,
       },
     ],
-    userCallback: (error, result) => {
+    userCallback: async (error, result) => {
       if (error) {
         reportError(error, callback);
       } else {
-        callback && callback();
+        const isAsync = callback && callback.constructor.name === 'AsyncFunction';
+        if (isAsync) callback && await callback();
+        else callback && callback();
       }
     },
   });

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -7,14 +7,6 @@ const reportError = (error, callback) => {
    }
 };
 
-const reportErrorAsync = async (error, callback) => {
-  if (callback) {
-    await callback(error);
-  } else {
-    throw error;
-  }
-};
-
 const internalLoginWithPassword = ({ selector, password, code, callback }) => {
   if (typeof selector === 'string')
     if (!selector.includes('@')) selector = { username: selector };
@@ -27,14 +19,11 @@ const internalLoginWithPassword = ({ selector, password, code, callback }) => {
         code,
       },
     ],
-    userCallback: async (error, result) => {
-      const isAsync = callback && callback.constructor.name === 'AsyncFunction';
+    userCallback: (error, result) => {
       if (error) {
-        if (isAsync) await reportErrorAsync(error, callback);
-        else reportError(error, callback);
+        reportError(error, callback);
       } else {
-        if (isAsync) callback && await callback();
-        else callback && callback();
+        callback && callback();
       }
     },
   });


### PR DESCRIPTION

We have an option of adding ``Meteor.userAsync()`` wich is not reactive ~yet~ because of tracker and keeping both. If you are using them in stateless calls things would look the same.

---
Also, made ``Meteor.loginWithPassword`` accept async values as callbacks

## TODO

 - [x] Decide what to do with ``Meteor.userId()`` as it is sync because the id is in the [method_invocation.js#constructor](https://github.com/meteor/meteor/blob/ef8796a44eaff508c285aa499ff7ce8f1dde2b05/packages/ddp-common/method_invocation.js#L48)
> There was nothing to decide, as since the userId is provided went instantiating that class.

#### Context
for those who wants to know where it gets the userId field it does this trip:

[Meteor.userId](https://github.com/meteor/meteor/blob/222022ecf0dde1d5ad35aed1ce223aa02c6e4041/packages/accounts-base/accounts_client.js#L46) -> [method_invocation.js#constructor](https://github.com/meteor/meteor/blob/ef8796a44eaff508c285aa499ff7ce8f1dde2b05/packages/ddp-common/method_invocation.js#L48) -> [accounts_common.js#_initConnection](https://github.com/meteor/meteor/blob/33015f00d1d00383012a35cb0e46bd84c3338e1d/packages/accounts-base/accounts_common.js#L330)
