### PR TITLE
Fix syntax issues with meteor package

### DIFF
--- a/packages/meteor/asl-helpers.js
+++ b/packages/meteor/asl-helpers.js
@@ -24,7 +24,7 @@ function getAslStore() {
     return {};
   }
 
-  let asyncLocalStorage = getAsl();
+  var asyncLocalStorage = getAsl();
   return asyncLocalStorage.getStore() || {};
 }
 
@@ -45,7 +45,7 @@ Meteor._runAsync = function (fn, ctx, store) {
   if (store === undefined) {
     store = {};
   }
-  let asyncLocalStorage = getAsl();
+  var asyncLocalStorage = getAsl();
 
   return asyncLocalStorage.run(
     store || Meteor._getAslStore(),

--- a/packages/meteor/asl-helpers.js
+++ b/packages/meteor/asl-helpers.js
@@ -1,29 +1,60 @@
-const getAslStore = () => (Meteor.isServer && global?.asyncLocalStorage?.getStore()) || {};
-const getValueFromAslStore = key => getAslStore()[key];
-const updateAslStore = (key, value) => getAslStore()[key] = value;
-
-
-// From 3.0 onwards, fibers is disabled by default.
-Meteor.isFibersDisabled = __meteor_bootstrap__ && __meteor_bootstrap__.isFibersDisabled !== false;
+// In Meteor versions with fibers, __meteor_bootstrap__.isFibersDisabled
+// is always undefined.
+Meteor.isFibersDisabled = typeof __meteor_bootstrap__ === 'object' &&
+  __meteor_bootstrap__.isFibersDisabled !== undefined;
 Meteor._isFibersEnabled = !Meteor.isFibersDisabled;
 
+function getAsl() {
+  if (!Meteor.isFibersDisabled) {
+    throw new Error('Can not use async hooks when fibers are enabled');
+  }
+
+  if (!global.asyncLocalStorage) {
+    // lazily create asyncLocalStorage since this might run in older Meteor
+    // versions that are incompatible with async hooks
+    var AsyncLocalStorage = Npm.require('async_hooks').AsyncLocalStorage;
+    global.asyncLocalStorage = new AsyncLocalStorage();
+  }
+
+  return global.asyncLocalStorage;
+}
+
+function getAslStore() {
+  if (!Meteor.isServer) {
+    return {};
+  }
+
+  let asyncLocalStorage = getAsl();
+  return asyncLocalStorage.getStore() || {};
+}
+
+function getValueFromAslStore(key) {
+  return getAslStore()[key];
+}
+
+function updateAslStore(key, value) {
+  return getAslStore()[key] = value;
+}
+
+Meteor._getAsl = getAsl;
 Meteor._getAslStore = getAslStore;
 Meteor._getValueFromAslStore = getValueFromAslStore;
 Meteor._updateAslStore = updateAslStore;
-if (Meteor.isServer && !global.asyncLocalStorage) {
-    const { AsyncLocalStorage } = Npm.require('async_hooks');
-    global.asyncLocalStorage = new AsyncLocalStorage();
-}
 
-Meteor._runAsync = (fn, ctx, store = {}) => {
-    return global.asyncLocalStorage.run(
-      store || Meteor._getAslStore(),
-      () => {
-        return fn.call(ctx);
-      }
-    );
+Meteor._runAsync = function (fn, ctx, store) {
+  if (store === undefined) {
+    store = {};
+  }
+  let asyncLocalStorage = getAsl();
+
+  return asyncLocalStorage.run(
+    store || Meteor._getAslStore(),
+    function () {
+      return fn.call(ctx);
+    }
+  );
 };
 
-Meteor._isPromise = (r) => {
-    return r && typeof r.then === 'function';
+Meteor._isPromise = function (r) {
+  return r && typeof r.then === 'function';
 };

--- a/packages/meteor/async_helpers.js
+++ b/packages/meteor/async_helpers.js
@@ -1,25 +1,26 @@
 Meteor._noYieldsAllowed = function (f) {
-  const result = f();
+  var result = f();
   if (Meteor._isPromise(result)) {
     throw new Error("function is a promise when calling Meteor._noYieldsAllowed");
   }
   return result
 };
 
-class FakeDoubleEndedQueue {
-  constructor() {
-    this.queue = [];
-  }
-  push(task) {
-    this.queue.push(task);
-  }
-  shift() {
-    return this.queue.shift();
-  }
-  isEmpty() {
-    return this.queue.length === 0;
-  }
+function FakeDoubleEndedQueue () {
+  this.queue = [];
 }
+
+FakeDoubleEndedQueue.prototype.push = function (task) {
+  this.queue.push(task);
+};
+
+FakeDoubleEndedQueue.prototype.shift = function () {
+  return this.queue.shift();
+};
+
+FakeDoubleEndedQueue.prototype.isEmpty = function () {
+  return this.queue.length === 0;
+};
 
 Meteor._DoubleEndedQueue = Meteor.isServer ? Npm.require('denque') : FakeDoubleEndedQueue;
 
@@ -40,17 +41,16 @@ Meteor._DoubleEndedQueue = Meteor.isServer ? Npm.require('denque') : FakeDoubleE
 // XXX could maybe use the npm 'schlock' module instead, which would
 //     also support multiple concurrent "read" tasks
 //
-class AsynchronousQueue {
-  constructor() {
-    this._taskHandles = new Meteor._DoubleEndedQueue();
-    this._runningOrRunScheduled = false;
-    // This is true if we're currently draining.  While we're draining, a further
-    // drain is a noop, to prevent infinite loops.  "drain" is a heuristic type
-    // operation, that has a meaning like unto "what a naive person would expect
-    // when modifying a table from an observe"
-    this._draining = false;
-  }
-
+function AsynchronousQueue () {
+  this._taskHandles = new Meteor._DoubleEndedQueue();
+  this._runningOrRunScheduled = false;
+  // This is true if we're currently draining.  While we're draining, a further
+  // drain is a noop, to prevent infinite loops.  "drain" is a heuristic type
+  // operation, that has a meaning like unto "what a naive person would expect
+  // when modifying a table from an observe"
+  this._draining = false;
+}
+Object.assign(AsynchronousQueue.prototype, {
   queueTask(task) {
     const self = this;
     self._taskHandles.push({
@@ -58,7 +58,7 @@ class AsynchronousQueue {
       name: task.name
     });
     self._scheduleRun();
-  }
+  },
 
   async _scheduleRun() {
     // Already running or scheduled? Do nothing.
@@ -80,7 +80,7 @@ class AsynchronousQueue {
       this._run().finally(resolve);
     });
     return promise;
-  }
+  },
 
   async _run() {
     if (!this._runningOrRunScheduled)
@@ -117,23 +117,23 @@ class AsynchronousQueue {
         taskHandle.resolver();
       }
     }
-  }
+  },
 
   async runTask(task) {
     let resolver;
     const promise = new Promise(
       (resolve, reject) =>
-        (resolver = (res, rej) => {
-          if (rej) {
-            reject(rej);
-            return;
-          }
-          resolve(res);
-        })
+      (resolver = (res, rej) => {
+        if (rej) {
+          reject(rej);
+          return;
+        }
+        resolve(res);
+      })
     );
 
     const handle = {
-      task: Meteor.bindEnvironment(task, function(e) {
+      task: Meteor.bindEnvironment(task, function (e) {
         Meteor._debug('Exception from task', e);
         throw e;
       }),
@@ -143,11 +143,11 @@ class AsynchronousQueue {
     this._taskHandles.push(handle);
     await this._scheduleRun();
     return promise;
-  }
+  },
 
   flush() {
-    return this.runTask(() => {});
-  }
+    return this.runTask(() => { });
+  },
 
   async drain() {
     if (this._draining)
@@ -159,7 +159,7 @@ class AsynchronousQueue {
     }
     this._draining = false;
   }
-}
+});
 
 Meteor._AsynchronousQueue = AsynchronousQueue;
 

--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -57,11 +57,13 @@ class EnvironmentVariableAsync {
         return ret;
       },
       this,
-      {
-        callId: `${this.slot}-${Math.random()}`,
-        [SLOT_CALL_KEY]: this.slot,
-        ...options,
-      }
+      Object.assign(
+        {
+          callId: `${this.slot}-${Math.random()}`,
+          [SLOT_CALL_KEY]: this.slot,
+        },
+        options,
+      )
     );
   }
 
@@ -177,6 +179,6 @@ Meteor.bindEnvironment = (func, onException, _this) => {
       return runWithEnvironment();
     }
 
-    return global.asyncLocalStorage.run({}, runWithEnvironment);
+    return Meteor._getAsl().run({}, runWithEnvironment);
   };
 };

