### PR TITLE
Remove built in regex validations

### DIFF
--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -5,7 +5,9 @@ description: Describes the high-level features and actions for the Meteor projec
 
 ## Introduction
 
-Last update: Setember 14, 2022.
+**Quick update moving items to Finished: June 1, 2023**
+
+**Last new items added: September 14, 2022.**
 
 This document describes the high-level features and actions for the Meteor project in the near-to-medium term future.
 The description of many items include sentences and ideas from Meteor community members.
@@ -17,14 +19,7 @@ Contributors are encouraged to focus their efforts on work that aligns with the 
 
 > If you have new feature requests or ideas you should open a new [discussion](https://github.com/meteor/meteor/discussions/new).
 
-### Priorities for 2022
-- Change how Meteor executes Async code or Fibers migration.
-- Improve MongoDB stability and support new async API.
-- Improve TypeScript support.
-
-----
-
-### Next releases
+### Meteor 3.0 release
 
 - Change how Meteor executes Async code; ([Discussion](https://github.com/meteor/meteor/discussions/11505))
   - Provide new async APIs where Fibers are required;
@@ -32,79 +27,59 @@ Contributors are encouraged to focus their efforts on work that aligns with the 
     - Provide async versions for Accounts and core packages;
     - Adapt Meteor Promise implementation;
 - Enable Top-Level Await (TLA) on Meteor server-side; ([PR](https://github.com/meteor/meteor/pull/12095))
-- Updated MongoDB driver to 4.8; ([PR](https://github.com/meteor/meteor/pull/12097))
-- Make MongoDB integration stable by fixing critical issues;
-- Typescript integration for Meteor packages; ([Discussion](https://github.com/meteor/meteor/discussions/12080))
+- Support Top-Level Await (TLA) on Reify;
+- Remove Fibers dependency from Meteor Public APIs;
+- Remove Fibers entirely;
+- Update Cordova integration to Meteor 3.0;
+- Run Meteor on Node.js 18;
+- Change web engine from Connect to Express;
+
+### Next releases
+
+- Improve TypeScript support for Meteor and packages; ([Discussion](https://github.com/meteor/meteor/discussions/12080))
 - Linux ARM Support; ([PR](https://github.com/meteor/meteor/pull/11809))
 - Improve release quality with test coverage and CI automation;
 - Review and help to modernize Meteor tools; ([Discussion](https://github.com/meteor/meteor/discussions/12073))
-- Evaluate and improve support for Meteor in VSCode; ([Repository](https://github.com/matheusccastroo/vscode-meteor-toolbox))
-- New skeleton for creating Meteor apps with Chakra UI;
-- Support Top-Level Await (TLA) on Reify;
-- Improve support for Windows 11;
-- Remove Fibers dependency from Meteor Public APIs;
-- Remove Fibers entirely;
-
-### Community items
-- Release Blaze 2.6.2; ([Milestone](https://github.com/meteor/blaze/milestone/9))
-- Vue 3 integration; ([Forums](https://forums.meteor.com/t/status-of-vue-3-meteor/57915/25) / [Discussion](https://github.com/meteor/meteor/discussions/11521))
-- SolidJS starter template;
-
-### Next educational items
-- Create a new Meteor Guide; ([Current Guide](https://guide.meteor.com/))
-- Login and Accounts course; ([Meteor University](https://university.meteor.com/))
-- Scaling Meteor Apps course; ([Meteor University](https://university.meteor.com/))
-
-### Future items
-We plan to implement these items in the near future. Community help would be greatly appreciated.
-- Support package.json exports fields; ([Discussion](https://github.com/meteor/meteor/discussions/11727))
-- MongoDB 6.0 Support; ([Discussion](https://github.com/meteor/meteor/discussions/12092))
+- Improve support for Windows 11 or adopt Windows with WSL;
 - Improve Meteor build time; ([Discussion](https://github.com/meteor/meteor/discussions/11587))
 - HTTP/3 Support;
 - Tree-shaking; ([PR](https://github.com/meteor/meteor/pull/11164))
+- Support package.json exports fields; ([Discussion](https://github.com/meteor/meteor/discussions/11727))
 
 ### Candidate items
 We need to discuss further to decide whether or not to proceed with these implementations.
 
-- Update and fix Meteor Client Bundler; ([Repository](https://github.com/Urigo/meteor-client-bundler))
+- Update and fix Meteor Client Bundler or Improve DDP Client;
 - Improve Passwordless package; ([Discussion](https://github.com/meteor/meteor/discussions/12075))
 - Support building mobile apps using CapacitorJS;
 - Bring Redis-oplog to core; ([Repository](https://github.com/Meteor-Community-Packages/redis-oplog))
 - MongoDB Change Streams support; ([Discussion](https://github.com/meteor/meteor/discussions/11842))
 - Better file upload support via DDP; ([Discussion](https://github.com/meteor/meteor/discussions/11523))
 
+### Next educational items
+
+- Create a new Meteor Guide; ([Current Guide](https://guide.meteor.com/))
+- Scaling Meteor Apps course; ([Meteor University](https://university.meteor.com/))
+
 ### Finished items
 
-- Release Blaze 2.6.1; ([Changelog](https://www.blazejs.org/changelog.html))
-- Ambassadors Program; ([Website](https://ambassador.meteor.com/))
-- Demo app: SimpleTasks (Meteor + Chakra UI); ([Repository](https://github.com/fredmaiaarantes/simpletasks))
-- Demo app: NFT Marketplace (Meteor + React); ([Repository](https://github.com/meteor/examples/tree/main/nft-marketplace) / [Blog post](https://blog.meteor.com/meteor-web3-building-an-nft-marketplace-9484b321e426))
-- New Meteor DevTools Evolved; ([Forums](https://forums.meteor.com/t/meteor-devtools-evolved-v1-2/52710))
-- Meteor Toolbox - VS Code Extension; ([Forums](https://forums.meteor.com/t/meteor-toolbox-vs-code-extension/58044))
-- New router for React and Meteor; ([Forums](https://forums.meteor.com/t/new-router-for-react-and-meteor/58346))
-- Meteor Desktop 3.0; ([Forums](https://forums.meteor.com/t/meteor-desktop-3-0/57863))
-- New Skeleton for Tailwind CSS 3; ([Blog post](https://blog.meteor.com/meteor-2-7-2-and-the-new-tailwind-skeleton-68ccde68af42))
-- Review/Update React, Vue, Blaze tutorials; ([Tutorials](https://www.meteor.com/developers/tutorials))
-- Video course: "MongoDB Collections and Schemas"; ([Meteor University](https://university.meteor.com/))
-- Video course: "Starting with Meteor"; ([Meteor University](https://university.meteor.com/))
-- Accounts 2FA package; ([Blog post](https://blog.meteor.com/meteor-2-7-and-the-new-2fa-package-5fc53e5027e0))
-- TailwindCSS 3.0 JIT Support; ([Blog post](https://blog.meteor.com/meteor-2-7-and-the-new-2fa-package-5fc53e5027e0))
-- node: Protocol Import Support;
-- Release Blaze 2.6; ([Changelog](https://www.blazejs.org/changelog.html))
-- Support to MongoDB 5.0; ([Migration Guide](https://guide.meteor.com/2.6-migration.html))
-- Add missing binaries to Fibers fork; ([Issue](https://github.com/meteor/meteor/issues/11791))
-- 2FA OTP support in Meteor Accounts; ([Forums](https://forums.meteor.com/t/2fa-otp-support-in-meteor-accounts-meteor-cloud/57248))
-- Meteor + SolidJS demo; ([Repository](https://github.com/edemaine/solid-meteor-demo))
-- TypeScript update to v4.4.1;
-- Mac M1 Support;
-- HMR now works on all architectures and legacy browsers;
-- New core package: accounts-passwordless;
-- New Meteor NPM installer;
-- Apollo skeleton upgraded to Apollo server v3;
-- Node.js update to v14 from 12.22.1; ([Changelog](https://docs.meteor.com/changelog.html#v2320210624))
-- Cordova update to version 10;
-- New Skeleton for Svelte;
-- Repository with [Meteor Examples](https://github.com/meteor/examples);
+- New Async Tracker; ([Blog Post](https://blog.meteor.com/new-meteor-js-2-10-and-the-async-tracker-feature-ffdbe817c801))
+- New Suspense hooks for React + Meteor; ([Blog Post](https://blog.meteor.com/new-suspense-hooks-for-meteor-5391570b3007))
+- Release Blaze 2.7 supporting async calls; ([Changelog](https://www.blazejs.org/changelog.html))
+- New Scaffold API / generate command; ([Blog Post](https://blog.meteor.com/new-meteor-2-9-and-the-scaffold-api-8b5b2b2b2b2b))
+- Types added to the core; ([Blog Post](https://blog.meteor.com/new-meteor-2-8-1-and-adding-types-to-the-core-8a6ee56f0141))
+- Update Apollo skeleton NPM dependencies;
+- MongoDB 6.0 Support; ([Discussion](https://github.com/meteor/meteor/discussions/12092) / [Blog Post](https://blog.meteor.com/new-meteor-2-11-and-the-new-embedded-mongodb-19767076961b))
+- Vite integration;
+- SolidJS integration;
+- Vue 3 integration; ([Forums](https://forums.meteor.com/t/status-of-vue-3-meteor/57915/25) / [Discussion](https://github.com/meteor/meteor/discussions/11521))
+- SolidJS starter template;
+- Login and Accounts Course; ([Meteor University](https://university.meteor.com/))
+- Updated MongoDB driver to 4.8; ([PR](https://github.com/meteor/meteor/pull/12097))
+- Make MongoDB integration stable by fixing critical issues;
+- New skeleton for creating Meteor apps with Chakra UI;
+- Evaluate and improve support for Meteor in VSCode; ([Repository](https://github.com/matheusccastroo/vscode-meteor-toolbox))
+- Release Blaze 2.6.2; ([Blog Post](https://blog.meteor.com/new-meteor-js-2-12-and-the-blaze-2-6-2-release-b72c2a7a593f))
 
 -----------
 

--- a/guide/source/collections.md
+++ b/guide/source/collections.md
@@ -91,14 +91,10 @@ Let's assume that we have a `Lists` collection.  To define a schema for this col
 ```js
 import SimpleSchema from 'simpl-schema';
 
-// Define a regular expression for MongoDB ObjectId.
-// This is a simple example, you might want to use a more specific regular expression.
-const userIdRegEx = /^[a-fA-F0-9]{24}$/;
-
 Lists.schema = new SimpleSchema({
   name: {type: String},
   incompleteCount: {type: Number, defaultValue: 0},
-  userId: {type: String, regEx: userIdRegEx, optional: true}
+  userId: {type: String, regEx: SimpleSchema.RegEx.Id, optional: true}
 });
 ```
 
@@ -106,7 +102,9 @@ This example from the Todos app defines a schema with a few simple rules:
 
 2. We specify that the `name` field of a list is required and must be a string.
 3. We specify the `incompleteCount` is a number, which on insertion is set to `0` if not otherwise specified.
-4. We specify that the `userId`, which is optional, must be a string that looks like the ID of a user document. SimpleSchema no more supports built-in regular expressions for security reasons, so we have to define it ourselves. Check out the [Simple Schema docs](https://github.com/longshotlabs/simpl-schema#regex) for more information.
+4. We specify that the `userId`, which is optional, must be a string that looks like the ID of a user document.
+
+We're using the SimpleSchema for Meteor related funcitonality, like IDs, but we encourage you to create custom regEx expressions for security reasons, for fields like `email` or `name`. Check out the [Simple Schema docs](https://github.com/longshotlabs/simpl-schema#regex) for more information.
 
 We attach the schema to the namespace of `Lists` directly, which allows us to check objects against this schema directly whenever we want, such as in a form or [Method](methods.html). In the [next section](#schemas-on-write) we'll see how to use this schema automatically when writing to the collection.
 

--- a/guide/source/collections.md
+++ b/guide/source/collections.md
@@ -91,10 +91,14 @@ Let's assume that we have a `Lists` collection.  To define a schema for this col
 ```js
 import SimpleSchema from 'simpl-schema';
 
+// Define a regular expression for MongoDB ObjectId.
+// This is a simple example, you might want to use a more specific regular expression.
+const userIdRegEx = /^[a-fA-F0-9]{24}$/;
+
 Lists.schema = new SimpleSchema({
   name: {type: String},
   incompleteCount: {type: Number, defaultValue: 0},
-  userId: {type: String, regEx: SimpleSchema.RegEx.Id, optional: true}
+  userId: {type: String, regEx: userIdRegEx, optional: true}
 });
 ```
 
@@ -102,7 +106,7 @@ This example from the Todos app defines a schema with a few simple rules:
 
 2. We specify that the `name` field of a list is required and must be a string.
 3. We specify the `incompleteCount` is a number, which on insertion is set to `0` if not otherwise specified.
-4. We specify that the `userId`, which is optional, must be a string that looks like the ID of a user document.
+4. We specify that the `userId`, which is optional, must be a string that looks like the ID of a user document. SimpleSchema no more supports built-in regular expressions for security reasons, so we have to define it ourselves. Check out the [Simple Schema docs](https://github.com/longshotlabs/simpl-schema#regex) for more information.
 
 We attach the schema to the namespace of `Lists` directly, which allows us to check objects against this schema directly whenever we want, such as in a form or [Method](methods.html). In the [next section](#schemas-on-write) we'll see how to use this schema automatically when writing to the collection.
 

--- a/guide/source/methods.md
+++ b/guide/source/methods.md
@@ -276,9 +276,7 @@ if (!this.isSimulation) {
 The main thing enabled by the `ValidationError` convention is integration between Methods and the forms that call them. In general, your app is likely to have a one-to-one mapping of forms in the UI to Methods. First, let's define a Method for our business logic:
 
 ```js
-// Define a regular expression for email validation.
-// SimpleSchema do not support built-in validations.
-// Follow the doc for more details: https://github.com/longshotlabs/simpl-schema#regex
+// Define a regular expression for email and amount validation.
 const emailRegEx = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
 const amountRegEx = /^\d*\.(\d\d)?$/;
 
@@ -305,6 +303,8 @@ export const insert = new ValidatedMethod({
   }
 });
 ```
+
+We encourage you to create custom regEx expressions for security reasons, for fields like `email` and `amout`. For Meteor related functionality, like `IDs`, you can use the `SimpleSchema.RegEx.Id` expression. Check out the [Simple Schema docs](https://github.com/longshotlabs/simpl-schema#regex) for more information.
 
 Let's define an HTML form:
 

--- a/guide/source/methods.md
+++ b/guide/source/methods.md
@@ -276,15 +276,21 @@ if (!this.isSimulation) {
 The main thing enabled by the `ValidationError` convention is integration between Methods and the forms that call them. In general, your app is likely to have a one-to-one mapping of forms in the UI to Methods. First, let's define a Method for our business logic:
 
 ```js
+// Define a regular expression for email validation.
+// SimpleSchema do not support built-in validations.
+// Follow the doc for more details: https://github.com/longshotlabs/simpl-schema#regex
+const emailRegEx = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+const amountRegEx = /^\d*\.(\d\d)?$/;
+
 // This Method encodes the form validation requirements.
 // By defining them in the Method, we do client and server-side
 // validation in one place.
 export const insert = new ValidatedMethod({
   name: 'Invoices.methods.insert',
   validate: new SimpleSchema({
-    email: { type: String, regEx: SimpleSchema.RegEx.Email },
+    email: { type: String, regEx: emailRegEx },
     description: { type: String, min: 5 },
-    amount: { type: String, regEx: /^\d*\.(\d\d)?$/ }
+    amount: { type: String, regEx: amountRegEx }
   }).validator(),
   run(newInvoice) {
     // In here, we can be sure that the newInvoice argument is


### PR DESCRIPTION
closes https://github.com/meteor/meteor/issues/12689

This pull request updates the no longer supported regEx built-in expressions from SimpleSchema.
The purpose here is to define a regular expression and link the SimpleSchema doc. that explains why it no longer supports built-in expressions.
