### PR TITLE
fix: Collection Async tests not working

### DIFF
--- a/packages/mongo/collection_async_tests.js
+++ b/packages/mongo/collection_async_tests.js
@@ -22,8 +22,9 @@ Tinytest.add('async collection - check for methods presence', function (test) {
 
 ['countDocuments', 'estimatedDocumentCount'].forEach(method => {
   Tinytest.addAsync(`async collection - ${method}`, async test => {
-    const collection = new Mongo.Collection(method + test.id);
-    for (let index = 0; index < 10; ++index) {
+    const collection = new Mongo.Collection();
+    const items = [...Array(10).keys()];
+    for await (const index of items) {
       test.instanceOf(collection[method](), Promise);
       test.equal(await collection[method](), index);
       await collection.insertAsync({});


### PR DESCRIPTION
Local collections can't be created with name. The test was failing because it was trying to save the client inserts on server side. Since there is no subscription for it, it can't count the documents back, so I believe it should not be sending the data to the server and only testing it locally.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
