### PR TITLE
fix: built-in dev mongo can't start on win32 when username has spaces

### DIFF
--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -28,6 +28,17 @@ function spawnMongod(mongodPath, port, dbPath, replSetName) {
   mongodPath = files.convertToOSPath(mongodPath);
   dbPath = files.convertToOSPath(dbPath);
 
+  // Because we're spawning the process with shell: true on win32, the
+  // command string and args array are effectively concatenated to
+  // a single string and passed into the shell. If any of those paths
+  // contain spaces, these will get broken up on white-spaces and treated
+  // as separate tokens. If they are quoted, they will be parsed
+  // correctly by the shell.
+  if (process.platform === 'win32') {
+    mongodPath = '"' + mongodPath + '"'
+    dbPath = '"' + dbPath + '"'
+  }
+
   let args = [
     // nb: cli-test.sh and findMongoPids make strong assumptions about the
     // order of the arguments! Check them before changing any arguments.


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

On win32, if the `.meteor` folder is located in a path containing Space characters, `meteor` command will fail to run.

On Windows, it's a pretty common pattern to have a user account name that contains spaces, say "John Smith". If that happens, Windows will create a user folder with that space. If one then installs meteor using such a user, `.meteor` folder, installed in `%APP_DATA%` will end up on a path with spaces. When then the `meteor` CLI is used to start up a project, this will fail to run when trying to start the local dev `mongo` server, with a message similar to:

```
=> Started proxy.
'C:\Users\Jan' is not recognized as an internal or external command, operable program or batch file.
Unexpected mongo exit code 1. Restarting.
'C:\Users\Jan' is not recognized as an internal or external command, operable program or batch file.
Unexpected mongo exit code 1. Restarting.
'C:\Users\Jan' is not recognized as an internal or external command, operable program or batch file.
Unexpected mongo exit code 1. Restarting.
'C:\Users\Jan' is not recognized as an internal or external command, operable program or batch file.
Unexpected mongo exit code 1. Restarting.
Can't start Mongo server.
MongoDB failed global initialization
```

The problem originates in the `mongo` executable being started with the `shell: true` option. In those circumstances, Node's integration with the OS effectively causes the `command` and `args` to be concatenated to a single string and passed off to the shell. This in turn will tokenize this string using white-spaces and mistakenly take the "pre-space" portion of the executable path to be the executable itself, resulting in the above message.

Wrapping the paths in quotes allows the command line processing in the shell to succeed.
