### PR TITLE
Using await when open tag is called #13175

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -516,7 +516,8 @@ async function doRunCommand(options) {
           open(`http://localhost:${options.port}`)
         }
       }
-    }
+    }, 
+    open: options.open,
   });
 }
 

--- a/tools/runners/run-all.js
+++ b/tools/runners/run-all.js
@@ -399,7 +399,11 @@ exports.run = async function (options) {
   var runner = new Runner(runOptions);
   await runner.init();
   // don't wait this on to finish
-  setTimeout(() => runner.start(), 0);
+  if (runOptions.open) {
+    await runner.start();
+  } else {
+    setTimeout(() => runner.start(), 0);
+  }
   onBuilt && onBuilt();
   var result = await promise;
   await runner.stop();


### PR DESCRIPTION
Issue #13175

https://github.com/meteor/meteor/issues/13175 

We added an if statement in run-all.js that gives the option whether to await runner.start() if runOptions.open is true or it runs the existing setTimeout() by passing the open parameter in commands.js.

<img width="569" alt="Screenshot 2024-08-14 at 11 24 46 AM" src="https://github.com/user-attachments/assets/be13f238-50be-490b-ae96-b68bef84bab7">
