### PR TITLE
Remove wrapAsync from email package

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,3 +1,25 @@
+## v3.0, TBD
+
+### Highlights
+
+#### Breaking Changes
+
+* `email`:
+ `Email.send` is no longer available. Use `Email.sendAsync` instead.
+
+####  Internal API changes
+
+
+#### Migration Steps
+
+You can follow in [here](https://guide.meteor.com/3.0-migration.html).
+
+#### Meteor Version Release
+
+#### Special thanks to
+
+For making this great framework even better!
+
 ## v2.9, 2022-12-12
 
 ### Highlights

--- a/docs/history.md
+++ b/docs/history.md
@@ -7,6 +7,11 @@
 * `email`:
  `Email.send` is no longer available. Use `Email.sendAsync` instead.
 
+* `accounts-password`:
+  - `Accounts.sendResetPasswordEmail` is now async
+  - `Accounts.sendEnrollmentEmail` is now async
+  - `Accounts.sendVerificationEmail` is now async
+
 ####  Internal API changes
 
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -11,7 +11,10 @@
   - `Accounts.sendResetPasswordEmail` is now async
   - `Accounts.sendEnrollmentEmail` is now async
   - `Accounts.sendVerificationEmail` is now async
-
+  
+* `accounts-passwordless`:
+  - `Accounts.sendLoginTokenEmail` is now async
+  
 ####  Internal API changes
 
 

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -368,7 +368,7 @@ const pluckAddresses = (emails = []) => emails.map(email => email.address);
 
 // Method called by a user to request a password reset email. This is
 // the start of the reset process.
-Meteor.methods({forgotPassword: options => {
+Meteor.methods({forgotPassword: async options => {
   check(options, {email: String})
 
   const user = Accounts.findUserByEmail(options.email, { fields: { emails: 1 } });
@@ -382,7 +382,7 @@ Meteor.methods({forgotPassword: options => {
     email => email.toLowerCase() === options.email.toLowerCase()
   );
 
-  Accounts.sendResetPasswordEmail(user._id, caseSensitiveEmail);
+  await Accounts.sendResetPasswordEmail(user._id, caseSensitiveEmail);
 }});
 
 /**
@@ -532,12 +532,12 @@ Accounts.generateVerificationToken = (userId, email, extraTokenData) => {
  * @returns {Object} Object with {email, user, token, url, options} values.
  * @importFromPackage accounts-base
  */
-Accounts.sendResetPasswordEmail = (userId, email, extraTokenData, extraParams) => {
+Accounts.sendResetPasswordEmail = async (userId, email, extraTokenData, extraParams) => {
   const {email: realEmail, user, token} =
     Accounts.generateResetToken(userId, email, 'resetPassword', extraTokenData);
   const url = Accounts.urls.resetPassword(token, extraParams);
   const options = Accounts.generateOptionsForEmail(realEmail, user, url, 'resetPassword');
-  Email.send(options);
+  await Email.sendAsync(options);
   if (Meteor.isDevelopment) {
     console.log(`\nReset password URL: ${url}`);
   }
@@ -562,12 +562,12 @@ Accounts.sendResetPasswordEmail = (userId, email, extraTokenData, extraParams) =
  * @returns {Object} Object with {email, user, token, url, options} values.
  * @importFromPackage accounts-base
  */
-Accounts.sendEnrollmentEmail = (userId, email, extraTokenData, extraParams) => {
+Accounts.sendEnrollmentEmail = async (userId, email, extraTokenData, extraParams) => {
   const {email: realEmail, user, token} =
     Accounts.generateResetToken(userId, email, 'enrollAccount', extraTokenData);
   const url = Accounts.urls.enrollAccount(token, extraParams);
   const options = Accounts.generateOptionsForEmail(realEmail, user, url, 'enrollAccount');
-  Email.send(options);
+  await Email.sendAsync(options);
   if (Meteor.isDevelopment) {
     console.log(`\nEnrollment email URL: ${url}`);
   }
@@ -711,7 +711,7 @@ Meteor.methods({resetPassword: async function (...args) {
  * @returns {Object} Object with {email, user, token, url, options} values.
  * @importFromPackage accounts-base
  */
-Accounts.sendVerificationEmail = (userId, email, extraTokenData, extraParams) => {
+Accounts.sendVerificationEmail = async (userId, email, extraTokenData, extraParams) => {
   // XXX Also generate a link using which someone can delete this
   // account if they own said address but weren't those who created
   // this account.
@@ -720,7 +720,7 @@ Accounts.sendVerificationEmail = (userId, email, extraTokenData, extraParams) =>
     Accounts.generateVerificationToken(userId, email, extraTokenData);
   const url = Accounts.urls.verifyEmail(token, extraParams);
   const options = Accounts.generateOptionsForEmail(realEmail, user, url, 'verifyEmail');
-  Email.send(options);
+  await Email.sendAsync(options);
   if (Meteor.isDevelopment) {
     console.log(`\nVerification email URL: ${url}`);
   }
@@ -979,9 +979,9 @@ Accounts.createUserVerifyingEmail = async (options) => {
   // that address.
   if (options.email && Accounts._options.sendVerificationEmail) {
     if (options.password) {
-      Accounts.sendVerificationEmail(userId, options.email);
+      await Accounts.sendVerificationEmail(userId, options.email);
     } else {
-      Accounts.sendEnrollmentEmail(userId, options.email);
+      await Accounts.sendEnrollmentEmail(userId, options.email);
     }
   }
 

--- a/packages/deprecated/http/httpcall_server.js
+++ b/packages/deprecated/http/httpcall_server.js
@@ -161,4 +161,5 @@ function _call (method, url, options, callback) {
     .catch(err => callback(err));
 }
 
+// we are keeping wrapAsync here as this package is deprecated
 HTTP.call = Meteor.wrapAsync(_call);

--- a/packages/email/email.d.ts
+++ b/packages/email/email.d.ts
@@ -17,7 +17,9 @@ export namespace Email {
     packageSettings?: unknown;
   }
 
+  /** @deprecated */
   function send(options: EmailOptions): void;
+  function sendAsync(options: EmailOptions): Promise<void>;
   function hookSend(fn: (options: EmailOptions) => boolean): void;
   function customTransport(fn: (options: CustomEmailOptions) => void): void;
 }

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -256,3 +256,22 @@ Email.sendAsync = async function (options) {
   }
   return devModeSendAsync(email, options);
 };
+
+/**
+ * @deprecated use Email.sendAsync
+ * @param options
+ */
+Email.send = function(options) {
+  Email.sendAsync(options)
+    .then(() =>
+      console.warn(
+        `Email.send is no longer recommended, you should use Email.sendAsync`
+      )
+    )
+    .catch(e =>
+      console.error(
+        `Email.send is no longer recommended and an error happened`,
+        e
+      )
+    );
+};

--- a/packages/email/email_tests.js
+++ b/packages/email/email_tests.js
@@ -10,22 +10,9 @@ const sleep = (ms) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
-// Create dynamic sync tests
-TEST_CASES.forEach(({ title, options, testCalls }) => {
-  Tinytest.add(`[Sync] ${title}`, function (test) {
-    smokeEmailTest((stream) => {
-      Object.entries(options).forEach(([key, option]) => {
-        const testCall = testCalls[key];
-        Email.send({ ...option, stream });
-        testCall(test, stream);
-      });
-    });
-  });
-});
-
 // Create dynamic async tests
 TEST_CASES.forEach(({ title, options, testCalls }) => {
-  Tinytest.addAsync(`[Async] ${title}`, function (test, onComplete) {
+  Tinytest.addAsync(`${title}`, function (test, onComplete) {
     smokeEmailTest((stream) => {
       const allPromises = Object.entries(options).map(([key, option]) => {
         const testCall = testCalls[key];
@@ -38,82 +25,10 @@ TEST_CASES.forEach(({ title, options, testCalls }) => {
   });
 });
 
-// Individual sync tests
-
-Tinytest.add(
-  '[Sync] email - alternate API is used for sending gets data',
-  function (test) {
-    smokeEmailTest(function (stream) {
-      Email.customTransport = (options) => {
-        test.equal(options.from, 'foo@example.com');
-      };
-      Email.send({
-        from: 'foo@example.com',
-        to: 'bar@example.com',
-        text: '*Cool*, man',
-        html: '<i>Cool</i>, man',
-        stream,
-      });
-      test.equal(stream.getContentsAsString('utf8'), false);
-    });
-
-    smokeEmailTest(function (stream) {
-      Meteor.settings.packages = CUSTOM_TRANSPORT_SETTINGS;
-      Email.customTransport = (options) => {
-        test.equal(options.from, 'foo@example.com');
-        test.equal(options.packageSettings?.service, '1on1');
-      };
-
-      Email.send({
-        from: 'foo@example.com',
-        to: 'bar@example.com',
-        text: '*Cool*, man',
-        html: '<i>Cool</i>, man',
-        stream,
-      });
-
-      test.equal(stream.getContentsAsString('utf8'), false);
-    });
-    Email.customTransport = undefined;
-    Meteor.settings.packages = undefined;
-  }
-);
-
-Tinytest.add('[Sync] email - hooks stop the sending', function (test) {
-  // Register hooks
-  const hook1 = Email.hookSend((options) => {
-    // Test that we get options through
-    test.equal(options.from, 'foo@example.com');
-    console.log('EXECUTE');
-    return true;
-  });
-  const hook2 = Email.hookSend(() => {
-    console.log('STOP');
-    return false;
-  });
-  const hook3 = Email.hookSend(() => {
-    console.log('FAIL');
-  });
-  smokeEmailTest(function (stream) {
-    Email.send({
-      from: 'foo@example.com',
-      to: 'bar@example.com',
-      text: '*Cool*, man',
-      html: '<i>Cool</i>, man',
-      stream,
-    });
-
-    test.equal(stream.getContentsAsString('utf8'), false);
-  });
-  hook1.stop();
-  hook2.stop();
-  hook3.stop();
-});
-
 // Individual Async tests
 
 Tinytest.addAsync(
-  '[Async] email - alternate API is used for sending gets data',
+  'email - alternate API is used for sending gets data',
   function (test, onComplete) {
     const allPromises = [];
     smokeEmailTest((stream) => {
@@ -161,7 +76,7 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
-  '[Async] email - hooks stop the sending',
+  'email - hooks stop the sending',
   function (test, onComplete) {
     // Register hooks
     const hook1 = Email.hookSend((options) => {
@@ -197,7 +112,7 @@ Tinytest.addAsync(
 
 // Another tests
 
-Tinytest.add('[Sync] email - URL string for known hosts', function (test) {
+Tinytest.add('email - URL string for known hosts', function (test) {
   const oneTransport = EmailTest.knowHostsTransport({
     service: '1und1',
     user: 'test',
@@ -254,7 +169,7 @@ Tinytest.add('[Sync] email - URL string for known hosts', function (test) {
 });
 
 Tinytest.addAsync(
-  '[Async] email - with custom transport exception',
+  'email - with custom transport exception',
   async function (test) {
     Meteor.settings.packages = CUSTOM_TRANSPORT_SETTINGS;
     Email.customTransport = (options) => {
@@ -274,7 +189,7 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
-  '[Async] email - with custom transport long time running',
+  'email - with custom transport long time running',
   async function (test) {
     Meteor.settings.packages = CUSTOM_TRANSPORT_SETTINGS;
     Email.customTransport = async (options) => {
@@ -288,24 +203,5 @@ Tinytest.addAsync(
     });
     Meteor.settings.packages = undefined;
     Email.customTransport = undefined;
-  }
-);
-
-Tinytest.addAsync(
-  '[Sync] email - with custom transport long time running',
-  function (test, onComplete) {
-    Meteor.settings.packages = CUSTOM_TRANSPORT_SETTINGS;
-    Email.customTransport = async (options) => {
-      await sleep(3000);
-      test.equal(options.from, 'foo@example.com');
-      test.equal(options.packageSettings?.service, '1on1');
-      Meteor.settings.packages = undefined;
-      Email.customTransport = undefined;
-      onComplete();
-    };
-    Email.send({
-      from: 'foo@example.com',
-      to: 'bar@example.com',
-    });
   }
 );


### PR DESCRIPTION
The goal of this PR is to remove wrapAsync from `email` package and also update its usage.

- [x] remove wrapAsync usage in email package
- [x] fix email package tests
- [x] replaces `Email.send` implementation by a call to `Email.sendAsync`
- [x] change usages of Email.send in accounts-password
- [x] change usages of Email.send in accounts-passwordless 
- [x] update email.d.ts to include sendAsync