### PR TITLE
Move compileForShell from ecmascript to babel-compiler

### DIFF
--- a/docs/generators/changelog/versions/3.0.md
+++ b/docs/generators/changelog/versions/3.0.md
@@ -109,6 +109,7 @@
 
 - `babel-compiler@8.0.0`:
 
+  - Add `Babel.compileForShell`
   - Removed `Promise.await` default transform.
   - Added top-level-await to packages.
 
@@ -240,6 +241,8 @@
 
 - `ecmascript@1.0.0`:
 
+  - `ECMAScript.compileForShell` was removed. Use `Babel.compileForShell` from
+  `babel-compiler` instead. This change makes some build plugins and apps that do not use `babel-compiler` 90mb smaller.
   - Added dependency to `@babel/runtime`.
   - Moved runtime tests.
 

--- a/packages/babel-compiler/babel.js
+++ b/packages/babel-compiler/babel.js
@@ -47,5 +47,16 @@ Babel = {
 
   getMinimumModernBrowserVersions: function () {
     return Npm.require("@meteorjs/babel/modern-versions.js").get();
+  },
+
+  compileForShell(command, cacheOptions) {
+    const babelOptions = Babel.getDefaultOptions({
+      nodeMajorVersion: parseInt(process.versions.node, 10),
+      compileForShell: true
+    });
+    delete babelOptions.sourceMap;
+    delete babelOptions.sourceMaps;
+    babelOptions.ast = false;
+    return Babel.compile(command, babelOptions, cacheOptions).code;
   }
 };

--- a/packages/ecmascript/ecmascript.js
+++ b/packages/ecmascript/ecmascript.js
@@ -1,12 +1,5 @@
 ECMAScript = {
-  compileForShell(command, cacheOptions) {
-    const babelOptions = Babel.getDefaultOptions({
-      nodeMajorVersion: parseInt(process.versions.node, 10),
-      compileForShell: true
-    });
-    delete babelOptions.sourceMap;
-    delete babelOptions.sourceMaps;
-    babelOptions.ast = false;
-    return Babel.compile(command, babelOptions, cacheOptions).code;
+  compileForShell() {
+    throw new Error('compileForShell was removed in Meteor 3. Use Babel.compileForShell instead from babel-compiler');
   }
 };

--- a/packages/ecmascript/package.js
+++ b/packages/ecmascript/package.js
@@ -18,7 +18,6 @@ Package.registerBuildPlugin({
 
 Package.onUse(function(api) {
   api.use('isobuild:compiler-plugin@1.0.0');
-  api.use('babel-compiler');
   api.use('react-fast-refresh');
 
   // The following api.imply calls should match those in

--- a/packages/shell-server/package.js
+++ b/packages/shell-server/package.js
@@ -7,5 +7,6 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.use("ecmascript", "server");
+  api.use("babel-compiler", "server");
   api.mainModule("main.js", "server");
 });

--- a/packages/shell-server/shell-server.js
+++ b/packages/shell-server/shell-server.js
@@ -235,9 +235,9 @@ class Server {
     const defaultEval = repl.eval;
 
     function wrappedDefaultEval(code, context, file, callback) {
-      if (Package.ecmascript) {
+      if (Package['babel-compiler']) {
         try {
-          code = Package.ecmascript.ECMAScript.compileForShell(code, {
+          code = Package['babel-compiler'].Babel.compileForShell(code, {
             cacheDirectory: getCacheDirectory(shellDir)
           });
         } catch (err) {


### PR DESCRIPTION
The babel-compiler package is 86mb. Since it is a runtime dependency of `ecmascript`, a copy of it is included in every app, build plugin, or meteor-tool version that uses `ecmascript`. A few years ago, I found that about half of the 10gb of disk space on my computer in ~/.meteor/packages was just copies of `babel-compiler`, and the multiple copies of it in each release contributed to the slow install times on Windows.

We've been needing to fix it for a while, and it seems Meteor 3 is a good time to do it.

The only reason babel-compiler is a runtime dependency of ecmascript is for `Ecmascript.compileForShell`, used by packages that implement the Meteor shell. This PR moves `compileForShell` to the `babel-compiler` package. This is a breaking change. It should only affect the small number of packages that implement a Meteor shell, and I think the benefits are large enough to make it worth while.

I left the `Ecmascript.compileForShell` function and have it throw an error with the migration instructions. If this PR is accepted, I can create a PR for Meteor 2 that adds `Babel.compileForShell` and adds a deprecation message.

I published `zodern:remove-client-js@1.0.1-beta.5` using these changes. This dropped the size of the package from 99.1mb to 4.9mb. In addition to using less space, it is significantly faster for Meteor to build it in development and for installing a published version.