### PR TITLE
Solving typos in migration guide for 2.11

### DIFF
--- a/guide/source/2.11-migration.md
+++ b/guide/source/2.11-migration.md
@@ -53,7 +53,7 @@ working properly after this upgrade. `meteor reset` is going to remove all the d
 #### ```meteor mongo```
 
 From MongoDB version 6.X, the `mongo` shell is not available anymore. It can be
-seen [here](https://www.mongodb.com/docs/manual/release-notes/6.0-compatibility/#legacy-mongo-shell-removed for more
+seen [here](https://www.mongodb.com/docs/manual/release-notes/6.0-compatibility/#legacy-mongo-shell-removed) for more
 info.
 For this reason the `meteor mongo` command is not going to work anymore. If you are using this command, you should use
 the `mongosh` command instead.
@@ -82,7 +82,7 @@ the [MongoDB 6.0.3 Release Notes](https://www.mongodb.com/docs/manual/release-no
 - $returnKey:
   Use [cursor.returnKey()](https://www.mongodb.com/docs/manual/reference/method/cursor.returnKey/#mongodb-method-cursor.returnKey)
 - $showDiskLoc: Use
-  cursor.showRecordId(https://www.mongodb.com/docs/manual/reference/method/cursor.returnKey/#mongodb-method-cursor.showRecordId)
+  [cursor.showRecordId](https://www.mongodb.com/docs/manual/reference/method/cursor.returnKey/#mongodb-method-cursor.showRecordId)
 - db.getLastError():
   See [Legacy Opcodes Removed](https://www.mongodb.com/docs/manual/release-notes/6.0-compatibility/#std-label-legacy-op-codes-removed)
 - db.getLastErrorObj():


### PR DESCRIPTION
Solving a few typos in migration guide for 2.11