### PR TITLE
Made standard-minifier-css debuggable

### DIFF
--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -9,7 +9,8 @@ Package.registerBuildPlugin({
   name: "minifyStdCSS",
   use: [
     'minifier-css',
-    'ecmascript'
+    'ecmascript',
+    'logging',
   ],
   npmDependencies: {
     "@babel/runtime": "7.18.9",
@@ -25,4 +26,5 @@ Package.registerBuildPlugin({
 Package.onUse(function(api) {
   api.use('minifier-css@1.5.4');
   api.use('isobuild:minifier-plugin@1.0.0');
+  api.use('logging@1.3.1');
 });

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'standard-minifier-css',
   version: '1.9.0',
   summary: 'Standard css minifier used with Meteor apps by default.',
-  documentation: 'README.md'
+  documentation: 'README.md',
 });
 
 Package.registerBuildPlugin({
@@ -16,10 +16,10 @@ Package.registerBuildPlugin({
     "@babel/runtime": "7.18.9",
     "source-map": "0.7.4",
     "lru-cache": "6.0.0",
-    "micromatch": "4.0.5"
+    "micromatch": "4.0.5",
   },
   sources: [
-    'plugin/minify-css.js'
+    'plugin/minify-css.js',
   ]
 });
 

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.8.3',
+  version: '1.8.4',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '1.8.4',
+  version: '1.9.0',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md'
 });

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -3,8 +3,9 @@ import { createHash } from "crypto";
 import LRU from "lru-cache";
 import { loadPostCss, watchAndHashDeps, usePostCss } from './postcss.js';
 
-const verbose = (process.env.DEBUG_CSS!=="false" && process.env.DEBUG_CSS!=="0" && (
-  process.env.DEBUG_CSS || process.argv.indexOf('--verbose') > -1 || process.argv.indexOf('--debug') > -1
+const { argv, env:{ DEBUG_CSS } } = process;
+const verbose = (DEBUG_CSS!=="false" && DEBUG_CSS!=="0" && (
+  DEBUG_CSS || argv.indexOf('--verbose') > -1 || argv.indexOf('--debug') > -1
 ));
 
 Plugin.registerMinifier({

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -11,7 +11,7 @@ const verbose = (DEBUG_CSS!=="false" && DEBUG_CSS!=="0" && (
 
 Plugin.registerMinifier({
   extensions: ["css"],
-  archMatching: "web"
+  archMatching: "web",
 }, function () {
   const minifier = new CssToolsMinifier();
   return minifier;
@@ -20,7 +20,7 @@ Plugin.registerMinifier({
 class CssToolsMinifier {
   constructor() {
     this.cache = new LRU({
-      max: 100
+      max: 100,
     });
 
     this.depsHashCache = Object.create(null);
@@ -86,7 +86,7 @@ class CssToolsMinifier {
       result = [{
         data: merged.code,
         sourceMap: merged.sourceMap,
-        path: 'merged-stylesheets.css'
+        path: 'merged-stylesheets.css',
       }];
     } else {
       if (verbose) process.stdout.write(` > minifying`);
@@ -106,7 +106,7 @@ class CssToolsMinifier {
     this.cache.set(cacheKey, {
       stylesheets: result,
       deps: merged.deps,
-      depsCacheKey: this.watchAndHashDeps(merged.deps, files[0])
+      depsCacheKey: this.watchAndHashDeps(merged.deps, files[0]),
     });
     return result;
   }
@@ -166,7 +166,7 @@ const mergeCss = Profile("mergeCss", async function (css, postcssConfig) {
           postcssConfig.plugins
         ).process(content, {
           from: Plugin.convertToOSPath(file.getSourcePath()),
-          parser: postcssConfig.options.parser
+          parser: postcssConfig.options.parser,
         });
 
         result.warnings().forEach(warning => {
@@ -188,7 +188,7 @@ const mergeCss = Profile("mergeCss", async function (css, postcssConfig) {
         file.error({
           message: e.reason,
           line: e.line,
-          column: e.column
+          column: e.column,
         });
       } else {
         // Just in case it's not the normal error the library makes.
@@ -209,7 +209,7 @@ const mergeCss = Profile("mergeCss", async function (css, postcssConfig) {
   const stringifiedCss = CssTools.stringifyCss(mergedCssAst, {
     sourcemap: true,
     // don't try to read the referenced sourcemaps from the input
-    inputSourcemaps: false
+    inputSourcemaps: false,
   });
 
   if (! stringifiedCss.code) {
@@ -258,7 +258,7 @@ const mergeCss = Profile("mergeCss", async function (css, postcssConfig) {
 
       let original = {
         line: mapping.originalLine,
-        column: mapping.originalColumn
+        column: mapping.originalColumn,
       };
 
       // If there is a source map for the original file, e.g., if it has been
@@ -294,7 +294,7 @@ const mergeCss = Profile("mergeCss", async function (css, postcssConfig) {
       newMap.addMapping({
         generated: {
           line: mapping.generatedLine,
-          column: mapping.generatedColumn
+          column: mapping.generatedColumn,
         },
         original,
         source,
@@ -319,7 +319,7 @@ const mergeCss = Profile("mergeCss", async function (css, postcssConfig) {
   return {
     code: stringifiedCss.code,
     sourceMap: newMap.toString(),
-    deps
+    deps,
   };
 });
 

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -59,8 +59,8 @@ class CssToolsMinifier {
       cachedResult.depsCacheKey === this.watchAndHashDeps(cachedResult.deps, files[0])
     ) {
       if (verbose && !this.haveHitAnyCache) {
-        clearTimeout(this.tmrShowStats); // after we hit the cache, it's a good time to show stats
-        this.tmrShowStats = setTimeout( () => { // we use a timeout to give all files a chance to finish being minified
+        this.haveHitAnyCache = true;
+        setTimeout( () => { // we use a timeout to give all files a chance to finish being minified
           const stats = [`minifyStdCSS: Total CSS ${this.formatSize(this.totalSize)}`];
           if (this.totalMinifiedSize!==0) {
             stats.push(`minified ${this.formatSize(this.totalMinifiedSize)}`);
@@ -68,7 +68,6 @@ class CssToolsMinifier {
           }
           console.log(stats.join(", "));
         }, 500);
-        this.haveHitAnyCache = true;
       }
       return cachedResult.stylesheets;
     }

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -2,6 +2,7 @@ import sourcemap from "source-map";
 import { createHash } from "crypto";
 import LRU from "lru-cache";
 import { loadPostCss, watchAndHashDeps, usePostCss } from './postcss.js';
+import { Log } from 'meteor/logging';
 
 const { argv, env:{ DEBUG_CSS } } = process;
 const verbose = (DEBUG_CSS!=="false" && DEBUG_CSS!=="0" && (
@@ -116,7 +117,7 @@ class CssToolsMinifier {
     const { error, postcssConfig } = await loadPostCss();
 
     if (error) {
-      if (verbose) console.error('processFilesForBundle loadPostCss error', error);
+      if (verbose) Log.error('processFilesForBundle loadPostCss error', error);
       files[0].error(error);
       return;
     }
@@ -326,5 +327,5 @@ function warnCb (filename, msg) {
   // XXX make this a buildmessage.warning call rather than a random log.
   //     this API would be like buildmessage.error, but wouldn't cause
   //     the build to fail.
-  console.log(`${filename}: warn: ${msg}`);
+  Log.warn(`${filename}: warn: ${msg}`);
 };

--- a/packages/standard-minifier-css/plugin/minify-css.js
+++ b/packages/standard-minifier-css/plugin/minify-css.js
@@ -116,7 +116,7 @@ class CssToolsMinifier {
     const { error, postcssConfig } = await loadPostCss();
 
     if (error) {
-      if (verbose) console.log('processFilesForBundle loadPostCss error', error);
+      if (verbose) console.error('processFilesForBundle loadPostCss error', error);
       files[0].error(error);
       return;
     }

--- a/packages/standard-minifier-css/plugin/postcss.js
+++ b/packages/standard-minifier-css/plugin/postcss.js
@@ -52,7 +52,7 @@ export async function loadPostCss() {
 
     e.message = `While loading postcss config: ${e.message}`;
     return {
-      error: e
+      error: e,
     };
   }
 

--- a/packages/standard-minifier-css/plugin/postcss.js
+++ b/packages/standard-minifier-css/plugin/postcss.js
@@ -95,7 +95,7 @@ export function usePostCss(file, postcssConfig) {
   const path = file.getPathInBundle();
 
   const excluded = excludedPackages.some(name => {
-    return path.includes(`packages/${name.replace(':', '_')}`)
+    return path.includes(`packages/${name.replace(':', '_')}`);
   });
 
   return !excluded;
@@ -136,7 +136,7 @@ export const watchAndHashDeps = Profile(
         const entries = fs.readdirWithTypesSync(absDir);
         for (const entry of entries) {
           const relPath = path.join(relDir, entry.name);
-  
+
           if (entry.isFile() && matchers.some(isMatch => isMatch(relPath))) {
             const absPath = path.join(absDir, entry.name);
             fileCount += 1;

--- a/packages/standard-minifier-css/plugin/postcss.js
+++ b/packages/standard-minifier-css/plugin/postcss.js
@@ -16,7 +16,7 @@ const missingPostCssError = new Error([
     'directory. Please run the following command to install it:',
     '    meteor npm install postcss@8',
     'or disable postcss by removing the postcss config.',
-    ''
+    '',
   ].join('\n'));
 
 export async function loadPostCss() {
@@ -73,7 +73,7 @@ export async function loadPostCss() {
       'directory. standard-minifier-css is only compatible with',
       'version 8 of PostCSS. Please restart Meteor after installing',
       'a supported version of PostCSS',
-      ''
+      '',
     ].join('\n'));
 
     return { error };

--- a/packages/standard-minifier-css/plugin/postcss.js
+++ b/packages/standard-minifier-css/plugin/postcss.js
@@ -109,7 +109,7 @@ export const watchAndHashDeps = Profile(
     let fileCount = 0;
     let folderCount = 0;
     let start = performance.now();
-  
+
     deps.forEach(dep => {
       if (dep.type === 'dependency') {
         fileCount += 1;
@@ -123,16 +123,16 @@ export const watchAndHashDeps = Profile(
         }
       }
     });
-  
-  
+
+
     Object.entries(globsByDir).forEach(([parentDir, globs]) => {
       const matchers = globs.map(glob => micromatch.matcher(glob));
-  
+
       function walk(relDir) {
         const absDir = path.join(parentDir, relDir);
         hash.update(absDir).update('\0');
         folderCount += 1;
-  
+
         const entries = fs.readdirWithTypesSync(absDir);
         for (const entry of entries) {
           const relPath = path.join(relDir, entry.name);
@@ -148,12 +148,12 @@ export const watchAndHashDeps = Profile(
           }
         }
       }
-  
+
       walk('./');
     });
-  
+
     let digest = hash.digest('hex');
-  
+
     if (DEBUG_CACHE) {
       console.log('--- PostCSS Cache Info ---');
       console.log('Glob deps', JSON.stringify(globsByDir, null, 2));
@@ -162,6 +162,6 @@ export const watchAndHashDeps = Profile(
       console.log('Created dep cache key in', performance.now() - start, 'ms');
       console.log('--------------------------');
     }
-  
+
     return digest;
 });


### PR DESCRIPTION
Thank you for contributing to Meteor. (My all-day every day stack since 2015)
Thank you for taking the time to review my PR!
Feedback and suggestions are welcome and appreciated.

# Scope
Made minifyStdCSS aka standard-minifier-css debuggable.

## How standard-minifier-css becomes verbose
* Either of the common debugging commandline arguments
  * `--verbose`
  * `--debug`
* Environment variable 
  * `DEBUG_CSS`

# Why I created this PR - TLDR
I suffered terribly because if a postcss-plugin goes into an infinite loop, the whole build process gets stuck and there's zero indication from the meteor build tool
* Whether the build process has stalled or not
* What part of the build is having trouble
Etc, `--debug` and `--verbose` had zero effect on `standard-minifier-css` yet it's probably the most likely part of the build process to fail. And if it fails, there's no way to see which file it failed on, whether it even failed while reading a file, or perhaps for some other reason, like a dependency, new bug or whatever.

## I made this PR because
* In my experience with Meteor full-time since 2015, if I can't build, it's usually a SCSS problem (with zero visibility which file etc)
* I like this debug feature that I've added and I intend to leave it enabled, most likely.
* I want this debug feature available for myself and my team
* I don't want other developers to suffer like I did. I want people to use and love Meteor, and not abandon it out of frustration as so many developers have.

# 264 issues mentioning standard-minifier-css
https://github.com/meteor/meteor/issues?q=is%3Aissue+standard-minifier-css
(granted not all of those issues will be about standard-minifier-css) but no-doubt a huge number of past and future issues, (both reported issues and unreported issues that developers silently struggle with) will be involving standard-minifier-css in some way; and it's not even debuggable at all. Literally can't see anything at all. It's currently like theoretical dark-matter.

I'm willing to bet that adding this feature will reduce the number of issues and give developers a better, quicker, easier experience. And free up all the Meteor contributors to contribute more to Meteor rather than helping with issues that could be prevented or getting slowed down by friction in the development experience that we can eliminate.

# How to prevent standard-minifier-css being verbose
`DEBUG_CSS=false` or `DEBUG_CSS=0` will prevent it from being verbose regardless of `--verbose` or `--debug` commandline arguments, because `DEBUG_CSS` is specific.

# Style
I love Meteor. I work with it all day every day. I've brought 3 of my biggest long-term web-dev clients and all their developers to Meteor.
I really want this package to be debuggable. If you don't like the style that I coded in, just tell me what style you want etc and I'll change it to meet your preferences. As long as it's debuggable, that's great.

# Why I created this PR - Detailed version
Prior to this PR `standard-minifier-css` was an absolute black box.

Recently I had not done a build for about a month, and my meteor build process was getting stuck after long delays, providing no feedback to me if the build process was even stuck or not. I just noticed 100% CPU usage and the `/ - \ |` spinner in the terminal seemed to stop spinning or be taking very long.

`--debug` and `--verbose` provided zero benefit to me.
It was incredibly frustrating and wasted so much of my time, checking out old/new versions of my project and reinstalling meteor and all packages many times before I realized via a process of randomly eliminating NPM modules and meteor packages that the problem was happening inside the standard-minifier-css.

From there I went on a wild-goose chase trying older versions of standard-minifier-css. Then I finally arrived at a theory that the problem must be triggered/caused by one of my CSS files, but I have a huge amount of CSS files and I had no way of knowing which file it was getting stuck on. I tried to manually process my SCSS files individually with postcss-cli, but couldn't get postcss-cli working with required plugins. Finally I had the idea to add functionality to standard-minifier-css to make it debuggable.

Now that standard-minifier-css has a verbose mode, the file that was having trouble being processed is revealed instantly, effortlessly and intuitively to any developer who's having trouble.

The actual problem is a postcss plugin was going into an infinite loop, but only during builds, due to a missing environment variable for the build (and lack of throwing an error when environment variable was missing) These are trivial problems to fix, but only when it's possible to debug CSS builds, which is what this PR does.

