### PR TITLE
[Accounts] set custom collection

### DIFF
--- a/docs/source/api/accounts-multi.md
+++ b/docs/source/api/accounts-multi.md
@@ -69,6 +69,11 @@ client, no arguments are passed.
   The `connection` object the request came in on. See
   [`Meteor.onConnection`](#meteor_onconnection) for details.
 {% enddtdd %}
+
+{% dtdd name:"collection" type:"Object" %}
+  The `collection` The name of the Mongo.Collection
+  or the Mongo.Collection object to hold the users.
+{% enddtdd %}
 </dl>
 
 {% apibox "AccountsClient" %}
@@ -210,6 +215,11 @@ are called with a single argument, the attempt info object:
 {% dtdd name:"connection" type:"Object" %}
   The `connection` object the request came in on. See
   [`Meteor.onConnection`](#meteor_onconnection) for details.
+{% enddtdd %}
+
+{% dtdd name:"collection" type:"Object" %}
+  The `collection` The name of the Mongo.Collection
+  or the Mongo.Collection object to hold the users.
 {% enddtdd %}
 
 {% dtdd name:"methodName" type:"String" %}

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -16,6 +16,7 @@ const VALID_CONFIG_KEYS = [
   'defaultFieldSelector',
   'loginTokenExpirationHours',
   'tokenSequenceLength',
+  'collection',
 ];
 
 /**
@@ -26,6 +27,8 @@ const VALID_CONFIG_KEYS = [
  * @param options {Object} an object with fields:
  * - connection {Object} Optional DDP connection to reuse.
  * - ddpUrl {String} Optional URL for creating a new DDP connection.
+ * - collection {String|Mongo.Collection} The name of the Mongo.Collection
+ *     or the Mongo.Collection object to hold the users.
  */
 export class AccountsCommon {
   constructor(options) {
@@ -40,10 +43,7 @@ export class AccountsCommon {
 
     // There is an allow call in accounts_server.js that restricts writes to
     // this collection.
-    this.users = new Mongo.Collection(process.env.MONGO_USERS_COLLECTION || 'users', {
-      _preventAutopublish: true,
-      connection: this.connection,
-    });
+    this.users = this._initializeCollection(options || {});
 
     // Callback exceptions are printed with Meteor._debug and ignored.
     this._onLoginHook = new Hook({
@@ -79,6 +79,29 @@ export class AccountsCommon {
     // should come up with a more generic way to do this (eg, with some sort of
     // symbolic error code rather than a number).
     this.LoginCancelledError.numericError = 0x8acdc2f;
+  }
+
+  _initializeCollection(options) {
+    if (options.collection && typeof options.collection !== 'string' && !(options.collection instanceof Mongo.Collection)) {
+      throw new Meteor.Error('Collection parameter can be only of type string or "Mongo.Collection"');
+    }
+
+    let collectionName = 'users';
+    if (typeof options.collection === 'string') {
+      collectionName = options.collection;
+    }
+
+    let collection;
+    if (options.collection instanceof Mongo.Collection) {
+      collection = options.collection;
+    } else {
+      collection = new Mongo.Collection(collectionName, {
+        _preventAutopublish: true,
+        connection: this.connection,
+      });
+    }
+
+    return collection;
   }
 
   /**
@@ -172,6 +195,8 @@ export class AccountsCommon {
   // - loginExpirationInDays {Number}
   //     Number of days since login until a user is logged out (login token
   //     expires).
+  // - collection {String|Mongo.Collection}
+  //     A collection name or a Mongo.Collection object to hold the users.
   // - passwordResetTokenExpirationInDays {Number}
   //     Number of days since password reset token creation until the
   //     token cannt be used any longer (password reset token expires).
@@ -198,6 +223,7 @@ export class AccountsCommon {
    * @param {Number} options.passwordEnrollTokenExpiration The number of milliseconds from when a link to set initial password is sent until token expires and user can't set password with the link anymore. If `passwordEnrollTokenExpirationInDays` is set, it takes precedent.
    * @param {Boolean} options.ambiguousErrorMessages Return ambiguous error messages from login failures to prevent user enumeration. Defaults to false.
    * @param {MongoFieldSpecifier} options.defaultFieldSelector To exclude by default large custom fields from `Meteor.user()` and `Meteor.findUserBy...()` functions when called without a field selector, and all `onLogin`, `onLoginFailure` and `onLogout` callbacks.  Example: `Accounts.config({ defaultFieldSelector: { myBigArray: 0 }})`. Beware when using this. If, for instance, you do not include `email` when excluding the fields, you can have problems with functions like `forgotPassword` that will break because they won't have the required data available. It's recommend that you always keep the fields `_id`, `username`, and `email`.
+   * @param {String|Mongo.Collection} options.collection A collection name or a Mongo.Collection object to hold the users.
    * @param {Number} options.loginTokenExpirationHours When using the package `accounts-2fa`, use this to set the amount of time a token sent is valid. As it's just a number, you can use, for example, 0.5 to make the token valid for just half hour. The default is 1 hour.
    * @param {Number} options.tokenSequenceLength When using the package `accounts-2fa`, use this to the size of the token sequence generated. The default is 6.
    */
@@ -251,11 +277,17 @@ export class AccountsCommon {
     VALID_CONFIG_KEYS.forEach(key => {
       if (key in options) {
         if (key in this._options) {
-          throw new Meteor.Error(`Can't set \`${key}\` more than once`);
+          if (key !== 'collection') {
+            throw new Meteor.Error(`Can't set \`${key}\` more than once`);
+          }
         }
         this._options[key] = options[key];
       }
     });
+
+    if (options.collection && options.collection !== this.users._name && options.collection !== this.users) {
+      this.users = this._initializeCollection(options);
+    }
   }
 
   /**

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -40,7 +40,7 @@ export class AccountsCommon {
 
     // There is an allow call in accounts_server.js that restricts writes to
     // this collection.
-    this.users = new Mongo.Collection('users', {
+    this.users = new Mongo.Collection(process.env.MONGO_USERS_COLLECTION || 'users', {
       _preventAutopublish: true,
       connection: this.connection,
     });

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -26,8 +26,8 @@ export class AccountsServer extends AccountsCommon {
   // Note that this constructor is less likely to be instantiated multiple
   // times than the `AccountsClient` constructor, because a single server
   // can provide only one set of methods.
-  constructor(server) {
-    super();
+  constructor(server, options) {
+    super(options || {});
 
     this._server = server || Meteor.server;
     // Set up the server's methods, as if by calling Meteor.methods.

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -1,3 +1,4 @@
+import { Mongo } from 'meteor/mongo';
 import { URL } from 'meteor/url';
 import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
@@ -795,6 +796,56 @@ Tinytest.add(
 );
 
 if(Meteor.isServer) {
+  Tinytest.add('accounts - config - collection - mongo.collection', test => {
+    const origCollection = Accounts.users;
+    // create same user in two different collections - should pass
+    const email = "test-collection@testdomain.com"
+
+    const collection0 = new Mongo.Collection('test1');
+
+    Accounts.config({
+      collection: collection0,
+    })
+    const uid0 = Accounts.createUser({email})
+    Meteor.users.remove(uid0);
+
+    const collection1 = new Mongo.Collection('test2');
+    Accounts.config({
+      collection: collection1,
+    })
+    const uid1 = Accounts.createUser({email})
+    Meteor.users.remove(uid1);
+
+    test.notEqual(uid0, uid1);
+
+    Accounts.config({
+      collection: origCollection,
+    });
+  });
+  Tinytest.add('accounts - config - collection - name', test => {
+    const origCollection = Accounts.users;
+    // create same user in two different collections - should pass
+    const email = "test-collection@testdomain.com"
+
+    Accounts.config({
+      collection: 'collection0',
+    })
+    const uid0 = Accounts.createUser({email})
+    Meteor.users.remove(uid0);
+
+    Accounts.config({
+      collection: 'collection1',
+    })
+    const uid1 = Accounts.createUser({email})
+    Meteor.users.remove(uid1);
+
+    test.notEqual(uid0, uid1);
+
+    Accounts.config({
+      collection: origCollection,
+    });
+  });
+
   Tinytest.add(
     'accounts - make sure that extra params to accounts urls are added',
     test => {


### PR DESCRIPTION
Add custom option to Accounts package:

`collection` {_String_|_Mongo.Collection_} - Instance of _Mongo.Collection_ or collection name as _String_



* [discussion](https://github.com/meteor/meteor/discussions/12544#discussioncomment-5240763) 
* [related issue](https://github.com/meteor/meteor-feature-requests/issues/20)



