### PR TITLE
[3.0] Solving meteor-promise tests

### DIFF
--- a/packages/promise/promise-tests.js
+++ b/packages/promise/promise-tests.js
@@ -7,14 +7,6 @@ Tinytest.addAsync("meteor-promise - sanity", function (test, done) {
     })
     .catch(function (error) {
       test.equal(error, expectedError);
-      if (Meteor.isServer) {
-        // TODO[FIBERS]: Remove this in 3.0
-        if (Meteor._isFibersEnabled) {
-          var Fiber = require("fibers");
-          // Make sure the Promise polyfill runs callbacks in a Fiber.
-          test.instanceOf(Fiber.current, Fiber);
-        }
-      }
     })
     .then(done, function (error) {
       test.exception(error);

--- a/packages/promise/promise-tests.js
+++ b/packages/promise/promise-tests.js
@@ -1,18 +1,24 @@
 Tinytest.addAsync("meteor-promise - sanity", function (test, done) {
   var expectedError = new Error("expected");
-  Promise.resolve("working").then(function (result) {
-    test.equal(result, "working");
-    throw expectedError;
-  }).catch(function (error) {
-    test.equal(error, expectedError);
-    if (Meteor.isServer) {
-      var Fiber = require("fibers");
-      // Make sure the Promise polyfill runs callbacks in a Fiber.
-      test.instanceOf(Fiber.current, Fiber);
-    }
-  }).then(done, function (error) {
-    test.exception(error);
-  });
+  Promise.resolve("working")
+    .then(function (result) {
+      test.equal(result, "working");
+      throw expectedError;
+    })
+    .catch(function (error) {
+      test.equal(error, expectedError);
+      if (Meteor.isServer) {
+        // TODO[FIBERS]: Remove this in 3.0
+        if (Meteor._isFibersEnabled) {
+          var Fiber = require("fibers");
+          // Make sure the Promise polyfill runs callbacks in a Fiber.
+          test.instanceOf(Fiber.current, Fiber);
+        }
+      }
+    })
+    .then(done, function (error) {
+      test.exception(error);
+    });
 });
 
 Tinytest.addAsync("meteor-promise - finally", function (test, done) {


### PR DESCRIPTION
In this PR I focus on making `promise` async, making it possible to have a Fibers-free MeteorJS.

- [x]  make tests pass
- [x]  Add docs in changelog (there were none)
![Screenshot 2023-01-16 at 20 29 57](https://user-images.githubusercontent.com/70247653/212779921-7273b993-d7f7-483d-9412-0dddcb70a95d.png)
