### PR TITLE
fix(bundle-visualizer): use 'node:assert' on imports to use internal …

### DIFF
--- a/packages/non-core/bundle-visualizer/server.js
+++ b/packages/non-core/bundle-visualizer/server.js
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "node:assert";
 import { readFileSync as fsReadFileSync } from "fs";
 
 import { Meteor } from "meteor/meteor";

--- a/packages/non-core/bundle-visualizer/sunburst.js
+++ b/packages/non-core/bundle-visualizer/sunburst.js
@@ -19,7 +19,7 @@
   limitations under the License.
 */
 
-import assert from "assert";
+import assert from "node:assert";
 import prettyBytes from "pretty-bytes";
 
 // Make a custom "d3" object containing exactly what we need from the


### PR DESCRIPTION
Attempt to fix #13319 where the package requires the unscoped node package `assert` which now is replaced by `node:assert` and should automatically be transformed by `meteor-node-stubs`.