### PR TITLE
Implement reset db option and default without cleaning db

### DIFF
--- a/guide/source/3.0-migration.md
+++ b/guide/source/3.0-migration.md
@@ -137,7 +137,7 @@ You can update your Meteor 2.x project by running the command below inside your 
 
 ```bash
 meteor update --release 3.0-rc.2
-meteor reset #resets local DB and project to a fresh state
+meteor reset #resets project to a fresh state
 ```
 
 ### When will Meteor 3.0 be ready?

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1769,11 +1769,11 @@ main.registerCommand({
       return 1;
     }
 
-    return files.rm_recursive_async(
+    await files.rm_recursive_async(
       files.pathJoin(options.appDir, '.meteor', 'local')
-    ).then(() => {
-      Console.info("Project reset.");
-    });
+    );
+    Console.info("Project reset.");
+    return;
   }
 
   var allExceptDb = files.getPathsInDir(files.pathJoin('.meteor', 'local'), {
@@ -1786,11 +1786,8 @@ main.registerCommand({
   var allRemovePromises = allExceptDb.map(_path => files.rm_recursive_async(
     files.pathJoin(options.appDir, _path)
   ));
-  console.log("-> allRemovePromises", allRemovePromises);
-
-  Promise.all(allRemovePromises).then(() => {
-    Console.info("Project reset.");
-  });
+  await Promise.all(allRemovePromises);
+  Console.info("Project reset.");
 });
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1738,7 +1738,11 @@ main.registerCommand({
   catalogRefresh: new catalog.Refresh.Never()
 }, async function (options) {
   if (options.args.length !== 0) {
-    Console.error("meteor reset might delete the local database using the --db option.");
+    Console.error("'meteor reset' command only affects the local project cache.");
+    Console.error();
+    Console.error("To remove also the local database use");
+    Console.error(
+      Console.command("meteor reset --db"), Console.options({ indent: 2 }));
     Console.error();
     Console.error("To reset a deployed application use");
     Console.error(

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -503,7 +503,7 @@ project directory, and the Meteor application must already be running.
 Reset the project state.
 Usage: meteor reset [--db]
 
-Reset the current project to a fresh state and clears the local cache.
+Reset the current project to a fresh state and clear the local cache.
 
 The --db flag also removes the local database.
 

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -500,11 +500,12 @@ development database. The current working directory must be a Meteor
 project directory, and the Meteor application must already be running.
 
 >>> reset
-Reset the project state. Erases the local database.
-Usage: meteor reset
+Reset the project state.
+Usage: meteor reset [--db]
 
-Reset the current project to a fresh state. Removes all local data.
+Reset the current project to a fresh state and clears the local cache.
 
+The --db flag also removes the local database.
 
 >>> deploy
 Deploy this project to Galaxy, Meteor's hosting service.

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -600,6 +600,7 @@ Profile("files.symlinkWithOverwrite", async function symlinkWithOverwrite(
 export function getPathsInDir(dir: string, options: {
   cwd?: string;
   output?: string[];
+  maxDepth?: number;
 }) {
   // Don't let this function yield so that the file system doesn't get changed
   // underneath us
@@ -619,6 +620,7 @@ export function getPathsInDir(dir: string, options: {
     }
 
     const output = options.output || [];
+    const maxDepth = options.maxDepth;
 
     function pathIsDirectory(path: string) {
       var stat = lstat(path);
@@ -631,10 +633,12 @@ export function getPathsInDir(dir: string, options: {
 
       output.push(newPath);
 
-      if (pathIsDirectory(newAbsPath)) {
+      const nextMaxDepth = maxDepth != null ? maxDepth - 1 : maxDepth;
+      if (pathIsDirectory(newAbsPath) && (nextMaxDepth == null || nextMaxDepth > 0)) {
         getPathsInDir(newPath, {
           cwd: cwd,
-          output: output
+          output: output,
+          ...nextMaxDepth != null && { maxDepth: nextMaxDepth },
         });
       }
     });

--- a/tools/tests/mongo.js
+++ b/tools/tests/mongo.js
@@ -86,7 +86,7 @@ selftest.define("mongo with multiple --port numbers (#7563)", async function () 
   }
 
   // Make absolutely sure we're creating the database for the first time.
-  await check(["reset"], ["Project reset."]);
+  await check(["reset", "--db"], ["Project reset."]);
 
   let count = 0;
   function next() {

--- a/tools/tests/reset.js
+++ b/tools/tests/reset.js
@@ -1,0 +1,35 @@
+var selftest = require('../tool-testing/selftest.js');
+var Sandbox = selftest.Sandbox;
+
+selftest.define("reset - clean cache vs database", async function () {
+  var s = new Sandbox();
+  await s.init();
+
+  function shouldIncludeDb(sandbox, only) {
+    var cacheFiles = sandbox.readDir('.meteor/local');
+    if (!cacheFiles) return false;
+    if (!only) return cacheFiles.includes('db');
+    return cacheFiles.length === 1 && cacheFiles.includes('db');
+  }
+
+  var run;
+
+  await s.createApp("myresetapp", "standard-app");
+  s.cd("myresetapp");
+  selftest.expectTrue(!shouldIncludeDb(s));
+
+  run = s.run("run");
+  await run.read("=> Started MongoDB", false);
+  selftest.expectTrue(shouldIncludeDb(s));
+  await run.stop();
+
+  run = s.run("reset");
+  run.waitSecs(5);
+  await run.expectExit(0);
+  selftest.expectTrue(shouldIncludeDb(s, true));
+
+  run = s.run("reset", "--db");
+  run.waitSecs(5);
+  await run.expectExit(0);
+  selftest.expectTrue(!shouldIncludeDb(s));
+});

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -316,6 +316,18 @@ export default class Sandbox {
     }
   }
 
+  // Reads a dir in the sandbox. 'filepath' is a
+  // path interpreted relative to the Sandbox's cwd.  Returns null if
+  // dir does not exist.
+  readDir(filepath) {
+    const file = files.pathJoin(this.cwd, filepath);
+    if (!files.exists(file)) {
+      return null;
+    } else {
+      return files.readdir(files.pathJoin(this.cwd, filepath), 'utf8');
+    }
+  }
+
   // Copy the contents of one file to another.  In these series of tests, we often
   // want to switch contents of package.js files. It is more legible to copy in
   // the backup file rather than trying to write into it manually.

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -788,11 +788,12 @@ with `meteor run`. This will be easier in the future.
 
 ## meteor reset {meteorreset}
 
-Reset the current project to a fresh state. Removes the local
-mongo database.
+Reset the current project to a fresh state and clear the local cache.
+
+To remove also the local mongo database use `--db` flag.
 
 ::: warning
-This deletes your data! Make sure you do not have any information you
+Reset with `--db` flag deletes your data! Make sure you do not have any information you
 care about in your local mongo database by running `meteor mongo`.
 From the mongo shell, use `show collections`
 and <code>db.<i>collection</i>.find()</code> to inspect your data.

--- a/v3-docs/v3-migration-docs/breaking-changes/index.md
+++ b/v3-docs/v3-migration-docs/breaking-changes/index.md
@@ -22,6 +22,8 @@ const doc = await MyCollection.findOneAsync({ _id: '123' }); // [!code highlight
 
 ## CLI
 
+### vue2
+
 The `--vue2` flag is no longer available. We droped support for vue2.
 You can see more information in this [PR](https://github.com/meteor/meteor/pull/13065).
 
@@ -30,6 +32,13 @@ You can see more information in this [PR](https://github.com/meteor/meteor/pull/
 This was decided because vue2 reached its [end of life](https://v2.vuejs.org/lts/#:~:text=Vue%202%20will%20reach%20End%20of%20Life%20(EOL)%20on%20December%2031st%2C%202023.%20After%20that%20date%2C%20Vue%202%20will%20continue%20to%20be%20available%20in%20all%20existing%20distribution%20channels%20(CDNs%20and%20package%20managers)%2C%20but%20will%20no%20longer%20receive%20updates%2C%20including%20security%20and%20browser%20compatibility%20fixes.)
 on 2023-12-31, the team decided to drop support for it.
 
+### reset
+
+The `meteor reset` command clears only the local cache by default. Using the `--db` option will also delete the local Mongo database. Ensure your CI flows accommodate any changes by passing the `--db` option if needed.
+
+#### Why?
+
+This command is often recommended to fix your development project by clearing the cache. Previously, it also cleared the local MongoDB, which could accidentally delete important data.
 
 ## Node v20
 
@@ -272,4 +281,3 @@ const user = Meteor.user(); // [!code error]
 const user = await Meteor.userAsync(); // [!code highlight]
 
 ```
-

--- a/v3-docs/v3-migration-docs/index.md
+++ b/v3-docs/v3-migration-docs/index.md
@@ -29,7 +29,13 @@ You can upgrade your Meteor 2.x project by running the command below inside your
 
 ```bash
 meteor update --release 3.0-rc.2
-meteor reset #resets project to a fresh state
+meteor reset # resets project to a fresh state
+```
+
+If you are upgrade from an older version of Meteor, you might have a different MongoDB driver version. If you encounter issues, consider clearing the local database.
+
+```bash
+meteor reset --db # resets local db
 ```
 
 Also, it's a good idea to completely remove `node_modules` and the `package-lock.json` before running `meteor npm install`:

--- a/v3-docs/v3-migration-docs/index.md
+++ b/v3-docs/v3-migration-docs/index.md
@@ -29,7 +29,7 @@ You can upgrade your Meteor 2.x project by running the command below inside your
 
 ```bash
 meteor update --release 3.0-rc.2
-meteor reset #resets local DB and project to a fresh state
+meteor reset #resets project to a fresh state
 ```
 
 Also, it's a good idea to completely remove `node_modules` and the `package-lock.json` before running `meteor npm install`:


### PR DESCRIPTION
Context: https://forums.meteor.com/t/post-your-tips-for-updating-to-meteor-v3/61625/16 and https://github.com/meteor/meteor/issues/7789

## Implementation

There are two ways to implement this to ensure by default the db is not removed.

1) Fetch beforehand all the folders and files within `~/.meteor/local` and trigger a promise in parallel per subfolder that is not the `~/.meteor/local/db` path
2) Upgrade `rimraf` to latest as they offer a way to filter the files to remove within a specific folder, and use it directly. The [dev_bundle is stuck into an old version](https://github.com/meteor/meteor/blob/devel/scripts/dev-bundle-tool-package.js#L52) of `rimraf@2.6.2` that [doesn't support a way to filter](https://github.com/isaacs/rimraf/tree/79b933fb362b2c51bedfa448be848e1d7ed32d7e).

I decided to go with 1), since 2) requires to generate a new bundle and update any usage. Though I think is straightforward since only [one spot would need to be changed](https://github.com/meteor/meteor/blob/devel/tools/fs/files.ts#L340-L342). 1) keeps being easier implementation and performance-wise should be fine.

## Pending

- [x] Can we cover `meteor reset [--db]` as a self-test for coverage?

<!---OSS-430--->