### PR TITLE
Reduce parser plugins used in js-analyze in Meteor 3

### DIFF
--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -1,7 +1,7 @@
 import { parse } from '@meteorjs/babel';
 import { analyze as analyzeScope } from 'escope';
 import LRU from "lru-cache";
-
+import { Profile } from '../tool-env/profile';
 import Visitor from "@meteorjs/reify/lib/visitor.js";
 import { findPossibleIndexes } from "@meteorjs/reify/lib/utils.js";
 
@@ -26,9 +26,23 @@ function tryToParse(source, hash) {
   }
 
   let ast;
-
   try {
-    ast = parse(source);
+    Profile.time('jsAnalyze.parse', () => {
+      ast = parse(source, {
+        strictMode: false,
+        sourceType: 'module',
+        allowImportExportEverywhere: true,
+        allowReturnOutsideFunction: true,
+        allowUndeclaredExports: true,
+        plugins: [
+          // Only plugins for stage 3 features are enabled
+          // Enabling some plugins significantly affects parser performance
+          'importAttributes',
+          'explicitResourceManagement',
+          'decorators'
+        ]
+      });
+    });
   } catch (e) {
     if (typeof e.loc === 'object') {
       e.$ParseError = true;
@@ -71,7 +85,10 @@ export function findImportedModuleIdentifiers(source, hash) {
   }
 
   const ast = tryToParse(source, hash);
-  importedIdentifierVisitor.visit(ast, source, possibleIndexes);
+  Profile.time('findImportedModuleIdentifiersVisitor', () => {
+    importedIdentifierVisitor.visit(ast, source, possibleIndexes);
+  });
+
   return importedIdentifierVisitor.identifiers;
 }
 


### PR DESCRIPTION
Meteor had been enabling every parser plugin, which makes parsing 3 - 4x slower compared to not enabling any plugins. js-analyze deals with files that have already been compiled, so it only needs to be able to parse code that Node and browsers are able to run and doesn't need as many plugins.

In a smaller app, this reduces the time spent parsing in `ImportScanner#findImportedModuleIdentifiers` from 18 - 23 seconds to less than 6 during the initial build. For some apps, that part of the initial build takes over a minute or two, so this should be a large improvement for those.

This change also makes finding globals in the linker ~2x faster. 

This optimization could be easily backported to Meteor 2.