### PR TITLE
Release 3.0 tests minifier css

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -64,6 +64,9 @@
 * `oauth2`:
   - `OAuth._requestHandlers['2']` is now async.
 
+* `minifier-css`:
+  - `minifyCss` is now async.
+
 * `webapp`:
   - `WebAppInternals.getBoilerplate` is now async.
   

--- a/packages/minifier-css/minifier-tests.js
+++ b/packages/minifier-css/minifier-tests.js
@@ -28,59 +28,61 @@ Tinytest.add(
   }
 );
 
-Tinytest.add('minifier-css - simple CSS minification', (test) => {
-  const checkMinified = (css, expected, desc) => {
-    test.equal(CssTools.minifyCss(css)[0], expected, desc);
-  };
+Tinytest.addAsync('minifier-css - simple CSS minification', async (test) => {
+  const checkMinified =
+    async (css, expected, desc) => {
+      const minified = await CssTools.minifyCss(css);
+      test.equal(minified[0], expected, desc);
+    };
 
-  checkMinified(
+  await checkMinified(
     'a \t\n{ color: red } \n',
     'a{color:red}',
     'whitespace check',
   );
-  checkMinified(
+  await checkMinified(
     'a \t\n{ color: red; margin: 1; } \n',
     'a{color:red;margin:1}',
     'only last one loses semicolon',
   );
-  checkMinified(
+  await checkMinified(
     'a \t\n{ color: red;;; margin: 1;;; } \n',
     'a{color:red;margin:1}',
     'more semicolons than needed',
   );
-  checkMinified(
+  await checkMinified(
     'a , p \t\n{ color: red; } \n',
     'a,p{color:red}',
     'multiple selectors',
   );
-  checkMinified(
+  await checkMinified(
     'body {}',
     '',
     'removing empty rules',
   );
-  checkMinified(
+  await checkMinified(
     '*.my-class { color: #fff; }',
     '.my-class{color:#fff}',
     'removing universal selector',
   );
-  checkMinified(
+  await checkMinified(
     'p > *.my-class { color: #fff; }',
     'p>.my-class{color:#fff}',
     'removing optional whitespace around ">" in selector',
   );
-  checkMinified(
+  await checkMinified(
     'p +  *.my-class { color: #fff; }',
     'p+.my-class{color:#fff}',
     'removing optional whitespace around "+" in selector',
   );
-  checkMinified(
+  await checkMinified(
     'a {\n\
     font:12px \'Helvetica\',"Arial",\'Nautica\';\n\
     background:url("/some/nice/picture.png");\n}',
     'a{font:12px Helvetica,Arial,Nautica;background:url(/some/nice/picture.png)}',
     'removing quotes in font and url (if possible)',
   );
-  checkMinified(
+  await checkMinified(
     '/* no comments */ a { color: red; }',
     'a{color:red}',
     'remove comments',

--- a/packages/minifier-css/minifier.js
+++ b/packages/minifier-css/minifier.js
@@ -61,10 +61,10 @@ const CssTools = {
    * Minify the passed in CSS string.
    *
    * @param {string} cssText CSS string to minify.
-   * @return {String[]} Array containing the minified CSS.
+   * @return {Promise<String[]>} Array containing the minified CSS.
    */
   minifyCss(cssText) {
-    return Promise.await(CssTools.minifyCssAsync(cssText));
+    return CssTools.minifyCssAsync(cssText);
   },
 
   /**


### PR DESCRIPTION
In this PR I focus on making `minifier-css` async, making it possible to have a Fibers-free MeteorJS.

- [x]  make tests pass
- [x]  Add docs in changelog
![image](https://user-images.githubusercontent.com/70247653/212779010-32b16d28-1a5e-431c-8fc5-b0fde72c4cef.png)
