### PR TITLE
Typescript 5

### DIFF
--- a/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
+++ b/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
@@ -14,15 +14,15 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "8.0.0",
     "node-pre-gyp": "0.15.0",
-    typescript: "4.9.5",
-    "@meteorjs/babel": "7.18.0-beta.6",
+    typescript: "5.0.4",
+    "@meteorjs/babel": "7.19.0-beta.1",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",
     fibers: "https://github.com/meteor/node-fibers/archive/refs/tags/5.0.0.tar.gz",
     "@meteorjs/reify": "0.24.0",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
-    "@babel/runtime": "7.15.3",
+    "@babel/runtime": "7.21.5",
     // For backwards compatibility with isopackets that still depend on
     // babel-runtime rather than @babel/runtime.
     "babel-runtime": "7.0.0-beta.3",

--- a/npm-packages/meteor-babel/package.json
+++ b/npm-packages/meteor-babel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meteorjs/babel",
   "author": "Meteor <dev@meteor.com>",
-  "version": "7.18.0-beta.7",
+  "version": "7.19.0-beta.1",
   "license": "MIT",
   "description": "Babel wrapper package for use with Meteor",
   "keywords": [
@@ -30,33 +30,33 @@
     "url": "https://github.com/meteor/babel/issues"
   },
   "dependencies": {
-    "@babel/core": "^7.17.2",
-    "@babel/parser": "^7.17.0",
-    "@babel/plugin-proposal-class-properties": "^7.16.7",
+    "@babel/core": "^7.21.8",
+    "@babel/parser": "^7.21.8",
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@babel/plugin-transform-modules-commonjs": "^7.16.8",
-    "@babel/plugin-transform-runtime": "^7.17.0",
-    "@babel/preset-react": "^7.16.7",
-    "@babel/runtime": "7.17.2",
-    "@babel/template": "^7.16.7",
-    "@babel/traverse": "^7.17.0",
-    "@babel/types": "^7.17.0",
-    "@meteorjs/reify": "0.23.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.21.5",
+    "@babel/plugin-transform-runtime": "^7.21.4",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/runtime": "7.21.5",
+    "@babel/template": "^7.20.7",
+    "@babel/traverse": "^7.21.5",
+    "@babel/types": "^7.21.5",
+    "@meteorjs/reify": "0.24.0",
     "babel-preset-meteor": "^7.10.0",
-    "babel-preset-minify": "^0.5.1",
-    "convert-source-map": "^1.6.0",
+    "babel-preset-minify": "^0.5.2",
+    "convert-source-map": "^1.9.0",
     "lodash": "^4.17.21",
     "meteor-babel-helpers": "0.0.3",
-    "typescript": "~4.9.5"
+    "typescript": "~5.0.4"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-decorators": "7.14.5",
-    "@babel/plugin-syntax-decorators": "7.14.5",
+    "@babel/plugin-proposal-decorators": "7.21.0",
+    "@babel/plugin-syntax-decorators": "7.21.0",
     "d3": "4.13.0",
-    "fibers": "5.0.0",
+    "fibers": "5.0.3",
     "meteor-promise": "0.9.0",
     "mocha": "6.2.3",
-    "promise": "8.1.0",
-    "source-map": "0.6.1"
+    "promise": "8.3.0",
+    "source-map": "0.7.4"
   }
 }

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   name: "babel-compiler",
   summary: "Parser/transpiler for ECMAScript 2015+ syntax",
-  version: '7.10.5',
+  version: '7.10.6',
 });
 
 Npm.depends({
-  '@meteorjs/babel': '7.18.0-beta.7',
+  '@meteorjs/babel': '7.19.0-beta.1',
   'json5': '2.1.1'
 });
 

--- a/packages/typescript/package.js
+++ b/packages/typescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'typescript',
-  version: '4.9.5',
+  version: '5.0.4',
   summary:
     'Compiler plugin that compiles TypeScript and ECMAScript in .ts and .tsx files',
   documentation: 'README.md',

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -14,15 +14,15 @@ var packageJson = {
     pacote: "https://github.com/meteor/pacote/tarball/a81b0324686e85d22c7688c47629d4009000e8b8",
     "node-gyp": "8.0.0",
     "node-pre-gyp": "0.15.0",
-    typescript: "4.9.5",
-    "@meteorjs/babel": "7.18.0-beta.7",
+    typescript: "5.0.4",
+    "@meteorjs/babel": "7.19.0-beta.1",
     // Keep the versions of these packages consistent with the versions
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",
     fibers: "5.0.1",
     "@meteorjs/reify": "0.24.0",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
-    "@babel/runtime": "7.15.3",
+    "@babel/runtime": "7.21.5",
     // For backwards compatibility with isopackets that still depend on
     // babel-runtime rather than @babel/runtime.
     "babel-runtime": "7.0.0-beta.3",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^18.16.5",
     "@types/react": "^18.2.5",
     "@types/react-dom": "^18.2.4",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.4"
   },
   "meteor": {
     "mainModule": {


### PR DESCRIPTION
Upgrade to Typescript 5
Release article: https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/

Also updated dependencies in `meteor-babel`.