### PR TITLE
Update coffeescript to 2.7.0

### DIFF
--- a/packages/non-core/coffeescript-compiler/coffeescript-compiler.js
+++ b/packages/non-core/coffeescript-compiler/coffeescript-compiler.js
@@ -2,16 +2,6 @@ import { BabelCompiler } from 'meteor/babel-compiler';
 import CoffeeScript from 'coffeescript';
 import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
 
-
-// The CoffeeScript compiler overrides Error.prepareStackTrace, mostly for the
-// use of coffee.run which we don't use. This conflicts with the tool's use of
-// Error.prepareStackTrace to properly show error messages in linked code.
-// Restore the tool's one after CoffeeScript clobbers it at import time.
-if (Error.METEOR_prepareStackTrace) {
-  Error.prepareStackTrace = Error.METEOR_prepareStackTrace;
-}
-
-
 // The CompileResult for this CachingCompiler is a {source, sourceMap} object.
 export class CoffeeScriptCompiler {
   constructor() {

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // so bumping the version of this package will be how they get newer versions
   // of `coffeescript-compiler`. If you change this, make sure to also update
   // ../coffeescript-compiler/package.js to match.
-  version: '2.4.1'
+  version: '2.7.0'
 });
 
 Package.registerBuildPlugin({


### PR DESCRIPTION
This enables many new js features in coffeescript, and removes the workaround Meteor used to prevent coffeescript from overriding `Error.prepareStackTrace`.

Publishing a new version of the coffeescript package will also include the caching fix from Meteor 1.10.2.