### PR TITLE
Docs: add multiple versions to docs

### DIFF
--- a/packages/modules/.npm/package/npm-shrinkwrap.json
+++ b/packages/modules/.npm/package/npm-shrinkwrap.json
@@ -12,9 +12,9 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg=="
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
     },
     "estree-walker": {
       "version": "2.0.2",

--- a/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-mongo/.npm/package/npm-shrinkwrap.json
@@ -56,129 +56,129 @@
       }
     },
     "@aws-sdk/client-cognito-identity": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.670.0.tgz",
-      "integrity": "sha512-4q/yYdtO/RisGdQ3a2E912YekIpQYvS4TYPYS/onCbTXW/7C8/Ha7yUEncE7Woou0MDXyoVh50UATcJEmUt0+Q=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.693.0.tgz",
+      "integrity": "sha512-WfycTcylmrSOnCN8x/xeIjHa4gIV4UhG85LWLZ3M4US8+HJQ8l4c4WUf+pUoTaSxN86vhbXlz0iRvA89nF854Q=="
     },
     "@aws-sdk/client-sso": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.670.0.tgz",
-      "integrity": "sha512-J+oz6uSsDvk4pimMDnKJb1wsV216zTrejvMTIL4RhUD1QPIVVOpteTdUShcjZUIZnkcJZGI+cym/SFK0kuzTpg=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.693.0.tgz",
+      "integrity": "sha512-QEynrBC26x6TG9ZMzApR/kZ3lmt4lEIs2D+cHuDxt6fDGzahBUsQFBwJqhizzsM97JJI5YvmJhmihoYjdSSaXA=="
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.670.0.tgz",
-      "integrity": "sha512-4qDK2L36Q4J1lfemaHHd9ZxqKRaos3STp44qPAHf/8QyX6Uk5sXgZNVO2yWM7SIEtVKwwBh/fZAsdBkGPBfZcw=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
+      "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg=="
     },
     "@aws-sdk/client-sts": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.670.0.tgz",
-      "integrity": "sha512-bExrNo8ZVWorS3cjMZKQnA2HWqDmAzcZoSN/cPVoPFNkHwdl1lzPxvcLzmhpIr48JHgKfybBjrbluDZfIYeEog=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
+      "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ=="
     },
     "@aws-sdk/core": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
-      "integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.693.0.tgz",
+      "integrity": "sha512-v6Z/kWmLFqRLDPEwl9hJGhtTgIFHjZugSfF1Yqffdxf4n1AWgtHS7qSegakuMyN5pP4K2tvUD8qHJ+gGe2Bw2A=="
     },
     "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.670.0.tgz",
-      "integrity": "sha512-l41x9lZtZnzyQ6+8D3i7BwqwG1u7JTfHwJDZmsh+sIbrccLlJm7TfxkegOwUbzJ6JdzdigCIM1cKBc52O8EG9w=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.693.0.tgz",
+      "integrity": "sha512-hlpV3tkOhpFl87aToH6Q6k7JBNNuARBPk+irPMtgE8ZqpYRP9tJ/RXftirzZ7CqSzc7NEWe/mnbJzRXw7DfgVQ=="
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
-      "integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.693.0.tgz",
+      "integrity": "sha512-hMUZaRSF7+iBKZfBHNLihFs9zvpM1CB8MBOTnTp5NGCVkRYF3SB2LH+Kcippe0ats4qCyB1eEoyQX99rERp2iQ=="
     },
     "@aws-sdk/credential-provider-http": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
-      "integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.693.0.tgz",
+      "integrity": "sha512-sL8MvwNJU7ZpD7/d2VVb3by1GknIJUxzTIgYtVkDVA/ojo+KRQSSHxcj0EWWXF5DTSh2Tm+LrEug3y1ZyKHsDA=="
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.670.0.tgz",
-      "integrity": "sha512-TB1gacUj75leaTt2JsCTzygDSIk4ksv9uZoR7VenlgFPRktyOeT+fapwIVBeB2Qg7b9uxAY2K5XkKstDZyBEEw=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.693.0.tgz",
+      "integrity": "sha512-kvaa4mXhCCOuW7UQnBhYqYfgWmwy7WSBSDClutwSLPZvgrhYj2l16SD2lN4IfYdxARYMJJ1lFYp3/jJG/9Yk4Q=="
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.670.0.tgz",
-      "integrity": "sha512-zwNrRYzubk4CaZ7zebeDhxsm8QtNWkbGKopZPOaZSnd5uqUGRcmx4ccVRngWUK68XDP44aEUWC8iU5Pc7btpHQ=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.693.0.tgz",
+      "integrity": "sha512-42WMsBjTNnjYxYuM3qD/Nq+8b7UdMopUq5OduMDxoM3mFTV6PXMMnfI4Z1TNnR4tYRvPXAnuNltF6xmjKbSJRA=="
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
-      "integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.693.0.tgz",
+      "integrity": "sha512-cvxQkrTWHHjeHrPlj7EWXPnFSq8x7vMx+Zn1oTsMpCY445N9KuzjfJTkmNGwU2GT6rSZI9/0MM02aQvl5bBBTQ=="
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.670.0.tgz",
-      "integrity": "sha512-5PkA8BOy4q57Vhe9AESoHKZ7vjRbElNPKjXA4qC01xY+DitClRFz4O3B9sMzFp0PHlz9nDVSXXKgq0yzF/nAag=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.693.0.tgz",
+      "integrity": "sha512-479UlJxY+BFjj3pJFYUNC0DCMrykuG7wBAXfsvZqQxKUa83DnH5Q1ID/N2hZLkxjGd4ZW0AC3lTOMxFelGzzpQ=="
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
-      "integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.693.0.tgz",
+      "integrity": "sha512-8LB210Pr6VeCiSb2hIra+sAH4KUBLyGaN50axHtIgufVK8jbKIctTZcVY5TO9Se+1107TsruzeXS7VeqVdJfFA=="
     },
     "@aws-sdk/credential-providers": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.670.0.tgz",
