### PR TITLE
[WIP] Faster and simpler linker for Meteor 3

### DIFF
--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -506,7 +506,6 @@ Object.assign(File.prototype, {
 
   getPrelinkedOutputFast: Profile('linker File#getPrelinkedOutputFast', function (options) {
     let header = this.bare ? '' : this._getClosureHeader() + '\n\n';
-    let footer = this.bare ? '' : this._getClosureFooter();
     let code = this.source;
     let map = this.sourceMap || null
 
@@ -517,7 +516,6 @@ Object.assign(File.prototype, {
       bannerLines.push('This file is in bare mode and is not in its own closure.');
     }
 
-    // TODO: add divider line to footer
     header += banner(bannerLines) + '\n';
 
     if (code) {
@@ -532,6 +530,11 @@ Object.assign(File.prototype, {
       }
     } else {
       code = '';
+    }
+    
+    let footer = dividerLine(MIN_BANNER_WIDTH) + '\n';
+    if (!this.bare) {
+      footer += this._getClosureFooter();
     }
 
     return { header, code, map, footer };
@@ -1102,6 +1105,7 @@ function getFooter ({
   return chunks.join('');
 }
 
+// TODO: simplify wrapWithHeaderAndFooter
 function wrapWithHeaderAndFooter(files, header, footer) {
   // Bias the source map by the length of the header without
   // (fully) parsing and re-serializing it. (We used to do this


### PR DESCRIPTION
This is a partial rewrite of the linker with these goals:

1. Simplify it. With TLA, the linker increased to having at least 5 different ways to link apps and packages, some of which were incompatible with TLA. This rewrite tries to reduce it to two: one way for apps and packages that use modules, and another way for those that don't.
2. Make it easier to understand so developers new to Isobuild's code can get a high level understanding easier, and make changes with more confidence. Some of this will probably be done in a separate PR to keep the diff smaller.
3. Make it fast, hopefully fast enough to remove many of the caches used in the linker. Each cache has an arbitrary size, and large apps can easily exceed the sizes which basically disables the caching and is a large performance cliff.
4. Always output code that supports top level await

This PR is still in progress. I spent some time the last couple weeks rewriting the linker from scratch to get a better understanding of it, and am now in the process of merging the good parts from that rewrite with the old linker code.

The old linker is still the default. To try the new linker, you can use the `feature/faster-simpler-linker` branch, and set the `METEOR_LINKER` env var to `new`.

### Sourcemaps

Sometimes packages or apps would not have source maps, especially if they didn't use a build plugin. The linker now generates source maps for these files. You can see the difference in these stack traces from an error thrown by the `meteor` package:
```
old linker:
meteor.js?hash=c409f5bd94650302c52417770bb8c173946c6d83:45 Error: error from meteor package
    at meteor.js?hash=c409f5bd94650302c52417770bb8c173946c6d83:45:15
    at meteor.js?hash=c409f5bd94650302c52417770bb8c173946c6d83:126:4
    at load (core-runtime.js?hash=e9797454b50ee00bed582d670c752999d4c84e41:149:16)
    at Object.queue (core-runtime.js?hash=e9797454b50ee00bed582d670c752999d4c84e41:144:5)
    at meteor.js?hash=c409f5bd94650302c52417770bb8c173946c6d83:11:25

new linker:
client_environment.js:4 Error: error from meteor package
    at client_environment.js:4:1
    at client_environment.js:81:1
    at load (load-js-image.js:41:1)
    at Object.queue (load-js-image.js:36:1)
    at meteor.js?hash=8a9e70569c9eccb0178ad88b35397819f175df6b:1:25
```

There are still some improvements needed, such as using a longer path for each file, and trying to not create source maps for files that have different content than on disk.

## Benchmarks

I excluded the time spent on `File#computeAssignedVariables` while linking since this PR doesn't address its performance (I plan to improve it later). Usually `File#computeAssignedVariables` took 250-300ms during the initial build, and none during rebuilds.

### Very small app that does not use modules

**Initial Build**
before - server: 54ms
after -server: 16ms (3.3x improvement)
before - client: 160ms
after - client: 46ms (3.4x improvement)

### Very small app that does use modules

before - server: 55ms
after - server: 16ms (3.4x improvement)
before - client: 155ms
after - client: 45ms (3.4x improvement)

**First rebuild**
before - client: 14ms
after - client: 3ms (4.6x improvement)

### Initial build, without cache, and dynamic imports
For this test, the app dynamically imported 100 copies of jquery-ui, which in total was over 12mb of js.

before - client: 31,871ms
after (unoptimized) - client: 2,317ms ( 13.7x improvement)
after (optimized) - client: 289ms (110.2x improvement)

The optimized time is from after https://github.com/meteor/meteor/commit/67df1a8e5df9c07dcebb7cac511c2c32d7c652bc.

There are a few more things we can do to make it faster.