### PR TITLE
fix: rename setPublicationStrategy and getPublicationStrategy arguments in v3

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1576,33 +1576,33 @@ Object.assign(Server.prototype, {
   },
 
   /**
-   * @summary Set publication strategy for the given publication. Publications strategies are available from `DDPServer.publicationStrategies`. You call this method from `Meteor.server`, like `Meteor.server.setPublicationStrategy()`
+   * @summary Set publication strategy for the given collection. Publications strategies are available from `DDPServer.publicationStrategies`. You call this method from `Meteor.server`, like `Meteor.server.setPublicationStrategy()`
    * @locus Server
    * @alias setPublicationStrategy
-   * @param publicationName {String}
+   * @param collectionName {String}
    * @param strategy {{useCollectionView: boolean, doAccountingForCollection: boolean}}
    * @memberOf Meteor.server
    * @importFromPackage meteor
    */
-  setPublicationStrategy(publicationName, strategy) {
+  setPublicationStrategy(collectionName, strategy) {
     if (!Object.values(publicationStrategies).includes(strategy)) {
       throw new Error(`Invalid merge strategy: ${strategy} 
-        for collection ${publicationName}`);
+        for collection ${collectionName}`);
     }
-    this._publicationStrategies[publicationName] = strategy;
+    this._publicationStrategies[collectionName] = strategy;
   },
 
   /**
-   * @summary Gets the publication strategy for the requested publication. You call this method from `Meteor.server`, like `Meteor.server.getPublicationStrategy()`
+   * @summary Gets the publication strategy for the requested collection. You call this method from `Meteor.server`, like `Meteor.server.getPublicationStrategy()`
    * @locus Server
    * @alias getPublicationStrategy
-   * @param publicationName {String}
+   * @param collectionName {String}
    * @memberOf Meteor.server
    * @importFromPackage meteor
    * @return {{useCollectionView: boolean, doAccountingForCollection: boolean}}
    */
-  getPublicationStrategy(publicationName) {
-    return this._publicationStrategies[publicationName]
+  getPublicationStrategy(collectionName) {
+    return this._publicationStrategies[collectionName]
       || this.options.defaultPublicationStrategy;
   },
 


### PR DESCRIPTION
Rename `setPublicationStrategy` and `getPublicationStrategy` arguments to use `collectionName` instead of `publicationName`.

Fix issue: https://github.com/meteor/meteor/issues/13470

Same issue was fixed in v2: https://github.com/meteor/meteor/pull/12166