### PR TITLE
Fix flaky roles tests by comparing expected array values equality regardless the order

### DIFF
--- a/packages/roles/tests/serverAsync.js
+++ b/packages/roles/tests/serverAsync.js
@@ -84,7 +84,7 @@ const sameDeepMembers = (test, value, expected) => {
   );
 };
 
-function sameDeepUnorderedMembers(test, value, expected) {
+const sameDeepUnorderedMembers = (test, value, expected) => {
   const sortAndStringify = (arr) => {
     return JSON.stringify(arr.map(item => JSON.stringify(sortObjectKeys(item))).sort());
   };
@@ -92,7 +92,7 @@ function sameDeepUnorderedMembers(test, value, expected) {
   const sortedExpected = sortAndStringify(expected);
 
   test.equal(sortedValue, sortedExpected, 'Arrays should have the same elements, regardless of order');
-}
+};
 
 const hasProp = (target, prop) => Object.hasOwnProperty.call(target, prop);
 

--- a/packages/roles/tests/serverAsync.js
+++ b/packages/roles/tests/serverAsync.js
@@ -57,23 +57,23 @@ const sameMembers = (test, value, expected) => {
   );
 };
 
-const sameDeepMembers = (test, value, expected) => {
-  // Helper to sort object keys recursively
-  const sortObjectKeys = (obj) => {
-    if (Array.isArray(obj)) {
-      return obj.map(sortObjectKeys);
-    }
-    if (obj && typeof obj === "object") {
-      return Object.keys(obj)
-        .sort()
-        .reduce((sorted, key) => {
-          sorted[key] = sortObjectKeys(obj[key]);
-          return sorted;
-        }, {});
-    }
-    return obj;
-  };
+// Helper to sort object keys recursively
+const sortObjectKeys = (obj) => {
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys);
+  }
+  if (obj && typeof obj === "object") {
+    return Object.keys(obj)
+      .sort()
+      .reduce((sorted, key) => {
+        sorted[key] = sortObjectKeys(obj[key]);
+        return sorted;
+      }, {});
+  }
+  return obj;
+};
 
+const sameDeepMembers = (test, value, expected) => {
   const sortedValue = sortObjectKeys(value);
   const sortedExpected = sortObjectKeys(expected);
 
@@ -83,6 +83,16 @@ const sameDeepMembers = (test, value, expected) => {
     "Role assignments should match expected structure"
   );
 };
+
+function sameDeepUnorderedMembers(test, value, expected) {
+  const sortAndStringify = (arr) => {
+    return JSON.stringify(arr.map(item => JSON.stringify(sortObjectKeys(item))).sort());
+  };
+  const sortedValue = sortAndStringify(value);
+  const sortedExpected = sortAndStringify(expected);
+
+  test.equal(sortedValue, sortedExpected, 'Arrays should have the same elements, regardless of order');
+}
 
 const hasProp = (target, prop) => Object.hasOwnProperty.call(target, prop);
 
@@ -1885,7 +1895,7 @@ Tinytest.addAsync("roles -keep assigned roles", async function (test) {
     anyScope: true,
     fullObjects: true,
   });
-  sameDeepMembers(
+  sameDeepUnorderedMembers(
     test,
     rolesForUser.map((obj) => {
       delete obj._id;
@@ -1914,7 +1924,7 @@ Tinytest.addAsync("roles -keep assigned roles", async function (test) {
     anyScope: true,
     fullObjects: true,
   });
-  sameDeepMembers(
+  sameDeepUnorderedMembers(
     test,
     rolesForUser2.map((obj) => {
       delete obj._id;
@@ -1949,7 +1959,7 @@ Tinytest.addAsync("roles -keep assigned roles", async function (test) {
     anyScope: true,
     fullObjects: true,
   });
-  sameDeepMembers(
+  sameDeepUnorderedMembers(
     test,
     rolesForUser3.map((obj) => {
       delete obj._id;
@@ -1973,7 +1983,7 @@ Tinytest.addAsync("roles -keep assigned roles", async function (test) {
     anyScope: true,
     fullObjects: true,
   });
-  sameDeepMembers(
+  sameDeepUnorderedMembers(
     test,
     rolesForUser4.map((obj) => {
       delete obj._id;
@@ -2063,7 +2073,7 @@ Tinytest.addAsync(
       anyScope: true,
       fullObjects: true,
     });
-    sameDeepMembers(
+    sameDeepUnorderedMembers(
       test,
       usersRoles.map((obj) => {
         delete obj._id;
@@ -2109,7 +2119,7 @@ Tinytest.addAsync(
       anyScope: true,
       fullObjects: true,
     });
-    sameDeepMembers(
+    sameDeepUnorderedMembers(
       test,
       usersRoles2.map((obj) => {
         delete obj._id;
@@ -2153,7 +2163,7 @@ Tinytest.addAsync(
       anyScope: true,
       fullObjects: true,
     });
-    sameDeepMembers(
+    sameDeepUnorderedMembers(
       test,
       usersRoles3.map((obj) => {
         delete obj._id;
@@ -2203,7 +2213,7 @@ Tinytest.addAsync(
       anyScope: true,
       fullObjects: true,
     });
-    sameDeepMembers(
+    sameDeepUnorderedMembers(
       test,
       usersRoles4.map((obj) => {
         delete obj._id;
@@ -2255,7 +2265,7 @@ Tinytest.addAsync(
       anyScope: true,
       fullObjects: true,
     });
-    sameDeepMembers(
+    sameDeepUnorderedMembers(
       test,
       usersRoles5.map((obj) => {
         delete obj._id;
@@ -2308,7 +2318,7 @@ Tinytest.addAsync(
       anyScope: true,
       fullObjects: true,
     });
-    sameDeepMembers(
+    sameDeepUnorderedMembers(
       test,
       usersRoles6.map((obj) => {
         delete obj._id;


### PR DESCRIPTION
OSS-632

This PR addresses flaky test behavior in the roles package.

## Issue

I reproduced at least [two intermittently failing tests](https://github.com/user-attachments/assets/311d9d86-3cec-48c7-ba40-2486ed17f58a).

The problem arises in some test scenarios where the roles config and expected values differ in element order, even though the elements themselves are identical. The example below illustrates this issue.

![image](https://github.com/user-attachments/assets/cbe1745f-c584-4b39-b45a-992c87d7ee41)


## Solution

I investigated the cause of this ordering flakiness but struggled to find it within the package, which I am still learning. Since the elements contents are identical and only their order varies across runs, I created a new test verifier to compare the contents without considering the order. This resolved the test's flakiness.

As I am not very familiar with this package, I’d appreciate feedback from @jankapunkt or @StorytellerCZ. My assumption is that the element order doesn’t matter in these tests, as long as the roles config for each item matches correctly.