### PR TITLE
Update NPM packages Node versions

### DIFF
--- a/.github/workflows/npm-eslint-plugin-meteor.yml
+++ b/.github/workflows/npm-eslint-plugin-meteor.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/eslint-plugin-meteor
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-meteor-babel.yml
+++ b/.github/workflows/npm-meteor-babel.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-babel
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-meteor-babel.yml
+++ b/.github/workflows/npm-meteor-babel.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-babel
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-meteor-promise.yml
+++ b/.github/workflows/npm-meteor-promise.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-promise
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-meteor-promise.yml
+++ b/.github/workflows/npm-meteor-promise.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-promise
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Update Node version on tests on NPM packages.

I've upped it to Node 14 and 16, but maybe for Meteor 3 we should up it for Node 16 and 18?