### PR TITLE
docs: update docs about --prototype

### DIFF
--- a/docs/source/commandline.md
+++ b/docs/source/commandline.md
@@ -91,6 +91,12 @@ You can pass an absolute or relative path.
 
 **Flags for default packages**
 
+`--prototype`
+
+Creates a package with the prototype packages. 
+It can be used together with other flags that create apps such as `--react` or `--typescript`.
+
+
 `--bare`
 
 Creates a basic, blaze project.

--- a/docs/source/commandline.md
+++ b/docs/source/commandline.md
@@ -93,7 +93,11 @@ You can pass an absolute or relative path.
 
 `--prototype`
 
-Creates a package with the prototype packages. 
+Creates a package with the prototype purpose packages(`autopublish` and `insecure`) 
+if you use them you can change your collections quickly, 
+but it is not supposed to be used in production.
+For more information about security you can check
+it [here](https://guide.meteor.com/security.html#checklist)
 It can be used together with other flags that create apps such as `--react` or `--typescript`.
 
 


### PR DESCRIPTION

In 2.9 was added the ``--prototype`` flag was missing updating docs for this new feature.

for context: 
https://forums.meteor.com/t/noob-issue-hello-meteor-links-not-displaying/59240