### PR TITLE
Update private npm modules link in structure.md

### DIFF
--- a/guide/source/structure.md
+++ b/guide/source/structure.md
@@ -316,7 +316,7 @@ The primary challenge is properly sharing code between the different application
 
 If you want to create Meteor applications with separate code, you'll have some modules that you'd like to share between them. If those modules are something the wider world could use, you should consider [publishing them to a package system](writing-packages.html), either npm or Atmosphere, depending on whether the code is Meteor-specific or otherwise.
 
-If the code is private, or of no interest to others, it typically makes sense to include the same module in both applications (you *can* do this with [private npm modules](https://www.npmjs.com/private-modules)). There are several ways to do this:
+If the code is private, or of no interest to others, it typically makes sense to include the same module in both applications (you *can* do this with [private npm modules](https://docs.npmjs.com/about-private-packages)). There are several ways to do this:
 
  - a straightforward approach is to include the common code as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) of both applications.
 


### PR DESCRIPTION
hey, just a small update on an outdated link. The current *private npm modules* link points to a 404 page
![image](https://github.com/meteor/meteor/assets/43085033/9d1a4456-0d14-4204-ac84-4f0004863ebe)

and I update it to this page:
![image](https://github.com/meteor/meteor/assets/43085033/732920f9-744d-40a4-b30a-75d228957d27)

To be honest I'm not sure if it's the appropriate page or not. I just found the outdated link when reading meteor guide and feels like updating it. So please review