### PR TITLE
[2.x] Fix tests after tinytest setup improvement

### DIFF
--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -102,6 +102,7 @@ Tinytest.addAsync(
     function (test, onComplete) {
 
         var cb = Meteor.onMessage(function (msg, session) {
+            if (msg.method !== 'livedata_server_test_inner') return;
             test.equal(msg.method, 'livedata_server_test_inner');
             cb.stop();
             onComplete();


### PR DESCRIPTION
OSS-383

[These last changes on tinytest](https://github.com/meteor/meteor/pull/13079) to output test names have introduced a failure on an existing test.

The issue is that a test that we expect `Meteor.onMessage` callback to retrieve the DDP message of one method we run as part of the test. But as the new tinytest setup to get current test name on the output adds and runs a new Meteor method, the test won't be get the first DDP message from the method run. I changed the test to actually check properly that we get the proper DDP message at some point to fix the test,