### PR TITLE
[Meteor 3] Fix missing globals and packages unable to import from app's node_modules

### DIFF
--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -1189,6 +1189,15 @@ export var fullLink = Profile("linker.fullLink", async function (inputFiles, {
       (bundleArch.startsWith('os.') || enableClientTLA);
 
     if (wrapForTLA) {
+      // Ensure there is always at least one file
+      // so the globals can be defined
+      if (prelinkedFiles.length === 0) {
+        prelinkedFiles.unshift({
+          source: '',
+          servePath: "/global-imports.js"
+        });
+      }
+
       let header = getHeader({
         name: null,
         imports,

--- a/tools/static-assets/server/npm-require.js
+++ b/tools/static-assets/server/npm-require.js
@@ -162,9 +162,6 @@ function resolve(id) {
     resolveInLocalBuild(id) ||
     resolveInNodeModules(id) ||
     resolveInDevBundle(id) ||
-    // TODO[fibers]: this is a workaround, fix it
-    (id === '/node_modules/@babel/runtime/helpers/objectSpread2.js' && '/home/denyhs/Documents/work/meteor/meteor/packages/logging/.npm/package/node_modules/@babel/runtime/helpers/objectSpread2.js')||
-    (id === '/node_modules/@babel/runtime/helpers/objectWithoutProperties.js' && '/home/denyhs/Documents/work/meteor/meteor/packages/logging/.npm/package/node_modules/@babel/runtime/helpers/objectWithoutProperties.js')||
     null;
 
   return resolve(id);


### PR DESCRIPTION
When there was no app code, the linker in Meteor 3 wouldn't add any linked files for the app. This caused two problems:

1. On the server, Meteor would only resolve npm packages in the app's node_module's folder if there were any linked files for the app. When running package tests, this broke importing @babel/runtime.
2. The globals Meteor would always create for the app were missing, which would be noticeable when using a debugger or the Meteor shell.

When top level await is enabled, globals are defined in the header that is added to the app file. If there is no file for the app, it will now add an empty file to ensure the header is still added.