### PR TITLE
Remove version constraints from http package in accounts-twitter

### DIFF
--- a/packages/accounts-twitter/package.js
+++ b/packages/accounts-twitter/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Login service for Twitter accounts",
-  version: '1.5.1',
+  version: '1.5.2',
 });
 
 Package.onUse(api => {
@@ -12,7 +12,7 @@ Package.onUse(api => {
   api.use('twitter-oauth');
   api.imply('twitter-oauth');
 
-  api.use('http@1.0.1', ['client', 'server']);
+  api.use('http', ['client', 'server']);
 
   api.use(['accounts-ui', 'twitter-config-ui'], ['client', 'server'], { weak: true });
   api.addFiles("notice.js");


### PR DESCRIPTION
Is it event needed anymore?

Looking on the code in the package it is not called anywhere.

Context. this is currently blocking me from getting the latest beta for MontiAPM:
```
While selecting package versions:
error: Conflict: Constraint http@3.0.0-alpha300.5 is not satisfied by http 1.4.4.
Constraints on package "http":
* http@1.0.1 <- accounts-twitter 1.5.1
* http@3.0.0-alpha300.5 <- montiapm:agent 3.0.0-beta.
```