### PR TITLE
Fix error message typo in mongo package

### DIFF
--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -898,7 +898,7 @@ Cursor.prototype.countAsync = async function () {
 
 Cursor.prototype.count = function () {
   throw new Error(
-    "count() is not avaible on the server. Please use countAsync() instead."
+    "count() is not available on the server. Please use countAsync() instead."
   );
 };
 


### PR DESCRIPTION
Hello, I encountered this error message in my app when migrating to Meteor 3, and noticed that it included a misspelling. I hope this edit is not too minor for a PR. 