### PR TITLE
[Meteor 3] Added `waitUntilAllLoaded` safety check.

### DIFF
--- a/packages/core-runtime/load-js-image.js
+++ b/packages/core-runtime/load-js-image.js
@@ -122,7 +122,7 @@ function checkAsyncModule (exports) {
 // For this to be accurate, all linked files must be queued before calling this
 // If all are loaded, returns null. Otherwise, returns a promise
 function waitUntilAllLoaded() {
-  if (pending.length === 0) {
+  if (pending.length === 0 && !isProcessing) {
     // All packages are loaded
     // If there were no async packages, then there might not be a promise
     // polyfill loaded either, so we don't create a promise to return

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -61,7 +61,7 @@ const hasOwn = Object.prototype.hasOwnProperty;
 // Cache the (slightly post-processed) results of linker.fullLink.
 const CACHE_SIZE = process.env.METEOR_LINKER_CACHE_SIZE || 1024*1024*100;
 const CACHE_DEBUG = !! process.env.METEOR_TEST_PRINT_LINKER_CACHE_DEBUG;
-const LINKER_CACHE_SALT = 25; // Increment this number to force relinking.
+const LINKER_CACHE_SALT = 26; // Increment this number to force relinking.
 const LINKER_CACHE = new LRU({
   max: CACHE_SIZE,
   // Cache is measured in bytes. We don't care about servePath.


### PR DESCRIPTION
As recommended in https://github.com/meteor/meteor/pull/13095#discussion_r1571327249, I added additional check in `waitUntilAllLoaded` in case it gets called while the last module is still being loaded. I was not able to prepare a test for that (the queue is never empty in my tests), I didn't add any.