### PR TITLE
[3.0] Persist local doc in the same way Meteor 2.x

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -850,7 +850,17 @@ export class Connection {
     }
 
     // If we added it to the first block, send it out now.
-    if (self._outstandingMethodBlocks.length === 1) methodInvoker.sendMessage();
+    if (self._outstandingMethodBlocks.length === 1) {
+      if (callback && future) {
+        // Ensure the method message after the result of the method ran in the client.
+        future = new Promise((resolve) => {
+          methodInvoker.sendMessage();
+          resolve();
+        });
+      } else {
+        methodInvoker.sendMessage();
+      }
+    }
 
     // If we're using the default callback on the server,
     // block waiting for the result.


### PR DESCRIPTION
OSS-350

# Context

Issue: https://github.com/meteor/meteor/issues/13036

A continuation of https://github.com/meteor/meteor/pull/12969, which provided a configuration to sort one of the problems on keeping the same behavior on running collection operations on Meteor 3.x in respect of Meteor 2.x. That fix resulted to be like a workaround, and hopefully with this new iteration is completely fixed.

## Reproduction

``` javascript
const NamedCollection = new Meteor.Collection('namedCollection');
    
await NamedCollection.insertAsync({ test: 1 });

console.log("-> isItemCreated?", NamedCollection.find().fetch()?.[0]);
setTimeout(() => {
    console.log("-> Later: isItemCreated?", NamedCollection.find().fetch()?.[0]);
}, 1_000);
```

![image](https://github.com/meteor/meteor/assets/2581993/fdd1ba1d-20c8-42fa-baa0-e96e27520f7f)

Thanks to @bhunjadi I was able to understand and debug further the core flow about this issue and realized how Meteor 2.x and 3.x behaves distinctly in the process to run a collection operation.

In Meteor 2.x:
- Run `insertAsync`
- The document is available on the same run cycle
- The document is removed on a later run cycle due to the `replace: undefined` message

In Meteor 3.x:
- Run `insertAsync`
- The document is removed on a later run cycle due to the `replace: undefined` message
- The document **IS NOT** available on the same run cycle

This PR aims to ensure 3.x behavior matches the 2.x behavior. Data won't be persisted as the original github issue states (https://github.com/meteor/meteor/issues/13036), that is not the behavior on Meteor 2.x . For that, in Meteor, you need to fetch via a subscription, a method or directly use the local collection for inserting. Anyway, matching this behavior in both versions will also fix all tests since they expect the data to be available in the same run cycle that the op happened.

## Fix

![image](https://github.com/meteor/meteor/assets/2581993/565d5e5e-67f7-4754-8503-891d4cdb7a9d)


