### PR TITLE
Allow multiple runtime config and updated runtime hooks

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -429,10 +429,11 @@ function getBoilerplateAsync(request, arch) {
       encodedCurrentConfig: boilerplate.baseData.meteorRuntimeConfig,
       updated: runtimeConfig.isUpdatedByArch[arch],
     });
-    if (!meteorRuntimeConfig) return;
+    if (!meteorRuntimeConfig) return true;
     boilerplate.baseData = Object.assign({}, boilerplate.baseData, {
       meteorRuntimeConfig,
     });
+    return true;
   });
   runtimeConfig.isUpdatedByArch[arch] = false;
   const data = Object.assign(
@@ -509,6 +510,7 @@ WebAppInternals.generateBoilerplateInstance = function(
   };
   runtimeConfig.updateHooks.forEach(cb => {
     cb({ arch, manifest, runtimeConfig: rtimeConfig });
+    return true;
   });
 
   const meteorRuntimeConfig = JSON.stringify(


### PR DESCRIPTION
The forEach method on Hook will stop iterating unless the iterator function returns a truthy value. Previously, this meant that only the first registered runtime config hook would be called.

(I ran into this by accident when I tried to add a second hook to my application in a different area of functionality. I attempted to look for other places throughout the codebase that might have this bug and wasn't able to find any others.)