### PR TITLE
[Meteor 3.0] Making our CI more easy to understand

### DIFF
--- a/packages/test-in-console/puppeteerRunner.js
+++ b/packages/test-in-console/puppeteerRunner.js
@@ -10,11 +10,10 @@ async function runNextUrl(browser) {
     // if the test is running for too long without any output to the console (10 minutes)
     if (msg._text !== undefined) console.log(msg._text);
     else {
-      // sometimes if the test is running in the client we have id: current-client-test with
-      // the name of the test
-      const element = await page.$('#current-client-test');
-      if (element) {
-        const currentClientTest = await page.evaluate(element => element.textContent, element);
+      testNumber++;
+      const currentClientTest =
+       await page.evaluate(() =>  __Tinytest._getCurrentRunningTestOnClient());
+      if (currentClientTest !== '') {
         console.log(`Currently running on the client test: ${ currentClientTest }`)
         return;
       }
@@ -29,7 +28,6 @@ async function runNextUrl(browser) {
       // we were not able to find the name of the test, this is a way to make sure the test is still running
       console.log(`Test number: ${ testNumber }`);
     }
-    testNumber++;
   });
 
   if (!process.env.URL) {
@@ -42,10 +40,6 @@ async function runNextUrl(browser) {
   async function poll() {
     if (await isDone(page)) {
       let failCount = await getFailCount(page);
-      console.log(`
-      The number of tests from Test number may be different because
-      of the way the test is written. causing the test to fail or
-      to run more than once. in the console. Test number total: ${ testNumber }`);
       console.log(`Tests complete with ${ failCount } failures`);
       console.log(`Tests complete with ${ await getPassCount(page) } passes`);
       if (failCount > 0) {

--- a/packages/tinytest/tinytest.js
+++ b/packages/tinytest/tinytest.js
@@ -531,9 +531,7 @@ export class TestRun {
 
   _runTest(test, onComplete, stop_at_offset) {
     var startTime = (+new Date);
-    if (Meteor.isServer){
-      Tinytest._currentRunningTestNameOnServer = test.name;
-    }
+    Tinytest._currentRunningTestName = test.name;
 
     return test.run(event => {
       /* onEvent */
@@ -705,19 +703,21 @@ Tinytest._runTests = function (onReport, onComplete, pathPrefix) {
   testRun.run(onComplete);
 };
 
-Tinytest._currentRunningTestNameOnServer = ""
+Tinytest._currentRunningTestName = ""
 
 Meteor.methods({
   'tinytest/getCurrentRunningTestName'() {
-    return Tinytest._currentRunningTestNameOnServer;
+    return Tinytest._currentRunningTestName;
   }
 })
 
-// Get current running test from server;
 Tinytest._getCurrentRunningTestOnServer = function () {
   return Meteor.callAsync('tinytest/getCurrentRunningTestName');
 }
 
+Tinytest._getCurrentRunningTestOnClient = function () {
+  return Tinytest._currentRunningTestName;
+}
 
 // Run just one test case, and stop the debugger at a particular
 // error, all as indicated by 'cookie', which will have come from a

--- a/packages/tinytest/tinytest.js
+++ b/packages/tinytest/tinytest.js
@@ -531,6 +531,9 @@ export class TestRun {
 
   _runTest(test, onComplete, stop_at_offset) {
     var startTime = (+new Date);
+    if (Meteor.isServer){
+      Tinytest._currentRunningTestNameOnServer = test.name;
+    }
 
     return test.run(event => {
       /* onEvent */
@@ -671,6 +674,7 @@ export class TestRun {
 /******************************************************************************/
 
 export const Tinytest = {};
+globalThis.__Tinytest = Tinytest;
 
 Tinytest.addAsync = function (name, func, options) {
   TestManager.addCase(new TestCase(name, func), options);
@@ -700,6 +704,20 @@ Tinytest._runTests = function (onReport, onComplete, pathPrefix) {
   var testRun = TestManager.createRun(onReport, pathPrefix);
   testRun.run(onComplete);
 };
+
+Tinytest._currentRunningTestNameOnServer = ""
+
+Meteor.methods({
+  'tinytest/getCurrentRunningTestName'() {
+    return Tinytest._currentRunningTestNameOnServer;
+  }
+})
+
+// Get current running test from server;
+Tinytest._getCurrentRunningTestOnServer = function () {
+  return Meteor.callAsync('tinytest/getCurrentRunningTestName');
+}
+
 
 // Run just one test case, and stop the debugger at a particular
 // error, all as indicated by 'cookie', which will have come from a


### PR DESCRIPTION
In this PR, I address the issue of the Travis CI not being so good to read when tests are running(currently only shows a `testNumber` variable). This PR will solve that(kind of). 

We will add the current test that is running if we do not have that in the context, we will still print the `testNumber` variable, but  for the most part, our ci will start to look like this:

<img width="915" alt="Screenshot 2024-04-03 at 15 38 30" src="https://github.com/meteor/meteor/assets/70247653/8df39f27-4125-4202-b55a-c8df4f29b086">

If it ever gets stuck somewhere, we will know it