### PR TITLE
[Meteor 3] Apollo skeleton upgrade

### DIFF
--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -2,17 +2,15 @@
   "name": "~name~",
   "private": true,
   "scripts": {
-    "start": "meteor run",
+    "start": "meteor run --open",
     "test": "meteor test --once --driver-package meteortesting:mocha",
     "test-app": "TEST_WATCH=1 meteor test --full-app --driver-package meteortesting:mocha",
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
-    "@apollo/client": "^3.8.8",
-    "@apollo/server": "^4.9.5",
-    "@babel/runtime": "^7.23.5",
-    "body-parser": "^1.20.2",
-    "express": "^4.18.2",
+    "@apollo/client": "^3.9.2",
+    "@apollo/server": "^4.10.0",
+    "@babel/runtime": "^7.23.9",
     "graphql": "^16.8.1",
     "meteor-node-stubs": "^1.2.7",
     "react": "^18.2.0",

--- a/tools/static-assets/skel-apollo/server/apollo.js
+++ b/tools/static-assets/skel-apollo/server/apollo.js
@@ -1,11 +1,11 @@
 import { ApolloServer } from '@apollo/server';
-import { WebApp } from 'meteor/webapp';
+import { WebApp, WebAppInternals } from 'meteor/webapp';
 import { getUser } from 'meteor/apollo';
 import { LinksCollection } from '/imports/api/links';
 import typeDefs from '/imports/apollo/schema.graphql';
-import express from 'express';
 import { expressMiddleware } from '@apollo/server/express4';
-import { json } from 'body-parser';
+
+const express = WebAppInternals.NpmModules.express.module;
 
 const resolvers = {
   Query: {
@@ -16,7 +16,7 @@ const resolvers = {
 
 const context = async ({ req }) => ({
   user: await getUser(req.headers.authorization)
-})
+});
 
 const server = new ApolloServer({
   cache: 'bounded',
@@ -29,10 +29,7 @@ export async function startApolloServer() {
 
   WebApp.handlers.use(
     '/graphql',                                     // Configure the path as you want.
-    express()                                       // Create new Express router.
-      .disable('etag')                              // We don't server GET requests, so there's no need for that.
-      .disable('x-powered-by')                      // A small safety measure.
-      .use(json())                                  // From `body-parser`.
-      .use(expressMiddleware(server, { context }))  // From `@apollo/server/express4`.
+    express.json(),
+    expressMiddleware(server, { context }) // From `@apollo/server/express4`
   );
 }


### PR DESCRIPTION
NOTE: Related GraphQL packages will require an update as well. These are `apollo` (just needs version bump and Meteor 3 in `versionsFrom`) and `swydo:graphql` requires an update, but looks like it is no longer maintained.

Apollo package PR: https://github.com/meteor/apollo/pull/4
`swydo:graphql` PR: https://github.com/Swydo/meteor-graphql/pull/54