### PR TITLE
OAuth async remove

### DIFF
--- a/packages/oauth/pending_credentials.js
+++ b/packages/oauth/pending_credentials.js
@@ -27,7 +27,7 @@ const _cleanStaleResults = () => {
   // Remove credentials older than 1 minute
   const timeCutoff = new Date();
   timeCutoff.setMinutes(timeCutoff.getMinutes() - 1);
-  OAuth._pendingCredentials.remove({ createdAt: { $lt: timeCutoff } });
+  OAuth._pendingCredentials.removeAsync({ createdAt: { $lt: timeCutoff } });
 };
 const _cleanupHandle = Meteor.setInterval(_cleanStaleResults, 60 * 1000);
 
@@ -78,7 +78,7 @@ OAuth._retrievePendingCredential = (key, credentialSecret = null) => {
   });
 
   if (pendingCredential) {
-    OAuth._pendingCredentials.remove({ _id: pendingCredential._id });
+    OAuth._pendingCredentials.removeAsync({ _id: pendingCredential._id });
     if (pendingCredential.credential.error)
       return recreateError(pendingCredential.credential.error);
     else


### PR DESCRIPTION
Address #12641 by moving remove calls to async. I think they can be just moved to async without any issue, but we'll see what the tests say. There are other DB calls that are not async, so that might still be a problem, but those will probably be a bit more involved and are beyond the scope of this simple PR.