### PR TITLE
Fix issue with `audit-argument-checks` after changes on env contexts

### DIFF
--- a/packages/meteor/dynamics_nodejs.js
+++ b/packages/meteor/dynamics_nodejs.js
@@ -55,7 +55,7 @@ class EnvironmentVariableAsync {
       Meteor._getValueFromAslStore(UPPER_CALL_DYNAMICS_KEY_NAME) || {}
     );
 
-    if (slotCall) {
+    if (slotCall != null) {
       dynamics[slotCall] = value;
     }
 

--- a/packages/meteor/dynamics_test.js
+++ b/packages/meteor/dynamics_test.js
@@ -20,8 +20,10 @@ if (Meteor.isServer) {
   Tinytest.addAsync(
     "environment - dynamic variables with two context (server)",
     async function (test) {
+      // Ensure "0" as the dynamic context spread properly
+      // https://github.com/meteor/meteor/pull/13089
       const context0 = new Meteor.EnvironmentVariable();
-      context0.slot = 0; // Ensure "0" as the dynamic context spread properly
+      context0.slot = 0;
 
       const context1 = new Meteor.EnvironmentVariable();
       const context2 = new Meteor.EnvironmentVariable();
@@ -54,8 +56,10 @@ if (Meteor.isServer) {
   Tinytest.add(
     "environment - dynamic variables with two context (client)",
     function (test) {
+      // Ensure "0" as the dynamic context spread properly
+      // https://github.com/meteor/meteor/pull/13089
       const context0 = new Meteor.EnvironmentVariable();
-      context0.slot = 0; // Ensure "0" as the dynamic context spread properly
+      context0.slot = 0;
 
       const context1 = new Meteor.EnvironmentVariable();
       const context2 = new Meteor.EnvironmentVariable();

--- a/packages/meteor/dynamics_test.js
+++ b/packages/meteor/dynamics_test.js
@@ -20,20 +20,30 @@ if (Meteor.isServer) {
   Tinytest.addAsync(
     "environment - dynamic variables with two context (server)",
     async function (test) {
+      const context0 = new Meteor.EnvironmentVariable();
+      context0.slot = 0; // Ensure "0" as the dynamic context spread properly
+
       const context1 = new Meteor.EnvironmentVariable();
       const context2 = new Meteor.EnvironmentVariable();
 
-      return context1.withValue(42, async () => {
-        test.equal(context2.get(), undefined);
-        await context2.withValue(1, async () => {
-          await context2.withValue(2, async () => {
-            test.equal(context2.get(), 2);
+      return context0.withValue(0, async () => {
+        test.equal(context1.get(), undefined);
+        await context1.withValue(42, async () => {
+          test.equal(context2.get(), undefined);
+          await context2.withValue(1, async () => {
+            await context2.withValue(2, async () => {
+              test.equal(context2.get(), 2);
+              test.equal(context0.get(), 0);
+            });
+            test.equal(context1.get(), 42);
+            test.equal(context2.get(), 1);
+            test.equal(context0.get(), 0);
           });
           test.equal(context1.get(), 42);
-          test.equal(context2.get(), 1);
+          test.equal(context2.get(), undefined);
+          test.equal(context0.get(), 0);
         });
-        test.equal(context1.get(), 42);
-        test.equal(context2.get(), undefined);
+        test.equal(context0.get(), 0);
       });
     }
   );
@@ -44,20 +54,29 @@ if (Meteor.isServer) {
   Tinytest.add(
     "environment - dynamic variables with two context (client)",
     function (test) {
+      const context0 = new Meteor.EnvironmentVariable();
+      context0.slot = 0; // Ensure "0" as the dynamic context spread properly
+
       const context1 = new Meteor.EnvironmentVariable();
       const context2 = new Meteor.EnvironmentVariable();
-
-      context1.withValue(42, () => {
-        test.equal(context2.get(), undefined);
-        context2.withValue(1, () => {
-          context2.withValue(2, () => {
-            test.equal(context2.get(), 2);
+      context0.withValue(0, async () => {
+        test.equal(context1.get(), undefined);
+        context1.withValue(42, () => {
+          test.equal(context2.get(), undefined);
+          context2.withValue(1, () => {
+            context2.withValue(2, () => {
+              test.equal(context2.get(), 2);
+              test.equal(context0.get(), 0);
+            });
+            test.equal(context1.get(), 42);
+            test.equal(context2.get(), 1);
+            test.equal(context0.get(), 0);
           });
           test.equal(context1.get(), 42);
-          test.equal(context2.get(), 1);
+          test.equal(context2.get(), undefined);
+          test.equal(context0.get(), 0);
         });
-        test.equal(context1.get(), 42);
-        test.equal(context2.get(), undefined);
+        test.equal(context0.get(), 0);
       });
     }
   );


### PR DESCRIPTION
Context: https://forums.meteor.com/t/meteor-3-0-beta-7-is-out/61417/27

## Issue

Following https://github.com/meteor/meteor/pull/13063, we encountered an issue where `audit-argument-checks` didn't validate correctly. This problem remained hidden until the inclusion of the `matb33:collection-hooks` package, which brought it to light through the error message: `Error: Did not check() all arguments during publisher`.

The code snippet for reproduction is as follows:

``` javascript
if (Meteor.isServer) {
	Meteor.publish('namedPub', function (testValue, testStr) {
	    check(arguments, [Match.Any])
	    console.log('testStr', testStr);
	    return [];
	});
}

if (Meteor.isClient) {
	Meteor.subscribe('namedPub', 1, 'test');
}
```

## Fix

Ensure proper validation of nullish values when preparing the context on `EnvironmentVariableAsync` code. `audit-argument-checks` used the `0` to hold its validation context.

## Pending

- [x] Create a regression test that properly test `audit-argument-checks` similarly as the reproduction as it was not covered.