### PR TITLE
bumped mongodb driver

### DIFF
--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -3,12 +3,12 @@
 
 Package.describe({
   summary: "Wrapper around the mongo npm package",
-  version: '4.16.0',
+  version: '4.17.0',
   documentation: null
 });
 
 Npm.depends({
-  mongodb: "4.16.0"
+  mongodb: "4.17.0"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Bumped MongoDB driver to 4.17.

We should be looking when Meteor v3 is released [to update our driver to the latest version(6.x) ](https://github.com/mongodb/node-mongodb-native/releases/tag/v6.0.0)
