### PR TITLE
Fix crashing on clone example error flow

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1060,7 +1060,7 @@ main.registerCommand({
     // Set GIT_TERMINAL_PROMPT=0 to disable prompting
     const [okClone, errClone] =
       await bash`GIT_TERMINAL_PROMPT=0 git clone --progress ${url} ${appPath}`;
-    if (errClone && !errClone.includes("Cloning into")) {
+    if (errClone && !errClone.message.includes("Cloning into")) {
       throw new Error("error cloning skeleton");
     }
     // remove .git folder from the example


### PR DESCRIPTION
On my testing with the RC previous to the official version, I was able to run into the issue tweaked here, https://github.com/meteor/meteor/pull/13217.

When an error cloning actually happens the meteor process crashes. This happened consistently on my Windows machine. But I believe the error happens all time a git clone error happens, which in common env may not be easy to reproduce.

## Issue

![image](https://github.com/user-attachments/assets/60924110-4740-439b-a037-197c8447218c)


## Fix

![image](https://github.com/user-attachments/assets/1ea2417c-bbd8-4725-ac87-4ae45914a0e7)
