### PR TITLE
Handled implicit collection creation oplog message (fixes #12627).

### DIFF
--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -308,6 +308,9 @@ Object.assign(OplogHandle.prototype, {
             trigger.collection = doc.o.drop;
             trigger.dropCollection = true;
             trigger.id = null;
+          } else if ("create" in doc.o && "idIndex" in doc.o) {
+            // A collection got implicitly created within a transaction. There's
+            // no need to do anything about it.
           } else {
             throw Error("Unknown command " + EJSON.stringify(doc));
           }

--- a/packages/mongo/oplog_tests.js
+++ b/packages/mongo/oplog_tests.js
@@ -164,6 +164,21 @@ process.env.MONGO_OPLOG_URL && testAsyncMulti(
   ]
 );
 
+import { Mongo, MongoInternals } from 'meteor/mongo';
+process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
+  'mongo-livedata - oplog - x - implicit collection creation',
+  async test => {
+    const collection = new Mongo.Collection(`oplog-implicit-${test.runId()}`);
+    const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo;
+    test.equal(await collection.find().countAsync(), 0);
+    await client.withSession(async session => {
+      await session.withTransaction(async () => {
+        await collection.rawCollection().insertOne({}, { session });
+      });
+    });
+    test.equal(await collection.find().countAsync(), 1);
+  },
+);
 
 // Meteor.isServer && Tinytest.addAsync(
 //   "mongo-livedata - oplog - _onFailover",


### PR DESCRIPTION
As I commented in https://github.com/meteor/meteor/issues/12627#issuecomment-1541489379, this oplog message can be safely ignored. I did that and added a test for it.