### PR TITLE
Update semver to 7.5.4

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.21.4.7
+BUNDLE_VERSION=14.21.4.8
 
 
 # OS Check. Put here because here is where we download the precompiled

--- a/npm-packages/meteor-babel/package-lock.json
+++ b/npm-packages/meteor-babel/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/babel",
-  "version": "7.18.3",
+  "version": "7.18.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1042,28 +1042,31 @@
       }
     },
     "@meteorjs/reify": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@meteorjs/reify/-/reify-0.24.0.tgz",
-      "integrity": "sha512-h7ZC9K9Ifqrkq7PBE8SnLD/2R6nhid63rNpJDDkjCLEYBZizEg7FBFe3QuyW7R0ZNKQ5uWFX9PxIARzHbcb3eA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@meteorjs/reify/-/reify-0.24.1.tgz",
+      "integrity": "sha512-2Jzg0WtrBzkSjt+AIYUwC4cobcLJ1EdXLVTxMRemNTCfBJl0fe2lE6BVhD6/JZ/jNHwMvRdggfLIXhuHZMwTNQ==",
       "requires": {
         "acorn": "^6.1.1",
         "acorn-dynamic-import": "^4.0.0",
         "magic-string": "^0.25.3",
         "periscopic": "^2.0.3",
-        "semver": "^5.7.1"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
     "@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "acorn": {
       "version": "6.4.2",
@@ -2276,6 +2279,14 @@
         "chalk": "^2.0.1"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -2855,6 +2866,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/npm-packages/meteor-babel/package.json
+++ b/npm-packages/meteor-babel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meteorjs/babel",
   "author": "Meteor <dev@meteor.com>",
-  "version": "7.18.3",
+  "version": "7.18.4",
   "license": "MIT",
   "type": "commonjs",
   "description": "Babel wrapper package for use with Meteor",
@@ -42,7 +42,7 @@
     "@babel/template": "^7.16.7",
     "@babel/traverse": "^7.17.0",
     "@babel/types": "^7.17.0",
-    "@meteorjs/reify": "0.24.0",
+    "@meteorjs/reify": "0.24.1",
     "babel-preset-meteor": "^7.10.0",
     "babel-preset-minify": "^0.5.1",
     "convert-source-map": "^1.6.0",

--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -5,7 +5,7 @@ Package.describe({
 });
 
 Npm.depends({
-  '@meteorjs/babel': '7.18.3',
+  '@meteorjs/babel': '7.18.4',
   'json5': '2.1.1'
 });
 

--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   name: "modules",
-  version: "0.19.0",
+  version: "0.20.0-beta2140.1",
   summary: "CommonJS module system",
   documentation: "README.md"
 });
 
 Npm.depends({
-  "@meteorjs/reify": "0.24.0",
+  "@meteorjs/reify": "0.24.1",
   "meteor-babel-helpers": "0.0.3"
 });
 

--- a/packages/package-version-parser/package-version-parser.js
+++ b/packages/package-version-parser/package-version-parser.js
@@ -212,10 +212,10 @@ PV.compare = function (versionOne, versionTwo) {
   // per the semver spec.)
   if (v1.semver !== v2.semver) {
     if (! v1._semverParsed) {
-      v1._semverParsed = new semver(v1.semver);
+      v1._semverParsed = semver.parse(v1.semver);
     }
     if (! v2._semverParsed) {
-      v2._semverParsed = new semver(v2.semver);
+      v2._semverParsed = semver.parse(v2.semver);
     }
     return semver.compare(v1._semverParsed, v2._semverParsed);
   } else {

--- a/packages/package-version-parser/package.js
+++ b/packages/package-version-parser/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Parses Meteor Smart Package version strings",
-  version: "3.2.1"
+  version: "3.2.2-beta2140.1",
 });
 
 Npm.depends({
-  semver: "5.4.1"
+  semver: "7.5.4"
 });
 
 Package.onUse(function (api) {

--- a/scripts/dev-bundle-server-package.js
+++ b/scripts/dev-bundle-server-package.js
@@ -13,12 +13,12 @@ var packageJson = {
     fibers: "5.0.1",
     "meteor-promise": "0.9.0",
     promise: "8.1.0",
-    "@meteorjs/reify": "0.24.0",
+    "@meteorjs/reify": "0.24.1",
     "@babel/parser": "7.17.0",
     underscore: "1.13.6",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
     "@types/semver": "5.5.0",
-    semver: "5.7.1"
+    semver: "7.5.4"
   },
   // These are only used in dev mode (by shell.js) so end-users can avoid
   // needing to install them if they use `npm install --production`.

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -20,7 +20,7 @@ var packageJson = {
     // found in dev-bundle-server-package.js.
     "meteor-promise": "0.9.0",
     fibers: "5.0.1",
-    "@meteorjs/reify": "0.24.0",
+    "@meteorjs/reify": "0.24.1",
     // So that Babel can emit require("@babel/runtime/helpers/...") calls.
     "@babel/runtime": "7.15.3",
     // For backwards compatibility with isopackets that still depend on
@@ -30,7 +30,7 @@ var packageJson = {
     underscore: "1.13.6",
     "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
     "@types/semver": "5.5.0",
-    semver: "5.7.1",
+    semver: "7.5.4",
     request: "2.88.2",
     uuid: "3.4.0",
     "graceful-fs": "4.2.6",


### PR DESCRIPTION
This comes from: https://security.snyk.io/package/npm/semver

Todo: 
- [x] Create new devbundle to make this changes happen.


It was already published the `npm meteor/babel`


