### PR TITLE
[3.0] AllowDeny async compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "packages/non-core/blaze"]
     path = packages/non-core/blaze
     url = https://github.com/meteor/blaze.git
-    branch = meteor-3.0
 [submodule "npm-packages/cordova-plugin-meteor-webapp/src/ios/GCDWebServer"]
 	path = npm-packages/cordova-plugin-meteor-webapp/src/ios/GCDWebServer
 	url = https://github.com/meteor/GCDWebServer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "packages/non-core/blaze"]
     path = packages/non-core/blaze
     url = https://github.com/meteor/blaze.git
-    branch = release-3.0
+    branch = meteor-3.0
 [submodule "npm-packages/cordova-plugin-meteor-webapp/src/ios/GCDWebServer"]
 	path = npm-packages/cordova-plugin-meteor-webapp/src/ios/GCDWebServer
 	url = https://github.com/meteor/GCDWebServer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "packages/non-core/blaze"]
     path = packages/non-core/blaze
     url = https://github.com/meteor/blaze.git
+    branch = release-3.0
 [submodule "npm-packages/cordova-plugin-meteor-webapp/src/ios/GCDWebServer"]
 	path = npm-packages/cordova-plugin-meteor-webapp/src/ios/GCDWebServer
 	url = https://github.com/meteor/GCDWebServer.git

--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -187,9 +187,10 @@ CollectionPrototype._defineMutationMethods = function(options) {
             }
 
             const syncMethodName = method.replace('Async', '');
-            // it forces to use async validated method as part of the method
-            const validatedMethodName =
-                  '_validated' + method.charAt(0).toUpperCase() + syncMethodName.slice(1) + 'Async';
+            const syncValidatedMethodName = '_validated' + method.charAt(0).toUpperCase() + syncMethodName.slice(1);
+            // it forces to use async validated behavior on the server
+            const validatedMethodName = Meteor.isServer ? syncValidatedMethodName + 'Async' : syncValidatedMethodName;
+
             args.unshift(this.userId);
             isInsert(method) && args.push(generatedId);
             return self[validatedMethodName].apply(self, args);

--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -580,7 +580,7 @@ CollectionPrototype._validatedRemoveAsync = async function(userId, selector) {
     throw new Meteor.Error(403, "Access denied");
   }
   // Any allow returns true means proceed. Throw error if they all fail.
-  if (await asyncEvery(self._validators.updateAsync.allow, async (validator) => {
+  if (await asyncEvery(self._validators.removeAsync.allow, async (validator) => {
     const result = validator(userId, transformDoc(validator, doc));
     return !(Meteor._isPromise(result) ? await result : result);
   })) {

--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -186,8 +186,10 @@ CollectionPrototype._defineMutationMethods = function(options) {
               );
             }
 
+            const syncMethodName = method.replace('Async', '');
+            // it forces to use async validated method as part of the method
             const validatedMethodName =
-                  '_validated' + method.charAt(0).toUpperCase() + method.slice(1);
+                  '_validated' + method.charAt(0).toUpperCase() + syncMethodName.slice(1) + 'Async';
             args.unshift(this.userId);
             isInsert(method) && args.push(generatedId);
             return self[validatedMethodName].apply(self, args);

--- a/packages/mongo/allow_tests.js
+++ b/packages/mongo/allow_tests.js
@@ -1164,7 +1164,7 @@ if (Meteor.isServer) {
 var AllowAsyncValidateCollection;
 
 Tinytest.addAsync(
-  "collection - validate server operations when using allow-deny rules on the client.",
+  "collection - validate server operations when using allow-deny rules on the client",
   async function (test) {
     AllowAsyncValidateCollection =
       AllowAsyncValidateCollection ||

--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -944,8 +944,7 @@ Object.assign(Mongo.Collection.prototype, {
 
     if (this._isRemoteCollection()) {
       const args = [selector, modifier, options];
-
-      return this._callMutatorMethod('update', args);
+      return this._callMutatorMethod('update', args, callback);
     }
 
     // it's my collection.  descend into the collection object
@@ -1000,12 +999,13 @@ Object.assign(Mongo.Collection.prototype, {
    * @memberof Mongo.Collection
    * @instance
    * @param {MongoSelector} selector Specifies which documents to remove
+   * @param {Function} [callback] Optional.  If present, called with an error object as the first argument and, if no error, the number of affected documents as the second.
    */
-  remove(selector) {
+  remove(selector, callback) {
     selector = Mongo.Collection._rewriteSelector(selector);
 
     if (this._isRemoteCollection()) {
-      return this._callMutatorMethod('remove', [selector]);
+      return this._callMutatorMethod('remove', [selector], callback);
     }
 
 

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -9,8 +9,8 @@ Package.registerBuildPlugin({
   name: "compileStaticHtmlBatch",
   use: [
     'ecmascript@0.16.8-beta300.7',
-    'caching-html-compiler@2.0.0-alpha300.16',
-    'templating-tools@2.0.0-alpha300.16'
+    'caching-html-compiler@1.2.2 || 2.0.0-alpha300.16',
+    'templating-tools@1.2.3 || 2.0.0-alpha300.16'
   ],
   sources: [
     'static-html.js'


### PR DESCRIPTION
This PR reviews the allow-deny package to make it async-compliant.

Two issues have been reported by the community. Feel free to report any other issues in the comments for the next RC.

## Issue 1

Context: https://github.com/meteor/meteor/issues/13143

Client-side collection operations trigger server failures. The server uses the `_validate<OP>` sync method, causing the error `Error: findOne + is not available on the server. Please use findOneAsync() instead`.

We now enforce async validation with proper test coverage.

- [x] Provide test case and fix for proper operation with async validation

## Issue 2

Context: https://forums.meteor.com/t/meteor-3-0-rc-1-is-out/61580/9

Async definitions on allow/deny rules don't work.

- [x] Provide test case and fix for async definitions on allow/deny rules.

