### PR TITLE
[Meteor 3] Removing broken methods in version 3

### DIFF
--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -201,12 +201,6 @@ export namespace Accounts {
 
   function setUsername(userId: string, newUsername: string): void;
 
-  function setPassword(
-    userId: string,
-    newPassword: string,
-    options?: { logout?: boolean | undefined }
-  ): void;
-
   function setPasswordAsync(
     userId: string,
     newPassword: string,

--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -346,7 +346,7 @@ export namespace Accounts {
    * properties `digest` and `algorithm` (in which case we bcrypt
    * `password.digest`).
    */
-  function _checkPassword(
+  function _checkPasswordAsync(
     user: Meteor.User,
     password: Password
   ): { userId: string; error?: any };

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -351,20 +351,6 @@ Accounts.setPasswordAsync =
   await Meteor.users.updateAsync({_id: user._id}, update);
 };
 
-/**
- * @summary Forcibly change the password for a user.
- * @locus Server
- * @param {String} userId The id of the user to update.
- * @param {String} newPassword A new password for the user.
- * @param {Object} [options]
- * @param {Object} options.logout Logout all current connections with this userId (default: true)
- * @importFromPackage accounts-base
- */
-Accounts.setPassword = (userId, newPlaintextPassword, options) => {
-  return Promise.await(Accounts.setPasswordAsync(userId, newPlaintextPassword, options));
-};
-
-
 ///
 /// RESETTING VIA EMAIL
 ///

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -100,11 +100,6 @@ const checkPasswordAsync = async (user, password) => {
   return result;
 };
 
-const checkPassword = (user, password) => {
-  return Promise.await(checkPasswordAsync(user, password));
-};
-
-Accounts._checkPassword = checkPassword;
 Accounts._checkPasswordAsync =  checkPasswordAsync;
 
 ///

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -1086,12 +1086,7 @@ Accounts.createUserAsync =
 // method calling Accounts.createUser could set?
 //
 
-Accounts.createUser =
-  !Meteor._isFibersEnabled
-    ? Accounts.createUserAsync
-    : (options, callback) =>
-        Promise.await(Accounts.createUserAsync(options, callback));
-
+Accounts.createUser = Accounts.createUserAsync;
 
 ///
 /// PASSWORD-SPECIFIC INDEXES ON USERS

--- a/packages/caching-compiler/caching-compiler.js
+++ b/packages/caching-compiler/caching-compiler.js
@@ -324,7 +324,7 @@ CachingCompiler = class CachingCompiler extends CachingCompilerBase {
       } else {
         const result = await getResult();
         if (result) {
-          this.addCompileResult(inputFile, result);
+          await this.addCompileResult(inputFile, result);
         }
       }
     }

--- a/packages/caching-compiler/multi-file-caching-compiler.js
+++ b/packages/caching-compiler/multi-file-caching-compiler.js
@@ -166,7 +166,7 @@ extends CachingCompilerBase {
       } else if (this.isRoot(inputFile)) {
         const result = await getResult();
         if (result) {
-          this.addCompileResult(inputFile, result);
+          await this.addCompileResult(inputFile, result);
         }
       }
     }

--- a/packages/email/.npm/package/npm-shrinkwrap.json
+++ b/packages/email/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 4,
   "dependencies": {
     "@types/node": {
-      "version": "20.11.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
-      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ=="
+      "version": "20.11.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
+      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg=="
     },
     "@types/nodemailer": {
       "version": "6.4.7",

--- a/packages/oauth1/oauth1_binding.js
+++ b/packages/oauth1/oauth1_binding.js
@@ -86,11 +86,6 @@ export class OAuth1Binding {
     return this.callAsync('POST', url, params, callback);
   }
 
-  call(method, url, params, callback) {
-    // Require changes when remove Fibers. Exposed to public api.
-    return Promise.await(this.callAsync(method, url, params, callback));
-  }
-
   get(url, params, callback) {
     // Require changes when remove Fibers. Exposed to public api.
     return this.call('GET', url, params, callback);

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -2242,19 +2242,6 @@ class JsImage {
            * @param {String} assetPath The path of the asset, relative to the application's `private` subdirectory.
            * @param {Function} [asyncCallback] Optional callback, which is called asynchronously with the error or result after the function is complete. If not provided, the function runs synchronously.
            */
-          getText: function (assetPath, callback) {
-            const result = getAsset(item.assets, assetPath, "utf8", callback);
-
-            if (!callback) {
-              if (!Fiber.current) {
-                throw new Error("The synchronous Assets API can " +
-                    "only be called from within a Fiber.");
-              }
-
-              return Promise.await(result);
-            }
-          },
-
           getTextAsync: function (assetPath) {
             return getAsset(item.assets, assetPath, "utf8");
           },
@@ -2266,19 +2253,6 @@ class JsImage {
            * @param {String} assetPath The path of the asset, relative to the application's `private` subdirectory.
            * @param {Function} [asyncCallback] Optional callback, which is called asynchronously with the error or result after the function is complete. If not provided, the function runs synchronously.
            */
-          getBinary: function (assetPath, callback) {
-            const result = getAsset(item.assets, assetPath, undefined, callback);
-
-            if (!callback) {
-              if (!Fiber.current) {
-                throw new Error("The synchronous Assets API can " +
-                    "only be called from within a Fiber.");
-              }
-
-              return Promise.await(result);
-            }
-          },
-
           getBinaryAsync: function (assetPath) {
             return getAsset(item.assets, assetPath, undefined);
           }

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -542,13 +542,13 @@ class InputFile extends buildPluginModule.InputFile {
    * @memberOf InputFile
    * @instance
    */
-  addHtml(options, lazyFinalizer) {
+  async addHtml(options, lazyFinalizer) {
     if (typeof lazyFinalizer === "function") {
       // For now, just call the lazyFinalizer function immediately. Since
       // HTML is not compiled, this immediate invocation is probably
       // permanently appropriate for addHtml, whereas methods like
       // addJavaScript benefit from waiting to call lazyFinalizer.
-      Object.assign(options, Promise.await(lazyFinalizer()));
+      Object.assign(options, await lazyFinalizer());
     }
 
     this._resourceSlot.addHtml(options);


### PR DESCRIPTION
Removing methods that use Promise.await to be sync. These won't work on version 3.

- `_checkPassword`: Now `_checkPasswordAsync`
- `setPassword`: Now `setPasswordAsync`
- `OAuth1Binding.call`: Now `OAuth1Binding.callAsync`
- `Assets.getText`: Now `Assets.getTextAsync`
- `Assets.getBinary`: Now `Assets.getBinaryAsync`


<!-- OSS-282 -->