### PR TITLE
Update Mongo.Collection types to allow async allow-deny rules

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -98,6 +98,9 @@ export namespace Mongo {
       insert?:
         | ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean)
         | undefined;
+      insertAsync?:
+        | ((userId: string, doc: DispatchTransform<Fn, T, U>) => Promise<boolean>|boolean)
+        | undefined;
       update?:
         | ((
             userId: string,
@@ -106,8 +109,19 @@ export namespace Mongo {
             modifier: any
           ) => boolean)
         | undefined;
+      updateAsync?:
+        | ((
+            userId: string,
+            doc: DispatchTransform<Fn, T, U>,
+            fieldNames: string[],
+            modifier: any
+          ) => Promise<boolean>|boolean)
+        | undefined;
       remove?:
         | ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean)
+        | undefined;
+      removeAsync?:
+        | ((userId: string, doc: DispatchTransform<Fn, T, U>) => Promise<boolean>|boolean)
         | undefined;
       fetch?: string[] | undefined;
       transform?: Fn | undefined;


### PR DESCRIPTION
This minor PR adds a few missing properties to the type of the parameter you can pass to `someCollection.allow`. The code already accepts async rules there, but since the type definitions don't include them, TypeScript complains. 

This issue was reported in #13444 by @Julusian.