### PR TITLE
Minor: update migration guide homepage with the latest version of Meteor (3.0.2)

### DIFF
--- a/v3-docs/v3-migration-docs/index.md
+++ b/v3-docs/v3-migration-docs/index.md
@@ -11,7 +11,7 @@ This guide is for users with Meteor 2.x projects understand the changes between 
 
 Meteor 3.0 is currently in its official version!
 
-**Latest version:** `3.0.1` <br/>
+**Latest version:** `3.0.2` <br/>
 **Node.js version:** `20.15.1 LTS` <br/>
 **NPM version:** `10.7.0`
 


### PR DESCRIPTION
This is a very minor PR to update the homepage of the v3 Migration Guide with the latest minor release (3.0.2, released in August 15th). 