### PR TITLE
[Meteor 3] Fix linker bug

### DIFF
--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -139,6 +139,7 @@ Object.assign(Module.prototype, {
 
         if (APP_PRELINK_CACHE.has(cacheKey)) {
           ret.push(APP_PRELINK_CACHE.get(cacheKey));
+          continue;
         }
 
         const node = await file.getPrelinkedOutput({ preserveLineNumbers: true });
@@ -167,14 +168,7 @@ Object.assign(Module.prototype, {
         ret.push(prelinked);
       }
 
-      // TODO[fibers]: This is a temporary hack to make sure that we don't return the same
-        // file twice. I'm not sure why, but self.files sometimes contains the same file twice.
-        // these tool tests fail without this hack:
-        // - assets - unicode asset names are allowed
-        // - javascript hot code push
-        // and probably others
-      const uniqueHashes = [...new Set(ret.map((f) => f.hash))];
-      return uniqueHashes.map((h) => ret.find((f) => f.hash === h));
+      return ret;
     }
 
     // Otherwise..


### PR DESCRIPTION
Fixes [this](https://github.com/meteor/meteor/discussions/12865#:~:text=test%20to%20fail.-,Fix%20Linker%20bug,-In%20this%20commit). 

There was an issue where we had a file linked twice. Previously we created a [workaround](https://github.com/meteor/meteor/pull/12580/commits/eb63a1b6643805590d3bf70ff9611e837aede1e9#diff-0972e87d5bf49b0ff289a29dee4ae83bb04b83d2e057976f7a7680e0e1ee2e0aR170-R177). This PR removes that workaround and fixes the issue.

<!-- OSS-286 -->