### PR TITLE
Add option to disable CORS in sockjs

### DIFF
--- a/packages/ddp-server/stream_server.js
+++ b/packages/ddp-server/stream_server.js
@@ -52,7 +52,7 @@ StreamServer = function () {
     disconnect_delay: 60 * 1000,
     // Allow disabling of CORS requests to address
     // https://github.com/meteor/meteor/issues/8317.
-    disable_cors: !!process.env.DISABLE_SOCKJS_CORS
+    disable_cors: !!process.env.DISABLE_SOCKJS_CORS,
     // Set the USE_JSESSIONID environment variable to enable setting the
     // JSESSIONID cookie. This is useful for setting up proxies with
     // session affinity.

--- a/packages/ddp-server/stream_server.js
+++ b/packages/ddp-server/stream_server.js
@@ -50,6 +50,9 @@ StreamServer = function () {
     // combining CPU-heavy processing with SockJS termination (eg a proxy which
     // converts to Unix sockets) but for now, raise the delay.
     disconnect_delay: 60 * 1000,
+    // Allow disabling of CORS requests to address
+    // https://github.com/meteor/meteor/issues/8317.
+    disable_cors: !!process.env.DISABLE_SOCKJS_CORS
     // Set the USE_JSESSIONID environment variable to enable setting the
     // JSESSIONID cookie. This is useful for setting up proxies with
     // session affinity.


### PR DESCRIPTION
This adds the ability to set an environment variable `DISABLE_SOCKJS_CORS` which activates the `disable_cors` flag in sockjs. This addresses a common issue that is flagged by many vulnerability scanners, discussed in #8317. 