### PR TITLE
Solving lint and deploy

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1325,6 +1325,7 @@ main.registerCommand({
       allowIncompatibleUpdate: options['allow-incompatible-update'],
       lintPackageWithSourceRoot: packageDir
     });
+    await projectContext.init()
 
     await main.captureAndExit("=> Errors while setting up package:",
       // Read metadata and initialize catalog.
@@ -1379,7 +1380,7 @@ main.registerCommand({
     Console.warn(bundle.warnings.formatMessages());
     return 1;
   }
-
+  console.log(green`=> Done linting.`);
   return 0;
 });
 
@@ -1586,12 +1587,12 @@ async function deployCommand(options, { rawOptions }) {
       "OVERRIDING DEPLOY ARCHITECTURE WITH LOCAL ARCHITECTURE.",
       "If your app contains binary code, it may break in unexpected " +
       "and terrible ways.");
-    buildArch = await archinfo.host();
+    buildArch =  archinfo.host();
   }
 
   const projectContext = new projectContextModule.ProjectContext({
     projectDir: options.appDir,
-    serverArchitectures: _.uniq([buildArch, await archinfo.host()]),
+    serverArchitectures: _.uniq([buildArch,  archinfo.host()]),
     allowIncompatibleUpdate: options['allow-incompatible-update']
   });
   await projectContext.init()

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -230,7 +230,7 @@ async function authedRpc(options) {
       suppressErrorMessage: true
     };
     if (await doInteractivePasswordLogin(loginOptions)) {
-      return authedRpc(options);
+      return await authedRpc(options);
     } else {
       return {
         statusCode: 403,
@@ -241,7 +241,7 @@ async function authedRpc(options) {
 
   if (infoResult.statusCode === 404) {
     // Doesn't exist, therefore not protected.
-    return preflight ? { } : deployRpc(rpcOptions);
+    return preflight ? { } : await deployRpc(rpcOptions);
   }
 
   if (infoResult.errorMessage) {
@@ -253,7 +253,7 @@ async function authedRpc(options) {
     // Not protected.
     //
     // XXX should prompt the user to claim the app (only if deploying?)
-    return preflight ? { } : deployRpc(rpcOptions);
+    return preflight ? { } : await deployRpc(rpcOptions);
   }
 
   if (info.protection === "account") {
@@ -281,7 +281,7 @@ async function authedRpc(options) {
         authorized: info.authorized
       };
     } else {
-      return deployRpc(rpcOptions);
+      return await deployRpc(rpcOptions);
     }
   }
 
@@ -409,7 +409,7 @@ async function pollForDeploy(pollingState, versionId, site, deployWithTokenProps
   } = pollingState;
 
   // Do a call to the version-status endpoint for the specified versionId
-  const versionStatusResult = deployRpc({
+  const versionStatusResult = await deployRpc({
     method: 'GET',
     operation: 'version-status',
     site,


### PR DESCRIPTION
In this PR I focus on making Lint and deploy command async, making it possible to have a Fibers-free MeteorJS.
_note_:
On the tools end did worked but on galaxy did not because of lack of commands(galaxy runs `meteor run`) but it should run meteor run with DISABLE_FIBERS flag