### PR TITLE
Feature/add is async call

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -56,6 +56,9 @@
 * `boilerplate-generator`:
   - `toHTML` is no longer available (it was already deprecated). Use `toHTMLStream` instead.
 
+*  `ddp`:
+ - Added method `Meteor.isAsyncCall` that can be used to check if the current method call is async or not. 
+
 * `oauth`:
   - `_endOfPopupResponseTemplate` and `_endOfRedirectResponseTemplate` are no longer a property but now a function that returns a promise of the same value as before
   - the following server methods are now async:

--- a/docs/source/api/methods.md
+++ b/docs/source/api/methods.md
@@ -80,6 +80,12 @@ with this ID has already been made.  Alternatively, you can use
 
 Read more about methods and how to use them in the [Methods](http://guide.meteor.com/methods.html) article in the Meteor Guide.
 
+{% apibox "Meteor.isAsyncCall" %}
+
+This method can be used to determine if the current method invocation is
+asynchronous.  It returns true if the method is running on the server and came from
+an async call(`Meteor.callAsync`)
+
 {% apibox "DDPCommon.MethodInvocation#userId" %}
 
 The user id is an arbitrary string &mdash; typically the id of the user record

--- a/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
+++ b/packages/babel-compiler/.npm/package/npm-shrinkwrap.json
@@ -3,6 +3,8 @@
   "dependencies": {
     "@meteorjs/babel": {
       "version": "7.19.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@meteorjs/babel/-/babel-7.19.0-beta.1.tgz",
+      "integrity": "sha512-4dy7oSXEo6Eb2PHfPkMX0VVnkQJ9Kb6Qv6/ssiXOqQRtTRpBAgeWeMzUd42u/8VzxG6l8NoNqIhPSOHZjC2usg==",
       "dependencies": {
         "@ampproject/remapping": {
           "version": "2.1.1",
@@ -1187,11 +1189,6 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
           "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-        },
-        "fibers": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
-          "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg=="
         },
         "find-up": {
           "version": "3.0.0",

--- a/packages/ddp-client/client/client_convenience.js
+++ b/packages/ddp-client/client/client_convenience.js
@@ -47,6 +47,7 @@ Meteor.connection = DDP.connect(ddpUrl, {
 [
   'subscribe',
   'methods',
+  'isAsyncCall',
   'call',
   'callAsync',
   'apply',

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -511,6 +511,17 @@ export class Connection {
     return handle;
   }
 
+  /**
+   * @summary Tells if the method call came from a call or a callAsync.
+   * @alias Meteor.isAsyncCall
+   * @locus Anywhere
+   * @memberOf Meteor
+   * @importFromPackage meteor
+   * @returns boolean
+   */
+  isAsyncCall(){
+    return DDP._CurrentMethodInvocation._isCallAsyncMethodRunning()
+  }
   methods(methods) {
     Object.entries(methods).forEach(([name, func]) => {
       if (typeof func !== 'function') {
@@ -722,7 +733,6 @@ export class Connection {
 
   _apply(name, stubCallValue, args, options, callback) {
     const self = this;
-
     // We were passed 3 arguments. They may be either (name, args, options)
     // or (name, args, callback)
     if (!callback && typeof options === 'function') {

--- a/packages/ddp-client/test/livedata_test_service.js
+++ b/packages/ddp-client/test/livedata_test_service.js
@@ -378,3 +378,9 @@ Meteor.methods({
     resultByValueArrays[testId].push(value);
   }
 });
+/// Helper for "livedata - isAsync call"
+Meteor.methods({
+  isCallAsync: function () {
+    return Meteor.isAsyncCall()
+  }
+})

--- a/packages/ddp-client/test/livedata_tests.js
+++ b/packages/ddp-client/test/livedata_tests.js
@@ -1208,6 +1208,12 @@ testAsyncMulti('livedata - methods with nested stubs', [
   },
 ]);
 
+ Tinytest.addAsync('livedata - isAsync call', async function (test) {
+  Meteor.call('isCallAsync', (err, result) => test.equal(result, false))
+  const result = await Meteor.callAsync('isCallAsync', { returnStubValue: true })
+  test.equal(result, true)
+})
+
 // XXX some things to test in greater detail:
 // staying in simulation mode
 // time warp

--- a/packages/ddp-server/server_convenience.js
+++ b/packages/ddp-server/server_convenience.js
@@ -14,6 +14,7 @@ Meteor.refresh = async function (notification) {
 _.each(
   [
     'publish',
+    'isAsyncCall',
     'methods',
     'call',
     'callAsync',


### PR DESCRIPTION
In this PR, I focus on bringing to the server something that may be useful for upgrading apps(it was already ready in the client), especially ones that cannot be updated that easily for some reason(Cordova). With this one, you can update your backend, and in it can decide how to approach this migration; you can send an email requesting to be upgraded or make it the user log off and log in again to get the newly updated version of your app.

Its usage can be seen in the docs, but I will place it here for future reference:

> `Meteor.isAsyncCall()` can be used to know if you are running a method that was called by an async method or not.