### PR TITLE
[Meteor 3] Fix missing non-hoisted exports

### DIFF
--- a/npm-packages/meteor-babel/package.json
+++ b/npm-packages/meteor-babel/package.json
@@ -41,7 +41,7 @@
     "@babel/template": "^7.16.7",
     "@babel/traverse": "^7.17.0",
     "@babel/types": "^7.17.0",
-    "@meteorjs/reify": "https://github.com/meteor/reify/tarball/0867be73ca61e87ae9d60edef62baf26b38719ef",
+    "@meteorjs/reify": "https://github.com/meteor/reify/tarball/cf61c57c6c4fefcbf164bf63d3c12fda1924b3d2",
     "babel-preset-meteor": "^7.10.0",
     "babel-preset-minify": "^0.5.1",
     "convert-source-map": "^1.6.0",

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "@meteorjs/reify": "git+https://github.com/meteor/reify.git#0867be73ca61e87ae9d60edef62baf26b38719ef",
+  "@meteorjs/reify": "git+https://github.com/meteor/reify.git#cf61c57c6c4fefcbf164bf63d3c12fda1924b3d2",
   "meteor-babel-helpers": "0.0.3",
 });
 


### PR DESCRIPTION
Updates reify to include the changes in https://github.com/meteor/reify/pull/4/commits/cf61c57c6c4fefcbf164bf63d3c12fda1924b3d2. Fixes non-hoisted exports (`export let ...`, `export const ....`) sometimes missing when a module does not use TLA and imports an async module.