### PR TITLE
[Meteor 3] Fix static files on client

### DIFF
--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -3,6 +3,8 @@
   "dependencies": {
     "@meteorjs/babel": {
       "version": "7.19.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@meteorjs/babel/-/babel-7.19.0-beta.1.tgz",
+      "integrity": "sha512-4dy7oSXEo6Eb2PHfPkMX0VVnkQJ9Kb6Qv6/ssiXOqQRtTRpBAgeWeMzUd42u/8VzxG6l8NoNqIhPSOHZjC2usg==",
       "dependencies": {
         "@ampproject/remapping": {
           "version": "2.1.1",

--- a/tools/runners/run-hmr.js
+++ b/tools/runners/run-hmr.js
@@ -258,12 +258,26 @@ export class HMRServer {
       };
     }
 
+    // TODO: try to improve the performance of this
+    const iterWithFn = async (iter, fn) => {
+      let arr = [];
+      for (let i = 0; i < iter.length; i++) {
+        try {
+          const d = await fn(iter[i]);
+          arr.push(d);
+        } catch (e) {
+          console.log(e);
+        }
+      }
+      return arr;
+    }
+
     const result = {
       fileHashes,
       unreloadableHashes: unreloadable,
       reloadable,
-      addedFiles: reloadable ? await Promise.all(addedFiles.map(saveFileDetails)) : [],
-      changedFiles: reloadable ? await Promise.all(changedFiles.map(saveFileDetails)) : [],
+      addedFiles: reloadable ? await iterWithFn(addedFiles, saveFileDetails) : [],
+      changedFiles: reloadable ? await iterWithFn(changedFiles, saveFileDetails) : [],
       linkedAt: Date.now(),
       id: this._createId(),
       name

--- a/tools/runners/run-hmr.js
+++ b/tools/runners/run-hmr.js
@@ -184,7 +184,7 @@ export class HMRServer {
     }
   }
 
-  compare({ name, arch, hmrAvailable, files, cacheKey }, getFileOutput) {
+  async compare({ name, arch, hmrAvailable, files, cacheKey }, getFileOutput) {
     if (this.firstBuild = null) {
       this.firstBuild = Date.now();
     }
@@ -248,9 +248,11 @@ export class HMRServer {
       onlyReplaceableChanges &&
       removedFilePaths.length === 0;
 
-    function saveFileDetails(file) {
+    async function saveFileDetails(file) {
+
+      const content = await getFileOutput(file);
       return {
-        content: getFileOutput(file).toStringWithSourceMap({}),
+        content: content.toStringWithSourceMap({}),
         path: file.absModuleId,
         meteorInstallOptions: file.meteorInstallOptions
       };
@@ -260,8 +262,8 @@ export class HMRServer {
       fileHashes,
       unreloadableHashes: unreloadable,
       reloadable,
-      addedFiles: reloadable ? addedFiles.map(saveFileDetails) : [],
-      changedFiles: reloadable ? changedFiles.map(saveFileDetails) : [],
+      addedFiles: reloadable ? await Promise.all(addedFiles.map(saveFileDetails)) : [],
+      changedFiles: reloadable ? await Promise.all(changedFiles.map(saveFileDetails)) : [],
       linkedAt: Date.now(),
       id: this._createId(),
       name


### PR DESCRIPTION
To test it, you need to run using those flags: `DISABLE_FIBERS=1 IGNORE_ASYNC_PLUGIN=1 METEOR_ENABLE_CLIENT_TOP_LEVEL_AWAIT=true mymeteor` 
Note that `METEOR_ENABLE_CLIENT_TOP_LEVEL_AWAIT` is a new one, to enable TLA on Client

Fixes HMR compare - it was breaking due to not having async await

Also, I noticed that HMR is a bit slow compared to Meteor 2.X
