### PR TITLE
Fix: remove dynamic import as hard dependency on packages

### DIFF
--- a/packages/deprecated/jshint/.versions
+++ b/packages/deprecated/jshint/.versions
@@ -11,7 +11,6 @@ ddp-client@2.4.1
 ddp-common@1.4.0
 ddp-server@2.3.3
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.1

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -24,7 +24,7 @@ Package.onUse(function(api) {
   api.imply('promise');
 
   // Runtime support for Meteor 1.5 dynamic import(...) syntax.
-  api.imply('dynamic-import');
+  api.use('dynamic-import', ['server', 'client'], { weak: true });
 
   api.addFiles('ecmascript.js', 'server');
   api.export('ECMAScript', 'server');

--- a/packages/non-core/bundle-visualizer/client.js
+++ b/packages/non-core/bundle-visualizer/client.js
@@ -5,11 +5,11 @@ import {
   packageName,
 } from "./common.js";
 import * as classes from "./classNames.js";
-
-import("./style.css");
+import "./style.css";
 
 Meteor.startup(() => {
-  import("./sunburst.js").then(s => main(s.Sunburst));
+  import s from "./sunburst.js";
+  main(s.Sunburst);
 });
 
 async function main(builder) {
@@ -30,7 +30,7 @@ async function main(builder) {
 
   try {
     const data = await fetch(url, { method: "GET" });
-    new builder({ container }).loadJson(await data.json())
+    new builder({ container }).loadJson(await data.json());
   } catch (err) {
     console.error([
       packageName + ": Couldn't load stats for visualization.",

--- a/packages/non-core/bundle-visualizer/package.js
+++ b/packages/non-core/bundle-visualizer/package.js
@@ -14,10 +14,9 @@ Npm.depends({
 });
 
 Package.onUse(function(api) {
-  api.use('isobuild:dynamic-import@1.5.0');
+  api.use('dynamic-import', ['server', 'client'], { weak: true });
   api.use([
     'ecmascript',
-    'dynamic-import',
     'fetch',
     'webapp',
   ]);

--- a/packages/non-core/coffeescript/package.js
+++ b/packages/non-core/coffeescript/package.js
@@ -39,7 +39,7 @@ Package.onUse(function (api) {
   api.imply('ecmascript-runtime');
   api.imply('babel-runtime');
   api.imply('promise');
-  api.imply('dynamic-import');
+  api.use('dynamic-import', ['server', 'client'], { weak: true });
 });
 
 Package.onTest(function (api) {

--- a/packages/non-core/less/.versions
+++ b/packages/non-core/less/.versions
@@ -13,7 +13,6 @@ ddp-client@2.5.0
 ddp-common@1.4.0
 ddp-server@2.4.0
 diff-sequence@1.1.1
-dynamic-import@0.7.1
 ecmascript@0.15.2
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.1

--- a/packages/tinytest/package.js
+++ b/packages/tinytest/package.js
@@ -13,7 +13,7 @@ Package.onUse(function (api) {
     'mongo',
     'check'
   ]);
-
+  api.imply('dynamic-import');
   api.mainModule('tinytest_client.js', 'client');
   api.mainModule('tinytest_server.js', 'server');
 

--- a/packages/typescript/package.js
+++ b/packages/typescript/package.js
@@ -24,7 +24,7 @@ Package.onUse(function(api) {
   api.imply('babel-runtime');
   api.imply('promise');
   // Runtime support for Meteor 1.5 dynamic import(...) syntax.
-  api.imply('dynamic-import');
+  api.use('dynamic-import', ['server', 'client'], { weak: true });
 });
 
 Package.onTest(function(api) {

--- a/tools/upgraders.js
+++ b/tools/upgraders.js
@@ -289,6 +289,7 @@ be removed if there is no need for the Blaze configuration interface.`,
   },
 
   "1.5-add-dynamic-import-package": function (projectContext) {
+    // FIXME: we need to make this a weak dependency here
     const packagesFile = projectContext.projectConstraintsFile;
     packagesFile.addPackages(["dynamic-import"]);
     packagesFile.writeIfModified();


### PR DESCRIPTION
This is an attempt to make `dynamic-import` a weak dependency in order to have it opt-in on projects. It should only be present in `.versions` when it's explcitly added by the project or a package that requires it. However, core packages should not require it by default.

- [x] make weak in `ecmascript`
- [x] make weak in `typescript`
- [x] make weak in `coffeescript`
- [x] make available in `tinytest`
- [x] make bundle-visualizer static; remove dependency
- [ ] tests running
- [ ] remove from skeletons
- [ ] make weak or remove in upgraders
