### PR TITLE
Updating the _config.yml to show 2.12

### DIFF
--- a/guide/_config.yml
+++ b/guide/_config.yml
@@ -41,7 +41,7 @@ sidebar_categories:
     - index
     - code-style
     - structure
-    - 2.11-migration
+    - 2.12-migration
   Data:
     - collections
     - data-loading


### PR DESCRIPTION
This is a fix for showing instead of the migration guide for 2.11, to show the migration guide for 2.12