### PR TITLE
Upgrade Express 5

### DIFF
--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -5,8 +5,8 @@ Package.describe({
 
 Npm.depends({
   "cookie-parser": "1.4.6",
-  express: "4.21.0",
-  "@types/express": "4.17.21",
+  express: "5.0.1",
+  "@types/express": "5.0.0",
   compression: "1.7.4",
   errorhandler: "1.5.1",
   parseurl: "1.3.3",
@@ -14,7 +14,6 @@ Npm.depends({
   "stream-to-string": "1.2.1",
   qs: "6.13.0",
   "useragent-ng": "2.4.3",
-  "@types/connect": "3.4.38",
   "tmp": "0.2.3",
 });
 

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -29,6 +29,7 @@ const createExpressApp = () => {
   // these headers come from these docs: https://expressjs.com/en/api.html#app.settings.table
   app.set('x-powered-by', false);
   app.set('etag', false);
+  app.set('query parser', qs.parse);
   return app;
 }
 export const WebApp = {};
@@ -1079,16 +1080,6 @@ async function runWebAppServer() {
     res.writeHead(400);
     res.write('Not a proxy');
     res.end();
-  });
-
-  // Parse the query string into res.query. Used by oauth_server, but it's
-  // generally pretty handy..
-  //
-  // Do this before the next middleware destroys req.url if a path prefix
-  // is set to close #10111.
-  app.use(function(request, response, next) {
-    request.query = qs.parse(parseUrl(request.url).query);
-    next();
   });
 
   function getPathParts(path) {

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -341,7 +341,7 @@ __meteor_runtime_config__.WEBAPP_TEST_B = '</script>';
 
 Tinytest.add("webapp - npm modules", function (test) {
   // Make sure the version number looks like a version number.
-  test.matches(WebAppInternals.NpmModules.express.version, /^4\.(\d+)\.(\d+)/);
+  test.matches(WebAppInternals.NpmModules.express.version, /^5\.(\d+)\.(\d+)/);
   test.equal(typeof(WebAppInternals.NpmModules.express.module), 'function');
 });
 

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -341,7 +341,7 @@ __meteor_runtime_config__.WEBAPP_TEST_B = '</script>';
 
 Tinytest.add("webapp - npm modules", function (test) {
   // Make sure the version number looks like a version number.
-  test.matches(WebAppInternals.NpmModules.express.version, /^4\.(\d+)\.(\d+)/);
+  test.matches(WebAppInternals.NpmModules.express.version, /^5\.(\d+)\.(\d+)/);
   test.equal(typeof(WebAppInternals.NpmModules.express.module), 'function');
 });
 
@@ -364,3 +364,53 @@ Tinytest.addAsync(
     test.isTrue(/__meteor_runtime_config__ = (.*customKey[^"].*customValue.*)/.test(html));
   }
 );
+
+Tinytest.addAsync("webapp - parse url queries", async function (test) {
+  WebApp.handlers.get("/queries", async (req, res) => {
+    res.json(req.query);
+  });
+
+  const queriesTestCases = [
+    'planet=Mars',
+    'galaxy=Andromeda&star=Betelgeuse',
+    'spacecraft=Voyager%202',
+    'meteor=Perseid&meteor=Leonid',
+    'astronaut[name]=Neil&astronaut[mission]=Apollo%2011',
+    'galaxy[name]=Milky%20Way&galaxy[diameter]=105700',
+    'constellation[name]=Orion&constellation[stars][]=Betelgeuse&constellation[stars][]=Rigel',
+    'galaxy[name]=Andromeda&galaxy[age]=10&meteors[]=Perseid&meteors[]=Geminid',
+    'astronaut[name]=Buzz&astronaut[missions][first]=Apollo%2011&astronaut[missions][second]=Apollo%2022',
+    'spacecraft[]=Voyager&spacecraft[]=Pioneer&spacecraft[0][type]=orbiter',
+    'comet=Halley&status=active%20comet',
+    'planet=&galaxy='
+  ];
+  const queryResults = [
+    { planet: 'Mars' },
+    { galaxy: 'Andromeda', star: 'Betelgeuse' },
+    { spacecraft: 'Voyager 2' },
+    { meteor: ['Perseid', 'Leonid'] },
+    { astronaut: { name: 'Neil', mission: 'Apollo 11' } },
+    { galaxy: { name: 'Milky Way', diameter: '105700' } },
+    { constellation: { name: 'Orion', stars: ['Betelgeuse', 'Rigel'] } },
+    {
+      galaxy: { name: 'Andromeda', age: '10' },
+      meteors: ['Perseid', 'Geminid']
+    },
+    {
+      astronaut: {
+        name: 'Buzz',
+        missions: { first: 'Apollo 11', second: 'Apollo 22' }
+      }
+    },
+    { spacecraft: ['Voyager', 'Pioneer', { type: 'orbiter' }] },
+    { comet: 'Halley', status: 'active comet' },
+    { planet: '', galaxy: '' }
+  ];
+  let i = 0;
+  for await (const queriesTestCase of queriesTestCases) {
+    const resp = await asyncGet(`${Meteor.absoluteUrl()}/queries?${queriesTestCase}`);
+    const queryParsed = JSON.parse(resp.content);
+    test.equal(queryParsed, queryResults[i]);
+    i++;
+  }
+});

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -341,7 +341,7 @@ __meteor_runtime_config__.WEBAPP_TEST_B = '</script>';
 
 Tinytest.add("webapp - npm modules", function (test) {
   // Make sure the version number looks like a version number.
-  test.matches(WebAppInternals.NpmModules.express.version, /^5\.(\d+)\.(\d+)/);
+  test.matches(WebAppInternals.NpmModules.express.version, /^4\.(\d+)\.(\d+)/);
   test.equal(typeof(WebAppInternals.NpmModules.express.module), 'function');
 });
 


### PR DESCRIPTION
OSS-571

This PR upgrades Express to the latest version 5. This will be included in the Meteor 3.1.x release.

You can find the full list of migration steps and breaking changes [here](https://expressjs.com/en/guide/migrating-5.html).

I've found only one breaking change in the Meteor Core. I’ve identified one regarding `request.query`, which is now read-only. We currently write to this field as part of an Express middleware for other endpoints, such as OAuth. I will provide tests to compare the current query parsing behavior with the new behavior and explore solutions to address this breaking change.

However, **this upgrade in general may require numerous migration steps for existing apps that fully utilize Express**, so we will decide on the release timing, whether to include it with other changes or isolate it.
