### PR TITLE
FIX: Issue with meteor publish with update option

### DIFF
--- a/tools/packaging/package-client.js
+++ b/tools/packaging/package-client.js
@@ -466,7 +466,7 @@ exports.handlePackageServerConnectionError = function (error) {
 };
 
 
-// Update the package metdata in the server catalog. Chane the docs,
+// Update the package metadata in the server catalog. Change the docs,
 // descriptions and the Git URL to new values.
 //
 // options:
@@ -537,7 +537,7 @@ exports.updatePackageMetadata = async function (options) {
 
   // Upload the new Readme.
   await buildmessage.enterJob('uploading documentation', async function () {
-    var readmePath = saveReadmeToTmp(readmeInfo);
+    var readmePath = await saveReadmeToTmp(readmeInfo);
     var uploadInfo =
       await callPackageServerBM(conn, "createReadme", versionIdentifier);
     if (!uploadInfo) {


### PR DESCRIPTION
<-- OSS-579 -->

As per my comment in https://github.com/meteor/meteor/issues/13394#issuecomment-2474951184
It was missing an await in the update readme function.

I did not add tests, as this snippet would require the usage of a network 
 and the following functions, too
https://github.com/meteor/meteor/blob/3747d4cb875f1282121ae7df473e0b00c3b3ce7c/tools/cli/commands-packages.js#L175-L184 

In the future, think of a way of mocking or being able to do tests in functions and not only system tests.

An increase in types could help, too.


this closes #13394


I tested it locally without the fix and with the fix:

<img width="1351" alt="Screenshot 2024-11-13 at 20 26 49" src="https://github.com/user-attachments/assets/ed7f6fe6-bf29-4250-8cbd-38f439e4eb05">

> without

<img width="1282" alt="Screenshot 2024-11-13 at 20 27 38" src="https://github.com/user-attachments/assets/269ed9e2-3a85-49f2-948a-262e6f25e835">

> with



