### PR TITLE
New mongo package options to optimize Oplog tailing performance to include/exclude certain collections

### DIFF
--- a/docs/source/api/collections.md
+++ b/docs/source/api/collections.md
@@ -1086,9 +1086,9 @@ certificates configurations.
 
 > Oplog options were introduced in Meteor 2.15.1
 
-If you set the [`MONGO_OPLOG_URL`](https://docs.meteor.com/environment-variables.html#MONGO-OPLOG-URL) env var, Meteor will use MongoDb's Oplog to show efficient, real time updates to your users via your subscriptions.
+If you set the [`MONGO_OPLOG_URL`](https://docs.meteor.com/environment-variables.html#MONGO-OPLOG-URL) env var, Meteor will use MongoDB's Oplog to show efficient, real time updates to your users via your subscriptions.
 
-Due to how Meteor's Oplog implementation is built behind the scenes, if you have certain collections where you expect **big amounts of `insert` or `update` transactions**, this might lead to **big CPU spikes on your meteor app server, even if you have no publications/subscriptions on any data/documents of these collections**. For more information on this, please have a look into [this blog post from 2016](https://blog.meteor.com/tuning-meteor-mongo-livedata-for-scalability-13fe9deb8908), [this github discussion from 2022](https://github.com/meteor/meteor/discussions/11842) or [this meteor forums post from 2023](https://forums.meteor.com/t/cpu-spikes-due-to-oplog-updates-without-subscriptions/60028).
+Due to how Meteor's Oplog implementation is built behind the scenes, if you have certain collections where you expect **big amounts of write operations**, this might lead to **big CPU spikes on your meteor app server, even if you have no publications/subscriptions on any data/documents of these collections**. For more information on this, please have a look into [this blog post from 2016](https://blog.meteor.com/tuning-meteor-mongo-livedata-for-scalability-13fe9deb8908), [this github discussion from 2022](https://github.com/meteor/meteor/discussions/11842) or [this meteor forums post from 2023](https://forums.meteor.com/t/cpu-spikes-due-to-oplog-updates-without-subscriptions/60028).
 
 To solve this, **2 Oplog settings** have been introduced **to tweak, which collections are *watched* or *ignored* in the oplog**.
 

--- a/docs/source/api/collections.md
+++ b/docs/source/api/collections.md
@@ -1082,6 +1082,38 @@ option:
 You can pass any MongoDB valid option, these are just examples using
 certificates configurations.
 
+<h3 id="mongo_oplog_options">Mongo Oplog Options</h3>
+
+> Oplog options were introduced in Meteor 2.15.1
+
+If you set the [`MONGO_OPLOG_URL`](https://docs.meteor.com/environment-variables.html#MONGO-OPLOG-URL) env var, Meteor will use MongoDb's Oplog to show efficient, real time updates to your users via your subscriptions.
+
+Due to how Meteor's Oplog implementation is built behind the scenes, if you have certain collections where you expect **big amounts of `insert` or `update` transactions**, this might lead to **big CPU spikes on your meteor app server, even if you have no publications/subscriptions on any data/documents of these collections**. For more information on this, please have a look into [this blog post from 2016](https://blog.meteor.com/tuning-meteor-mongo-livedata-for-scalability-13fe9deb8908), [this github discussion from 2022](https://github.com/meteor/meteor/discussions/11842) or [this meteor forums post from 2023](https://forums.meteor.com/t/cpu-spikes-due-to-oplog-updates-without-subscriptions/60028).
+
+To solve this, **2 Oplog settings** have been introduced **to tweak, which collections are *watched* or *ignored* in the oplog**.
+
+**Exclusion**: To *exclude* for example all updates/inserts of documents in the 2 collections called `products` and `prices`, you would need to set the following setting in your Meteor settings file:
+
+```json
+  "packages": {
+    "mongo": {
+      "oplogExcludeCollections": ["products", "prices"]
+    }
+  }
+```
+
+**Inclusion**: vice versa, if you only want to watch/*include* the oplog for changes on documents in the 2 collections `chats` and `messages`, you would use:
+
+```json
+  "packages": {
+    "mongo": {
+      "oplogIncludeCollections": ["chats", "messages"]
+    }
+  }
+```
+
+For obvious reasons, using both `oplogExcludeCollections` and `oplogIncludeCollections` at the same time is not possible and will result in an error.
+
 <h3 id="mongo_connection_options_settings">Mongo.setConnectionOptions</h3>
 
 You can also call `Mongo.setConnectionOptions` to set the connection options but

--- a/packages/mongo/collection_tests.js
+++ b/packages/mongo/collection_tests.js
@@ -210,7 +210,7 @@ Tinytest.add('collection - calling find with an invalid readPreference',
 Tinytest.add('collection - inserting a document with a binary should return a document with a binary',
   function(test) {
     if (Meteor.isServer) {
-      const collection = new Mongo.Collection('testBinary1');
+      const collection = new Mongo.Collection('testBinary1' + test.id);
       const _id = Random.id();
       collection.insert({
         _id,
@@ -232,7 +232,7 @@ Tinytest.add('collection - inserting a document with a binary should return a do
 Tinytest.add('collection - inserting a document with a binary (sub type 0) should return a document with a uint8array',
   function(test) {
     if (Meteor.isServer) {
-      const collection = new Mongo.Collection('testBinary8');
+      const collection = new Mongo.Collection('testBinary8' + test.id);
       const _id = Random.id();
       collection.insert({
         _id,
@@ -254,7 +254,7 @@ Tinytest.add('collection - inserting a document with a binary (sub type 0) shoul
 Tinytest.add('collection - updating a document with a binary should return a document with a binary',
   function(test) {
     if (Meteor.isServer) {
-      const collection = new Mongo.Collection('testBinary2');
+      const collection = new Mongo.Collection('testBinary2' + test.id);
       const _id = Random.id();
       collection.insert({
         _id
@@ -277,7 +277,7 @@ Tinytest.add('collection - updating a document with a binary should return a doc
 Tinytest.add('collection - updating a document with a binary (sub type 0) should return a document with a uint8array',
   function(test) {
     if (Meteor.isServer) {
-      const collection = new Mongo.Collection('testBinary7');
+      const collection = new Mongo.Collection('testBinary7' + test.id);
       const _id = Random.id();
       collection.insert({
         _id
@@ -300,7 +300,7 @@ Tinytest.add('collection - updating a document with a binary (sub type 0) should
 Tinytest.add('collection - inserting a document with a uint8array should return a document with a uint8array',
   function(test) {
     if (Meteor.isServer) {
-      const collection = new Mongo.Collection('testBinary3');
+      const collection = new Mongo.Collection('testBinary3' + test.id);
       const _id = Random.id();
       collection.insert({
         _id,
@@ -322,7 +322,7 @@ Tinytest.add('collection - inserting a document with a uint8array should return 
 Tinytest.add('collection - updating a document with a uint8array should return a document with a uint8array',
   function(test) {
     if (Meteor.isServer) {
-      const collection = new Mongo.Collection('testBinary4');
+      const collection = new Mongo.Collection('testBinary4' + test.id);
       const _id = Random.id();
       collection.insert({
         _id
@@ -348,7 +348,7 @@ Tinytest.add('collection - updating a document with a uint8array should return a
 Tinytest.add('collection - finding with a query with a uint8array field should return the correct document',
   function(test) {
     if (Meteor.isServer) {
-      const collection = new Mongo.Collection('testBinary5');
+      const collection = new Mongo.Collection('testBinary5' + test.id);
       const _id = Random.id();
       collection.insert({
         _id,
@@ -368,7 +368,7 @@ Tinytest.add('collection - finding with a query with a uint8array field should r
 Tinytest.add('collection - finding with a query with a binary field should return the correct document',
   function(test) {
     if (Meteor.isServer) {
-      const collection = new Mongo.Collection('testBinary6');
+      const collection = new Mongo.Collection('testBinary6' + test.id);
       const _id = Random.id();
       collection.insert({
         _id,
@@ -455,6 +455,4 @@ Meteor.isServer && Tinytest.addAsync('collection - simple add', async function(t
   id = await collection.insertAsync({a: 2});
   test.equal((await collection.findOneAsync(id)).a, 2);
   await collection.removeAsync({});
-  
-})
-
+});

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -231,6 +231,11 @@ MongoConnection.prototype.close = function() {
   Future.wrap(_.bind(self.client.close, self.client))(true).wait();
 };
 
+MongoConnection.prototype._setOplogHandle = function(oplogHandle) {
+  this._oplogHandle = oplogHandle;
+  return this;
+};
+
 // Returns the Mongo Collection object; may yield.
 MongoConnection.prototype.rawCollection = function (collectionName) {
   var self = this;

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -995,6 +995,14 @@ Cursor.prototype.getTransform = function () {
 Cursor.prototype._publishCursor = function (sub) {
   var self = this;
   var collection = self._cursorDescription.collectionName;
+  const oplogOptions = self?._mongo?._oplogHandle?._oplogOptions || {};
+  const { includeCollections, excludeCollections } = oplogOptions;
+  if (excludeCollections?.length && excludeCollections.includes(collection)) {
+    console.warn(`Meteor.settings.packages.mongo.oplogExcludeCollections includes the collection ${collection} - no subscriptions/publications on this collection will return any updates`);
+  }
+  if (includeCollections?.length && !includeCollections.includes(collection)) {
+    console.warn(`Meteor.settings.packages.mongo.oplogIncludeCollections does not include the collection ${collection} - no subscriptions/publications on this collection will return any updates`);
+  }
   return Mongo.Collection._publishCursor(self, sub, collection);
 };
 

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -30,6 +30,7 @@ OplogHandle = function (oplogUrl, dbName) {
   var self = this;
   self._oplogUrl = oplogUrl;
   self._dbName = dbName;
+  console.log('OplogHandle CONSTRUCTOR()');
 
   self._oplogLastEntryConnection = null;
   self._oplogTailConnection = null;
@@ -84,6 +85,8 @@ OplogHandle = function (oplogUrl, dbName) {
 
   self._startTailing();
 };
+
+MongoInternals.OplogHandle = OplogHandle;
 
 Object.assign(OplogHandle.prototype, {
   stop: function () {
@@ -241,7 +244,7 @@ Object.assign(OplogHandle.prototype, {
       self._lastProcessedTS = lastOplogEntry.ts;
     }
 
-    // These 2 settings allow you to either only watch certain collections (oplogWatchCollections), or exclude some collections you don't want to watch for oplog updates (oplogExcludeCollections)
+    // These 2 settings allow you to either only watch certain collections (oplogIncludeCollections), or exclude some collections you don't want to watch for oplog updates (oplogExcludeCollections)
     // Usage:
     // settings.json = {
     //   "packages": {
@@ -251,11 +254,12 @@ Object.assign(OplogHandle.prototype, {
     //     }
     //   }
     // }
-    const includeCollections = Meteor.settings?.packages?.mongo?.oplogWatchCollections;
+    const includeCollections = Meteor.settings?.packages?.mongo?.oplogIncludeCollections;
     const excludeCollections = Meteor.settings?.packages?.mongo?.oplogExcludeCollections;
     if (includeCollections?.length && excludeCollections?.length) {
-      throw new Error("Can't use both mongo oplog settings oplogWatchCollections and oplogExcludeCollections at the same time.");
+      throw new Error("Can't use both mongo oplog settings oplogIncludeCollections and oplogExcludeCollections at the same time.");
     }
+    console.log('OplogHandle _startTailing() excludeCollections', excludeCollections);
     if (excludeCollections?.length) {
       oplogSelector.ns = {
         $regex: oplogSelector.ns,

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -33,6 +33,7 @@ OplogHandle = function (oplogUrl, dbName) {
 
   self._oplogLastEntryConnection = null;
   self._oplogTailConnection = null;
+  self._oplogOptions = null;
   self._stopped = false;
   self._tailHandle = null;
   self._readyFuture = new Future();
@@ -263,6 +264,7 @@ Object.assign(OplogHandle.prototype, {
         $regex: oplogSelector.ns,
         $nin: excludeCollections.map((collName) => `${self._dbName}.${collName}`)
       }
+      self._oplogOptions = { excludeCollections };
     }
     else if (includeCollections?.length) {
       oplogSelector = { $and: [
@@ -273,6 +275,7 @@ Object.assign(OplogHandle.prototype, {
         { $or: oplogSelector.$or }, // the initial $or to select only certain operations (op)
         { ts: oplogSelector.ts }
       ] };
+      self._oplogOptions = { includeCollections };
     }
 
     var cursorDescription = new CursorDescription(

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -30,7 +30,6 @@ OplogHandle = function (oplogUrl, dbName) {
   var self = this;
   self._oplogUrl = oplogUrl;
   self._dbName = dbName;
-  console.log('OplogHandle CONSTRUCTOR()');
 
   self._oplogLastEntryConnection = null;
   self._oplogTailConnection = null;
@@ -259,7 +258,6 @@ Object.assign(OplogHandle.prototype, {
     if (includeCollections?.length && excludeCollections?.length) {
       throw new Error("Can't use both mongo oplog settings oplogIncludeCollections and oplogExcludeCollections at the same time.");
     }
-    console.log('OplogHandle _startTailing() excludeCollections', excludeCollections);
     if (excludeCollections?.length) {
       oplogSelector.ns = {
         $regex: oplogSelector.ns,

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -241,7 +241,16 @@ Object.assign(OplogHandle.prototype, {
       self._lastProcessedTS = lastOplogEntry.ts;
     }
 
-    // these 2 settings allow you to either only watch certain collections (oplogWatchCollections), or exclude some collections you don't want to watch for oplog updates (oplogExcludeCollections)
+    // These 2 settings allow you to either only watch certain collections (oplogWatchCollections), or exclude some collections you don't want to watch for oplog updates (oplogExcludeCollections)
+    // Usage:
+    // settings.json = {
+    //   "packages": {
+    //     "mongo": {
+    //       "oplogExcludeCollections": ["products", "prices"] // This would exclude both collections "products" and "prices" from any oplog tailing. 
+    //                                                            Beware! This means, that no subscriptions on these 2 collections will update anymore!
+    //     }
+    //   }
+    // }
     const includeCollections = Meteor.settings?.packages?.mongo?.oplogWatchCollections;
     const excludeCollections = Meteor.settings?.packages?.mongo?.oplogExcludeCollections;
     if (includeCollections?.length && excludeCollections?.length) {

--- a/packages/mongo/oplog_tests.js
+++ b/packages/mongo/oplog_tests.js
@@ -226,9 +226,6 @@ async function oplogOptionsTest({
 
     test.equal(await shouldBeTracked, true);
     test.equal(await shouldBeIgnored, true);
-  } catch(err) {
-    // we just have this catch to be able to use the finally! ;)
-    throw err;
   } finally {
     // Reset:
     Meteor.settings.packages.mongo = { ...previousMongoPackageSettings };

--- a/packages/mongo/oplog_tests.js
+++ b/packages/mongo/oplog_tests.js
@@ -182,7 +182,7 @@ process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
   },
 );
 
-let defaultOplogHandle = MongoInternals.defaultRemoteCollectionDriver().mongo._oplogHandle;
+const defaultOplogHandle = MongoInternals.defaultRemoteCollectionDriver().mongo._oplogHandle;
 
 async function oplogOptionsTest({
   test,
@@ -224,8 +224,9 @@ async function oplogOptionsTest({
   test.equal(await shouldBeTracked, true);
   test.equal(await shouldBeIgnored, true);
 
-  // reset the package settings:
+  // Reset:
   delete Meteor.settings.packages.mongo;
+  MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(defaultOplogHandle);
 }
 
 process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
@@ -276,15 +277,15 @@ process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
       await oplogOptionsTest({
         test,
         includeCollectionName: collectionNameA,
-        oplogExcludeCollections: collectionNameB,
+        excludeCollectionName: collectionNameB,
         mongoPackageSettings
       });
-      // reset the package settings:
+      // Reset:
       delete Meteor.settings.packages.mongo;
       MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(defaultOplogHandle);
       test.fail();
     } catch (err) {
-      // reset the package settings:
+      // Reset:
       delete Meteor.settings.packages.mongo;
       MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(defaultOplogHandle);
       test.expect_fail();

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -100,7 +100,7 @@ Package.onTest(function (api) {
   api.addFiles('collection_tests.js', ['client', 'server']);
   api.addFiles('collection_async_tests.js', ['client', 'server']);
   api.addFiles('observe_changes_tests.js', ['client', 'server']);
+  api.addFiles('oplog_tests.js', 'server');
   api.addFiles('oplog_v2_converter_tests.js', 'server');
   api.addFiles('doc_fetcher_tests.js', 'server');
-  api.addFiles('oplog_tests.js', 'server');
 });

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -100,7 +100,7 @@ Package.onTest(function (api) {
   api.addFiles('collection_tests.js', ['client', 'server']);
   api.addFiles('collection_async_tests.js', ['client', 'server']);
   api.addFiles('observe_changes_tests.js', ['client', 'server']);
-  api.addFiles('oplog_tests.js', 'server');
   api.addFiles('oplog_v2_converter_tests.js', 'server');
   api.addFiles('doc_fetcher_tests.js', 'server');
+  api.addFiles('oplog_tests.js', 'server');
 });


### PR DESCRIPTION
Hello all,

Following several conversations on the drawbacks of Meteor's oplog implementation and its limitations when it comes to scaling (see: [my forums post](https://forums.meteor.com/t/cpu-spikes-due-to-oplog-updates-without-subscriptions/60028), [a slightly older blog post](https://blog.meteor.com/tuning-meteor-mongo-livedata-for-scalability-13fe9deb8908) and a [2 year old github discussion](https://github.com/meteor/meteor/discussions/11842)), I investigated in the core a bit and propose an easy solution which, I hope, should work for many users who have issues with this.

Please consider our situation at Orderlion: We have several collections, where huge amounts of data are being updated on a daily basis. On all of these collections we have not a single publication, for these we don't care about any reactivity.

Due to Meteor's Oplog implementation, even in these cases a big batch insert/update of data results often in very big sustained CPU spikes on the meteor app server.

Internal tests I did with my suggested implementation have shown, **that the CPU load due to Oplog tailing collections with big batch updates, can be reduced about 100x with just completely ignoring those collections**. 
During an import of about 600k documents in a test collection, I could reduce the CPU load from an average 25-30% down to approx. 0,2 - 0,3%.

The usage is actually very straight forward: Consider a `settings.json` file like this:

```js
{
  // ... all other settings,
  "public": {
    // all your public settings
  },
  "packages": {
    "mongo": {
      "oplogExcludeCollections": ["products", "prices"] // This would exclude both collections "products" and "prices" from any oplog tailing.
      // OR:
      "oplogIncludeCollections": ["messages"] // ONLY watch the "messages" collection for oplog updates (and all "admin.$cmd" oplogs)
    }
  }
}
```

Please feel free to comment but I really hope this can be merged soon. It would help us at Orderlion a lot and solve many unwanted server restarts (server is auto-restarting because it becomes unresponsive due to the sustained high CPU load).

Cheers, Patrick