### PR TITLE
Fix: correctly re-create text indexes when needed

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -1132,8 +1132,11 @@ Object.assign(Mongo.Collection.prototype, {
       ) {
         import { Log } from 'meteor/logging';
 
-        Log.info(`Re-creating index ${ index } for ${ self._name } due to options mismatch.`);
-        await self._collection.dropIndexAsync(index);
+        Log.info(`Re-creating index ${ JSON.stringify(index) } for ${ self._name } due to options mismatch.`);
+        // We can only drop text indexes (or compound indexes that contains a text index) by its name
+        const isTextIndex = Object.values(index).some(v => v === "text");
+        const indexName = isTextIndex && Object.entries(index).reduce((acc, [key, value], currentIndex) => `${acc}${currentIndex === 0 ? "" : "_"}${key}_${value}`, "");
+        await self._collection.dropIndexAsync(isTextIndex ? indexName : index);
         await self._collection.createIndexAsync(index, options);
       } else {
         console.error(e);


### PR DESCRIPTION
This PR fixes the behavior of re-creating indexes when the index is a text index or compound index that contains a text specification. For those cases, `mongo` requires the usage of the index name when dropping.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
