### PR TITLE
[ Meteor 3.0 ] - Updating collection and cursor methods

### DIFF
--- a/packages/accounts-base/accounts_client_tests.js
+++ b/packages/accounts-base/accounts_client_tests.js
@@ -164,24 +164,29 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
-  'accounts - Meteor.user() obeys explicit and default field selectors',
+  "accounts - Meteor.user() obeys explicit and default field selectors",
   (test, done) => {
+
     logoutAndCreateUser(test, done, () => {
-      Meteor.loginWithPassword(username, password, () => {
+      Meteor.loginWithPassword(username, password, async () => {
+        const u = await Meteor.user();
         // by default, all fields should be returned
-        test.equal(Meteor.user().profile[excludeField], excludeValue);
+        test.equal(u.profile[excludeField], excludeValue);
 
         // this time we want to exclude the default fields
         const options = Accounts._options;
         Accounts._options = {};
-        Accounts.config({defaultFieldSelector: {['profile.'+defaultExcludeField]: 0}});
-        let user = Meteor.user();
+        Accounts.config({
+          defaultFieldSelector: { ["profile." + defaultExcludeField]: 0 },
+        });
+
+        let user = await Meteor.user();
         test.isUndefined(user.profile[defaultExcludeField]);
         test.equal(user.profile[excludeField], excludeValue);
         test.equal(user.profile.name, username);
 
         // this time we only want certain fields...
-        user = Meteor.user({fields: {'profile.name': 1}});
+        user = await Meteor.user({ fields: { "profile.name": 1 } });
         test.isUndefined(user.profile[excludeField]);
         test.isUndefined(user.profile[defaultExcludeField]);
         test.equal(user.profile.name, username);

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -121,28 +121,6 @@ Accounts.createUser = (options, callback) => {
   });
 };
 
-/**
- * @summary Create a new user and returns a promise of its result.
- * @locus Anywhere
- * @param {Object} options
- * @param {String} options.username A unique name for this user.
- * @param {String} options.email The user's email address.
- * @param {String} options.password The user's password. This is __not__ sent in plain text over the wire.
- * @param {Object} options.profile The user's profile, typically including the `name` field.
- * @importFromPackage accounts-base
- */
-Accounts.createUserAsync = (options) => {
-  return new Promise((resolve, reject) =>
-    Accounts.createUser(options, (e) => {
-      if (e) {
-        reject(e);
-      } else {
-        resolve();
-      }
-    })
-  );
-};
-
 // Change password. Must be logged in.
 //
 // @param oldPassword {String|null} By default servers no longer allow

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -121,6 +121,28 @@ Accounts.createUser = (options, callback) => {
   });
 };
 
+/**
+ * @summary Create a new user and returns a promise of its result.
+ * @locus Anywhere
+ * @param {Object} options
+ * @param {String} options.username A unique name for this user.
+ * @param {String} options.email The user's email address.
+ * @param {String} options.password The user's password. This is __not__ sent in plain text over the wire.
+ * @param {Object} options.profile The user's profile, typically including the `name` field.
+ * @importFromPackage accounts-base
+ */
+Accounts.createUserAsync = (options) => {
+  return new Promise((resolve, reject) =>
+    Accounts.createUser(options, (e) => {
+      if (e) {
+        reject(e);
+      } else {
+        resolve();
+      }
+    })
+  );
+};
+
 // Change password. Must be logged in.
 //
 // @param oldPassword {String|null} By default servers no longer allow

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -65,18 +65,18 @@ if (Meteor.isClient) (() => {
       loggedInAs(this.username, test, expect));
   };
   const logoutStep = (test, expect) =>
-    Meteor.logout(expect(error => {
+    Meteor.logout(expect(async error => {
       if (error) {
         test.fail(error.message);
       }
-      test.equal(Meteor.user(), null);
+      test.equal( await Meteor.user(), null);
     }));
   const loggedInAs = (someUsername, test, expect) => {
-    return expect(error => {
+    return expect(async error => {
       if (error) {
         test.fail(error.message);
       }
-      test.equal(Meteor.userId() && Meteor.user().username, someUsername);
+      test.equal(Meteor.userId() && (await Meteor.user()).username, someUsername);
     });
   };
   const loggedInUserHasEmail = (someEmail, test, expect) => {
@@ -148,17 +148,17 @@ if (Meteor.isClient) (() => {
       // Set up a reactive context that only refreshes when Meteor.user() is
       // invalidated.
       let loaded = false;
-      const handle = Tracker.autorun(() => {
-        if (Meteor.user() && Meteor.user().emails)
+      const handle = Tracker.autorun(async () => {
+        if ((await Meteor.user()) && (await Meteor.user()).emails)
           loaded = true;
       });
       // At the beginning, we're not logged in.
       test.isFalse(loaded);
-      Meteor.loginWithPassword(this.username, this.password, expect(error => {
+      Meteor.loginWithPassword(this.username, this.password, expect(async error => {
         test.equal(error, undefined);
         test.notEqual(Meteor.userId(), null);
         // By the time of the login callback, the user should be loaded.
-        test.isTrue(Meteor.user().emails);
+        test.isTrue(await Meteor.user().emails);
         // Flushing should get us the rerun as well.
         Tracker.flush();
         test.isTrue(loaded);
@@ -700,8 +700,8 @@ if (Meteor.isClient) (() => {
     // test Meteor.user(). This test properly belongs in
     // accounts-base/accounts_tests.js, but this is where the tests that
     // actually log in are.
-    function (test, expect) {
-      const clientUser = Meteor.user();
+    async function (test, expect) {
+      const clientUser = await Meteor.user();
       Accounts.connection.call('testMeteorUser', expect((err, result) => {
         test.equal(result._id, clientUser._id);
         test.equal(result.username, clientUser.username);
@@ -719,8 +719,8 @@ if (Meteor.isClient) (() => {
         // https://github.com/meteor/meteor/pull/12294
       let resolve;
       const promise = new Promise(res => resolve = res);
-      Meteor.setTimeout(() => {
-        test.equal(Meteor.user(), { _id: Meteor.userId() });
+      Meteor.setTimeout(async () => {
+        test.equal(await Meteor.user(), { _id: Meteor.userId() });
         resolve();
       }, 100);
       return promise;

--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -7,9 +7,9 @@
       "integrity": "sha512-VCvq454Two3oLtBHrkWx6OC1lO6jepYOCC9PhlcHcQCDC2R8mlDTmox0XvW2rCTVOth0qEIbdxKeKxa8WkD7eA=="
     },
     "@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
     },
     "acorn": {
       "version": "8.10.0",

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -555,7 +555,7 @@ Object.assign(Mongo.Collection.prototype, {
    * @returns {Object}
    */
   findOne(...args) {
-    return this._collection.findOne(
+    return this._collection.findOneAsync(
       this._getFindSelector(args),
       this._getFindOptions(args)
     );
@@ -724,11 +724,14 @@ Object.assign(Mongo.Collection.prototype, {
       // result will be returned through the callback instead.
       let result;
       if (!!wrappedCallback) {
-        this._collection.insert(doc, wrappedCallback);
+        this._collection
+          .insertAsync(doc)
+          .then((doc) => wrappedCallback(null, doc._id))
+          .catch((e) => wrappedCallback(e, null));
       } else {
         // If we don't have the callback, we assume the user is using the promise.
         // We can't just pass this._collection.insert to the promisify because it would lose the context.
-        result = this._collection.insert(doc);
+        result = this._collection.insertAsync(doc);
       }
 
       return chooseReturnValueFromCollectionResult(result);
@@ -1012,7 +1015,7 @@ Object.assign(Mongo.Collection.prototype, {
 
     // it's my collection.  descend into the collection1 object
     // and propagate any exception.
-    return this._collection.remove(selector);
+    return this._collection.removeAsync(selector);
   },
 
 

--- a/packages/mongo/collection_tests.js
+++ b/packages/mongo/collection_tests.js
@@ -132,8 +132,8 @@ Tinytest.addAsync('collection - calling native find with $reverse hint should re
       await collection.insertAsync({a: 1});
       await collection.insertAsync({a: 2});
     } else {
-      collection.insert({ a: 1 });
-      collection.insert({ b: 1 });
+      await collection.insertAsync({ a: 1 });
+      await collection.insertAsync({ b: 1 });
     }
 
     function m(doc) { return doc.a; }
@@ -155,7 +155,7 @@ Tinytest.addAsync('collection - calling native find with good hint and maxTimeMs
     if (Meteor.isServer) {
       await collection.insertAsync({ a: 1 });
     } else {
-      collection.insert({ a: 1 });
+      await collection.insertAsync({ a: 1 });
     }
 
     return Promise.resolve(
@@ -413,24 +413,27 @@ Tinytest.addAsync(
       await collection.insertAsync({ _id: '3' });
       const preCount = client.s.activeSessions.size;
 
-      test.equal(await collection.find().count(), 3);
+      test.equal(await collection.find().countAsync(), 3);
       // options and selector still work
       test.equal(
-        await collection.find({ _id: { $ne: '1' } }, { skip: 1 }).count(),
+        await collection.find({ _id: { $ne: '1' } }, { skip: 1 }).countAsync(),
         1
       );
 
       // cursor reuse
       const cursor1 = collection.find({ _id: { $ne: '1' } }, { skip: 1 });
-      test.equal(await cursor1.count(), 1);
-      test.equal((await cursor1.fetch()).length, 1);
-
+      cursor1.countAsync()
+      cursor1.fetchAsync()
       const cursor2 = collection.find({ _id: { $ne: '1' } }, { skip: 1 });
-      test.equal((await cursor2.fetch()).length, 1);
-      test.equal(await cursor2.count(), 1);
+      test.equal((await cursor2.fetchAsync()).length, 1);
+      test.equal(await cursor2.countAsync(), 1);
 
       const postCount = client.s.activeSessions.size;
       test.equal(preCount, postCount);
+
+      test.equal(await cursor1.count(), 1);
+      test.equal((await cursor1.fetch()).length, 1);
+
     }
   }
 );

--- a/packages/mongo/collection_tests.js
+++ b/packages/mongo/collection_tests.js
@@ -413,21 +413,21 @@ Tinytest.addAsync(
       await collection.insertAsync({ _id: '3' });
       const preCount = client.s.activeSessions.size;
 
-      test.equal(await collection.find().countAsync(), 3);
+      test.equal(await collection.find().count(), 3);
       // options and selector still work
       test.equal(
-        await collection.find({ _id: { $ne: '1' } }, { skip: 1 }).countAsync(),
+        await collection.find({ _id: { $ne: '1' } }, { skip: 1 }).count(),
         1
       );
 
       // cursor reuse
       const cursor1 = collection.find({ _id: { $ne: '1' } }, { skip: 1 });
-      test.equal(await cursor1.countAsync(), 1);
-      test.equal((await cursor1.fetchAsync()).length, 1);
+      test.equal(await cursor1.count(), 1);
+      test.equal((await cursor1.fetch()).length, 1);
 
       const cursor2 = collection.find({ _id: { $ne: '1' } }, { skip: 1 });
-      test.equal((await cursor2.fetchAsync()).length, 1);
-      test.equal(await cursor2.countAsync(), 1);
+      test.equal((await cursor2.fetch()).length, 1);
+      test.equal(await cursor2.count(), 1);
 
       const postCount = client.s.activeSessions.size;
       test.equal(preCount, postCount);

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -869,11 +869,6 @@ Cursor.prototype.countAsync = async function () {
 };
 
 [...ASYNC_CURSOR_METHODS, Symbol.iterator, Symbol.asyncIterator].forEach(methodName => {
-  // count is handled specially since we don't want to create a cursor.
-  // it is still included in ASYNC_CURSOR_METHODS because we still want an async version of it to exist.
-  if (methodName === 'count') {
-    return
-  }
   Cursor.prototype[methodName] = function (...args) {
     const cursor = setupSynchronousCursor(this, methodName);
     return cursor[methodName](...args);

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -3214,9 +3214,10 @@ if (Meteor.isClient) {
       const cname = Random.id();
       const coll1 = new Mongo.Collection(cname, { connection: null });
       const doc = { foo: 'bar' };
-      const docId = coll1.insert(doc, function(err, id) {
+      const docId = coll1.insert(doc, async function(err, id) {
         test.equal(docId, id);
-        test.equal(coll1.findOne(doc)._id, id);
+        const d = await coll1.findOne(doc)
+        test.equal(d._id, id);
         onComplete();
       });
     }


### PR DESCRIPTION
From this [community thread(slack)](https://meteor-community.slack.com/archives/C01SWPPE81F/p1694427385872349)


For some reason, insert, findOne and remove were using non-existing methods. This pr addresses that