### PR TITLE
async minifier js

### DIFF
--- a/packages/minifier-js/minifier-tests.js
+++ b/packages/minifier-js/minifier-tests.js
@@ -1,23 +1,22 @@
-Tinytest.add('minifier-js - verify how terser handles an empty string', (test) => {
-  let result = meteorJsMinify('');
+Tinytest.addAsync('minifier-js - verify how terser handles an empty string', async (test) => {
+  let result = await meteorJsMinify('');
   test.equal(result.code, '');
   test.equal(result.minifier, 'terser');
 });
 
-Tinytest.add('minifier-js - verify terser is able to minify valid javascript', (test) => {
-  let result = meteorJsMinify('function add(first,second){return first + second; }\n');
+Tinytest.addAsync('minifier-js - verify terser is able to minify valid javascript', async (test) => {
+  let result = await meteorJsMinify('function add(first,second){return first + second; }\n');
   test.equal(result.code, 'function add(n,d){return n+d}');
   test.equal(result.minifier, 'terser');
 });
 
-Tinytest.add('minifier-js - verify error handling is done as expected', (test) => {
-  test.throws( () => meteorJsMinify('let name = {;\n'), undefined );
+Tinytest.addAsync('minifier-js - verify error handling is done as expected', async (test) => {
+  await test.throwsAsync( async () => await meteorJsMinify('let name = {;\n'), undefined );
 });
 
-Tinytest.add('minifier-js - verify tersers error object has the fields we use for reporting errors to users', (test) => {
-  let result;
+Tinytest.addAsync('minifier-js - verify tersers error object has the fields we use for reporting errors to users', async (test) => {
   try {
-    result = meteorJsMinify('let name = {;\n');
+    await meteorJsMinify('let name = {;\n');
   }
   catch (err) {
     test.isNotUndefined(err.name);

--- a/packages/minifier-js/minifier.js
+++ b/packages/minifier-js/minifier.js
@@ -1,18 +1,11 @@
 let terser;
 
-const terserMinify = async (source, options, callback) => {
+const terserMinify = async (source, options) => {
   terser = terser || Npm.require("terser");
-  try {
-    const result = await terser.minify(source, options);
-    callback(null, result);
-    return result;
-  } catch (e) {
-    callback(e);
-    return e;
-  }
+  return await terser.minify(source, options);
 };
 
-export const meteorJsMinify = function (source) {
+export const meteorJsMinify = async function (source) {
   const result = {};
   const NODE_ENV = process.env.NODE_ENV || "development";
 
@@ -33,13 +26,7 @@ export const meteorJsMinify = function (source) {
     safari10: true,          // set this option to true to work around the Safari 10/11 await bug
   };
 
-  const terserJsMinify = Meteor.wrapAsync(terserMinify);
-  let terserResult;
-  try {
-    terserResult = terserJsMinify(source, options);
-  } catch (e) {
-    throw e;
-  }
+  const terserResult = await terserMinify(source, options);
 
   // this is kept to maintain backwards compatability
   result.code = terserResult.code;

--- a/packages/standard-minifier-js/plugin/minify-js.js
+++ b/packages/standard-minifier-js/plugin/minify-js.js
@@ -9,7 +9,7 @@ Plugin.registerMinifier({
 
 class MeteorMinifier {
 
-  processFilesForBundle (files, options) {
+  async processFilesForBundle (files, options) {
     const mode = options.minifyMode;
 
     // don't minify anything for development
@@ -63,7 +63,7 @@ class MeteorMinifier {
       stats: Object.create(null)
     };
 
-    files.forEach(file => {
+    for await (file of files) {
       // Don't reminify *.min.js.
       if (/\.min\.js$/.test(file.getPathInBundle())) {
         toBeAdded.data += file.getContentsAsString();
@@ -71,7 +71,7 @@ class MeteorMinifier {
       else {
         let minified;
         try {
-          minified = meteorJsMinify(file.getContentsAsString());
+          minified = await meteorJsMinify(file.getContentsAsString());
         }
         catch (err) {
           maybeThrowMinifyErrorBySourceFile(err, file);
@@ -94,7 +94,7 @@ class MeteorMinifier {
       toBeAdded.data += '\n\n';
 
       Plugin.nudge();
-    });
+    }
 
     // this is where the minified code gets added to one
     // JS file that is delivered to the client


### PR DESCRIPTION
Upgrades minifier-js to expose an async function and use terser with pure async as well.

We didn't had to migrate tools as the minifier-css was already running with async since this [change](https://github.com/meteor/meteor/commit/d726f49a85a1d15662f1db0659fdf3707c45067d ) and this function is called with [Promise.await()](https://github.com/meteor/meteor/blob/088e52f38601d8a0fb40d463d031ec15d8d2eb4a/tools/isobuild/bundler.js#L1927).

- [x] Update minifier-js
- [x] Update tests