### PR TITLE
Update guide code for GraphQL initialization

### DIFF
--- a/guide/source/apollo.md
+++ b/guide/source/apollo.md
@@ -73,18 +73,37 @@ meteor add apollo
 On server you import `getUser` function and include it into the context option when setting up Apollo server:
 
 ```javascript
-import { ApolloServer } from 'apollo-server-express';
+import { ApolloServer } from '@apollo/server';
+import { WebApp } from 'meteor/webapp';
 import { getUser } from 'meteor/apollo';
 import typeDefs from '/imports/apollo/schema.graphql';
 import { resolvers } from '/server/resolvers';
+import express from 'express';
+import { expressMiddleware } from '@apollo/server/express4';
+import { json } from 'body-parser'
+
+const context = async ({ req }) => ({
+  user: await getUser(req.headers.authorization)
+})
 
 const server = new ApolloServer({
+  cache: 'bounded',
   typeDefs,
   resolvers,
-  context: async ({ req }) => ({
-    user: await getUser(req.headers.authorization)
-  })
 });
+
+export async function startApolloServer() {
+  await server.start();
+
+  WebApp.connectHandlers.use(
+    '/graphql',                                     // Configure the path as you want.
+    express()                                       // Create new Express router.
+      .disable('etag')                     // We don't server GET requests, so there's no need for that.
+      .disable('x-powered-by')             // A small safety measure.
+      .use(json())                                  // From `body-parser`.
+      .use(expressMiddleware(server, { context })), // From `@apollo/server/express4`.
+  )
+}
 ```
 
 This will make user data available (if user is logged in) as the option in the query:

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -8,10 +8,10 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@apollo/client": "^3.7.5",
-    "@apollo/server": "^4.3.2",
-    "@babel/runtime": "^7.20.13",
-    "body-parser": "^1.20.1",
+    "@apollo/client": "^3.7.14",
+    "@apollo/server": "^4.7.1",
+    "@babel/runtime": "^7.21.5",
+    "body-parser": "^1.20.2",
     "express": "^4.18.2",
     "graphql": "^16.6.0",
     "meteor-node-stubs": "^1.2.5",


### PR DESCRIPTION
It was pointed out to me on the [forums](https://forums.meteor.com/t/apollo-package-v5-suggestion/59889/3?u=storyteller&utm_source=storyteller&utm_medium=online&utm_campaign=Q2-2022-Ambassadors) that the Apollo server setup code in the Guide is outdated. This PR fixes that by including code from the Apollo skeleton.

While at it I have also updated the skeleton's NPM dependencies 📦 to their latest version.