### PR TITLE
docs: update CI badges and links in the top README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <div align="center">
 
-[![TravisCI Status](https://travis-ci.org/meteor/meteor.svg?branch=devel)](https://travis-ci.org/meteor/meteor)
-[![CircleCI Status](https://circleci.com/gh/meteor/meteor/tree/devel.svg?style=shield&circle-token=c2d3c041506bd493ef3795ffa4448684cfce97b8)](https://circleci.com/gh/meteor/meteor/tree/devel)
+[![Travis CI Status](https://api.travis-ci.com/meteor/meteor.svg?branch=devel)](https://app.travis-ci.com/github/meteor/meteor)
+[![CircleCI Status](https://circleci.com/gh/meteor/meteor.svg?style=svg)](https://app.circleci.com/pipelines/github/meteor/meteor?branch=devel)
 [![built with Meteor](https://img.shields.io/badge/Meteor-2.12-green?logo=meteor&logoColor=white)](https://meteor.com)
   
 </div>


### PR DESCRIPTION
CI badges and links to CI results have been dead on https://github.com/meteor/meteor/blob/master/README.md

## Links

- `https://travis-ci.org/meteor/meteor` (dead) => https://app.travis-ci.com/github/meteor/meteor
- `https://circleci.com/gh/meteor/meteor/tree/devel` (to avoid an extra redirection) => https://app.circleci.com/pipelines/github/meteor/meteor?branch=devel

## Badges
### before

![github com_meteor_meteor_blob_master_README md](https://user-images.githubusercontent.com/10229505/236084160-00af1f29-6cac-4ad1-9013-92c2b6674059.png)

(https://github.com/meteor/meteor/blob/1d6983c0ecfb351400363f7eafb20d2686455704/README.md)

### after

![github com_tnir_meteor_tree_devel](https://user-images.githubusercontent.com/10229505/236084331-1fc4bc8b-a851-46f1-8cd7-2996f71d3351.png)

(`https://github.com/tnir/meteor/blob/289a46fdc6e9c1d131769c94761c6d134879058d/README.md`)
