### PR TITLE
Reverting packages version that didn't have any changes

### DIFF
--- a/packages/accounts-facebook/package.js
+++ b/packages/accounts-facebook/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Login service for Facebook accounts",
-  version: '2.0.0-alpha300.11',
+  version: "1.3.3",
 });
 
 Package.onUse(api => {

--- a/packages/accounts-github/package.js
+++ b/packages/accounts-github/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Login service for Github accounts',
-  version: '2.0.0-alpha300.11',
+  version: '1.5.0',
 });
 
 Package.onUse(api => {

--- a/packages/accounts-google/package.js
+++ b/packages/accounts-google/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Login service for Google accounts",
-  version: '2.0.0-alpha300.11',
+  version: "1.4.0",
 });
 
 Package.onUse(api => {

--- a/packages/accounts-meetup/package.js
+++ b/packages/accounts-meetup/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Login service for Meetup accounts',
-  version: '2.0.0-alpha300.11',
+  version: '1.5.0',
 });
 
 Package.onUse(api => {

--- a/packages/accounts-meteor-developer/package.js
+++ b/packages/accounts-meteor-developer/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Login service for Meteor developer accounts',
-  version: '2.0.0-alpha300.11',
+  version: '1.5.0',
 });
 
 Package.onUse(api => {

--- a/packages/accounts-oauth/package.js
+++ b/packages/accounts-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth-based login services",
-  version: '2.0.0-alpha300.11',
+  version: "1.4.2",
 });
 
 Package.onUse(api => {

--- a/packages/accounts-twitter/package.js
+++ b/packages/accounts-twitter/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Login service for Twitter accounts",
-  version: '2.0.0-alpha300.11',
+  version: "1.5.0",
 });
 
 Package.onUse(api => {
@@ -12,7 +12,7 @@ Package.onUse(api => {
   api.use('twitter-oauth');
   api.imply('twitter-oauth');
 
-  api.use('http@1.0.1', ['client', 'server']);
+  api.use('http', ['client', 'server']);
 
   api.use(['accounts-ui', 'twitter-config-ui'], ['client', 'server'], { weak: true });
   api.addFiles("notice.js");

--- a/packages/accounts-ui-unstyled/package.js
+++ b/packages/accounts-ui-unstyled/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Unstyled version of login widgets',
-  version: '2.0.0-alpha300.11',
+  version: '1.7.0',
 });
 
 Package.onUse(function(api) {
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
       'service-configuration',
       'accounts-base',
       'ecmascript',
-      'templating@2.0.0-alpha300.5',
+      'templating@1.4.1',
       'session',
     ],
     'client'

--- a/packages/accounts-ui/package.js
+++ b/packages/accounts-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Simple templates to add login widgets to an app",
-  version: '2.0.0-alpha300.11',
+  version: "1.4.2",
 });
 
 Package.onUse(api => {

--- a/packages/accounts-weibo/package.js
+++ b/packages/accounts-weibo/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Login service for Sina Weibo accounts",
-  version: '2.0.0-alpha300.11',
+  version: "1.4.0",
 });
 
 Package.onUse(api => {

--- a/packages/appcache/package.js
+++ b/packages/appcache/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Enable the application cache in the browser",
-  version: '2.0.0-alpha300.11',
+  version: '1.2.9-alpha300.11',
   deprecated: true,
 });
 

--- a/packages/audit-argument-checks/package.js
+++ b/packages/audit-argument-checks/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Try to detect inadequate input sanitization",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.7'
 });
 
 // This package is empty; its presence is detected by livedata.

--- a/packages/autopublish/package.js
+++ b/packages/autopublish/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "(For prototyping only) Publish the entire database to all clients",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.7'
 });
 
 // This package is empty; its presence is detected by several other packages

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "babel-compiler",
   summary: "Parser/transpiler for ECMAScript 2015+ syntax",
-  version: '8.0.0-alpha300.11',
+  version: '7.11.0-alpha300.11',
 });
 
 Npm.depends({

--- a/packages/babel-runtime/package.js
+++ b/packages/babel-runtime/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "babel-runtime",
   summary: "Runtime support for output of Babel transpiler",
-  version: '2.0.0-alpha300.11',
+  version: '1.5.1',
   documentation: 'README.md'
 });
 

