### PR TITLE
Update NPM packages Node version tests

### DIFF
--- a/.github/workflows/npm-eslint-plugin-meteor.yml
+++ b/.github/workflows/npm-eslint-plugin-meteor.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/eslint-plugin-meteor
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 18.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-meteor-babel.yml
+++ b/.github/workflows/npm-meteor-babel.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-babel
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 18.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-meteor-promise.yml
+++ b/.github/workflows/npm-meteor-promise.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-promise
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 18.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
In #12861 I have noticed that NPM packages run tests on Node v12. In this PR I update them to run on Node v14 and v18 to account for the upcoming Meteor v3 and remove outdated Node version from testing.