### PR TITLE
Fix #11336 for forgotPassword

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -376,6 +376,7 @@ Meteor.methods({forgotPassword: options => {
   if (!user && !Accounts._options.ambiguousErrorMessages) {
     Accounts._handleError("User not found");
   }
+  if (!user) return null
 
   const emails = pluckAddresses(user.emails);
   const caseSensitiveEmail = emails.find(

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -373,7 +373,7 @@ Meteor.methods({forgotPassword: options => {
 
   const user = Accounts.findUserByEmail(options.email, { fields: { emails: 1 } });
 
-  if (!user) {
+  if (!user && !Accounts._options.ambiguousErrorMessages) {
     Accounts._handleError("User not found");
   }
 


### PR DESCRIPTION
It was correctly pointed out by @tchax in #11336 that we are still returning error on `forgotPassword` which can be used to enumerate users through inference. I have added an extra condition to the error handling of missing user to only do so when `ambiguousErrorMessages` is set to `true`. This way there shouldn't be any errors returned in production, while still giving the developers the option for testing. Though we could have a debate if not to remove this error completely.