### PR TITLE
[Meteor 3] Fix git clone error when running `meteor create`

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -944,38 +944,6 @@ main.registerCommand({
       })
     );
   }
-  await files.cp_r(files.pathJoin(__dirnameConverted, '..', 'static-assets',
-    `skel-${skeleton}`), appPath, {
-    transformFilename: function (f) {
-      return transform(f);
-    },
-    transformContents: function (contents, f) {
-
-      // check if this app is just for prototyping if it is then we need to add autopublish and insecure in the packages file
-      if ((/packages/).test(f)) {
-
-        const prototypePackages =
-          () =>
-            'autopublish             # Publish all data to the clients (for prototyping)\n' +
-            'insecure                # Allow all DB writes from clients (for prototyping)';
-
-        // XXX: if there is the need to add more options maybe we should have a better abstraction for this if-else
-        if (options.prototype) {
-          return Buffer.from(contents.toString().replace(/~prototype~/g, prototypePackages()))
-        } else {
-          return Buffer.from(contents.toString().replace(/~prototype~/g, ''))
-        }
-      }
-      if ((/(\.html|\.[jt]sx?|\.css)/).test(f)) {
-        return Buffer.from(transform(contents.toString()));
-      } else {
-        return contents;
-      }
-    },
-    ignore: toIgnore,
-    preserveSymlinks: true,
-  });
-
   // Setup fn, which is called after the app is created, to print a message
   // about how to run the app.
   async function setupMessages() {
@@ -1089,7 +1057,12 @@ main.registerCommand({
   const setupExampleByURL = async (url) => {
     const [ok, err] = await bash`git -v`;
     if (err) throw new Error("git is not installed");
-    await bash`git clone --progress ${url} ${appPath} `;
+    // Set GIT_TERMINAL_PROMPT=0 to disable prompting
+    const [okClone, errClone] =
+      await bash`GIT_TERMINAL_PROMPT=0 git clone --progress ${url} ${appPath}`;
+    if (errClone && !errClone.includes("Cloning into")) {
+      throw new Error("error cloning skeleton");
+    }
     // remove .git folder from the example
     await files.rm_recursive_async(files.pathJoin(appPath, ".git"));
     await setupMessages();


### PR DESCRIPTION
<!--OSS-471-->

For some reason, we had [this](https://github.com/meteor/meteor/pull/13217/files#diff-a65d7a89d948df5e2e7122e62391d58d20521d447c7ebbf2c4f22faf0d12f048L947-L978) code [duplicated](https://github.com/meteor/meteor/blob/3c3a1345aa67db06503f782819cefc2fb824b910/tools/cli/commands.js#L1132-L1170). And what it does is copy the skeleton folder to the user's machine. The problem was that we were doing this before the `git clone` [command](https://github.com/meteor/meteor/blob/3c3a1345aa67db06503f782819cefc2fb824b910/tools/cli/commands.js#L1062) ran, thus the error:

![image](https://github.com/meteor/meteor/assets/29639852/a0dc7d7e-3572-469a-ada3-9bede48f5489)

Now:

![Screenshot from 2024-07-04 15-05-11](https://github.com/meteor/meteor/assets/29639852/2d1bd7c2-6610-4b34-9934-0b31335e2de7)

I've also added the env `GIT_TERMINAL_PROMPT=0` to avoid getting stuck in the clone command while waiting for credentials.
