### PR TITLE
Make archinfo.host sync

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -187,8 +187,8 @@ main.registerCommand({
   requiresRelease: false,
   pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
-}, async function () {
-  Console.rawInfo(await archinfo.host() + "\n");
+}, function () {
+  Console.rawInfo(archinfo.host() + "\n");
 });
 
 // Prints the current release in use. Note that if there is not
@@ -1041,11 +1041,11 @@ var buildCommand = async function (options) {
     showInvalidArchMsg(options.architecture);
     return 1;
   }
-  var bundleArch = options.architecture || await archinfo.host();
+  var bundleArch = options.architecture || archinfo.host();
 
   var projectContext = new projectContextModule.ProjectContext({
     projectDir: options.appDir,
-    serverArchitectures: _.uniq([bundleArch, await archinfo.host()]),
+    serverArchitectures: _.uniq([bundleArch, archinfo.host()]),
     allowIncompatibleUpdate: options['allow-incompatible-update']
   });
   await projectContext.init();
@@ -1346,7 +1346,7 @@ main.registerCommand({
   if (! projectContext && appDir) {
     projectContext = new projectContextModule.ProjectContext({
       projectDir: appDir,
-      serverArchitectures: [await archinfo.host()],
+      serverArchitectures: [archinfo.host()],
       allowIncompatibleUpdate: options['allow-incompatible-update'],
       lintAppAndLocalPackages: true
     });
@@ -1848,7 +1848,7 @@ async function doTestCommand(options) {
 
   // Download packages for our architecture, and for the deploy server's
   // architecture if we're deploying.
-  const archInfoHost = await archinfo.host();
+  const archInfoHost = archinfo.host();
   var serverArchitectures = [archInfoHost];
   if (options.deploy && DEPLOY_ARCH !== archInfoHost) {
     serverArchitectures.push(DEPLOY_ARCH);

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -1557,7 +1557,8 @@ makeGlobalAsyncLocalStorage().run({}, async function () {
     } else if (e instanceof main.ExitWithCode) {
       process.exit(e.code);
     } else {
-      throw e;
+      console.error(e);
+      process.exit(1);
     }
   }
 

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -495,7 +495,7 @@ var springboard = async function (rel, options) {
   });
 
   if (!toolRecord) {
-    throw Error("missing tool for " + await archinfo.host() + " in " +
+    throw Error("missing tool for " + archinfo.host() + " in " +
                 toolsPkg + "@" + toolsVersion);
   }
 

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -372,9 +372,7 @@ function watchLibraryWatch(absPath: string, callback: EntryCallback) {
 
 let suggestedRaisingWatchLimit = false;
 
-// This function is async so that archinfo.host() (which may call
-// utils.execFileSync) will run in a Fiber.
-async function maybeSuggestRaisingWatchLimit(error: Error & { errno: number }) {
+function maybeSuggestRaisingWatchLimit(error: Error & { errno: number }) {
   var constants = require('constants');
   var archinfo = require('../utils/archinfo');
   if (! suggestedRaisingWatchLimit &&
@@ -388,7 +386,7 @@ async function maybeSuggestRaisingWatchLimit(error: Error & { errno: number }) {
       // proposed PR, which had a slightly different interface).
       error.errno === constants.ENOSPC &&
       // The only suggestion we currently have is for Linux.
-      archinfo.matches(await archinfo.host(), 'os.linux')) {
+      archinfo.matches(archinfo.host(), 'os.linux')) {
 
     // Check suggestedRaisingWatchLimit again because archinfo.host() may
     // have yielded.

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -951,7 +951,7 @@ class Target {
         if (p.testOnly && this.buildMode !== 'test') {
           continue;
         }
-        const unibuild = await p.getUnibuildAtArch(this.arch);
+        const unibuild = p.getUnibuildAtArch(this.arch);
         unibuild && rootUnibuilds.push(unibuild);
       }
 
@@ -2594,7 +2594,7 @@ class JsImage {
     ret.arch = json.arch;
 
     // Rebuild binary npm packages if host arch matches image arch.
-    const rebuildBinaries = archinfo.matches(await archinfo.host(), ret.arch);
+    const rebuildBinaries = archinfo.matches(archinfo.host(), ret.arch);
 
     for (const item of json.load) {
       rejectBadPath(item.path);
@@ -3209,7 +3209,7 @@ async function bundle({
 }) {
   buildOptions = buildOptions || {};
 
-  var serverArch = buildOptions.serverArch || await archinfo.host();
+  var serverArch = buildOptions.serverArch || archinfo.host();
   var webArchs;
   if (buildOptions.webArchs) {
     // Don't attempt to build web.cordova when platforms have been removed
@@ -3596,7 +3596,7 @@ exports.buildJsImage = Profile("bundler.buildJsImage", async function (options) 
     // cross-bundling, not cross-package-building, and this function is only
     // used to build plugins (during package build) and for isopack.load
     // (which always wants to build for the current host).
-    arch: await archinfo.host()
+    arch: archinfo.host()
   });
 
   await target.make({ packages: [isopack] });

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -1110,7 +1110,7 @@ export class PackageSourceBatch {
 
     self.useMeteorInstall =
         _.isString(self.sourceRoot) &&
-        await self.processor.isopackCache.uses(
+        self.processor.isopackCache.uses(
             self.unibuild.pkg,
             "modules",
             self.unibuild.arch

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -675,7 +675,7 @@ api.addAssets('${relPath}', 'client').`);
   var arch = inputSourceArch.arch;
   if (arch === "os" && ! isPortable) {
     // Contains non-portable compiled npm modules, so set arch correctly
-    arch = await archinfo.host();
+    arch = archinfo.host();
   }
 
   let nodeModulesDirsOrUndefined = nodeModulesDirectories;
@@ -733,7 +733,7 @@ async function runLinters({inputSourceArch, isopackCache, sources,
   // exists instead of failing because a dependency does not have an 'os'
   // unibuild.
   const whichArch = inputSourceArch.arch === 'os'
-          ? await archinfo.host() : inputSourceArch.arch;
+          ? archinfo.host() : inputSourceArch.arch;
 
   // For linters, figure out what are the global imports from other packages
   // that we use directly, or are implied.
@@ -897,7 +897,7 @@ export async function getActivePluginPackages(isopk, {
   // and because plugins always have to run on the host architecture.
   await compiler.eachUsedUnibuild({
     dependencies: uses,
-    arch: await archinfo.host(),
+    arch: archinfo.host(),
     isopackCache: isopackCache,
     skipUnordered: true
     // implicitly skip weak deps by not specifying acceptableWeakPackages option
@@ -971,7 +971,7 @@ compiler.eachUsedUnibuild = async function (
       continue;
     }
 
-    var unibuild = await usedPackage.getUnibuildAtArch(arch);
+    var unibuild = usedPackage.getUnibuildAtArch(arch);
     if (!unibuild) {
       // The package exists but there's no unibuild for us. A buildmessage has
       // already been issued. Recover by skipping.

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -140,7 +140,7 @@ export class IsopackCache {
     return null;
   }
 
-  async uses(isopack, name, arch) {
+  uses(isopack, name, arch) {
     if (! isopack) {
       return false;
     }
@@ -150,13 +150,13 @@ export class IsopackCache {
       return true;
     }
 
-    const unibuild = await isopack.getUnibuildAtArch(arch);
+    const unibuild = isopack.getUnibuildAtArch(arch);
     if (! unibuild) {
       return false;
     }
 
     for (const use of unibuild.uses) {
-      const implies = await this.implies(
+      const implies = this.implies(
           this._isopacks[use.package],
           name,
           arch,
@@ -166,7 +166,7 @@ export class IsopackCache {
     }
   }
 
-  async implies(isopack, name, arch) {
+  implies(isopack, name, arch) {
     if (! isopack) {
       return false;
     }
@@ -176,13 +176,13 @@ export class IsopackCache {
       return true;
     }
 
-    const unibuild = await isopack.getUnibuildAtArch(arch);
+    const unibuild = isopack.getUnibuildAtArch(arch);
     if (! unibuild) {
       return false;
     }
 
     for (const imp of unibuild.implies) {
-      const implies = await this.implies(
+      const implies = this.implies(
           this._isopacks[imp.package],
           name,
           arch,

--- a/tools/isobuild/isopack.js
+++ b/tools/isobuild/isopack.js
@@ -401,7 +401,7 @@ Object.assign(Isopack.prototype, {
   // Return the unibuild of the package to use for a given target architecture
   // (eg, 'os.linux.x86_64' or 'web'), or throw an exception if that
   // packages can't be loaded under these circumstances.
-  getUnibuildAtArch: Profile("Isopack#getUnibuildAtArch", async function (arch) {
+  getUnibuildAtArch: Profile("Isopack#getUnibuildAtArch", function (arch) {
     var self = this;
 
     let chosenArch = archinfo.mostSpecificMatch(
@@ -412,7 +412,7 @@ Object.assign(Isopack.prototype, {
       // are processing a local package with binary npm deps).  Search
       // again for the host version, which might find the Mac version.
       chosenArch =
-        archinfo.mostSpecificMatch(await archinfo.host(), _.pluck(self.unibuilds, 'arch'));
+        archinfo.mostSpecificMatch(archinfo.host(), _.pluck(self.unibuilds, 'arch'));
     }
     if (! chosenArch) {
       buildmessage.error(
@@ -453,7 +453,7 @@ Object.assign(Isopack.prototype, {
 
     for (const [name, pluginsByArch] of Object.entries(self.plugins)) {
       var arch = archinfo.mostSpecificMatch(
-          await archinfo.host(), Object.keys(pluginsByArch));
+          archinfo.host(), Object.keys(pluginsByArch));
       if (! arch) {
         buildmessage.error("package `" + name + "` is built for incompatible " +
             "architecture");
@@ -1444,7 +1444,7 @@ Object.assign(Isopack.prototype, {
     });
 
     // Set up builder to write to the correct directory
-    var toolPath = 'mt-' + await archinfo.host();
+    var toolPath = 'mt-' + archinfo.host();
     builder = await builder.enter(toolPath);
 
     const sourceRootDir = files.getCurrentToolsDir();
@@ -1524,7 +1524,7 @@ Object.assign(Isopack.prototype, {
 
     return [{
       name: 'meteor',
-      arch: await archinfo.host(),
+      arch: archinfo.host(),
       path: toolPath
     }];
   }),

--- a/tools/isobuild/unibuild.js
+++ b/tools/isobuild/unibuild.js
@@ -213,7 +213,7 @@ export class Unibuild {
         packageName: isopack.name,
         sourceRoot: unibuildBasePath,
         // Rebuild binary npm packages if unibuild arch matches host arch.
-        rebuildBinaries: archinfo.matches(await archinfo.host(), arch)
+        rebuildBinaries: archinfo.matches(archinfo.host(), arch)
       });
 
     return new this(isopack, {

--- a/tools/packaging/tropohouse.js
+++ b/tools/packaging/tropohouse.js
@@ -552,7 +552,7 @@ Object.assign(exports.Tropohouse.prototype, {
     var self = this;
     buildmessage.assertInCapture();
     options = options || {};
-    var serverArchs = options.serverArchitectures || [await archinfo.host()];
+    var serverArchs = options.serverArchitectures || [archinfo.host()];
 
     var downloader;
     var downloaders = [];

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -157,7 +157,7 @@ Object.assign(ProjectContext.prototype, {
     self._serverArchitectures = options.serverArchitectures || [];
     // We always need to download host versions of packages, at least for
     // plugins.
-    self._serverArchitectures.push(await archinfo.host());
+    self._serverArchitectures.push(archinfo.host());
     self._serverArchitectures = _.uniq(self._serverArchitectures);
 
     // test-packages overrides this to load local packages from your real app

--- a/tools/tool-env/isopackets.js
+++ b/tools/tool-env/isopackets.js
@@ -98,7 +98,7 @@ export async function loadIsopackage(packageName, isopacketName = "combined") {
   // it yields the first time we call it, which is a problem for the
   // fiberHelpers.noYieldsAllowed block below. Calling it here ensures the
   // result is cached, so no yielding occurs later.
-  assert.strictEqual((await archinfo.host()).split(".", 1)[0], "os");
+  assert.strictEqual((archinfo.host()).split(".", 1)[0], "os");
 
   async function load() {
     if (_.has(loadedIsopackets, isopacketName)) {

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -489,7 +489,7 @@ export default class Sandbox {
     // XXX this is hacky
     await files.linkToMeteorScript(
       files.pathJoin(this.warehouse, packagesDirectoryName, "meteor-tool", toolPackageVersion,
-        'mt-' + await archInfoHost(), 'meteor'),
+        'mt-' + archInfoHost(), 'meteor'),
       files.pathJoin(this.warehouse, 'meteor'));
   }
 }

--- a/tools/utils/archinfo.ts
+++ b/tools/utils/archinfo.ts
@@ -135,22 +135,22 @@ export const VALID_ARCHITECTURES: Record<string, boolean> = {
 };
 
 // Returns the fully qualified arch of this host -- something like
-// "os.linux.x86_32" or "os.osx.x86_64". Must be called inside
-// a fiber. Throws an error if it's not a supported architecture.
+// "os.linux.x86_32" or "os.osx.x86_64". 
+// Throws an error if it's not a supported architecture.
 //
 // If you change this, also change scripts/admin/launch-meteor
 let _host: string | null = null; // memoize
 
-export async function host() {
+export function host() {
   if (!_host) {
-    const run = async function (...args: Array<string | boolean>) {
-      const result = (await utils.execFile(args[0], args.slice(1))).stdout;
+    const run = function (...args: Array<string | boolean>) {
+      const result = utils.execFileSync(args[0], args.slice(1)).stdout;
 
       if (! result) {
         throw new Error(`Can't get arch with ${args.join(" ")}?`);
       }
 
-      return result.replace(/\s*$/, ''); // trailing whitespace
+      return result.replace(/\s*$/, ''); // remove trailing whitespace
     };
 
     const platform = os.platform();
@@ -158,10 +158,10 @@ export async function host() {
     if (platform === "darwin") {
       // Can't just test uname -m = x86_64, because Snow Leopard can
       // return other values.
-      const arch = await run('uname', '-p');
+      const arch = run('uname', '-p');
 
       if ((arch !== "i386" && arch !== "arm") ||
-          await run('sysctl', '-n', 'hw.cpu64bit_capable') !== "1") {
+         run('sysctl', '-n', 'hw.cpu64bit_capable') !== "1") {
         throw new Error("Only 64-bit Intel and M1 processors are supported on OS X");
       }
       if(arch === "arm"){
@@ -170,7 +170,7 @@ export async function host() {
         _host  = "os.osx.x86_64";
       }
     } else if (platform === "linux") {
-      const machine = await run('uname', '-m');
+      const machine = run('uname', '-m');
       if (["x86_64", "amd64", "ia64"].includes(machine)) {
         _host = "os.linux.x86_64";
       } else {

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -135,7 +135,7 @@ exports.getHost = async function (...args) {
     }
   };
 
-  if (archinfo.matches(await archinfo.host(), 'os.osx')) {
+  if (archinfo.matches(archinfo.host(), 'os.osx')) {
     // On OSX, to get the human-readable hostname that the user chose,
     // we call:
     //   scutil --get ComputerName
@@ -146,8 +146,8 @@ exports.getHost = async function (...args) {
     }
   }
 
-  if (archinfo.matches(await archinfo.host(), 'os.osx') ||
-      archinfo.matches(await archinfo.host(), 'os.linux')) {
+  if (archinfo.matches(archinfo.host(), 'os.osx') ||
+      archinfo.matches(archinfo.host(), 'os.linux')) {
     // On Unix-like platforms, try passing -s to hostname to strip off
     // the domain name, to reduce the extent to which the output
     // varies with DNS.
@@ -181,7 +181,7 @@ exports.getAgentInfo = async function () {
   ret.agent = "Meteor";
   ret.agentVersion =
     files.inCheckout() ? "checkout" : files.getToolsVersion();
-  ret.arch = await archinfo.host();
+  ret.arch = archinfo.host();
 
   return ret;
 };

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -512,6 +512,36 @@ exports.isValidVersion = function (version, {forCordova}) {
     || (forCordova ? exports.isUrlWithSha(version): exports.isNpmUrl(version));
 };
 
+exports.execFileSync = function (file, args, opts) {
+  var child_process = require('child_process');
+
+  opts = opts || {};
+  if (!_.has(opts, 'maxBuffer')) {
+    opts.maxBuffer = 1024 * 1024 * 10;
+  }
+
+  if (!_.has(opts, 'encoding')) {
+    opts.encoding = 'utf8';
+  }
+
+  let result;
+  try {
+    result = child_process.execFileSync(file, args, opts);
+  } catch (error) {
+    return {
+      success: false,
+      stdout: error.stdout,
+      stderr: error.stderr
+    };
+  }
+
+  return {
+    stdout: result,
+    success: true,
+    stderr: ''
+  };
+}
+
 
 exports.execFile = async function (file, args, opts) {
   var child_process = require('child_process');


### PR DESCRIPTION
There are some places where archinfo.host needs to be sync. With fibers this worked since it would be async the first time it was used, and then be sync rest of the times. That isn't as easy to do with promises, so this PR changes it to always be sync.

This also fixes a couple other bugs in #12471:
- When a cli command fails, the process will now correctly exit with an error code instead of logging a warning about an unhandled promise rejection and keep running.
- As a side effect of making some functions sync, it fixes a few places where it wasn't correctly awaiting the result when checking if an app or package used another package.