### PR TITLE
[Meteor 3]: Removing unnecessary async Profile.time

### DIFF
--- a/packages/constraint-solver/constraint-solver.js
+++ b/packages/constraint-solver/constraint-solver.js
@@ -96,8 +96,7 @@ CS.PackagesResolver.prototype.resolve = async function (dependencies, constraint
       });
     });
   }
-
-  await Profile.time(
+  await Profile.time( 
     "Input#loadOnlyPreviousSolution",
     function () {
       return input.loadOnlyPreviousSolution(self.catalogLoader);
@@ -176,14 +175,12 @@ CS.PackagesResolver._resolveWithInput = async function (input, options) {
     console.log(JSON.stringify(input.toJSONable(), null, 2));
   }
 
-  var solver = await (options.Profile || CS.DummyProfile).time("new CS.Solver", async function () {
+  var solver = (options.Profile || CS.DummyProfile).time("new CS.Solver", function () {
     const _solver = new CS.Solver(input, {
       nudge: options.nudge,
       yield: options.yield,
       Profile: options.Profile
     });
-    await _solver.init();
-
     return _solver;
   });
 

--- a/packages/constraint-solver/constraint-solver.js
+++ b/packages/constraint-solver/constraint-solver.js
@@ -49,14 +49,20 @@ CS.PackagesResolver.prototype.resolve = async function (dependencies, constraint
   options = options || {};
   var Profile = (self._options.Profile || CS.DummyProfile);
 
-  var input = await Profile.time("new CS.Input", function () {
-    return new CS.Input(dependencies, constraints, self.catalogCache,
-                         _.pick(options,
-                                'upgrade',
-                                'anticipatedPrereleases',
-                                'previousSolution',
-                                'allowIncompatibleUpdate',
-                                'upgradeIndirectDepPatchVersions'));
+  var input = Profile.time("new CS.Input", function () {
+    return new CS.Input(
+      dependencies,
+      constraints,
+      self.catalogCache,
+      _.pick(
+        options,
+        "upgrade",
+        "anticipatedPrereleases",
+        "previousSolution",
+        "allowIncompatibleUpdate",
+        "upgradeIndirectDepPatchVersions"
+      )
+    );
   });
 
   // The constraint solver avoids re-solving everything from scratch on
@@ -99,11 +105,12 @@ CS.PackagesResolver.prototype.resolve = async function (dependencies, constraint
 
   if (options.previousSolution && options.missingPreviousVersionIsError) {
     // see comment where missingPreviousVersionIsError is passed in
-    await Profile.time("check for previous versions in catalog", function () {
+    Profile.time("check for previous versions in catalog", function () {
       _.each(options.previousSolution, function (version, pkg) {
-        if (! input.catalogCache.hasPackageVersion(pkg, version)) {
+        if (!input.catalogCache.hasPackageVersion(pkg, version)) {
           CS.throwConstraintSolverError(
-            "Package version not in catalog: " + pkg + " " + version);
+            "Package version not in catalog: " + pkg + " " + version
+          );
         }
       });
     });

--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -142,7 +142,7 @@ Object.assign(Module.prototype, {
         }
 
         const node = await file.getPrelinkedOutput({ preserveLineNumbers: true });
-        const results = await Profile.time(
+        const results = Profile.time(
             "toStringWithSourceMap (app)", () => {
               return node.toStringWithSourceMap({
                 file: file.servePath
@@ -244,7 +244,7 @@ Object.assign(Module.prototype, {
 
     var node = new sourcemap.SourceNode(null, null, null, chunks);
 
-    await Profile.time(
+    Profile.time(
       'getPrelinkedFiles toStringWithSourceMap',
       function () {
         if (fileCount > 0) {


### PR DESCRIPTION
Relates to this public [card](https://github.com/orgs/meteor/projects/10/views/1?pane=issue&itemId=27872403)


- [x] Remove all non required uses of Profile.time

- [x] Check if all cases where is no longer needed async await have been adjusted upstream


The wrong uses were removed. Now is needed to make these changes go upstream.