### PR TITLE
fix(minimongo): sync upsert doesn't create new documents

### DIFF
--- a/packages/minimongo/local_collection.js
+++ b/packages/minimongo/local_collection.js
@@ -660,6 +660,22 @@ export default class LocalCollection {
 
     this._observeQueue.drain();
 
+
+    // If we are doing an upsert, and we didn't modify any documents yet, then
+    // it's time to do an insert. Figure out what document we are inserting, and
+    // generate an id for it.
+    let insertedId;
+    if (updateCount === 0 && options.upsert) {
+      const doc = LocalCollection._createUpsertDocument(selector, mod);
+      if (!doc._id && options.insertedId) {
+        doc._id = options.insertedId;
+      }
+
+      insertedId = this.insert(doc);
+      updateCount = 1;
+    }
+
+
     return this.finishUpdate({
       options,
       updateCount,

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -212,6 +212,21 @@ Tinytest.addAsync('minimongo - basics', async test => {
   test.equal(after.d, undefined);
 });
 
+
+Tinytest.addAsync('minimongo - upsert', async test => {
+  const c = new LocalCollection();
+
+  await c.upsertAsync({ name: 'doc' }, { name: 'doc' });
+  
+  test.equal(c.find({}).count(), 1);
+
+  await c.removeAsync({});
+
+  c.upsert({ name: 'doc' }, { name: 'doc' });
+  test.equal(c.find({}).count(), 1);
+});
+
+
 Tinytest.add('minimongo - error - no options', test => {
   try {
     throw MinimongoError('Not fun to have errors');


### PR DESCRIPTION
Issue:
During the migration to Meteor 3 , for some reason, our UI was not working anymore.

Collections were returning empty arrays for some reason. After changing `upsert` to `upsertAsync`, everything seemed to start working as expected again.

I reviewed the documentation, and it explicitly states that Minimongo will continue to provide synchronous functions. Investigating the code, I realized that both functions are practically identical, except for the part that deals with the case where no record has been modified, where it is assumed that an insertion should be performed. Adding this code to the application made it return to normal, and it now honors what is written in the documentation.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
