### PR TITLE
OSS-462 Tweak npm-shrinkwrap.json permissions on newer npm versions to proper app server bundle setup

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1533,6 +1533,11 @@ https://guide.meteor.com/cordova.html#submitting-android
   }
 
   await files.rm_recursive(buildDir);
+
+  const npmShrinkwrapFilePath = files.pathJoin(bundlePath, 'programs/server/npm-shrinkwrap.json');
+  if (files.exists(npmShrinkwrapFilePath)) {
+    files.chmod(npmShrinkwrapFilePath, 0o755);
+  }
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1536,7 +1536,7 @@ https://guide.meteor.com/cordova.html#submitting-android
 
   const npmShrinkwrapFilePath = files.pathJoin(bundlePath, 'programs/server/npm-shrinkwrap.json');
   if (files.exists(npmShrinkwrapFilePath)) {
-    files.chmod(npmShrinkwrapFilePath, 0o755);
+    files.chmod(npmShrinkwrapFilePath, 0o644);
   }
 };
 


### PR DESCRIPTION
<!--OSS-462-->

Context: https://github.com/meteor/meteor/issues/12932


Refer to this comment for extra information about this problem: https://github.com/meteor/meteor/issues/12932#issuecomment-2214665318

## Fix

After the meteor build process [ensure the `npm-shrinkwrap.json` file has the proper write permission](https://github.com/meteor/meteor/assets/2581993/0d1883a9-a24b-47ee-9d03-a7857af75305), so that the server app can be installed properly later on.

![image](https://github.com/meteor/meteor/assets/2581993/3c289a44-785d-4e21-b2e7-d3bdd445dd47)