### PR TITLE
Add instructions for enabling back gesture on iOS

### DIFF
--- a/guide/source/cordova.md
+++ b/guide/source/cordova.md
@@ -695,3 +695,9 @@ From this point on, the process for submitting the app to the Play Store is the 
 Because Crosswalk bundles native code for Chromium, you will end up with APKs for both ARM and x86. You can find the generated APKs in the `<build-output-directory>/android/project/build/outputs/apk` directory.
 
 You will have to sign and `zipalign` both APKs. You will also have to submit both to the Play Store, see  [submitting multiple APKs](http://developer.android.com/google/play/publishing/multiple-apks.html) for more information.
+
+<h2>Other tips</h2>
+
+The back gesture is disabled by default on iOS, but it can be enabled at runtime like this:
+
+```window.WkWebView.allowsBackForwardNavigationGestures(true);```


### PR DESCRIPTION
Most users expect to be able to use the back gesture in apps. My app really felt 2nd-class until I enabled this. I wasn't able to figure out how through a web search. Eventually I asked on the forums and got an answer (https://forums.meteor.com/t/getting-back-gesture-to-work-on-ios/60771)

I really this is a very important feature that should be mentioned here. Perhaps it should even be the default setting?