### PR TITLE
Fixed issue with Firefox IOS not being marked as modern browser (#13126)

### DIFF
--- a/docs/generators/changelog/versions/0-before-2.10.md
+++ b/docs/generators/changelog/versions/0-before-2.10.md
@@ -2935,6 +2935,7 @@ N/A
   setMinimumBrowserVersions({
     chrome: 49,
     firefox: 45,
+    firefoxIOS: 100,
     edge: 12,
     ie: Infinity, // Sorry, IE11.
     mobile_safari: [9, 2], // 9.2.0+

--- a/docs/history.md
+++ b/docs/history.md
@@ -4651,6 +4651,7 @@ N/A
   setMinimumBrowserVersions({
     chrome: 49,
     firefox: 45,
+    firefoxIOS: 100,
     edge: 12,
     ie: Infinity, // Sorry, IE11.
     mobile_safari: [9, 2], // 9.2.0+

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "prettier": "^2.8.6",
+        "prettier": "^2.8.8",
         "typescript": "^5.4.5"
       }
     },
@@ -4236,6 +4236,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "prettier": "^2.8.6",
+    "prettier": "^2.8.8",
     "typescript": "^5.4.5"
   },
   "jshintConfig": {

--- a/packages/ecmascript-runtime-client/versions.js
+++ b/packages/ecmascript-runtime-client/versions.js
@@ -9,6 +9,7 @@ setMinimumBrowserVersions({
   // (pre-Edge) from the modern classification. #9818 #9839
   ie: 12,
   firefox: 45,
+  firefoxIOS: 100,
   mobileSafari: 10,
   opera: 38,
   safari: 10,

--- a/packages/fetch/server.js
+++ b/packages/fetch/server.js
@@ -12,6 +12,7 @@ setMinimumBrowserVersions({
   chrome: 42,
   edge: 14,
   firefox: 39,
+  firefoxIOS: 100,
   mobile_safari: [10, 3],
   opera: 29,
   safari: [10, 1],

--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -6,9 +6,9 @@ const hasOwn = Object.prototype.hasOwnProperty;
 const browserAliases = {
   chrome: [
     // chromeMobile*, per https://github.com/meteor/meteor/pull/9793,
-    'chromeMobile',
-    'chromeMobileIOS',
-    'chromeMobileWebView',
+    "chromeMobile",
+    "chromeMobileIOS",
+    "chromeMobileWebView",
 
     // The major version number of Chromium and Headless Chrome track with the
     // releases of Chrome Dev, Canary and Stable, so we should be okay to
@@ -18,24 +18,24 @@ const browserAliases = {
     // Chromium is particularly important to list here since, unlike macOS
     // builds, Linux builds list Chromium in the userAgent along with Chrome:
     //   e.g. Chromium/70.0.3538.77 Chrome/70.0.3538.77
-    'chromium',
-    'headlesschrome',
+    "chromium",
+    "headlesschrome",
   ],
 
-  // If a call to setMinimumBrowserVersions specifies Edge 12 as a minimum
+  // If a call to  specifies Edge 12 as a minimum
   // version, that means no version of Internet Explorer pre-Edge should
   // be classified as modern. This edge:["ie"] alias effectively enforces
   // that logic, because there is no IE12. #9818 #9839
-  edge: ['ie'],
+  edge: ["ie"],
 
-  firefox: ['firefoxMobile'],
+  firefox: ["firefoxMobile"],
 
   // The webapp package converts browser names to camel case, so
   // mobile_safari and mobileSafari should be synonymous.
-  mobile_safari: ['mobileSafari', 'mobileSafariUI', 'mobileSafariUI/WKWebView'],
+  mobile_safari: ["mobileSafari", "mobileSafariUI", "mobileSafariUI/WKWebView"],
 
   // Embedded WebViews on iPads will be reported as Apple Mail
-  safari: ['appleMail'],
+  safari: ["appleMail"],
 };
 
 // Expand the given minimum versions by reusing chrome versions for
@@ -43,16 +43,16 @@ const browserAliases = {
 function applyAliases(versions) {
   const lowerCaseVersions = Object.create(null);
 
-  Object.keys(versions).forEach(browser => {
+  Object.keys(versions).forEach((browser) => {
     lowerCaseVersions[browser.toLowerCase()] = versions[browser];
   });
 
-  Object.keys(browserAliases).forEach(original => {
+  Object.keys(browserAliases).forEach((original) => {
     const aliases = browserAliases[original];
     original = original.toLowerCase();
 
     if (hasOwn.call(lowerCaseVersions, original)) {
-      aliases.forEach(alias => {
+      aliases.forEach((alias) => {
         alias = alias.toLowerCase();
         if (!hasOwn.call(lowerCaseVersions, alias)) {
           lowerCaseVersions[alias] = lowerCaseVersions[original];
@@ -72,7 +72,7 @@ function applyAliases(versions) {
 // "modern" according to all requested version constraints.
 function isModern(browser) {
   const lowerCaseName =
-    browser && typeof browser.name === 'string' && browser.name.toLowerCase();
+    browser && typeof browser.name === "string" && browser.name.toLowerCase();
 
   return (
     !!lowerCaseName &&
@@ -92,7 +92,7 @@ function isModern(browser) {
 function setMinimumBrowserVersions(versions, source) {
   const lowerCaseVersions = applyAliases(versions);
 
-  Object.keys(lowerCaseVersions).forEach(lowerCaseName => {
+  Object.keys(lowerCaseVersions).forEach((lowerCaseName) => {
     const version = lowerCaseVersions[lowerCaseName];
 
     if (
@@ -104,7 +104,7 @@ function setMinimumBrowserVersions(versions, source) {
 
     minimumVersions[lowerCaseName] = {
       version: copy(version),
-      source: source || getCaller('setMinimumBrowserVersions'),
+      source: source || getCaller("setMinimumBrowserVersions"),
     };
   });
 }
@@ -112,7 +112,7 @@ function setMinimumBrowserVersions(versions, source) {
 function getCaller(calleeName) {
   const error = new Error();
   Error.captureStackTrace(error);
-  const lines = error.stack.split('\n');
+  const lines = error.stack.split("\n");
   let caller;
   lines.some((line, i) => {
     if (line.indexOf(calleeName) >= 0) {
@@ -123,24 +123,26 @@ function getCaller(calleeName) {
   return caller;
 }
 
-function getMinimumBrowserVersions() { return minimumVersions; }
+function getMinimumBrowserVersions() {
+  return minimumVersions;
+}
 
 Object.assign(exports, {
   isModern,
   setMinimumBrowserVersions,
   getMinimumBrowserVersions,
   calculateHashOfMinimumVersions() {
-    const { createHash } = require('crypto');
-    return createHash('sha1')
+    const { createHash } = require("crypto");
+    return createHash("sha1")
       .update(JSON.stringify(minimumVersions))
-      .digest('hex');
+      .digest("hex");
   },
 });
 
 // For making defensive copies of [major, minor, ...] version arrays, so
 // they don't change unexpectedly.
 function copy(version) {
-  if (typeof version === 'number') {
+  if (typeof version === "number") {
     return version;
   }
 
@@ -156,8 +158,8 @@ function greaterThanOrEqualTo(a, b) {
 }
 
 function greaterThan(a, b) {
-  const as = typeof a === 'number' ? [a] : a;
-  const bs = typeof b === 'number' ? [b] : b;
+  const as = typeof a === "number" ? [a] : a;
+  const bs = typeof b === "number" ? [b] : b;
   const maxLen = Math.max(as.length, bs.length);
 
   for (let i = 0; i < maxLen; ++i) {
@@ -177,7 +179,7 @@ function greaterThan(a, b) {
 }
 
 function makeSource(feature) {
-  return module.id + ' (' + feature + ')';
+  return module.id + " (" + feature + ")";
 }
 
 setMinimumBrowserVersions(
@@ -185,6 +187,7 @@ setMinimumBrowserVersions(
     chrome: 49,
     edge: 12,
     firefox: 45,
+    firefoxIOS: 100,
     mobileSafari: [9, 2],
     opera: 36,
     safari: 9,
@@ -192,7 +195,7 @@ setMinimumBrowserVersions(
     // https://github.com/Kilian/electron-to-chromium/blob/master/full-versions.js
     electron: 1,
   },
-  makeSource('classes')
+  makeSource("classes")
 );
 
 setMinimumBrowserVersions(
@@ -200,6 +203,7 @@ setMinimumBrowserVersions(
     chrome: 39,
     edge: 13,
     firefox: 26,
+    firefoxIOS: 100,
     mobileSafari: 10,
     opera: 26,
     safari: 10,
@@ -207,7 +211,7 @@ setMinimumBrowserVersions(
     phantomjs: Infinity,
     electron: [0, 20],
   },
-  makeSource('generator functions')
+  makeSource("generator functions")
 );
 
 setMinimumBrowserVersions(
@@ -215,12 +219,13 @@ setMinimumBrowserVersions(
     chrome: 41,
     edge: 13,
     firefox: 34,
+    firefoxIOS: 100,
     mobileSafari: [9, 2],
     opera: 29,
     safari: [9, 1],
     electron: [0, 24],
   },
-  makeSource('template literals')
+  makeSource("template literals")
 );
 
 setMinimumBrowserVersions(
@@ -228,10 +233,11 @@ setMinimumBrowserVersions(
     chrome: 38,
     edge: 12,
     firefox: 36,
+    firefoxIOS: 100,
     mobileSafari: 9,
     opera: 25,
     safari: 9,
     electron: [0, 20],
   },
-  makeSource('symbols')
+  makeSource("symbols")
 );


### PR DESCRIPTION
Fixed this issue by updating the 'setMinimumBrowserVersions' function to include Firefox IOS.