### PR TITLE
Improve CI script to handle PR branch cloning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,7 +759,13 @@ jobs:
       - run:
           name: Cloning "meteor" Repository's current branch
           command: |
-            git clone --branch $CIRCLE_BRANCH https://github.com/meteor/meteor.git ${CHECKOUT_METEOR_DOCS}
+            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+              PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | sed 's|.*/pull/\([0-9]*\)|\1|')
+              PR_BRANCH=$(curl -s https://api.github.com/repos/meteor/meteor/pulls/$PR_NUMBER | jq -r .head.ref)
+              git clone --branch $PR_BRANCH https://github.com/meteor/meteor.git ${CHECKOUT_METEOR_DOCS}
+            else
+              git clone --branch $CIRCLE_BRANCH https://github.com/meteor/meteor.git ${CHECKOUT_METEOR_DOCS}
+            fi
       # Run almost the same steps the meteor/docs repository runs, minus deploy.
       - run:
           name: Generating Meteor documentation for JSDoc testing


### PR DESCRIPTION
## Problem

When running the tests for docs on CircleCI, we were getting an error where CircleCI didn't get the proper branch name: 

![image](https://github.com/user-attachments/assets/6592d2b4-b9be-4f91-ba5d-3b92f653be28)

This happens for PRs from a fork, like [this](https://github.com/meteor/meteor/pull/12961/checks?check_run_id=28103488452). In these cases, a `CIRCLE_PULL_REQUEST` EV is provided:

![Screenshot from 2024-07-31 10-48-21](https://github.com/user-attachments/assets/edfc92cc-48e7-4618-a802-a1a5a8ed4bf6)

This is not the case for branches created inside the Meteor repository:

![Screenshot from 2024-07-31 10-58-31](https://github.com/user-attachments/assets/80c2c5fb-eaab-4408-ba48-8234608c7890)

## Changes
- Modify the cloning command to check if the build is for a PR
- Extract the PR number from the CIRCLE_PULL_REQUEST URL
- Fetch the branch associated with the PR using the GitHub API
- Clone the repository using the PR branch
- Fallback to default behavior for regular branch builds

