### PR TITLE
[Meteor 3] Stop loading packages in pararel

### DIFF
--- a/tools/isobuild/linker.js
+++ b/tools/isobuild/linker.js
@@ -956,9 +956,8 @@ var getHeader = function (options) {
   });
 
   chunks.push(
-      `Package["core-runtime"].queue("${options.name}", [`,
-      orderedDeps.join(', '),
-      '], function () {'
+      `Package["core-runtime"].queue("${options.name}",`,
+      'function () {'
   );
 
   if (isApp) {


### PR DESCRIPTION
<!--OSS-376-->

For more context: https://forums.meteor.com/t/order-of-loading-packages/61112.

We are getting error reports about the order in the packages that are being imported.

There isn't a bug. The code works by design, but the new brings some issues.

### Solution

As @zodern [suggested](https://forums.meteor.com/t/order-of-loading-packages/61112/16?u=denyhs), I'm removing all deps code from `code-runtime` and `linker`.

But It's not working correctly. I'm getting this error:

![Screenshot from 2024-03-27 11-17-07](https://github.com/meteor/meteor/assets/29639852/8a7bd13b-9904-4128-922e-c673f2384b15)

Inside `ddp-server`, `Webapp` object is not being found, even though the `webapp` package loads first.

I'll contact @zodern, and hopefully, they can set us on the right path.

**Reproduction:** https://github.com/plbkbx/testLoadingPackages (run this app with your local Meteor at this branch).