### PR TITLE
Replace double-ended-queue with denque

### DIFF
--- a/packages/meteor/fiber_helpers.js
+++ b/packages/meteor/fiber_helpers.js
@@ -13,7 +13,7 @@ Meteor._noYieldsAllowed = function (f) {
   }
 };
 
-Meteor._DoubleEndedQueue = Npm.require('double-ended-queue');
+Meteor._DoubleEndedQueue = Npm.require('denque');
 
 // Meteor._SynchronousQueue is a queue which runs task functions serially.
 // Tasks are assumed to be synchronous: ie, it's assumed that they are

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -11,7 +11,7 @@ Package.registerBuildPlugin({
 });
 
 Npm.depends({
-  "double-ended-queue": "2.1.0-0"
+  "denque": "2.1.0"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Replace https://github.com/petkaantonov/deque with https://github.com/invertase/denque a [faster](https://docs.page/invertase/denque/benchmarks) and much more maintained alternative 