### PR TITLE
Fix Cordova issue when using accounts-base

### DIFF
--- a/packages/url/legacy.js
+++ b/packages/url/legacy.js
@@ -4,7 +4,7 @@ try {
   exports.URLSearchParams = URLSearchParams;
 
   require("core-js/proposals/url");
-  URL = window.URLSearchParams;
+  URL = window.URL;
   exports.URL = URL;
 } catch (e) {
   console.log(' error', e);

--- a/packages/url/legacy.js
+++ b/packages/url/legacy.js
@@ -1,6 +1,13 @@
 try {
+  require("url-search-params-polyfill");
+  URLSearchParams = window.URLSearchParams;
+  exports.URLSearchParams = URLSearchParams;
+
   require("core-js/proposals/url");
+  URL = window.URLSearchParams;
+  exports.URL = URL;
 } catch (e) {
+  console.log(' error', e);
   throw new Error([
     "The core-js npm package could not be found in your node_modules ",
     "directory. Please run the following command to install it:",

--- a/packages/url/legacy.js
+++ b/packages/url/legacy.js
@@ -7,7 +7,6 @@ try {
   URL = window.URL;
   exports.URL = URL;
 } catch (e) {
-  console.log(' error', e);
   throw new Error([
     "The core-js npm package could not be found in your node_modules ",
     "directory. Please run the following command to install it:",

--- a/packages/url/package.js
+++ b/packages/url/package.js
@@ -6,7 +6,8 @@ Package.describe({
 });
 
 Npm.depends({
-  "core-js": "3.38.1"
+  "core-js": "3.39.0",
+  "url-search-params-polyfill": "8.2.5",
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
OSS-616

Context: https://github.com/meteor/meteor/issues/13450 and [forum post](https://forums.meteor.com/t/meteor-meteor-3-0-4-meteor-run-ios-throws-several-errors-and-warnings/62514)


## Issue

This PR addresses an issue that started to happen on early Meteor 3 versions (including 3.0.1 launch) and caused from [updating "core-js" packages](https://github.com/meteor/meteor/commit/79551fb53b2f48ac1f42405f2893b8f9d5553054) to the latest version. The Meteor `url` package, used by `accounts-base`, relies on `core-js` to maintain compatibility with legacy builds, which are essential for running the app in Cordova webviews. Updating `core-js` required handling breaking changes like the one here, and we currently lack regression tests to verify Cordova builds with the accounts package.

## Solution

To resolve the issue with newer versions, I added `url-search-params-polyfill` for legacy builds, as latest `core-js` no longer supports `URLSearchParams` and assumes it’s available, but only does for modern bundles.

## Conclusion

In future reviews, we should be particularly cautious with version bumps, especially with minor or major updates, to find impacts on related packages, specially in those we don't have any kind of coverage or result hard to achieve (like legacy bundles).
