### PR TITLE
mongo: In async wrappers, catch exceptions and reject

### DIFF
--- a/packages/minimongo/cursor.js
+++ b/packages/minimongo/cursor.js
@@ -520,6 +520,10 @@ export default class Cursor {
 ASYNC_CURSOR_METHODS.forEach(method => {
   const asyncName = getAsyncMethodName(method);
   Cursor.prototype[asyncName] = function(...args) {
-    return Promise.resolve(this[method].apply(this, args));
+    try {
+      return Promise.resolve(this[method].apply(this, args));
+    } catch (error) {
+      return Promise.reject(error);
+    }
   };
 });

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -919,6 +919,10 @@ function popCallbackFromArgs(args) {
 ASYNC_COLLECTION_METHODS.forEach(methodName => {
   const methodNameAsync = getAsyncMethodName(methodName);
   Mongo.Collection.prototype[methodNameAsync] = function(...args) {
-    return Promise.resolve(this[methodName](...args));
+    try {
+      return Promise.resolve(this[methodName](...args));
+    } catch (error) {
+      return Promise.reject(error);
+    }
   };
 });

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -945,7 +945,11 @@ Cursor.prototype.count = function () {
 
   const methodNameAsync = getAsyncMethodName(methodName);
   Cursor.prototype[methodNameAsync] = function (...args) {
-    return Promise.resolve(this[methodName](...args));
+    try {
+      return Promise.resolve(this[methodName](...args));
+    } catch (error) {
+      return Promise.reject(error);
+    }
   };
 });
 


### PR DESCRIPTION
Previously, if an exception was thrown in an async method, it would not be caught, which is unusual in an async method. Instead, catch the exception and return it as a rejected promise.