### PR TITLE
Updated addRule documentation to include setErrorMessageOnRule

### DIFF
--- a/packages/ddp-rate-limiter/ddp-rate-limiter.js
+++ b/packages/ddp-rate-limiter/ddp-rate-limiter.js
@@ -74,7 +74,7 @@ DDPRateLimiter.setErrorMessageOnRule = (ruleId, message) => {
  * - `connectionId`: A string representing the user's DDP connection
  * - `clientAddress`: The IP address of the user
  *
- * Returns unique `ruleId` that can be passed to `removeRule`.
+ * Returns unique `ruleId` that can be passed to `removeRule` and `setErrorMessageOnRule`
  *
  * @param {Object} matcher
  *   Matchers specify which events are counted towards a rate limit. A matcher


### PR DESCRIPTION
The current return shows that it can be passed to removeRule. This PR adds the additional  `setErrorMessageOnRule` argument as a possible usage for ruleId.