### PR TITLE
Remove Blaze dependency and types that live in blaze.d.ts

### DIFF
--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -1,6 +1,5 @@
 import { Mongo } from 'meteor/mongo';
 import { EJSONable, EJSONableProperty } from 'meteor/ejson';
-import { Blaze } from 'meteor/blaze';
 import { DDP } from 'meteor/ddp';
 
 export type global_Error = Error;
@@ -372,26 +371,6 @@ export namespace Meteor {
   ): void;
   /** Login **/
 
-  /** Event **/
-  interface Event {
-    type: string;
-    target: HTMLElement;
-    currentTarget: HTMLElement;
-    which: number;
-    stopPropagation(): void;
-    stopImmediatePropagation(): void;
-    preventDefault(): void;
-    isPropagationStopped(): boolean;
-    isImmediatePropagationStopped(): boolean;
-    isDefaultPrevented(): boolean;
-  }
-  interface EventHandlerFunction extends Function {
-    (event?: Meteor.Event, templateInstance?: Blaze.TemplateInstance): void;
-  }
-  interface EventMap {
-    [id: string]: Meteor.EventHandlerFunction;
-  }
-  /** Event **/
 
   /** Connection **/
   function reconnect(): void;


### PR DESCRIPTION
EventsMap and friends are already in the @types/Meteor blaze.d.ts (not imported to meteor/blaze repo yet though)

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/meteor/blaze.d.ts