### PR TITLE
Improve contrast in docs and migration docs

### DIFF
--- a/v3-docs/docs/.vitepress/theme/theme.css
+++ b/v3-docs/docs/.vitepress/theme/theme.css
@@ -113,9 +113,13 @@
   --vc-c-orange-3: #b35e00;
   --vc-c-orange-soft: rgba(255, 126, 23, 0.16);
 
-  --vc-c-meteor-red-1: #BF212E;
-  --vc-c-meteor-red-2: #A01A24;
-  --vc-c-meteor-red-3: #7F141D;
+  --vp-c-meteor-red-1: #E9A0A7;
+  --vp-c-meteor-red-2: #e9b4b8;
+  --vp-c-meteor-red-3: #f0c8cb;
+
+  --vc-c-meteor-red-1: #E9A0A7;
+  --vc-c-meteor-red-2: #e9b4b8;
+  --vc-c-meteor-red-3: #f0c8cb;
   --vc-c-meteor-red-soft: rgba(191, 33, 46, 0.16);
 
   --vp-c-yellow-1: #f9b44e;

--- a/v3-docs/v3-migration-docs/.vitepress/theme/custom.css
+++ b/v3-docs/v3-migration-docs/.vitepress/theme/custom.css
@@ -113,9 +113,13 @@
   --vc-c-orange-3: #b35e00;
   --vc-c-orange-soft: rgba(255, 126, 23, 0.16);
 
-  --vc-c-meteor-red-1: #BF212E;
-  --vc-c-meteor-red-2: #A01A24;
-  --vc-c-meteor-red-3: #7F141D;
+  --vp-c-meteor-red-1: #E9A0A7;
+  --vp-c-meteor-red-2: #e9b4b8;
+  --vp-c-meteor-red-3: #f0c8cb;
+
+  --vc-c-meteor-red-1: #E9A0A7;
+  --vc-c-meteor-red-2: #e9b4b8;
+  --vc-c-meteor-red-3: #f0c8cb;
   --vc-c-meteor-red-soft: rgba(191, 33, 46, 0.16);
 
   --vp-c-yellow-1: #f9b44e;


### PR DESCRIPTION
Improve contrast in docs and migration docs. Reported by @rj-david.

Deploy Preview: https://deploy-preview-13336--v3-meteor-api-docs.netlify.app/history.html#v3-0-2024-07-15

**Before:**
![docs-red](https://github.com/user-attachments/assets/26f8fbd2-0e0c-4421-a57e-137106b072ba)

**After:**
<img width="683" alt="Screenshot 2024-09-09 at 11 51 58" src="https://github.com/user-attachments/assets/2564acc0-91f1-4de8-b6b9-7ee9b2af95d3">
