### PR TITLE
Get default options from meteor settings

### DIFF
--- a/docs/source/api/accounts.md
+++ b/docs/source/api/accounts.md
@@ -338,3 +338,41 @@ Accounts.ui.config({
 
 
 Since Meteor 2.7 you can configure these in your Meteor settings under `Meteor.settings.public.packages.accounts-ui-unstyled`.
+
+<h3 id="initialize-with-custom-settings">Initialize with custom settings</h3>
+
+This feature allows users to specify custom configuration parameters for both client-side and server-side initialization.
+
+* Client
+
+{% apibox "AccountsClient" %}
+
+On the client-side, AccountsClient can be initialized with custom parameters provided through Meteor settings configuration. Below is an example of how to use this functionality:
+
+```json
+{
+  "public": {
+    "packages": {
+      "accounts": {
+        ...configParams
+      }
+    }
+  }
+}
+```
+
+* Server
+
+{% apibox "AccountsServer" %}
+
+On the server-side, AccountsServer can also be initialized with custom parameters. Server-specific configuration may differ from the client and can also be specified through Meteor settings. Below is an example of how to do it:
+
+```json
+{
+  "packages": {
+    "accounts": {
+      ...configParams
+    }
+  }
+}
+```

--- a/packages/accounts-base/client_main.js
+++ b/packages/accounts-base/client_main.js
@@ -7,7 +7,7 @@ import {
  * @namespace Accounts
  * @summary The namespace for all client-side accounts-related methods.
  */
-Accounts = new AccountsClient();
+Accounts = new AccountsClient(Meteor.settings?.public?.packages?.accounts || {});
 
 /**
  * @summary A [Mongo.Collection](#collections) containing user documents.

--- a/packages/accounts-base/server_main.js
+++ b/packages/accounts-base/server_main.js
@@ -4,7 +4,7 @@ import { AccountsServer } from "./accounts_server.js";
  * @namespace Accounts
  * @summary The namespace for all server-side accounts-related methods.
  */
-Accounts = new AccountsServer(Meteor.server);
+Accounts = new AccountsServer(Meteor.server, Meteor.settings.packages?.accounts || {});
 
 // Users table. Don't use the normal autopublish, since we want to hide
 // some fields. Code to autopublish this is in accounts_server.js.


### PR DESCRIPTION
### Add support for custom configuration in AccountsClient initialization
**Description**
Currently, the _accounts-base_ package begins before your own project does it. If you want to use a custom configuration, you must wait for the package to start and then pass the configuration you need. This can cause problems when, for example, you want to use a different DDP connection, such as login attempts to the wrong server on the first login attempt.

At this time, the _accounts-base_ package is ready to receive different configuration parameters, however, you will have to wait for the package to start, and then, when your application starts, you can change the configuration.

To solve this problem, I modified the _accounts-base_ **client_main.js** file to allow custom configuration when initializing **AccountsClient**. In my version, the **AccountsClient** constructor accepts the path to the **meteor.settings** file. If the **Meteor.settings.public.packages.accounts** field exists, the accounts will use the settings defined there. Otherwise, it will initialize with the default settings as it currently works.

**Proposed Changes**
Modification of the client_main.js file, line 10, to accept the path to the Meteor settings file and utilize it in the initialization of AccountsClient.

**Related Issue**
This change addresses the problem reported in issue #12870: [Link to the issue](https://github.com/meteor/meteor/issues/12870)

**Additional Notes**
This change has minimal impact on the existing _accounts-base_ codebase and resolves a significant issue for users needing custom configurations.

** Example of use**
![settings_example](https://github.com/meteor/meteor/assets/86612394/08a6cd3c-45ab-4848-b3b2-0a62eeeab9b6)


