### PR TITLE
fix TypeScript version for meteor itself

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,7 +14,7 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "8.0.0",
     "node-pre-gyp": "0.15.0",
-    typescript: "4.5.4",
+    typescript: "4.7.4",
     "@meteorjs/babel": "7.18.0-beta.5",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.


### PR DESCRIPTION
Fix it until too late)

Lets synchronise our knowledge about the typescript upgrade process:

1) increase a TypeScript version in `npm-packages/meteor-babel/package.json`(@meteorjs/babel) and publish it.
2) update `typescript` and `@meteorjs/babel` in `scripts/dev-bundle-tool-package.js` (Meteor uses it to compile files from `tools` etc. AFAIK)
3) update `@meteorjs/babel` in `packages/babel-compiler/package.js`(it is for end users)
4) publish Meteor packages with new versions:
- `babel-compiler` (`packages/babel-compiler/package.js`)
- `ecmascript` (`packages/ecmascript/package.js`)
- `typescript` (`packages/typescript`)
5) Update skeletons:
- `tools/static-assets/skel-typescript/package.json`

You can see how it was done in my previous PR https://github.com/meteor/meteor/pull/11449/files

Maybe @zodern or @benjamn could correct me if I'm wrong.