### PR TITLE
feat: stop using rosetta for bundled mongo in macos

### DIFF
--- a/scripts/generate-dev-bundle.sh
+++ b/scripts/generate-dev-bundle.sh
@@ -70,9 +70,8 @@ case $OS in
         ;;
 esac
 
-
 if [ $OS = "macos" ] && [ "$(uname -m)" = "arm64" ] ; then
-  MONGO_NAME="mongodb-${OS}-x86_64-${MONGO_VERSION}"
+  MONGO_NAME="mongodb-${OS}-arm64-${MONGO_VERSION}"
 elif [ $OS = "linux" ] && [ "$ARCH" = "aarch64" ] ; then
   MONGO_NAME="mongodb-linux-aarch64-ubuntu2204-${MONGO_VERSION}"
 else
@@ -83,6 +82,13 @@ MONGO_TGZ="${MONGO_NAME}.tgz"
 MONGO_URL="${MONGO_BASE_URL}/${MONGO_TGZ}"
 echo "Downloading Mongo from ${MONGO_URL}"
 curl -L "${MONGO_URL}" | tar zx
+
+# The tarball outputs as folder name "mongodb-macos-aarch64-X.X.X" even though the URL and the tarball name suggest "mongodb-macos-arm64-X.X.X"
+# So we need to rename the folder to match the expected folder name
+# Watch out for newer versions of the tarball that might already be named correctly
+if [ $OS = "macos" ] && [ "$(uname -m)" = "arm64" ] ; then
+  MONGO_NAME=$(echo "$MONGO_NAME" | sed 's/arm64/aarch64/g')
+fi
 
 # Put Mongo binaries in the right spot (mongodb/bin)
 mkdir -p "mongodb/bin"

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -1,3 +1,4 @@
+import { loadIsopackage } from '../tool-env/isopackets.js';
 import { MongoExitCodes } from '../utils/mongo-exit-codes';
 var files = require('../fs/files');
 var utils = require('../utils/utils.js');
@@ -5,7 +6,6 @@ var fiberHelpers = require('../utils/fiber-helpers.js');
 var runLog = require('./run-log.js');
 var child_process = require('child_process');
 var _ = require('underscore');
-import { loadIsopackage } from '../tool-env/isopackets.js';
 var Console = require('../console/console.js').Console;
 
 // Given a Mongo URL, open an interactive Mongo shell on this terminal
@@ -51,11 +51,6 @@ function spawnMongod(mongodPath, port, dbPath, replSetName) {
     args.push('--storageEngine', 'mmapv1', '--smallfiles');
   }
 
-  // run with rosetta on mac m1
-  if (process.platform === 'darwin' && process.arch === 'arm64') {
-    args = ['-x86_64', mongodPath, ...args];
-    mongodPath = 'arch';
-  }
   return child_process.spawn(mongodPath, args, {
     // Apparently in some contexts, Mongo crashes if your locale isn't set up
     // right. I wasn't able to reproduce it, but many people on #4019


### PR DESCRIPTION
I was having an issue where the process would hang and nothing, not even fire, would kill it... by stop using rosetta the issue is fixed for me, and for sure results better performance etc as well

possibly related to https://github.com/meteor/meteor/issues/13108