### PR TITLE
Update source-map-support

### DIFF
--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -17,7 +17,7 @@ var packageJson = {
     "@babel/parser": "7.15.3",
     "@types/underscore": "1.11.2",
     underscore: "1.13.1",
-    "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
+    "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/81bce1f99625e62af73338f63afcf2b44c6cfa5e",
     "@types/semver": "5.4.0",
     semver: "5.4.1"
   },

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -28,7 +28,7 @@ var packageJson = {
     "babel-runtime": "7.0.0-beta.3",
     "@types/underscore": "1.11.2",
     underscore: "1.13.1",
-    "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
+    "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/81bce1f99625e62af73338f63afcf2b44c6cfa5e",
     "@types/semver": "5.4.0",
     semver: "5.4.1",
     request: "2.88.2",


### PR DESCRIPTION
Updates it to the latest commit in https://github.com/meteor/node-source-map-support. This fixes handling errors that happen in the first line of a linked file. Usually there are no errors on the first line, but we've encountered it a few times in Meteor 3 when there was a bug in the linker.