### PR TITLE
Making oauth async

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -18,6 +18,14 @@
 * `boilerplate-generator`:
   - `toHTML` is no longer available (it was already deprecated). Use `toHTMLStream` instead.
   
+* `oauth`:
+  - `_endOfPopupResponseTemplate` and `_endOfRedirectResponseTemplate` are no longer a property but now a function that returns a promise of the same value as before
+  - the following methods are now async: 
+  - `OAuth._renderOauthResults`
+  - `OAuth._endOfLoginResponse`
+  - `OAuth.renderEndOfLoginResponse`
+  - `OAuth._storePendingCredential`
+  - `OAuth._retrievePendingCredential`
 ####  Internal API changes
 
 

--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -251,7 +251,7 @@ const isSafe = value => {
 };
 
 // Internal: used by the oauth1 and oauth2 packages
-OAuth._renderOauthResults = (res, query, credentialSecret) => {
+OAuth._renderOauthResults = async (res, query, credentialSecret) => {
   // For tests, we support the `only_credential_secret_for_test`
   // parameter, which just returns the credential secret without any
   // surrounding HTML. (The test needs to be able to easily grab the
@@ -282,21 +282,23 @@ OAuth._renderOauthResults = (res, query, credentialSecret) => {
       }
     }
 
-    OAuth._endOfLoginResponse(res, details);
+    await OAuth._endOfLoginResponse(res, details);
   }
 };
 
