### PR TITLE
Switch typescript skeleton to zodern:types and test that it works

### DIFF
--- a/tools/static-assets/skel-typescript/.meteor/packages
+++ b/tools/static-assets/skel-typescript/.meteor/packages
@@ -20,3 +20,4 @@ hot-module-replacement  # Update client in development without reloading the pag
 ~prototype~
 static-html             # Define static page content in .html files
 react-meteor-data       # React higher-order component for reactively tracking Meteor data
+zodern:types            # Pull in type declarations from other Meteor packages

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -14,7 +14,6 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/meteor": "^1.4.87",
     "@types/mocha": "^8.2.3",
     "@types/node": "^18.13.0",
     "@types/react": "^18.0.26",

--- a/tools/static-assets/skel-typescript/tsconfig.json
+++ b/tools/static-assets/skel-typescript/tsconfig.json
@@ -25,7 +25,12 @@
     "baseUrl": ".",
     "paths": {
       /* Support absolute /imports/* with a leading '/' */
-      "/*": ["*"]
+      "/*": ["*"],
+      /* Pull in type declarations for Meteor packages from either zodern:types or @types/meteor packages */
+      "meteor/*": [
+        "node_modules/@types/meteor/*",
+        ".meteor/local/types/packages.d.ts"
+      ]
     },
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/tools/tests/typescript.js
+++ b/tools/tests/typescript.js
@@ -1,0 +1,22 @@
+var selftest = require('../tool-testing/selftest.js');
+var Sandbox = selftest.Sandbox;
+
+selftest.define("typescript template works", function () {
+  const s = new Sandbox;
+
+  let run = s.run("create", "--typescript", "typescript");
+  run.waitSecs(60);
+  run.match("Created a new Meteor app in 'typescript'.");
+  run.match("To run your new app");
+
+  s.cd("typescript");
+  run = s.run("lint");
+  run.waitSecs(60);
+  run.match("[zodern:types] Exiting \"meteor lint\" early")
+  run.expectExit(0);
+
+  run = s.run("npx", "tsc");
+  run.waitSecs(60);
+  run.expectEnd();
+  run.expectExit(0);
+});


### PR DESCRIPTION
As type definitions are moved to be shipped directly with the core Meteor packages, the @types/meteor NPM package is trending towards deprecation, so we should steer people to use the preferred way of pulling in type definitions.

Additionally, add a test to make sure we're not steering them too far astray.