### PR TITLE
Fix errors in Mongo types

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -269,7 +269,7 @@ export namespace Mongo {
       transform?: Fn | undefined;
     }): boolean;
     dropCollectionAsync(): Promise<void>;
-    dropIndexAsync(indexName: string): void;
+    dropIndexAsync(indexName: string): Promise<void>;
     /**
      * Find the documents in a collection that match the selector.
      * @param selector A query describing the documents to find
@@ -541,8 +541,8 @@ export namespace Mongo {
       callbacks: ObserveChangesCallbacks<T>,
       options?: { nonMutatingCallbacks?: boolean | undefined }
     ): Meteor.LiveQueryHandle;
-    [Symbol.iterator](): Iterator<T, never, never>;
-    [Symbol.asyncIterator](): AsyncIterator<T, never, never>;
+    [Symbol.iterator](): Iterator<T>;
+    [Symbol.asyncIterator](): AsyncIterator<T>;
   }
 
   var ObjectID: ObjectIDStatic;


### PR DESCRIPTION
Both the synchronous and asynchronous iterators for Mongo.Cursor are defined to have a "next" argument type of never. However, TypeScript will reject using such an iterator in a for-of loop with:

> Cannot iterate value because the 'next' method of its iterator expects
> type 'never', but for-of will always send 'undefined'.ts(2763)

This changes back to the default (undefined), which is acceptable, since the iterators ignore any arguments passed into next() anyway.

It also correctly declares the return type of dropIndexAsync, which should return a Promise, not void.

(This is an analog to the PR I submitted to DefinitelyTyped: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63748)