-      "integrity": "sha512-2O7Ditryao7/8pCS4GPP2pba/Ia/rruejKoI8STiSmdgccssHcaHtiJ3mYNkKtRUEdi19ulspfz1nU+Ew4x4fA=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.693.0.tgz",
+      "integrity": "sha512-0CCH8GuH1E41Kpq52NujErbUIRewDWLkdbYO8UJGybDbUQ8KC5JG1tP7K20tKYHmVgJGXDHo+XUIG7ogHD6/JA=="
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
-      "integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.693.0.tgz",
+      "integrity": "sha512-BCki6sAZ5jYwIN/t3ElCiwerHad69ipHwPsDCxJQyeiOnJ8HG+lEpnVIfrnI8A0fLQNSF3Gtx6ahfBpKiv1Oug=="
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
-      "integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.693.0.tgz",
+      "integrity": "sha512-dXnXDPr+wIiJ1TLADACI1g9pkSB21KkMIko2u4CJ2JCBoxi5IqeTnVoa6YcC8GdFNVRl+PorZ3Zqfmf1EOTC6w=="
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
-      "integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.693.0.tgz",
+      "integrity": "sha512-0LDmM+VxXp0u3rG0xQRWD/q6Ubi7G8I44tBPahevD5CaiDZTkmNTrVUf0VEJgVe0iCKBppACMBDkLB0/ETqkFw=="
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.669.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.669.0.tgz",
-      "integrity": "sha512-K8ScPi45zjJrj5Y2gRqVsvKKQCQbvQBfYGcBw9ZOx9TTavH80bOCBjWg/GFnvs4f37tqVc1wMN2oGvcTF6HveQ=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.693.0.tgz",
+      "integrity": "sha512-/KUq/KEpFFbQmNmpp7SpAtFAdViquDfD2W0QcG07zYBfz9MwE2ig48ALynXm5sMpRmnG7sJXjdvPtTsSVPfkiw=="
     },
     "@aws-sdk/region-config-resolver": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
-      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.693.0.tgz",
+      "integrity": "sha512-YLUkMsUY0GLW/nfwlZ69cy1u07EZRmsv8Z9m0qW317/EZaVx59hcvmcvb+W4bFqj5E8YImTjoGfE4cZ0F9mkyw=="
     },
     "@aws-sdk/token-providers": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
-      "integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.693.0.tgz",
+      "integrity": "sha512-nDBTJMk1l/YmFULGfRbToOA2wjf+FkQT4dMgYCv+V9uSYsMzQj8A7Tha2dz9yv4vnQgYaEiErQ8d7HVyXcVEoA=="
     },
     "@aws-sdk/types": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
-      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg=="
+      "version": "3.692.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.692.0.tgz",
+      "integrity": "sha512-RpNvzD7zMEhiKgmlxGzyXaEcg2khvM7wd5sSHVapOcrde1awQSOMGI4zKBQ+wy5TnDfrm170ROz/ERLYtrjPZA=="
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
-      "integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.693.0.tgz",
+      "integrity": "sha512-eo4F6DRQ/kxS3gxJpLRv+aDNy76DxQJL5B3DPzpr9Vkq0ygVoi4GT5oIZLVaAVIJmi6k5qq9dLsYZfWLUxJJSg=="
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.568.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
-      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.693.0.tgz",
+      "integrity": "sha512-ttrag6haJLWABhLqtg1Uf+4LgHWIMOVSYL+VYZmAp2v4PUGOwWmWQH0Zk8RM7YuQcLfH/EoR72/Yxz6A4FKcuw=="
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.670.0.tgz",
-      "integrity": "sha512-iRynWWazqEcCKwGMcQcywKTDLdLvqts1Yx474U64I9OKQXXwhOwhXbF5CAPSRta86lkVNAVYJa/0Bsv45pNn1A=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.693.0.tgz",
+      "integrity": "sha512-6EUfuKOujtddy18OLJUaXfKBgs+UcbZ6N/3QV4iOkubCUdeM1maIqs++B9bhCbWeaeF5ORizJw5FTwnyNjE/mw=="
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.669.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.669.0.tgz",
-      "integrity": "sha512-9jxCYrgggy2xd44ZASqI7AMiRVaSiFp+06Kg8BQSU0ijKpBJlwcsqIS8pDT/n6LxuOw2eV5ipvM2C0r1iKzrGA=="
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.693.0.tgz",
+      "integrity": "sha512-td0OVX8m5ZKiXtecIDuzY3Y3UZIzvxEr57Hp21NOwieqKCG2UeyQWWeGPv0FQaU7dpTkvFmVNI+tx9iB8V/Nhg=="
     },
     "@mongodb-js/saslprep": {
       "version": "1.1.9",
@@ -186,39 +186,39 @@
       "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw=="
     },
     "@smithy/abort-controller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.5.tgz",
-      "integrity": "sha512-DhNPnqTqPoG8aZ5dWkFOgsuY+i0GQ3CI6hMmvCoduNsnU9gUZWZBwGfDQsTTB7NvFPkom1df7jMIJWU90kuXXg=="
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.8.tgz",
+      "integrity": "sha512-+3DOBcUn5/rVjlxGvUPKc416SExarAQ+Qe0bqk30YSUjbepwpS7QN0cyKUSifvLJhdMZ0WPzPP5ymut0oonrpQ=="
     },
     "@smithy/config-resolver": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.9.tgz",
-      "integrity": "sha512-5d9oBf40qC7n2xUoHmntKLdqsyTMMo/r49+eqSIjJ73eDfEtljAxEhzIQ3bkgXJtR3xiv7YzMT/3FF3ORkjWdg=="
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.12.tgz",
+      "integrity": "sha512-YAJP9UJFZRZ8N+UruTeq78zkdjUHmzsY62J4qKWZ4SXB4QXJ/+680EfXXgkYA2xj77ooMqtUY9m406zGNqwivQ=="
     },
     "@smithy/core": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.8.tgz",
-      "integrity": "sha512-x4qWk7p/a4dcf7Vxb2MODIf4OIcqNbK182WxRvZ/3oKPrf/6Fdic5sSElhO1UtXpWKBazWfqg0ZEK9xN1DsuHA=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.3.tgz",
+      "integrity": "sha512-96uW8maifUSmehaeW7uydWn7wBc98NEeNI3zN8vqakGpyCQgzyJaA64Z4FCOUmAdCJkhppd/7SZ798Fo4Xx37g=="
     },
     "@smithy/credential-provider-imds": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.4.tgz",
