### PR TITLE
chore: fix warnings about calling Meteor.user() instead of Meteor.userAsync on the server when running accounts-password's test suite

### DIFF
--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1212,10 +1212,10 @@ if (Meteor.isServer) (() => {
 
   // This test properly belongs in accounts-base/accounts_tests.js, but
   // this is where the tests that actually log in are.
-  Tinytest.addAsync('accounts - user() out of context', async test => {
+  Tinytest.addAsync('accounts - userAsync() out of context', async test => {
     await test.throwsAsync(
       async () =>
-        await Meteor.user()
+        await Meteor.userAsync()
     );
     await Meteor.users.removeAsync({});
   });

--- a/packages/accounts-password/password_tests_setup.js
+++ b/packages/accounts-password/password_tests_setup.js
@@ -121,7 +121,7 @@ Accounts.config({
 Meteor.methods(
   {
     testMeteorUser:
-      async () => await Meteor.user(),
+      async () => await Meteor.userAsync(),
 
     clearUsernameAndProfile:
       async function () {


### PR DESCRIPTION
This PR removes some warnings when running the `accounts-password` test suite.

### Before
![fix-warning-accounts-password-before](https://github.com/user-attachments/assets/797fd89f-7a80-4280-b14d-50ea1cd22c89)

### After
![fix-warning-accounts-password-after](https://github.com/user-attachments/assets/c0a6ad83-36c0-4756-b4f7-8e078cc3e93c)
