### PR TITLE
Fix type declaration for MethodApplyOptions

### DIFF
--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -159,7 +159,13 @@ export namespace Meteor {
    */
   function callAsync(name: string, ...args: any[]): Promise<any>;
 
-  interface MethodApplyOptions {
+  interface MethodApplyOptions<
+    Result extends
+      | EJSONable
+      | EJSONable[]
+      | EJSONableProperty
+      | EJSONableProperty[]
+  > {
     /**
      * (Client only) If true, don't send this method until all previous method calls have completed, and don't send any subsequent method calls until this one is completed.
      */
@@ -203,7 +209,7 @@ export namespace Meteor {
   >(
     name: string,
     args: ReadonlyArray<EJSONable | EJSONableProperty>,
-    options?: MethodApplyOptions,
+    options?: MethodApplyOptions<Result>,
     asyncCallback?: (
       error: global_Error | Meteor.Error | undefined,
       result?: Result


### PR DESCRIPTION
Fixes the following error:

```
.meteor/local/types/node_modules/package-types/meteor/package/os/packages/meteor/meteor.d.ts:173:20 - error TS2304: Cannot find name 'Result'.

173           result?: Result
                       ~~~~~~
```