-      "integrity": "sha512-S9bb0EIokfYEuar4kEbLta+ivlKCWOCFsLZuilkNy9i0uEUEHSi47IFLPaxqqCl+0ftKmcOTHayY5nQhAuq7+w=="
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.7.tgz",
+      "integrity": "sha512-cEfbau+rrWF8ylkmmVAObOmjbTIzKyUC5TkBL58SbLywD0RCBC4JAUKbmtSm2w5KUJNRPGgpGFMvE2FKnuNlWQ=="
     },
     "@smithy/fetch-http-handler": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
-      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
+      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA=="
     },
     "@smithy/hash-node": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.7.tgz",
-      "integrity": "sha512-SAGHN+QkrwcHFjfWzs/czX94ZEjPJ0CrWJS3M43WswDXVEuP4AVy9gJ3+AF6JQHZD13bojmuf/Ap/ItDeZ+Qfw=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.10.tgz",
+      "integrity": "sha512-3zWGWCHI+FlJ5WJwx73Mw2llYR8aflVyZN5JhoqLxbdPZi6UyKSdCeXAWJw9ja22m6S6Tzz1KZ+kAaSwvydi0g=="
     },
     "@smithy/invalid-dependency": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.7.tgz",
-      "integrity": "sha512-Bq00GsAhHeYSuZX8Kpu4sbI9agH2BNYnqUmmbTGWOhki9NVsWn2jFr896vvoTMH8KAjNX/ErC/8t5QHuEXG+IA=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.10.tgz",
+      "integrity": "sha512-Lp2L65vFi+cj0vFMu2obpPW69DU+6O5g3086lmI4XcnRCG8PxvpWC7XyaVwJCxsZFzueHjXnrOH/E0pl0zikfA=="
     },
     "@smithy/is-array-buffer": {
       "version": "3.0.0",
@@ -226,89 +226,89 @@
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ=="
     },
     "@smithy/middleware-content-length": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.9.tgz",
-      "integrity": "sha512-t97PidoGElF9hTtLCrof32wfWMqC5g2SEJNxaVH3NjlatuNGsdxXRYO/t+RPnxA15RpYiS0f+zG7FuE2DeGgjA=="
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.12.tgz",
+      "integrity": "sha512-1mDEXqzM20yywaMDuf5o9ue8OkJ373lSPbaSjyEvkWdqELhFMyNNgKGWL/rCSf4KME8B+HlHKuR8u9kRj8HzEQ=="
     },
     "@smithy/middleware-endpoint": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.4.tgz",
-      "integrity": "sha512-/ChcVHekAyzUbyPRI8CzPPLj6y8QRAfJngWcLMgsWxKVzw/RzBV69mSOzJYDD3pRwushA1+5tHtPF8fjmzBnrQ=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.3.tgz",
+      "integrity": "sha512-Hdl9296i/EMptaX7agrSzJZDiz5Y8XPUeBbctTmMtnCguGpqfU3jVsTUan0VLaOhsnquqWLL8Bl5HrlbVGT1og=="
     },
     "@smithy/middleware-retry": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.23.tgz",
-      "integrity": "sha512-x9PbGXxkcXIpm6L26qRSCC+eaYcHwybRmqU8LO/WM2RRlW0g8lz6FIiKbKgGvHuoK3dLZRiQVSQJveiCzwnA5A=="
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.27.tgz",
+      "integrity": "sha512-H3J/PjJpLL7Tt+fxDKiOD25sMc94YetlQhCnYeNmina2LZscAdu0ZEZPas/kwePHABaEtqp7hqa5S4UJgMs1Tg=="
     },
     "@smithy/middleware-serde": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.7.tgz",
-      "integrity": "sha512-VytaagsQqtH2OugzVTq4qvjkLNbWehHfGcGr0JLJmlDRrNCeZoWkWsSOw1nhS/4hyUUWF/TLGGml4X/OnEep5g=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.10.tgz",
+      "integrity": "sha512-MnAuhh+dD14F428ubSJuRnmRsfOpxSzvRhaGVTvd/lrUDE3kxzCCmH8lnVTvoNQnV2BbJ4c15QwZ3UdQBtFNZA=="
     },
     "@smithy/middleware-stack": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.7.tgz",
-      "integrity": "sha512-EyTbMCdqS1DoeQsO4gI7z2Gzq1MoRFAeS8GkFYIwbedB7Lp5zlLHJdg+56tllIIG5Hnf9ZWX48YKSHlsKvugGA=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.10.tgz",
+      "integrity": "sha512-grCHyoiARDBBGPyw2BeicpjgpsDFWZZxptbVKb3CRd/ZA15F/T6rZjCCuBUjJwdck1nwUuIxYtsS4H9DDpbP5w=="
     },
     "@smithy/node-config-provider": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.8.tgz",
-      "integrity": "sha512-E0rU0DglpeJn5ge64mk8wTGEXcQwmpUTY5Zr7IzTpDLmHKiIamINERNZYrPQjg58Ck236sEKSwRSHA4CwshU6Q=="
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.11.tgz",
+      "integrity": "sha512-URq3gT3RpDikh/8MBJUB+QGZzfS7Bm6TQTqoh4CqE8NBuyPkWa5eUXj0XFcFfeZVgg3WMh1u19iaXn8FvvXxZw=="
     },
     "@smithy/node-http-handler": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.4.tgz",
-      "integrity": "sha512-49reY3+JgLMFNm7uTAKBWiKCA6XSvkNp9FqhVmusm2jpVnHORYFeFZ704LShtqWfjZW/nhX+7Iexyb6zQfXYIQ=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.1.tgz",
+      "integrity": "sha512-fr+UAOMGWh6bn4YSEezBCpJn9Ukp9oR4D32sCjCo7U81evE11YePOQ58ogzyfgmjIO79YeOdfXXqr0jyhPQeMg=="
     },
     "@smithy/property-provider": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.7.tgz",
-      "integrity": "sha512-QfzLi1GPMisY7bAM5hOUqBdGYnY5S2JAlr201pghksrQv139f8iiiMalXtjczIP5f6owxFn3MINLNUNvUkgtPw=="
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.10.tgz",
+      "integrity": "sha512-n1MJZGTorTH2DvyTVj+3wXnd4CzjJxyXeOgnTlgNVFxaaMeT4OteEp4QrzF8p9ee2yg42nvyVK6R/awLCakjeQ=="
     },
     "@smithy/protocol-http": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.4.tgz",
