### PR TITLE
Contribution: built-in dev mongo can't start on win32 when username has spaces

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1058,7 +1058,7 @@ main.registerCommand({
     process.env.GIT_TERMINAL_PROMPT = 0;
 
     const gitCommand = isWindows
-      ? `git clone --progress ${url} ${files.convertToOSPath(appPath)}`
+      ? `git clone --progress ${url} "${files.convertToOSPath(appPath)}"`
       : `git clone --progress ${url} ${appPath}`;
     const [okClone, errClone] = await bash`${gitCommand}`;
     const errorMessage = errClone && typeof errClone === "string" ? errClone : errClone?.message;

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -28,6 +28,17 @@ function spawnMongod(mongodPath, port, dbPath, replSetName) {
   mongodPath = files.convertToOSPath(mongodPath);
   dbPath = files.convertToOSPath(dbPath);
 
+  // Because we're spawning the process with shell: true on win32, the
+  // command string and args array are effectively concatenated to
+  // a single string and passed into the shell. If any of those paths
+  // contain spaces, these will get broken up on white-spaces and treated
+  // as separate tokens. If they are quoted, they will be parsed
+  // correctly by the shell.
+  if (process.platform === 'win32') {
+    mongodPath = '"' + mongodPath + '"'
+    dbPath = '"' + dbPath + '"'
+  }
+
   let args = [
     // nb: cli-test.sh and findMongoPids make strong assumptions about the
     // order of the arguments! Check them before changing any arguments.


### PR DESCRIPTION
Continues: https://github.com/meteor/meteor/pull/13540

Context: [forum post](https://forums.meteor.com/t/cannot-start-meteor-3-0-4-on-windows/62524)

Validate to include on next 3.1.1 version.

## Fix on `meteor run`

Using spaced folder context now run properly the meteor app.

![image](https://github.com/user-attachments/assets/205ff959-7407-4edf-afd8-add62242d2a3)

## Fix on `meteor create`

On my way testing this fix I found other caused on create the meteor app on a path using spaces. Fixed.

![image](https://github.com/user-attachments/assets/56d076a9-55fb-4653-be1e-ade8c81cc317)
