### PR TITLE
fix(skell): remove builtin regex expressions from simpleSchema

### DIFF
--- a/guide/source/collections.md
+++ b/guide/source/collections.md
@@ -104,6 +104,8 @@ This example from the Todos app defines a schema with a few simple rules:
 3. We specify the `incompleteCount` is a number, which on insertion is set to `0` if not otherwise specified.
 4. We specify that the `userId`, which is optional, must be a string that looks like the ID of a user document.
 
+We're using the SimpleSchema for Meteor related funcitonality, like IDs, but we encourage you to create custom regEx expressions for security reasons, for fields like `email` or `name`. Check out the [Simple Schema docs](https://github.com/longshotlabs/simpl-schema#regex) for more information.
+
 We attach the schema to the namespace of `Lists` directly, which allows us to check objects against this schema directly whenever we want, such as in a form or [Method](methods.html). In the [next section](#schemas-on-write) we'll see how to use this schema automatically when writing to the collection.
 
 You can see that with relatively little code we've managed to restrict the format of a list significantly. You can read more about more complex things that can be done with schemas in the [Simple Schema docs](https://www.npmjs.com/package/simpl-schema).

--- a/guide/source/methods.md
+++ b/guide/source/methods.md
@@ -276,15 +276,19 @@ if (!this.isSimulation) {
 The main thing enabled by the `ValidationError` convention is integration between Methods and the forms that call them. In general, your app is likely to have a one-to-one mapping of forms in the UI to Methods. First, let's define a Method for our business logic:
 
 ```js
+// Define a regular expression for email and amount validation.
+const emailRegEx = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+const amountRegEx = /^\d*\.(\d\d)?$/;
+
 // This Method encodes the form validation requirements.
 // By defining them in the Method, we do client and server-side
 // validation in one place.
 export const insert = new ValidatedMethod({
   name: 'Invoices.methods.insert',
   validate: new SimpleSchema({
-    email: { type: String, regEx: SimpleSchema.RegEx.Email },
+    email: { type: String, regEx: emailRegEx },
     description: { type: String, min: 5 },
-    amount: { type: String, regEx: /^\d*\.(\d\d)?$/ }
+    amount: { type: String, regEx: amountRegEx }
   }).validator(),
   run(newInvoice) {
     // In here, we can be sure that the newInvoice argument is
@@ -299,6 +303,8 @@ export const insert = new ValidatedMethod({
   }
 });
 ```
+
+We encourage you to create custom regEx expressions for security reasons, for fields like `email` and `amout`. For Meteor related functionality, like `IDs`, you can use the `SimpleSchema.RegEx.Id` expression. Check out the [Simple Schema docs](https://github.com/longshotlabs/simpl-schema#regex) for more information.
 
 Let's define an HTML form:
 


### PR DESCRIPTION
closes https://github.com/meteor/meteor/issues/12689

Open it again because I deleted the meteor repo from my account 😅

This pull request updates the no longer supported regEx built-in expressions from SimpleSchema.
The purpose here is to define a regular expression and link the SimpleSchema doc. that explains why it no longer supports built-in expressions.