-      "integrity": "sha512-MlWK8eqj0JlpZBnWmjQLqmFp71Ug00P+m72/1xQB3YByXD4zZ+y9N4hYrR0EDmrUCZIkyATWHOXFgtavwGDTzQ=="
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.7.tgz",
+      "integrity": "sha512-FP2LepWD0eJeOTm0SjssPcgqAlDFzOmRXqXmGhfIM52G7Lrox/pcpQf6RP4F21k0+O12zaqQt5fCDOeBtqY6Cg=="
     },
     "@smithy/querystring-builder": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.7.tgz",
-      "integrity": "sha512-65RXGZZ20rzqqxTsChdqSpbhA6tdt5IFNgG6o7e1lnPVLCe6TNWQq4rTl4N87hTDD8mV4IxJJnvyE7brbnRkQw=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.10.tgz",
+      "integrity": "sha512-nT9CQF3EIJtIUepXQuBFb8dxJi3WVZS3XfuDksxSCSn+/CzZowRLdhDn+2acbBv8R6eaJqPupoI/aRFIImNVPQ=="
     },
     "@smithy/querystring-parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.7.tgz",
-      "integrity": "sha512-Fouw4KJVWqqUVIu1gZW8BH2HakwLz6dvdrAhXeXfeymOBrZw+hcqaWs+cS1AZPVp4nlbeIujYrKA921ZW2WMPA=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.10.tgz",
+      "integrity": "sha512-Oa0XDcpo9SmjhiDD9ua2UyM3uU01ZTuIrNdZvzwUTykW1PM8o2yJvMh1Do1rY5sUQg4NDV70dMi0JhDx4GyxuQ=="
     },
     "@smithy/service-error-classification": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.7.tgz",
-      "integrity": "sha512-91PRkTfiBf9hxkIchhRKJfl1rsplRDyBnmyFca3y0Z3x/q0JJN480S83LBd8R6sBCkm2bBbqw2FHp0Mbh+ecSA=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.10.tgz",
+      "integrity": "sha512-zHe642KCqDxXLuhs6xmHVgRwy078RfqxP2wRDpIyiF8EmsWXptMwnMwbVa50lw+WOGNrYm9zbaEg0oDe3PTtvQ=="
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.8.tgz",
-      "integrity": "sha512-0NHdQiSkeGl0ICQKcJQ2lCOKH23Nb0EaAa7RDRId6ZqwXkw4LJyIyZ0t3iusD4bnKYDPLGy2/5e2rfUhrt0Acw=="
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.11.tgz",
+      "integrity": "sha512-AUdrIZHFtUgmfSN4Gq9nHu3IkHMa1YDcN+s061Nfm+6pQ0mJy85YQDB0tZBCmls0Vuj22pLwDPmL92+Hvfwwlg=="
     },
     "@smithy/signature-v4": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
-      "integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.3.tgz",
+      "integrity": "sha512-pPSQQ2v2vu9vc8iew7sszLd0O09I5TRc5zhY71KA+Ao0xYazIG+uLeHbTJfIWGO3BGVLiXjUr3EEeCcEQLjpWQ=="
     },
     "@smithy/smithy-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.0.tgz",
-      "integrity": "sha512-nOfJ1nVQsxiP6srKt43r2My0Gp5PLWCW2ASqUioxIiGmu6d32v4Nekidiv5qOmmtzIrmaD+ADX5SKHUuhReeBQ=="
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.4.tgz",
+      "integrity": "sha512-dPGoJuSZqvirBq+yROapBcHHvFjChoAQT8YPWJ820aPHHiowBlB3RL1Q4kPT1hx0qKgJuf+HhyzKi5Gbof4fNA=="
     },
     "@smithy/types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.5.0.tgz",
-      "integrity": "sha512-QN0twHNfe8mNJdH9unwsCK13GURU7oEAZqkBI+rsvpv1jrmserO+WnLE7jidR9W/1dxwZ0u/CB01mV2Gms/K2Q=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.1.tgz",
+      "integrity": "sha512-XKLcLXZY7sUQgvvWyeaL/qwNPp6V3dWcUjqrQKjSb+tzYiCy340R/c64LV5j+Tnb2GhmunEX0eou+L+m2hJNYA=="
     },
     "@smithy/url-parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.7.tgz",
-      "integrity": "sha512-70UbSSR8J97c1rHZOWhl+VKiZDqHWxs/iW8ZHrHp5fCCPLSBE7GcUlUvKSle3Ca+J9LLbYCj/A79BxztBvAfpA=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.10.tgz",
+      "integrity": "sha512-j90NUalTSBR2NaZTuruEgavSdh8MLirf58LoGSk4AtQfyIymogIhgnGUU2Mga2bkMkpSoC9gxb74xBXL5afKAQ=="
     },
     "@smithy/util-base64": {
       "version": "3.0.0",
@@ -336,19 +336,19 @@
       "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ=="
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.23.tgz",
-      "integrity": "sha512-Y07qslyRtXDP/C5aWKqxTPBl4YxplEELG3xRrz2dnAQ6Lq/FgNrcKWmV561nNaZmFH+EzeGOX3ZRMbU8p1T6Nw=="
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.27.tgz",
+      "integrity": "sha512-GV8NvPy1vAGp7u5iD/xNKUxCorE4nQzlyl057qRac+KwpH5zq8wVq6rE3lPPeuFLyQXofPN6JwxL1N9ojGapiQ=="
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.23.tgz",
-      "integrity": "sha512-9Y4WH7f0vnDGuHUa4lGX9e2p+sMwODibsceSV6rfkZOvMC+BY3StB2LdO1NHafpsyHJLpwAgChxQ38tFyd6vkg=="
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.27.tgz",
+      "integrity": "sha512-7+4wjWfZqZxZVJvDutO+i1GvL6bgOajEkop4FuR6wudFlqBiqwxw3HoH6M9NgeCd37km8ga8NPp2JacQEtAMPg=="
     },
     "@smithy/util-endpoints": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.3.tgz",
-      "integrity": "sha512-34eACeKov6jZdHqS5hxBMJ4KyWKztTMulhuQ2UdOoP6vVxMLrOKUqIXAwJe/wiWMhXhydLW664B02CNpQBQ4Aw=="
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.6.tgz",
+      "integrity": "sha512-mFV1t3ndBh0yZOJgWxO9J/4cHZVn5UG1D8DeCc6/echfNkeEJWu9LD7mgGH5fHrEdR7LDoWw7PQO6QiGpHXhgA=="
     },
     "@smithy/util-hex-encoding": {
       "version": "3.0.0",
@@ -356,19 +356,19 @@
       "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ=="
     },
     "@smithy/util-middleware": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.7.tgz",
