### PR TITLE
[Meteor 3] Add Accounts.addEmailAsync alias

### DIFF
--- a/docs/source/api/passwords.md
+++ b/docs/source/api/passwords.md
@@ -53,7 +53,7 @@ insensitive duplicates before updates.
 
 {% apibox "Accounts.setUsername" %}
 
-{% apibox "Accounts.addEmail" %}
+{% apibox "Accounts.addEmailAsync" %}
 
 By default, an email address is added with `{ verified: false }`. Use
 [`Accounts.sendVerificationEmail`](#Accounts-sendVerificationEmail) to send an

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1690,10 +1690,10 @@ if (Meteor.isServer) (() => {
       });
 
       const newEmail = `${ Random.id() }@turing.com`;
-      await Accounts.addEmail(userId, newEmail);
+      await Accounts.addEmailAsync(userId, newEmail);
 
       const thirdEmail = `${ Random.id() }@turing.com`;
-      await Accounts.addEmail(userId, thirdEmail, true);
+      await Accounts.addEmailAsync(userId, thirdEmail, true);
       const u1 = await Accounts._findUserByQuery({ id: userId })
       test.equal(u1.emails, [
         { address: origEmail, verified: false },
@@ -1733,7 +1733,7 @@ if (Meteor.isServer) (() => {
     });
 
     const newEmail = `${ Random.id() }@turing.com`;
-    await Accounts.addEmail(userId, newEmail);
+    await Accounts.addEmailAsync(userId, newEmail);
     const u1 = await Accounts._findUserByQuery({ id: userId })
     test.equal(u1.emails, [
       { address: newEmail, verified: false },
@@ -1749,10 +1749,10 @@ if (Meteor.isServer) (() => {
     });
 
     const newEmail = `${ Random.id() }@turing.com`;
-    await Accounts.addEmail(userId, newEmail);
+    await Accounts.addEmailAsync(userId, newEmail);
 
     const thirdEmail = origEmail.toUpperCase();
-    await Accounts.addEmail(userId, thirdEmail, true);
+    await Accounts.addEmailAsync(userId, thirdEmail, true);
     const u1 = await Accounts._findUserByQuery({ id: userId })
     test.equal(u1.emails, [
       { address: thirdEmail, verified: true },
@@ -1775,7 +1775,7 @@ if (Meteor.isServer) (() => {
 
     const dupEmail = user1Email.toUpperCase();
     await test.throwsAsync(
-     async () => await Accounts.addEmail(userId2, dupEmail),
+     async () => await Accounts.addEmailAsync(userId2, dupEmail),
       /Email already exists/
     );
 
@@ -1797,10 +1797,10 @@ if (Meteor.isServer) (() => {
     });
 
     const newEmail = `${ Random.id() }@turing.com`;
-    await Accounts.addEmail(userId, newEmail);
+    await Accounts.addEmailAsync(userId, newEmail);
 
     const thirdEmail = `${ Random.id() }@turing.com`;
-    await Accounts.addEmail(userId, thirdEmail, true);
+    await Accounts.addEmailAsync(userId, thirdEmail, true);
     const u1 = await Accounts._findUserByQuery({ id: userId })
     test.equal(u1.emails, [
       { address: origEmail, verified: false },

--- a/v3-docs/docs/api/accounts.md
+++ b/v3-docs/docs/api/accounts.md
@@ -815,7 +815,7 @@ insensitive duplicates before updates.
 
 <ApiBox name="Accounts.setUsername" />
 
-<ApiBox name="Accounts.addEmail" />
+<ApiBox name="Accounts.addEmailAsync" />
 
 By default, an email address is added with `{ verified: false }`. Use
 [`Accounts.sendVerificationEmail`](#Accounts-sendVerificationEmail) to send an

--- a/v3-docs/v3-migration-docs/api/renamed-functions.md
+++ b/v3-docs/v3-migration-docs/api/renamed-functions.md
@@ -71,5 +71,29 @@ async function someFunction() {
 
 ```
 
+## Accounts.addEmail
+
+It is no longer available, you should use `Accounts.addEmailAsync`.
+
+```javascript
+import { Accounts } from "meteor/accounts-base";
+
+// Before
+
+Accounts.addEmail(
+  "userId",
+  "newEmail",
+  false,  // this param is optional 
+);
+// After
+
+await Accounts.addEmailAsync(
+  "userId",
+  "newEmail",
+  false,  // this param is optional 
+);
+
+```
+
 
 For a full list of changes check the [changelog](https://v3-docs.meteor.com/history.html#changelog) for Meteor v3


### PR DESCRIPTION
<!--OSS-448-->

We already did this for version 2 https://github.com/meteor/meteor/pull/13164, but for version 3, even though `Accounts.addEmail` is async now, we still didn't have added the `Async` suffix to it. So, in this PR, we:

- rename `Accounts.addEmail` to `Accounts.addEmailAsync`.
- updated the Migration Guide and Docs about this change.