### PR TITLE
Update readme links on deprecated packages

### DIFF
--- a/packages/deprecated/appcache/README.md
+++ b/packages/deprecated/appcache/README.md
@@ -1,5 +1,5 @@
 # appcache
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/appcache) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/appcache)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/appcache) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/appcache)
 ***
 
 The `appcache` package, part of

--- a/packages/deprecated/code-prettify/README.md
+++ b/packages/deprecated/code-prettify/README.md
@@ -1,5 +1,5 @@
 # code-prettify
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/code-prettify) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/code-prettify)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/code-prettify) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/code-prettify)
 ***
 
 This internal Meteor package is now unnecessary and has been deprecated. To

--- a/packages/deprecated/deps/README.md
+++ b/packages/deprecated/deps/README.md
@@ -1,5 +1,5 @@
 # deps
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deps) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deps)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/deps) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/deps)
 ***
 
 This is an internal Meteor package.

--- a/packages/deprecated/facebook/README.md
+++ b/packages/deprecated/facebook/README.md
@@ -1,5 +1,5 @@
 # facebook
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/facebook) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/facebook)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/facebook) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/facebook)
 ***
 
 ** Deprecated, use facebook-oauth instead**

--- a/packages/deprecated/facts/README.md
+++ b/packages/deprecated/facts/README.md
@@ -1,5 +1,5 @@
 # facts
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/facts) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/facts)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/facts) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/facts)
 ***
 
 This is a legacy internal Meteor package. Use facts-ui or facts-base instead.

--- a/packages/deprecated/fastclick/README.md
+++ b/packages/deprecated/fastclick/README.md
@@ -1,5 +1,5 @@
 # fastclick
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/fastclick) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/fastclick)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/fastclick) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/fastclick)
 ***
 
 > **Warning:** As of late 2015 most mobile browsers - notably Chrome and Safari - no longer have a 300ms touch delay, so fastclick offers no benefit on newer browsers, and risks introducing [bugs](https://github.com/ftlabs/fastclick/issues) into your application. Consider carefully whether you really need to use it.

--- a/packages/deprecated/github/README.md
+++ b/packages/deprecated/github/README.md
@@ -1,5 +1,5 @@
 # github
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/github) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/github)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/github) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/github)
 ***
 
 **Deprecated, use github-oauth instead.**

--- a/packages/deprecated/google/README.md
+++ b/packages/deprecated/google/README.md
@@ -1,5 +1,5 @@
 # google-oauth
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/google) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/google)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/google) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/google)
 ***
 
 ** Deprecated, use google-oauth instead**

--- a/packages/deprecated/handlebars/README.md
+++ b/packages/deprecated/handlebars/README.md
@@ -1,5 +1,5 @@
 # handlebars
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/handlebars) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/handlebars)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/handlebars) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/handlebars)
 ***
 
 This is an internal Meteor package.

--- a/packages/deprecated/jquery-waypoints/README.md
+++ b/packages/deprecated/jquery-waypoints/README.md
@@ -1,5 +1,5 @@
 # jquery-waypoints
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/jquery-waypoints) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/jquery-waypoints)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/jquery-waypoints) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/jquery-waypoints)
 ***
 
 This is a wrapper package for the JQuery Waypoints library. You can use it to add callbacks that fire when the user scrolls to certain elements on a page, for example to implement table of contents highlighting.

--- a/packages/deprecated/jshint/README.md
+++ b/packages/deprecated/jshint/README.md
@@ -1,5 +1,5 @@
 # jshint
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/jshint) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/jshint)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/jshint) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/jshint)
 ***
 
 JSHint for Meteor

--- a/packages/deprecated/jsparse/README.md
+++ b/packages/deprecated/jsparse/README.md
@@ -1,5 +1,5 @@
 # jsparse
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/jsparse) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/jsparse)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/jsparse) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/jsparse)
 ***
 
 This internal Meteor package is now unnecessary and has been deprecated. To

--- a/packages/deprecated/livedata/README.md
+++ b/packages/deprecated/livedata/README.md
@@ -1,5 +1,5 @@
 # livedata
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/livedata) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/livedata)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/livedata) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/livedata)
 ***
 
 This is an internal Meteor package.

--- a/packages/deprecated/meetup/README.md
+++ b/packages/deprecated/meetup/README.md
@@ -1,5 +1,5 @@
 # meetup
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/meetup) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/meetup)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/meetup) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/meetup)
 ***
 
 **Deprecated, use meetup-oauth instead.**