-      "integrity": "sha512-OVA6fv/3o7TMJTpTgOi1H5OTwnuUa8hzRzhSFDtZyNxi6OZ70L/FHattSmhE212I7b6WSOJAAmbYnvcjTHOJCA=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.10.tgz",
+      "integrity": "sha512-eJO+/+RsrG2RpmY68jZdwQtnfsxjmPxzMlQpnHKjFPwrYqvlcT+fHdT+ZVwcjlWSrByOhGr9Ff2GG17efc192A=="
     },
     "@smithy/util-retry": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.7.tgz",
-      "integrity": "sha512-nh1ZO1vTeo2YX1plFPSe/OXaHkLAHza5jpokNiiKX2M5YpNUv6RxGJZhpfmiR4jSvVHCjIDmILjrxKmP+/Ghug=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.10.tgz",
+      "integrity": "sha512-1l4qatFp4PiU6j7UsbasUHL2VU023NRB/gfaa1M0rDqVrRN4g3mCArLRyH3OuktApA4ye+yjWQHjdziunw2eWA=="
     },
     "@smithy/util-stream": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.9.tgz",
-      "integrity": "sha512-7YAR0Ub3MwTMjDfjnup4qa6W8gygZMxikBhFMPESi6ASsl/rZJhwLpF/0k9TuezScCojsM0FryGdz4LZtjKPPQ=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.1.tgz",
+      "integrity": "sha512-Ff68R5lJh2zj+AUTvbAU/4yx+6QPRzg7+pI7M1FbtQHcRIp7xvguxVsQBKyB3fwiOwhAKu0lnNyYBaQfSW6TNw=="
     },
     "@smithy/util-uri-escape": {
       "version": "3.0.0",
@@ -381,9 +381,9 @@
       "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA=="
     },
     "@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ=="
     },
     "@types/webidl-conversions": {
       "version": "7.0.3",
@@ -486,9 +486,9 @@
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA=="
     },
     "tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "undici-types": {
       "version": "6.19.8",

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitepress";
+import metadata from "../generators/meteor-versions/metadata.generated";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -127,6 +128,22 @@ export default defineConfig({
       },
       { text: "API", link: "/api/" },
       { text: "Galaxy Cloud", link: "https://www.meteor.com/cloud" },
+      {
+        text: metadata.currentVersion,
+        items: metadata.versions.reverse().map((v) => {
+          if (v.isCurrent) {
+            return {
+              text: `${v.version} (Current)`,
+              link: "/",
+              activeMatch: "/",
+            };
+          }
+          return {
+            text: v.version,
+            link: v.url,
+          };
+        }),
+      },
     ],
     sidebar: [
       {

--- a/v3-docs/docs/.vitepress/theme/GoToLatest.vue
+++ b/v3-docs/docs/.vitepress/theme/GoToLatest.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import { useRouter } from "vitepress";
+const router = useRouter();
+let url = ref(`https://docs.meteor.com${router.route.path}`);
+
+if (typeof window !== 'undefined') watch(() => router.route.path, (path) =>
+  url.value = `https://docs.meteor.com${path}`
+  , { immediate: true })
+</script>
+
+<template>
+  <div class="tip custom-block">
+    <p class="custom-block-title">TIP</p>
+    <p>You are viewing an old version of the Meteor documentation. Click <a v-bind:href="url">here</a> to
+      go to the latest version.</p>
+  </div>
+  <br />
+</template>

--- a/v3-docs/docs/.vitepress/theme/GoToLatest.vue
+++ b/v3-docs/docs/.vitepress/theme/GoToLatest.vue
@@ -10,8 +10,8 @@ if (typeof window !== 'undefined') watch(() => router.route.path, (path) =>
 </script>
 
 <template>
-  <div class="tip custom-block">
-    <p class="custom-block-title">TIP</p>
+  <div class="warning custom-block">
+    <p class="custom-block-title">Warning</p>
     <p>You are viewing an old version of the Meteor documentation. Click <a v-bind:href="url">here</a> to
       go to the latest version.</p>
   </div>

--- a/v3-docs/docs/.vitepress/theme/Layout.vue
+++ b/v3-docs/docs/.vitepress/theme/Layout.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import NotFound from './NotFound.vue'
+import GoToLatest from './GoToLatest.vue'
 import { useData, useRouter } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import { nextTick, provide } from 'vue'
@@ -48,12 +49,17 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
     }
   )
 })
+
+const inLatestDeployedDoc = () => window.location.href.startsWith("https://docs.meteor.com/")
 </script>
 
 <template>
-  <DefaultTheme.Layout >
+  <DefaultTheme.Layout>
     <template #not-found>
       <NotFound />
+    </template>
+    <template #doc-before v-if="!inLatestDeployedDoc()">
+      <GoToLatest />
     </template>
   </DefaultTheme.Layout>
 </template>

--- a/v3-docs/docs/.vitepress/theme/Layout.vue
+++ b/v3-docs/docs/.vitepress/theme/Layout.vue
@@ -50,7 +50,7 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
   )
 })
 
-const inLatestDeployedDoc = () => window.location.href.startsWith("https://docs.meteor.com/")
+const inLatestDeployedDoc = () => isClient && window.location.href.startsWith("https://docs.meteor.com/")
 </script>
 
 <template>

--- a/v3-docs/docs/about/install.md
+++ b/v3-docs/docs/about/install.md
@@ -1,4 +1,3 @@
-
 # Install
 
 You need to install the Meteor command line tool to create, run, and manage your Meteor.js projects. Check the prerequisites and follow the installation process below.
