### PR TITLE
Update skeletons to use React 18

### DIFF
--- a/packages/react-fast-refresh/package.js
+++ b/packages/react-fast-refresh/package.js
@@ -1,14 +1,14 @@
 Package.describe({
   name: 'react-fast-refresh',
-  version: '0.2.3',
+  version: '0.2.4',
   summary: 'Automatically update React components with HMR',
   documentation: 'README.md',
   devOnly: true,
 });
 
 Npm.depends({
-  'react-refresh': '0.11.0',
-  semver: '7.3.4',
+  'react-refresh': '0.14.0',
+  semver: '7.3.8',
 });
 
 Package.onUse(function(api) {

--- a/tools/static-assets/skel-apollo/client/main.jsx
+++ b/tools/static-assets/skel-apollo/client/main.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { createRoot } from 'react-dom/client';
 import { Meteor } from 'meteor/meteor';
-import { render } from 'react-dom';
 import { App } from '/imports/ui/App';
 
 Meteor.startup(() => {
-  render(<App/>, document.getElementById('react-target'));
+  const container = document.getElementById('react-target');
+  const root = createRoot(container);
+  root.render(<App />);
 });

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -8,12 +8,12 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
-    "@babel/runtime": "^7.18.6",
+    "@apollo/client": "^3.7.3",
+    "@babel/runtime": "^7.20.7",
     "apollo-server-express": "^3.10.0",
     "express": "^4.18.1",
-    "graphql": "^15.8.0",
-    "meteor-node-stubs": "^1.2.3",
+    "graphql": "^16.6.0",
+    "meteor-node-stubs": "^1.2.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/static-assets/skel-react/client/main.jsx
+++ b/tools/static-assets/skel-react/client/main.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { createRoot } from 'react-dom/client';
 import { Meteor } from 'meteor/meteor';
-import { render } from 'react-dom';
 import { App } from '/imports/ui/App';
 
 Meteor.startup(() => {
-  render(<App/>, document.getElementById('react-target'));
+  const container = document.getElementById('react-target');
+  const root = createRoot(container);
+  root.render(<App />);
 });

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -8,10 +8,10 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
-    "meteor-node-stubs": "^1.2.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "@babel/runtime": "^7.20.7",
+    "meteor-node-stubs": "^1.2.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "meteor": {
     "mainModule": {

--- a/tools/static-assets/skel-typescript/client/main.tsx
+++ b/tools/static-assets/skel-typescript/client/main.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { createRoot } from 'react-dom/client';
 import { Meteor } from 'meteor/meteor';
-import { render } from 'react-dom';
-import { App } from '/imports/ui/App'
+import { App } from '/imports/ui/App';
 
 Meteor.startup(() => {
-  render(<App />, document.getElementById('react-target'));
+  const container = document.getElementById('react-target');
+  const root = createRoot(container!);
+  root.render(<App />);
 });

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -8,16 +8,16 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.9",
-    "meteor-node-stubs": "^1.2.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "@babel/runtime": "^7.20.7",
+    "meteor-node-stubs": "^1.2.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/meteor": "^1.4.87",
     "@types/mocha": "^8.2.3",
-    "@types/react": "^17.0.43",
-    "@types/react-dom": "^17.0.14",
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.0.10",
     "typescript": "^4.6.4"
   },
   "meteor": {


### PR DESCRIPTION
Updated the following skeletons to use React 18 and the new `createRoot` function:
* Apollo
* React
* Typescript