### PR TITLE
[meteor-installer] fix: add a missing dep

### DIFF
--- a/npm-packages/meteor-installer/install.js
+++ b/npm-packages/meteor-installer/install.js
@@ -1,5 +1,4 @@
 const { DownloaderHelper } = require('node-downloader-helper');
-const HttpsProxyAgent = require('https-proxy-agent');
 const cliProgress = require('cli-progress');
 const Seven = require('node-7z');
 const path = require('path');
@@ -149,6 +148,8 @@ function generateProxyAgent() {
   if (!proxyUrl) {
     return undefined;
   }
+
+  const HttpsProxyAgent = require('https-proxy-agent');
 
   return new HttpsProxyAgent(proxyUrl);
 }

--- a/npm-packages/meteor-installer/package.json
+++ b/npm-packages/meteor-installer/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "7zip-bin": "^5.2.0",
     "cli-progress": "^3.11.1",
+    "https-proxy-agent": "^5.0.1",
     "node-7z": "^2.1.2",
     "node-downloader-helper": "^1.0.19",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
An issue occurs starting from 2.8.1

Fix https://github.com/meteor/meteor/issues/12307

Also, require only if it needs.

A discussion: https://github.com/meteor/meteor/pull/12149#pullrequestreview-1185887093