### PR TITLE
[3.0] Debug mode

### DIFF
--- a/docs/generators/changelog/versions/3.0.md
+++ b/docs/generators/changelog/versions/3.0.md
@@ -667,6 +667,9 @@
 
   - `Meteor.callAsync()`
 
+- `meteor`:
+  - Added `Meteor.isDebug` to execute code in debug builds, activated with the --inspect mode.
+
 - `minifier-css`: (2.9+)
 
   - `CssTools.minifyCssAsync()`

--- a/packages/ddp-client/client/queueStubsHelpers.js
+++ b/packages/ddp-client/client/queueStubsHelpers.js
@@ -107,7 +107,7 @@ export const loadAsyncStubHelpers = () => {
         });
 
         Meteor._setImmediate(() => {
-          if (!finished) {
+          if (!finished && Meteor.isDebug) {
             console.warn(
               `Method stub (${name}) took too long and could cause unexpected problems. Learn more at https://github.com/zodern/fix-async-stubs/#limitations`
             );

--- a/packages/ddp-client/client/queueStubsHelpers.js
+++ b/packages/ddp-client/client/queueStubsHelpers.js
@@ -107,7 +107,7 @@ export const loadAsyncStubHelpers = () => {
         });
 
         Meteor._setImmediate(() => {
-          if (!finished && Meteor.isDebug) {
+          if (!finished) {
             console.warn(
               `Method stub (${name}) took too long and could cause unexpected problems. Learn more at https://github.com/zodern/fix-async-stubs/#limitations`
             );

--- a/packages/meteor/debug.js
+++ b/packages/meteor/debug.js
@@ -1,3 +1,19 @@
+if (Meteor.isServer) {
+  if (typeof __meteor_runtime_config__ === 'object') {
+    __meteor_runtime_config__.debug =
+      !!process.env.NODE_INSPECTOR_IPC ||
+      !!process.env.VSCODE_INSPECTOR_OPTIONS ||
+      process.execArgv.some(_arg =>
+        /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(_arg),
+      );
+  }
+}
+
+Meteor.isDebug = Meteor.isClient
+  ? typeof window === 'object' && !!window.__meteor_runtime_config__.debug
+  : typeof __meteor_runtime_config__ === 'object' &&
+  !!__meteor_runtime_config__.debug;
+
 var suppress = 0;
 
 // replacement for console.log. This is a temporary API. We should
@@ -61,4 +77,3 @@ Meteor._suppress_log = function (count) {
 Meteor._suppressed_log_expected = function () {
   return suppress !== 0;
 };
-

--- a/packages/meteor/debug.js
+++ b/packages/meteor/debug.js
@@ -3,9 +3,9 @@ if (Meteor.isServer) {
     __meteor_runtime_config__.debug =
       !!process.env.NODE_INSPECTOR_IPC ||
       !!process.env.VSCODE_INSPECTOR_OPTIONS ||
-      process.execArgv.some(_arg =>
-        /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(_arg),
-      );
+      process.execArgv.some(function(_arg) {
+        return /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(_arg);
+      });
   }
 }
 


### PR DESCRIPTION
OSS-347

This PR spreads the debug mode used on the server via `--inspect*`/`-brk` to the client. Therefore you can ignore certain code execution on the client in a normal execution (`meteor run`), like ignoring log messages.

Specifically, we have introduced the following variables to handle debug-only flows in Meteor code or your app code:

- `__meteor_runtime_config__.debug`
- `Meteor.isDebug`

Besides, and as a practical example, we have ignored in normal app execution the `Method stub took too long` warning message.

## Demo

### Debug OFF

![image](https://github.com/meteor/meteor/assets/2581993/1d8c7f45-9539-4f4d-9fd5-62ea891e9811)

### Debug ON

![image](https://github.com/meteor/meteor/assets/2581993/f8464818-9457-4a34-994f-bb90ac90adc5)
