### PR TITLE
Docs: Meteor methods callAsync promises and resolverType option

### DIFF
--- a/v3-docs/docs/api/collections.md
+++ b/v3-docs/docs/api/collections.md
@@ -183,6 +183,21 @@ issue, since it's unusual for a client to have enough data that an
 index is worthwhile.
 :::
 
+Use the `resolverType` option to determine the default method for resolving the functions of the collection methods. In Meteor 3.x, a distinction exists between stub and server promises on call methods. The former handles client simulation and minimongo population, while the latter solely manages success or error on the server call without populating the data in minimongo. The resolverType option offers `stub` and `server` values.
+
+This option is particularly useful on test environments to maintain isomorphic code without needing to manage different code for the server and stub scenarios.
+
+```javascript
+const Greetings = new Meteor.Collection('greetUser', { resolverType: 'stub' });
+    
+await Greetings.insertAsync({ test: 1 });
+
+// 🔵 Client simulation
+Greetings.findOne({ name: 'John' }); // 🧾 Data is available (Optimistic-UI)
+```
+
+Read more about server and stub promises on calling methods, [please refer to the docs](./meteor.md#Meteor-callAsync).
+
 Read more about collections and how to use them in the [Collections](http://guide.meteor.com/collections.html) article in the Meteor Guide.
 
 

--- a/v3-docs/docs/api/meteor.md
+++ b/v3-docs/docs/api/meteor.md
@@ -401,7 +401,71 @@ Use `Meteor.call` only to call methods that do not have a stub, or have a sync s
 
 <ApiBox name="Meteor.callAsync" />
 
-`Meteor.callAsync` is just like `Meteor.call`, except that it'll return a promise that you need to solve to get the result.
+`Meteor.callAsync` is just like `Meteor.call`, except that it'll return a promise that you need to solve to get the server result. Along with the promise returned by `callAsync`, you can also handle `stubPromise` and `serverPromise` for managing client-side simulation and server response.
+
+The following sections guide you in understanding these promises and how to manage them effectively.
+
+#### serverPromise
+
+```javascript
+try {
+	await Meteor.callAsync('greetUser', 'John');
+	// 🟢 Server ended with success
+} catch(e) {
+	console.error("Error:", error.reason); // 🔴 Server ended with error
+}
+
+Greetings.findOne({ name: 'John' }); // 🗑️ Data is NOT available
+```
+
+#### stubPromise
+
+```javascript
+await Meteor.callAsync('greetUser', 'John').stubPromise;
+
+// 🔵 Client simulation
+Greetings.findOne({ name: 'John' }); // 🧾 Data is available (Optimistic-UI)
+```
+
+#### stubPromise and serverPromise
+
+```javascript
+const { stubPromise, serverPromise } = Meteor.callAsync('greetUser', 'John');
+
+await stubPromise;
+
+// 🔵 Client simulation
+Greetings.findOne({ name: 'John' }); // 🧾 Data is available (Optimistic-UI)
+
+try {
+  await serverPromise;
+  // 🟢 Server ended with success
+} catch(e) {
+  console.error("Error:", error.reason); // 🔴 Server ended with error
+}
+
+Greetings.findOne({ name: 'John' }); // 🗑️ Data is NOT available
+```
+
+#### Meteor 2.x contrast
+
+For those familiar with legacy Meteor 2.x, the handling of client simulation and server response was managed using fibers, as explained in the following section. This comparison illustrates how async inclusion with standard promises has transformed the way Meteor operates in modern versions.
+
+``` javascript
+Meteor.call('greetUser', 'John', function(error, result) {
+  if (error) {
+    console.error("Error:", error.reason); // 🔴 Server ended with error
+  } else {
+    console.log("Result:", result); // 🟢 Server ended with success
+  }
+
+  Greetings.findOne({ name: 'John' }); // 🗑️ Data is NOT available
+});
+
+// 🔵 Client simulation
+Greetings.findOne({ name: 'John' }); // 🧾 Data is available (Optimistic-UI)
+```
+
 
 <ApiBox name="Meteor.apply" />
 


### PR DESCRIPTION
This PR adds [a helpful comment](https://github.com/meteor/meteor/pull/13052#issuecomment-2007677624) to the documentation explaining how to understand Meteor method promises (both stub and server) in Meteor 3 compared to Meteor 2. This will assist developers in managing them effectively.