### PR TITLE
Update `json5` and `semver` dependencies

### DIFF
--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -6,8 +6,8 @@ Package.describe({
 
 Npm.depends({
   '@meteorjs/babel': '7.20.1',
-  'json5': '2.1.1',
-  'semver': '7.3.8'
+  'json5': '2.2.3',
+  'semver': '7.6.3'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
This PR separates the upgrade of the json5 and semver dependencies from [#13510](https://github.com/meteor/meteor/pull/13510). This allows us to directly verify the checks and include the changes in the next release.

I reviewed the changelogs for the minor version updates in these libraries, and they don't appear to introduce risks.
Reference: https://github.com/json5/json5/tags and https://github.com/npm/node-semver/blob/main/CHANGELOG.md

