### PR TITLE
Remove toHTML method from boilerplate-generator

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -5,7 +5,7 @@
 #### Breaking Changes
 
 * `email`:
- `Email.send` is no longer available. Use `Email.sendAsync` instead.
+  - `Email.send` is no longer available. Use `Email.sendAsync` instead.
 
 * `accounts-password`:
   - `Accounts.sendResetPasswordEmail` is now async
@@ -14,6 +14,9 @@
   
 * `accounts-passwordless`:
   - `Accounts.sendLoginTokenEmail` is now async
+
+* `boilerplate-generator`:
+  - `toHTML` is no longer available (it was already deprecated). Use `toHTMLStream` instead.
   
 ####  Internal API changes
 

--- a/packages/boilerplate-generator/generator.js
+++ b/packages/boilerplate-generator/generator.js
@@ -18,8 +18,6 @@ function appendToStream(chunk, stream) {
   }
 }
 
-let shouldWarnAboutToHTMLDeprecation = ! Meteor.isProduction;
-
 export class Boilerplate {
   constructor(arch, manifest, options = {}) {
     const { headTemplate, closeTemplate } = getTemplate(arch);
@@ -34,17 +32,10 @@ export class Boilerplate {
   }
 
   toHTML(extraData) {
-    if (shouldWarnAboutToHTMLDeprecation) {
-      shouldWarnAboutToHTMLDeprecation = false;
-      console.error(
-        "The Boilerplate#toHTML method has been deprecated. " +
-          "Please use Boilerplate#toHTMLStream instead."
-      );
-      console.trace();
-    }
-
-    // Calling .await() requires a Fiber.
-    return this.toHTMLAsync(extraData).await();
+    throw new Error(
+      "The Boilerplate#toHTML method has been removed. " +
+        "Please use Boilerplate#toHTMLStream instead."
+    );
   }
 
   // Returns a Promise that resolves to a string of HTML.

--- a/packages/boilerplate-generator/package.js
+++ b/packages/boilerplate-generator/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Generates the boilerplate html from program's manifest",
-  version: '1.7.1'
+  version: '1.8.0'
 });
 
 Npm.depends({


### PR DESCRIPTION
Remove Fibers usage from the boilerplate-generator (actually just remove this method, since it was already deprecated). However, we can still keep the method there and throw an error if someone tries to use? Internally this is not used anymore, but someone may still use it.