### PR TITLE
update to the latest version of terser

### DIFF
--- a/packages/minifier-js/package.js
+++ b/packages/minifier-js/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Npm.depends({
-  terser: "5.14.2"
+  terser: "5.31.0"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
We spent 3 hours to find that the terser version used in Meteor (5.14.2) has a bug that make minifying React generates a bug in "finally" part.

Upgrading to the latest version 5.31.0 of terser fix the problem.

We cloned the minify-js package locally so it's ok for us but please include this bump version in rc3

Here is the only diff (version bump)
https://github.com/acemtp/meteor/commit/63630ef40d52eaf69806e16d110d39cd4e6d784c