### PR TITLE
Update `meteor-vite` packages in Vue and Solid skeleton apps

### DIFF
--- a/tools/static-assets/skel-solid/.meteor/packages
+++ b/tools/static-assets/skel-solid/.meteor/packages
@@ -19,4 +19,4 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-jorgenvatle:vite-bundler@2.0.0-beta.12
+jorgenvatle:vite-bundler

--- a/tools/static-assets/skel-vue/.meteor/packages
+++ b/tools/static-assets/skel-vue/.meteor/packages
@@ -18,6 +18,6 @@ shell-server                   # Server-side component of the `meteor shell` com
 hot-module-replacement         # Update client in development without reloading the page
 
 static-html                    # Define static page content in .html files
-jorgenvatle:vite-bundler@2.0.0-beta.12
+jorgenvatle:vite-bundler
 ~prototype~
 

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -26,7 +26,7 @@
     "@types/meteor": "^2.9.7",
     "@vitejs/plugin-vue": "^3.2.0",
     "autoprefixer": "^10.4.16",
-    "meteor-vite": "^1.7.1",
+    "meteor-vite": "^1.10.3",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "vite": "^3.2.7"


### PR DESCRIPTION
The `meteor-vite` npm package in the Vue skeleton app was a bit too out of date to function correctly with the associated `jorgenvatle:vite-bundler` Atmosphere package version.

The Atmosphere package now has a full 2.0 release that's compatible exclusively with Meteor v3, so I also went ahead and removed the version pin to avoid any more head scratching down the line.

Fixes 
- #12937