### PR TITLE
Proposed fix for #13329

### DIFF
--- a/tools/static-assets/skel-minimal/.meteor/packages
+++ b/tools/static-assets/skel-minimal/.meteor/packages
@@ -13,6 +13,7 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 typescript              # Enable TypeScript syntax in .ts and .tsx modules
 shell-server            # Server-side component of the `meteor shell` command
 webapp                  # Serves a Meteor app over HTTP
+ddp                     # The protocol and client/server libraries that Meteor uses to send data
 server-render           # Support for server-side rendering
 hot-module-replacement  # Rebuilds the client if there is a change on the client without restarting the server
 ~prototype~


### PR DESCRIPTION
Proposed fix for #13329 
Add the `ddp` package to ensure that methods are always available. Though the question is if DDP should be in the minimal skeleton. If no, then it is a bit odd that methods are available there at all as shown in the issue.
Maybe I'm missing something?