### PR TITLE
Replace deprecated reference with current one

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -891,7 +891,7 @@ Object.assign(Mongo.Collection.prototype, {
       throw new Error(
         'Can only call _createCappedCollection on server collections'
       );
-    
+
     // [FIBERS]
     // TODO: Remove this when 3.0 is released.
     warnUsingOldApi(
@@ -979,7 +979,7 @@ Mongo.Collection.ObjectID = Mongo.ObjectID;
 Meteor.Collection = Mongo.Collection;
 
 // Allow deny stuff is now in the allow-deny package
-Object.assign(Meteor.Collection.prototype, AllowDeny.CollectionPrototype);
+Object.assign(Mongo.Collection.prototype, AllowDeny.CollectionPrototype);
 
 function popCallbackFromArgs(args) {
   // Pull off any callback (or perhaps a 'callback' variable that was passed


### PR DESCRIPTION
Saw use of deprecated `Meteor.Collection` highlighted in my IDE, so I replaced it with the current one as indicated on the backward compatibility few lines above. Since this was deprecated in `v0.9.1` we should consider removing it. From the quick search I did `Meteor.Collection` is after this no longer used anywhere else in the code. Same for `Mongo.Collection.ObjectID` and `Mongo.Collection.Cursor`.