### PR TITLE
chore: Add Viewport tags to all skeletons to fix mobile look

### DIFF
--- a/tools/static-assets/skel-apollo/client/main.html
+++ b/tools/static-assets/skel-apollo/client/main.html
@@ -1,5 +1,13 @@
 <head>
   <title>Apollo Skeleton</title>
+  <meta charset="utf-8"/>
+  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+  <meta
+      name="viewport"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+  />
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-apollo/client/main.html
+++ b/tools/static-assets/skel-apollo/client/main.html
@@ -1,13 +1,6 @@
 <head>
   <title>Apollo Skeleton</title>
-  <meta charset="utf-8"/>
-  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-  <meta
-      name="viewport"
-      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-  />
-  <meta name="mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/tools/static-assets/skel-blaze/client/main.html
+++ b/tools/static-assets/skel-blaze/client/main.html
@@ -1,5 +1,13 @@
 <head>
   <title>~name~</title>
+  <meta charset="utf-8"/>
+  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+  <meta
+      name="viewport"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+  />
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-blaze/client/main.html
+++ b/tools/static-assets/skel-blaze/client/main.html
@@ -1,13 +1,6 @@
 <head>
   <title>~name~</title>
-  <meta charset="utf-8"/>
-  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-  <meta
-      name="viewport"
-      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-  />
-  <meta name="mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/tools/static-assets/skel-chakra-ui/client/main.html
+++ b/tools/static-assets/skel-chakra-ui/client/main.html
@@ -1,5 +1,13 @@
 <head>
   <title>~name~</title>
+  <meta charset="utf-8"/>
+  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+  <meta
+      name="viewport"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+  />
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-chakra-ui/client/main.html
+++ b/tools/static-assets/skel-chakra-ui/client/main.html
@@ -1,13 +1,6 @@
 <head>
   <title>~name~</title>
-  <meta charset="utf-8"/>
-  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-  <meta
-      name="viewport"
-      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-  />
-  <meta name="mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/tools/static-assets/skel-full/client/head.html
+++ b/tools/static-assets/skel-full/client/head.html
@@ -1,11 +1,4 @@
 <head>
   <title>~name~</title>
-  <meta charset="utf-8"/>
-  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-  <meta
-      name="viewport"
-      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-  />
-  <meta name="mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>

--- a/tools/static-assets/skel-full/client/head.html
+++ b/tools/static-assets/skel-full/client/head.html
@@ -1,3 +1,11 @@
 <head>
   <title>~name~</title>
+  <meta charset="utf-8"/>
+  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+  <meta
+      name="viewport"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+  />
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>

--- a/tools/static-assets/skel-minimal/client/main.html
+++ b/tools/static-assets/skel-minimal/client/main.html
@@ -1,5 +1,13 @@
 <head>
   <title>Minimal Meteor app</title>
+  <meta charset="utf-8"/>
+  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+  <meta
+      name="viewport"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+  />
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-react/client/main.html
+++ b/tools/static-assets/skel-react/client/main.html
@@ -1,5 +1,13 @@
 <head>
   <title>~name~</title>
+  <meta charset="utf-8"/>
+  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+  <meta
+      name="viewport"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+  />
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-solid/client/main.html
+++ b/tools/static-assets/skel-solid/client/main.html
@@ -1,13 +1,6 @@
 <head>
     <title>~name~</title>
-    <meta charset="utf-8"/>
-    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-    <meta
-        name="viewport"
-        content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-    />
-    <meta name="mobile-web-app-capable" content="yes"/>
-    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/tools/static-assets/skel-solid/client/main.html
+++ b/tools/static-assets/skel-solid/client/main.html
@@ -1,5 +1,13 @@
 <head>
     <title>~name~</title>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <meta
+        name="viewport"
+        content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+    />
+    <meta name="mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-svelte/client/main.html
+++ b/tools/static-assets/skel-svelte/client/main.html
@@ -1,13 +1,6 @@
 <head>
     <title>~name~</title>
-    <meta charset="utf-8"/>
-    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-    <meta
-        name="viewport"
-        content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-    />
-    <meta name="mobile-web-app-capable" content="yes"/>
-    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/tools/static-assets/skel-svelte/client/main.html
+++ b/tools/static-assets/skel-svelte/client/main.html
@@ -1,5 +1,13 @@
 <head>
     <title>~name~</title>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <meta
+        name="viewport"
+        content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+    />
+    <meta name="mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-tailwind/client/main.html
+++ b/tools/static-assets/skel-tailwind/client/main.html
@@ -1,13 +1,6 @@
 <head>
     <title>~name~</title>
-    <meta charset="utf-8"/>
-    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-    <meta
-            name="viewport"
-            content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-    />
-    <meta name="mobile-web-app-capable" content="yes"/>
-    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/tools/static-assets/skel-typescript/client/main.html
+++ b/tools/static-assets/skel-typescript/client/main.html
@@ -1,5 +1,13 @@
 <head>
   <title>~name~</title>
+  <meta charset="utf-8"/>
+  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+  <meta
+      name="viewport"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+  />
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-typescript/client/main.html
+++ b/tools/static-assets/skel-typescript/client/main.html
@@ -1,13 +1,6 @@
 <head>
   <title>~name~</title>
-  <meta charset="utf-8"/>
-  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-  <meta
-      name="viewport"
-      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-  />
-  <meta name="mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/tools/static-assets/skel-vue-2/client/main.html
+++ b/tools/static-assets/skel-vue-2/client/main.html
@@ -1,5 +1,13 @@
 <head>
   <title>~name~</title>
+  <meta charset="utf-8"/>
+  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+  <meta
+      name="viewport"
+      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+  />
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
 </head>
 
 <body>

--- a/tools/static-assets/skel-vue-2/client/main.html
+++ b/tools/static-assets/skel-vue-2/client/main.html
@@ -1,13 +1,6 @@
 <head>
   <title>~name~</title>
-  <meta charset="utf-8"/>
-  <meta http-equiv="x-ua-compatible" content="ie=edge"/>
-  <meta
-      name="viewport"
-      content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-  />
-  <meta name="mobile-web-app-capable" content="yes"/>
-  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/tools/static-assets/skel-vue/client/main.html
+++ b/tools/static-assets/skel-vue/client/main.html
@@ -1,13 +1,6 @@
 <head>
   <title>~name~</title>
-  <meta charset="utf-8" />
-  <meta http-equiv="x-ua-compatible" content="ie=edge" />
-  <meta
-    name="viewport"
-    content="width=device-width, height=device-height, viewport-fit=cover, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-  />
-  <meta name="mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>


### PR DESCRIPTION
To optimize the mobile viewing experience, it's recommended to add viewport tags to our apps.

This simple fix, adds them to all our skeletons and can ensure that the content on the website appears properly on different mobile devices, regardless of their screen size or orientation. After this is released, we can also remove [one step](https://react-tutorial.meteor.com/simple-todos/01-creating-app.html#1-6-Mobile-look) from our tutorials, making it easier to create new Meteor apps.