### PR TITLE
Release 3.0 tests webapp

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -63,6 +63,9 @@
 
 * `oauth2`:
   - `OAuth._requestHandlers['2']` is now async.
+
+* `webapp`:
+  - `WebAppInternals.getBoilerplate` is now async.
   
 ####  Internal API changes
 

--- a/packages/server-render/server-render-tests.js
+++ b/packages/server-render/server-render-tests.js
@@ -51,7 +51,7 @@ Tinytest.addAsync(
     });
 
     try {
-      const { stream } = WebAppInternals.getBoilerplate({
+      const { stream } = await WebAppInternals.getBoilerplate({
         isServerRenderTest: true,
         browser: { name: "fake" },
         url: "/server-render/test",

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -326,7 +326,7 @@ WebAppInternals.registerBoilerplateDataCallback = function(key, callback) {
 // scripts are currently allowed.
 // XXX so far this function is always called with arch === 'web.browser'
 function getBoilerplate(request, arch) {
-  return getBoilerplateAsync(request, arch).await();
+  return getBoilerplateAsync(request, arch);
 }
 
 /**


### PR DESCRIPTION
In this PR I focus on making `webapp` async, making it possible to have a Fibers-free MeteorJS.

- [x]  make tests pass
- [x]  Add docs in changelog

![Screenshot 2023-01-11 at 19 06 15](https://user-images.githubusercontent.com/70247653/211928013-a720e7c0-1562-4903-91fb-5ea36dbce4c1.png)