--- a/packages/base64/package.js
+++ b/packages/base64/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Base64 encoding and decoding",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.12',
 });
 
 Package.onUse(api => {

--- a/packages/binary-heap/package.js
+++ b/packages/binary-heap/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Binary Heap datastructure implementation",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.11'
 });
 
 Package.onUse(api => {

--- a/packages/boilerplate-generator-tests/package.js
+++ b/packages/boilerplate-generator-tests/package.js
@@ -2,7 +2,7 @@ Package.describe({
   // These tests are in a separate package so that we can Npm.depend on
   // parse5, a html parsing library.
   summary: "Tests for the boilerplate-generator package",
-  version: '2.0.0-alpha300.11',
+  version: '1.5.1',
   documentation: null
 });
 

--- a/packages/browser-policy-common/package.js
+++ b/packages/browser-policy-common/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for browser-policy packages",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.13-alpha300.11',
 });
 
 Package.onUse(function (api) {

--- a/packages/browser-policy-content/browser-policy-content.js
+++ b/packages/browser-policy-content/browser-policy-content.js
@@ -300,8 +300,6 @@ _.each(resources, function (resource) {
   };
 });
 
-// TODO[fibers]: change this when we have TLA
 await setDefaultPolicy();
-
 
 exports.BrowserPolicy = BrowserPolicy;

--- a/packages/browser-policy-framing/package.js
+++ b/packages/browser-policy-framing/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Restrict which websites can frame your app",
-  version: '2.0.0-alpha300.11',
+  version: '1.1.2'
 });
 
 Package.onUse(function (api) {

--- a/packages/browser-policy/package.js
+++ b/packages/browser-policy/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Configure security policies enforced by the browser",
-  version: '2.0.0-alpha300.11',
+  version: '1.1.2'
 });
 
 Package.onUse(function (api) {

--- a/packages/callback-hook/package.js
+++ b/packages/callback-hook/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Register callbacks on a hook",
-  version: '2.0.0-alpha300.11',
+  version: '1.6.0-alpha300.11',
 });
 
 Package.onUse(function (api) {

--- a/packages/check/package.js
+++ b/packages/check/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Check whether a value matches a pattern',
-  version: '2.0.0-alpha300.11',
+  version: '1.3.2',
 });
 
 Package.onUse(api => {

--- a/packages/core-runtime/package.js
+++ b/packages/core-runtime/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Core runtime to load packages and the app",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.0-alpha300.11',
   documentation: null
 });
 

--- a/packages/crosswalk/package.js
+++ b/packages/crosswalk/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary: "Makes your Cordova application use the Crosswalk WebView \
 instead of the System WebView on Android",
-  version: '2.0.0-alpha300.11',
+  version: '1.7.1',
   documentation: null
 });
 

--- a/packages/ddp-common/package.js
+++ b/packages/ddp-common/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Code shared beween ddp-client and ddp-server",
-  version: '2.0.0-alpha300.11',
+  version: '1.4.1-alpha300.11',
   documentation: null
 });
 

--- a/packages/ddp-rate-limiter/package.js
+++ b/packages/ddp-rate-limiter/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ddp-rate-limiter',
-  version: '2.0.0-alpha300.11',
+  version: '1.2.0',
   // Brief, one-line summary of the package.
   summary: 'The DDPRateLimiter allows users to add rate limits to DDP' +
   ' methods and subscriptions.',

--- a/packages/ddp/package.js
+++ b/packages/ddp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data framework",
-  version: '2.0.0-alpha300.11',
+  version: '1.4.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/deprecated/facts/package.js
+++ b/packages/deprecated/facts/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use(['underscore'], ['client', 'server']);
-  api.use(['templating@2.0.0-alpha300.5', 'mongo', 'ddp'], ['client']);
+  api.use(['templating@1.2.13', 'mongo', 'ddp'], ['client']);
 
   // Detect whether autopublish is used.
   api.use('autopublish', 'server', {weak: true});

--- a/packages/dev-error-overlay/package.js
+++ b/packages/dev-error-overlay/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '1.0.0-alpha300.11',
+  version: '0.1.2',
   summary: 'Show build errors in client when using HMR',
   documentation: 'README.md',
   devOnly: true

--- a/packages/diff-sequence/package.js
+++ b/packages/diff-sequence/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "An implementation of a diff algorithm on arrays and objects.",
-  version: '2.0.0-alpha300.11',
+  version: '1.1.2',
   documentation: null
 });
 

