### PR TITLE
Release 3.0 fix tests oauth webapp

### DIFF
--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -239,7 +239,7 @@ const oauthServiceName = req => {
 const ensureConfigured =
   async serviceName => {
     const config =
-      await ServiceConfiguration.configurations.findOne({ service: serviceName })
+      await ServiceConfiguration.configurations.findOneAsync({ service: serviceName });
     if (!config) {
       throw new ServiceConfiguration.ConfigError();
     }

--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -239,7 +239,7 @@ const oauthServiceName = req => {
 const ensureConfigured =
   async serviceName => {
     const config =
-      await ServiceConfiguration.configurations.findOneAsync({ service: serviceName });
+      await ServiceConfiguration.configurations.findOne({ service: serviceName })
     if (!config) {
       throw new ServiceConfiguration.ConfigError();
     }

--- a/packages/oauth1/oauth1_pending_request_tokens.js
+++ b/packages/oauth1/oauth1_pending_request_tokens.js
@@ -53,7 +53,7 @@ OAuth._storeRequestToken = async (key, requestToken, requestTokenSecret) => {
   // We do an upsert here instead of an insert in case the user happens
   // to somehow send the same `state` parameter twice during an OAuth
   // login; we don't want a duplicate key error.
-  await OAuth._pendingRequestTokens.upsertAsync({
+  await OAuth._pendingRequestTokens.upsert({
     key,
   }, {
     key,
@@ -72,9 +72,9 @@ OAuth._storeRequestToken = async (key, requestToken, requestTokenSecret) => {
 OAuth._retrieveRequestToken = async key => {
   check(key, String);
 
-  const pendingRequestToken =  await OAuth._pendingRequestTokens.findOneAsync({ key: key });
+  const pendingRequestToken =  await OAuth._pendingRequestTokens.findOne({ key: key });
   if (pendingRequestToken) {
-    await OAuth._pendingRequestTokens.removeAsync({ _id: pendingRequestToken._id });
+    await OAuth._pendingRequestTokens.remove({ _id: pendingRequestToken._id });
     return {
       requestToken: OAuth.openSecret(pendingRequestToken.requestToken),
       requestTokenSecret: OAuth.openSecret(

--- a/packages/oauth1/oauth1_pending_request_tokens.js
+++ b/packages/oauth1/oauth1_pending_request_tokens.js
@@ -53,7 +53,7 @@ OAuth._storeRequestToken = async (key, requestToken, requestTokenSecret) => {
   // We do an upsert here instead of an insert in case the user happens
   // to somehow send the same `state` parameter twice during an OAuth
   // login; we don't want a duplicate key error.
-  await OAuth._pendingRequestTokens.upsert({
+  await OAuth._pendingRequestTokens.upsertAsync({
     key,
   }, {
     key,
@@ -72,9 +72,9 @@ OAuth._storeRequestToken = async (key, requestToken, requestTokenSecret) => {
 OAuth._retrieveRequestToken = async key => {
   check(key, String);
 
-  const pendingRequestToken =  await OAuth._pendingRequestTokens.findOne({ key: key });
+  const pendingRequestToken =  await OAuth._pendingRequestTokens.findOneAsync({ key: key });
   if (pendingRequestToken) {
-    await OAuth._pendingRequestTokens.remove({ _id: pendingRequestToken._id });
+    await OAuth._pendingRequestTokens.removeAsync({ _id: pendingRequestToken._id });
     return {
       requestToken: OAuth.openSecret(pendingRequestToken.requestToken),
       requestTokenSecret: OAuth.openSecret(

--- a/packages/oauth1/oauth1_server.js
+++ b/packages/oauth1/oauth1_server.js
@@ -26,7 +26,7 @@ OAuth._queryParamsWithAuthTokenUrl = (authUrl, oauthBinding, params = {}, whitel
 
 // connect middleware
 OAuth._requestHandlers['1'] = async (service, query, res) => {
-  const config = await ServiceConfiguration.configurations.findOneAsync({service: service.serviceName});
+  const config = await ServiceConfiguration.configurations.findOne({service: service.serviceName});
   if (! config) {
     throw new ServiceConfiguration.ConfigError(service.serviceName);
   }

--- a/packages/oauth1/oauth1_server.js
+++ b/packages/oauth1/oauth1_server.js
@@ -26,7 +26,7 @@ OAuth._queryParamsWithAuthTokenUrl = (authUrl, oauthBinding, params = {}, whitel
 
 // connect middleware
 OAuth._requestHandlers['1'] = async (service, query, res) => {
-  const config = await ServiceConfiguration.configurations.findOne({service: service.serviceName});
+  const config = await ServiceConfiguration.configurations.findOneAsync({service: service.serviceName});
   if (! config) {
     throw new ServiceConfiguration.ConfigError(service.serviceName);
   }

--- a/packages/oauth1/oauth1_tests.js
+++ b/packages/oauth1/oauth1_tests.js
@@ -23,7 +23,7 @@ const testPendingCredential = async (test, method) => {
     this.accessTokenSecret = twitterfooAccessTokenSecret;
   };
 
-  await ServiceConfiguration.configurations.insert({service: serviceName});
+  await ServiceConfiguration.configurations.insertAsync({service: serviceName});
 
   try {
     // register a fake login service

--- a/packages/oauth1/oauth1_tests.js
+++ b/packages/oauth1/oauth1_tests.js
@@ -23,7 +23,7 @@ const testPendingCredential = async (test, method) => {
     this.accessTokenSecret = twitterfooAccessTokenSecret;
   };
 
-  await ServiceConfiguration.configurations.insertAsync({service: serviceName});
+  await ServiceConfiguration.configurations.insert({service: serviceName});
 
   try {
     // register a fake login service

--- a/packages/oauth2/oauth2_tests.js
+++ b/packages/oauth2/oauth2_tests.js
@@ -6,7 +6,7 @@ const testPendingCredential = async function (test, method) {
   const credentialToken = Random.id();
   const serviceName = Random.id();
 
-  await ServiceConfiguration.configurations.insert({service: serviceName});
+  await ServiceConfiguration.configurations.insertAsync({service: serviceName});
 
   try {
     // register a fake login service

--- a/packages/oauth2/oauth2_tests.js
+++ b/packages/oauth2/oauth2_tests.js
@@ -6,7 +6,7 @@ const testPendingCredential = async function (test, method) {
   const credentialToken = Random.id();
   const serviceName = Random.id();
 
-  await ServiceConfiguration.configurations.insertAsync({service: serviceName});
+  await ServiceConfiguration.configurations.insert({service: serviceName});
 
   try {
     // register a fake login service

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -221,11 +221,11 @@ var specialArgPaths = {
   }
 };
 
-const loadServerBundles = Profile("Load server bundles", async function () {
-  const infos = [];
-  const nonLocalNodeModulesPaths = new Set();
+var loadServerBundles = Profile("Load server bundles", async function () {
+  var infos = [];
+  var nonLocalNodeModulesPaths = new Set();
   for (const fileInfo of serverJson.load) {
-    const code = fs.readFileSync(path.resolve(serverDir, fileInfo.path));
+    var code = fs.readFileSync(path.resolve(serverDir, fileInfo.path));
 
     function addNodeModulesPath(path) {
       nonLocalNodeModulesPaths.add(
@@ -255,7 +255,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
       }
     }
 
-    const Npm = {
+    var Npm = {
       /**
        * @summary Require a package that was specified using
        * `Npm.depends()`.
@@ -267,7 +267,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
         return "Npm.require(" + JSON.stringify(name) + ")";
       }, function (name, error) {
         if (fileInfo.node_modules || nonLocalNodeModulesPaths.size > 0) {
-          let fullPath;
+          var fullPath;
 
           // Replace all backslashes with forward slashes, just in case
           // someone passes a Windows-y module identifier.
@@ -282,7 +282,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
             }
           } else {
             for (const nodeModuleBase of nonLocalNodeModulesPaths) {
-              const packageBase = files.convertToOSPath(files.pathResolve(
+              var packageBase = files.convertToOSPath(files.pathResolve(
                   nodeModuleBase,
                   name.split("/", 1)[0]
               ));
@@ -301,7 +301,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
           }
         }
 
-        const resolved = require.resolve(name);
+        var resolved = require.resolve(name);
         if (resolved === name && ! path.isAbsolute(resolved)) {
           // If require.resolve(id) === id and id is not an absolute
           // identifier, it must be a built-in module like fs or http.
@@ -314,7 +314,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
       })
     };
 
-    const getAsset = function (assetPath, encoding, callback) {
+    var getAsset = function (assetPath, encoding, callback) {
       let promiseResolver, promise;
       if (! callback) {
         promise = new Promise(r => promiseResolver = r);
@@ -324,7 +324,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
       // itself can't call Assets.get*. (We could change this function so that
       // it doesn't call bindEnvironment if you don't pass a callback if we need
       // to.)
-      const _callback = Package.meteor.Meteor.bindEnvironment(function (err, result) {
+      var _callback = Package.meteor.Meteor.bindEnvironment(function (err, result) {
         if (result && ! encoding)
             // Sadly, this copies in Node 0.10.
           result = new Uint8Array(result);
@@ -344,14 +344,14 @@ const loadServerBundles = Profile("Load server bundles", async function () {
       if (! fileInfo.assets || ! hasOwn.call(fileInfo.assets, assetPath)) {
         _callback(new Error("Unknown asset: " + assetPath));
       } else {
-        const filePath = path.join(serverDir, fileInfo.assets[assetPath]);
+        var filePath = path.join(serverDir, fileInfo.assets[assetPath]);
         fs.readFile(files.convertToOSPath(filePath), encoding, _callback);
       }
       if (promise)
         return promise;
     };
 
-    const Assets = {
+    var Assets = {
       getText: function (assetPath, callback) {
         return getAsset(assetPath, "utf8", callback);
       },
@@ -382,20 +382,20 @@ const loadServerBundles = Profile("Load server bundles", async function () {
       }
     };
 
-    const wrapParts = ["(function(Npm,Assets"];
+    var wrapParts = ["(function(Npm,Assets"];
 
-    const specialArgs =
+    var specialArgs =
         hasOwn.call(specialArgPaths, fileInfo.path) &&
         specialArgPaths[fileInfo.path](fileInfo);
 
-    const specialKeys = Object.keys(specialArgs || {});
+    var specialKeys = Object.keys(specialArgs || {});
     specialKeys.forEach(function (key) {
       wrapParts.push("," + key);
     });
 
     // \n is necessary in case final line is a //-comment
     wrapParts.push("){", code, "\n})");
-    const wrapped = wrapParts.join("");
+    var wrapped = wrapParts.join("");
 
     // It is safer to use the absolute path when source map is present as
     // different tooling, such as node-inspector, can get confused on relative
@@ -403,18 +403,18 @@ const loadServerBundles = Profile("Load server bundles", async function () {
 
     // fileInfo.path is a standard path, convert it to OS path to join with
     // __dirname
-    const fileInfoOSPath = files.convertToOSPath(fileInfo.path);
-    const absoluteFilePath = path.resolve(__dirname, fileInfoOSPath);
+    var fileInfoOSPath = files.convertToOSPath(fileInfo.path);
+    var absoluteFilePath = path.resolve(__dirname, fileInfoOSPath);
 
-    const scriptPath =
+    var scriptPath =
         parsedSourceMaps[absoluteFilePath] ? absoluteFilePath : fileInfoOSPath;
 
-    const func = await require('vm').runInThisContext(wrapped, {
+    var func = await require('vm').runInThisContext(wrapped, {
       filename: scriptPath,
       displayErrors: true
     });
 
-    const args = [Npm, Assets];
+    var args = [Npm, Assets];
 
     specialKeys.forEach(function (key) {
       args.push(specialArgs[key]);

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -274,27 +274,18 @@ const loadServerBundles = Profile("Load server bundles", async function () {
           // someone passes a Windows-y module identifier.
           name = name.split("\\").join("/");
 
-          if (fileInfo.node_modules) {
-            const packageBase = files.convertToOSPath(files.pathResolve(fileInfo.node_modules, name.split("/", 1)[0]));
+          nonLocalNodeModulesPaths.some(function (nodeModuleBase) {
+            const packageBase = files.convertToOSPath(files.pathResolve(
+              nodeModuleBase,
+              name.split("/", 1)[0]
+            ));
+
             if (statOrNull(packageBase)) {
-              fullPath = files.convertToOSPath(
-                  files.pathResolve(fileInfo.node_modules, name)
+              return fullPath = files.convertToOSPath(
+                files.pathResolve(nodeModuleBase, name)
               );
             }
-          } else {
-            nonLocalNodeModulesPaths.some(function (nodeModuleBase) {
-              const packageBase = files.convertToOSPath(files.pathResolve(
-                nodeModuleBase,
-                name.split("/", 1)[0]
-              ));
-
-              if (statOrNull(packageBase)) {
-                return fullPath = files.convertToOSPath(
-                  files.pathResolve(nodeModuleBase, name)
-                );
-              }
-            });
-          }
+          });
 
           if (fullPath) {
             return require(fullPath);

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -221,11 +221,11 @@ var specialArgPaths = {
   }
 };
 
-var loadServerBundles = Profile("Load server bundles", async function () {
-  var infos = [];
-  var nonLocalNodeModulesPaths = new Set();
+const loadServerBundles = Profile("Load server bundles", async function () {
+  const infos = [];
+  const nonLocalNodeModulesPaths = new Set();
   for (const fileInfo of serverJson.load) {
-    var code = fs.readFileSync(path.resolve(serverDir, fileInfo.path));
+    const code = fs.readFileSync(path.resolve(serverDir, fileInfo.path));
 
     function addNodeModulesPath(path) {
       nonLocalNodeModulesPaths.add(
@@ -255,7 +255,7 @@ var loadServerBundles = Profile("Load server bundles", async function () {
       }
     }
 
-    var Npm = {
+    const Npm = {
       /**
        * @summary Require a package that was specified using
        * `Npm.depends()`.
@@ -267,7 +267,7 @@ var loadServerBundles = Profile("Load server bundles", async function () {
         return "Npm.require(" + JSON.stringify(name) + ")";
       }, function (name, error) {
         if (fileInfo.node_modules || nonLocalNodeModulesPaths.size > 0) {
-          var fullPath;
+          let fullPath;
 
           // Replace all backslashes with forward slashes, just in case
           // someone passes a Windows-y module identifier.
@@ -282,7 +282,7 @@ var loadServerBundles = Profile("Load server bundles", async function () {
             }
           } else {
             for (const nodeModuleBase of nonLocalNodeModulesPaths) {
-              var packageBase = files.convertToOSPath(files.pathResolve(
+              const packageBase = files.convertToOSPath(files.pathResolve(
                   nodeModuleBase,
                   name.split("/", 1)[0]
               ));
@@ -301,7 +301,7 @@ var loadServerBundles = Profile("Load server bundles", async function () {
           }
         }
 
-        var resolved = require.resolve(name);
+        const resolved = require.resolve(name);
         if (resolved === name && ! path.isAbsolute(resolved)) {
           // If require.resolve(id) === id and id is not an absolute
           // identifier, it must be a built-in module like fs or http.
@@ -314,7 +314,7 @@ var loadServerBundles = Profile("Load server bundles", async function () {
       })
     };
 
-    var getAsset = function (assetPath, encoding, callback) {
+    const getAsset = function (assetPath, encoding, callback) {
       let promiseResolver, promise;
       if (! callback) {
         promise = new Promise(r => promiseResolver = r);
@@ -324,7 +324,7 @@ var loadServerBundles = Profile("Load server bundles", async function () {
       // itself can't call Assets.get*. (We could change this function so that
       // it doesn't call bindEnvironment if you don't pass a callback if we need
       // to.)
-      var _callback = Package.meteor.Meteor.bindEnvironment(function (err, result) {
+      const _callback = Package.meteor.Meteor.bindEnvironment(function (err, result) {
         if (result && ! encoding)
             // Sadly, this copies in Node 0.10.
           result = new Uint8Array(result);
@@ -344,14 +344,14 @@ var loadServerBundles = Profile("Load server bundles", async function () {
       if (! fileInfo.assets || ! hasOwn.call(fileInfo.assets, assetPath)) {
         _callback(new Error("Unknown asset: " + assetPath));
       } else {
-        var filePath = path.join(serverDir, fileInfo.assets[assetPath]);
+        const filePath = path.join(serverDir, fileInfo.assets[assetPath]);
         fs.readFile(files.convertToOSPath(filePath), encoding, _callback);
       }
       if (promise)
         return promise;
     };
 
-    var Assets = {
+    const Assets = {
       getText: function (assetPath, callback) {
         return getAsset(assetPath, "utf8", callback);
       },
@@ -382,20 +382,20 @@ var loadServerBundles = Profile("Load server bundles", async function () {
       }
     };
 
-    var wrapParts = ["(function(Npm,Assets"];
+    const wrapParts = ["(function(Npm,Assets"];
 
-    var specialArgs =
+    const specialArgs =
         hasOwn.call(specialArgPaths, fileInfo.path) &&
         specialArgPaths[fileInfo.path](fileInfo);
 
-    var specialKeys = Object.keys(specialArgs || {});
+    const specialKeys = Object.keys(specialArgs || {});
     specialKeys.forEach(function (key) {
       wrapParts.push("," + key);
     });
 
     // \n is necessary in case final line is a //-comment
     wrapParts.push("){", code, "\n})");
-    var wrapped = wrapParts.join("");
+    const wrapped = wrapParts.join("");
 
     // It is safer to use the absolute path when source map is present as
     // different tooling, such as node-inspector, can get confused on relative
@@ -403,18 +403,18 @@ var loadServerBundles = Profile("Load server bundles", async function () {
 
     // fileInfo.path is a standard path, convert it to OS path to join with
     // __dirname
-    var fileInfoOSPath = files.convertToOSPath(fileInfo.path);
-    var absoluteFilePath = path.resolve(__dirname, fileInfoOSPath);
+    const fileInfoOSPath = files.convertToOSPath(fileInfo.path);
+    const absoluteFilePath = path.resolve(__dirname, fileInfoOSPath);
 
-    var scriptPath =
+    const scriptPath =
         parsedSourceMaps[absoluteFilePath] ? absoluteFilePath : fileInfoOSPath;
 
-    var func = await require('vm').runInThisContext(wrapped, {
+    const func = await require('vm').runInThisContext(wrapped, {
       filename: scriptPath,
       displayErrors: true
     });
 
-    var args = [Npm, Assets];
+    const args = [Npm, Assets];
 
     specialKeys.forEach(function (key) {
       args.push(specialArgs[key]);

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -267,7 +267,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
       require: Profile(function getBucketName(name) {
         return "Npm.require(" + JSON.stringify(name) + ")";
       }, function (name, error) {
-        if (fileInfo.node_modules || nonLocalNodeModulesPaths.length > 0) {
+        if (nonLocalNodeModulesPaths.length > 0) {
           let fullPath;
 
           // Replace all backslashes with forward slashes, just in case


### PR DESCRIPTION
In this PR we're fixing tests for packages:
- oauth
- oauth1
- oauth2
- webapp

The main problem here was that the function [loadServerBundles](https://github.com/meteor/meteor/blob/b4c6274108fa53a3f67900096f5b9e744f387387/tools/static-assets/server/boot.js#L224), inside boot.js, was using `var` in a loop, and that was causing an override the values from the previous time the loop ran.

The solution was to change all the `var` for `const` or `let`.