### PR TITLE
Update CI scripts to use only latest Node 14

### DIFF
--- a/.github/workflows/npm-eslint-plugin-meteor.yml
+++ b/.github/workflows/npm-eslint-plugin-meteor.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/eslint-plugin-meteor
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-meteor-babel.yml
+++ b/.github/workflows/npm-meteor-babel.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-babel
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-meteor-promise.yml
+++ b/.github/workflows/npm-meteor-promise.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-promise
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 os: linux
 dist: xenial
 node_js:
-  - "14.17.6"
+  - "14.21.3"
 cache:
   directories:
     - ".meteor"


### PR DESCRIPTION
No Node 12 tests, which should slightly speed things up. Also there is no reason to run Node 12 tests anymore.
