### PR TITLE
[Meteor.deprecate] ObjectID alias to backward compatible of meteor packages and allow-deny changes

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1806,21 +1806,6 @@ const setupUsersCollection = async users => {
 
       return true;
     },
-    updateAsync: (userId, user, fields, modifier) => {
-      // make sure it is our record
-      if (user._id !== userId) {
-        return false;
-      }
-
-      // user can only modify the 'profile' field. sets to multiple
-      // sub-keys (eg profile.foo and profile.bar) are merged into entry
-      // in the fields list.
-      if (fields.length !== 1 || fields[0] !== 'profile') {
-        return false;
-      }
-
-      return true;
-    },
     fetch: ['_id'] // we only look at _id.
   });
 
@@ -1861,4 +1846,3 @@ const generateCasePermutationsForString = string => {
   }
   return permutations;
 }
-

--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -554,7 +554,7 @@ function addValidator(collection, allowOrDeny, options) {
     const isAsyncKey = key.includes('Async');
     if (isAsyncKey) {
       const syncKey = key.replace('Async', '');
-      console.warn(allowOrDeny + `: The "${key}" key is deprecated. Use "${syncKey}" instead.`);
+      Meteor.deprecate(allowOrDeny + `: The "${key}" key is deprecated. Use "${syncKey}" instead.`);
     }
   });
 

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -10,6 +10,7 @@ function cleanStackTrace(stackTrace) {
         trace.push(_line);
       } else if (_line && _line.indexOf('/') !== -1) {
         // Stop processing if a valid path that does not start with 'packages/**' is found
+        trace.push(_line);
         break;
       }
     }

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -1,16 +1,20 @@
 function cleanStackTrace(stackTrace) {
-  if (!stackTrace) return [];
+  if (!stackTrace || typeof stackTrace !== 'string') return [];
   var lines = stackTrace.split('\n');
   var trace = [];
-  for (var i = 0; i < lines.length; i++) {
-    var _line = lines[i].trim();
-    if (_line.indexOf('Meteor.deprecate') !== -1) continue;
-    if (_line.indexOf('packages/') !== -1) {
-      trace.push(_line);
-    } else if (_line && _line.indexOf('/') !== -1) {
-      // Stop processing if a valid path that does not start with 'packages/**' is found
-      break;
+  try {
+    for (var i = 0; i < lines.length; i++) {
+      var _line = lines[i].trim();
+      if (_line.indexOf('Meteor.deprecate') !== -1) continue;
+      if (_line.indexOf('packages/') !== -1) {
+        trace.push(_line);
+      } else if (_line && _line.indexOf('/') !== -1) {
+        // Stop processing if a valid path that does not start with 'packages/**' is found
+        break;
+      }
     }
+  } catch (e) {
+    console.error('Error cleaning stack trace: ', e);
   }
   return trace.join('\n');
 }

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -15,21 +15,18 @@ function cleanStackTrace(stackTrace) {
   return trace.join('\n');
 }
 
-Meteor.deprecate = function (...messages) {
+Meteor.deprecate = function () {
   if (!Meteor.isDevelopment) {
     return;
   }
   if (typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
     var stackStrace = cleanStackTrace(new Error().stack || '');
-    console.warn(
-      '[DEPRECATION]',
-      ...messages,
-      ...stackStrace?.length > 0 && [
-        '\n\n',
-        'Trace:',
-        '\n',
-        stackStrace
-      ] || []
-    );
+    var messages = Array.prototype.slice.call(arguments); // Convert arguments to array
+
+    if (stackStrace.length > 0) {
+      messages.push('\n\n', 'Trace:', '\n', stackStrace);
+    }
+
+    console.warn.apply(console, ['[DEPRECATION]'].concat(messages));
   }
 };

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -2,12 +2,12 @@ function cleanStackTrace(stackTrace) {
   if (!stackTrace) return [];
   var lines = stackTrace.split('\n');
   var trace = [];
-  for (var line of lines) {
-    var _line = line.trim();
-    if (_line.includes('Meteor.deprecate')) continue;
-    if (_line.includes('packages/')) {
+  for (var i = 0; i < lines.length; i++) {
+    var _line = lines[i].trim();
+    if (_line.indexOf('Meteor.deprecate') !== -1) continue;
+    if (_line.indexOf('packages/') !== -1) {
       trace.push(_line);
-    } else if (_line && _line.includes('/')) {
+    } else if (_line && _line.indexOf('/') !== -1) {
       // Stop processing if a valid path that does not start with 'packages/**' is found
       break;
     }

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -1,9 +1,9 @@
 function cleanStackTrace(stackTrace) {
   if (!stackTrace) return [];
-  const lines = stackTrace.split('\n');
-  const trace = [];
-  for (const line of lines) {
-    const _line = line.trim();
+  var lines = stackTrace.split('\n');
+  var trace = [];
+  for (var line of lines) {
+    var _line = line.trim();
     if (_line.includes('Meteor.deprecate')) continue;
     if (_line.includes('packages/')) {
       trace.push(_line);
@@ -20,7 +20,7 @@ Meteor.deprecate = function (...messages) {
     return;
   }
   if (typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
-    const stackStrace = cleanStackTrace(new Error().stack || '');
+    var stackStrace = cleanStackTrace(new Error().stack || '');
     console.warn(
       '[DEPRECATION]',
       ...messages,

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -1,0 +1,35 @@
+function cleanStackTrace(stackTrace) {
+  if (!stackTrace) return [];
+  const lines = stackTrace.split('\n');
+  const trace = [];
+  for (const line of lines) {
+    const _line = line.trim();
+    if (_line.includes('Meteor.deprecate')) continue;
+    if (_line.includes('packages/')) {
+      trace.push(_line);
+    } else if (_line && _line.includes('/')) {
+      // Stop processing if a valid path that does not start with 'packages/**' is found
+      break;
+    }
+  }
+  return trace.join('\n');
+}
+
+Meteor.deprecate = function (...messages) {
+  if (!Meteor.isDevelopment) {
+    return;
+  }
+  if (typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
+    const stackStrace = cleanStackTrace(new Error().stack || '');
+    console.warn(
+      '[DEPRECATION]',
+      ...messages,
+      ...stackStrace?.length > 0 && [
+        '\n\n',
+        'Trace:',
+        '\n',
+        stackStrace
+      ] || []
+    );
+  }
+};

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -41,6 +41,7 @@ Package.onUse(function (api) {
   api.addFiles('startup_client.js', ['client']);
   api.addFiles('startup_server.js', ['server']);
   api.addFiles('debug.js', ['client', 'server']);
+  api.addFiles('deprecate.js', ['client', 'server']);
   api.addFiles('string_utils.js', ['client', 'server']);
   api.addFiles('test_environment.js', ['client', 'server']);
 

--- a/packages/mongo/mongo_common.js
+++ b/packages/mongo/mongo_common.js
@@ -1,7 +1,9 @@
 import clone from 'lodash.clone'
 
 /** @type {import('mongodb')} */
-export const MongoDB = NpmModuleMongodb;
+export const MongoDB = Object.assign(NpmModuleMongodb, {
+  ObjectID: NpmModuleMongodb.ObjectId,
+});
 
 // The write methods block until the database has confirmed the write (it may
 // not be replicated or stable on disk, but one server has confirmed it) if no

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -18,7 +18,17 @@ MongoInternals.NpmModules = {
 // MongoInternals.NpmModules.mongodb.module.  It was never documented, but
 // people do use it.
 // XXX COMPAT WITH 1.0.3.2
-MongoInternals.NpmModule = MongoDB;
+MongoInternals.NpmModule = new Proxy(MongoDB, {
+  get(target, propertyKey, receiver) {
+    if (propertyKey === 'ObjectID') {
+      console.warn(
+        `Accessing 'MongoInternals.NpmModule.ObjectID' directly is deprecated. ` +
+        `Use 'MongoInternals.NpmModules.mongodb.module.ObjectId' instead.`
+      );
+    }
+    return Reflect.get(target, propertyKey, receiver);
+  },
+});
 
 MongoInternals.OplogHandle = OplogHandle;
 

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -23,7 +23,7 @@ MongoInternals.NpmModule = new Proxy(MongoDB, {
     if (propertyKey === 'ObjectID') {
       console.warn(
         `Accessing 'MongoInternals.NpmModule.ObjectID' directly is deprecated. ` +
-        `Use 'MongoInternals.NpmModules.mongodb.module.ObjectId' instead.`
+        `Use 'MongoInternals.NpmModule.ObjectId' instead.`
       );
     }
     return Reflect.get(target, propertyKey, receiver);

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -21,7 +21,7 @@ MongoInternals.NpmModules = {
 MongoInternals.NpmModule = new Proxy(MongoDB, {
   get(target, propertyKey, receiver) {
     if (propertyKey === 'ObjectID') {
-      console.warn(
+      Meteor.deprecate(
         `Accessing 'MongoInternals.NpmModule.ObjectID' directly is deprecated. ` +
         `Use 'MongoInternals.NpmModule.ObjectId' instead.`
       );

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -3967,6 +3967,11 @@ Meteor.isServer &&
       typeof MongoInternals.NpmModules.mongodb.module.ObjectId,
       'function'
     );
+    test.equal(
+      MongoInternals.NpmModule.ObjectID,
+      MongoInternals.NpmModule.ObjectId,
+      'MongoInternals.ObjectID should be an alias for MongoInternals.ObjectId'
+    );
 
     var c = new Mongo.Collection(Random.id());
     var rawCollection = c.rawCollection();


### PR DESCRIPTION
This PR introduces a new Meteor helper for handling deprecations. The helper logs deprecation warnings only in development mode and includes a trace to help identify the context for resolving the issue.

It also addresses deprecations related to `ObjectID` and recent changes to `allow-deny` rules.

## ObjectID

Some packages use `MongoInternals.NpmModule.ObjectID`, but after the Mongo driver update, it is now `MongoInternals.NpmModule.ObjectId`.

`MongoInternals.NpmModule` refers to the driver module, but the driver no longer provides a direct reference to `ObjectID.` Access now is `MongoInternals.NpmModule.ObjectId`.

Ideally, packages should address this MongoDB driver breaking change themselves. Since this change surfaced with Meteor 3.1 and wasn’t reported as a breaking change, this PR restores it for backwards compatibility with existing packages. A stricter enforcement can be considered in a later Meteor minor release. Additionally, `Meteor.deprecate` is applied to guide developers in updating their packages.

## allow-deny

[A previous PR](https://github.com/meteor/meteor/pull/13499) deprecated allow/deny async rules, but these logs appeared in some apps without sufficient context, annoying devs. With the new `Meteor.deprecate` helper, such cases now provide better insights on where changes for deprecations are needed. For example, with this helper I identified and fixed an allow/deny rule within the Meteor core itself.

---------

![image](https://github.com/user-attachments/assets/868d556e-1947-47ee-9ac0-8fa9c51b5e53)
