### PR TITLE
Fix for old API usage

### DIFF
--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -156,7 +156,7 @@ const middleware = async (req, res, next) => {
       throw new Error(`Unexpected OAuth service ${serviceName}`);
 
     // Make sure we're configured
-    ensureConfigured(serviceName);
+    await ensureConfigured(serviceName);
 
     const handler = OAuth._requestHandlers[service.version];
     if (!handler)
@@ -237,8 +237,8 @@ const oauthServiceName = req => {
 };
 
 // Make sure we're configured
-const ensureConfigured = serviceName => {
-  if (!ServiceConfiguration.configurations.findOne({service: serviceName})) {
+const ensureConfigured = async serviceName => {
+  if (!(await ServiceConfiguration.configurations.findOneAsync({service: serviceName}))) {
     throw new ServiceConfiguration.ConfigError();
   }
 };


### PR DESCRIPTION
Fixes "Error in OAuth Server: findOne +  is not available on the server. Please use findOneAsync() instead."

The error stems from `oauth_server.js` still using the sync Mongo API at `ServiceConfiguration.configurations.findOne(...)`