@@ -17,7 +16,6 @@ npx meteor
 - If you are on a Mac M1 (Arm64 version) you need to have Rosetta 2 installed, as Meteor uses it for running MongoDB. Check how to install it [here](https://osxdaily.com/2020/12/04/how-install-rosetta-2-apple-silicon-mac/).
 - Disabling antivirus (Windows Defender, etc.) will improve performance.
 - For compatibility, Linux binaries are built with CentOS 6.4 i386/amd64.
-
 
 ### Mobile Development {#prereqs-mobile}
 
@@ -63,10 +61,9 @@ curl https://install.meteor.com/\?release\=2.8 | sh
 
 > Do not install the npm Meteor Tool in your project's package.json. This library is just an installer.
 
-
 ## Troubleshooting {#troubleshooting}
 
-If your user doesn't have permission to install global binaries, and you need to use sudo, it's necessary to append *--unsafe-perm* to the above command:
+If your user doesn't have permission to install global binaries, and you need to use sudo, it's necessary to append _--unsafe-perm_ to the above command:
 
 ```bash
 sudo npm install -g meteor --unsafe-perm
@@ -79,7 +76,6 @@ If you only use sudo because of a distribution default permission system, [check
 
 In some cases you can get this error `npm WARN checkPermissions Missing write access to /usr/local/lib/node_modules` because your Node.js installation was performed with wrong permissions. An easy way to fix this is to install Node.js using [nvm](https://github.com/nvm-sh/nvm) and forcing it to be used in your terminal. You can force it in the current session of your terminal by running `nvm use 14`.
 
-
 ## PATH management {#path-management}
 
 By default, the Meteor installer adds its install path (by default, `~/.meteor/`) to your PATH by updating either your `.bashrc`, `.bash_profile`, or `.zshrc` as appropriate. To disable this behavior, install Meteor by running:
@@ -88,10 +84,7 @@ By default, the Meteor installer adds its install path (by default, `~/.meteor/`
 npm install -g meteor --ignore-meteor-setup-exec-path --foreground-script
 ```
 
-
-
 (or by setting the environment variable `npm_config_ignore_meteor_setup_exec_path=true`)
-
 
 ## Old Versions on Apple M1 {#old-versions-m1}
 
@@ -103,7 +96,6 @@ arch -x86_64 npm install -g meteor
 
 or select Terminal in the Applications folder, press CMD(⌘)+I and check the "Open using Rosetta" option.
 
-
 ## Meteor Docker image {#meteor-docker}
 
 You can also use a Docker container for running Meteor inside your CI, or even in your local development toolchain.
@@ -112,25 +104,19 @@ We do provide the meteor/meteor-base ubuntu-based Docker image, that comes pre-b
 
 You can refer to our meteor/galaxy-images repository to see how to use it, and the latest version. [More about meteor-base here.](https://github.com/meteor/galaxy-images/blob/master/meteor-base/README.md)
 
-
-
 ## Note for Windows users {#windows}
 
 On Windows, the installer runs faster when [Windows Developer Mode](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) is enabled. The installation extracts a large number of small files, which Windows Defender can cause to be very slow.
 
-
-
 ## Node version manager {#nvm}
 
 If you use a node version manager that uses a separate global `node_modules` folder for each Node version, you will need to re-install the `meteor` npm package when changing to a Node version for the first time. Otherwise, the `meteor` command will no longer be found.
-
 
 ## Note for fish shell users (Linux) {#fish-shell}
 
 To be able to use the `meteor` command from fish it's needed to include `/home/<user>/.meteor` in `$PATH`; to do that just add this line in `/home/<user>/.config/fish/config.fish` file (replace `<user>` with your username):
 
 `set PATH /home/<user>/.meteor $PATH`
-
 
 ## Uninstalling Meteor {#uninstall}
 
@@ -143,4 +129,4 @@ npx meteor uninstall
 If you installed Meteor using curl or as a fallback solution, run:
 
 `rm -rf ~/.meteor`
-`sudo rm /usr/local/bin/meteor` 
+`sudo rm /usr/local/bin/meteor`

--- a/v3-docs/docs/api/packages-listing.md
+++ b/v3-docs/docs/api/packages-listing.md
@@ -45,7 +45,6 @@
 ### [callback-hook](https://github.com/meteor/meteor/tree/devel/packages/callback-hook) {#callback-hook}
 ### [check](https://github.com/meteor/meteor/tree/devel/packages/check) {#check}
 ### [constraint-solver](https://github.com/meteor/meteor/tree/devel/packages/constraint-solver) {#constraint-solver}
-### [context](https://github.com/meteor/meteor/tree/devel/packages/context) {#context}
 ### [core-runtime](https://github.com/meteor/meteor/tree/devel/packages/core-runtime) {#core-runtime}
 ### [crosswalk](https://github.com/meteor/meteor/tree/devel/packages/crosswalk) {#crosswalk}
 ### [ddp](https://github.com/meteor/meteor/tree/devel/packages/ddp) {#ddp}
@@ -134,6 +133,7 @@
 ### [standard-minifier-js](https://github.com/meteor/meteor/tree/devel/packages/standard-minifier-js) {#standard-minifier-js}
 ### [standard-minifiers](https://github.com/meteor/meteor/tree/devel/packages/standard-minifiers) {#standard-minifiers}
 ### [static-html](https://github.com/meteor/meteor/tree/devel/packages/static-html) {#static-html}
+### [static-html-tools](https://github.com/meteor/meteor/tree/devel/packages/static-html-tools) {#static-html-tools}
 ### [test-helpers](https://github.com/meteor/meteor/tree/devel/packages/test-helpers) {#test-helpers}
 ### [test-in-browser](https://github.com/meteor/meteor/tree/devel/packages/test-in-browser) {#test-in-browser}
 ### [test-in-console](https://github.com/meteor/meteor/tree/devel/packages/test-in-console) {#test-in-console}

--- a/v3-docs/docs/generators/changelog/README.md
+++ b/v3-docs/docs/generators/changelog/README.md
@@ -32,7 +32,7 @@ organized changelog, since all the files will be reflecting at least one version
 
 ## Update ordering.
 
-If you want to make sure that the changelog is correcly ordered, take a look at the `order-packages.js` file.
+If you want to make sure that the changelog is correctly ordered, take a look at the `order-packages.js` file.
 to use it, run the command below:
 
 ```bash

--- a/v3-docs/docs/generators/codegen.js
+++ b/v3-docs/docs/generators/codegen.js
@@ -1,10 +1,11 @@
 const { generateChangelog } = require("./changelog/script.js");
 const { listPackages } = require("./packages-listing/script.js");
-
+const { generateMeteorVersions } = require("./meteor-versions/script.js");
 async function main() {
   console.log("🚂 Started codegen 🚂");
   await generateChangelog();
   await listPackages();
+  await generateMeteorVersions();
   console.log("🚀 Done codegen 🚀");
 }
 

--- a/v3-docs/docs/generators/meteor-versions/README.md
+++ b/v3-docs/docs/generators/meteor-versions/README.md
@@ -1,0 +1,22 @@
+## Meteor version generator for docs
+
+This is a generator for the meteor versions for the docs, this is used to generate the links in the docs
+to the correct version of the meteor release and docs version.
+
+
+## Why?
+
+This is a way to ensure that the links in the docs are always pointing to the correct version of the docs and release.
+In an automated way.
+
+
+## How to use
+
+To use this generator you must run the following command:
+
+```bash
+node script.js
+```
+
+and it will check in the `changelog` dir for every version and generate a `versions.generated.json` file that will be used by the docs to generate the links to the correct version of the docs.
+

--- a/v3-docs/docs/generators/meteor-versions/metadata.generated.js
+++ b/v3-docs/docs/generators/meteor-versions/metadata.generated.js
@@ -1,0 +1,26 @@
+export default {
+  "versions": [
+    {
+      "version": "v3.0.0",
+      "url": "https://3-0-0-docs.meteor.com/"
+    },
+    {
+      "version": "v3.0.1",
+      "url": "https://3-0-1-docs.meteor.com/"
+    },
+    {
+      "version": "v3.0.2",
+      "url": "https://3-0-2-docs.meteor.com/"
+    },
+    {
+      "version": "v3.0.3",
+      "url": "https://3-0-3-docs.meteor.com/"
+    },
+    {
+      "version": "v3.0.4",
+      "url": "https://3-0-4-docs.meteor.com/",
+      "isCurrent": true
+    }
+  ],
+  "currentVersion": "v3.0.4"
+}

--- a/v3-docs/docs/generators/meteor-versions/metadata.generated.js
+++ b/v3-docs/docs/generators/meteor-versions/metadata.generated.js
@@ -1,20 +1,20 @@
 export default {
   "versions": [
     {
-      "version": "v3.0.0",
-      "url": "https://3-0-0-docs.meteor.com/"
+      "version": "v3.0",
+      "url": "https://release-3.0.docs.meteor.com/"
     },
     {
       "version": "v3.0.2",
-      "url": "https://3-0-2-docs.meteor.com/"
+      "url": "https://release-3.0.2.docs.meteor.com/"
     },
     {
       "version": "v3.0.3",
-      "url": "https://3-0-3-docs.meteor.com/"
+      "url": "https://release-3.0.3.docs.meteor.com/"
     },
     {
       "version": "v3.0.4",
-      "url": "https://3-0-4-docs.meteor.com/",
+      "url": "https://release-3.0.4.docs.meteor.com/",
       "isCurrent": true
     }
   ],

--- a/v3-docs/docs/generators/meteor-versions/metadata.generated.js
+++ b/v3-docs/docs/generators/meteor-versions/metadata.generated.js
@@ -5,10 +5,6 @@ export default {
       "url": "https://3-0-0-docs.meteor.com/"
     },
     {
-      "version": "v3.0.1",
-      "url": "https://3-0-1-docs.meteor.com/"
-    },
-    {
       "version": "v3.0.2",
       "url": "https://3-0-2-docs.meteor.com/"
     },

--- a/v3-docs/docs/generators/meteor-versions/metadata.generated.js
+++ b/v3-docs/docs/generators/meteor-versions/metadata.generated.js
@@ -2,19 +2,19 @@ export default {
   "versions": [
     {
       "version": "v3.0",
-      "url": "https://release-3.0.docs.meteor.com/"
+      "url": "https://release-3-0.docs.meteor.com/"
     },
     {
       "version": "v3.0.2",
-      "url": "https://release-3.0.2.docs.meteor.com/"
+      "url": "https://release-3-0-2.docs.meteor.com/"
     },
     {
       "version": "v3.0.3",
-      "url": "https://release-3.0.3.docs.meteor.com/"
+      "url": "https://release-3-0-3.docs.meteor.com/"
     },
     {
       "version": "v3.0.4",
-      "url": "https://release-3.0.4.docs.meteor.com/",
+      "url": "https://release-3-0-4.docs.meteor.com/",
       "isCurrent": true
     }
   ],

--- a/v3-docs/docs/generators/meteor-versions/script.js
+++ b/v3-docs/docs/generators/meteor-versions/script.js
@@ -1,7 +1,8 @@
 const _fs = require("fs");
 const fs = _fs.promises;
 
-const getDocsUrl = (version = "") => `https://${version}docs.meteor.com/`;
+const getDocsUrl = (version = "") =>
+  `https://release-${version}.docs.meteor.com/`;
 
 exports.generateMeteorVersions = async () => {
   console.log("Reading meteor versions...");
@@ -11,10 +12,11 @@ exports.generateMeteorVersions = async () => {
     .filter((f) => f !== "99999-generated-code-warning.md")
     .map((f) => f.replace(".md", ""))
     .filter((v) => v !== "3.0.1") // there is no 3.0.1 version
+    .map((v) => (v.endsWith(".0") ? v.slice(0, -2) : v)) // remove .0 from versions
     .map((version) => {
       return {
         version: `v${version}`,
-        url: getDocsUrl(`${version.replaceAll(".", "-")}-`),
+        url: getDocsUrl(`${version}`),
       };
     })
     .map((v, index, arr) => {

--- a/v3-docs/docs/generators/meteor-versions/script.js
+++ b/v3-docs/docs/generators/meteor-versions/script.js
@@ -1,0 +1,41 @@
+const _fs = require("fs");
+const fs = _fs.promises;
+
+const getDocsUrl = (version = "") => `https://${version}docs.meteor.com/`;
+
+exports.generateMeteorVersions = async () => {
+  console.log("Reading meteor versions...");
+  const files = await fs.readdir("./generators/changelog/versions", "utf8");
+
+  const versions = files
+    .filter((f) => f !== "99999-generated-code-warning.md")
+    .map((f) => f.replace(".md", ""))
+    .map((version) => {
+      return {
+        version: `v${version}`,
+        url: getDocsUrl(`${version.replaceAll(".", "-")}-`),
+      };
+    })
+    .map((v, index, arr) => {
+      const isLast = index === arr.length - 1;
+      if (isLast) {
+        v.isCurrent = true;
+      }
+      return v;
+    });
+  const { version: currentVersion } = versions.find((v) => v.isCurrent);
+
+  console.log("Writing meteor versions...");
+  await fs.writeFile(
+    "./generators/meteor-versions/metadata.generated.js",
+    `export default ${JSON.stringify(
+      {
+        versions,
+        currentVersion,
+      },
+      null,
+      2
+    )}`
+  );
+  console.log("Meteor versions generated!");
+};

--- a/v3-docs/docs/generators/meteor-versions/script.js
+++ b/v3-docs/docs/generators/meteor-versions/script.js
@@ -10,6 +10,7 @@ exports.generateMeteorVersions = async () => {
   const versions = files
     .filter((f) => f !== "99999-generated-code-warning.md")
     .map((f) => f.replace(".md", ""))
+    .filter((v) => v !== "3.0.1") // there is no 3.0.1 version
     .map((version) => {
       return {
         version: `v${version}`,

--- a/v3-docs/docs/generators/meteor-versions/script.js
+++ b/v3-docs/docs/generators/meteor-versions/script.js
@@ -9,14 +9,14 @@ exports.generateMeteorVersions = async () => {
   const files = await fs.readdir("./generators/changelog/versions", "utf8");
 
   const versions = files
-    .filter((f) => f !== "99999-generated-code-warning.md")
+    .filter((f) => f.startsWith("3."))
     .map((f) => f.replace(".md", ""))
     .filter((v) => v !== "3.0.1") // there is no 3.0.1 version
-    .map((v) => (v.endsWith(".0") ? v.slice(0, -2) : v)) // remove .0 from versions
+    .map((v) => (v === "3.0.0" ? v.slice(0, -2) : v)) // 3.0 doesn't have a patch version in the URL
     .map((version) => {
       return {
         version: `v${version}`,
-        url: getDocsUrl(`${version}`),
+        url: getDocsUrl(`${version}`.replaceAll(".", "-")),
       };
     })
     .map((v, index, arr) => {

--- a/v3-docs/docs/history.md
+++ b/v3-docs/docs/history.md
@@ -12,6 +12,115 @@ This is a complete history of changes for Meteor releases.
 
 
 
+## v3.0.4, 2024-10-15
+
+### Highlights
+
+- Node 20.18.0 & Typescript 5.6.2
+- Updated webapp dependencies.
+- DDP-server and DDP-client removed underscore
+- Remove dependencies on Blaze packages when using static-html
+- Fix Cordova on Windows
+- Fix Cordova build on using plugins describing dependencies
+- Various Windows specific fixes
+
+#### Breaking Changes
+
+N/A
+
+####  Internal API changes
+
+N/A
+
+#### Migration Steps
+
+Please run the following command to update your project:
+
+```bash
+
+meteor update --release 3.0.4
+
+```
+
+#### Meteor Version Release
+
+* `Bumped packages`:
+  - accounts-base@3.0.3                
+  - babel-compiler@7.11.1              
+  - caching-compiler@2.0.1             
+  - check@1.4.4                        
+  - ddp-client@3.0.2                   
+  - ddp-server@3.0.2                   
+  - ecmascript-runtime@0.8.3           
+  - modules@0.20.2                     
+  - static-html-tools@1.0.0            
+  - static-html@1.4.0                  
+  - url@1.3.4                          
+  - webapp@2.0.3                       
+  - meteor-tool@3.0.4
+
+#### Special thanks to
+N/A
+## v3.0.3, 2024-09-11
+
+### Highlights
+
+- Fixed `Meteor.userId` only being invoked with `bindEnvironment`.
+- Updated to Node `20.17.x`.
+- Fixed an issue where `meteor --open` opens the browser before the app is started.
+- Investigated and addressed the error when installing the `jam:method` package.
+- Improved the message for new available versions when running an app.
+- Updated the documentation link inside `install.sh`.
+- Resolved the issue where subscriptions stopped after a parameter change.
+- Added MongoDB connection telemetry.
+- Bumped the `email` package to prevent update errors.
+- Cordova package updates
+
+#### Breaking Changes
+
+N/A
+
+####  Internal API changes
+
+- Some internal changes to how async contexts are handled, ensuring better performance and garbage collection.
+
+#### Migration Steps
+
+Please run the following command to update your project:
+
+```bash
+
+meteor update --release 3.0.3
+
+```
+
+If you've had your Meteor installation for over a year, we suggest reinstalling it to avoid any package installation issues. You can do this by running a few quick commands:
+
+```bash
+npx meteor uninstall // or rm -rf ~/.meteor
+npx meteor
+```
+
+
+
+#### Meteor Version Release
+
+* `Bumped packages`:
+  - accounts-base@3.0.2
+  - accounts-password@3.0.2
+  - email@3.1.0
+  - mongo@2.0.2
+
+
+#### Special thanks to
+
+- [@ayewo](https://github.com/ayewo).
+- [@denihs](https://github.com/denihs).
+- [@harryadel](https://github.com/harryadel).
+- [@kbarr1212](https://github.com/kbarr1212).
+- [@leonardoventurini](https://github.com/leonardoventurini).
+- [@nachocodoner](https://github.com/nachocodoner).
+
 ## v3.0.2, 2024-08-14
 
 ### Highlights


### PR DESCRIPTION
Continuation of https://github.com/meteor/meteor/pull/13466 (I've screwed up the git history there)
 

<-- OSS-620 -->

This adds a metadata generator for meteor versions to the docs and adds a new item on the header to select the version of the docs.

<img width="648" alt="Screenshot 2024-11-18 at 11 57 14" src="https://github.com/user-attachments/assets/3541bc38-8898-4a07-84b6-8c83b16bd67a">
<img width="1246" alt="Screenshot 2024-11-18 at 11 57 29" src="https://github.com/user-attachments/assets/f36d277d-6967-4cc6-9b19-afc9c021d682">

I'm working with the DevOps team so that we have those old links up and running and then I'll work on a banner similar to the one we have for [Ember.js](https://guides.emberjs.com/v5.8.0/):

<img width="815" alt="Screenshot 2024-11-18 at 11 59 10" src="https://github.com/user-attachments/assets/23272d7f-1b8d-4159-8fdb-dd522d6c5b5e">


<img width="815" alt="Screenshot 2024-11-19 at 20 37 47" src="https://github.com/user-attachments/assets/c7b0789e-e05f-491f-bd2c-d8bdb30d6a4b">

