### PR TITLE
Fixes latestVersion as [object Promise] on package upgrade command

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1973,10 +1973,10 @@ main.registerCommand({
     var nonlatestDirectDeps = [];
     var nonlatestIndirectDeps = [];
     var deprecatedDeps = [];
-    projectContext.packageMap.eachPackage(function (name, info) {
+    await projectContext.packageMap.eachPackage(async function(name, info) {
       var selectedVersion = info.version;
       var catalog = projectContext.projectCatalog;
-      var latestVersion = getNewerVersion(name, selectedVersion, catalog);
+      var latestVersion = await getNewerVersion(name, selectedVersion, catalog);
       if (latestVersion) {
         var rec = { name: name, selectedVersion: selectedVersion,
                     latestVersion: latestVersion };


### PR DESCRIPTION
See below:

```
Newer versions of the following indirect dependencies are available:
 * accounts-base 3.0.0-alpha300.18 ([object Promise] is available)
```

This PR fixes this log message.