### PR TITLE
OnlyOneOf support for match.js

### DIFF
--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -59,6 +59,10 @@ export const Match = {
   OneOf: function(...args) {
     return new OneOf(args);
   },
+  
+  OnlyOneOf: function(...args) {
+    return new OnlyOneOf(args);
+  },
 
   Any: ['__any__'],
   Where: function(condition) {
@@ -140,6 +144,16 @@ class OneOf {
   constructor(choices) {
     if (!choices || choices.length === 0) {
       throw new Error('Must provide at least one choice to Match.OneOf');
+    }
+
+    this.choices = choices;
+  }
+}
+
+class OnlyOneOf {
+  constructor(choices) {
+    if (!choices || choices.length === 0) {
+      throw new Error('Must provide at least one choice to Match.OnlyOneOf');
     }
 
     this.choices = choices;
@@ -349,6 +363,24 @@ const testSubtree = (value, pattern) => {
     // XXX this error is terrible
     return {
       message: 'Failed Match.OneOf, Match.Maybe or Match.Optional validation',
+      path: '',
+    };
+  }
+  
+  if (pattern instanceof OnlyOneOf) {
+    const results = [];
+    for (let i = 0; i < pattern.choices.length; ++i) {
+      results.push(testSubtree(value, pattern.choices[i]));
+    }
+
+    if (results.filter(r => r === false).length === 1) {
+
+      // Only one succeeded? Yay, return.
+      return false;
+    }
+
+    return {
+      message: 'Failed Match.OnlyOneOf validation',
       path: '',
     };
   }


### PR DESCRIPTION
Proposing to add `OnlyOneOf` as the equivalent of JSON Schema's [oneOf](https://json-schema.org/understanding-json-schema/reference/combining.html?highlight=oneof#oneof). It checks that there is one and only one match among the choices passed in. Could also be called `ExactlyOneOf` but I went with the shorter version.

I assumed that changing `Match.OneOf` to `Match.AnyOf`(to mimic JSON Schema's nomenclature) and using `Match.OneOf` for this new proposal would probably not be great for people who rely on this package.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
