### PR TITLE
oplog-converter: Handle array item updates

### DIFF
--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -77,6 +77,71 @@ const cases = [
     { $v: 2, diff: { u: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } } } },
     { $v: 2, $set: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } } },
   ],
+  [
+    {
+      $v: 2,
+      diff: {
+        sitems: {
+          a: true,
+          s0: {
+            u: { id: 'm57DsX8g8L66bM5JX', name: 'Alice' },
+            sbio: { u: { en: 'Just Alice' } },
+            slanguages: {
+              a: true,
+              s0: {
+                u: { englishName: 'English', key: 'en', localName: 'English' },
+              },
+            },
+          },
+          u1: {
+            id: 'FJwSQHqwpenCN6RQH',
+            name: 'Bob',
+            title: { en: 'Fictional character', sv: '' },
+            bio: { en: 'Just Bob', sv: '' },
+            avatar: null,
+            languages: [
+              { key: 'sv', englishName: 'Swedish', localName: 'Sverige' },
+            ],
+          },
+          u2: null
+        },
+      },
+    },
+    {
+      $v: 2,
+      $set: {
+        'items.0.id': 'm57DsX8g8L66bM5JX',
+        'items.0.name': 'Alice',
+        'items.0.bio.en': 'Just Alice',
+        'items.0.languages.0.englishName': 'English',
+        'items.0.languages.0.key': 'en',
+        'items.0.languages.0.localName': 'English',
+        'items.1': {
+          id: 'FJwSQHqwpenCN6RQH',
+          name: 'Bob',
+          title: {
+            en: 'Fictional character',
+            sv: '',
+          },
+          bio: {
+            en: 'Just Bob',
+            sv: '',
+          },
+          avatar: null,
+          languages: [
+            {
+              key: 'sv',
+              englishName: 'Swedish',
+              localName: 'Sverige',
+            },
+          ],
+        },
+      },
+      $unset: {
+        'items.2': true
+      }
+    },
+  ]
 ];
 
 Tinytest.add('oplog - v2/v1 conversion', function (test) {


### PR DESCRIPTION
This was my first glance at the oplog converter, _or oplog "under the hood" in general_, so I'm not a 100% sure I got it right. I'm still running this against a real app and trying to break it, and it probably will.

That being said, all Mongo tests ran succesfully and it fixes the test case I added + the known bug in our app.

**Explanation**: It seemed like the oplog converter wasn't handling array items updates, at all, such as:

```
sitems: {
   u1: { name: 'Foo' }
}
```

which should have translated to 

```
$set: {
  'items.1': { name: 'Foo' }
}
```

_Potentially_ fixes #12325