### PR TITLE
GCDWebServer missing in cordova-plugin-meteor-webapp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "packages/non-core/blaze"]
     path = packages/non-core/blaze
     url = https://github.com/meteor/blaze.git
+[submodule "npm-packages/cordova-plugin-meteor-webapp/src/ios/GCDWebServer"]
+	path = npm-packages/cordova-plugin-meteor-webapp/src/ios/GCDWebServer
+	url = https://github.com/meteor/GCDWebServer.git
+	branch = master

--- a/npm-packages/cordova-plugin-meteor-webapp/package-lock.json
+++ b/npm-packages/cordova-plugin-meteor-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-meteor-webapp",
-  "version": "2.0.0",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-packages/cordova-plugin-meteor-webapp/package.json
+++ b/npm-packages/cordova-plugin-meteor-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-meteor-webapp",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Cordova plugin that serves a Meteor web app through a local server and implements hot code push",
   "cordova": {
     "id": "cordova-plugin-meteor-webapp",

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Serves a Meteor app over HTTP',
-  version: '1.13.6',
+  version: '1.13.7',
 });
 
 Npm.depends({

--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -25,7 +25,7 @@ Npm.strip({
 
 // whitelist plugin is now included in the core
 Cordova.depends({
-  'cordova-plugin-meteor-webapp': '2.0.3',
+  'cordova-plugin-meteor-webapp': '2.0.4',
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Report: https://github.com/meteor/meteor/issues/12946

## Reproduction

![image](https://github.com/meteor/meteor/assets/2581993/cbf30916-0008-4adb-b064-5e67193f49b7)

## Fix

It seems that when we migrated the `cordova-plugin-meteor-webapp` from its [own repository](https://github.com/meteor/cordova-plugin-meteor-webapp/tree/master) to the meteor monorepo, we missed to set up the git submodule included in the other repository.

- [x] Add missing submodule in the `cordova-plugin-meteor-webapp` package
- [x] Test fix locally by changing `.meteor/cordova-plugins` file of an example app and using a local path reference
- [x] Publish a new version of npm  `cordova-plugin-meteor-webapp@2.0.4`, https://www.npmjs.com/package/cordova-plugin-meteor-webapp
- [x] Update default references for  `cordova-plugin-meteor-webapp` (`webapp`) to use newer version including missing libraries
- [x] Test to check if issue is fixed for a new app pointing the new npm version
![image](https://github.com/meteor/meteor/assets/2581993/7b3bf329-daa4-42f8-bd22-6ab179605e7e)
