### PR TITLE
Update and deprecate crosswalk

### DIFF
--- a/packages/crosswalk/package.js
+++ b/packages/crosswalk/package.js
@@ -2,9 +2,10 @@ Package.describe({
   summary: "Makes your Cordova application use the Crosswalk WebView \
 instead of the System WebView on Android",
   version: '1.7.1',
-  documentation: null
+  documentation: null,
+  deprecated: true
 });
 
 Cordova.depends({
-  'cordova-plugin-crosswalk-webview': '2.3.0'
+  'cordova-plugin-crosswalk-webview': '2.4.0'
 });


### PR DESCRIPTION
Fix #12834 
Update the NPM package to the latest version and deprecate it as per #12834.

Maybe we should move it into the deprecated folder in the next release after this?