### PR TITLE
Docs: solve mismatch issue

### DIFF
--- a/v3-docs/docs/.vitepress/theme/Layout.vue
+++ b/v3-docs/docs/.vitepress/theme/Layout.vue
@@ -51,10 +51,10 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
 })
 
 
-const shouldShowGoToLatest = ref(false);
+const isLatestVersion = ref(false);
 
 onMounted(() => {
-  shouldShowGoToLatest.value = isClient && window.location.href.startsWith("https://docs.meteor.com/")
+  isLatestVersion.value = isClient && window.location.href.startsWith("https://docs.meteor.com/")
 });
 
 </script>
@@ -64,7 +64,7 @@ onMounted(() => {
     <template #not-found>
       <NotFound />
     </template>
-    <template #doc-before v-if="!shouldShowGoToLatest">
+    <template #doc-before v-if="!isLatestVersion">
       <GoToLatest />
     </template>
   </DefaultTheme.Layout>

--- a/v3-docs/docs/.vitepress/theme/Layout.vue
+++ b/v3-docs/docs/.vitepress/theme/Layout.vue
@@ -3,7 +3,7 @@ import NotFound from './NotFound.vue'
 import GoToLatest from './GoToLatest.vue'
 import { useData, useRouter } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
-import { nextTick, provide } from 'vue'
+import { nextTick, onMounted, provide, ref } from 'vue'
 import { redirect } from './redirects/script';
 const { isDark } = useData()
 const router = useRouter()
@@ -50,7 +50,13 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
   )
 })
 
-const inLatestDeployedDoc = () => isClient && window.location.href.startsWith("https://docs.meteor.com/")
+
+const shouldShowGoToLatest = ref(false);
+
+onMounted(() => {
+  shouldShowGoToLatest.value = isClient && window.location.href.startsWith("https://docs.meteor.com/")
+});
+
 </script>
 
 <template>
@@ -58,7 +64,7 @@ const inLatestDeployedDoc = () => isClient && window.location.href.startsWith("h
     <template #not-found>
       <NotFound />
     </template>
-    <template #doc-before v-if="!inLatestDeployedDoc()">
+    <template #doc-before v-if="!shouldShowGoToLatest">
       <GoToLatest />
     </template>
   </DefaultTheme.Layout>


### PR DESCRIPTION

We were getting some errors in our docs page: 

![image](https://github.com/user-attachments/assets/02162851-7153-4cc3-b267-e6fb5a026eb5)


This happens because that on `https://docs.meteor.com/` `shouldShowGoToLatest` is actually true, leading to a mismatch in both client and server...

older versions and non official versions are ok