### PR TITLE
Removed http option from side menu in 'docs/_config.yml'

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -58,7 +58,6 @@ sidebar_categories:
     - api/reactive-var
     - api/reactive-dict
     - api/ejson
-    - api/http
     - api/email
     - api/assets
     - api/packagejs


### PR DESCRIPTION
I have removed html option from sidebar in docs/_config.yml file.

Please review the changes and merge this pull request. @harryadel 
@StorytellerCZ