### PR TITLE
Add asyncIterator to AsyncCursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Travis CI Status](https://api.travis-ci.com/meteor/meteor.svg?branch=devel)](https://app.travis-ci.com/github/meteor/meteor)
 [![CircleCI Status](https://circleci.com/gh/meteor/meteor.svg?style=svg)](https://app.circleci.com/pipelines/github/meteor/meteor?branch=devel)
-[![built with Meteor](https://img.shields.io/badge/Meteor-2.13.3-green?logo=meteor&logoColor=white)](https://meteor.com)
+[![built with Meteor](https://img.shields.io/badge/Meteor-2.14-green?logo=meteor&logoColor=white)](https://meteor.com)
 
 </div>
 
@@ -46,7 +46,7 @@ Use the same code whether you’re developing for web, iOS, Android, or desktop 
 
 # 🔥 Getting Started
 
-How about trying a getting started tutorial in your favorite technology?
+How about trying a tutorial to get started with your favorite technology?
 
 | [<img align="left" width="25" src="https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg"> React](https://react-tutorial.meteor.com/) |
 | - |

--- a/guide/source/3.0-migration.md
+++ b/guide/source/3.0-migration.md
@@ -7,7 +7,7 @@ description: How to migrate your application to Meteor 3.0.
 
 ## What's the status of version 3.0?
 
-**Latest version:** `3.0-alpha.20` <br/>
+**Latest version:** `3.0-beta.0` <br/>
 **Node.js version:** `20.9.0 LTS`
 
 Meteor 3.0 is in alpha and not recommended for production. You can check the "[Release 3.0 Pull Request](https://github.com/meteor/meteor/pull/12359)" to see what is being changed.
@@ -112,7 +112,7 @@ findOne is not available on the server. Please use findOneAsync instead.
 You can create a new Meteor 3.0 project by running the command below:
 
 ```bash
-meteor create my-new-project --release 3.0-alpha.20
+meteor create my-new-project --release 3.0-beta.0
 ```
 
 ### How to update from version 2?
@@ -120,7 +120,7 @@ meteor create my-new-project --release 3.0-alpha.20
 You can update your Meteor 2.x project by running the command below inside your project folder:
 
 ```bash
-meteor update --release 3.0-alpha.20
+meteor update --release 3.0-beta.0
 ```
 
 ### How to follow the progress on version 3?
@@ -143,7 +143,7 @@ The migration will look like this:
 ```js
 // in you package.js
 Package.onUse((api) => {
-  api.versionsFrom(['1.10', '2.3', '3.0-alpha.20']);
+  api.versionsFrom(['1.10', '2.3', '3.0-beta.0']);
   //                               ^^^^^^^ for testing your package with meteor 3.0
 
   api.versionsFrom(['1.10', '2.3', '3.0']);

--- a/guide/source/writing-atmosphere-packages.md
+++ b/guide/source/writing-atmosphere-packages.md
@@ -296,6 +296,14 @@ Package.onTest(function(api) {
 
 From within your test entry point, you can import other files as you would in the package proper.
 
+You can also use [`mtest`](https://github.com/zodern/mtest) to test your packages like so:
+
+```bash
+mtest --package ./ --once 2.14
+```
+
+Which helps immensely if you'd like to test your package in CI/CD setup. You can see an example [here](https://github.com/monti-apm/monti-apm-agent/blob/master/.github/workflows/test.yml).
+
 You can read more about testing in Meteor in the [Testing article](testing.html).
 
 <h2 id="publishing-atmosphere">Publishing your package</h2>

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1043,6 +1043,20 @@ class AsynchronousCursor {
   [Symbol.iterator]() {
     return this._cursor[Symbol.iterator]();
   }
+  
+  [Symbol.asyncIterator]() {
+    return {
+      next: async () => {
+        const next = await this._nextObjectPromise();
+        if (next) {
+          return { done: false, value: next };
+        }
+        return {
+          done: true,
+        };
+      },
+    };
+  }
 
   // Returns a Promise for the next object from the underlying cursor (before
   // the Mongo->Meteor type replacement).

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1046,14 +1046,9 @@ class AsynchronousCursor {
   
   [Symbol.asyncIterator]() {
     return {
-      next: async () => {
-        const next = await this._nextObjectPromise();
-        if (next) {
-          return { done: false, value: next };
-        }
-        return {
-          done: true,
-        };
+      async next {
+        const value = await this._nextObjectPromise();
+        return { done: !value, value };
       },
     };
   }

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1042,7 +1042,7 @@ class AsynchronousCursor {
   
   [Symbol.asyncIterator]() {
     return {
-      async next {
+      async next() {
         const value = await this._nextObjectPromise();
         return { done: !value, value };
       },

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1039,10 +1039,6 @@ class AsynchronousCursor {
 
     this._visitedIds = new LocalCollection._IdMap;
   }
-
-  [Symbol.iterator]() {
-    return this._cursor[Symbol.iterator]();
-  }
   
   [Symbol.asyncIterator]() {
     return {


### PR DESCRIPTION
As mentioned in this issue https://github.com/meteor/meteor/issues/12959 the new asynchronous cursor doesn't have the asyncIterator on it which would be a breaking change from version 2.0

This PR adds an async iterator following the example here https://javascript.info/async-iterators-generators
This enables this code:

```
for await (const item of collection){
doStuff(item)
}
```
