### PR TITLE
Fix WebApp.addRuntimeConfigHook

### DIFF
--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -354,9 +354,7 @@ Tinytest.addAsync(
         ...WebApp.decodeRuntimeConfig(config.encodedCurrentConfig),
         customKey: 'customValue',
       };
-      return JSON.stringify(
-        encodeURIComponent(JSON.stringify(nextConfig))
-      );
+      return WebApp.encodeRuntimeConfig(nextConfig);
     });
 
     const req = new http.IncomingMessage();
@@ -364,7 +362,6 @@ Tinytest.addAsync(
     req.browser = { name: 'headless' };
     const boilerplate = await WebAppInternals.getBoilerplate(req, 'web.browser');
     const html = await streamToString(boilerplate.stream);
-    console.log("-> html", html);
     test.isTrue(/__meteor_runtime_config__ = (.*customKey[^"].*customValue.*)/.test(html));
   }
 );


### PR DESCRIPTION
<!---OSS-401--->

## Issue

This issue was reported and reproduced https://github.com/meteor/meteor/issues/13101 and https://github.com/meteor/meteor/issues/12939.

## Fix

The provided fix is to make `WebApp.addRuntimeConfigHook` async compatible.

The callbacks provided to this function [describe hooks](https://github.com/meteor/meteor/blob/devel/packages/webapp/webapp_server.js#L357) and [these wraps async by default](https://github.com/meteor/meteor/blob/devel/packages/callback-hook/hook.js#L82). This is a behavior we must to keep to offer flexibility on use configurable async flows.

- [x] Provide a regression test to cover  `addRuntimeConfigHook` use case

I served from [this doc](https://v3-docs.meteor.com/packages/webapp.html#dynamic-runtime-configuration) to understand how to use  `addRuntimeConfigHook` and provide the missing test scenario.