### PR TITLE
Explain why package is top level

### DIFF
--- a/packages/constraint-solver/constraint-solver-input.js
+++ b/packages/constraint-solver/constraint-solver-input.js
@@ -43,6 +43,7 @@ CS.Input = function (dependencies, constraints, catalogCache, options) {
   self.allowIncompatibleUpdate = options.allowIncompatibleUpdate || false;
   self.upgradeIndirectDepPatchVersions =
     options.upgradeIndirectDepPatchVersions || false;
+  self.explainTopLevel = options.explainTopLevel || (() => {});
 
   _check(self.dependencies, [String]);
   _check(self.constraints, [PV.PackageConstraint]);

--- a/packages/constraint-solver/constraint-solver.js
+++ b/packages/constraint-solver/constraint-solver.js
@@ -56,7 +56,8 @@ CS.PackagesResolver.prototype.resolve = async function (dependencies, constraint
                                 'anticipatedPrereleases',
                                 'previousSolution',
                                 'allowIncompatibleUpdate',
-                                'upgradeIndirectDepPatchVersions'));
+                                'upgradeIndirectDepPatchVersions',
+                                'explainTopLevel'));
   });
 
   // The constraint solver avoids re-solving everything from scratch on

--- a/packages/constraint-solver/solver.js
+++ b/packages/constraint-solver/solver.js
@@ -1043,7 +1043,14 @@ CS.Solver.prototype.listConstraintsOnPackage = function (pkg) {
         paths = self.getPathsToPackageVersion(
           CS.PackageAndVersion.fromString(c.fromVar));
       } else {
-        paths = [['top level']];
+        let description = 'top level';
+        let explanation = self.input.explainTopLevel(c.toPackage);
+
+        if (explanation) {
+          description += ' (' + explanation + ')';
+        }
+
+        paths = [[description]];
       }
       _.each(paths, function (path) {
         result += '\n* ' + (new PV.PackageConstraint(

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -654,14 +654,14 @@ Object.assign(ProjectContext.prototype, {
           supportedIsobuildFeaturePackages: KNOWN_ISOBUILD_FEATURE_PACKAGES,
           explainTopLevel(name) {
             if (localPackages.includes(name)) {
-              return 'local package'
+              return 'local package';
             }
 
             if (
               self._releaseForConstraints &&
               self._releaseForConstraints.packages[name]
             ) {
-              return 'constrained by release'
+              return 'constrained by release';
             }
           }
         };


### PR DESCRIPTION
When there are conflicts in the version constraints for a package, Meteor lists all of the constraints along with the path. Sometimes the path is simply `top level`. The meaning of `top level` doesn't seem to be common knowledge anymore (if it ever was), so this PR adds an explanation for why the package is top level (it is either a local package, or the constraint is from the release).

I haven't tested the code for top level packages from a release since when running Meteor locally every core package is a local package. I thought the meteor-tool might have a way to test this, but I didn't find one.

``` 
=> Errors while adding packages:             
                                              
While selecting package versions:
error: Conflict: Constraint caching-html-compiler@2.0.0-alpha300.16 is not satisfied by caching-html-compiler 1.2.1.
Constraints on package "caching-html-compiler":
* caching-html-compiler@=1.2.1 <- top level (is local package)
* caching-html-compiler@2.0.0-alpha300.16 <- static-html 1.3.3-alpha300.19

Conflict: Constraint templating-tools@2.0.0-alpha300.16 is not satisfied by templating-tools 1.2.2.
Constraints on package "templating-tools":
* templating-tools@=1.2.2 <- top level (is local package)
* templating-tools@2.0.0-alpha300.16 <- static-html 1.3.3-alpha300.19
* templating-tools@1.2.1 <- caching-html-compiler 1.2.1 <- static-html 1.3.3-alpha300.19

Conflict: Constraint caching-compiler@1.2.2 is not satisfied by caching-compiler 2.0.0-alpha300.19.
Constraints on package "caching-compiler":
* caching-compiler@=2.0.0-alpha300.19 <- top level (is local package)
* caching-compiler@1.2.2 <- caching-html-compiler 1.2.1 <- static-html 1.3.3-alpha300.19
```