### PR TITLE
Deprecate appcache package

### DIFF
--- a/docs/source/packages/appcache.md
+++ b/docs/source/packages/appcache.md
@@ -3,6 +3,8 @@ title: appcache
 description: Documentation of Meteor's `appcache` package.
 ---
 
+> This package has been deprecated since [applicationCache](https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache), which this package relies on, has been deprecated and is not available on the latest browsers. Plaese consider using [Service Worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) as an replacement.
+
 The `appcache` package stores the static parts of a Meteor application
 (the client side Javascript, HTML, CSS, and images) in the browser's
 [application cache](https://en.wikipedia.org/wiki/AppCache). To enable

--- a/packages/appcache/CHANGELOG.md
+++ b/packages/appcache/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.2.8, 2022-01-19
+
+* Package has been deprecated since [applicationCache](https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache), which this package relies on, has been deprecated and is not available on the latest browsers.
+
 ## v1.2.3, 2019-12-13
 
 * Rewrite appcache resources exceed recommended cache size debug message. Fixes [Issue #10321](https://github.com/meteor/meteor/issues/10321). Thanks [@CaptainN](https://github.com/CaptainN)

--- a/packages/appcache/package.js
+++ b/packages/appcache/package.js
@@ -1,6 +1,7 @@
 Package.describe({
   summary: "Enable the application cache in the browser",
-  version: "1.2.7",
+  version: "1.2.8",
+  deprecated: true,
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
Deprecate the `appcache` package as its underlying technology is no longer supported on latest Chrome. #12445