### PR TITLE
Update App.svelte

### DIFF
--- a/tools/static-assets/skel-svelte/imports/ui/App.svelte
+++ b/tools/static-assets/skel-svelte/imports/ui/App.svelte
@@ -6,15 +6,11 @@
   const addToCounter = () => {
     counter += 1;
   }
-  
-  let subIsReady = false;
-  $m: {
-    const handle = Meteor.subscribe("links.all");
-    subIsReady = handle.ready();
-  }
 
   // more information about $m at https://atmospherejs.com/zodern/melte#tracker-statements
-  let links;
+  $m: handle = Meteor.subscribe("links.all");
+  $m: subIsReady = handle.ready();
+
   $m: links = LinksCollection.find().fetch();
 </script>
 


### PR DESCRIPTION
Small change to recommend moving `handle.ready` into its own `$m` statement. Having it in the same `$m` as the subscription causes `Meteor.subscribe` to be called multiple times which I think is harmless but feels unnecessary.

Also removed `let links`. It's not needed.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