--- a/packages/disable-oplog/package.js
+++ b/packages/disable-oplog/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Disables oplog tailing",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.7'
 });
 
 // This package is empty; its presence is detected by mongo-livedata.

--- a/packages/dynamic-import/package.js
+++ b/packages/dynamic-import/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "dynamic-import",
-  version: '1.0.0-alpha300.11',
+  version: "0.7.3",
   summary: "Runtime support for Meteor 1.5 dynamic import(...) syntax",
   documentation: "README.md"
 });

--- a/packages/ecmascript-runtime-client/package.js
+++ b/packages/ecmascript-runtime-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript-runtime-client',
-  version: '1.0.0-alpha300.11',
+  version: '0.12.1',
   summary: 'Polyfills for new ECMAScript 2015 APIs like Map and Set',
   git:
     'https://github.com/meteor/meteor/tree/devel/packages/ecmascript-runtime-client',

--- a/packages/ecmascript-runtime-server/package.js
+++ b/packages/ecmascript-runtime-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "ecmascript-runtime-server",
-  version: '1.0.0-alpha300.11',
+  version: "0.11.0",
   summary: "Polyfills for new ECMAScript 2015 APIs like Map and Set",
   git: "https://github.com/meteor/meteor/tree/devel/packages/ecmascript-runtime-client",
   documentation: "README.md"

--- a/packages/ecmascript-runtime/package.js
+++ b/packages/ecmascript-runtime/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "ecmascript-runtime",
-  version: '1.0.0-alpha300.11',
+  version: '0.8.2-alpha300.11',
   summary: "Polyfills for new ECMAScript 2015 APIs like Map and Set",
   git: "https://github.com/meteor/ecmascript-runtime",
   documentation: "README.md"

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ecmascript',
-  version: '1.0.0-alpha300.11',
+  version: '0.16.8-alpha300.11',
   summary: 'Compiler plugin that supports ES2015+ in all .js files',
   documentation: 'README.md',
 });

--- a/packages/ejson/package.js
+++ b/packages/ejson/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Extended and Extensible JSON library',
-  version: '2.0.0-alpha300.11',
+  version: '1.1.3'
 });
 
 Package.onUse(function onUse(api) {

--- a/packages/es5-shim/package.js
+++ b/packages/es5-shim/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "es5-shim",
-  version: '5.0.0-alpha300.11',
+  version: "4.8.0",
   summary: "Shims and polyfills to improve ECMAScript 5 support",
   documentation: "README.md"
 });

--- a/packages/facebook-config-ui/package.js
+++ b/packages/facebook-config-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Blaze configuration templates for Facebook OAuth.",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.4-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/facebook-oauth/package.js
+++ b/packages/facebook-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Facebook OAuth flow",
-  version: '2.0.0-alpha300.11',
+  version: '1.11.2'
 });
 
 Package.onUse(api => {

--- a/packages/facts-base/package.js
+++ b/packages/facts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Publish internal app statistics",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.2-alpha300.11',
 });
 
 Package.onUse(function (api) {

--- a/packages/facts-ui/package.js
+++ b/packages/facts-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Display internal app statistics",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.2-alpha300.11',
 });
 
 Package.onUse(function (api) {

--- a/packages/fetch/package.js
+++ b/packages/fetch/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "fetch",
-  version: '1.0.0-alpha300.11',
+  version: '0.1.3',
   summary: "Isomorphic modern/legacy/Node polyfill for WHATWG fetch()",
   documentation: "README.md"
 });

--- a/packages/force-ssl-common/package.js
+++ b/packages/force-ssl-common/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Internal force-ssl common code.',
-  version: '2.0.0-alpha300.11',
+  version: '1.1.0'
 });
 
 Npm.depends({

--- a/packages/force-ssl/package.js
+++ b/packages/force-ssl/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Require this application to use HTTPS",
-  version: '2.0.0-alpha300.11',
+  version: "1.1.0",
   prodOnly: true
 });
 

