### PR TITLE
Missing vue2 declaration

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -521,6 +521,7 @@ export const AVAILABLE_SKELETONS = [
   DEFAULT_SKELETON,
   "typescript",
   "vue",
+  'vue-2',
   "svelte",
   "tailwind",
   "chakra-ui",


### PR DESCRIPTION

In the changes for 2.9.0, we added vue 3 as the default creation for app but for creating a vue2 app we had forgotten to add it to the listed apps skeleton variables
Thanks to [mlanning](https://github.com/mlanning) we have solved this one
Notes:
this closes #12395