### PR TITLE
Fix an issue with methods interacting with unblocking mechanisms

### DIFF
--- a/packages/ddp-client/client/queueStubsHelpers.js
+++ b/packages/ddp-client/client/queueStubsHelpers.js
@@ -95,14 +95,13 @@ export const loadAsyncStubHelpers = () => {
           const applyAsyncPromise = oldApplyAsync.apply(this, args);
           stubPromiseResolver(applyAsyncPromise.stubPromise);
           serverPromiseResolver(applyAsyncPromise.serverPromise);
-          applyAsyncPromise.stubPromise.finally(() => {
-            finished = true;
-          });
           applyAsyncPromise
             .then((result) => {
+              finished = true;
               resolve(result);
             })
             .catch((err) => {
+              finished = true;
               reject(err);
             });
         });

--- a/packages/ddp-client/client/queueStubsHelpers.js
+++ b/packages/ddp-client/client/queueStubsHelpers.js
@@ -20,7 +20,7 @@ export const loadAsyncStubHelpers = () => {
 
     queue = queue.finally(() => {
       fn(resolve, reject);
-      return promise;
+      return promise.stubPromise;
     });
 
     promise.finally(() => {
@@ -95,13 +95,14 @@ export const loadAsyncStubHelpers = () => {
           const applyAsyncPromise = oldApplyAsync.apply(this, args);
           stubPromiseResolver(applyAsyncPromise.stubPromise);
           serverPromiseResolver(applyAsyncPromise.serverPromise);
+          applyAsyncPromise.stubPromise.finally(() => {
+            finished = true;
+          });
           applyAsyncPromise
             .then((result) => {
-              finished = true;
               resolve(result);
             })
             .catch((err) => {
-              finished = true;
               reject(err);
             });
         });

--- a/packages/ddp-client/client/queueStubsHelpers.js
+++ b/packages/ddp-client/client/queueStubsHelpers.js
@@ -95,13 +95,14 @@ export const loadAsyncStubHelpers = () => {
           const applyAsyncPromise = oldApplyAsync.apply(this, args);
           stubPromiseResolver(applyAsyncPromise.stubPromise);
           serverPromiseResolver(applyAsyncPromise.serverPromise);
+          applyAsyncPromise.stubPromise.finally(() => {
+            finished = true;
+          });
           applyAsyncPromise
             .then((result) => {
-              finished = true;
               resolve(result);
             })
             .catch((err) => {
-              finished = true;
               reject(err);
             });
         });

--- a/packages/ddp-client/test/async_stubs/client.js
+++ b/packages/ddp-client/test/async_stubs/client.js
@@ -326,27 +326,16 @@ Tinytest.addAsync(
   async function (test) {
     await Meteor.callAsync("getAndResetEvents");
 
-    Meteor.callAsync("unblockedMethod", { delay: 200 }); // unblock + sleep for 200 milliseconds
-    Meteor.callAsync("blockingMethod"); // run straight + block
+    await Promise.all([
+      Meteor.callAsync("unblockedMethod", { delay: 200 }), // unblock + sleep for 200 milliseconds
+      Meteor.callAsync("blockingMethod"), // run straight + block
+    ]);
 
     let serverEvents = await Meteor.callAsync("getAndResetEvents");
-
     test.equal(
       serverEvents,
-      ["unblock start", "blockingMethod"],
-      "should have started the unblock method and the block method straight"
-    );
-
-    return new Promise((resolve) =>
-      setTimeout(async () => {
-        serverEvents = await Meteor.callAsync("getAndResetEvents");
-        test.equal(
-          serverEvents,
-          ["unblock end"],
-          "should have ended the unblock method as sleep finished"
-        );
-        resolve();
-      }, 400)
+      ["unblock start", "blockingMethod", "unblock end"],
+      "should have properly executed the unblocking mechanism"
     );
   }
 );

--- a/packages/ddp-client/test/async_stubs/client.js
+++ b/packages/ddp-client/test/async_stubs/client.js
@@ -326,7 +326,7 @@ Tinytest.addAsync(
   async function (test) {
     await Meteor.callAsync("getAndResetEvents");
 
-    Meteor.callAsync("unblockedMethod", { delay: 200 }); // unblock + sleep for 20 milliseconds
+    Meteor.callAsync("unblockedMethod", { delay: 200 }); // unblock + sleep for 200 milliseconds
     Meteor.callAsync("blockingMethod"); // run straight + block
 
     let serverEvents = await Meteor.callAsync("getAndResetEvents");
@@ -345,7 +345,6 @@ Tinytest.addAsync(
           ["unblock end"],
           "should have ended the unblock method as sleep finished"
         );
-
         resolve();
       }, 400)
     );

