### PR TITLE
TypeScript skeleton fixes

### DIFF
--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/meteor": "^1.4.87",
     "@types/mocha": "^8.2.3",
+    "@types/node": "^18.13.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
     "typescript": "^4.7.4"

--- a/tools/static-assets/skel-typescript/server/main.ts
+++ b/tools/static-assets/skel-typescript/server/main.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
-import { LinksCollection } from '/imports/api/links';
+import { Link, LinksCollection } from '/imports/api/links';
 
-async function insertLink({ title, url }) {
+async function insertLink({ title, url }: Pick<Link, 'title' | 'url'>) {
   await LinksCollection.insertAsync({ title, url, createdAt: new Date() });
 }
 


### PR DESCRIPTION
Two straightforward issues with the TypeScript skeleton:

- Since tsconfig.json has `types: ['node' ...`, we need to include `@types/node`; not having those type definitions is an error:
  
  ```
  error TS2688: Cannot find type definition file for 'node'.
    The file is in the program because:
      Entry point of type library 'node' specified in compilerOptions

    tsconfig.json:37:15
      37     "types": ["node", "mocha"],
                    ~~~~~~
      File is entry point of type library specified here.
  ```

- Since tsconfig has `noImplicitAny: true`, we need to not have parameters which are implicitly `any`:
  
  ```
  server/main.ts:4:29 - error TS7031: Binding element 'title' implicitly has an 'any' type.

  4 async function insertLink({ title, url }) {
                                ~~~~~

  server/main.ts:4:36 - error TS7031: Binding element 'url' implicitly has an 'any' type.

  4 async function insertLink({ title, url }) {
                                       ~~~
  ```