### PR TITLE
update actions used in GitHub workflows to newest versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,14 +10,14 @@ jobs:
       run:
         working-directory: docs/
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 12.x
       - name: Build the Docs
         run: npm ci && npm run build
       - name: Deploy to Netlify for preview
-        uses: nwtgck/actions-netlify@v1.2.2
+        uses: nwtgck/actions-netlify@v1.2.4
         with:
           publish-dir: './docs/public/'
           production-branch: devel

--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -10,14 +10,14 @@ jobs:
       run:
         working-directory: guide/
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 12.x
       - name: Build the Guide
         run: npm ci && npm run build
       - name: Deploy to Netlify for preview
-        uses: nwtgck/actions-netlify@v1.2.2
+        uses: nwtgck/actions-netlify@v1.2.4
         with:
           publish-dir: './guide/public'
           production-branch: devel

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,6 +17,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/npm-eslint-plugin-meteor.yml
+++ b/.github/workflows/npm-eslint-plugin-meteor.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         node-version: [12.x, 14.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/npm-meteor-babel.yml
+++ b/.github/workflows/npm-meteor-babel.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         node-version: [12.x, 14.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/npm-meteor-promise.yml
+++ b/.github/workflows/npm-meteor-promise.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         node-version: [12.x, 14.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
- bump actions/checkout to v3
- bump actions/setup-node to v3
- bump actions/labeler to v4
- bump nwtgck/actions-netlify to v1.2.4