### PR TITLE
Remove Fibers reference from v3-docs

### DIFF
--- a/v3-docs/docs/api/meteor.md
+++ b/v3-docs/docs/api/meteor.md
@@ -943,7 +943,7 @@ Returns a handle that can be used by `Meteor.clearInterval`.
 
 ## Enviroment variables {#envs}
 
-teor runs most app code within Fibers, which allows keeping track of the context a function is running in. `Meteor.EnvironmentVariable` works with `Meteor.bindEnvironment`, promises, and many other Meteor API's to preserve the context in async code. Some examples of how it is used in Meteor are to store the current user in methods, and record which arguments have been checked when using `audit-argument-checks`.
+Meteor implements `Meteor.EnvironmentVariable` with AsyncLocalStorage, which allows for maintaining context across asynchronous boundaries. `Meteor.EnvironmentVariable` works with `Meteor.bindEnvironment`, promises, and many other Meteor API's to preserve the context in async code. Some examples of how it is used in Meteor are to store the current user in methods, and record which arguments have been checked when using `audit-argument-checks`.
 
 ```js
 import { Meteor } from "meteor/meteor";


### PR DESCRIPTION
<!--OSS-553-->

Issue reported in our [Forums ](https://forums.meteor.com/t/old-reference-to-fibers-in-m3-docs/62161/2) by [@vikr00001](https://forums.meteor.com/u/vikr00001)