### PR TITLE
chore: updating vue2 skeleton app subscriptions

### DIFF
--- a/tools/static-assets/skel-vue-2/imports/ui/components/Info.vue
+++ b/tools/static-assets/skel-vue-2/imports/ui/components/Info.vue
@@ -9,28 +9,26 @@
           <input type="submit" name="submit" @click="submit($event)" value="Add new link">
         </form>
       </li>
-      <li v-for="link in links"><a :href="link.url" target="_blank">{{link.title}}</a></li>
+
+      <li v-for="link in links" v-bind:key="link._id">
+        <a :href="link.url" target="_blank">{{ link.title }}</a>
+      </li>
+
     </ul>
   </div>
 </template>
 
 <script>
 import Links from '../../api/collections/Links'
+import { subscribe, autorun } from "vue-meteor-tracker";
 
 export default {
   data() {
     return {
       title: "",
       url: "",
+      links: []
     }
-  },
-  meteor: {
-    $subscribe: {
-      'links': [],
-    },
-    links () {
-      return Links.find({})
-    },
   },
   methods: {
     submit(event) {
@@ -43,13 +41,19 @@ export default {
           this.url = ''
         }
       })
-    }
+    },
   },
+  mounted() {
+    subscribe('links')
+    autorun(() => {
+      this.links = Links.find().fetch()
+    })
+  }
 }
 </script>
 
 <style scoped>
-  ul {
-    font-family: monospace;
-  }
+ul {
+  font-family: monospace;
+}
 </style>

--- a/tools/static-assets/skel-vue-2/package.json
+++ b/tools/static-assets/skel-vue-2/package.json
@@ -11,7 +11,7 @@
     "@babel/runtime": "^7.17.9",
     "meteor-node-stubs": "^1.2.1",
     "vue": "^2.6.14",
-    "vue-meteor-tracker": "^2.0.0-beta.5"
+    "vue-meteor-tracker": "^3.0.0-beta.7"
   },
   "meteor": {
     "mainModule": {


### PR DESCRIPTION
Since Meteor.js 2.9 in this https://github.com/meteor/meteor/pull/12220 we do not have insecure package by default anymore.
In this PR I focus on making links that are already available in the subscription appear in the UI