### PR TITLE
[2.x] Report and extend test cases for the old async behaviors

### DIFF
--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -172,6 +172,9 @@ MongoConnection = function (url, options) {
     // set it for replSet, it will be ignored if we're not using a replSet.
     mongoOptions.maxPoolSize = options.maxPoolSize;
   }
+  if (_.has(options, 'minPoolSize')) {
+    mongoOptions.minPoolSize = options.minPoolSize;
+  }
 
   // Transform options like "tlsCAFileAsset": "filename.pem" into
   // "tlsCAFile": "/<fullpath>/filename.pem"
@@ -788,7 +791,7 @@ MongoConnection.prototype.upsert = function (collectionName, selector, mod,
   var self = this;
 
 
-  
+
   if (typeof options === "function" && ! callback) {
     callback = options;
     options = {};
@@ -844,7 +847,7 @@ MongoConnection.prototype.createIndexAsync = function (collectionName, index,
 MongoConnection.prototype.createIndex = function (collectionName, index,
                                                    options) {
   var self = this;
-  
+
 
   return Future.fromPromise(self.createIndexAsync(collectionName, index, options));
 };
@@ -866,7 +869,7 @@ MongoConnection.prototype._ensureIndex = MongoConnection.prototype.createIndex;
 MongoConnection.prototype._dropIndex = function (collectionName, index) {
   var self = this;
 
-  
+
   // This function is only used by test code, not within a method, so we don't
   // interact with the write fence.
   var collection = self.rawCollection(collectionName);

--- a/packages/mongo/oplog_tailing.js
+++ b/packages/mongo/oplog_tailing.js
@@ -206,12 +206,12 @@ Object.assign(OplogHandle.prototype, {
     // The tail connection will only ever be running a single tail command, so
     // it only needs to make one underlying TCP connection.
     self._oplogTailConnection = new MongoConnection(
-      self._oplogUrl, {maxPoolSize: 1});
+      self._oplogUrl, {maxPoolSize: 1, minPoolSize: 1});
     // XXX better docs, but: it's to get monotonic results
     // XXX is it safe to say "if there's an in flight query, just use its
     //     results"? I don't think so but should consider that
     self._oplogLastEntryConnection = new MongoConnection(
-      self._oplogUrl, {maxPoolSize: 1});
+      self._oplogUrl, {maxPoolSize: 1, minPoolSize: 1});
 
     // Now, make sure that there actually is a repl set here. If not, oplog
     // tailing won't ever find anything!

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -9,7 +9,7 @@
 
 Package.describe({
   summary: "Adaptor for using MongoDB and Minimongo over DDP",
-  version: '1.16.8',
+  version: '1.16.9',
 });
 
 Npm.depends({


### PR DESCRIPTION
This PR aims to add test cases to track the behaviors around data persistence resulted on run collection operations in 2.x to help to understand and match 3.x later.

These tests will be added in this https://github.com/meteor/meteor/pull/13052 3.x branch to also ensure the same exact API is perserved on the next version.

As mentioned on 3.x PR, data is temporary persisted when using collection operations, and the only way to persist them is through using local collection operations (or publications which actually use these). As part of this PR I also added aync versions of local collection operations, since these are enabled in 3.x and facilitates the same test form for the two versions, and allow any migration in 2.x.