### PR TITLE
[Meteor 3] Fix app code not running on the client

### DIFF
--- a/packages/meteor/asl-helpers.js
+++ b/packages/meteor/asl-helpers.js
@@ -2,7 +2,9 @@ const getAslStore = () => (Meteor.isServer && global?.asyncLocalStorage?.getStor
 const getValueFromAslStore = key => getAslStore()[key];
 const updateAslStore = (key, value) => getAslStore()[key] = value;
 
-Meteor.isFibersDisabled = !!__meteor_bootstrap__.isFibersDisabled;
+const bootstrap = global.__meteor_bootstrap__; 
+
+Meteor.isFibersDisabled = !!(bootstrap && bootstrap.isFibersDisabled);
 Meteor._isFibersEnabled = !Meteor.isFibersDisabled;
 
 Meteor._getAslStore = getAslStore;

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -60,6 +60,7 @@ var Module = function (options) {
   // options
   self.useGlobalNamespace = options.useGlobalNamespace;
   self.combinedServePath = options.combinedServePath;
+  self.addEagerRequires = !!options.addEagerRequires;
 };
 
 Object.assign(Module.prototype, {
@@ -208,6 +209,10 @@ Object.assign(Module.prototype, {
           result.eagerModulePaths.push(file.absModuleId);
           if (file.mainModule) {
             result.mainModulePath = file.absModuleId;
+          }
+
+          if (self.addEagerRequires) {
+            chunks.push(`\nrequire(${JSON.stringify(file.absModuleId)});`);
           }
         }
       }
@@ -1151,6 +1156,10 @@ export var fullLink = Profile("linker.fullLink", async function (inputFiles, {
     bundleArch,
     useGlobalNamespace: isApp,
     combinedServePath,
+    // To support `/client/compatibility`, we can't use the runtime for the
+    // app on the client when TLA is disabled since it wraps all of
+    // the app code in a function. Instead, we have the module add eager requires.
+    addEagerRequires: !bundleArch.startsWith('os.') && isApp && !enableClientTLA 
   });
 
   // Check if the core-runtime package will already be loaded


### PR DESCRIPTION
On the client, we can't use the runtime to handle eager requires for the app code since it would break files in `/client/compatibility`. This adds an alternative way to handle eager requires.