### PR TITLE
Making oauth2 async 

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -61,6 +61,9 @@
   - `OAuth._storeRequestToken`
   - `OAuth._retrieveRequestToken`
 
+* `oauth2`:
+  - `OAuth._requestHandlers['2']` is now async.
+  
 ####  Internal API changes
 
 

--- a/packages/oauth2/oauth2_server.js
+++ b/packages/oauth2/oauth2_server.js
@@ -14,7 +14,7 @@ OAuth._requestHandlers['2'] = async (service, query, res) => {
 
     // Store the login result so it can be retrieved in another
     // browser tab by the result handler
-    OAuth._storePendingCredential(credentialToken, {
+    await OAuth._storePendingCredential(credentialToken, {
       serviceName: service.serviceName,
       serviceData: oauthResult.serviceData,
       options: oauthResult.options
@@ -23,5 +23,5 @@ OAuth._requestHandlers['2'] = async (service, query, res) => {
 
   // Either close the window, redirect, or render nothing
   // if all else fails
-  OAuth._renderOauthResults(res, query, credentialSecret);
+  await OAuth._renderOauthResults(res, query, credentialSecret);
 };

--- a/packages/oauth2/oauth2_tests.js
+++ b/packages/oauth2/oauth2_tests.js
@@ -6,7 +6,7 @@ const testPendingCredential = async function (test, method) {
   const credentialToken = Random.id();
   const serviceName = Random.id();
 
-  ServiceConfiguration.configurations.insert({service: serviceName});
+  await ServiceConfiguration.configurations.insert({service: serviceName});
 
   try {
     // register a fake login service
@@ -55,7 +55,7 @@ const testPendingCredential = async function (test, method) {
     const credentialSecret = respData;
 
     // Test that the result for the token is available
-    let result = OAuth._retrievePendingCredential(credentialToken,
+    let result = await OAuth._retrievePendingCredential(credentialToken,
                                                   credentialSecret);
     const serviceData = OAuth.openSecrets(result.serviceData);
     test.equal(result.serviceName, serviceName);
@@ -64,7 +64,7 @@ const testPendingCredential = async function (test, method) {
     test.equal(result.options.option1, foobookOption1);
 
     // Test that pending credential is removed after being retrieved
-    result = OAuth._retrievePendingCredential(credentialToken);
+    result = await OAuth._retrievePendingCredential(credentialToken);
     test.isUndefined(result);
 
   } finally {


### PR DESCRIPTION
In this PR I focus on making `oauth2` async, making it possible to have a Fibers-free MeteorJS.

- [x]  make tests pass
- [x]  Add docs in changelog