### PR TITLE
Fix performance issue with bundler ensuring proper parallelization

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1374,7 +1374,7 @@ ${Console.command("meteor build ../output")}`,
       files.pathJoin(outputPath, 'bundle')) :
       files.pathJoin(buildDir, 'bundle');
 
-  await stats.recordPackages({
+  stats.recordPackages({
     what: "sdk.bundle",
     projectContext: projectContext
   });

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1223,13 +1223,16 @@ class Target {
           continue;
         }
 
+        var data = await resource.data;
+        var hash = await resource.hash;
+
         const fileOptions = {
           info: 'unbuild ' + resource,
           arch: this.arch,
-          data: await resource.data,
+          data,
           cacheable: false,
-          hash: await resource.hash,
-          skipSri: !!await resource.hash
+          hash,
+          skipSri: !!hash
         };
 
         const file = new File(fileOptions);
@@ -1290,15 +1293,17 @@ class Target {
             continue;
           }
 
+          var data = await resource.data;
+          var hash = await resource.hash;
           let sourcePath;
-          if ((await resource.data) && resource.sourceRoot && resource.sourcePath) {
+          if (data && resource.sourceRoot && resource.sourcePath) {
             sourcePath = files.pathJoin(resource.sourceRoot, resource.sourcePath);
           }
           const f = new File({
             info: 'resource ' + resource.servePath,
             arch: this.arch,
-            data: await resource.data,
-            hash: await resource.hash,
+            data,
+            hash,
             cacheable: false,
             replaceable: resource.type === 'js' && sourceBatch.hmrAvailable,
             sourcePath
@@ -1323,14 +1328,15 @@ class Target {
             });
           }
 
+          var sourceMap = await resource.sourceMap;
           // Both CSS and JS files can have source maps
-          if (await resource.sourceMap) {
+          if (sourceMap) {
             // XXX we used to set sourceMapRoot to
             // files.pathDirname(relPath) but it's unclear why.  With the
             // currently generated source map file names, it works without it
             // and doesn't work well with it... maybe?  we were getting
             // 'packages/packages/foo/bar.js'
-            f.setSourceMap(await resource.sourceMap, null);
+            f.setSourceMap(sourceMap, null);
           }
 
           this[resource.type].push(f);

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -1720,21 +1720,21 @@ export class PackageSourceBatch {
     const fileHashes = [];
     const cacheKeyPrefix = sha1(JSON.stringify({
       linkerOptions,
-      files: await jsResources.reduce(async (acc, inputFile) => {
-        const resolvedAcc = await acc;
-
-        fileHashes.push(await inputFile.hash);
-        return [...resolvedAcc, {
-          meteorInstallOptions: inputFile.meteorInstallOptions,
-          absModuleId: inputFile.absModuleId,
-          sourceMap: !! await inputFile.sourceMap,
-          mainModule: inputFile.mainModule,
-          imported: inputFile.imported,
-          alias: inputFile.alias,
-          lazy: inputFile.lazy,
-          bare: inputFile.bare,
-        }];
-      }, Promise.resolve([]))
+      files: await Promise.all(
+        jsResources.map(async (inputFile) => {
+          fileHashes.push(await inputFile.hash);
+          return {
+            meteorInstallOptions: inputFile.meteorInstallOptions,
+            absModuleId: inputFile.absModuleId,
+            sourceMap: !!(await inputFile.sourceMap),
+            mainModule: inputFile.mainModule,
+            imported: inputFile.imported,
+            alias: inputFile.alias,
+            lazy: inputFile.lazy,
+            bare: inputFile.bare,
+          };
+        })
+      )
     }));
     const cacheKeySuffix = sha1(JSON.stringify({
       LINKER_CACHE_SALT,

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -911,7 +911,7 @@ Object.assign(AppRunner.prototype, {
 
         var oldPromise = self.runPromise = self._makePromise("run");
 
-        await refreshClient();
+        refreshClient();
 
         // Establish a watcher on the new files.
         setupClientWatcher();

--- a/tools/runners/run-app.js
+++ b/tools/runners/run-app.js
@@ -574,7 +574,7 @@ Object.assign(AppRunner.prototype, {
 
       if (self.recordPackageUsage) {
         // Maybe this doesn't need to be awaited for?
-        await stats.recordPackages({
+        stats.recordPackages({
           what: "sdk.run",
           projectContext: self.projectContext
         });


### PR DESCRIPTION
OSS-586

Context: https://github.com/meteor/meteor/issues/13430 and  [forum post](https://forums.meteor.com/t/super-slow-hmr-in-meteor-3-0)

This PR investigates the performance impact on app builds/rebuilds in Meteor 3.0.

## Issue

Some parts of the code lost parallelism when adapted to use fibers, leading to performance issues in async operations.

I added `console.time` and `console.timeEnd` to detect where timing mismatches occurred in the Meteor build process, especially compared to Meteor 2. The next picture shows that makeClientTarget introduced a significant delay. I debugged further, identified the problematic code section, and fixed it.

![image](https://github.com/user-attachments/assets/a468c823-1449-4d8f-8463-7c23970afe62)

## Solution

In several parts of the code, Promise.all could be used to speed things up. For this specific issue, I identified and fixed the slow spot causing the problem.

![image](https://github.com/user-attachments/assets/db3dd41e-a31c-46f7-864a-f7ddf32a99e7)

This issue could generally improve the build process, and with the latest Node's speed, we'll start seeing real gains.

This pattern could be applied more broadly, but we should focus on areas with notable gains. Additionally, adding benchmark monitoring for Meteor builds could help catch and resolve future regressions, the same way we have in [meteor/performance](https://github.com/meteor/performance) for Meteor runtime.

## Pending

- [x] Review package usage recording under poor network conditions

- [x] Test with the reported app as I used a scenario using a small example where was enough and quick to find and work out the regression.

## Other perf improvements

### recordPackageUsage

https://github.com/meteor/meteor/pull/13448#issuecomment-2459752591

### refreshClient

Don't need to await as in Meteor 2, https://github.com/meteor/meteor/blob/2.x.x/tools/runners/run-app.js#L911

![image](https://github.com/user-attachments/assets/0cafa5e2-f6f3-4cf2-a9f6-3c00d9d41bdb)


