### PR TITLE
[@meteorjs/eslint-config-meteor] chore: update links

### DIFF
--- a/npm-packages/eslint-config-meteor/README.md
+++ b/npm-packages/eslint-config-meteor/README.md
@@ -1,4 +1,4 @@
-# eslint-config-meteor
+# @meteorjs/eslint-config-meteor
 
 This is an [ESLint](https://eslint.org) configuration for [Meteor](https://www.meteor.com) apps which implements the recommendations from the [Meteor Guide](https://guide.meteor.com/)'s section on [Code style](https://guide.meteor.com/code-style.html#eslint).
 

--- a/npm-packages/eslint-config-meteor/index.js
+++ b/npm-packages/eslint-config-meteor/index.js
@@ -1,21 +1,16 @@
 module.exports = {
   parser: 'babel-eslint',
   parserOptions: {
-    allowImportExportEverywhere: true
+    allowImportExportEverywhere: true,
   },
   env: {
     node: true,
-    browser: true
+    browser: true,
   },
-  plugins: [
-    'meteor'
-  ],
-  extends: [
-    'airbnb',
-    'plugin:meteor/recommended'
-  ],
+  plugins: ['meteor'],
+  extends: ['airbnb', 'plugin:meteor/recommended'],
   settings: {
-    'import/resolver': 'meteor'
+    'import/resolver': 'meteor',
   },
   rules: {
     'react/jsx-filename-extension': 0,
@@ -30,24 +25,21 @@ module.exports = {
     'no-underscore-dangle': [
       'error',
       {
-        allow: [
-          '_id',
-          '_ensureIndex'
-        ]
-      }
+        allow: ['_id', '_ensureIndex'],
+      },
     ],
     'object-shorthand': [
       'error',
       'always',
       {
-        avoidQuotes: false
-      }
+        avoidQuotes: false,
+      },
     ],
 
     'space-before-function-paren': 0,
-    
+
     // for Meteor API's that rely on `this` context, e.g. Template.onCreated and publications
     'func-names': 0,
-    'prefer-arrow-callback': 0
-  }
+    'prefer-arrow-callback': 0,
+  },
 };

--- a/npm-packages/eslint-config-meteor/package.json
+++ b/npm-packages/eslint-config-meteor/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/meteor/eslint-config-meteor.git"
+    "url": "git+https://github.com/meteor/meteor.git"
   },
   "author": "David Burles",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/meteor/eslint-config-meteor/issues"
+    "url": "https://github.com/meteor/meteor/issues"
   },
-  "homepage": "https://github.com/meteor/eslint-config-meteor#readme",
+  "homepage": "https://github.com/meteor/meteor/tree/devel/npm-packages/eslint-config-meteor#readme",
   "peerDependencies": {
     "babel-eslint": ">= 7",
     "eslint": ">= 3",


### PR DESCRIPTION
- update links to actual code
- replace H1 in readme
- apply ESLint rules to index.js

We don't need to publish anything, just some cleanup.

Another strange thing that it has `1.0.4` in package.json version while npm shows `1.0.5`. Is it ok?

https://www.npmjs.com/package/@meteorjs/eslint-config-meteor