### PR TITLE
[Meteor 3] Accounts Ambiguous error messages in production set to true by default

### DIFF
--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -203,7 +203,7 @@ export class AccountsCommon {
   //     A collection name or a Mongo.Collection object to hold the users.
   // - passwordResetTokenExpirationInDays {Number}
   //     Number of days since password reset token creation until the
-  //     token cannt be used any longer (password reset token expires).
+  //     token can't be used any longer (password reset token expires).
   // - ambiguousErrorMessages {Boolean}
   //     Return ambiguous error messages from login failures to prevent
   //     user enumeration.
@@ -225,7 +225,7 @@ export class AccountsCommon {
    * @param {Number} options.passwordResetTokenExpiration The number of milliseconds from when a link to reset password is sent until token expires and user can't reset password with the link anymore. If `passwordResetTokenExpirationInDays` is set, it takes precedent.
    * @param {Number} options.passwordEnrollTokenExpirationInDays The number of days from when a link to set initial password is sent until token expires and user can't set password with the link anymore. Defaults to 30.
    * @param {Number} options.passwordEnrollTokenExpiration The number of milliseconds from when a link to set initial password is sent until token expires and user can't set password with the link anymore. If `passwordEnrollTokenExpirationInDays` is set, it takes precedent.
-   * @param {Boolean} options.ambiguousErrorMessages Return ambiguous error messages from login failures to prevent user enumeration. Defaults to false.
+   * @param {Boolean} options.ambiguousErrorMessages Return ambiguous error messages from login failures to prevent user enumeration. Defaults to `false`, but in production environments it is recommended it defaults to `true`.
    * @param {MongoFieldSpecifier} options.defaultFieldSelector To exclude by default large custom fields from `Meteor.user()` and `Meteor.findUserBy...()` functions when called without a field selector, and all `onLogin`, `onLoginFailure` and `onLogout` callbacks.  Example: `Accounts.config({ defaultFieldSelector: { myBigArray: 0 }})`. Beware when using this. If, for instance, you do not include `email` when excluding the fields, you can have problems with functions like `forgotPassword` that will break because they won't have the required data available. It's recommend that you always keep the fields `_id`, `username`, and `email`.
    * @param {String|Mongo.Collection} options.collection A collection name or a Mongo.Collection object to hold the users.
    * @param {Number} options.loginTokenExpirationHours When using the package `accounts-2fa`, use this to set the amount of time a token sent is valid. As it's just a number, you can use, for example, 0.5 to make the token valid for just half hour. The default is 1 hour.

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -181,7 +181,7 @@ export class AccountsServer extends AccountsCommon {
     }
 
     this._onCreateLoginTokenHook = func;
-  };
+  }
 
   /**
    * @summary Customize new user creation.
@@ -1518,9 +1518,10 @@ export class AccountsServer extends AccountsCommon {
   }
 
   _handleError = (msg, throwError = true, errorCode = 403) => {
+    const isErrorAmbiguous = this._options.ambiguousErrorMessages ?? Meteor.isProduction;
     const error = new Meteor.Error(
       errorCode,
-      this._options.ambiguousErrorMessages
+      isErrorAmbiguous
         ? "Something went wrong. Please check your credentials."
         : msg
     );

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1419,17 +1419,17 @@ if (Meteor.isServer) (() => {
         },
       );
 
-      Accounts._options.ambiguousErrorMessages = true
+      Accounts._options.ambiguousErrorMessages = true;
       await test.throwsAsync(
         async () => await Meteor.callAsync('forgotPassword', wrongOptions),
         'Something went wrong. Please check your credentials'
-      )
+      );
 
-      Accounts._options.ambiguousErrorMessages = false
+      Accounts._options.ambiguousErrorMessages = false;
       await test.throwsAsync(
         async () => await Meteor.callAsync('forgotPassword', wrongOptions),
         /User not found/
-      )
+      );
       // return accounts as it were
       Accounts._options = options
     });


### PR DESCRIPTION
Set `ambiguousErrorMessages` to true if in production. This increases default security.