--- a/packages/ddp-client/test/async_stubs/server_setup.js
+++ b/packages/ddp-client/test/async_stubs/server_setup.js
@@ -40,7 +40,16 @@ Meteor.methods({
     events.push('callAsyncStubFromAsyncStub');
 
     return 'server result';
-  }
+  },
+  async 'unblockedMethod'({ delay }) {
+    events.push('unblock start');
+    this.unblock();
+    await Meteor._sleepForMs(delay);
+    events.push('unblock end');
+  },
+  'blockingMethod'() {
+    events.push('blockingMethod');
+  },
 });
 
 Meteor.publish("simple-publication", function () {

--- a/packages/ddp-client/test/livedata_tests.js
+++ b/packages/ddp-client/test/livedata_tests.js
@@ -1201,30 +1201,6 @@ testAsyncMulti('livedata - methods with nested stubs', [
   },
 ]);
 
-Tinytest.addAsync('livedata - method interaction with unblocking mechanism', async function(test) {
-  let serverEvents = [];
-
-  // server-only methods
-  Meteor.methods({
-    [`unblockedMethod${test.runId()}`]:  async function() {
-      serverEvents.push('unblock start');
-      this.unblock();
-      await Meteor._sleepForMs(2000);
-      serverEvents.push('unblock end')
-    },
-    [`blockingMethod${test.runId()}`]: async function() {
-      serverEvents.push('blockingMethod');
-    }
-  });
-
-  Meteor.callAsync(`unblockedMethod${test.runId()}`);
-  Meteor.callAsync(`blockingMethod${test.runId()}`);
-
-  if (Meteor.isServer) {
-    test.equal(serverEvents, ['unblock start', 'blockingMethod']);
-  }
-});
-
 // TODO [FIBERS] - check if this still makes sense to have
 
 //  Tinytest.addAsync('livedata - isAsync call', async function (test) {

--- a/packages/ddp-client/test/livedata_tests.js
+++ b/packages/ddp-client/test/livedata_tests.js
@@ -1201,6 +1201,32 @@ testAsyncMulti('livedata - methods with nested stubs', [
   },
 ]);
 
+Tinytest.addAsync('livedata - method interaction with unblocking mechanism', async function(test) {
+  let serverEvents = [];
+
+  // server-only methods
+  if (Meteor.isServer) {
+    Meteor.methods({
+      [`unblockedMethod${test.runId()}`]:  async function() {
+        serverEvents.push('unblock start');
+        this.unblock();
+        await Meteor._sleepForMs(2000);
+        serverEvents.push('unblock end')
+      },
+      [`blockingMethod${test.runId()}`]: async function() {
+        serverEvents.push('blockingMethod');
+      }
+    });
+  }
+
+  Meteor.callAsync(`unblockedMethod${test.runId()}`);
+  Meteor.callAsync(`blockingMethod${test.runId()}`);
+
+  if (Meteor.isServer) {
+    test.equal(serverEvents, ['unblock start', 'blockingMethod']);
+  }
+});
+
 // TODO [FIBERS] - check if this still makes sense to have
 
 //  Tinytest.addAsync('livedata - isAsync call', async function (test) {

--- a/packages/ddp-client/test/livedata_tests.js
+++ b/packages/ddp-client/test/livedata_tests.js
@@ -1205,19 +1205,17 @@ Tinytest.addAsync('livedata - method interaction with unblocking mechanism', asy
   let serverEvents = [];
 
   // server-only methods
-  if (Meteor.isServer) {
-    Meteor.methods({
-      [`unblockedMethod${test.runId()}`]:  async function() {
-        serverEvents.push('unblock start');
-        this.unblock();
-        await Meteor._sleepForMs(2000);
-        serverEvents.push('unblock end')
-      },
-      [`blockingMethod${test.runId()}`]: async function() {
-        serverEvents.push('blockingMethod');
-      }
-    });
-  }
+  Meteor.methods({
+    [`unblockedMethod${test.runId()}`]:  async function() {
+      serverEvents.push('unblock start');
+      this.unblock();
+      await Meteor._sleepForMs(2000);
+      serverEvents.push('unblock end')
+    },
+    [`blockingMethod${test.runId()}`]: async function() {
+      serverEvents.push('blockingMethod');
+    }
+  });
 
   Meteor.callAsync(`unblockedMethod${test.runId()}`);
   Meteor.callAsync(`blockingMethod${test.runId()}`);


### PR DESCRIPTION
OSS-352

Context: https://github.com/meteor/meteor/pull/13054#discussion_r1514578297

## Reproduction

Describe the next methods in the server.

``` javascript
let events = [];

Meteor.methods({
  async 'unblockedMethod'({ delay }) {
    events.push('unblock start');
    this.unblock();
    await Meteor._sleepForMs(delay);
    events.push('unblock end');
  },
  'blockingMethod'() {
    events.push('blockingMethod');
  },
});
```

Run on the client:

``` javascript
Meteor.callAsync("unblockedMethod", { delay: 200 }); // unblock + sleep for 20 milliseconds
Meteor.callAsync("blockingMethod"); // run straight + block

// assert 1: `events` should have `["unblock start", "blockingMethod"]` at this point as two methods are executed in parallel and the first one is unblocked. 
// assert 2: `events` should have added `["unblock end"]` at some point in the future as `unblockedMethod` finished
```

Check how the test is described on the PR. A failing scenario that reproduce the issue is depicted in the next picture. Warning logs `Method took too long` also showed up.

![image](https://github.com/meteor/meteor/assets/2581993/6fd08402-e602-4bfe-8283-c56ba6f1a72a)

### Fix

The fix relied on ensure the client queue triggers next method after the stub(simulation) finished for the previous one. This also fixed the logs.

![image](https://github.com/meteor/meteor/assets/2581993/5b31ca6b-cbe5-4406-a779-204e8c97f7bf)

