### PR TITLE
[ Meteor 3.0 ] - added createUserAsync in the client

### DIFF
--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -121,6 +121,29 @@ Accounts.createUser = (options, callback) => {
   });
 };
 
+
+/**
+ * @summary Create a new user and returns a promise of its result.
+ * @locus Anywhere
+ * @param {Object} options
+ * @param {String} options.username A unique name for this user.
+ * @param {String} options.email The user's email address.
+ * @param {String} options.password The user's password. This is __not__ sent in plain text over the wire.
+ * @param {Object} options.profile The user's profile, typically including the `name` field.
+ * @importFromPackage accounts-base
+ */
+Accounts.createUserAsync = (options) => {
+  return new Promise((resolve, reject) =>
+    Accounts.createUser(options, (e) => {
+      if (e) {
+        reject(e);
+      } else {
+        resolve();
+      }
+    })
+  );
+};
+
 // Change password. Must be logged in.
 //
 // @param oldPassword {String|null} By default servers no longer allow


### PR DESCRIPTION
Relates to #12300.

This brings createUserAsync to client-side

Maybe this pr should contain all the missing in client-side accounts methods.

We should backport this to 2.x ASAP.