### PR TITLE
fix: add `Meteor.applyAsync` typings

### DIFF
--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -159,6 +159,41 @@ export namespace Meteor {
    */
   function callAsync(name: string, ...args: any[]): Promise<any>;
 
+  interface MethodApplyOptions {
+    /**
+     * (Client only) If true, don't send this method until all previous method calls have completed, and don't send any subsequent method calls until this one is completed.
+     */
+    wait?: boolean | undefined;
+    /**
+     * (Client only) This callback is invoked with the error or result of the method (just like `asyncCallback`) as soon as the error or result is available. The local cache may not yet reflect the writes performed by the method.
+     */
+    onResultReceived?:
+      | ((
+          error: global_Error | Meteor.Error | undefined,
+          result?: Result
+        ) => void)
+      | undefined;
+    /**
+     * (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
+     */
+    noRetry?: boolean | undefined;
+    /**
+     * (Client only) If true then in cases where we would have otherwise discarded the stub's return value and returned undefined, instead we go ahead and return it. Specifically, this is any time other than when (a) we are already inside a stub or (b) we are in Node and no callback was provided. Currently we require this flag to be explicitly passed to reduce the likelihood that stub return values will be confused with server return values; we may improve this in future.
+     */
+    returnStubValue?: boolean | undefined;
+    /**
+     * (Client only) If true, exceptions thrown by method stubs will be thrown instead of logged, and the method will not be invoked on the server.
+     */
+    throwStubExceptions?: boolean | undefined;
+  }
+
+  /**
+   * Invokes a method with a sync stub, passing any number of arguments.
+   * @param name Name of method to invoke
+   * @param args Method arguments
+   * @param options Optional execution options
+   * @param asyncCallback Optional callback
+   */
   function apply<
     Result extends
       | EJSONable
@@ -168,26 +203,35 @@ export namespace Meteor {
   >(
     name: string,
     args: ReadonlyArray<EJSONable | EJSONableProperty>,
-    options?: {
-      wait?: boolean | undefined;
-      onResultReceived?:
-        | ((
-            error: global_Error | Meteor.Error | undefined,
-            result?: Result
-          ) => void)
-        | undefined;
-      /**
-       * (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
-       */
-      noRetry?: boolean | undefined;
-      returnStubValue?: boolean | undefined;
-      throwStubExceptions?: boolean | undefined;
-    },
+    options?: MethodApplyOptions,
     asyncCallback?: (
       error: global_Error | Meteor.Error | undefined,
       result?: Result
     ) => void
   ): any;
+
+  /**
+   * Invokes a method with an async stub, passing any number of arguments.
+   * @param name Name of method to invoke
+   * @param args Method arguments
+   * @param options Optional execution options
+   * @param asyncCallback Optional callback
+   */
+  function applyAsync<
+    Result extends
+      | EJSONable
+      | EJSONable[]
+      | EJSONableProperty
+      | EJSONableProperty[]
+  >(
+    name: string,
+    args: ReadonlyArray<EJSONable | EJSONableProperty>,
+    options?: MethodApplyOptions,
+    asyncCallback?: (
+      error: global_Error | Meteor.Error | undefined,
+      result?: Result
+    ) => void
+  ): Promise<Result>;
   /** Method **/
 
   /** Url **/


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

Typescript typings for `Meteor.callAsync` were added a while ago, but `Meteor.applyAsync` was missing.

`Meteor.apply` has been refactored a bit to allow for sharing types across the two, and jsdoc has been copied from the implementation to make it available to intellisense.