### PR TITLE
Fixed changePassword and resetPassword functions type checking conditions

### DIFF
--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -142,7 +142,7 @@ Accounts.changePassword = (oldPassword, newPassword, callback) => {
     return reportError(new Error("Must be logged in to change password."), callback);
   }
 
-  if (!newPassword instanceof String) {
+  if (!(typeof newPassword === "string" || newPassword instanceof String)) {
     return reportError(new Meteor.Error(400, "Password must be a string"), callback);
   }
 
@@ -209,11 +209,11 @@ Accounts.forgotPassword = (options, callback) => {
  * @importFromPackage accounts-base
  */
 Accounts.resetPassword = (token, newPassword, callback) => {
-  if (!token instanceof String) {
+  if (!(typeof token === "string" || token instanceof String)) {
     return reportError(new Meteor.Error(400, "Token must be a string"), callback);
   }
 
-  if (!newPassword instanceof String) {
+  if (!(typeof newPassword === "string" || newPassword instanceof String)) {
     return reportError(new Meteor.Error(400, "Password must be a string"), callback);
   }
 


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
Fixes #12454, by implementing the suggested change. The issue is indeed true. Look at the example below.

![217182201-7fe72c91-a1cd-4449-a810-d2a13134261c](https://user-images.githubusercontent.com/53434192/217191600-bebd6c2e-8bcc-4a31-9c7b-bf2196077a59.png)

In the devtools I have created a variable `newPassword` which is clearly a number and not a String. However the clause `if (!newPassword instanceof String) {...}` fails to detect this. This happens because of operator precedence.

- `!` has a higher precedence than `instanceof` and thus `!` is always evaluted first. Hence `!newPassword` will always return false, and _false_ is not an instance of _String_, thus the if condition check never runs.

- The issue also mentioned about the infrequent use of String object. So as proposed in the issue itself, I made appropriate changes in the `changePassword` and `resetPassword`.

Please be kind enough to tell me if there is anything that I did wrong.