### PR TITLE
Fix for old API usage

### DIFF
--- a/packages/google-oauth/google_server.js
+++ b/packages/google-oauth/google_server.js
@@ -125,7 +125,7 @@ Accounts.registerLoginHandler(async (request) => {
 // - expiresIn: lifetime of token in seconds
 // - refreshToken, if this is the first authorization request
 const getTokens = async (query, callback) => {
-  const config = ServiceConfiguration.configurations.findOne({
+  const config = await ServiceConfiguration.configurations.findOneAsync({
     service: 'google',
   });
   if (!config) throw new ServiceConfiguration.ConfigError();


### PR DESCRIPTION
Fixes "Error in OAuth Server: findOne + is not available on the server. Please use findOneAsync() instead."

The error stems from `google_server.js` still using the sync Mongo API at `ServiceConfiguration.configurations.findOne(...)`.
