### PR TITLE
MongoID._looksLikeObjectID bugfix

### DIFF
--- a/packages/mongo-id/id.js
+++ b/packages/mongo-id/id.js
@@ -3,7 +3,7 @@ import { Random } from 'meteor/random';
 
 const MongoID = {};
 
-MongoID._looksLikeObjectID = str => str.length === 24 && str.match(/^[0-9a-f]*$/);
+MongoID._looksLikeObjectID = str => str.length === 24 && (str.match(/^[0-9a-f]*$/) != null);
 
 MongoID.ObjectID = class ObjectID {
   constructor (hexString) {

--- a/packages/mongo-id/id.js
+++ b/packages/mongo-id/id.js
@@ -3,7 +3,7 @@ import { Random } from 'meteor/random';
 
 const MongoID = {};
 
-MongoID._looksLikeObjectID = str => str.length === 24 && (str.match(/^[0-9a-f]*$/) != null);
+MongoID._looksLikeObjectID = str => str.length === 24 && /^[0-9a-f]*$/.test(str);
 
 MongoID.ObjectID = class ObjectID {
   constructor (hexString) {


### PR DESCRIPTION
str.match() returns an array on success which is not coerced into boolean true. An explicit not null check is now performed instead.