--- a/packages/geojson-utils/package.js
+++ b/packages/geojson-utils/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'GeoJSON utility functions (from https://github.com/maxogden/geojson-js-utils)',
-  version: '2.0.0-alpha300.11',
+  version: '1.0.11'
 });
 
 Package.onUse(function (api) {

--- a/packages/github-config-ui/package.js
+++ b/packages/github-config-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Blaze configuration templates for GitHub OAuth.',
-  version: '2.0.0-alpha300.11',
+  version: '1.0.3-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/github-oauth/package.js
+++ b/packages/github-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'GitHub OAuth flow',
-  version: '2.0.0-alpha300.11',
+  version: '1.4.1'
 });
 
 Package.onUse(api => {

--- a/packages/google-config-ui/package.js
+++ b/packages/google-config-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Blaze configuration templates for Google OAuth.',
-  version: '2.0.0-alpha300.11',
+  version: '1.0.4-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/google-oauth/package.js
+++ b/packages/google-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Google OAuth flow",
-  version: '2.0.0-alpha300.11',
+  version: "1.4.4",
 });
 
 Cordova.depends({

--- a/packages/hot-code-push/package.js
+++ b/packages/hot-code-push/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'hot-code-push',
-  version: '2.0.0-alpha300.11',
+  version: '1.0.4',
   // Brief, one-line summary of the package.
   summary: 'Update the client in place when new code is available.',
   // URL to the Git repository containing the source code for this package.

--- a/packages/hot-module-replacement/package.js
+++ b/packages/hot-module-replacement/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'hot-module-replacement',
-  version: '1.0.0-alpha300.11',
+  version: '0.5.4-alpha300.11',
   summary: 'Update code in development without reloading the page',
   documentation: 'README.md',
   debugOnly: true,

--- a/packages/id-map/package.js
+++ b/packages/id-map/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dictionary data structure allowing non-string keys",
-  version: '2.0.0-alpha300.11',
+  version: '1.2.0-alpha300.11',
 });
 
 Package.onUse(function (api) {

--- a/packages/insecure/package.js
+++ b/packages/insecure/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "(For prototyping only) Allow all database writes from the client",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.7'
 });
 
 // This package is empty; its presence is detected by mongo-livedata.

--- a/packages/inter-process-messaging/package.js
+++ b/packages/inter-process-messaging/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "inter-process-messaging",
-  version: '1.0.0-alpha300.11',
+  version: "0.1.1",
   summary: "Support for sending messages from the build process to the server process",
   documentation: "README.md"
 });

--- a/packages/launch-screen/package.js
+++ b/packages/launch-screen/package.js
@@ -6,7 +6,7 @@ Package.describe({
   // between such packages and the build tool.
   name: 'launch-screen',
   summary: 'Default and customizable launch screen on mobile.',
-  version: '2.0.0-alpha300.11',
+  version: '1.3.0'
 });
 
 Cordova.depends({

--- a/packages/localstorage/package.js
+++ b/packages/localstorage/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Simulates local storage on IE 6,7 using userData",
-  version: '2.0.0-alpha300.11',
+  version: "1.2.0"
 });
 
 Package.onUse(function (api) {

--- a/packages/logging/package.js
+++ b/packages/logging/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Logging facility.',
-  version: '2.0.0-alpha300.11',
+  version: '1.3.3-alpha300.11',
 });
 
 Npm.depends({

--- a/packages/meetup-config-ui/package.js
+++ b/packages/meetup-config-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Blaze configuration templates for the Meetup OAuth flow.',
-  version: '2.0.0-alpha300.11',
+  version: '1.0.3-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/meetup-oauth/package.js
+++ b/packages/meetup-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Meetup OAuth flow',
-  version: '2.0.0-alpha300.11',
+  version: '1.1.2'
 });
 
 Package.onUse(api => {

--- a/packages/meteor-base/package.js
+++ b/packages/meteor-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'meteor-base',
-  version: '2.0.0-alpha300.11',
+  version: '1.5.1',
   // Brief, one-line summary of the package.
   summary: 'Packages that every Meteor app needs',
   // By default, Meteor will default to using README.md for documentation.

--- a/packages/meteor-developer-config-ui/package.js
+++ b/packages/meteor-developer-config-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Blaze configuration templates for the Meteor developer accounts OAuth.',
-  version: '2.0.0-alpha300.11',
+  version: '1.0.3-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/meteor-developer-oauth/package.js
+++ b/packages/meteor-developer-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Meteor developer accounts OAuth flow',
-  version: '2.0.0-alpha300.11',
+  version: '1.3.2'
 });
 
 Package.onUse(api => {

--- a/packages/mobile-experience/package.js
+++ b/packages/mobile-experience/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mobile-experience',
-  version: '2.0.0-alpha300.11',
+  version: '1.1.0',
   summary: 'Packages for a great mobile user experience',
   documentation: 'README.md'
 });

