### PR TITLE
Bump Typescript to v4.9.4

### DIFF
--- a/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
+++ b/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
@@ -14,8 +14,8 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "8.0.0",
     "node-pre-gyp": "0.15.0",
-    typescript: "4.7.4",
-    "@meteorjs/babel": "7.18.0-beta.5",
+    typescript: "4.9.4",
+    "@meteorjs/babel": "7.18.0-beta.6",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",

--- a/npm-packages/meteor-babel/package.json
+++ b/npm-packages/meteor-babel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meteorjs/babel",
   "author": "Meteor <dev@meteor.com>",
-  "version": "7.18.0-beta.5",
+  "version": "7.18.0-beta.6",
   "license": "MIT",
   "description": "Babel wrapper package for use with Meteor",
   "keywords": [
@@ -47,7 +47,7 @@
     "convert-source-map": "^1.6.0",
     "lodash": "^4.17.21",
     "meteor-babel-helpers": "0.0.3",
-    "typescript": "~4.7.4"
+    "typescript": "~4.9.4"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "7.14.5",

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   name: "babel-compiler",
   summary: "Parser/transpiler for ECMAScript 2015+ syntax",
-  version: '7.10.2'
+  version: '7.10.3'
 });
 
 Npm.depends({
-  '@meteorjs/babel': '7.18.0-beta.5',
+  '@meteorjs/babel': '7.18.0-beta.6',
   'json5': '2.1.1'
 });
 

--- a/packages/typescript/package.js
+++ b/packages/typescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'typescript',
-  version: '4.7.4',
+  version: '4.9.4',
   summary:
     'Compiler plugin that compiles TypeScript and ECMAScript in .ts and .tsx files',
   documentation: 'README.md',

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,8 +14,8 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "8.0.0",
     "node-pre-gyp": "0.15.0",
-    typescript: "4.7.4",
-    "@meteorjs/babel": "7.18.0-beta.5",
+    typescript: "4.9.4",
+    "@meteorjs/babel": "7.18.0-beta.6",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -18,7 +18,7 @@
     "@types/mocha": "^8.2.3",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.4"
   },
   "meteor": {
     "mainModule": {


### PR DESCRIPTION
Feature: Bump TS to 4.9.4

Done in accordance with the changes in https://github.com/meteor/meteor/pull/12393 and https://github.com/meteor/meteor/pull/12441
