### PR TITLE
Fix Oauth issues

### DIFF
--- a/packages/accounts-oauth/oauth_client.js
+++ b/packages/accounts-oauth/oauth_client.js
@@ -82,10 +82,7 @@ Accounts.oauth.tryLoginAfterPopupClosed = (
   // In some case the function OAuth._retrieveCredentialSecret() can return null, because the local storage might not
   // be ready. So we retry after a timeout.
 
-  if (!credentialSecret) {
-    if (!shouldRetry) {
-      return;
-    }
+  if (!credentialSecret && shouldRetry) {
     Meteor.setTimeout(
       () =>
         Accounts.oauth.tryLoginAfterPopupClosed(
@@ -97,10 +94,11 @@ Accounts.oauth.tryLoginAfterPopupClosed = (
     );
     return;
   }
+
   // continue with the rest of the function
   Accounts.callLoginMethod({
     methodArguments: [{ oauth: { credentialToken, credentialSecret } }],
-    userCallback: callback && (err => callback(convertError(err))),
+    userCallback: callback ? err => callback(convertError(err)) : () => {},
   });
 };
 
@@ -112,4 +110,3 @@ Accounts.oauth.credentialRequestCompleteHandler = callback =>
       Accounts.oauth.tryLoginAfterPopupClosed(credentialTokenOrError, callback);
     }
   }
-

--- a/packages/accounts-oauth/oauth_client.js
+++ b/packages/accounts-oauth/oauth_client.js
@@ -77,15 +77,19 @@ Accounts.oauth.tryLoginAfterPopupClosed = (
   timeout = 1000
 ) => {
   let startTime = Date.now();
+  let calledOnce = false;
   let intervalId;
   const checkForCredentialSecret = (clearInterval = false) => {
     const credentialSecret = OAuth._retrieveCredentialSecret(credentialToken);
-    if (clearInterval || credentialSecret) {
+    if (!calledOnce && (credentialSecret || clearInterval)) {
+      calledOnce = true;
       Meteor.clearInterval(intervalId);
       Accounts.callLoginMethod({
         methodArguments: [{ oauth: { credentialToken, credentialSecret } }],
         userCallback: callback ? err => callback(convertError(err)) : () => {},
       });
+    } else if (clearInterval) {
+      Meteor.clearInterval(intervalId);
     }
   };
 

--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -26,11 +26,12 @@ Facebook.handleAuthFromAccessToken = async (accessToken, expiresAt) => {
   };
 };
 
-Accounts.registerLoginHandler(request => {
+Accounts.registerLoginHandler(async request => {
   if (request.facebookSignIn !== true) {
     return;
   }
-  const facebookData = Facebook.handleAuthFromAccessToken(request.accessToken, (+new Date) + (1000 * request.expirationTime));
+  const facebookData = await Facebook.handleAuthFromAccessToken(request.accessToken, (+new Date) + (1000 * request.expirationTime));
+  if (!facebookData) return;
   return Accounts.updateOrCreateUserFromExternalService('facebook', facebookData.serviceData, facebookData.options);
 });
 

--- a/packages/facebook-oauth/facebook_server.js
+++ b/packages/facebook-oauth/facebook_server.js
@@ -97,7 +97,6 @@ const getTokenResponse = async (query) => {
     .then((res) => res.json())
     .then(data => {
       const fbAccessToken = data.access_token;
-      console.log("-> fbAccessToken", fbAccessToken);
       const fbExpires = data.expires_in;
       if (!fbAccessToken) {
         throw new Error("Failed to complete OAuth handshake with facebook " +

--- a/packages/oauth/oauth_cordova.js
+++ b/packages/oauth/oauth_cordova.js
@@ -34,9 +34,17 @@ OAuth.showPopup = (url, callback, dimensions) => {
         throw new Error("No hash fragment in OAuth popup?");
       }
 
-      const credentials = JSON.parse(decodeURIComponent(hashFragment));
-      OAuth._handleCredentialSecret(credentials.credentialToken,
-                                    credentials.credentialSecret);
+      try {
+        const credentials = JSON.parse(decodeURIComponent(hashFragment));
+        OAuth._handleCredentialSecret(credentials.credentialToken,
+          credentials.credentialSecret);
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          // Ignore or a default value if parsing fails
+        } else {
+          throw error; // Re-throw if it's not a syntax error
+        }
+      }
 
       oauthFinished = true;
 

--- a/packages/oauth/oauth_cordova.js
+++ b/packages/oauth/oauth_cordova.js
@@ -64,6 +64,12 @@ OAuth.showPopup = (url, callback, dimensions) => {
   };
 
   const onExit = () => {
+    // Force callback to throw cancel error when exit
+    // and oauth process didn't start
+    if (!oauthFinished) {
+      callback();
+    }
+
     popup.removeEventListener('loadstop', pageLoaded);
     popup.removeEventListener('loaderror', fail);
     popup.removeEventListener('exit', onExit);


### PR DESCRIPTION
OSS-638

Context: https://github.com/meteor/meteor/issues/12601, https://github.com/meteor/meteor/issues/12949 and review other reports on slack or forums

## Issues

### Browser oauth callback / Retry mechanism / Cancel popup error

 https://github.com/meteor/meteor/issues/12601

❌ The issue occurred after implementing a retry mechanism to handle login attempts when the pop-up closed before credentials were saved to localStorage.

🟢 The fix triggers the callback after a retry interval with a timeout. If login is never completed, it runs the callback and raises the `Accounts.LoginCancelledError` as expected. This improves the retry behavior where local storage might not be ready immediately due to a delay.

This fix will be compatible with patch 1.4.6 for any Meteor 2.x app, although it is officially provided for Meteor 3. If issues arise requiring Meteor 2.x patching, we may consider a separate patch.

https://github.com/user-attachments/assets/4f5f99f9-85ba-4c0e-adad-2259bb133ad0


### Facebook Oauth async compatibility

https://github.com/meteor/meteor/issues/12949

❌ The server flow error with `Meteor.call('login'`/`facebookSignIn` occurs because the async handleAuthFromAccessToken function is not awaited.

🟢 To resolve this, ensure `handleAuthFromAccessToken` is properly awaited in `Accounts.registerLoginHandler` for Facebook.


### Native oauth callback / Cancel popup error

❌  While testing natively, I encountered an issue that causes a crash and displays a white screen on cancel the login process. The code is managed separately from the browser's logic. [picture](https://github.com/user-attachments/assets/bbd4e4f4-592f-4641-9c74-a80bd4235ab7)

🟢 Ignore the parse result error when the popup is canceled, as it doesn't affect the flow and the callback will continue.

https://github.com/user-attachments/assets/750e0bd6-6147-44d6-b42b-9f6bf1977c49

🟢 Trigger a cancel error when the popup is exited by clicking the "Done" button or another exit method before the OAuth process begins

https://github.com/user-attachments/assets/c4d29718-5c5b-430c-bb59-32b7bd9e484d