--- a/packages/mobile-status-bar/package.js
+++ b/packages/mobile-status-bar/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'mobile-status-bar',
   summary: "Good defaults for the mobile status bar",
-  version: '2.0.0-alpha300.11',
+  version: "1.1.0"
 });
 
 Cordova.depends({

--- a/packages/modern-browsers/package.js
+++ b/packages/modern-browsers/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'modern-browsers',
-  version: '1.0.0-alpha300.11',
+  version: '0.1.9',
   summary:
     'API for defining the boundary between modern and legacy ' +
     'JavaScript clients',

--- a/packages/modules-runtime-hot/package.js
+++ b/packages/modules-runtime-hot/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'modules-runtime-hot',
-  version: '1.0.0-alpha300.11',
+  version: '0.14.2',
   summary: 'Patches modules-runtime to support Hot Module Replacement',
   git: 'https://github.com/benjamn/install',
   documentation: 'README.md',

--- a/packages/modules-runtime/package.js
+++ b/packages/modules-runtime/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules-runtime",
-  version: '1.0.0-alpha300.11',
+  version: '0.13.1',
   summary: "CommonJS module system",
   git: "https://github.com/benjamn/install",
   documentation: "README.md"

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: '1.0.0-alpha300.11',
+  version: '0.19.1-alpha300.11',
   summary: "CommonJS module system",
   documentation: "README.md"
 });

--- a/packages/mongo-dev-server/package.js
+++ b/packages/mongo-dev-server/package.js
@@ -3,7 +3,7 @@ Package.describe({
   documentation: 'README.md',
   name: 'mongo-dev-server',
   summary: 'Start MongoDB alongside Meteor, in development mode.',
-  version: '2.0.0-alpha300.11',
+  version: '1.1.0',
 });
 
 Package.onUse(function (api) {

--- a/packages/mongo-id/package.js
+++ b/packages/mongo-id/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'JS simulation of MongoDB ObjectIDs',
-  version: '2.0.0-alpha300.11',
+  version: '1.0.8',
   documentation: null
 });
 

