### PR TITLE
Updating mongo types

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -176,12 +176,12 @@ export namespace Mongo {
      * @param selector The query for filtering the set of documents to count
      * @param options All options are listed in [MongoDB documentation](https://mongodb.github.io/node-mongodb-native/4.11/interfaces/CountDocumentsOptions.html). Please note that not all of them are available on the client.
      */
-    countDocuments(selector?: Selector<T> | ObjectID | string, options?: MongoNpmModule.CountDocumentsOptions): Promise<number>;
+    countDocuments(selector?: Selector<T> | ObjectID | string, options?: NpmModuleMongodb.CountDocumentsOptions): Promise<number>;
     /**
      * Gets an estimate of the count of documents in a collection using collection metadata. For an exact count of the documents in a collection see `countDocuments`.
      * @param options All options are listed in [MongoDB documentation](https://mongodb.github.io/node-mongodb-native/4.11/interfaces/CountDocumentsOptions.html). Please note that not all of them are available on the client.
      */
-    estimatedDocumentCount(options?: MongoNpmModule.EstimatedDocumentCountOptions): Promise<number>;
+    estimatedDocumentCount(options?: NpmModuleMongodb.EstimatedDocumentCountOptions): Promise<number>;
     /**
      * Insert a document in the collection.  Returns its unique _id.
      * @param doc The document to insert. May not yet have an _id attribute, in which case Meteor will generate one for you.


### PR DESCRIPTION
As commented in [Slack](https://meteor-community.slack.com/archives/CS46CNDN0/p1683748449822519) by @zodern, it was wrong the .d.ts files.

As a future todo, I've added the addition of tests to be sure that this does not happen again.

Below there is a print showing that it works now, before, the options parameter was being treated as `any`:
![Screenshot 2023-05-17 at 14 19 01](https://github.com/meteor/meteor/assets/70247653/5affc187-7dcb-4093-a8b5-d2767cd1eac8)