--- a/packages/deprecated/meteor-developer/README.md
+++ b/packages/deprecated/meteor-developer/README.md
@@ -1,5 +1,5 @@
 # meteor-developer
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/meteor-developer) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/meteor-developer)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/meteor-developer) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/meteor-developer)
 ***
 
 **Deprecated, use meteor-developer-oauth instead.**

--- a/packages/deprecated/meteor-platform/README.md
+++ b/packages/deprecated/meteor-platform/README.md
@@ -1,5 +1,5 @@
 # meteor-platform
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/meteor-platform) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/meteor-platform)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/meteor-platform) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/meteor-platform)
 ***
 
 This package used to be added to every app by `meteor create`, but is now deprecated in favor of `meteor-base` and a carefully chosen set of other packages.

--- a/packages/deprecated/meyerweb-reset/README.md
+++ b/packages/deprecated/meyerweb-reset/README.md
@@ -1,5 +1,5 @@
 # meyerweb-reset
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/meyerweb-reset) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/meyerweb-reset)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/meyerweb-reset) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/meyerweb-reset)
 ***
 
 This internal Meteor package is now unnecessary and has been deprecated. To

--- a/packages/deprecated/npm-bcrypt/README.md
+++ b/packages/deprecated/npm-bcrypt/README.md
@@ -1,4 +1,4 @@
 # npm-bcrypt
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/npm-bcrypt) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/npm-bcrypt)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/npm-bcrypt) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/npm-bcrypt)
 ***
 

--- a/packages/deprecated/preserve-inputs/README.md
+++ b/packages/deprecated/preserve-inputs/README.md
@@ -1,5 +1,5 @@
 # preserve-inputs
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/preserve-inputs) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/preserve-inputs)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/preserve-inputs) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/preserve-inputs)
 ***
 
 This is an internal Meteor package.

--- a/packages/deprecated/showdown/README.md
+++ b/packages/deprecated/showdown/README.md
@@ -1,5 +1,5 @@
 # showdown
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/showdown) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/showdown)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/showdown) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/showdown)
 ***
 
 This is an internal Meteor package.

--- a/packages/deprecated/spiderable/README.md
+++ b/packages/deprecated/spiderable/README.md
@@ -1,5 +1,5 @@
 # spiderable
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/spiderable) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/spiderable)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/spiderable) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/spiderable)
 ***
 
 `spiderable` is part of [Webapp](https://github.com/meteor/meteor/tree/master/packages/webapp). It's one possible way to allow web search engines to index a Meteor application. It uses the [AJAX Crawling specification](https://developers.google.com/webmasters/ajax-crawling/) published by Google to serve HTML to compatible spiders (Google, Bing, Yandex, and more).

--- a/packages/deprecated/srp/README.md
+++ b/packages/deprecated/srp/README.md
@@ -1,5 +1,5 @@
 # srp
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/srp) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/srp)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/srp) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/srp)
 ***
 
 This is an internal Meteor package.

--- a/packages/deprecated/standard-app-packages/README.md
+++ b/packages/deprecated/standard-app-packages/README.md
@@ -1,5 +1,5 @@
 # standard-app-packages
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/standard-app-packages) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/standard-app-packages)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/standard-app-packages) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/standard-app-packages)
 ***
 
 This is an internal Meteor package.

--- a/packages/deprecated/startup/README.md
+++ b/packages/deprecated/startup/README.md
@@ -1,5 +1,5 @@
 # startup
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/startup) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/startup)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/startup) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/startup)
 ***
 
 This is an internal Meteor package.

--- a/packages/deprecated/stylus/README.md
+++ b/packages/deprecated/stylus/README.md
@@ -1,5 +1,5 @@
 # stylus
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/stylus) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/stylus)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/stylus) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/stylus)
 ***
 
 **DEPRECATED:** This package is no longer supported/maintained as part of the

--- a/packages/deprecated/twitter/README.md
+++ b/packages/deprecated/twitter/README.md
@@ -1,5 +1,5 @@
 # twitter
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/twitter) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/twitter)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/twitter) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/twitter)
 ***
 
 ** Deprecated, use twitter-oauth instead**

--- a/packages/deprecated/weibo/README.md
+++ b/packages/deprecated/weibo/README.md
@@ -1,5 +1,5 @@
 # weibo
-[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/weibo) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/weibo)
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/deprecated/weibo) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/deprecated/weibo)
 ***
 
 ** Deprecated, use weibo-oauth instead**


### PR DESCRIPTION
Fixes for: https://forums.meteor.com/t/wrong-repo-links-in-atmosphere/61244?u=storyteller

I think the metadata update should be enough, but not sure.