### PR TITLE
Update logging package to chalk 5

### DIFF
--- a/packages/logging/package.js
+++ b/packages/logging/package.js
@@ -4,8 +4,8 @@ Package.describe({
 });
 
 Npm.depends({
-  'chalk': '4.1.1',
-  '@babel/runtime': '7.20.7'
+  'chalk': '5.3.0',
+  '@babel/runtime': '7.23.5'
 });
 
 Npm.strip({
@@ -20,8 +20,8 @@ Package.onUse(function (api) {
   // `ecmascript-runtime-client@0.6.2` or newer.
   api.use(['ejson', 'ecmascript', 'ecmascript-runtime-client']);
   api.mainModule('logging.js');
-  api.addFiles('logging_server.js', 'server')
-  api.addFiles('logging_browser.js', 'client')
+  api.addFiles('logging_server.js', 'server');
+  api.addFiles('logging_browser.js', 'client');
   api.mainModule('logging_cordova.js', 'web.cordova');
 });
 


### PR DESCRIPTION
Update logging package dependencies to latest.

The v5 gets rid of external dependencies for chalk, so it reduces the package size by half.

With that I think we will be able to get rid of `ecmascript-runtime-client` and `@babel/runtime` dependencies here. I will experiment with that once the initial tests pass.

Also once #12669 is merged it will include the types as well.