-const getAsset = async (name) => {
-  return await new Promise((resolve, reject) => Assets.getText(
+const getAsset = (name) => {
+  return new Promise((resolve, reject) => Assets.getText(
     `${name}.html`,
     (err, data) => err ? reject(err) : resolve(data)))
 }
 // This "template" (not a real Spacebars template, just an HTML file
 // with some ##PLACEHOLDER##s) communicates the credential secret back
 // to the main window and then closes the popup.
-OAuth._endOfPopupResponseTemplate = getAsset('end_of_popup_response')
+OAuth._endOfPopupResponseTemplate =
+  async () => await getAsset('end_of_popup_response')
 
-OAuth._endOfRedirectResponseTemplate = getAsset('end_of_redirect_response')
+OAuth._endOfRedirectResponseTemplate =
+  async () => await getAsset('end_of_redirect_response')
 
 // Renders the end of login response template into some HTML and JavaScript
 // that closes the popup or redirects at the end of the OAuth flow.
@@ -309,7 +311,7 @@ OAuth._endOfRedirectResponseTemplate = getAsset('end_of_redirect_response')
 //   - redirectUrl
 //   - isCordova (boolean)
 //
-const renderEndOfLoginResponse = options => {
+const renderEndOfLoginResponse = async options => {
   // It would be nice to use Blaze here, but it's a little tricky
   // because our mustaches would be inside a <script> tag, and Blaze
   // would treat the <script> tag contents as text (e.g. encode '&' as
@@ -341,13 +343,12 @@ const renderEndOfLoginResponse = options => {
 
   let template;
   if (options.loginStyle === 'popup') {
-    template = OAuth._endOfPopupResponseTemplate;
+    template = await OAuth._endOfPopupResponseTemplate();
   } else if (options.loginStyle === 'redirect') {
-    template = OAuth._endOfRedirectResponseTemplate;
+    template = await OAuth._endOfRedirectResponseTemplate();
   } else {
     throw new Error(`invalid loginStyle: ${options.loginStyle}`);
   }
-
   const result = template.replace(/##CONFIG##/, JSON.stringify(config))
     .replace(
       /##ROOT_URL_PATH_PREFIX##/, __meteor_runtime_config__.ROOT_URL_PATH_PREFIX
@@ -387,7 +388,7 @@ const renderEndOfLoginResponse = options => {
 //        so shouldn't be trusted for security decisions or included in
 //        the response without sanitizing it first. Only one of `error`
 //        or `credentials` should be set.
-OAuth._endOfLoginResponse = (res, details) => {
+OAuth._endOfLoginResponse = async (res, details) => {
   res.writeHead(200, {'Content-Type': 'text/html'});
 
   let redirectUrl;
@@ -409,7 +410,7 @@ OAuth._endOfLoginResponse = (res, details) => {
     Log.warn("Error in OAuth Server: " +
              (details.error instanceof Error ?
               details.error.message : details.error));
-    res.end(renderEndOfLoginResponse({
+    res.end(await renderEndOfLoginResponse({
       loginStyle: details.loginStyle,
       setCredentialToken: false,
       redirectUrl,
@@ -421,7 +422,7 @@ OAuth._endOfLoginResponse = (res, details) => {
   // If we have a credentialSecret, report it back to the parent
   // window, with the corresponding credentialToken. The parent window
   // uses the credentialToken and credentialSecret to log in over DDP.
-  res.end(renderEndOfLoginResponse({
+  res.end(await renderEndOfLoginResponse({
     loginStyle: details.loginStyle,
     setCredentialToken: true,
     credentialToken: details.credentials.token,

--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -286,14 +286,17 @@ OAuth._renderOauthResults = (res, query, credentialSecret) => {
   }
 };
 
+const getAsset = async (name) => {
+  return await new Promise((resolve, reject) => Assets.getText(
+    `${name}.html`,
+    (err, data) => err ? reject(err) : resolve(data)))
+}
 // This "template" (not a real Spacebars template, just an HTML file
 // with some ##PLACEHOLDER##s) communicates the credential secret back
 // to the main window and then closes the popup.
-OAuth._endOfPopupResponseTemplate = Assets.getText(
-  "end_of_popup_response.html");
+OAuth._endOfPopupResponseTemplate = getAsset('end_of_popup_response')
 
-OAuth._endOfRedirectResponseTemplate = Assets.getText(
-  "end_of_redirect_response.html");
+OAuth._endOfRedirectResponseTemplate = getAsset('end_of_redirect_response')
 
 // Renders the end of login response template into some HTML and JavaScript
 // that closes the popup or redirects at the end of the OAuth flow.

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -77,8 +77,8 @@ Tinytest.addAsync("oauth - _endOfLoginResponse with popup loginStyle supports un
   }
 );
 
-Tinytest.add("oauth - _endOfLoginResponse with popup loginStyle supports ROOT_URL_PATH_PREFIX",
-  test => {
+Tinytest.addAsync("oauth - _endOfLoginResponse with popup loginStyle supports ROOT_URL_PATH_PREFIX",
+  async test => {
     const rootUrlPathPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
     __meteor_runtime_config__.ROOT_URL_PATH_PREFIX = '/test-root-url-prefix';
     const res = {
@@ -95,7 +95,7 @@ Tinytest.add("oauth - _endOfLoginResponse with popup loginStyle supports ROOT_UR
       credentials: {},
       loginStyle: 'popup'
     };
-    OAuth._endOfLoginResponse(res, details);
+    await OAuth._endOfLoginResponse(res, details);
   }
 );
 

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -58,8 +58,8 @@ Tinytest.addAsync("oauth - pendingCredential requires credential secret",
     test.equal(await OAuth._retrievePendingCredential(key, secret), cred);
   });
 
-Tinytest.add("oauth - _endOfLoginResponse with popup loginStyle supports unspecified ROOT_URL_PATH_PREFIX",
-  test => {
+Tinytest.addAsync("oauth - _endOfLoginResponse with popup loginStyle supports unspecified ROOT_URL_PATH_PREFIX",
+  async test => {
     const res = {
       writeHead: () => {},
       end: content => {
@@ -73,7 +73,7 @@ Tinytest.add("oauth - _endOfLoginResponse with popup loginStyle supports unspeci
       credentials: {},
       loginStyle: 'popup'
     };
-    OAuth._endOfLoginResponse(res, details);
+    await OAuth._endOfLoginResponse(res, details);
   }
 );
 

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -1,16 +1,17 @@
-Tinytest.add("oauth - pendingCredential handles Errors", test => {
-  const credentialToken = Random.id();
+Tinytest.addAsync("oauth - pendingCredential handles Errors",
+  async test => {
+    const credentialToken = Random.id();
 
-  const testError = new Error("This is a test error");
-  testError.stack = 'test stack';
-  OAuth._storePendingCredential(credentialToken, testError);
+    const testError = new Error("This is a test error");
+    testError.stack = 'test stack';
+    await OAuth._storePendingCredential(credentialToken, testError);
 
-  // Test that the result for the token is the expected error
-  const result = OAuth._retrievePendingCredential(credentialToken);
-  test.instanceOf(result, Error);
-  test.equal(result.message, testError.message);
-  test.equal(result.stack, testError.stack);
-});
+    // Test that the result for the token is the expected error
+    const result = await OAuth._retrievePendingCredential(credentialToken);
+    test.instanceOf(result, Error);
+    test.equal(result.message, testError.message);
+    test.equal(result.stack, testError.stack);
+  });
 
 Tinytest.add("oauth - pendingCredential handles Meteor.Errors", test => {
   const credentialToken = Random.id();

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -13,15 +13,15 @@ Tinytest.addAsync("oauth - pendingCredential handles Errors",
     test.equal(result.stack, testError.stack);
   });
 
-Tinytest.add("oauth - pendingCredential handles Meteor.Errors", test => {
+Tinytest.addAsync("oauth - pendingCredential handles Meteor.Errors", async test => {
   const credentialToken = Random.id();
 
   const testError = new Meteor.Error(401, "This is a test error");
   testError.stack = 'test stack';
-  OAuth._storePendingCredential(credentialToken, testError);
+  await OAuth._storePendingCredential(credentialToken, testError);
 
   // Test that the result for the token is the expected error
-  const result = OAuth._retrievePendingCredential(credentialToken);
+  const result = await OAuth._retrievePendingCredential(credentialToken);
   test.instanceOf(result, Meteor.Error);
   test.equal(result.error, testError.error);
   test.equal(result.message, testError.message);

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -33,18 +33,19 @@ Tinytest.addAsync("oauth - pendingCredential handles Meteor.Errors",
 
 Tinytest.addAsync("oauth - null, undefined key for pendingCredential",
   async test => {
-  const cred = Random.id();
-  await test.throwsAsync(() => OAuth._storePendingCredential(null, cred));
-  await test.throwsAsync(() => OAuth._storePendingCredential(undefined, cred));
-});
+    const cred = Random.id();
+    await test.throwsAsync(() => OAuth._storePendingCredential(null, cred));
+    await test.throwsAsync(() => OAuth._storePendingCredential(undefined, cred));
+  });
 
-Tinytest.add("oauth - pendingCredential handles duplicate key", test => {
+Tinytest.addAsync("oauth - pendingCredential handles duplicate key",
+    async test => {
   const key = Random.id();
   const cred = Random.id();
-  OAuth._storePendingCredential(key, cred);
+  await OAuth._storePendingCredential(key, cred);
   const newCred = Random.id();
-  OAuth._storePendingCredential(key, newCred);
-  test.equal(OAuth._retrievePendingCredential(key), newCred);
+  await OAuth._storePendingCredential(key, newCred);
+  test.equal(await OAuth._retrievePendingCredential(key), newCred);
 });
 
 Tinytest.add("oauth - pendingCredential requires credential secret", test => {

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -39,23 +39,24 @@ Tinytest.addAsync("oauth - null, undefined key for pendingCredential",
   });
 
 Tinytest.addAsync("oauth - pendingCredential handles duplicate key",
-    async test => {
-  const key = Random.id();
-  const cred = Random.id();
-  await OAuth._storePendingCredential(key, cred);
-  const newCred = Random.id();
-  await OAuth._storePendingCredential(key, newCred);
-  test.equal(await OAuth._retrievePendingCredential(key), newCred);
-});
+  async test => {
+    const key = Random.id();
+    const cred = Random.id();
+    await OAuth._storePendingCredential(key, cred);
+    const newCred = Random.id();
+    await OAuth._storePendingCredential(key, newCred);
+    test.equal(await OAuth._retrievePendingCredential(key), newCred);
+  });
 
-Tinytest.add("oauth - pendingCredential requires credential secret", test => {
-  const key = Random.id();
-  const cred = Random.id();
-  const secret = Random.id();
-  OAuth._storePendingCredential(key, cred, secret);
-  test.equal(OAuth._retrievePendingCredential(key), undefined);
-  test.equal(OAuth._retrievePendingCredential(key, secret), cred);
-});
+Tinytest.addAsync("oauth - pendingCredential requires credential secret",
+  async test => {
+    const key = Random.id();
+    const cred = Random.id();
+    const secret = Random.id();
+    await OAuth._storePendingCredential(key, cred, secret);
+    test.equal(await OAuth._retrievePendingCredential(key), undefined);
+    test.equal(await OAuth._retrievePendingCredential(key, secret), cred);
+  });
 
 Tinytest.add("oauth - _endOfLoginResponse with popup loginStyle supports unspecified ROOT_URL_PATH_PREFIX",
   test => {

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -13,27 +13,29 @@ Tinytest.addAsync("oauth - pendingCredential handles Errors",
     test.equal(result.stack, testError.stack);
   });
 
-Tinytest.addAsync("oauth - pendingCredential handles Meteor.Errors", async test => {
-  const credentialToken = Random.id();
+Tinytest.addAsync("oauth - pendingCredential handles Meteor.Errors",
+  async test => {
+    const credentialToken = Random.id();
 
-  const testError = new Meteor.Error(401, "This is a test error");
-  testError.stack = 'test stack';
-  await OAuth._storePendingCredential(credentialToken, testError);
+    const testError = new Meteor.Error(401, "This is a test error");
+    testError.stack = 'test stack';
+    await OAuth._storePendingCredential(credentialToken, testError);
 
-  // Test that the result for the token is the expected error
-  const result = await OAuth._retrievePendingCredential(credentialToken);
-  test.instanceOf(result, Meteor.Error);
-  test.equal(result.error, testError.error);
-  test.equal(result.message, testError.message);
-  test.equal(result.reason, testError.reason);
-  test.equal(result.stack, testError.stack);
-  test.isUndefined(result.meteorError);
-});
+    // Test that the result for the token is the expected error
+    const result = await OAuth._retrievePendingCredential(credentialToken);
+    test.instanceOf(result, Meteor.Error);
+    test.equal(result.error, testError.error);
+    test.equal(result.message, testError.message);
+    test.equal(result.reason, testError.reason);
+    test.equal(result.stack, testError.stack);
+    test.isUndefined(result.meteorError);
+  });
 
-Tinytest.add("oauth - null, undefined key for pendingCredential", test => {
+Tinytest.addAsync("oauth - null, undefined key for pendingCredential",
+  async test => {
   const cred = Random.id();
-  test.throws(() => OAuth._storePendingCredential(null, cred));
-  test.throws(() => OAuth._storePendingCredential(undefined, cred));
+  await test.throwsAsync(() => OAuth._storePendingCredential(null, cred));
+  await test.throwsAsync(() => OAuth._storePendingCredential(undefined, cred));
 });
 
 Tinytest.add("oauth - pendingCredential handles duplicate key", test => {

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -124,8 +124,8 @@ Tinytest.addAsync("oauth - _endOfLoginResponse with redirect loginStyle supports
 );
 
 
-Tinytest.add("oauth - _endOfLoginResponse with redirect loginStyle supports ROOT_URL_PATH_PREFIX",
-  test => {
+Tinytest.addAsync("oauth - _endOfLoginResponse with redirect loginStyle supports ROOT_URL_PATH_PREFIX",
+  async test => {
     const rootUrlPathPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
     __meteor_runtime_config__.ROOT_URL_PATH_PREFIX = '/test-root-url-prefix';
     const res = {
@@ -147,6 +147,6 @@ Tinytest.add("oauth - _endOfLoginResponse with redirect loginStyle supports ROOT
         }), 'binary').toString('base64')
       }
     };
-    OAuth._endOfLoginResponse(res, details);
+    await OAuth._endOfLoginResponse(res, details);
   }
 );

--- a/packages/oauth/oauth_tests.js
+++ b/packages/oauth/oauth_tests.js
@@ -99,8 +99,8 @@ Tinytest.addAsync("oauth - _endOfLoginResponse with popup loginStyle supports RO
   }
 );
 
-Tinytest.add("oauth - _endOfLoginResponse with redirect loginStyle supports unspecified ROOT_URL_PATH_PREFIX",
-  test => {
+Tinytest.addAsync("oauth - _endOfLoginResponse with redirect loginStyle supports unspecified ROOT_URL_PATH_PREFIX",
+  async test => {
     const res = {
       writeHead: () => {},
       end: content => {
@@ -119,7 +119,7 @@ Tinytest.add("oauth - _endOfLoginResponse with redirect loginStyle supports unsp
         }), 'binary').toString('base64')
       }
     };
-    OAuth._endOfLoginResponse(res, details);
+    await OAuth._endOfLoginResponse(res, details);
   }
 );
 


### PR DESCRIPTION
In this PR I focus on making ``oauth`` async, making it possible to have a Fibers-free MeteorJS.

- [x]  make tests pass
- [x]  Add docs in changelog