### PR TITLE
Don't flatten ObjectIDs in oplogV2V1Converter (fixes #12855)

### DIFF
--- a/packages/mongo/oplog_v2_converter.js
+++ b/packages/mongo/oplog_v2_converter.js
@@ -47,7 +47,8 @@ function isArrayOperator(operator) {
 }
 
 function flattenObjectInto(target, source, prefix) {
-  if (Array.isArray(source) || typeof source !== 'object' || source === null) {
+  if (Array.isArray(source) || typeof source !== 'object' || source === null ||
+      source instanceof Mongo.ObjectID) {
     target[prefix] = source;
   } else {
     const entries = Object.entries(source);

--- a/packages/mongo/oplog_v2_converter_tests.js
+++ b/packages/mongo/oplog_v2_converter_tests.js
@@ -78,6 +78,10 @@ const cases = [
     { $v: 2, $set: { params: { e: { _str: '5f953cde8ceca90030bdb86f' } } } },
   ],
   [
+    { $v: 2, diff: { i: { id: new Mongo.ObjectID('ffffffffffffffffffffffff') } } },
+    { $v: 2, $set: { id: new Mongo.ObjectID('ffffffffffffffffffffffff') } },
+  ],
+  [
     {
       $v: 2,
       diff: {


### PR DESCRIPTION
Attempts to fix #12855: When setting a Mongo.ObjectID in a document, the ObjectID gets transformed into a plain object in Minimongo, until the page is refreshed / the document is refetched.

Includes the fix and a matching test.

Thanks for any feedback.