### PR TITLE
Deprecation messages can be managed through environment variables.

### DIFF
--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -9,12 +9,12 @@ if (Meteor.isServer && Meteor.isDevelopment) {
 }
 
 function oncePerArgument(func) {
-  const cache = new Map();
+  var cache = new Map();
 
-  return function (...args) {
-    const key = JSON.stringify(args);
+  return function _oncePerArgument() {
+    var key = JSON.stringify(arguments);
     if (!cache.has(key)) {
-      const result = func.apply(this, args);
+      var result = func.apply(this, arguments);
       cache.set(key, result);
     }
     return cache.get(key);
@@ -43,13 +43,13 @@ function cleanStackTrace(stackTrace) {
   return trace.join('\n');
 }
 
-const onceWarning = oncePerArgument((message) => {
+var onceWarning = oncePerArgument(function _onceWarning(message) {
   console.warn.apply(console, message);
 });
 
-const onceFixDeprecation = () => {
+function onceFixDeprecation() {
   onceWarning(['Deprecation warnings are hidden but crucial to address for future Meteor updates.', '\n', 'Remove the `METEOR_NO_DEPRECATION` env var to reveal them, then report or fix the issues.']);
-};
+}
 
 Meteor.deprecate = function () {
   if (!Meteor.isDevelopment) {
@@ -60,7 +60,7 @@ Meteor.deprecate = function () {
     var messages = Array.prototype.slice.call(arguments); // Convert arguments to array
 
     if (typeof __meteor_runtime_config__.noDeprecation === 'string') {
-      const noDeprecationPattern = new RegExp(__meteor_runtime_config__.noDeprecation);
+      var noDeprecationPattern = new RegExp(__meteor_runtime_config__.noDeprecation);
       if (noDeprecationPattern.test(stackStrace)) {
         onceFixDeprecation();
         return;

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -1,6 +1,6 @@
 if (Meteor.isServer && Meteor.isDevelopment) {
   if (typeof __meteor_runtime_config__ === 'object') {
-    var noDeprecation = process.env.METEOR_NO_DEPRECATION;
+    var noDeprecation = process.env.METEOR_NO_DEPRECATION || process.noDeprecation;
     if (noDeprecation === 'true' || noDeprecation === 'false') {
       noDeprecation = noDeprecation === 'true';
     }

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -1,3 +1,13 @@
+if (Meteor.isServer && Meteor.isDevelopment) {
+  if (typeof __meteor_runtime_config__ === 'object') {
+    var noDeprecations = process.env.METEOR_NO_DEPRECATIONS;
+    if (noDeprecations === 'true' || noDeprecations === 'false') {
+      noDeprecations = noDeprecations === 'true';
+    }
+    __meteor_runtime_config__.noDeprecations = noDeprecations;
+  }
+}
+
 function cleanStackTrace(stackTrace) {
   if (!stackTrace || typeof stackTrace !== 'string') return [];
   var lines = stackTrace.split('\n');
@@ -28,6 +38,14 @@ Meteor.deprecate = function () {
     var stackStrace = cleanStackTrace(new Error().stack || '');
     var messages = Array.prototype.slice.call(arguments); // Convert arguments to array
 
+    if (typeof __meteor_runtime_config__.noDeprecations === 'string') {
+      const noDeprecationPattern = new RegExp(__meteor_runtime_config__.noDeprecations);
+      if (noDeprecationPattern.test(stackStrace)) {
+        return;
+      }
+    } else if (typeof __meteor_runtime_config__.noDeprecations === 'boolean' && __meteor_runtime_config__.noDeprecations) {
+      return;
+    }
     if (stackStrace.length > 0) {
       messages.push('\n\n', 'Trace:', '\n', stackStrace);
     }

--- a/packages/meteor/deprecate.js
+++ b/packages/meteor/deprecate.js
@@ -47,6 +47,10 @@ const onceWarning = oncePerArgument((message) => {
   console.warn.apply(console, message);
 });
 
+const onceFixDeprecation = () => {
+  onceWarning(['Deprecation warnings are hidden but crucial to address for future Meteor updates.', '\n', 'Remove the `METEOR_NO_DEPRECATION` env var to reveal them, then report or fix the issues.']);
+};
+
 Meteor.deprecate = function () {
   if (!Meteor.isDevelopment) {
     return;
@@ -58,9 +62,11 @@ Meteor.deprecate = function () {
     if (typeof __meteor_runtime_config__.noDeprecation === 'string') {
       const noDeprecationPattern = new RegExp(__meteor_runtime_config__.noDeprecation);
       if (noDeprecationPattern.test(stackStrace)) {
+        onceFixDeprecation();
         return;
       }
     } else if (typeof __meteor_runtime_config__.noDeprecation === 'boolean' && __meteor_runtime_config__.noDeprecation) {
+      onceFixDeprecation();
       return;
     }
     if (stackStrace.length > 0) {


### PR DESCRIPTION
OSS-650

Context: https://github.com/meteor/meteor/issues/13518 and [forum post](https://forums.meteor.com/t/disable-deprecation-messages/62841)

This PR addresses feedback on controlling deprecation warnings using environment variables. These updates are part of the final adjustments for the official 3.1.1 release.

- Deprecation warnings are shown by default.
- Use `METEOR_NO_DEPRECATION` (set to true or a regex) to control visibility.
- Each warning is displayed only once per stack trace.
- Node's `--no-deprecate` option also suppresses Meteor deprecation logs.
- When METEOR_NO_DEPRECATION is used, a log will appear once if there are existing deprecations, encouraging their report or fix.


![image](https://github.com/user-attachments/assets/6726da30-eb1b-4f61-8a11-afcf85f50eb2)

![image](https://github.com/user-attachments/assets/1c15c82e-89fa-4b73-b4cd-bf7a23bf1133)

When deprecation is hidden, a single message will appear, prompting users to report or address it.

![image](https://github.com/user-attachments/assets/25817d85-5eff-46f0-9295-aadf02d222af)

