### PR TITLE
Updating tracker types 

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -36,6 +36,9 @@ N/A
 * `mongo@1.16.5`:
   - In async wrappers, catch exceptions and reject
 
+* `Tracker@1.3.1`:
+  - Added missing withComputation method in types
+
 * `typescript@4.9.4`
   - Updated typescript to version 4.9.4.
 

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dependency tracker to allow reactive callbacks",
-  version: "1.3.0"
+  version: "1.3.1-beta2110.0"
 });
 
 Package.onUse(function (api) {

--- a/packages/tracker/tracker.d.ts
+++ b/packages/tracker/tracker.d.ts
@@ -110,6 +110,16 @@ export namespace Tracker {
   ): Computation;
 
   /**
+   * Helper function to make the tracker work with promises.
+   * @param computation Computation that tracked
+   * @param func async function that needs to be called and be reactive
+   */
+  function withComputation<T>(
+    computation: Computation,
+    func: () => Promise<T>
+  ): Promise<T>;
+
+  /**
    * Process all reactive updates immediately and ensure that all invalidated computations are rerun.
    */
   function flush(): void;


### PR DESCRIPTION
With the addition of ``Tracker.withComputation`` in meteor 2.10, the type definitions of this new method were left missing.
In this PR I focus on adding it.