### PR TITLE
Fix bugs with test-in-console

### DIFF
--- a/packages/test-in-console/driver.js
+++ b/packages/test-in-console/driver.js
@@ -210,7 +210,9 @@ runTests = function () {
 
       // Also log xUnit output
       xunit('<testsuite errors="" failures="" name="meteor" skips="" tests="" time="">');
-      resultSet.forEach(function (result, name) {
+      Object.keys(resultSet).forEach(function (name) {
+        let result = resultSet[name];
+
         var classname = result.testPath.join('.').replace(/ /g, '-') + (result.server ? "-server" : "-client");
         var name = result.test.replace(/ /g, '-') + (result.server ? "-server" : "-client");
         var time = "";

--- a/packages/test-in-console/package.js
+++ b/packages/test-in-console/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.use(['tinytest', 'random', 'ejson', 'check']);
+  api.use(['tinytest', 'random', 'ejson', 'check', 'jquery']);
   api.use('fetch', 'server');
 
   api.export('TEST_STATUS', 'client');


### PR DESCRIPTION
test-in-console wasn't running client tests due to missing a dependency on jQuery. This also fixes another error that happens after the client tests finished.

It would be nice if this could be released in a patch update instead of waiting for the next 2.x release.