### PR TITLE
Fixes #12516 - Mongo query hangs all clients subscribed to a query/collection

### DIFF
--- a/packages/mongo/oplog_observe_driver.js
+++ b/packages/mongo/oplog_observe_driver.js
@@ -887,15 +887,11 @@ _.extend(OplogObserveDriver.prototype, {
       // there.
       // XXX if this is slow, remove it later
       if (self._published.size() !== newResults.size()) {
-        console.error('The Mongo server and the Meteor query disagree on how ' +
+        Meteor._debug('The Mongo server and the Meteor query disagree on how ' +
           'many documents match your query. Cursor description: ',
           self._cursorDescription);
-        throw Error(
-          "The Mongo server and the Meteor query disagree on how " +
-            "many documents match your query. Maybe it is hitting a Mongo " +
-            "edge case? The query is: " +
-            EJSON.stringify(self._cursorDescription.selector));
       }
+      
       self._published.forEach(function (doc, id) {
         if (!newResults.has(id))
           throw Error("_published has a doc that newResults doesn't; " + id);


### PR DESCRIPTION
Throwing an error will break this particular observer for this particular query, causing all clients subscribed to this query (or even collection?) to hang (not receiving results for any of the methods they call).

I'm open to alternative approaches, but throwing an error breaking the entire client connection is way too much.