### PR TITLE
chore: resetPassword and verifyEmail to no longer sign in the user automatically

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -9,7 +9,9 @@
 
 #### Breaking Changes
 
-N/A
+* `accounts-password@2.3.3`
+  - The methods `resetPassword` and `verifyEmail` no longer logs the user if they have 2FA enabled. Now, the functions work as before, but instead of automatically logging in the user at the end, an error with the code `2fa-enabled` will be thrown.
+
 
 ####  Internal API changes
 

--- a/docs/source/api/passwords.md
+++ b/docs/source/api/passwords.md
@@ -59,6 +59,10 @@ email with a link the user can use to verify their email address.
 
 {% apibox "Accounts.verifyEmail" %}
 
+If the user trying to verify the email has 2FA enabled, this error will be thrown:
+* "Email verified, but user not logged in because 2FA is enabled [2fa-enabled]": No longer signing in the user automatically if the user has 2FA enabled. 
+
+
 This function accepts tokens passed into the callback registered with
 [`Accounts.onEmailVerificationLink`](#Accounts-onEmailVerificationLink).
 
@@ -88,6 +92,9 @@ new password and call `resetPassword`.
 This function accepts tokens passed into the callbacks registered with
 [`AccountsClient#onResetPasswordLink`](#Accounts-onResetPasswordLink) and
 [`Accounts.onEnrollmentLink`](#Accounts-onEnrollmentLink).
+
+If the user trying to reset the password has 2FA enabled, this error will be thrown:
+* "Changed password, but user not logged in because 2FA is enabled [2fa-enabled]": No longer signing in the user automatically if the user has 2FA enabled.
 
 {% apibox "Accounts.setPassword" %}
 

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -5,7 +5,7 @@ Package.describe({
   // 2.2.x in the future. The version was also bumped to 2.0.0 temporarily
   // during the Meteor 1.5.1 release process, so versions 2.0.0-beta.2
   // through -beta.5 and -rc.0 have already been published.
-  version: '2.3.2',
+  version: '2.3.3-beta291.3',
 });
 
 Npm.depends({

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -201,7 +201,7 @@ Accounts.forgotPassword = (options, callback) => {
 // @param callback (optional) {Function(error|undefined)}
 
 /**
- * @summary Reset the password for a user using a token received in email. Logs the user in afterwards.
+ * @summary Reset the password for a user using a token received in email. Logs the user in afterwards if the user doesn't have 2FA enabled.
  * @locus Client
  * @param {String} token The token retrieved from the reset password URL.
  * @param {String} newPassword A new password for the user. This is __not__ sent in plain text over the wire.
@@ -234,7 +234,7 @@ Accounts.resetPassword = (token, newPassword, callback) => {
 // @param callback (optional) {Function(error|undefined)}
 
 /**
- * @summary Marks the user's email address as verified. Logs the user in afterwards.
+ * @summary Marks the user's email address as verified. Logs the user in afterwards if the user doesn't have 2FA enabled.
  * @locus Client
  * @param {String} token The token retrieved from the verification URL.
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -687,6 +687,17 @@ Meteor.methods({resetPassword: async function (...args) {
       // password should invalidate existing sessions).
       Accounts._clearAllLoginTokens(user._id);
 
+      if (Accounts._check2faEnabled?.(user)) {
+        return {
+          userId: user._id,
+          error: Accounts._handleError(
+            'Changed password, but user not logged in because 2FA is enabled',
+            false,
+            '2fa-enabled'
+          ),
+        };
+      }
+
       return {userId: user._id};
     }
   );
@@ -777,6 +788,17 @@ Meteor.methods({verifyEmail: async function (...args) {
          'emails.address': tokenRecord.address},
         {$set: {'emails.$.verified': true},
          $pull: {'services.email.verificationTokens': {address: tokenRecord.address}}});
+
+      if (Accounts._check2faEnabled?.(user)) {
+        return {
+          userId: user._id,
+          error: Accounts._handleError(
+            'Email verified, but user not logged in because 2FA is enabled',
+            false,
+            '2fa-enabled'
+          ),
+        };
+      }
 
       return {userId: user._id};
     }


### PR DESCRIPTION
Changing the methods `resetPassword()` and `verifyEmail()` to no longer sign in the user automatically if they have 2fa enabled.

By default these methods already work has the 2FA, sort of speaking, because you need to have access to the user's email in order to finish the operation.

This PR just adds one more layer to that.