### PR TITLE
Fix Cordova build when using plugins with indirect plugin usage [Meteor 3]

### DIFF
--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -22,6 +22,8 @@ import { CORDOVA_PLATFORMS, CORDOVA_PLATFORM_VERSIONS, displayNameForPlatform, d
   newPluginId, convertPluginVersions, convertToGitUrl } from './index.js';
 import { CordovaBuilder } from './builder.js';
 
+const cordovaPackagesFile = 'cordova-packages.json';
+
 cordova_events.on('verbose', logIfVerbose);
 cordova_events.on('log', logIfVerbose);
 cordova_events.on('info', logIfVerbose);
@@ -462,14 +464,21 @@ to Cordova project`, async () => {
       // with the dependencies so that when running any npm command
       // it keeps the dependencies installed.
       const packageLock = JSON.parse(files.readFile(
-        files.pathJoin(self.projectRoot, 'node_modules/.package-lock.json')
+          files.pathJoin(self.projectRoot, 'node_modules/.package-lock.json')
       ));
+      // Accumulated dependencies from plugins
+      const cordovaPackagesPath = files.pathJoin(self.projectRoot, cordovaPackagesFile);
+      const cordovaPackageLock = files.exists(cordovaPackagesPath) ? JSON.parse(files.readFile(cordovaPackagesPath)) : {};
+
+      // Ensure all packages are kept installed
+      const packages = { ...(cordovaPackageLock?.packages || {}), ...(packageLock?.packages || {}) };
+
       const getPackageName = (pkgPath) => {
         const split = pkgPath.split("node_modules/");
         return split[split.length - 1];
       };
 
-      const packageJsonObj = Object.entries(packageLock.packages).reduce((acc, [key, value]) => {
+      const packageJsonObj = Object.entries(packages).reduce((acc, [key, value]) => {
         const name = getPackageName(key);
         return ({
           dependencies: {
@@ -477,7 +486,7 @@ to Cordova project`, async () => {
             [name]: value.version,
           }
         });
-      }, { dependencies: {} });
+      }, { dependencies: { [`cordova-${platform}`]: version  } });
       files.writeFile(
         files.pathJoin(self.projectRoot, "package.json"),
         JSON.stringify(packageJsonObj, null, 2) + "\n"
@@ -625,6 +634,26 @@ from Cordova project`, async () => {
         await this.runCommands(`adding plugin ${target} \
 to Cordova project`, cordova_lib.plugin.bind(undefined, 'add', [target],
           commandOptions));
+
+        // Accumulate dependencies from plugins to later installation
+        const cordovaPackagesPath = files.pathJoin(this.projectRoot, cordovaPackagesFile);
+        const packageLock = JSON.parse(files.readFile(
+            files.pathJoin(this.projectRoot, 'node_modules/.package-lock.json')
+        ));
+        const existingPackageLock = files.exists(cordovaPackagesPath) ?
+            JSON.parse(files.readFile(cordovaPackagesPath))
+            : {};
+        const accumulatedCordovaPackages = {
+          packages: {
+            ...existingPackageLock.packages,
+            ...packageLock.packages,
+          }
+        };
+        files.writeFile(
+            cordovaPackagesPath,
+            JSON.stringify(accumulatedCordovaPackages, null, 2) + "\n"
+        );
+
       } catch (error) {
         if (retry && utils.isUrlWithSha(version)) {
           Console.warn(`Cordova plugin add for ${id} failed with plugin id 


### PR DESCRIPTION
OSS-566

Context: https://github.com/meteor/meteor/issues/13303

This PR addresses an issue some developers encountered when building their Cordova app with Meteor 3. They were blocked from the upgrade to Meteor 3.

After some investigation, we identified the problem: Cordova plugins that [rely on dependency definitions](https://github.com/apache/cordova-plugin-screen-orientation/blob/master/plugin.xml?rgh-link-date=2024-09-26T09%3A32%3A20Z#L56) are affected by an issue in newer NPM version, which causes [these dependencies to be removed](https://github.com/apache/cordova-lib/issues/868) and not available for Meteor to include them during Cordova building. In Meteor 3, we upgraded to newer Node and NPM versions, which caused this issue to arise.

To resolve this, we enhanced Meteor's handling of dependencies. Now, the relevant dependencies are accumulated in a file, ensuring they are properly included in the final Cordova bundle, resulting in a successful build.