### PR TITLE
fix: throw all missing key errors when using `{ throwAllErrors: true }`

### DIFF
--- a/packages/check/match.js
+++ b/packages/check/match.js
@@ -482,13 +482,18 @@ const testSubtree = (value, pattern, collectErrors = false, errors = [], path = 
 
   const keys = Object.keys(requiredPatterns);
   if (keys.length) {
-    const result = {
-      message: `Missing key '${keys[0]}'`,
-      path: '',
-    };
+    const createMissingError = key => ({
+      message: `Missing key '${key}'`,
+      path: collectErrors ? path : '',
+    });
 
-    if (!collectErrors) return result;
-    errors.push(result);
+    if (!collectErrors) {
+      return createMissingError(keys[0]);
+    }
+
+    for (const key of keys) {
+      errors.push(createMissingError(key));
+    }
   }
 
   if (!collectErrors) return false;

--- a/packages/check/match_test.js
+++ b/packages/check/match_test.js
@@ -573,7 +573,8 @@ Tinytest.add('check - check throw all errors deeply nested', test => {
     int: { i: 1.2, a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
     oneOf: { f: 'm', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
     where: { w: 'a', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
-    whereArr: [1, 2, 3]
+    whereArr: [1, 2, 3],
+    embedded: { thing: '1' }
   };
 
   const pattern = {
@@ -599,7 +600,10 @@ Tinytest.add('check - check throw all errors deeply nested', test => {
     whereArr: Match.Where((x) => {
       check(x, [String]);
       return x.length === 1;
-    })
+    }),
+    missing1: String,
+    missing2: String,
+    embedded: { thing: String, another: String }
   }
 
   try {
@@ -609,7 +613,8 @@ Tinytest.add('check - check throw all errors deeply nested', test => {
   }
 
   test.isTrue(error);
-  test.equal(error.length, 37);
+  test.equal(error.length, 40);
+  test.equal(error.filter(e => e.message.includes('Missing key')).map(e => e.message), [`Match error: Missing key 'another' in field embedded`, `Match error: Missing key 'missing1'`, `Match error: Missing key 'missing2'`]);
   error.every(e => test.instanceOf(e, Match.Error));
   test.isFalse(Match.test(value, pattern));
 })

--- a/packages/check/package.js
+++ b/packages/check/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Check whether a value matches a pattern',
-  version: '1.4.2',
+  version: '1.4.3',
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
This ensures that all `Missing key` errors are thrown when using `{ throwAllErrors: true }`. I missed this in my previous [PR](https://github.com/meteor/meteor/pull/12970)