### PR TITLE
Future proof NPM packages

### DIFF
--- a/npm-packages/babel-preset-meteor/babel-presets-meteor/package.json
+++ b/npm-packages/babel-preset-meteor/babel-presets-meteor/package.json
@@ -1,11 +1,12 @@
 {
   "name": "babel-preset-meteor",
-  "version": "7.10.1",
+  "version": "7.10.2",
   "description": "Babel preset for ES2015+ features supported by Meteor",
   "author": "Ben Newman <ben@meteor.com>",
   "license": "MIT",
   "repository": "https://github.com/meteor/babel-preset-meteor",
   "main": "index.js",
+  "type": "commonjs",
   "scripts": {
     "update-versions": "bash scripts/update-versions"
   },

--- a/npm-packages/cordova-plugin-meteor-webapp/package.json
+++ b/npm-packages/cordova-plugin-meteor-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-meteor-webapp",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Cordova plugin that serves a Meteor web app through a local server and implements hot code push",
   "cordova": {
     "id": "cordova-plugin-meteor-webapp",
@@ -22,6 +22,7 @@
   ],
   "author": "Meteor Development Group",
   "license": "MIT",
+  "type": "commonjs",
   "scripts": {
     "pretest": "ios-sim start --devicetypeid=iPhone-11-Pro-Max",
     "test": "cordova-paramedic --plugin . --platform ios --target 'iPhone-11-Pro-Max' --args=--buildFlag='-UseModernBuildSystem=0' --verbose"

--- a/npm-packages/eslint-config-meteor/package.json
+++ b/npm-packages/eslint-config-meteor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/eslint-config-meteor",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Eslint configuration for Meteor",
   "main": "index.js",
   "scripts": {
@@ -16,6 +16,7 @@
     "url": "https://github.com/meteor/meteor/issues"
   },
   "homepage": "https://github.com/meteor/meteor/tree/devel/npm-packages/eslint-config-meteor#readme",
+  "type": "commonjs",
   "peerDependencies": {
     "babel-eslint": ">= 7",
     "eslint": ">= 3",

--- a/npm-packages/eslint-plugin-meteor/package.json
+++ b/npm-packages/eslint-plugin-meteor/package.json
@@ -1,9 +1,10 @@
 {
   "name": "eslint-plugin-meteor",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "author": "Dominik Ferber <dominik.ferber+npm@gmail.com>",
   "description": "Meteor specific linting rules for ESLint",
   "main": "lib/index.js",
+  "type": "commonjs",
   "publishConfig": {
     "tag": "next"
   },

--- a/npm-packages/meteor-babel/package.json
+++ b/npm-packages/meteor-babel/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@meteorjs/babel",
   "author": "Meteor <dev@meteor.com>",
-  "version": "7.18.0-beta.6",
+  "version": "7.18.0",
   "license": "MIT",
+  "type": "commonjs",
   "description": "Babel wrapper package for use with Meteor",
   "keywords": [
     "meteor",

--- a/npm-packages/meteor-installer/package.json
+++ b/npm-packages/meteor-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Install Meteor",
   "main": "install.js",
   "scripts": {
@@ -8,6 +8,7 @@
   },
   "author": "zodern",
   "license": "MIT",
+  "type": "commonjs",
   "dependencies": {
     "7zip-bin": "^5.2.0",
     "cli-progress": "^3.11.1",

--- a/npm-packages/meteor-node-stubs/package.json
+++ b/npm-packages/meteor-node-stubs/package.json
@@ -2,10 +2,11 @@
   "name": "meteor-node-stubs",
   "author": "Ben Newman <ben@meteor.com>",
   "description": "Stub implementations of Node built-in modules, a la Browserify",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "main": "index.js",
   "license": "MIT",
   "homepage": "https://github.com/meteor/meteor/blob/devel/npm-packages/meteor-node-stubs/README.md",
+  "type": "commonjs",
   "scripts": {
     "prepare": "node scripts/build-deps.js"
   },

--- a/npm-packages/meteor-promise/package.json
+++ b/npm-packages/meteor-promise/package.json
@@ -1,8 +1,9 @@
 {
   "name": "meteor-promise",
   "author": "Ben Newman <ben@meteor.com>",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "ES6 Promise polyfill with Fiber support",
+  "type": "commonjs",
   "keywords": [
     "meteor",
     "promise",


### PR DESCRIPTION
Future proof NPM packages by adding `"type": "commonjs"` to `package.json`.
See latest Node release notes: https://github.com/nodejs/node/releases/tag/v21.1.0

With that I also suggest publishing `@meteorjs/babel` without the beta tag.
@Grubba27 if you want I can update it in the bundle as well and it to this PR, so then we merge this PR in first, release NPM packages and then we can build the new bundle.
