### PR TITLE
Set minPoolSize for oplog

### DIFF
--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -172,6 +172,9 @@ MongoConnection = function (url, options) {
     // set it for replSet, it will be ignored if we're not using a replSet.
     mongoOptions.maxPoolSize = options.maxPoolSize;
   }
+  if (_.has(options, 'minPoolSize')) {
+    mongoOptions.minPoolSize = options.minPoolSize;
+  }
 
   // Transform options like "tlsCAFileAsset": "filename.pem" into
   // "tlsCAFile": "/<fullpath>/filename.pem"
@@ -788,7 +791,7 @@ MongoConnection.prototype.upsert = function (collectionName, selector, mod,
   var self = this;
 
 
-  
+
   if (typeof options === "function" && ! callback) {
     callback = options;
     options = {};
@@ -844,7 +847,7 @@ MongoConnection.prototype.createIndexAsync = function (collectionName, index,
 MongoConnection.prototype.createIndex = function (collectionName, index,
                                                    options) {
   var self = this;
-  
+
 
   return Future.fromPromise(self.createIndexAsync(collectionName, index, options));
 };
@@ -866,7 +869,7 @@ MongoConnection.prototype._ensureIndex = MongoConnection.prototype.createIndex;
 MongoConnection.prototype._dropIndex = function (collectionName, index) {
   var self = this;
 
-  
+
   // This function is only used by test code, not within a method, so we don't
   // interact with the write fence.
   var collection = self.rawCollection(collectionName);

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -206,12 +206,12 @@ Object.assign(OplogHandle.prototype, {
     // The tail connection will only ever be running a single tail command, so
     // it only needs to make one underlying TCP connection.
     self._oplogTailConnection = new MongoConnection(
-      self._oplogUrl, {maxPoolSize: 1});
+      self._oplogUrl, {maxPoolSize: 1, minPoolSize: 1});
     // XXX better docs, but: it's to get monotonic results
     // XXX is it safe to say "if there's an in flight query, just use its
     //     results"? I don't think so but should consider that
     self._oplogLastEntryConnection = new MongoConnection(
-      self._oplogUrl, {maxPoolSize: 1});
+      self._oplogUrl, {maxPoolSize: 1, minPoolSize: 1});
 
     // Now, make sure that there actually is a repl set here. If not, oplog
     // tailing won't ever find anything!

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.16.8',
+  version: '1.16.9',
 });
 
 Npm.depends({


### PR DESCRIPTION
Oplog has its specific startup, but it was missing a condition for `minPoolSize` which made it impossible to set `minPoolSize` for normal connection as setting it in the `mongo` settings would set it as well for oplog connection which would result in error as `maxPoolSize` for oplog is `1`. So setting `minPoolSize` to 30 would result in failed startup on Galaxy when the oplog was started as `minPoolSize` for oplog could not be more than `maxPoolSize` (which is 1). So by setting `minPoolSize` for oplog to 1 and adding a copy of if function in startup for oplog connection for `minPoolSize` as well should avoid that error.

I think this should be released asap as a bug fix as Atlas has recommended me to work on the connection pool sizes in my connection, so more people are likely to work on these.