### PR TITLE
Update docs to inform that Meteor 3.0 is released

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,7 +2,7 @@
 title: Docs
 ---
 
-> Meteor 2.x runs on a deprecated Node.js version (14). Meteor 3.0, currently in its Release Candidate version, runs on Node.js v20. For more information, please consult our [migration guide](https://guide.meteor.com/3.0-migration.html).
+> Meteor 2.x uses the deprecated Node.js 14. Meteor 3.0 has been released and runs on Node.js 20. Check out our [v3 docs](https://v3-docs.meteor.com) and [migration guide](https://v3-migration-docs.meteor.com/).
 
 <!--  XXX: note that this content is somewhat duplicated on the guide, and should be updated in parallel -->
 <h2 id="what-is-meteor">What is Meteor?</h2>

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -8,7 +8,7 @@ You need to install the Meteor command line tool to create, run, and manage your
 
 <h3 id="prereqs-node">Node.js version</h3>
 
-> Meteor 2.x runs on a deprecated Node.js version (14). Meteor 3.0, currently in its Release Candidate version, runs on Node.js v20. For more information, please consult our [migration guide](https://guide.meteor.com/3.0-migration.html).
+> Meteor 2.x uses the deprecated Node.js 14. Meteor 3.0 has been released and runs on Node.js 20. Check out our [v3 docs](https://v3-docs.meteor.com) and [migration guide](https://v3-migration-docs.meteor.com/).
 
 - Node.js version >= 10 and <= 14 is required.
 - We recommend you using [nvm](https://github.com/nvm-sh/nvm) or [Volta](https://volta.sh/) for managing Node.js versions.

--- a/guide/source/index.md
+++ b/guide/source/index.md
@@ -3,7 +3,7 @@ title: Introduction
 description: This is the guide for using Meteor, a full-stack JavaScript platform for developing modern web and mobile applications.
 ---
 
-> Meteor 2.x runs on a deprecated Node.js version (14). Meteor 3.0, currently in its Release Candidate version, runs on Node.js v20. For more information, please consult our [migration guide](https://guide.meteor.com/3.0-migration.html).
+> Meteor 2.x uses the deprecated Node.js 14. Meteor 3.0 has been released and runs on Node.js 20. Check out our [v3 docs](https://v3-docs.meteor.com) and [migration guide](https://v3-migration-docs.meteor.com/).
 
 <!--  XXX: note that this content is somewhat duplicated on the docs, and should be updated in parallel -->
 <h2 id="what-is-meteor">What is Meteor?</h2>


### PR DESCRIPTION
Update the docs to announce the release of Meteor 3.0 and include links to the v3 docs and migration guide.