### PR TITLE
Add method name to `MethodInvocation`

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -911,6 +911,7 @@ export class Connection {
     };
 
     const invocation = new DDPCommon.MethodInvocation({
+      name,
       isSimulation: true,
       userId: self.userId(),
       isFromCallAsync: options?.isFromCallAsync,

--- a/packages/ddp-common/method_invocation.js
+++ b/packages/ddp-common/method_invocation.js
@@ -18,6 +18,16 @@ DDPCommon.MethodInvocation = class MethodInvocation {
     // zero-latency connection to the user.
 
     /**
+     * @summary The name given to the method.
+     * @locus Anywhere
+     * @name  name
+     * @memberOf DDPCommon.MethodInvocation
+     * @instance
+     * @type {String}
+     */
+    this.name = options.name;
+
+    /**
      * @summary Access inside a method invocation.  Boolean value, true if this invocation is a stub.
      * @locus Anywhere
      * @name  isSimulation

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -764,6 +764,7 @@ Object.assign(Session.prototype, {
       };
 
       var invocation = new DDPCommon.MethodInvocation({
+        name: msg.method,
         isSimulation: false,
         userId: self.userId,
         setUserId: setUserId,


### PR DESCRIPTION
Small PR to add the method name to the `MethodInvocation`. This allows you to know what method is being called when you use `DDP._CurrentMethodInvocation.get()`. This will be helpful for a package I'm developing.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
