### PR TITLE
Review and fix git clone meteor examples issues

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1054,7 +1054,7 @@ main.registerCommand({
     const isWindows = process.platform === "win32";
     // Set GIT_TERMINAL_PROMPT=0 to disable prompting
     const gitCommand = isWindows
-      ? `set GIT_TERMINAL_PROMPT=0 && git clone --progress ${url} ${appPath}`
+      ? `$env:GIT_TERMINAL_PROMPT=0; git clone --progress ${url} ${appPath}`
       : `GIT_TERMINAL_PROMPT=0 git clone --progress ${url} ${appPath}`;
     const [okClone, errClone] = await bash`${gitCommand}`;
     const errorMessage = errClone && typeof errClone === "string" ? errClone : errClone?.message;

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -41,12 +41,6 @@ const runCommand = async (command) => {
         reject(error);
         return;
       }
-      if (stderr) {
-        if (stderr.includes("Cloning into")) console.log(green`${ stderr }`);
-        else console.log(red`stderr: ${ stderr }`);
-        reject(stderr);
-        return;
-      }
       resolve(stdout);
     });
   })
@@ -1055,7 +1049,7 @@ main.registerCommand({
    * @param {string} url
    */
   const setupExampleByURL = async (url) => {
-    const [ok, err] = await bash`git -v`;
+    const [ok, err] = await bash`git --version`;
     if (err) throw new Error("git is not installed");
     const isWindows = process.platform === "win32";
     // Set GIT_TERMINAL_PROMPT=0 to disable prompting
@@ -1063,7 +1057,8 @@ main.registerCommand({
       ? `set GIT_TERMINAL_PROMPT=0 && git clone --progress ${url} ${appPath}`
       : `GIT_TERMINAL_PROMPT=0 git clone --progress ${url} ${appPath}`;
     const [okClone, errClone] = await bash`${gitCommand}`;
-    if (errClone && !errClone.message.includes("Cloning into")) {
+    const errorMessage = errClone && typeof errClone === "string" ? errClone : errClone?.message;
+    if (errorMessage && errorMessage.includes("Cloning into")) {
       throw new Error("error cloning skeleton");
     }
     // remove .git folder from the example

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -35,7 +35,7 @@ const { exec } = require("child_process");
  */
 const runCommand = async (command) => {
   return new Promise((resolve, reject) => {
-    exec(command, (error, stdout, stderr) => {
+    exec(command, { env: process.env }, (error, stdout) => {
       if (error) {
         console.log(red`error: ${ error.message }`);
         reject(error);

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1054,7 +1054,7 @@ main.registerCommand({
     const isWindows = process.platform === "win32";
     // Set GIT_TERMINAL_PROMPT=0 to disable prompting
     const gitCommand = isWindows
-      ? `$env:GIT_TERMINAL_PROMPT=0; git clone --progress ${url} ${appPath}`
+      ? `$env:GIT_TERMINAL_PROMPT=0; git clone --progress ${url} ${files.convertToOSPath(appPath)}`
       : `GIT_TERMINAL_PROMPT=0 git clone --progress ${url} ${appPath}`;
     const [okClone, errClone] = await bash`${gitCommand}`;
     const errorMessage = errClone && typeof errClone === "string" ? errClone : errClone?.message;

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1053,8 +1053,9 @@ main.registerCommand({
     if (err) throw new Error("git is not installed");
     const isWindows = process.platform === "win32";
 
-    process.env.GIT_TERMINAL_PROMPT = 0;
     // Set GIT_TERMINAL_PROMPT=0 to disable prompting
+    process.env.GIT_TERMINAL_PROMPT = 0;
+
     const gitCommand = isWindows
       ? `git clone --progress ${url} ${files.convertToOSPath(appPath)}`
       : `git clone --progress ${url} ${appPath}`;

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1052,10 +1052,12 @@ main.registerCommand({
     const [ok, err] = await bash`git --version`;
     if (err) throw new Error("git is not installed");
     const isWindows = process.platform === "win32";
+
+    process.env.GIT_TERMINAL_PROMPT = 0;
     // Set GIT_TERMINAL_PROMPT=0 to disable prompting
     const gitCommand = isWindows
-      ? `$env:GIT_TERMINAL_PROMPT=0; git clone --progress ${url} ${files.convertToOSPath(appPath)}`
-      : `GIT_TERMINAL_PROMPT=0 git clone --progress ${url} ${appPath}`;
+      ? `git clone --progress ${url} ${files.convertToOSPath(appPath)}`
+      : `git clone --progress ${url} ${appPath}`;
     const [okClone, errClone] = await bash`${gitCommand}`;
     const errorMessage = errClone && typeof errClone === "string" ? errClone : errClone?.message;
     if (errorMessage && errorMessage.includes("Cloning into")) {


### PR DESCRIPTION
<!--OSS-471-->

This PR is a continuation of https://github.com/meteor/meteor/pull/13217 and https://github.com/meteor/meteor/pull/13227.

- [x] Fix issue on `git -v` not existing in some envs or git versions [image](https://github.com/user-attachments/assets/afc8958a-59a0-4fcc-9ace-be6b3d2786ac). Use `git --version` as is cross-version compatible.
- [x] Fix issue with `git clone` throwing false positive errors as a success process [uses stderr to log `--progress`](https://stackoverflow.com/questions/32685568/git-clone-writes-to-sderr-fine-but-why-cant-i-redirect-to-stdout)
- [x] Fix an error on `git clone` command used on Windows
- [x] Fix an error on cross-os issue on `errClone` being a string or an error object with message string
- [x] Fix an error on `git clone` command used on Windows
- [x] `process.env.GIT_TERMINAL_PROMPT = 0;` for cross-compatibility of env set in UNIX and Windows.
	- 	In Windows could have been by using `$env:GIT_TERMINAL_PROMPT=0;
git clone --progress "..." "..."` and then ```exec(`powershell.exe -Command "${command.replace(/\n/g, '; ')}"`)```, but I decided to make it simpler with `process.env`

## Testing

- [x] Success: Clone sucessfully in UNIX
![image](https://github.com/user-attachments/assets/04d4ad43-0c94-4ffa-a3db-51b62df1e757)

- [x] Error: forced clone error in UNIX
![image](https://github.com/user-attachments/assets/539ed72c-7a0c-48a4-8991-f94fc957bb50)

- [x] Success: Clone sucessfully in Windows
![image](https://github.com/user-attachments/assets/c1758949-2080-44d3-88ca-ab2be694a1fe)


- [x] Error: forced clone error in Windows
![image](https://github.com/user-attachments/assets/473033e4-26eb-42d4-ad5f-95979b936e27)


