### PR TITLE
Fix iPad user agent

### DIFF
--- a/packages/modern-browsers/modern-tests.js
+++ b/packages/modern-browsers/modern-tests.js
@@ -29,4 +29,11 @@ Tinytest.add('modern-browsers - versions - basic', function (test) {
     minor: 5,
     patch: 2,
   }));
+
+  test.isTrue(isModern({
+    name: "appleMail", 
+    major: 605, 
+    minor: 1,
+    patch: 15,
+  }));
 });

--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -32,7 +32,10 @@ const browserAliases = {
 
   // The webapp package converts browser names to camel case, so
   // mobile_safari and mobileSafari should be synonymous.
-  mobile_safari: ['mobileSafari', 'mobileSafariUI', 'mobileSafariUI/WKWebView', 'appleMail'],
+  mobile_safari: ['mobileSafari', 'mobileSafariUI', 'mobileSafariUI/WKWebView'],
+
+  // Embedded WebViews on iPads will be reported as Apple Mail
+  safari: ['appleMail'],
 };
 
 // Expand the given minimum versions by reusing chrome versions for

--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -32,7 +32,7 @@ const browserAliases = {
 
   // The webapp package converts browser names to camel case, so
   // mobile_safari and mobileSafari should be synonymous.
-  mobile_safari: ['mobileSafari', 'mobileSafariUI', 'mobileSafariUI/WKWebView'],
+  mobile_safari: ['mobileSafari', 'mobileSafariUI', 'mobileSafariUI/WKWebView', 'appleMail'],
 };
 
 // Expand the given minimum versions by reusing chrome versions for


### PR DESCRIPTION
We noticed that on iPads Meteor serves the legacy bundle (`Meteor.isModern === false`). We determined this is because the user agent is reported as 'Apple Mail' (for example `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko)`). This PR adds an alias for this user agent so (modern) iPads also receive the modern bundle.