### PR TITLE
[2.x] Update Cordova dependency versions to the latest

### DIFF
--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -13,11 +13,11 @@ export const CORDOVA_ARCH = "web.cordova";
 
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
-const CORDOVA_ANDROID_VERSION = "12.0.1";
+const CORDOVA_ANDROID_VERSION = "13.0.0";
 
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
-  'cordova-lib': '10.0.0',
-  'cordova-common': '4.0.2',
+  'cordova-lib': '12.0.1',
+  'cordova-common': '5.0.0',
   'cordova-create': '2.0.0',
   'cordova-registry-mapper': '1.1.15',
   'cordova-android': CORDOVA_ANDROID_VERSION,
@@ -25,7 +25,7 @@ export const CORDOVA_DEV_BUNDLE_VERSIONS = {
 
 export const CORDOVA_PLATFORM_VERSIONS = {
   'android': CORDOVA_ANDROID_VERSION,
-  'ios': '7.0.1',
+  'ios': '7.1.1',
 };
 
 export const SWIFT_VERSION = 5;


### PR DESCRIPTION
This PR is a preparation for Cordova upgrade in the next version of Meteor 2.

I have started to test that this will work as expected on Meteor 2, specially after seeing some of Cordova latest updates rely on newer versions of Node, but this has resulted as not really required on last versions.

For 3.x: https://github.com/meteor/meteor/pull/13239