### PR TITLE
In the client, don't wait if the stub doesn't return a promise

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -695,7 +695,14 @@ export class Connection {
           invocation
         );
         try {
-          stubOptions.stubReturnValue = await stubInvocation();
+          const resultOrThenable = stubInvocation();
+          const isThenable =
+            resultOrThenable && typeof resultOrThenable.then === 'function';
+          if (isThenable) {
+            stubOptions.stubReturnValue = await resultOrThenable;
+          } else {
+            stubOptions.stubReturnValue = resultOrThenable;
+          }
         } finally {
           DDP._CurrentMethodInvocation._set(currentContext);
         }


### PR DESCRIPTION
As suggested by @zodern [here](https://github.com/meteor/meteor/pull/12057/files#r996452189), we don't need to `await` if the stub is sync.