### PR TITLE
Fix outstanding subscription init order generally

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -18,6 +18,9 @@ export class AccountsClient extends AccountsCommon {
     this._loggingIn = new ReactiveVar(false);
     this._loggingOut = new ReactiveVar(false);
 
+    this._loginServicesHandle =
+      this.connection.subscribe("meteor.loginServiceConfiguration");
+
     this._pageLoadLoginCallbacks = [];
     this._pageLoadLoginAttemptInfo = null;
 
@@ -35,15 +38,6 @@ export class AccountsClient extends AccountsCommon {
     // This tracks whether callbacks registered with
     // Accounts.onLogin have been called
     this._loginCallbacksCalled = false;
-
-    Tracker.autorun(() => {
-      // This means that the socket connection is established and not that the `connected` message has been received
-      // and the first `connect` message is triggered by `onopen` and then `onReset`
-      if (this.connection.status().connected) {
-        this._loginServicesHandle =
-          this.connection.subscribe("meteor.loginServiceConfiguration");
-      }
-    })
   }
 
   initStorageLocation(options) {

--- a/packages/accounts-base/accounts_client_tests.js
+++ b/packages/accounts-base/accounts_client_tests.js
@@ -348,15 +348,17 @@ Tinytest.addAsync('accounts - storage',
 Tinytest.addAsync('accounts - should only start subscription when connected', async function (test) {
   const { conn, messages, cleanup } = await captureConnectionMessagesClient(test);
 
-  new AccountsClient({
+  const acc = new AccountsClient({
     connection: conn,
   })
+
+  acc.callLoginMethod()
 
   await Meteor._sleepForMs(100);
 
   // The sub call needs to come right after `connect` since this is when `status().connected` gets to be true and
   // not after `connected` as it is based on the socket connection status.
-  const expectedMessages = ['connect', 'sub', 'connected', 'ready']
+  const expectedMessages = ['connect', 'method', 'sub', 'connected', 'updated', 'result', 'ready']
 
   const parsedMessages = messages.map(m => m.msg).filter(Boolean).filter(m => m !== 'added')
 

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -1998,7 +1998,7 @@ export class Connection {
     // add new subscriptions at the end. this way they take effect after
     // the handlers and we don't see flicker.
     Object.entries(this._subscriptions).forEach(([id, sub]) => {
-      this._send({
+      this._sendQueued({
         msg: 'sub',
         id: id,
         name: sub.name,

--- a/packages/test-helpers/connection_client.js
+++ b/packages/test-helpers/connection_client.js
@@ -6,7 +6,10 @@ captureConnectionMessagesClient = async function () {
   const send = conn._stream.send;
 
   conn._stream.send = function (...args) {
-    messages.push(EJSON.parse(args[0]));
+    // Messages are not really sent when the socket is not connected, duh
+    if (conn._stream.currentStatus.connected) {
+      messages.push(EJSON.parse(args[0]));
+    }
     send.apply(this, args);
   }
 


### PR DESCRIPTION
Now the methods are called before the subscription init calls by adding them to the queue as well.

<!--OSS-498-->
