### PR TITLE
Update mongo.d.ts with projection

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -30,8 +30,12 @@ export namespace Mongo {
     skip?: number | undefined;
     /** Maximum number of results to return */
     limit?: number | undefined;
-    /** Dictionary of fields to return or exclude. */
+    /**
+     * Dictionary of fields to return or exclude.
+     * @deprecated use projection instead
+     */
     fields?: FieldSpecifier | undefined;
+    /** Dictionary of fields to return or exclude. */
     projection?: FieldSpecifier | undefined;
     /** (Server only) Overrides MongoDB's default index selection and query optimization process. Specify an index to force its use, either by its name or index specification. */
     hint?: NpmModuleMongodb.Hint | undefined;

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -32,6 +32,7 @@ export namespace Mongo {
     limit?: number | undefined;
     /** Dictionary of fields to return or exclude. */
     fields?: FieldSpecifier | undefined;
+    projection?: FieldSpecifier | undefined;
     /** (Server only) Overrides MongoDB's default index selection and query optimization process. Specify an index to force its use, either by its name or index specification. */
     hint?: NpmModuleMongodb.Hint | undefined;
     /** (Client only) Default `true`; pass `false` to disable reactivity */

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -146,7 +146,7 @@ Object.assign(OplogHandle.prototype, {
       try {
         lastEntry = self._oplogLastEntryConnection.findOne(
           OPLOG_COLLECTION, self._baseOplogSelector,
-          {fields: {ts: 1}, sort: {$natural: -1}});
+          {projection: {ts: 1}, sort: {$natural: -1}});
         break;
       } catch (e) {
         // During failover (eg) if we get an exception we should log and retry
@@ -229,7 +229,7 @@ Object.assign(OplogHandle.prototype, {
 
     // Find the last oplog entry.
     var lastOplogEntry = self._oplogLastEntryConnection.findOne(
-      OPLOG_COLLECTION, {}, {sort: {$natural: -1}, fields: {ts: 1}});
+      OPLOG_COLLECTION, {}, {sort: {$natural: -1}, projection: {ts: 1}});
 
     var oplogSelector = _.clone(self._baseOplogSelector);
     if (lastOplogEntry) {


### PR DESCRIPTION
Fields have been renamed to projection upstream and while in Meteor we can use both, it was not accounted for in the TS definitions.