### PR TITLE
Fix assets method names

### DIFF
--- a/packages/oauth/oauth_server.js
+++ b/packages/oauth/oauth_server.js
@@ -291,7 +291,7 @@ OAuth._renderOauthResults = async (res, query, credentialSecret) => {
 };
 
 const getAsset = (name) => {
-  return new Promise((resolve, reject) => Assets.getText(
+  return new Promise((resolve, reject) => Assets.getTextAsync(
     `${name}.html`,
     (err, data) => err ? reject(err) : resolve(data)))
 }

--- a/packages/reload-safetybelt/reload-safety-belt-tests.js
+++ b/packages/reload-safetybelt/reload-safety-belt-tests.js
@@ -1,5 +1,5 @@
 await (async () => {
-  var script = await Assets.getText("safetybelt.js");
+  var script = await Assets.getTextAsync("safetybelt.js");
 
   Tinytest.add("reload-safetybelt - safety belt is added", function (test) {
     test.isTrue(

--- a/packages/reload-safetybelt/reload-safety-belt.js
+++ b/packages/reload-safetybelt/reload-safety-belt.js
@@ -4,5 +4,5 @@
 // CSS.  This prevents you from displaying the page in that case, and instead
 // reloads it, presumably all on the new version now.
 await (async () => {
-  WebAppInternals.addStaticJs(await Assets.getText("safetybelt.js"));
+  WebAppInternals.addStaticJs(await Assets.getTextAsync("safetybelt.js"));
 })();

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -354,10 +354,10 @@ const loadServerBundles = Profile("Load server bundles", async function () {
     };
 
     const Assets = {
-      getText: function (assetPath, callback) {
+      getTextAsync: function (assetPath, callback) {
         return getAsset(assetPath, "utf8", callback);
       },
-      getBinary: function (assetPath, callback) {
+      getBinaryAsync: function (assetPath, callback) {
         return getAsset(assetPath, undefined, callback);
       },
       /**

--- a/tools/tests/apps/compiler-plugin-add-asset/use-asset.js
+++ b/tools/tests/apps/compiler-plugin-add-asset/use-asset.js
@@ -1,3 +1,3 @@
 (async () => {
-  console.log("Asset says", await Assets.getText("foo.printme"));
+  console.log("Asset says", await Assets.getTextAsync("foo.printme"));
 })();

--- a/tools/tests/apps/compiler-plugin-asset-and-source/packages/asset-and-source/asset-and-source.js
+++ b/tools/tests/apps/compiler-plugin-asset-and-source/packages/asset-and-source/asset-and-source.js
@@ -1,6 +1,6 @@
 if (Meteor.isServer) {
   // Printing out my own source code!
   (async () => {
-    console.log(await Assets.getText("asset-and-source.js"));
+    console.log(await Assets.getTextAsync("asset-and-source.js"));
   })();
 }

--- a/tools/tests/apps/unicode-asset-app/index.js
+++ b/tools/tests/apps/unicode-asset-app/index.js
@@ -13,7 +13,7 @@
 
     let index = 0;
     for (const filename of filenames) {
-      console.log(`${++index} - getText: ${await Assets.getText(filename)}`);
+      console.log(`${++index} - getText: ${await Assets.getTextAsync(filename)}`);
     }
 
     filenames.forEach((filename, index) => {


### PR DESCRIPTION
In the [docs](https://v3-docs.meteor.com/api/assets.html#assets) we mentioned that now, `getText` is called `getTextAsync`, and `getBinary` is `getBinaryAsync`.

But that was true only for the [build plugin assets methods](https://github.com/meteor/meteor/blob/31d1f28eef82720c3649bc1bab3b7cb8f2e58090/tools/isobuild/bundler.js#L2245-L2258). The ones in for the app files were not updated.

This PR now creates these methods to be concise with the docs as well.

This issue was reported in our [Forums](https://forums.meteor.com/t/assets-gettextasync-is-not-a-function/61622).

<!--OSS-427-->