### PR TITLE
Documentation addition about Accounts.createUserVerifyingEmail

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -31,7 +31,7 @@
   by [henriquealbert](https://github.com/henriquealbert).
 
 #### Breaking Changes
- N/A
+* `Accounts.createUserVerifyingEmail` is now async
 
 ####  Internal API changes
 * Internal methods from `OAuth` that are now async:

--- a/guide/source/2.9-migration.md
+++ b/guide/source/2.9-migration.md
@@ -70,6 +70,12 @@ We now have async version of methods that you already use. They are:
 - [Meteor.userAsync()](https://github.com/meteor/meteor/pull/12274)
 - [CssTools.minifyCssAsync()](https://github.com/meteor/meteor/pull/12105)
 
+<h3 id="breaking-async">Breaking async</h3>
+
+`Accounts.createUserVerifyingEmail` is now completely async:
+
+- [Accounts.createUserVerifyingEmail](https://github.com/meteor/meteor/issues/12398)
+
 <h3 id="accounts-base">Accounts-base without service-configuration</h3>
 
 Now `accounts-base` is [no longer tied up](https://github.com/meteor/meteor/pull/12202) with `service-configuration`. So, if you don't use third-party login on your project, you don't need to add the package `service-configuration` anymore.

--- a/guide/source/2.9-migration.md
+++ b/guide/source/2.9-migration.md
@@ -76,6 +76,37 @@ We now have async version of methods that you already use. They are:
 
 - [Accounts.createUserVerifyingEmail](https://github.com/meteor/meteor/issues/12398)
 
+To upgrade change from
+```js
+Meteor.methods({
+  createUserAccount (user) {
+    /**
+     * This seems to be the issue.
+     * Using the other method `createUser` works as expected.
+     */
+    Accounts.createUserVerifyingEmail({
+      username: user.username,
+      email: user.email,
+      password: user.password,
+    });
+  }
+});
+```
+
+to
+
+```js
+Meteor.methods({
+  async createUserAccount (user) {
+    await Accounts.createUserVerifyingEmail({
+      username: user.username,
+      email: user.email,
+      password: user.password,
+    });
+  }
+});
+```
+
 <h3 id="accounts-base">Accounts-base without service-configuration</h3>
 
 Now `accounts-base` is [no longer tied up](https://github.com/meteor/meteor/pull/12202) with `service-configuration`. So, if you don't use third-party login on your project, you don't need to add the package `service-configuration` anymore.


### PR DESCRIPTION
Add info to history and migration guide about `Accounts.createUserVerifyingEmail` as per #12398 

@Grubba27 I put created this very quickly so we might need to adjust wording.