### PR TITLE
[3.x] Fix error log create cmd

### DIFF
--- a/packages/test-helpers/wait.js
+++ b/packages/test-helpers/wait.js
@@ -2,7 +2,7 @@ function isPromise(obj) {
   return obj && typeof obj.then === 'function';
 }
 
-waitUntil = function _waitUntil(checkFunction, { timeout = 15_000, interval = 200, leading = false, description = '' } = {}) {
+waitUntil = function _waitUntil(checkFunction, { timeout = 15_000, interval = 200, leading = true, description = '' } = {}) {
   let waitTime = interval;
   return new Promise((resolve, reject) => {
     if (leading && checkFunction()) {

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1143,7 +1143,7 @@ main.registerCommand({
   } catch (e) {
 
     if (
-      e.message !== "Using prototype option" ||
+      e.message !== "Using prototype option" &&
       e.message !== "Using release option"
     ) {
       // something has happened while creating the app using git clone


### PR DESCRIPTION
OSS-409

## Issue

Context: https://github.com/meteor/meteor/issues/13106

Several developers reported issues with failures when using Meteor create. I followed further research into the issue.

Initially, I thought it was caused by the new machinery [introduced in this PR](https://github.com/meteor/meteor/pull/12697) to prepare the template projects fetching from github using `git clone` command.

The reported errors, such as "Will use cached version of skeletons" and "Something has happened while creating your app using git clone", [correspond to a specific part of the code](https://github.com/meteor/meteor/blob/release-3.0/tools/cli/commands.js#L1134-L1156).. However, it turns out that these errors occur consistently when the --release option is used, with the message "Error message: Using release option" always present. This error is unrelated to network connectivity and is, in fact, a false alarm.

In the following image, you can see how the false error appears, yet the meteor create command continues to execute, fetching packages remotely to set up your new app. The errors manifest afterwards this.

![image](https://github.com/meteor/meteor/assets/2581993/e47d7f6c-5f5e-42aa-92ac-cfade66fc073)

Occasionally, this process triggers timeouts for developers with unstable internet connections, leading to errors like `ECONNRESET` and `ENETUNREACH`, typically corresponding of client-side issues. However, we will pay more attention, we can't confirm 100% that is not a problem in Meteor side, but we need clear reproduction steps to follow. 

As part of this pull request we have indeed fixed the false error.