### PR TITLE
Simplify Meteor.EnvironmentVariable on the server

### DIFF
--- a/packages/accounts-2fa/.npm/package/npm-shrinkwrap.json
+++ b/packages/accounts-2fa/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 4,
   "dependencies": {
     "@types/node": {
-      "version": "22.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
-      "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw=="
+      "version": "22.7.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
+      "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg=="
     },
     "@types/notp": {
       "version": "2.0.5",

--- a/packages/ddp-client/test/livedata_test_service.js
+++ b/packages/ddp-client/test/livedata_test_service.js
@@ -334,38 +334,41 @@ if (Meteor.isServer) {
 One = new Mongo.Collection('collectionOne');
 Two = new Mongo.Collection('collectionTwo');
 
-Meteor.startup(async () => {
-  if (Meteor.isServer) {
-    await One.removeAsync({});
-    await One.insertAsync({ name: 'value1' });
-    await One.insertAsync({ name: 'value2' });
+async function populateDatabase() {
+  await One.removeAsync({});
+  await One.insertAsync({ name: 'value1' });
+  await One.insertAsync({ name: 'value2' });
 
-    await Two.removeAsync({});
-    await Two.insertAsync({ name: 'value3' });
-    await Two.insertAsync({ name: 'value4' });
-    await Two.insertAsync({ name: 'value5' });
+  await Two.removeAsync({});
+  await Two.insertAsync({ name: 'value3' });
+  await Two.insertAsync({ name: 'value4' });
+  await Two.insertAsync({ name: 'value5' });
+}
 
-    Meteor.publish('multiPublish', function(options) {
-      // See below to see what options are accepted.
-      check(options, Object);
-      if (options.normal) {
-        return [One.find(), Two.find()];
-      } else if (options.dup) {
-        // Suppress the log of the expected internal error.
-        Meteor._suppress_log(1);
-        return [
-          One.find(),
-          One.find({ name: 'value2' }), // multiple cursors for one collection - error
-          Two.find(),
-        ];
-      } else if (options.notCursor) {
-        // Suppress the log of the expected internal error.
-        Meteor._suppress_log(1);
-        return [One.find(), 'not a cursor', Two.find()];
-      } else throw 'unexpected options';
-    });
-  }
-});
+if (Meteor.isServer) {
+  Meteor.publish('multiPublish', async function (options) {
+    // See below to see what options are accepted.
+    check(options, Object);
+
+    await populateDatabase();
+
+    if (options.normal) {
+      return [One.find(), Two.find()];
+    } else if (options.dup) {
+      // Suppress the log of the expected internal error.
+      Meteor._suppress_log(1);
+      return [
+        One.find(),
+        One.find({ name: 'value2' }), // multiple cursors for one collection - error
+        Two.find(),
+      ];
+    } else if (options.notCursor) {
+      // Suppress the log of the expected internal error.
+      Meteor._suppress_log(1);
+      return [One.find(), 'not a cursor', Two.find()];
+    } else throw 'unexpected options';
+  });
+}
 
 /// Helper for "livedata - result by value"
 const resultByValueArrays = Object.create(null);

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1794,7 +1794,6 @@ Object.assign(Server.prototype, {
     const options = args[0]?.hasOwnProperty('returnStubValue')
       ? args.shift()
       : {};
-    DDP._CurrentMethodInvocation._set();
     DDP._CurrentMethodInvocation._setCallAsyncMethodRunning(true);
     const promise = new Promise((resolve, reject) => {
       DDP._CurrentCallAsyncInvocation._set({ name, hasCallAsyncParent: true });

--- a/packages/email/.npm/package/npm-shrinkwrap.json
+++ b/packages/email/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,9 @@
   "lockfileVersion": 4,
   "dependencies": {
     "@types/node": {
-      "version": "22.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
-      "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw=="
+      "version": "22.7.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
+      "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg=="
     },
     "@types/nodemailer": {
       "version": "6.4.14",

--- a/packages/email/email_tests.js
+++ b/packages/email/email_tests.js
@@ -18,7 +18,7 @@ TEST_CASES.forEach(({ title, options, testCalls }) => {
           testCall(test, stream);
         });
       });
-      Promise.all(allPromises).then(() => resolver());
+      Promise.all(allPromises).then(() => resolver()).catch(console.error);
     });
     await promise;
   });

--- a/packages/meteor/async_helpers.js
+++ b/packages/meteor/async_helpers.js
@@ -171,3 +171,5 @@ const _sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 Meteor._sleepForMs = function (ms) {
   return _sleep(ms);
 };
+
+Meteor.sleep = _sleep;

--- a/packages/tinytest/tinytest.js
+++ b/packages/tinytest/tinytest.js
@@ -435,7 +435,7 @@ export class TestCase {
         stop_at_offset
       );
 
-      const result = this.func(results, resolve);
+      const result = Meteor._runFresh(() => this.func(results, resolve));
       if (result && typeof result.then === "function") {
         return result.then(resolve, reject);
       }

--- a/packages/tinytest/tinytest_server.js
+++ b/packages/tinytest/tinytest_server.js
@@ -43,7 +43,7 @@ Meteor.methods({
     const collections = await MongoInternals.defaultRemoteCollectionDriver().mongo.db.collections();
 
     for (const collection of collections) {
-      await collection.drop();
+      await collection.deleteMany({});
     }
 
     this.unblock();

--- a/packages/tinytest/tinytest_server.js
+++ b/packages/tinytest/tinytest_server.js
@@ -12,7 +12,7 @@ export { Tinytest };
 const handlesForRun = new Map;
 const reportsForRun = new Map;
 
-Meteor.publish(ServerTestResultsSubscription, function (runId) {
+Meteor.publish(ServerTestResultsSubscription, async function (runId) {
   check(runId, String);
 
   if (! handlesForRun.has(runId)) {
@@ -36,9 +36,16 @@ Meteor.publish(ServerTestResultsSubscription, function (runId) {
 });
 
 Meteor.methods({
-  'tinytest/run'(runId, pathPrefix) {
+  async 'tinytest/run'(runId, pathPrefix) {
     check(runId, String);
     check(pathPrefix, Match.Optional([String]));
+
+    const collections = await MongoInternals.defaultRemoteCollectionDriver().mongo.db.collections();
+
+    for (const collection of collections) {
+      await collection.drop();
+    }
+
     this.unblock();
 
     reportsForRun.set(runId, Object.create(null));


### PR DESCRIPTION
I have difficulty understanding the current implementation of EnvironmentVariable's, so this PR rewrites it to be simpler. The implementation is now very similar to how it worked with fibers. It simply uses a sparse array to store all of the values. Whenever it changes the value, it clones the array and runs with a new store (two exceptions are `_set` and `_setNewContextAndGetCurrent`, which we probably should move away from).

All of the tests pass locally, including the new one added in #13423 for #13420 (which is not included in this PR).

<!--OSS-589-->