### PR TITLE
Support for synchronous method calls from the client

### DIFF
--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -186,8 +186,15 @@ CollectionPrototype._defineMutationMethods = function(options) {
               );
             }
 
-            const validatedMethodName =
+            let validatedMethodName =
                   '_validated' + method.charAt(0).toUpperCase() + method.slice(1);
+
+
+            // force to use the async version of the method
+            if(Meteor.isServer && !validatedMethodName?.endsWith('Async')){
+                validatedMethodName += 'Async';
+            }
+
             args.unshift(this.userId);
             isInsert(method) && args.push(generatedId);
             return self[validatedMethodName].apply(self, args);


### PR DESCRIPTION
This fixes a backward compatibility issue when you manage a remote collection on the client side using synchronous methods (e.g. collection.insert(...), collection.update(...)).

For more details see [meteor forum](https://forums.meteor.com/t/error-in-collection-update-call-from-client-in-version-3/60553)