### PR TITLE
Fix Meteor.promisify and add a test for it

### DIFF
--- a/packages/meteor/helpers.js
+++ b/packages/meteor/helpers.js
@@ -85,6 +85,10 @@ Meteor.promisify = function (fn, context, errorFirst) {
   }
 
   return function () {
+    var self = this;
+    var filteredArgs = Array.prototype.slice.call(arguments)
+      .filter(function (i) { return i !== undefined; });
+
     return new Promise(function (resolve, reject) {
       var callback = Meteor.bindEnvironment(function (error, result) {
         var _error = error, _result = result;
@@ -100,11 +104,9 @@ Meteor.promisify = function (fn, context, errorFirst) {
         resolve(_result);
       });
 
-      var filteredArgs = Array.prototype.slice.call(arguments)
-        .filter(function (i) { return i !== undefined; });
       filteredArgs.push(callback);
 
-      return fn.apply(context || this, filteredArgs);
+      return fn.apply(context || self, filteredArgs);
     });
   };
 };

--- a/packages/meteor/helpers_test.js
+++ b/packages/meteor/helpers_test.js
@@ -100,3 +100,24 @@ Tinytest.add("environment - startup", function (test) {
   });
   test.isTrue(called);
 });
+
+Tinytest.addAsync("environment - promisify", async function (test) {
+  function TestClass(value) {
+    this.value = value;
+  }
+
+  TestClass.prototype.method = function (arg1, arg2, callback) {
+    var value = this.value;
+    setTimeout(function () {
+      callback(null, arg1 + arg2 + value);
+    }, 0);
+  };
+
+  TestClass.prototype.methodAsync = Meteor.promisify(TestClass.prototype.method);
+
+  var instance = new TestClass(5);
+  test.equal(await instance.methodAsync(1, 2), 8);
+
+  var asyncMethodWithContext = Meteor.promisify(instance.method, instance);
+  test.equal(await asyncMethodWithContext(2, 3), 10);
+});


### PR DESCRIPTION
This fixes a regression introduced in commit 87f8697941.

That commit switched from arrow functions to regular functions, which caused `this` and `arguments` to change. The fix is to capture `this` and `arguments` in the correct context.

Adding a simple test as well, to watch for regressions here.