### PR TITLE
[Meteor 3] Fix missing files when copying node modules to rebuild native deps

### DIFF
--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -420,7 +420,7 @@ async function copyNpmPackageWithSymlinkedNodeModules(fromPkgDir, toPkgDir) {
     if (item === "node_modules") {
       // We'll link or copy node_modules in a follow-up step.
       needToHandleNodeModules = true;
-      return;
+      continue;
     }
 
     await files.cp_r(
@@ -442,7 +442,7 @@ async function copyNpmPackageWithSymlinkedNodeModules(fromPkgDir, toPkgDir) {
     if (depPath === ".bin") {
       // Avoid copying node_modules/.bin because commands like
       // .bin/node-gyp and .bin/node-pre-gyp tend to cause problems.
-      return;
+      continue;
     }
 
     const absDepFromPath = files.pathJoin(nodeModulesFromPath, depPath);
@@ -450,7 +450,7 @@ async function copyNpmPackageWithSymlinkedNodeModules(fromPkgDir, toPkgDir) {
     if (! files.stat(absDepFromPath).isDirectory()) {
       // Only copy package directories, even though there might be other
       // kinds of files in node_modules.
-      return;
+      continue;
     }
 
     const absDepToPath = files.pathJoin(nodeModulesToPath, depPath);


### PR DESCRIPTION
The code for copying the node modules folders was converted to use for loops instead of forEach, but the returns were left which caused it to stop before it had copied all files.

This should fix #12530. The first time Meteor was run, it would save the isopacks to disk. The second time Meteor was run, it would try to rebuild any native deps, which involves copying part of the node_modules folder, rebuilding native deps, and then overwriting the original files with the copy. Due to the bug this PR fixes, the copy was missing files which would break the package.

I found it surprising that Meteor was rebuilding native deps here since it should have already ensured they were built correctly when writing the isopack. There might be another issue someplace here, or this something we can optimize in the future.