### PR TITLE
Fix fetch() type declaration

### DIFF
--- a/packages/fetch/fetch.d.ts
+++ b/packages/fetch/fetch.d.ts
@@ -1,4 +1,4 @@
-export declare function fetch(): typeof globalThis.fetch;
+export declare var fetch: typeof globalThis.fetch;
 export declare var Headers: typeof globalThis.Headers;
 export declare var Request: typeof globalThis.Request;
 export declare var Response: typeof globalThis.Response;


### PR DESCRIPTION
`fetch()` is the type of `globalThis.fetch`; it is not a function which returns a `globalThis.fetch`.

Fixes #12351.