### PR TITLE
Add Tracker.autorunAsync to allow for await-able autorun blocks

### DIFF
--- a/packages/tracker/tracker.js
+++ b/packages/tracker/tracker.js
@@ -578,6 +578,37 @@ Tracker.autorun = function (f, options) {
   return c;
 };
 
+/**
+ * @callback Tracker.ComputationFunction
+ * @param {Tracker.Computation}
+ */
+/**
+ * @summary Await-able Tracker.autorun. Run a function now and rerun it later whenever its dependencies
+ * change. Returns a promise for the Computation object that can be used to stop or observe the
+ * rerunning.
+ * @locus Client
+ * @param {Tracker.ComputationFunction} runFunc The function to run. It receives
+ * one argument: the Computation object that will be returned.
+ * @param {Object} [options]
+ * @param {Function} options.onError Optional. The function to run when an error
+ * happens in the Computation. The only argument it receives is the Error
+ * thrown. Defaults to the error being logged to the console.
+ * @returns {Tracker.Computation}
+ */
+Tracker.autorunAsync = function (f, options) {
+  let fPromise
+  const newF = async(...args) => {
+    fPromise = f(...args)
+  }
+
+  const c = Tracker.autorun(newF, options)
+
+  return fPromise.then(() => {
+    return c
+  })
+};
+
+
 // http://docs.meteor.com/#tracker_nonreactive
 //
 // Run `f` with no current computation, returning the return value


### PR DESCRIPTION
PR which adds a new, `await`-able `Tracker.autorunAsync` to allow Autorun blocks with async autorun functions to be run in a predictable manner.

There's also a separate PR on the blaze repo with an equivalent `Template.autorunAsync` function: [Add Template.autorunAsync to allow for await-able autorun blocks #427.
](https://github.com/meteor/blaze/pull/427)
The explanations in both PRs are basically identical, so if you understood the first one, you got both, only one's for `Tracker.autorunAsync`, and the other one is for `Template.aurorunAsync`.

The issue I'm trying to mitigate is this.

Having multiple "traditional" autorun blocks in a row like this, with async autorun funcs:

```
// autorun 1
Tracker.autorun(async(c) => {
    // 1
    await Tracker.withComputation(c, () => { ... }) 
    // 2
    await Tracker.withComputation(c, () => { ... }) 
    // 3
    await Tracker.withComputation(c, () => { ... })     
    // 4
})

// autorun 2
Tracker.autorun(async(c) => {
    // 5
    await Tracker.withComputation(c, () => { ... }) 
    // 6
    await Tracker.withComputation(c, () => { ... }) 
    // 7
    await Tracker.withComputation(c, () => { ... })     
    // 8
})

// autorun 3
Tracker.autorun(async(c) => {
    // 9
    await Tracker.withComputation(c, () => { ... }) 
    // 10
    await Tracker.withComputation(c, () => { ... }) 
    // 11
    await Tracker.withComputation(c, () => { ... })     
    // 12
})

```

... will lead to **each autorun being entered, executed til after the first `await`, then the interpreter will skip the rest of the autorun function, start with the next synchronous task in the script, eg. the autorun2 function.**

There it'll run til after the first `await` & yield, and then again with the third block.

After that all bets are off: Whenever some of the awaited code returns, it'll be continued eventually. Until the next await block.. :D 

**So the interpreter will actually zig-zag back and forth between the different Autorun blocks until all the awaits have been passed and finished.**

That makes it really hard to reason about the autoruns & probably might lead to issues during runtime too, eg. certain subscriptions not being made / ready because the interpreter "skipped ahead" a previous autorun, which until async were guaranteed to run in order once.

It gets even more fun in the context of eg. Blaze Templates, where for example here:

```

Template.onCreated(function() {
    // autorun 1
    Tracker.autorun(async(c) => {
        // 1
        await Tracker.withComputation(c, () => { ... }) 
        // 2
        // (...)
    })

    // autorun 2
    Tracker.autorun(async(c) => {
        // 5
        await Tracker.withComputation(c, () => { ... }) 
        // 6
        // (...)
    })

    // autorun 3
    Tracker.autorun(async(c) => {
        // 9
        await Tracker.withComputation(c, () => { ... }) 
        // 10
        // (...)
    })
})

Template.onRendered(function() {
    // autorun 4
    Tracker.autorun(async(c) => {
        // 13
        await Tracker.withComputation(c, () => { ... }) 
        // 14
        // (...)
    })
})

```

Here, autorun 4 in `onRendered` will be started to be executed _before_ any of the first autoruns have been ran through completely, if that makes sense.

The only way I could conceive to put everything "in order" again was to use `async` function in `onCreated` and `onRendered` and then making the autorun blocks `await`able by awaiting each one in turn.

This way it'd also be possible to wait for the `rendered` event by setting eg. a reactive var in `onRendered` and checking that in `onCreated` (or wherever you want) in an autorun...

---

So then the above code could look like this with my added `Tracker.autorunAsync` function:

```

Template.onCreated(async function() {
    // autorun 1
    await Tracker.autorunAsync(async(c) => {
        // 1
        await Tracker.withComputation(c, () => { ... }) 
        // 2
        // (...)
    })

    // autorun 2
    await Tracker.autorunAsync(async(c) => {
        // 5
        await Tracker.withComputation(c, () => { ... }) 
        // 6
        // (...)
    })

    // autorun 3
    await Tracker.autorunAsync(async(c) => {
        // 9
        await Tracker.withComputation(c, () => { ... }) 
        // 10
        // (...)
    })
})

Template.onRendered(async function() {
    // autorun 4
    await Tracker.autorunAsync(async(c) => {
        // 13
        await Tracker.withComputation(c, () => { ... }) 
        // 14
        // (...)
    })
})

```

This forces all the code in the autorun blocks to run in their _expected_ order again. It's possible to _reason_ again about the order of things. Otherwise there might be a lot of really hard to debug race conditions.

The good thing is, the PR adds a new function, `Tracker.autorunAsync`, so it shouldn't break any existing code.

I've adopted the *Async syntax here for easy differentiation between Async and not-Async variants.

I'm not sure if that means that in the future / with 3.0 we should _only_ use the `autorunAsync` - functions, but for now I think its good to have these in there explicitly as an option.

I'm not sure if this should go into the mainline immediately? Please, I'd be happy for some feedback.

Also, sorry, there's no

a) Typescript definitions - I have no clue about that, but probably could fumble something together, but I wouldn't actually know how to check whether it'd be correct either
b) Tests - sorry guys
c) Nothing added to the Meteor Docs yet - let me know if this is something which might actually make it into meteor and I'll gladly add some lines to the docs.

Thx & best!

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
