### PR TITLE
Small Ferature: Add a way to see if any method is currently invoked

### DIFF
--- a/packages/ddp-client/common/namespace.js
+++ b/packages/ddp-client/common/namespace.js
@@ -89,3 +89,9 @@ DDP.onReconnect = callback => DDP._reconnectHook.register(callback);
 DDP._allSubscriptionsReady = () => allConnections.every(
   conn => Object.values(conn._subscriptions).every(sub => sub.ready)
 );
+
+// Sometimes data is loaded using a method, this hack provide a way
+// to see if any method is currently invoked
+DDP._noMethodIsCurrentlytInvoked = () => allConnections.every(
+    conn => Object.keys(conn._methodInvokers).length == 0
+);

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data client",
-  version: '2.6.1',
+  version: '2.6.2',
   documentation: null
 });
 


### PR DESCRIPTION
Some times apps load the data using methods instead of publications. This patch will allow the developer to easily know if the client is waiting on any method.
