### PR TITLE
[3.x] Fix Cordova

### DIFF
--- a/tools/cordova/run-targets.js
+++ b/tools/cordova/run-targets.js
@@ -138,7 +138,7 @@ export class AndroidRunTarget extends CordovaRunTarget {
         `CordovaLog:${logLevel}`, `chromium:${logLevel}`,
         `SystemWebViewClient:${logLevel}`, '*:F'];
 
-      const { Log } = loadIsopackage('logging');
+      const { Log } = await loadIsopackage('logging');
 
       const logStream = transform(line => {
         const logEntry = logFromAndroidLogcatLine(Log, line);


### PR DESCRIPTION
OSS-391

----

## Issues

Critical issues on Cordova experience on Meteor 3.x.

Two issues reported and described on Meteor Discord, https://discord.com/channels/679410334292901888/1225337436784037919

- [x] Running your app and the development server breaks. (Missing async on loading `logging` package.)
- [x] Running an app with Accounts imported crashes systematically due to the Accounts package? Not reproduced.

Published on forums as well.
https://forums.meteor.com/t/meteor-3-typeerror-cannot-read-properties-of-undefined-reading-format/61390
