### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/commandline.md
+++ b/docs/source/commandline.md
@@ -926,7 +926,7 @@ from npm to your `node_modules` directory and save its usage in your
 Using the `meteor npm ...` commands in place of traditional `npm ...` commands
 is particularly important when using Node.js modules that have binary
 dependencies that make native C calls (like [`bcrypt`](https://www.npmjs.com/package/bcrypt))
-because doing so ensures that they are built using the same libaries.
+because doing so ensures that they are built using the same libraries.
 
 Additionally, this access to the npm that comes with Meteor avoids the need to
 download and install npm separately.

--- a/tools/isobuild/compiler-deprecated-compile-step.js
+++ b/tools/isobuild/compiler-deprecated-compile-step.js
@@ -1,7 +1,7 @@
 // This file contains an old definition of CompileStep, an object that is passed
 // to the package-provided file handler.
 // Since then, the newer API called "Batch Plugins" have replaced it but we keep
-// the functionality for the backwards-compitability.
+// the functionality for the backwards-compatibility.
 // @deprecated
 // XXX COMPAT WITH 1.1.0.2
 

--- a/tools/utils/buildmessage.js
+++ b/tools/utils/buildmessage.js
@@ -75,7 +75,7 @@ Object.assign(Job.prototype, {
         }
         line += ": ";
       } else {
-        // not sure how to display messages without a filenanme.. try this?
+        // not sure how to display messages without a file name.. try this?
         line += "error: ";
       }
       // XXX line wrapping would be nice..


### PR DESCRIPTION
There are small typos in:
- docs/source/commandline.md
- tools/isobuild/compiler-deprecated-compile-step.js
- tools/utils/buildmessage.js

Fixes:
- Should read `libraries` rather than `libaries`.
- Should read `file name` rather than `filenanme`.
- Should read `compatibility` rather than `compitability`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md