--- a/packages/meteor/emitter-promise.js
+++ b/packages/meteor/emitter-promise.js
@@ -1,7 +1,7 @@
-const { EventEmitter } = Npm.require('node:events');
+const { EventEmitter } = Npm.require('events');
 
 const DEFAULT_TIMEOUT =
-  Meteor.settings?.EMITTER_PROMISE_DEFAULT_TIMEOUT || 3000;
+  Meteor.settings && Meteor.settings.EMITTER_PROMISE_DEFAULT_TIMEOUT || 3000;
 
 /**
  *

--- a/scripts/admin/check-legacy-syntax/check-syntax.js
+++ b/scripts/admin/check-legacy-syntax/check-syntax.js
@@ -5,8 +5,8 @@
 // and when used in build plugins can run in old Meteor versions
 
 const clientEcmascriptVersion = 5;
-// Node 8 (Meteor 1.6+) fully supports 2016
-const serverEcmascriptVersion = "2016";
+// Node 8 (Meteor 1.6+) fully supports 2016, and supports most of 2017
+const serverEcmascriptVersion = "2017";
 
 // Latest version - (has TLA)
 const latestEcmascriptVersion = "2022";
@@ -26,15 +26,14 @@ const packages = {
   meteor: {
     serverFiles: [
       "server_environment.js",
+      "dynamics_nodejs.js",
+      "emitter-promise.js"
     ],
 
     // TODO: Fibers
     // Ignored server files that has a features > 2016
     ignoredFiles: [
-      "emitter-promise.js",
-      "dynamics_nodejs.js",
       "async_helpers.js",
-      "asl-helpers.js",
     ]
   },
   "accounts-ui": {},


### PR DESCRIPTION
Some of the new code in the `meteor` package uses newer syntax that breaks the legacy client and breaks build plugins that want to run in both Meteor 2 and 3.

This PR re-enables the check-syntax script for more of the files in the `meteor` package and fixes the issues it found.
I increased the ecmascript version for server files to es2017 which allows us to use async/await. There are some es2017 features not supported in Node 8, but we currently don't use those features so this still verifies that these core packages can be used in build plugins compatible back to Meteor 1.6.

There are some remaining issues with the `async_helpers.js` file. I fixed enough so it works in build plugins in older Meteor releases, but not enough for it to run in legacy clients.

I tested these changes with `zodern:remove-client-js@1.0.1-beta.5`. These changes allows it to be published with Meteor 3 (required for build plugins that use `ecmascript` to work in Meteor 3) and still be compatible back to Meteor 1.6.