--- a/packages/mongo-livedata/package.js
+++ b/packages/mongo-livedata/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Moved to the 'mongo' package",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.12'
 });
 
 Package.onUse(function (api) {

--- a/packages/non-core/coffeescript-compiler/package.js
+++ b/packages/non-core/coffeescript-compiler/package.js
@@ -12,6 +12,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
+  api.versionsFrom("1.8.1");
   api.use('babel-compiler');
   api.use('ecmascript');
 

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -11,7 +11,7 @@ Package.describe({
 
 Package.registerBuildPlugin({
   name: 'compile-coffeescript',
-  use: ['caching-compiler', 'ecmascript@1.0.0-alpha300.5', 'coffeescript-compiler@2.4.1'],
+  use: ['caching-compiler@1.2.1', 'ecmascript@0.12.7', 'coffeescript-compiler@2.4.1'],
   sources: ['compile-coffeescript.js'],
   npmDependencies: {
     // A breaking change was introduced in @babel/runtime@7.0.0-beta.56
@@ -27,6 +27,7 @@ Package.registerBuildPlugin({
 });
 
 Package.onUse(function (api) {
+  api.versionsFrom("1.8.1");
   api.use('isobuild:compiler-plugin@1.0.0');
 
   // Because the CoffeeScript plugin now calls

--- a/packages/non-core/less/package.js
+++ b/packages/non-core/less/package.js
@@ -8,8 +8,8 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "compileLessBatch",
   use: [
-    "caching-compiler",
-    "ecmascript@1.0.0-alpha300.5",
+    "caching-compiler@1.2.2",
+    "ecmascript@0.15.2",
   ],
   sources: [
     'plugin/compile-less.js'

--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,7 +3,7 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '5.0.0-alpha300.11',
+  version: '4.16.0',
   documentation: null
 });
 

--- a/packages/oauth-encryption/package.js
+++ b/packages/oauth-encryption/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Encrypt account secrets stored in the database",
-  version: '2.0.0-alpha300.11',
+  version: '1.3.3-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/oauth1/package.js
+++ b/packages/oauth1/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth1-based login services",
-  version: '2.0.0-alpha300.11',
+  version: '1.5.2-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/oauth2/package.js
+++ b/packages/oauth2/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Common code for OAuth2-based login services",
-  version: '2.0.0-alpha300.11',
+  version: '1.3.3-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/ordered-dict/package.js
+++ b/packages/ordered-dict/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Ordered traversable dictionary with a mutable ordering",
-  version: '2.0.0-alpha300.11',
+  version: '1.2.0-alpha300.11',
   documentation: null
 });
 

--- a/packages/package-stats-opt-out/package.js
+++ b/packages/package-stats-opt-out/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Opt out of sending package stats",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.7'
 });
 
 Package.onUse(function (api) {

--- a/packages/package-version-parser/package.js
+++ b/packages/package-version-parser/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Parses Meteor Smart Package version strings",
-  version: '4.0.0-alpha300.11',
+  version: "3.2.1"
 });
 
 Npm.depends({

--- a/packages/random/package.js
+++ b/packages/random/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Random number generator and utilities',
-  version: '2.0.0-alpha300.11',
+  version: '1.2.1',
 });
 
 Package.onUse(function (api) {

--- a/packages/rate-limit/package.js
+++ b/packages/rate-limit/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'rate-limit',
-  version: '2.0.0-alpha300.11',
+  version: '1.1.1',
   // Brief, one-line summary of the package.
   summary: 'An algorithm for rate limiting anything',
   // URL to the Git repository containing the source code for this package.

--- a/packages/react-fast-refresh/package.js
+++ b/packages/react-fast-refresh/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'react-fast-refresh',
-  version: '1.0.0-alpha300.11',
+  version: '0.2.7',
   summary: 'Automatically update React components with HMR',
   documentation: 'README.md',
   devOnly: true,

--- a/packages/reactive-dict/package.js
+++ b/packages/reactive-dict/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Reactive dictionary",
-  version: '2.0.0-alpha300.11',
+  version: '1.3.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/reactive-var/package.js
+++ b/packages/reactive-var/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Reactive variable",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.12'
 });
 
 Package.onUse(function (api) {

--- a/packages/reload/package.js
+++ b/packages/reload/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Reload the page while preserving application state.",
-  version: '2.0.0-alpha300.11',
+  version: '1.3.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/retry/package.js
+++ b/packages/retry/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Retry logic with exponential backoff",
-  version: '2.0.0-alpha300.11',
+  version: '1.1.0'
 });
 
 Package.onUse(function (api) {

--- a/packages/routepolicy/package.js
+++ b/packages/routepolicy/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "route policy declarations",
-  version: '2.0.0-alpha300.11',
+  version: '1.1.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/server-render/package.js
+++ b/packages/server-render/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "server-render",
-  version: '1.0.0-alpha300.11',
+  version: "0.4.1",
   summary: "Generic support for server-side rendering in Meteor apps",
   documentation: "README.md"
 });

--- a/packages/service-configuration/package.js
+++ b/packages/service-configuration/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Manage the configuration for third-party services',
-  version: '2.0.0-alpha300.11',
+  version: '1.3.1',
 });
 
 Package.onUse(function(api) {

--- a/packages/session/package.js
+++ b/packages/session/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Session variable",
-  version: '2.0.0-alpha300.11',
+  version: '1.2.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/sha/package.js
+++ b/packages/sha/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  version: '2.0.0-alpha300.11',
+  version: '1.0.9',
   summary: 'SHA256 implementation',
   git: 'https://github.com/meteor/meteor'
 });

--- a/packages/shell-server/package.js
+++ b/packages/shell-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "shell-server",
-  version: '1.0.0-alpha300.11',
+  version: '0.6.0-alpha300.11',
   summary: "Server-side component of the `meteor shell` command.",
   documentation: "README.md"
 });

--- a/packages/socket-stream-client/package.js
+++ b/packages/socket-stream-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "socket-stream-client",
-  version: '1.0.0-alpha300.11',
+  version: '0.5.1',
   summary: "Provides the ClientStream abstraction used by ddp-client",
   documentation: "README.md"
 });

--- a/packages/standard-minifier-css/package.js
+++ b/packages/standard-minifier-css/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifier-css',
-  version: '2.0.0-alpha300.11',
+  version: '1.9.3-alpha300.11',
   summary: 'Standard css minifier used with Meteor apps by default.',
   documentation: 'README.md',
 });

