### PR TITLE
Update history.md to include proper release command

### DIFF
--- a/v3-docs/docs/history.md
+++ b/v3-docs/docs/history.md
@@ -44,7 +44,7 @@ Please run the following command to update your project:
 
 ```bash
 
-meteor update --release 3.1.0
+meteor update --release 3.1
 
 ```
 


### PR DESCRIPTION
The 3.1.0 doesn't work, it has to be 3.1

```
wreiske@removed:~/prj/bluehive-provider$ meteor update --release=3.1.0
Meteor 3.1.0: unknown release.
wreiske@removed:~/prj/bluehive-provider$ meteor update --release=3.1
   Selecting package versions                \
```
