### PR TITLE
[3.x] Fix checks

### DIFF
--- a/.github/workflows/npm-meteor-promise.yml
+++ b/.github/workflows/npm-meteor-promise.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: npm-packages/meteor-promise
     strategy:
       matrix:
-        node-version: [14.x, 20.x]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/npm-packages/meteor-promise/promise_server.js
+++ b/npm-packages/meteor-promise/promise_server.js
@@ -9,7 +9,7 @@ exports.makeCompatible = function (Promise, Fiber) {
   }
 
   if (es6PromiseThen.name === "meteorPromiseThen") {
-    return; // Already compatible.
+    return; // Already compatible
   }
 
   function meteorPromiseThen(onResolved, onRejected) {


### PR DESCRIPTION
OSS-384

## Reproduction

Release 3.0 has still a pending [check suddently failing.](https://github.com/meteor/meteor/assets/2581993/d2bacf6a-5bdd-4fca-8fc2-7badefd89661)

Changing only `meteor-promise` package triggers the GitHub action check. Other PRs from `release-3.0` don't trigger this check. However, the check relies on fibers, expecting node version 14.x, not 20.x, as updated [here](https://github.com/meteor/meteor/pull/12925). Yet, the node upgrade PR didn't trigger the `meteor-promise` check to confirm the node upgrade keeps the check green.

![image](https://github.com/meteor/meteor/assets/2581993/72111117-037e-4d4e-ac6e-4bc4c7fb033e)

## Fix

Use node 14.x as part of meteor-promise check.

![image](https://github.com/meteor/meteor/assets/2581993/0cb74e37-5368-4457-9d26-ae83852c7469)
