### PR TITLE
Use PowerShell to set PATH instead of setx on Windows

### DIFF
--- a/npm-packages/meteor-installer/install.js
+++ b/npm-packages/meteor-installer/install.js
@@ -302,7 +302,9 @@ async function setup() {
 async function setupExecPath() {
   if (isWindows()) {
     // set for the current session and beyond
-    child_process.execSync(`powershell -c "$path = (Get-Item 'HKCU:\\Environment').GetValue('Path', '', 'DoNotExpandEnvironmentNames'); [Environment]::SetEnvironmentVariable('PATH', \\"${meteorPath};$path\\", 'User');"`);
+    child_process.execSync(
+      `powershell -c "$path = (Get-Item 'HKCU:\\Environment').GetValue('Path', '', 'DoNotExpandEnvironmentNames'); [Environment]::SetEnvironmentVariable('PATH', \\"${meteorPath};$path\\", 'User');"`
+    );
     return;
   }
   const exportCommand = `export PATH=${meteorPath}:$PATH`;

--- a/npm-packages/meteor-installer/install.js
+++ b/npm-packages/meteor-installer/install.js
@@ -302,7 +302,7 @@ async function setup() {
 async function setupExecPath() {
   if (isWindows()) {
     // set for the current session and beyond
-    child_process.execSync(`setx path "${meteorPath}/;%path%`);
+    child_process.execSync(`powershell -c "$path = (Get-Item 'HKCU:\\Environment').GetValue('Path', '', 'DoNotExpandEnvironmentNames'); [Environment]::SetEnvironmentVariable('PATH', \\"${meteorPath};$path\\", 'User');"`);
     return;
   }
   const exportCommand = `export PATH=${meteorPath}:$PATH`;

--- a/npm-packages/meteor-installer/install.js
+++ b/npm-packages/meteor-installer/install.js
@@ -303,7 +303,7 @@ async function setupExecPath() {
   if (isWindows()) {
     // set for the current session and beyond
     child_process.execSync(
-      `powershell -c "$path = (Get-Item 'HKCU:\\Environment').GetValue('Path', '', 'DoNotExpandEnvironmentNames'); [Environment]::SetEnvironmentVariable('PATH', \\"${meteorPath};$path\\", 'User');"`
+      `powershell -c "$path = (Get-Item 'HKCU:\\Environment').GetValue('Path', '', 'DoNotExpandEnvironmentNames'); [Environment]::SetEnvironmentVariable('PATH', \\"${meteorPath};$path\\", 'User');"`,
     );
     return;
   }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

This PR makes the Meteor installer use PowerShell instead of `setx` to add Meteor to the user's `PATH` environment variable on Windows.

This resolves the issues described in #13253:

1. The Meteor install no longer mangles the user's `PATH` environment variable by copying the system `PATH` environment variable into it.
2. The Meteor install no longer expands referenced environment variables.
3. The Meteor install no longer truncates the user's `PATH` environment variable to 1024 characters.

Fixes #13253