### PR TITLE
Fix Cordova build on indirect dependencies [Part 2]

### DIFF
--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -11,6 +11,7 @@ import { Profile } from '../tool-env/profile';
 import buildmessage from '../utils/buildmessage.js';
 import main from '../cli/main.js';
 import { execFileAsync } from '../utils/processes';
+var meteorNpm = require('../isobuild/meteor-npm');
 
 import { cordova as cordova_lib, events as cordova_events, CordovaError }
   from 'cordova-lib';
@@ -492,6 +493,8 @@ to Cordova project`, async () => {
         files.pathJoin(self.projectRoot, "package.json"),
         JSON.stringify(packageJsonObj, null, 2) + "\n"
       );
+
+      await meteorNpm.runNpmCommand(["install"], self.projectRoot);
     });
   }
 


### PR DESCRIPTION
OSS-566

Context: https://github.com/meteor/meteor/issues/13303

Continues: https://github.com/meteor/meteor/pull/13376

It turns out that this issue still isn't fully resolved in release 3.0.4. This has been frustrating because all my local testing, and even the beta, showed it was fixed on the past. However, the issue resurfaced on recent testing, it seems the Cordova dependencies in `meteor build` are not being installed as expected. The fix I provided on the previous PR was enough to have all cordova dependencies kept on package.json file within `.meteor/local/cordova-build` context, and apparently these were automatically installed and available to `node_modules`, which passed the build.

I implemented a fix on this forcing a reinstallation of cordova dependencies after my previous fix. Tested locally and it works.

This will be included on next patch or minor release.

![image](https://github.com/user-attachments/assets/62a15cc6-b725-411f-a59c-4f7b7b934b82)
