### PR TITLE
Fix TypeScript type dependencies for mongo, webapp, and underscore

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -1,12 +1,4 @@
-import * as MongoNpmModule from 'mongodb';
-import {
-  Collection as MongoCollection,
-  CreateIndexesOptions,
-  Db as MongoDb,
-  Hint,
-  IndexSpecification,
-  MongoClient,
-} from 'mongodb';
+import { NpmModuleMongodb } from 'meteor/npm-mongo';
 import { Meteor } from 'meteor/meteor';
 
 // Based on https://github.com/microsoft/TypeScript/issues/28791#issuecomment-443520161
@@ -16,13 +8,13 @@ export type UnionOmit<T, K extends keyof any> = T extends T
 
 export namespace Mongo {
 
-  export type Selector<T> = MongoNpmModule.Filter<T>;
+  export type Selector<T> = NpmModuleMongodb.Filter<T>;
 
-  type Modifier<T> = MongoNpmModule.UpdateFilter<T>;
+  type Modifier<T> = NpmModuleMongodb.UpdateFilter<T>;
 
   export type OptionalId<TSchema> = UnionOmit<TSchema, '_id'> & { _id?: any };
 
-  type SortSpecifier = MongoNpmModule.Sort;
+  type SortSpecifier = NpmModuleMongodb.Sort;
 
   export interface FieldSpecifier {
     [id: string]: Number;
@@ -40,7 +32,7 @@ export namespace Mongo {
     /** Dictionary of fields to return or exclude. */
     fields?: FieldSpecifier | undefined;
     /** (Server only) Overrides MongoDB's default index selection and query optimization process. Specify an index to force its use, either by its name or index specification. */
-    hint?: Hint | undefined;
+    hint?: NpmModuleMongodb.Hint | undefined;
     /** (Client only) Default `true`; pass `false` to disable reactivity */
     reactive?: boolean | undefined;
     /**  Overrides `transform` on the  [`Collection`](#collections) for this cursor.  Pass `null` to disable transformation. */
@@ -61,7 +53,7 @@ export namespace Mongo {
      * Constructor for a Collection
      * @param name The name of the collection. If null, creates an unmanaged (unsynchronized) local collection.
      */
-    new <T extends MongoNpmModule.Document, U = T>(
+    new <T extends NpmModuleMongodb.Document, U = T>(
       name: string | null,
       options?: {
         /**
@@ -86,7 +78,7 @@ export namespace Mongo {
       }
     ): Collection<T, U>;
   }
-  interface Collection<T extends MongoNpmModule.Document, U = T> {
+  interface Collection<T extends NpmModuleMongodb.Document, U = T> {
     allow<Fn extends Transform<T> = undefined>(options: {
       insert?:
         | ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean)
@@ -110,12 +102,10 @@ export namespace Mongo {
       maxDocuments?: number
     ): Promise<void>;
     createIndex(
-      indexSpec: IndexSpecification,
-      options?: CreateIndexesOptions
+      options?: NpmModuleMongodb.CreateIndexesOptions
     ): void;
     createIndexAsync(
-      indexSpec: IndexSpecification,
-      options?: CreateIndexesOptions
+      options?: NpmModuleMongodb.CreateIndexesOptions
     ): Promise<void>;
     deny<Fn extends Transform<T> = undefined>(options: {
       insert?:
@@ -194,12 +184,12 @@ export namespace Mongo {
      * Returns the [`Collection`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html) object corresponding to this collection from the
      * [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
      */
-    rawCollection(): MongoCollection<T>;
+    rawCollection(): NpmModuleMongodb.Collection<T>;
     /**
      * Returns the [`Db`](http://mongodb.github.io/node-mongodb-native/3.0/api/Db.html) object corresponding to this collection's database connection from the
      * [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.
      */
-    rawDatabase(): MongoDb;
+    rawDatabase(): NpmModuleMongodb.Db;
     /**
      * Remove documents from the collection
      * @param selector Specifies which documents to remove
@@ -303,8 +293,7 @@ export namespace Mongo {
     _createCappedCollection(byteSize?: number, maxDocuments?: number): void;
     /** @deprecated */
     _ensureIndex(
-      indexSpec: IndexSpecification,
-      options?: CreateIndexesOptions
+      options?: NpmModuleMongodb.CreateIndexesOptions
     ): void;
     _dropCollection(): Promise<void>;
     _dropIndex(indexName: string): void;
@@ -448,8 +437,8 @@ export namespace Mongo {
 
 export declare module MongoInternals {
   interface MongoConnection {
-    db: MongoDb;
-    client: MongoClient;
+    db: NpmModuleMongodb.Db;
+    client: NpmModuleMongodb.MongoClient;
   }
 
   function defaultRemoteCollectionDriver(): {
@@ -459,7 +448,7 @@ export declare module MongoInternals {
   var NpmModules: {
     mongodb: {
       version: string;
-      module: typeof MongoNpmModule;
+      module: typeof NpmModuleMongodb;
     };
   };
 }

--- a/packages/npm-mongo/index.d.ts
+++ b/packages/npm-mongo/index.d.ts
@@ -1,0 +1,3 @@
+import * as NpmModuleMongodb from 'mongodb';
+declare const NpmModuleMongodbVersion: string;
+export { NpmModuleMongodb, NpmModuleMongodbVersion };

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -17,4 +17,5 @@ Package.onUse(function (api) {
     "NpmModuleMongodb",
     "NpmModuleMongodbVersion",
   ], "server");
+  api.addAssets('index.d.ts', 'server');
 });

--- a/packages/underscore/package.js
+++ b/packages/underscore/package.js
@@ -1,3 +1,7 @@
+Npm.depends({
+  '@types/underscore': '1.11.4',
+});
+
 Package.describe({
   summary: "Collection of small helpers: _.map, _.each, ...",
   version: '1.0.11'

--- a/packages/webapp/.npm/package/npm-shrinkwrap.json
+++ b/packages/webapp/.npm/package/npm-shrinkwrap.json
@@ -1,25 +1,35 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ=="
+    },
+    "@types/node": {
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
+    },
     "@vlasky/whomst": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@vlasky/whomst/-/whomst-0.1.7.tgz",
       "integrity": "sha512-rwJApvgTsws9LHJwskPSVfe9zmXu/Ownhoq2hX4CcVTL+aWH6bZxW34ycXWAdEuX+c/oYxhmovlAMpoMGOxaSg=="
     },
     "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="
     },
     "basic-auth-connect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-      "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI="
+      "integrity": "sha512-kiV+/DTgVro4aZifY/hwRwALBISViL5NP4aReaR2EVJEObpbUBHIkdJh/YpcoEiYt7nBodZ6U2ajZeZvSxUCCg=="
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
     },
     "call-bind": {
       "version": "1.0.2",
@@ -61,7 +71,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -76,22 +86,22 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
     },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "errorhandler": {
       "version": "1.5.1",
@@ -101,12 +111,12 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
     "execa": {
       "version": "5.1.1",
@@ -128,7 +138,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -136,9 +146,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q=="
     },
     "get-stream": {
       "version": "6.0.1",
@@ -151,9 +161,9 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw=="
     },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "http-errors": {
       "version": "1.7.3",
@@ -178,7 +188,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -196,14 +206,14 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg=="
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -213,17 +223,17 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -231,14 +241,14 @@
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="
     },
     "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="
     },
     "on-headers": {
       "version": "1.0.2",
@@ -253,7 +263,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "parseurl": {
       "version": "1.3.3",
@@ -268,12 +278,12 @@
     "promise-polyfill": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
-      "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+      "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "qs": {
       "version": "6.10.1",
@@ -323,14 +333,14 @@
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw=="
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
     },
     "stream-to-string": {
       "version": "1.2.0",
@@ -355,7 +365,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "useragent": {
       "version": "2.3.0",
@@ -365,12 +375,12 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "which": {
       "version": "2.0.2",
@@ -380,7 +390,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     }
   }
 }

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -15,6 +15,7 @@ Npm.depends({
   qs: '6.10.1',
   useragent: '2.3.0',
   '@vlasky/whomst': '0.1.7',
+  '@types/connect': '3.4.35',
 });
 
 Npm.strip({


### PR DESCRIPTION
A newly created TypeScript Meteor project today will fail to type check. This is for a handful of reasons, although this PR only addresses a subset of them (stay tuned for more!).

In this PR, we deal with the fact that some of the type declarations for Meteor packages require type declarations for upstream NPM packages. If a Meteor package depends on an NPM package and that NPM package includes type declarations directly, then everything works fine. However, if the NPM package doesn't include type declarations, and instead type declarations have to come from a DefinitelyTyped `@types` package, then we have a problem.

Out of the box, a newly created TypeScript template project sees an assortment of errors caused by this:

```
evan@mathias meteor-types-test (main) % meteor npx tsc
[...]
.meteor/local/types/node_modules/package-types/mongo/package/os/packages/mongo/mongo.d.ts:1:33 - error TS2307: Cannot find module 'mongodb' or its corresponding type declarations.

1 import * as MongoNpmModule from 'mongodb';
                                  ~~~~~~~~~

.meteor/local/types/node_modules/package-types/mongo/package/os/packages/mongo/mongo.d.ts:9:8 - error TS2307: Cannot find module 'mongodb' or its corresponding type declarations.

9 } from 'mongodb';
         ~~~~~~~~~

.meteor/local/types/node_modules/package-types/underscore/package/os/packages/underscore/underscore.d.ts:1:20 - error TS2307: Cannot find module 'underscore' or its corresponding type declarations.

1 import * as _ from 'underscore';
                     ~~~~~~~~~~~~

.meteor/local/types/node_modules/package-types/webapp/package/os/packages/webapp/webapp.d.ts:2:26 - error TS7016: Could not find a declaration file for module 'connect'. '/Users/evan/src/meteor-types-test/.meteor/local/types/node_modules/package-types/webapp/node_modules/connect/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/connect` if it exists or add a new declaration (.d.ts) file containing `declare module 'connect';`

2 import * as connect from 'connect';
                           ~~~~~~~~~
```

For `underscore` and `webapp`, just add the `@types/` packages directly as dependencies. Meteor has no concept of a "dev dependency", but as these files aren't required in any way at runtime, they'll increase the size of the package's isopacks but not change the resulting application. (I also cleaned up `packages/webapp/.npm`, since the current `.gitignore` file implies that it never should have been committed in the first place)

For `mongo`, I opted for something slightly more complicated. The `npm-mongo` package already has `mongodb` as an NPM dependency (which _does_ include its own type declarations). However, because `npm-mongo` doesn't itself export type declarations, the types from `mongodb` aren't made accessible. Therefore, I added type declarations to `npm-mongo` and rephrased the `mongo` package to import the `mongodb` types from `npm-mongo`.