### PR TITLE
339 Support observeChangesAsync and observeAsync and keep SYNC versions [Meteor 3.x][WIP]

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -999,7 +999,7 @@ export class AccountsServer extends AccountsCommon {
         const observe = await this.users.find({
           _id: userId,
           'services.resume.loginTokens.hashedToken': newToken
-        }, { fields: { _id: 1 } }).observeChanges({
+        }, { fields: { _id: 1 } }).observeChangesAsync({
           added: () => {
             foundMatchingUser = true;
           },
@@ -1860,4 +1860,3 @@ const generateCasePermutationsForString = string => {
   }
   return permutations;
 }
-

--- a/packages/minimongo/cursor.js
+++ b/packages/minimongo/cursor.js
@@ -373,6 +373,13 @@ export default class Cursor {
     return handle;
   }
 
+  observeChangesAsync(options) {
+    return new Promise((resolve) => {
+      const handle = this.observeChanges(options);
+      handle.isReadyPromise.then(() => resolve(handle));
+    });
+  }
+
   // XXX Maybe we need a version of observe that just calls a callback if
   // anything changed.
   _depend(changers, _allow_unordered) {

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -565,7 +565,7 @@ Object.assign(Mongo.Collection.prototype, {
 
 Object.assign(Mongo.Collection, {
   async _publishCursor(cursor, sub, collection) {
-    var observeHandle = await cursor.observeChanges(
+    var observeHandle = await cursor.observeChangesAsync(
         {
           added: function(id, fields) {
             sub.added(collection, id, fields);

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -965,6 +965,13 @@ Cursor.prototype.observeChanges = function (callbacks, options = {}) {
     self._cursorDescription, ordered, callbacks, options.nonMutatingCallbacks);
 };
 
+Cursor.prototype.observeChangesAsync = async function (callbacks, options = {}) {
+  var self = this;
+  var handler = self.observeChanges(callbacks, options);
+  await handler.ready();
+  return handler;
+};
+
 MongoConnection.prototype._createSynchronousCursor = function(
     cursorDescription, options) {
   var self = this;
@@ -1436,7 +1443,7 @@ MongoConnection.prototype.tail = function (cursorDescription, docCallback, timeo
 };
 
 Object.assign(MongoConnection.prototype, {
-  _observeChanges: async function (
+  _observeChanges: function (
       cursorDescription, ordered, callbacks, nonMutatingCallbacks) {
     var self = this;
 
@@ -1531,7 +1538,7 @@ Object.assign(MongoConnection.prototype, {
       });
 
       if (observeDriver._init) {
-        await observeDriver._init();
+        observeHandle.initObserver = observeDriver._init();
       }
 
       // This field is only set for use in tests.
@@ -1539,7 +1546,7 @@ Object.assign(MongoConnection.prototype, {
     }
     self._observeMultiplexers[observeKey] = multiplexer;
     // Blocks until the initial adds have been sent.
-    await multiplexer.addHandleAndSendInitialAdds(observeHandle);
+    observeHandle.initHandler = multiplexer.addHandleAndSendInitialAdds(observeHandle);
 
     return observeHandle;
   },

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -700,7 +700,7 @@ _.each( [ 'MONGO', 'STRING'], function(idGeneration) {
           },
         });
 
-        const handle2 = await coll.find({ run }).observeChanges(
+        const handle2 = await coll.find({ run }).observeChangesAsync(
           {
             added: expectNotMutatable,
             changed: function(id, o) {
@@ -2017,7 +2017,7 @@ _.each( [ 'MONGO', 'STRING'], function(idGeneration) {
         let polls = {};
         const handlesToStop = [];
         const observe = async function(name, query) {
-          const handle = await coll.find(query).observeChanges({
+          const handle = await coll.find(query).observeChangesAsync({
             // Make sure that we only poll on invalidation, not due to time, and
             // keep track of when we do. Note: this option disables the use of
             // oplogs (which admittedly is somewhat irrelevant to this feature).
@@ -3149,7 +3149,7 @@ if (Meteor.isServer) {
     async function (test, expect) {
       var self = this;
       if (self.miniC) {
-        self.obs = await self.miniC.find().observeChanges({
+        self.obs = await self.miniC.find().observeChangesAsync({
           added: async function (id, fields) {
             self.events.push({evt: "a", id: id});
             await Meteor._sleepForMs(200);
@@ -3476,13 +3476,13 @@ Meteor.isServer &&
     if (MongoInternals.defaultRemoteCollectionDriver().mongo._oplogHandle) {
       var observeWithOplog = await coll
         .find({ x: 5 })
-        .observeChanges({ added: function() {} });
+        .observeChangesAsync({ added: function() {} });
       test.isTrue(observeWithOplog._multiplexer._observeDriver._usesOplog);
       await observeWithOplog.stop();
     }
     var observeWithoutOplog = await coll
       .find({ x: 6 }, { _disableOplog: true })
-      .observeChanges({ added: function() {} });
+      .observeChangesAsync({ added: function() {} });
     test.isFalse(observeWithoutOplog._multiplexer._observeDriver._usesOplog);
     await observeWithoutOplog.stop();
   });
@@ -3506,7 +3506,7 @@ Meteor.isServer &&
       var output = [];
       var handle = await coll
         .find({ a: 1, b: 2 }, { fields: { c: 1 } })
-        .observeChanges({
+        .observeChangesAsync({
           added: function(id, fields) {
             output.push(['added', id, fields]);
           },
@@ -3559,7 +3559,7 @@ Meteor.isServer &&
     );
 
     var changesOutput = [];
-    var changesHandle = await cursor.observeChanges({
+    var changesHandle = await cursor.observeChangesAsync({
       added: function(id, fields) {
         changesOutput.push(['added', fields]);
       },
@@ -3604,7 +3604,7 @@ Meteor.isServer &&
     var tmp;
 
     var output = [];
-    var handle = await coll.find({ a: 'foo' }).observeChanges({
+    var handle = await coll.find({ a: 'foo' }).observeChangesAsync({
       added: function(id, fields) {
         output.push(['added', id, fields]);
       },
@@ -3717,7 +3717,7 @@ testAsyncMulti('mongo-livedata - oplog - update EJSON', [
   async function(test, expect) {
     var self = this;
     self.changes = [];
-    self.handle = await self.collection.find({}).observeChanges({
+    self.handle = await self.collection.find({}).observeChangesAsync({
       added: function(id, fields) {
         self.changes.push(['a', id, fields]);
       },
@@ -3819,7 +3819,7 @@ Meteor.isServer &&
     _.times(100, async function() {
       await coll.insertAsync({ foo: 'baz' });
     });
-    var handler = await coll.find({}).observeChanges({
+    var handler = await coll.find({}).observeChangesAsync({
       added: async function(id) {
         await coll.updateAsync(id, { $set: { foo: 'bar' } });
       },
@@ -4050,7 +4050,7 @@ if (Meteor.isClient) {
       futuresByNonce[nonce] = new Promise(r => (resolver = r));
       var observe = await fenceOnBeforeFireErrorCollection
         .find({ nonce: nonce })
-        .observeChanges({ added: function() {} });
+        .observeChangesAsync({ added: function() {} });
       Meteor.setTimeout(async function() {
         try {
           await fenceOnBeforeFireErrorCollection.insertAsync({ nonce });
@@ -4214,7 +4214,7 @@ if (Meteor.isServer) {
         resolve();
       }
 
-      const observeHandle = await Collection.find().observeChanges({
+      const observeHandle = await Collection.find().observeChangesAsync({
         async changed(id, fields) {
           let expectedValue;
 

--- a/packages/mongo/observe_changes_tests.js
+++ b/packages/mongo/observe_changes_tests.js
@@ -25,7 +25,7 @@ _.each ([{added: 'added', forceOrdered: true},
         var barid = await c.insertAsync({ thing: 'stuff' });
         var fooid = await c.insertAsync({ noodles: 'good', bacon: 'bad', apples: 'ok' });
 
-        var handle = await c.find(fooid).observeChanges(logger);
+        var handle = await c.find(fooid).observeChangesAsync(logger);
         if (added === 'added') {
           await logger.expectResult(added, [
             fooid,
@@ -60,7 +60,7 @@ _.each ([{added: 'added', forceOrdered: true},
 
         const badCursor = c.find({}, { fields: { noodles: 1, _id: false } });
         await test.throwsAsync(async function() {
-          await badCursor.observeChanges(logger);
+          await badCursor.observeChangesAsync(logger);
         });
 
         onComplete();
@@ -81,10 +81,10 @@ Tinytest.addAsync('observeChanges - callback isolation', async function(
     async function(logger) {
       var handles = [];
       var cursor = c.find();
-      handles.push(await cursor.observeChanges(logger));
+      handles.push(await cursor.observeChangesAsync(logger));
       // fields-tampering observer
       handles.push(
-        await cursor.observeChanges({
+        await cursor.observeChangesAsync({
           added: function(id, fields) {
             fields.apples = 'green';
           },
@@ -122,7 +122,7 @@ Tinytest.addAsync('observeChanges - single id - initial adds', async function(
     Meteor.isServer,
     async function(logger) {
       var fooid = await c.insertAsync({ noodles: 'good', bacon: 'bad', apples: 'ok' });
-      var handle = await c.find(fooid).observeChanges(logger);
+      var handle = await c.find(fooid).observeChangesAsync(logger);
       await logger.expectResult('added', [
         fooid,
         { noodles: 'good', bacon: 'bad', apples: 'ok' },
@@ -148,7 +148,7 @@ Tinytest.addAsync('observeChanges - unordered - initial adds', async function(
     async function(logger) {
       var fooid = await c.insertAsync({ noodles: 'good', bacon: 'bad', apples: 'ok' });
       var barid = await c.insertAsync({ noodles: 'good', bacon: 'weird', apples: 'ok' });
-      var handle = await c.find().observeChanges(logger);
+      var handle = await c.find().observeChangesAsync(logger);
       await logger.expectResultUnordered([
         {
           callback: 'added',
@@ -176,7 +176,7 @@ Tinytest.addAsync('observeChanges - unordered - basics', async function(
     ['added', 'changed', 'removed'],
     Meteor.isServer,
     async function(logger) {
-      var handle = await c.find().observeChanges(logger);
+      var handle = await c.find().observeChangesAsync(logger);
       var barid = await c.insertAsync({ thing: 'stuff' });
       await logger.expectResultOnly('added', [barid, { thing: 'stuff' }]);
 
@@ -228,7 +228,7 @@ if (Meteor.isServer) {
       async function(logger) {
         var handle = await c
           .find({}, { fields: { noodles: 1, bacon: 1 } })
-          .observeChanges(logger);
+          .observeChangesAsync(logger);
         var barid = await c.insertAsync({ thing: 'stuff' });
         await logger.expectResultOnly('added', [barid, {}]);
 
@@ -281,7 +281,7 @@ if (Meteor.isServer) {
               { mac: 1, cheese: 2 },
               { fields: { noodles: 1, bacon: 1, eggs: 1 } }
             )
-            .observeChanges(logger);
+            .observeChangesAsync(logger);
           var barid = await c.insertAsync({ thing: 'stuff', mac: 1, cheese: 2 });
           await logger.expectResultOnly('added', [barid, {}]);
 
@@ -360,7 +360,7 @@ Tinytest.addAsync(
             { mac: 1, cheese: 2 },
             { fields: { noodles: 1, bacon: 1, eggs: 1 } }
           )
-          .observeChanges(logger);
+          .observeChangesAsync(logger);
         var fooid = await c.insertAsync({
           noodles: 'good',
           bacon: 'bad',
@@ -402,7 +402,7 @@ Tinytest.addAsync(
       async function(logger) {
         var handle = await c
           .find({}, { fields: { 'type.name': 1 } })
-          .observeChanges(logger);
+          .observeChangesAsync(logger);
         var id = await c.insertAsync({ type: { name: 'foobar' } });
         await logger.expectResultOnly('added', [id, { type: { name: 'foobar' } }]);
 
@@ -428,7 +428,7 @@ Tinytest.addAsync(
       ['added', 'changed', 'removed'],
       Meteor.isServer,
       async function(logger) {
-        var handle = await c.find({ noodles: 'good' }).observeChanges(logger);
+        var handle = await c.find({ noodles: 'good' }).observeChangesAsync(logger);
         var barid = await c.insertAsync({ thing: 'stuff' });
 
         var fooid = await c.insertAsync({ noodles: 'good', bacon: 'bad', apples: 'ok' });
@@ -492,7 +492,7 @@ if (Meteor.isServer) {
       self.expects.push(resolver);
 
       var cursor = coll.find({ y: { $ne: 7 } }, { tailable: true });
-      self.handle = await cursor.observeChanges({
+      self.handle = await cursor.observeChangesAsync({
         added: function(id, fields) {
           self.xs.push(fields.x);
           test.notEqual(self.expects.length, 0);
@@ -550,7 +550,7 @@ testAsyncMulti("observeChanges - bad query", [
     var c = makeCollection();
     var observeThrows = async function () {
       await test.throwsAsync(async function () {
-        await c.find({__id: {$in: null}}).observeChanges({
+        await c.find({__id: {$in: null}}).observeChangesAsync({
           added: function () {
             test.fail("added shouldn't be called");
           }
@@ -588,7 +588,7 @@ if (Meteor.isServer) {
       await environmentVariable.withValue(true, async function() {
         var handle = await c
           .find({}, { fields: { 'type.name': 1 } })
-          .observeChanges({
+          .observeChangesAsync({
             added: function() {
               test.isTrue(environmentVariable.get());
               handle.stop();

--- a/packages/mongo/observe_multiplex.js
+++ b/packages/mongo/observe_multiplex.js
@@ -222,11 +222,19 @@ ObserveHandle = class {
     this._stopped = false;
     this._id = nextObserveHandleId++;
     this.nonMutatingCallbacks = nonMutatingCallbacks;
+    this.initObserver = undefined;
+    this.initHandler = undefined;
+  }
+
+  async ready() {
+    if (this.initObserver) await this.initObserver;
+    if (this.initHandler) await this.initHandler;
   }
 
   async stop() {
     if (this._stopped) return;
     this._stopped = true;
+    await this.ready();
     await this._multiplexer.removeHandle(this._id);
   }
 };

--- a/packages/mongo/oplog_tests.js
+++ b/packages/mongo/oplog_tests.js
@@ -8,7 +8,7 @@ Tinytest.addAsync('mongo-livedata - oplog - cursorSupported', async function(
 
   var supported = async function(expected, selector, options) {
     var cursor = OplogCollection.find(selector, options);
-    var handle = await cursor.observeChanges({ added: function() {} });
+    var handle = await cursor.observeChangesAsync({ added: function() {} });
     // If there's no oplog at all, we shouldn't ever use it.
     if (!oplogEnabled) expected = false;
     test.equal(!!handle._multiplexer._observeDriver._usesOplog, expected);
@@ -125,7 +125,7 @@ process.env.MONGO_OPLOG_URL &&
           species: 'dog',
           color: 'blue',
         })
-        .observeChanges({
+        .observeChangesAsync({
           added(id, fields) {
             if (fields.name === 'dog 5') {
               blueDog5Id = id;

--- a/tools/tests/apps/failover-test/server/failover-test.js
+++ b/tools/tests/apps/failover-test/server/failover-test.js
@@ -63,7 +63,7 @@ steps.steppedDown = function () {
   process.exit(0);
 };
 
-C.find().observeChanges({
+C.find().observeChangesAsync({
   added: function (id, fields) {
     if (nextStepTimeout) {
       Meteor.clearTimeout(nextStepTimeout);


### PR DESCRIPTION
OSS-339

Context: https://github.com/meteor/meteor/issues/12918

Trying to keep observeChanges SYNC if possible in Meteor 3.x to match 2.x and in both client and server. But if not possible, we will just create everything async and we will create `observeChangesAsync ` and `observeAsync` everywhere to help with the migration from 2.x.

- [x] Make observeChanges and observe to remove directly a query handler
- [x] Implement observeChangesAsync and use it broadly in favor of observeChanges 
- [ ] New test for observeChanges vs observeChangesAsync usage
- [ ] Implement observeAsync 
- [ ] New test for observeAsync usage


