### PR TITLE
Fix Meteor npm subcommand among others [Meteor 3]

### DIFF
--- a/scripts/windows/ci/install.ps1
+++ b/scripts/windows/ci/install.ps1
@@ -19,6 +19,12 @@ If ($LASTEXITCODE -ne 0) {
   throw "Updating submodules failed."
 }
 
+# The `meteor npm install` subcommand should work
+& "$meteorBat" npm install
+If ($LASTEXITCODE -ne 0) {
+  throw "'meteor npm install' failed."
+}
+
 # The `meteor --get-ready` command is susceptible to EPERM errors, so
 # we attempt it three times.
 $attempt = 3

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -31,8 +31,6 @@ async function getChildProcess({ isFirstTry }) {
     return null;
   }
 
-  console.log('-> cmd', cmd);
-
   const child = require('child_process').spawn(cmd, args, {
     stdio: 'inherit',
     env: env,

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -33,10 +33,10 @@ async function getChildProcess({ isFirstTry }) {
 
   console.log('-> cmd', cmd);
 
-  const child = require("child_process").spawn(cmd, args, {
-    stdio: "inherit",
+  const child = require('child_process').spawn(cmd, args, {
+    stdio: 'inherit',
     env: env,
-    ...process.platform === 'win32' && { shell: true },
+    shell: process.platform === 'win32' && ['.cmd', '.bat'].some(_extension => cmd.endsWith(_extension)),
   });
   require("./flush-buffers-on-exit-in-windows");
   child.on("error", function (error) {

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -31,6 +31,8 @@ async function getChildProcess({ isFirstTry }) {
     return null;
   }
 
+  console.log('-> cmd', cmd);
+
   const child = require("child_process").spawn(cmd, args, {
     stdio: "inherit",
     env: env,

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -34,7 +34,7 @@ async function getChildProcess({ isFirstTry }) {
   const child = require("child_process").spawn(cmd, args, {
     stdio: "inherit",
     env: env,
-    ...process.platform === 'win32' && { shell: true },
+    ...process.platform === 'win32' && cmd.includes('npm') && { shell: true },
   });
   require("./flush-buffers-on-exit-in-windows");
   child.on("error", function (error) {

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -33,7 +33,8 @@ async function getChildProcess({ isFirstTry }) {
 
   const child = require("child_process").spawn(cmd, args, {
     stdio: "inherit",
-    env: env
+    env: env,
+    shell: true,
   });
   require("./flush-buffers-on-exit-in-windows");
   child.on("error", function (error) {

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -34,7 +34,7 @@ async function getChildProcess({ isFirstTry }) {
   const child = require("child_process").spawn(cmd, args, {
     stdio: "inherit",
     env: env,
-    shell: true,
+    ...process.platform === 'win32' && { shell: true },
   });
   require("./flush-buffers-on-exit-in-windows");
   child.on("error", function (error) {

--- a/tools/cli/dev-bundle-bin-commands.js
+++ b/tools/cli/dev-bundle-bin-commands.js
@@ -34,7 +34,7 @@ async function getChildProcess({ isFirstTry }) {
   const child = require("child_process").spawn(cmd, args, {
     stdio: "inherit",
     env: env,
-    ...process.platform === 'win32' && cmd.includes('npm') && { shell: true },
+    ...process.platform === 'win32' && { shell: true },
   });
   require("./flush-buffers-on-exit-in-windows");
   child.on("error", function (error) {


### PR DESCRIPTION
OSS-528

Context: https://github.com/meteor/meteor/issues/13260

### Issue

[In this PR](https://github.com/meteor/meteor/pull/13090#issuecomment-2113923381) we adapted major of the Node child spawn processes in Windows, which got a breaking change, requiring pass `shell: true`. I remember some tests reacted on this, but it seems other places needed to be adapted, and failed silently. And this issue was one of them.

![image](https://github.com/user-attachments/assets/a1bc37cd-54fd-4cd2-b9d3-9e2be2e23b4b)

### Fix

Adding the missing `shell: true` seems to have solved the problem. Hopefully it doesn't break other flows as I experienced on the past on upgrading Node to the breaking change version and adapting some specific spawn child processes.

![image](https://github.com/user-attachments/assets/7971bad5-8364-4e6a-93aa-b86bbb09ace2)

I added a regression tests for us to be able to identify any regression on `meteor npm install` command on Windows.
