### PR TITLE
Update Accounts with Async methods

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1774,21 +1774,21 @@ const setupUsersCollection = users => {
   });
 
   /// DEFAULT INDEXES ON USERS
-  users.createIndex('username', { unique: true, sparse: true });
-  users.createIndex('emails.address', { unique: true, sparse: true });
-  users.createIndex('services.resume.loginTokens.hashedToken',
+  users.createIndexAsync('username', { unique: true, sparse: true });
+  users.createIndexAsync('emails.address', { unique: true, sparse: true });
+  users.createIndexAsync('services.resume.loginTokens.hashedToken',
     { unique: true, sparse: true });
-  users.createIndex('services.resume.loginTokens.token',
+  users.createIndexAsync('services.resume.loginTokens.token',
     { unique: true, sparse: true });
   // For taking care of logoutOtherClients calls that crashed before the
   // tokens were deleted.
-  users.createIndex('services.resume.haveLoginTokensToDelete',
+  users.createIndexAsync('services.resume.haveLoginTokensToDelete',
     { sparse: true });
   // For expiring login tokens
-  users.createIndex("services.resume.loginTokens.when", { sparse: true });
+  users.createIndexAsync("services.resume.loginTokens.when", { sparse: true });
   // For expiring password tokens
-  users.createIndex('services.password.reset.when', { sparse: true });
-  users.createIndex('services.password.enroll.when', { sparse: true });
+  users.createIndexAsync('services.password.reset.when', { sparse: true });
+  users.createIndexAsync('services.password.enroll.when', { sparse: true });
 };
 
 

--- a/packages/accounts-oauth/oauth_common.js
+++ b/packages/accounts-oauth/oauth_common.js
@@ -36,7 +36,7 @@ Accounts.oauth.registerService = name => {
     // so this should be a unique index. You might want to add indexes for other
     // fields returned by your service (eg services.github.login) but you can do
     // that in your app.
-    Meteor.users.createIndex(`services.${name}.id`, {unique: true, sparse: true});
+    Meteor.users.createIndexAsync(`services.${name}.id`, {unique: true, sparse: true});
   }
 };
 

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -1054,9 +1054,9 @@ Accounts.createUser = (options, callback) => {
 ///
 /// PASSWORD-SPECIFIC INDEXES ON USERS
 ///
-Meteor.users.createIndex('services.email.verificationTokens.token',
+Meteor.users.createIndexAsync('services.email.verificationTokens.token',
                           { unique: true, sparse: true });
-Meteor.users.createIndex('services.password.reset.token',
+Meteor.users.createIndexAsync('services.password.reset.token',
                           { unique: true, sparse: true });
-Meteor.users.createIndex('services.password.enroll.token',
+Meteor.users.createIndexAsync('services.password.enroll.token',
                           { unique: true, sparse: true });

--- a/packages/accounts-passwordless/passwordless_server.js
+++ b/packages/accounts-passwordless/passwordless_server.js
@@ -231,11 +231,11 @@ Accounts.sendLoginTokenEmail = ({ userId, sequence, email, extra = {} }) => {
 };
 
 const setupUsersCollection = () => {
-  Meteor.users.createIndex('services.passwordless.tokens.token', {
+  Meteor.users.createIndexAsync('services.passwordless.tokens.token', {
     unique: true,
     sparse: true,
   });
-  Meteor.users.createIndex('services.passwordless.token', {
+  Meteor.users.createIndexAsync('services.passwordless.token', {
     unique: true,
     sparse: true,
   });

--- a/packages/service-configuration/service_configuration_server.js
+++ b/packages/service-configuration/service_configuration_server.js
@@ -5,7 +5,7 @@ import { Meteor } from 'meteor/meteor';
 // otherwise lead to an inconsistent database state (when there are multiple
 // configurations for a single service, which configuration is correct?)
 try {
-  ServiceConfiguration.configurations.createIndex(
+  ServiceConfiguration.configurations.createIndexAsync(
     { service: 1 },
     { unique: true }
   );


### PR DESCRIPTION
Updates multiple accounts packages to use new `async` API methods.

`users.createIndex` --> `users.createIndexAsync`
`OAuth._pendingCredentials.remove` --> `OAuth._pendingCredentials.removeAsync`
`OAuth._pendingCredentials.upsert` --> `OAuth._pendingCredentials.upsertAsync`

**Note** that I have not changed any parent functions to use async/await. Will continue testing to make sure there are no breaking changes by these methods becoming async.

Look forward to your feedback!