### PR TITLE
Move underscore types to dev dependencies in server bundle

### DIFF
--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -15,7 +15,6 @@ var packageJson = {
     promise: "8.1.0",
     "@meteorjs/reify": "0.24.0",
     "@babel/parser": "7.15.3",
-    "@types/underscore": "1.11.2",
     underscore: "1.13.1",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
     "@types/semver": "5.4.0",
@@ -24,6 +23,7 @@ var packageJson = {
   // These are only used in dev mode (by shell.js) so end-users can avoid
   // needing to install them if they use `npm install --production`.
   devDependencies: {
+    "@types/underscore": "1.11.2",
     split2: "3.2.2",
     multipipe: "1.0.2",
     chalk: "0.5.1"


### PR DESCRIPTION
I have noticed that we have a `devDependencies` in server dev bundle generator, so I have moved the `@types/underscore` into that section from the main dependencies as it is a dev dependency which I think it belongs.