### PR TITLE
feat: Auto import React on jsx,tsx files

### DIFF
--- a/npm-packages/meteor-babel/options.js
+++ b/npm-packages/meteor-babel/options.js
@@ -80,7 +80,11 @@ exports.getDefaults = function getDefaults(features) {
 
 function maybeAddReactPlugins(features, options) {
   if (features && features.react) {
-    options.presets.push(require("@babel/preset-react"));
+    options.presets.push(
+      [require("@babel/preset-react"), {
+        runtime: "automatic"
+      }]
+    );
     options.plugins.push(
       [require("@babel/plugin-proposal-class-properties"), {
         loose: true


### PR DESCRIPTION
This change will auto import React on jsx and tsx files by default.

You don't need to repeat yourself writing `import React from 'react'` in every React file.

You can read more about it on React documentation: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#manual-babel-setup

We already support it on `@babel/preset-react` since we are using v7.16.7 and this is added on v7.9

This was requested on forums and also part of our backlog. 
https://forums.meteor.com/t/solved-why-i-still-need-to-import-react-on-each-jsx-tsx-file/58358

TODO:
- [ ] Deploy new @meteorjs/babel version and replace this version everywhere it's used