### PR TITLE
fix(passwordless): align function with MongoDB convention

### DIFF
--- a/packages/accounts-passwordless/passwordless_server.js
+++ b/packages/accounts-passwordless/passwordless_server.js
@@ -18,8 +18,8 @@ const findUserWithOptions = ({ selector }) => {
   return Meteor.users.findOne(
     { 
       ...rest,
-      ...(id && {_id: id}), 
-      ...(email && {'emails.address': email}) 
+      ...(id && { _id: id }), 
+      ...(email && { 'emails.address': email }) 
     },
     {
       fields: {


### PR DESCRIPTION
Hello :)

With this PR I propose to solve the [Accounts Passwordless login doesn't work with id and token](https://github.com/meteor/meteor/issues/12401) issue, at the `accounts-passwordless` package.

The problem is already documented on the issue, So I'll explain directly my solution.

This fix checks the `id` field in the `selector` object. If found, it will replace `id` with `_id`  before passing to the `findOne`.

cc @filipenevola 