### PR TITLE
Fix `cordova` launch screen warnings on `2.14`

### DIFF
--- a/tools/cordova/builder.js
+++ b/tools/cordova/builder.js
@@ -771,7 +771,7 @@ configuration. The key may be deprecated.`);
         Object.keys(splashIosKeys).concat(Object.keys(splashAndroidKeys));
 
       Object.keys(launchScreens).forEach((key) => {
-        if (!(key in validDevices)) {
+        if (!validDevices.includes(key)) {
           Console.labelWarn(`${key}: unknown key in App.launchScreens \
 configuration. The key may be deprecated.`);
         }
@@ -780,7 +780,7 @@ configuration. The key may be deprecated.`);
         if (typeof value !== "string" && key.includes("android")) {
           throw new Error("Android splash screen path must be a string. To enable dark splash screens for your app, check out the android developer guide: https://developer.android.com/develop/ui/views/theming/darktheme.");
         }
-      })
+      });
       Object.assign(builder.imagePaths.splash, launchScreens);
     },
 


### PR DESCRIPTION
Use correct method to check if used key exists or not. This was throwing the warning even when the right keys where being used because `validDevices` is an `array` and not an `object`.
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
