### PR TITLE
Fix Cordova build when using custom plugins using protocols

### DIFF
--- a/tools/cordova/project.js
+++ b/tools/cordova/project.js
@@ -463,6 +463,8 @@ to Cordova project`, async () => {
       let platformSpec = version ? `${platform}@${version}` : platform;
       await cordova_lib.platform('add', platformSpec, this.defaultOptions);
 
+      const installedPlugins = this.listInstalledPluginVersions();
+
       // As per Npm 8, we need now do inject a package.json file
       // with the dependencies so that when running any npm command
       // it keeps the dependencies installed.
@@ -482,10 +484,11 @@ to Cordova project`, async () => {
 
       const packageJsonObj = Object.entries(packages).reduce((acc, [key, value]) => {
         const name = getPackageName(key);
+        const originalPluginVersion = installedPlugins[name];
         return ({
           dependencies: {
             ...acc.dependencies,
-            [name]: value.version,
+            [name]: originalPluginVersion || value.version,
           }
         });
       }, { dependencies: { [`cordova-${platform}`]: version  } });


### PR DESCRIPTION
OSS-566

Context:  https://github.com/meteor/meteor/issues/13303, https://github.com/meteor/meteor/pull/13358#issuecomment-2465717148

Continues: https://github.com/meteor/meteor/pull/13416

This PR solves an edge case not covered on the fix that prepared npm packages for cordova build, supporting indirect dependencies. With the changes on this PR it will also support cordova dependencies that you describe using the common protocols, `git+https://`, `git+ssh://`, `git://` and `file://`.

The fix will use the version described by on cordova file if exists, otherwise the automatically resolved and used as part of the package-lock.json on prepare the npm dependencies for cordova.

After building Cordova app, the `.meteor/local/cordova-build/package.json` resolve the dependencies properly as shown here:

![image](https://github.com/user-attachments/assets/ef2dd1a2-2fee-46c7-b3f0-a979f98ba6e9)