--- a/packages/standard-minifiers/package.js
+++ b/packages/standard-minifiers/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'standard-minifiers',
-  version: '2.0.0-alpha300.11',
+  version: '1.1.0',
   summary: 'Standard minifiers used with Meteor apps by default.',
   documentation: 'README.md'
 });

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'static-html',
   summary: "Define static page content in .html files",
-  version: '2.0.0-alpha300.11',
+  version: '1.3.3-alpha300.11',
   git: 'https://github.com/meteor/meteor.git'
 });
 

--- a/packages/test-in-browser/package.js
+++ b/packages/test-in-browser/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Run tests interactively in the browser",
-  version: '2.0.0-alpha300.11',
+  version: '1.4.0-alpha300.11',
   documentation: null
 });
 

--- a/packages/test-server-tests-in-console-once/package.js
+++ b/packages/test-server-tests-in-console-once/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Run server tests noninteractively, with results going to the console.",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.11'
 });
 
 Package.onUse(function (api) {

--- a/packages/tinytest-harness/package.js
+++ b/packages/tinytest-harness/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'tinytest-harness',
-  version: '1.0.0-alpha300.11',
+  version: '0.0.4',
   summary: 'In development, lets your app define Tinytests, run them and see results',
   documentation: null
 });

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Dependency tracker to allow reactive callbacks",
-  version: '2.0.0-alpha300.11',
+  version: '1.3.2',
 });
 
 Package.onUse(function (api) {

--- a/packages/twitter-config-ui/package.js
+++ b/packages/twitter-config-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Blaze configuration templates for Twitter OAuth.",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.2-alpha300.11',
 });
 
 Package.onUse(function(api) {

--- a/packages/twitter-oauth/package.js
+++ b/packages/twitter-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Twitter OAuth flow",
-  version: '2.0.0-alpha300.11',
+  version: '1.3.3'
 });
 
 Package.onUse(function(api) {

--- a/packages/typescript/package.js
+++ b/packages/typescript/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'typescript',
-  version: '5.0.0-alpha300.11',
+  version: '4.9.4',
   summary:
     'Compiler plugin that compiles TypeScript and ECMAScript in .ts and .tsx files',
   documentation: 'README.md',

--- a/packages/underscore-tests/package.js
+++ b/packages/underscore-tests/package.js
@@ -2,7 +2,7 @@ Package.describe({
   // These tests can't be directly in the underscore packages since
   // Tinytest depends on underscore
   summary: "Tests for the underscore package",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.8'
 });
 
 Package.onTest(function (api) {

--- a/packages/underscore/package.js
+++ b/packages/underscore/package.js
@@ -1,7 +1,7 @@
 
 Package.describe({
   summary: "Collection of small helpers: _.map, _.each, ...",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.14-alpha300.11',
 });
 
 Npm.depends({

--- a/packages/url/package.js
+++ b/packages/url/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "url",
-  version: '2.0.0-alpha300.11',
+  version: "1.3.2",
   summary: "Isomorphic modern/legacy/Node polyfill for WHATWG URL/URLSearchParams",
   documentation: "README.md"
 });

--- a/packages/webapp-hashing/package.js
+++ b/packages/webapp-hashing/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Used internally by WebApp. Knows how to hash programs from manifests.",
-  version: '2.0.0-alpha300.11',
+  version: '1.1.1'
 });
 
 Package.onUse(function(api) {

--- a/packages/weibo-config-ui/package.js
+++ b/packages/weibo-config-ui/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Blaze configuration templates for Weibo OAuth.",
-  version: '2.0.0-alpha300.11',
+  version: '1.0.3-alpha300.11',
 });
 
 Package.onUse(api => {

--- a/packages/weibo-oauth/package.js
+++ b/packages/weibo-oauth/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Weibo OAuth flow",
-  version: '2.0.0-alpha300.11',
+  version: "1.3.2",
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
A few days ago, we had [discussions](https://meteor-community.slack.com/archives/CN350MY1G/p1693515808517419) in the Slack community about how bumping core packages, that didn't have a breaking change, to a new major version wasn't a good idea because this is now making harder to update an app from version 2 to 3. So, we will review every package and revert this change to packages that don't need a bump.