### PR TITLE
fix: oauth_.fetch invocation on github_server and google_server

### DIFF
--- a/packages/github-oauth/github_server.js
+++ b/packages/github-oauth/github_server.js
@@ -47,8 +47,8 @@ const getAccessToken = async (query) => {
     });
     const request = await OAuth._fetch(
       `https://github.com/login/oauth/access_token?${content.toString()}`,
+      'POST',
       {
-        method: 'POST',
         headers: {
           Accept: 'application/json',
           'User-Agent': userAgent
@@ -76,8 +76,7 @@ const getAccessToken = async (query) => {
 
 const getIdentity = async (accessToken) => {
   try {
-    const request = await OAuth._fetch('https://api.github.com/user', {
-      method: 'GET',
+    const request = await OAuth._fetch('https://api.github.com/user', 'GET', {
       headers: {
         Accept: 'application/json',
         'User-Agent': userAgent,
@@ -95,8 +94,7 @@ const getIdentity = async (accessToken) => {
 
 const getEmails = async (accessToken) => {
   try {
-    const request = await OAuth._fetch('https://api.github.com/user/emails', {
-      method: 'GET',
+    const request = await OAuth._fetch('https://api.github.com/user/emails', 'GET', {
       headers: {
         'User-Agent': userAgent,
         Accept: 'application/json',

--- a/packages/google-oauth/google_server.js
+++ b/packages/google-oauth/google_server.js
@@ -137,8 +137,7 @@ const getTokens = async (query, callback) => {
     redirect_uri: OAuth._redirectUri('google', config),
     grant_type: 'authorization_code',
   });
-  const request = await OAuth._fetch('https://accounts.google.com/o/oauth2/token', {
-    method: 'POST',
+  const request = await OAuth._fetch('https://accounts.google.com/o/oauth2/token', 'POST', {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -176,8 +175,8 @@ const getIdentity = async (accessToken, callback) => {
   try {
     const request = await OAuth._fetch(
       `https://www.googleapis.com/oauth2/v1/userinfo?${content.toString()}`,
+      'GET',
       {
-        method: 'GET',
         headers: { Accept: 'application/json' },
       }
     );
@@ -196,8 +195,8 @@ const getScopes = async (accessToken, callback) => {
   try {
     const request = await OAuth._fetch(
       `https://www.googleapis.com/oauth2/v1/tokeninfo?${content.toString()}`,
+      'GET',
       {
-        method: 'GET',
         headers: { Accept: 'application/json' },
       }
     );


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

### Description

This PR fixes the invocation of the OAuth._fetch() method on the `github_server` and `google_server` of their oauth.
This fix is explained in more details on the Additional Notes of the Issue #13152.

I've set the base of the Pull Request as `release-3.0` since the `devel` branch seems to not be fully updated with the code on `release-3.0` (on the `devel` branch, this implementation was still using Fetch API and `findOne` invocations.)
