### PR TITLE
Fix Cordova on Windows

### DIFF
--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -378,10 +378,6 @@ $npmToolArgs = @{
 }
 Add-NpmModulesFromJsBundleFile @npmToolArgs
 
-# Leaving these probably doesn't hurt, but are removed for consistency w/ Unix.
-Remove-Item $(Join-Path $dirLib 'package.json')
-Remove-Item $(Join-Path $dirLib 'package-lock.json')
-
 Write-Host "Done writing node_modules build(s)..." -ForegroundColor Magenta
 
 Write-Host "Removing temp scratch $dirTemp" -ForegroundColor Magenta

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -461,9 +461,9 @@ to Cordova project`, async () => {
       // As per Npm 8, we need now do inject a package.json file
       // with the dependencies so that when running any npm command
       // it keeps the dependencies installed.
-      const packageLock = JSON.parse(files.readFile(
+      const packageLock = files.exists('node_modules/.package-lock.json') ? JSON.parse(files.readFile(
         files.pathJoin(self.projectRoot, 'node_modules/.package-lock.json')
-      ));
+      )) : { packages: {} };
       const getPackageName = (pkgPath) => {
         const split = pkgPath.split("node_modules/");
         return split[split.length - 1];

--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -463,7 +463,7 @@ to Cordova project`, async () => {
       // it keeps the dependencies installed.
       const packageLock = files.exists('node_modules/.package-lock.json') ? JSON.parse(files.readFile(
         files.pathJoin(self.projectRoot, 'node_modules/.package-lock.json')
-      )) : { packages: {} };
+      )) : { packages: { [`cordova-${platform}`]: { version }  } };
       const getPackageName = (pkgPath) => {
         const split = pkgPath.split("node_modules/");
         return split[split.length - 1];


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/issues/13250, https://github.com/meteor/meteor/issues/13250, [forum post #1](https://forums.meteor.com/t/meteor-3-add-platform-android-breaks-meteor-installation-on-windows-11/61894/2), [forum post #2](https://forums.meteor.com/t/meteor-missing-modules/62354)

This PR continues solving Cordova development, this time on Windows, since it seems that latest Node versions produced a problem on the Meteor bundle that require dependencies to be locked.

## Issue

Using the `meteor add-platform android` command while setting up the Cordova project with the necessary npm dependencies corrupts the `dev_bundle`, removing critical dependencies. This can leave the entire Meteor installation unusable, requiring a complete reinstallation of Meteor. In practice, Cordova development does not work on the latest Meteor versions (it works on WSL, however).

After thorough debugging, I identified the issue. The problem is that the `dev_bundle` generated for Windows is missing the creation of the `package.json` context and the lock file in the dev_bundle's `lib/` directory. During the preparation of the Cordova project, it creates these files but removes existing critical dependencies (like npm) that are not locked, leading to the complete break of Meteor setup and the reported issues.

See the attached picture for clarification.

![image](https://github.com/user-attachments/assets/a8835f8b-d5d4-407b-b081-5668e7837989)

## Solution

We create a Meteor `dev_bundle` specifically for Unix and Windows systems. After reviewing the code, [I found that we explicitly removed these files](https://github.com/meteor/meteor/blob/devel/scripts/generate-dev-bundle.ps1#L381-L383) in earlier Meteor versions. However, newer Node versions require these dependencies to fix the dev_bundle. Likewise, for Unix, as part of Meteor 3, [we specifically copied these files](https://github.com/meteor/meteor/blob/devel/scripts/generate-dev-bundle.sh#L151-L154).

This PR simply updates the Windows scenario to align with the same expectation as Unix.

## Testing

The issue is solved:

![image](https://github.com/user-attachments/assets/fbefe5f7-3a01-4302-8928-87dfc68c4449)

However, I am performing tests to verify Cordova setup would work well now in raw Windows. I found another issue now with cordova running itself, so after adding proper Java and Android SDK envs, when running other error faced now ([error](https://github.com/user-attachments/assets/cfea1b6c-6e25-45fc-9e95-dc4129023ce0))

This PR is going to be a full review of Windows Cordova and ensure Cordova works as expected.
