### PR TITLE
Upgrade Apollo starter to Apollo server v4

### DIFF
--- a/tools/static-assets/skel-apollo/imports/ui/App.jsx
+++ b/tools/static-assets/skel-apollo/imports/ui/App.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { InMemoryCache, ApolloProvider, ApolloClient, ApolloLink } from '@apollo/client';
-import { BatchHttpLink } from '@apollo/client/link/batch-http'
+import { InMemoryCache, ApolloProvider, ApolloClient, ApolloLink, HttpLink } from '@apollo/client';
 // import { MeteorAccountsLink } from 'meteor/apollo'
 import { Hello } from './Hello.jsx';
 import { Info } from './Info.jsx';
@@ -9,7 +8,7 @@ const cache = new InMemoryCache().restore(window.__APOLLO_STATE__);
 
 const link = ApolloLink.from([
   // MeteorAccountsLink(),
-  new BatchHttpLink({
+  new HttpLink({
     uri: '/graphql'
   })
 ]);

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -8,10 +8,11 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@apollo/client": "^3.7.3",
-    "@babel/runtime": "^7.20.7",
-    "apollo-server-express": "^3.10.0",
-    "express": "^4.18.1",
+    "@apollo/client": "^3.7.5",
+    "@apollo/server": "^4.3.2",
+    "@babel/runtime": "^7.20.13",
+    "body-parser": "^1.20.1",
+    "express": "^4.18.2",
     "graphql": "^16.6.0",
     "meteor-node-stubs": "^1.2.5",
     "react": "^18.2.0",

--- a/tools/static-assets/skel-apollo/server/apollo.js
+++ b/tools/static-assets/skel-apollo/server/apollo.js
@@ -1,8 +1,11 @@
-import { ApolloServer } from 'apollo-server-express';
+import { ApolloServer } from '@apollo/server';
 import { WebApp } from 'meteor/webapp';
 import { getUser } from 'meteor/apollo';
 import { LinksCollection } from '/imports/api/links';
 import typeDefs from '/imports/apollo/schema.graphql';
+import express from 'express';
+import { expressMiddleware } from '@apollo/server/express4';
+import { json } from 'body-parser';
 
 const resolvers = {
   Query: {
@@ -11,21 +14,25 @@ const resolvers = {
   }
 };
 
+const context = async ({ req }) => ({
+  user: await getUser(req.headers.authorization)
+})
+
 const server = new ApolloServer({
   cache: 'bounded',
   typeDefs,
   resolvers,
-  context: async ({ req }) => ({
-    user: await getUser(req.headers.authorization)
-  })
 });
 
 export async function startApolloServer() {
   await server.start();
-  const app = WebApp.connectHandlers;
 
-  server.applyMiddleware({
-    app,
-    cors: true
-  });
+  WebApp.connectHandlers.use(
+    '/graphql',                                     // Configure the path as you want.
+    express()                                       // Create new Express router.
+      .disable('etag')                     // We don't server GET requests, so there's no need for that.
+      .disable('x-powered-by')             // A small safety measure.
+      .use(json())                                  // From `body-parser`.
+      .use(expressMiddleware(server, { context })), // From `@apollo/server/express4`.
+  )
 }


### PR DESCRIPTION
As title suggest, this PR upgrades the Apollo starter to use Apollo Server v4.

Another change is disabling http batching on client as it was disabled on the server:
https://www.apollographql.com/docs/apollo-server/migration/#http-batching-is-off-by-default

Thanks to @radekmie for consultation on this.