### PR TITLE
[3.x] Fix async OP behaviors on server (oauth packages)

### DIFF
--- a/packages/facebook-oauth/facebook-oauth_tests.js
+++ b/packages/facebook-oauth/facebook-oauth_tests.js
@@ -1,7 +1,7 @@
 Tinytest.addAsync(
   'facebook-oauth - run service oauth with mocked flow as expected',
   async function (test) {
-    const oauthMock = disableBehaviours(OAuth, {
+    const oauthMock = mockBehaviours(OAuth, {
       _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken' })}),
     });
 

--- a/packages/facebook-oauth/facebook-oauth_tests.js
+++ b/packages/facebook-oauth/facebook-oauth_tests.js
@@ -13,7 +13,7 @@ Tinytest.addAsync(
       const result = await OAuthTest.registeredServices[service].handleOauthRequest({});
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['_redirectUri','openSecret','_fetch','openSecret','_fetch'],
         'should run mock oauth behaviors',
       );
@@ -21,7 +21,7 @@ Tinytest.addAsync(
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
       Facebook.requestCredential({});
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],
         'should run mock oauth behaviors',
       );

--- a/packages/facebook-oauth/facebook-oauth_tests.js
+++ b/packages/facebook-oauth/facebook-oauth_tests.js
@@ -1,0 +1,33 @@
+Tinytest.addAsync(
+  'facebook-oauth - run service oauth with mocked flow as expected',
+  async function (test) {
+    const oauthMock = disableBehaviours(OAuth, {
+      _fetch: () => Promise.resolve({ json: () => ({})}),
+    });
+
+    const serviceMockConfig = { service: 'facebook' };
+    const mockConfig = { clientId: "test", secret: "test", loginStyle: "popup" };
+    if (Meteor.isServer) {
+      await ServiceConfiguration.configurations.upsertAsync(serviceMockConfig, { $set: mockConfig });
+      const result = await Facebook.handleAuthFromAccessToken('testToken');
+      test.isTrue(!!result?.serviceData, 'should return mocked result');
+      test.equal(
+        oauthMock.disabledRuns.map(({ name }) => name),
+        ['openSecret', '_fetch'],
+        'should run mock oauth behaviors',
+      );
+    } else if (Meteor.isClient) {
+      ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
+      Facebook.requestCredential({});
+      test.equal(
+        oauthMock.disabledRuns.map(({ name }) => name),
+        ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],
+        'should run mock oauth behaviors',
+      );
+    }
+
+    oauthMock.stop();
+
+    return Promise.resolve();
+  },
+);

--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -73,7 +73,7 @@ function getAbsoluteUrlOptions(query) {
  * @returns {Promise<UserAccessToken>} - Promise with an Object containing the accessToken and expiresIn (lifetime of token in seconds)
  */
 const getTokenResponse = async (query) => {
-  const config = ServiceConfiguration.configurations.findOne({
+  const config = await ServiceConfiguration.configurations.findOneAsync({
     service: 'facebook',
   });
   if (!config) throw new ServiceConfiguration.ConfigError();
@@ -117,7 +117,7 @@ const getTokenResponse = async (query) => {
 };
 
 const getIdentity = async (accessToken, fields) => {
-  const config = ServiceConfiguration.configurations.findOne({
+  const config = await ServiceConfiguration.configurations.findOneAsync({
     service: 'facebook',
   });
   if (!config) throw new ServiceConfiguration.ConfigError();
@@ -145,4 +145,3 @@ const getIdentity = async (accessToken, fields) => {
 
 Facebook.retrieveCredential = (credentialToken, credentialSecret) =>
   OAuth.retrieveCredential(credentialToken, credentialSecret);
-

--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -96,6 +96,7 @@ const getTokenResponse = async (query) => {
     .then((res) => res.json())
     .then(data => {
       const fbAccessToken = data.access_token;
+      console.log("-> fbAccessToken", fbAccessToken);
       const fbExpires = data.expires_in;
       if (!fbAccessToken) {
         throw new Error("Failed to complete OAuth handshake with facebook " +

--- a/packages/facebook-oauth/package.js
+++ b/packages/facebook-oauth/package.js
@@ -15,3 +15,9 @@ Package.onUse(api => {
 
   api.export('Facebook');
 });
+
+Package.onTest(function(api) {
+  api.use('facebook-oauth');
+  api.use(['tinytest', 'ecmascript', 'test-helpers', 'oauth', 'oauth2', 'service-configuration']);
+  api.addFiles('facebook-oauth_tests.js');
+});

--- a/packages/github-oauth/github-oauth_tests.js
+++ b/packages/github-oauth/github-oauth_tests.js
@@ -1,7 +1,7 @@
 Tinytest.addAsync(
   'github-oauth - run service oauth with mocked flow as expected',
   async function (test) {
-    const oauthMock = disableBehaviours(OAuth, {
+    const oauthMock = mockBehaviours(OAuth, {
       _fetch: () => Promise.resolve({ json: () => ([{ access_token: 'testToken', email: { primary: 'email' } }])}),
     });
 

--- a/packages/github-oauth/github-oauth_tests.js
+++ b/packages/github-oauth/github-oauth_tests.js
@@ -1,11 +1,11 @@
 Tinytest.addAsync(
-  'facebook-oauth - run service oauth with mocked flow as expected',
+  'github-oauth - run service oauth with mocked flow as expected',
   async function (test) {
     const oauthMock = disableBehaviours(OAuth, {
-      _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken' })}),
+      _fetch: () => Promise.resolve({ json: () => ([{ access_token: 'testToken', email: { primary: 'email' } }])}),
     });
 
-    const service = 'facebook';
+    const service = 'github';
     const serviceMockConfig = { service };
     const mockConfig = { clientId: "test", secret: "test", loginStyle: "popup" };
     if (Meteor.isServer) {
@@ -14,12 +14,12 @@ Tinytest.addAsync(
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
-        ['_redirectUri','openSecret','_fetch','openSecret','_fetch'],
+        ['_redirectUri','_fetch','_fetch','_fetch','sealSecret'],
         'should run mock oauth behaviors',
       );
     } else if (Meteor.isClient) {
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
-      Facebook.requestCredential({});
+      Github.requestCredential({});
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],

--- a/packages/github-oauth/github-oauth_tests.js
+++ b/packages/github-oauth/github-oauth_tests.js
@@ -13,7 +13,7 @@ Tinytest.addAsync(
       const result = await OAuthTest.registeredServices[service].handleOauthRequest({});
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['_redirectUri','_fetch','_fetch','_fetch','sealSecret'],
         'should run mock oauth behaviors',
       );
@@ -21,7 +21,7 @@ Tinytest.addAsync(
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
       Github.requestCredential({});
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],
         'should run mock oauth behaviors',
       );

--- a/packages/github-oauth/github_server.js
+++ b/packages/github-oauth/github_server.js
@@ -29,7 +29,7 @@ let userAgent = 'Meteor';
 if (Meteor.release) userAgent += `/${Meteor.release}`;
 
 const getAccessToken = async (query) => {
-  const config = ServiceConfiguration.configurations.findOne({
+  const config = await ServiceConfiguration.configurations.findOneAsync({
     service: 'github'
   });
   if (!config) throw new ServiceConfiguration.ConfigError();
@@ -45,7 +45,7 @@ const getAccessToken = async (query) => {
         config
       )
     });
-    const request = await fetch(
+    const request = await OAuth._fetch(
       `https://github.com/login/oauth/access_token?${content.toString()}`,
       {
         method: 'POST',
@@ -76,7 +76,7 @@ const getAccessToken = async (query) => {
 
 const getIdentity = async (accessToken) => {
   try {
-    const request = await fetch('https://api.github.com/user', {
+    const request = await OAuth._fetch('https://api.github.com/user', {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -95,7 +95,7 @@ const getIdentity = async (accessToken) => {
 
 const getEmails = async (accessToken) => {
   try {
-    const request = await fetch('https://api.github.com/user/emails', {
+    const request = await OAuth._fetch('https://api.github.com/user/emails', {
       method: 'GET',
       headers: {
         'User-Agent': userAgent,

--- a/packages/github-oauth/package.js
+++ b/packages/github-oauth/package.js
@@ -9,10 +9,17 @@ Package.onUse(api => {
   api.use('oauth', ['client', 'server']);
   api.use('fetch', 'server');
   api.use('random', 'client');
+  api.use('accounts-base', ['client', 'server']);
   api.use('service-configuration', ['client', 'server']);
 
   api.addFiles('github_client.js', 'client');
   api.addFiles('github_server.js', 'server');
 
   api.export('Github');
+});
+
+Package.onTest(function(api) {
+  api.use('github-oauth');
+  api.use(['tinytest', 'ecmascript', 'test-helpers', 'oauth', 'oauth2', 'service-configuration']);
+  api.addFiles('github-oauth_tests.js');
 });

--- a/packages/google-oauth/google-oauth_tests.js
+++ b/packages/google-oauth/google-oauth_tests.js
@@ -1,11 +1,11 @@
 Tinytest.addAsync(
-  'facebook-oauth - run service oauth with mocked flow as expected',
+  'google-oauth - run service oauth with mocked flow as expected',
   async function (test) {
     const oauthMock = disableBehaviours(OAuth, {
-      _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken' })}),
+      _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken', scope: '1 2 3' })}),
     });
 
-    const service = 'facebook';
+    const service = 'google';
     const serviceMockConfig = { service };
     const mockConfig = { clientId: "test", secret: "test", loginStyle: "popup" };
     if (Meteor.isServer) {
@@ -14,12 +14,12 @@ Tinytest.addAsync(
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
-        ['_redirectUri','openSecret','_fetch','openSecret','_fetch'],
+        ['openSecret','_redirectUri','_fetch','_fetch','_fetch'],
         'should run mock oauth behaviors',
       );
     } else if (Meteor.isClient) {
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
-      Facebook.requestCredential({});
+      Google.requestCredential({});
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],

--- a/packages/google-oauth/google-oauth_tests.js
+++ b/packages/google-oauth/google-oauth_tests.js
@@ -1,7 +1,7 @@
 Tinytest.addAsync(
   'google-oauth - run service oauth with mocked flow as expected',
   async function (test) {
-    const oauthMock = disableBehaviours(OAuth, {
+    const oauthMock = mockBehaviours(OAuth, {
       _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken', scope: '1 2 3' })}),
     });
 

--- a/packages/google-oauth/google-oauth_tests.js
+++ b/packages/google-oauth/google-oauth_tests.js
@@ -13,7 +13,7 @@ Tinytest.addAsync(
       const result = await OAuthTest.registeredServices[service].handleOauthRequest({});
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['openSecret','_redirectUri','_fetch','_fetch','_fetch'],
         'should run mock oauth behaviors',
       );
@@ -21,7 +21,7 @@ Tinytest.addAsync(
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
       Google.requestCredential({});
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],
         'should run mock oauth behaviors',
       );

--- a/packages/google-oauth/google_server.js
+++ b/packages/google-oauth/google_server.js
@@ -125,7 +125,7 @@ Accounts.registerLoginHandler(async (request) => {
 // - expiresIn: lifetime of token in seconds
 // - refreshToken, if this is the first authorization request
 const getTokens = async (query, callback) => {
-  const config = ServiceConfiguration.configurations.findOne({
+  const config = await ServiceConfiguration.configurations.findOneAsync({
     service: 'google',
   });
   if (!config) throw new ServiceConfiguration.ConfigError();
@@ -137,7 +137,7 @@ const getTokens = async (query, callback) => {
     redirect_uri: OAuth._redirectUri('google', config),
     grant_type: 'authorization_code',
   });
-  const request = await fetch('https://accounts.google.com/o/oauth2/token', {
+  const request = await OAuth._fetch('https://accounts.google.com/o/oauth2/token', {
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -174,7 +174,7 @@ const getIdentity = async (accessToken, callback) => {
   const content = new URLSearchParams({ access_token: accessToken });
   let response;
   try {
-    const request = await fetch(
+    const request = await OAuth._fetch(
       `https://www.googleapis.com/oauth2/v1/userinfo?${content.toString()}`,
       {
         method: 'GET',
@@ -194,7 +194,7 @@ const getScopes = async (accessToken, callback) => {
   const content = new URLSearchParams({ access_token: accessToken });
   let response;
   try {
-    const request = await fetch(
+    const request = await OAuth._fetch(
       `https://www.googleapis.com/oauth2/v1/tokeninfo?${content.toString()}`,
       {
         method: 'GET',

--- a/packages/google-oauth/package.js
+++ b/packages/google-oauth/package.js
@@ -23,3 +23,9 @@ Package.onUse(api => {
 
   api.export('Google');
 });
+
+Package.onTest(function(api) {
+  api.use('google-oauth');
+  api.use(['tinytest', 'ecmascript', 'test-helpers', 'oauth', 'oauth2', 'service-configuration']);
+  api.addFiles('google-oauth_tests.js');
+});

--- a/packages/meetup-oauth/meetup-oauth_tests.js
+++ b/packages/meetup-oauth/meetup-oauth_tests.js
@@ -13,7 +13,7 @@ Tinytest.addAsync(
       const result = await OAuthTest.registeredServices[service].handleOauthRequest({});
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['openSecret','_redirectUri','_addValuesToQueryParams','_fetch','_addValuesToQueryParams','_fetch'],
         'should run mock oauth behaviors',
       );
@@ -21,7 +21,7 @@ Tinytest.addAsync(
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
       Meetup.requestCredential({});
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],
         'should run mock oauth behaviors',
       );

--- a/packages/meetup-oauth/meetup-oauth_tests.js
+++ b/packages/meetup-oauth/meetup-oauth_tests.js
@@ -1,11 +1,11 @@
 Tinytest.addAsync(
-  'facebook-oauth - run service oauth with mocked flow as expected',
+  'meetup-oauth - run service oauth with mocked flow as expected',
   async function (test) {
     const oauthMock = disableBehaviours(OAuth, {
       _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken' })}),
     });
 
-    const service = 'facebook';
+    const service = 'meetup';
     const serviceMockConfig = { service };
     const mockConfig = { clientId: "test", secret: "test", loginStyle: "popup" };
     if (Meteor.isServer) {
@@ -14,12 +14,12 @@ Tinytest.addAsync(
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
-        ['_redirectUri','openSecret','_fetch','openSecret','_fetch'],
+        ['openSecret','_redirectUri','_addValuesToQueryParams','_fetch','_addValuesToQueryParams','_fetch'],
         'should run mock oauth behaviors',
       );
     } else if (Meteor.isClient) {
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
-      Facebook.requestCredential({});
+      Meetup.requestCredential({});
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],

--- a/packages/meetup-oauth/meetup-oauth_tests.js
+++ b/packages/meetup-oauth/meetup-oauth_tests.js
@@ -1,7 +1,7 @@
 Tinytest.addAsync(
   'meetup-oauth - run service oauth with mocked flow as expected',
   async function (test) {
-    const oauthMock = disableBehaviours(OAuth, {
+    const oauthMock = mockBehaviours(OAuth, {
       _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken' })}),
     });
 

--- a/packages/meetup-oauth/meetup_server.js
+++ b/packages/meetup-oauth/meetup_server.js
@@ -34,7 +34,7 @@ OAuth.registerService('meetup', 2, null, async query => {
 });
 
 const getAccessToken = async query => {
-  const config = ServiceConfiguration.configurations.findOne({service: 'meetup'});
+  const config = await ServiceConfiguration.configurations.findOneAsync({service: 'meetup'});
   if (!config)
     throw new ServiceConfiguration.ConfigError();
 

--- a/packages/meetup-oauth/package.js
+++ b/packages/meetup-oauth/package.js
@@ -15,3 +15,9 @@ Package.onUse(api => {
 
   api.export('Meetup');
 });
+
+Package.onTest(function(api) {
+  api.use('meetup-oauth');
+  api.use(['tinytest', 'ecmascript', 'test-helpers', 'oauth', 'oauth2', 'service-configuration']);
+  api.addFiles('meetup-oauth_tests.js');
+});

--- a/packages/meteor-developer-oauth/meteor-developer-oauth_tests.js
+++ b/packages/meteor-developer-oauth/meteor-developer-oauth_tests.js
@@ -1,7 +1,7 @@
 Tinytest.addAsync(
   'meteor-developer-oauth - run service oauth with mocked flow as expected',
   async function (test) {
-    const oauthMock = disableBehaviours(OAuth, {
+    const oauthMock = mockBehaviours(OAuth, {
       _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken' })}),
     });
 

--- a/packages/meteor-developer-oauth/meteor-developer-oauth_tests.js
+++ b/packages/meteor-developer-oauth/meteor-developer-oauth_tests.js
@@ -1,11 +1,11 @@
 Tinytest.addAsync(
-  'facebook-oauth - run service oauth with mocked flow as expected',
+  'meteor-developer-oauth - run service oauth with mocked flow as expected',
   async function (test) {
     const oauthMock = disableBehaviours(OAuth, {
       _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken' })}),
     });
 
-    const service = 'facebook';
+    const service = 'meteor-developer';
     const serviceMockConfig = { service };
     const mockConfig = { clientId: "test", secret: "test", loginStyle: "popup" };
     if (Meteor.isServer) {
@@ -14,15 +14,15 @@ Tinytest.addAsync(
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
-        ['_redirectUri','openSecret','_fetch','openSecret','_fetch'],
+        ['openSecret','_redirectUri','_addValuesToQueryParams','_fetch','_fetch','sealSecret'],
         'should run mock oauth behaviors',
       );
     } else if (Meteor.isClient) {
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
-      Facebook.requestCredential({});
+      MeteorDeveloperAccounts.requestCredential({});
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
-        ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],
+        ['_loginStyle','_stateParam','_redirectUri','launchLogin'],
         'should run mock oauth behaviors',
       );
     }

--- a/packages/meteor-developer-oauth/meteor-developer-oauth_tests.js
+++ b/packages/meteor-developer-oauth/meteor-developer-oauth_tests.js
@@ -13,7 +13,7 @@ Tinytest.addAsync(
       const result = await OAuthTest.registeredServices[service].handleOauthRequest({});
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['openSecret','_redirectUri','_addValuesToQueryParams','_fetch','_fetch','sealSecret'],
         'should run mock oauth behaviors',
       );
@@ -21,7 +21,7 @@ Tinytest.addAsync(
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
       MeteorDeveloperAccounts.requestCredential({});
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['_loginStyle','_stateParam','_redirectUri','launchLogin'],
         'should run mock oauth behaviors',
       );

--- a/packages/meteor-developer-oauth/package.js
+++ b/packages/meteor-developer-oauth/package.js
@@ -15,3 +15,9 @@ Package.onUse(api => {
 
   api.export('MeteorDeveloperAccounts');
 });
+
+Package.onTest(function(api) {
+  api.use('meteor-developer-oauth');
+  api.use(['tinytest', 'ecmascript', 'test-helpers', 'oauth', 'oauth2', 'service-configuration']);
+  api.addFiles('meteor-developer-oauth_tests.js');
+});

--- a/packages/mongo/mongo_livedata_tests.js
+++ b/packages/mongo/mongo_livedata_tests.js
@@ -4342,14 +4342,11 @@ testAsyncMulti(
       test.equal(itemIds, ['a']); // temporary data accessible
 
       if (Meteor.isClient) {
-        return new Promise(resolve => {
-          Meteor.setTimeout(async () => {
-            items = await Collection.find().fetchAsync();
-            itemIds = items.map(_item => _item._id);
-            test.equal(itemIds, []); // data IS NOT persisted
-            resolve();
-          }, 1500);
-        });
+        return waitUntil(async () => {
+          items = await Collection.find().fetchAsync();
+          itemIds = items.map(_item => _item._id);
+          return itemIds?.length === []?.length; // data IS NOT persisted
+        }, { description: 'data IS NOT persisted'});
       }
 
       return Promise.resolve();
@@ -4384,14 +4381,11 @@ testAsyncMulti(
       test.equal(itemIds, ['a']); // temporary data accessible
 
       if (Meteor.isClient) {
-        return new Promise(resolve => {
-          Meteor.setTimeout(async () => {
-            items = await Collection.find().fetchAsync();
-            itemIds = items.map(_item => _item._id);
-            test.equal(itemIds, ['a']); // data is persisted
-            resolve();
-          }, 1500);
-        });
+        return waitUntil(async () => {
+          items = await Collection.find().fetchAsync();
+          itemIds = items.map(_item => _item._id);
+          return itemIds?.length === 1 && itemIds[0] === 'a'; // data is persisted
+        }, { description: 'data is persisted'});
       }
 
       return Promise.resolve();
@@ -4443,14 +4437,11 @@ testAsyncMulti(
           await promise.serverPromise;
         } catch (e) {
           // error as no insert method enabled on server
-          return new Promise(resolve => {
-            Meteor.setTimeout(async () => {
-              items = await Collection.find().fetchAsync();
-              itemIds = items.map(_item => _item._id);
-              test.equal(itemIds, []); // data IS NOT persisted
-              resolve();
-            }, 1500);
-          });
+          return waitUntil(async () => {
+            items = await Collection.find().fetchAsync();
+            itemIds = items.map(_item => _item._id);
+            return itemIds?.length === []?.length ; // data IS NOT persisted
+          }, { description: 'data IS NOT persisted'});
         }
       } else {
         return Promise.resolve();

--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -211,6 +211,8 @@ WebApp.handlers.use(middleware);
 
 OAuthTest.middleware = middleware;
 
+OAuthTest.registeredServices = registeredServices;
+
 // Handle /_oauth/* paths and extract the service name.
 //
 // @returns {String|null} e.g. "facebook", or null if this isn't an

--- a/packages/test-helpers/async_multi.js
+++ b/packages/test-helpers/async_multi.js
@@ -220,3 +220,37 @@ runAndThrowIfNeeded = async (fn, test, shouldErrorOut) => {
 
   return result;
 };
+
+disableBehaviours = function (obj, mockBehaviors = {}) {
+  const originalFunctions = {};
+  const disabledRuns = [];
+
+  // Store original functions
+  for (const key in obj) {
+    if (typeof obj[key] === 'function') {
+      originalFunctions[key] = obj[key];
+    }
+  }
+
+  // Mutate functions to identity functions
+  for (const key in obj) {
+    if (typeof obj[key] === 'function') {
+      obj[key] = function(...params) {
+        disabledRuns.push({ name: key, params });
+        if (typeof mockBehaviors?.[key] === 'function') {
+          return mockBehaviors[key](...params);
+        }
+        return params?.[0];
+      };
+    }
+  }
+
+  // Method to revert the mutation
+  const stop = function() {
+    for (const key in originalFunctions) {
+      obj[key] = originalFunctions[key];
+    }
+  };
+
+  return { stop, disabledRuns };
+};

--- a/packages/test-helpers/async_multi.js
+++ b/packages/test-helpers/async_multi.js
@@ -220,37 +220,3 @@ runAndThrowIfNeeded = async (fn, test, shouldErrorOut) => {
 
   return result;
 };
-
-disableBehaviours = function (obj, mockBehaviors = {}) {
-  const originalFunctions = {};
-  const disabledRuns = [];
-
-  // Store original functions
-  for (const key in obj) {
-    if (typeof obj[key] === 'function') {
-      originalFunctions[key] = obj[key];
-    }
-  }
-
-  // Mutate functions to identity functions
-  for (const key in obj) {
-    if (typeof obj[key] === 'function') {
-      obj[key] = function(...params) {
-        disabledRuns.push({ name: key, params });
-        if (typeof mockBehaviors?.[key] === 'function') {
-          return mockBehaviors[key](...params);
-        }
-        return params?.[0];
-      };
-    }
-  }
-
-  // Method to revert the mutation
-  const stop = function() {
-    for (const key in originalFunctions) {
-      obj[key] = originalFunctions[key];
-    }
-  };
-
-  return { stop, disabledRuns };
-};

--- a/packages/test-helpers/mock.js
+++ b/packages/test-helpers/mock.js
@@ -1,4 +1,4 @@
-disableBehaviours = function _disableBehaviours(obj, mockBehaviors = {}) {
+mockBehaviours = function _mockBehaviours(obj, mockBehaviors = {}) {
   const originalFunctions = {};
   const disabledRuns = [];
 

--- a/packages/test-helpers/mock.js
+++ b/packages/test-helpers/mock.js
@@ -1,6 +1,6 @@
 mockBehaviours = function _mockBehaviours(obj, mockBehaviors = {}) {
   const originalFunctions = {};
-  const disabledRuns = [];
+  const mockedRuns = [];
 
   // Store original functions
   for (const key in obj) {
@@ -13,7 +13,7 @@ mockBehaviours = function _mockBehaviours(obj, mockBehaviors = {}) {
   for (const key in obj) {
     if (typeof obj[key] === 'function') {
       obj[key] = function(...params) {
-        disabledRuns.push({ name: key, params });
+        mockedRuns.push({ name: key, params });
         if (typeof mockBehaviors?.[key] === 'function') {
           return mockBehaviors[key](...params);
         }
@@ -29,5 +29,5 @@ mockBehaviours = function _mockBehaviours(obj, mockBehaviors = {}) {
     }
   };
 
-  return { stop, disabledRuns };
+  return { stop, mockedRuns };
 };

--- a/packages/test-helpers/mock.js
+++ b/packages/test-helpers/mock.js
@@ -1,0 +1,33 @@
+disableBehaviours = function _disableBehaviours(obj, mockBehaviors = {}) {
+  const originalFunctions = {};
+  const disabledRuns = [];
+
+  // Store original functions
+  for (const key in obj) {
+    if (typeof obj[key] === 'function') {
+      originalFunctions[key] = obj[key];
+    }
+  }
+
+  // Mutate functions to identity functions
+  for (const key in obj) {
+    if (typeof obj[key] === 'function') {
+      obj[key] = function(...params) {
+        disabledRuns.push({ name: key, params });
+        if (typeof mockBehaviors?.[key] === 'function') {
+          return mockBehaviors[key](...params);
+        }
+        return params?.[0];
+      };
+    }
+  }
+
+  // Method to revert the mutation
+  const stop = function() {
+    for (const key in originalFunctions) {
+      obj[key] = originalFunctions[key];
+    }
+  };
+
+  return { stop, disabledRuns };
+};

--- a/packages/test-helpers/package.js
+++ b/packages/test-helpers/package.js
@@ -30,7 +30,7 @@ Package.onUse(function (api) {
     'renderToDiv', 'clickIt',
     'withCallbackLogger', 'testAsyncMulti',
     'simplePoll', 'runAndThrowIfNeeded',
-    'makeTestConnection', 'DomUtils', 'disableBehaviours']);
+    'makeTestConnection', 'DomUtils', 'disableBehaviours', 'waitUntil']);
 
   api.addFiles('try_all_permutations.js');
   api.addFiles('async_multi.js');
@@ -40,6 +40,8 @@ Package.onUse(function (api) {
   api.addFiles('render_div.js');
   api.addFiles('current_style.js');
   api.addFiles('callback_logger.js');
+  api.addFiles('mock.js');
+  api.addFiles('wait.js');
   api.addFiles('domutils.js', 'client');
   api.addFiles('connection.js', 'server');
 });

--- a/packages/test-helpers/package.js
+++ b/packages/test-helpers/package.js
@@ -30,7 +30,7 @@ Package.onUse(function (api) {
     'renderToDiv', 'clickIt',
     'withCallbackLogger', 'testAsyncMulti',
     'simplePoll', 'runAndThrowIfNeeded',
-    'makeTestConnection', 'DomUtils', 'disableBehaviours', 'waitUntil']);
+    'makeTestConnection', 'DomUtils', 'mockBehaviours', 'waitUntil']);
 
   api.addFiles('try_all_permutations.js');
   api.addFiles('async_multi.js');

--- a/packages/test-helpers/package.js
+++ b/packages/test-helpers/package.js
@@ -30,7 +30,7 @@ Package.onUse(function (api) {
     'renderToDiv', 'clickIt',
     'withCallbackLogger', 'testAsyncMulti',
     'simplePoll', 'runAndThrowIfNeeded',
-    'makeTestConnection', 'DomUtils']);
+    'makeTestConnection', 'DomUtils', 'disableBehaviours']);
 
   api.addFiles('try_all_permutations.js');
   api.addFiles('async_multi.js');

--- a/packages/test-helpers/wait.js
+++ b/packages/test-helpers/wait.js
@@ -4,7 +4,6 @@ function isPromise(obj) {
 
 waitUntil = function _waitUntil(checkFunction, { timeout = 15_000, interval = 200, leading = false, description = '' } = {}) {
   let waitTime = interval;
-  console.log("-> waitTime", waitTime);
   return new Promise((resolve, reject) => {
     if (leading && checkFunction()) {
       resolve();

--- a/packages/test-helpers/wait.js
+++ b/packages/test-helpers/wait.js
@@ -1,0 +1,50 @@
+function isPromise(obj) {
+  return obj && typeof obj.then === 'function';
+}
+
+waitUntil = function _waitUntil(checkFunction, { timeout = 15_000, interval = 200, leading = false, description = '' } = {}) {
+  let waitTime = interval;
+  console.log("-> waitTime", waitTime);
+  return new Promise((resolve, reject) => {
+    if (leading && checkFunction()) {
+      resolve();
+      return;
+    }
+    const handler = setInterval(() => {
+      const shouldWait = checkFunction();
+      if (isPromise(shouldWait)) {
+        shouldWait
+          .then(_shouldWait => {
+            if (_shouldWait) {
+              resolve();
+              clearInterval(handler);
+              return;
+            }
+
+            if (waitTime > timeout) {
+              console.error(description, 'timed out');
+              reject();
+              clearInterval(handler);
+            }
+
+            waitTime += interval;
+          })
+          .catch((_error) => {
+            console.error(description, _error?.message);
+            reject();
+            clearInterval(handler);
+          });
+      } else if (shouldWait) {
+        resolve();
+        clearInterval(handler);
+      } else {
+        if (waitTime > timeout) {
+          console.error(description, 'timed out');
+          reject();
+          clearInterval(handler);
+        }
+        waitTime += interval;
+      }
+    }, interval);
+  });
+};

--- a/packages/weibo-oauth/package.js
+++ b/packages/weibo-oauth/package.js
@@ -14,3 +14,9 @@ Package.onUse(api => {
 
   api.export('Weibo');
 });
+
+Package.onTest(function(api) {
+  api.use('weibo-oauth');
+  api.use(['tinytest', 'ecmascript', 'test-helpers', 'oauth', 'oauth2', 'service-configuration']);
+  api.addFiles('weibo-oauth_tests.js');
+});

--- a/packages/weibo-oauth/weibo-oauth_tests.js
+++ b/packages/weibo-oauth/weibo-oauth_tests.js
@@ -1,7 +1,7 @@
 Tinytest.addAsync(
   'weibo-oauth - run service oauth with mocked flow as expected',
   async function (test) {
-    const oauthMock = disableBehaviours(OAuth, {
+    const oauthMock = mockBehaviours(OAuth, {
       _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken', uid: '12345' })}),
     });
 

--- a/packages/weibo-oauth/weibo-oauth_tests.js
+++ b/packages/weibo-oauth/weibo-oauth_tests.js
@@ -13,7 +13,7 @@ Tinytest.addAsync(
       const result = await OAuthTest.registeredServices[service].handleOauthRequest({});
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['openSecret','_redirectUri','_fetch','_fetch'],
         'should run mock oauth behaviors',
       );
@@ -21,7 +21,7 @@ Tinytest.addAsync(
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
       Weibo.requestCredential({});
       test.equal(
-        oauthMock.disabledRuns.map(({ name }) => name),
+        oauthMock.mockedRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],
         'should run mock oauth behaviors',
       );

--- a/packages/weibo-oauth/weibo-oauth_tests.js
+++ b/packages/weibo-oauth/weibo-oauth_tests.js
@@ -1,11 +1,11 @@
 Tinytest.addAsync(
-  'facebook-oauth - run service oauth with mocked flow as expected',
+  'weibo-oauth - run service oauth with mocked flow as expected',
   async function (test) {
     const oauthMock = disableBehaviours(OAuth, {
-      _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken' })}),
+      _fetch: () => Promise.resolve({ json: () => ({ access_token: 'testToken', uid: '12345' })}),
     });
 
-    const service = 'facebook';
+    const service = 'weibo';
     const serviceMockConfig = { service };
     const mockConfig = { clientId: "test", secret: "test", loginStyle: "popup" };
     if (Meteor.isServer) {
@@ -14,12 +14,12 @@ Tinytest.addAsync(
       test.isTrue(!!result?.serviceData, 'should return mocked result');
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
-        ['_redirectUri','openSecret','_fetch','openSecret','_fetch'],
+        ['openSecret','_redirectUri','_fetch','_fetch'],
         'should run mock oauth behaviors',
       );
     } else if (Meteor.isClient) {
       ServiceConfiguration.configurations.insert({ ...serviceMockConfig, ...mockConfig });
-      Facebook.requestCredential({});
+      Weibo.requestCredential({});
       test.equal(
         oauthMock.disabledRuns.map(({ name }) => name),
         ['_loginStyle', '_redirectUri', '_stateParam', 'launchLogin'],

--- a/packages/weibo-oauth/weibo_server.js
+++ b/packages/weibo-oauth/weibo_server.js
@@ -32,7 +32,7 @@ OAuth.registerService('weibo', 2, null, async query => {
 // - access_token
 // - expires_in: lifetime of this token in seconds (5 years(!) right now)
 const getTokenResponse = async (query) => {
-  const config = ServiceConfiguration.configurations.findOne({
+  const config = await ServiceConfiguration.configurations.findOneAsync({
     service: 'weibo',
   });
   if (!config) throw new ServiceConfiguration.ConfigError();


### PR DESCRIPTION
OSS-411

## Issue

Context: https://forums.meteor.com/t/meteor-3-0-rc-0-is-out/61515/28

In some parts of the code, `findOne` is still being utilized sync on Meteor 3.x, resulting in errors asking for migration, such as: `Error: findOne + is not available on the server. Please use findOneAsync() instead`.

## Fix

Review all occurrences of `findOne` and other operations needing asynchronous migration on Meteor 3.x packages. Additionally, I'll supply a few regression tests to ensure coverage of the affected flow, enabling us to detect any missing adaptions in the future through test failures.

The regression test triggering properly the requirement of this migration as showed in the next example:

![image](https://github.com/meteor/meteor/assets/2581993/cdefd569-32df-407e-a8ae-92e0b3aa0f0e)

## New test helpers

I've added two new test helpers:

- `mockBehaviours`: This acts as a mock to halt the run on an entire module. Useful for testing specific flows while ignoring unwanted side-effects.

- `waitUntil`: Prevents flakiness by awaiting a test assert with a timeout. It continuously checks for the condition and exits early upon its occurrence. This approach is more effective in overcoming flakiness.
