### PR TITLE
Update useragent-ng to v2.4.4, fix #13539

### DIFF
--- a/packages/webapp/package.js
+++ b/packages/webapp/package.js
@@ -13,7 +13,7 @@ Npm.depends({
   send: "1.1.0",
   "stream-to-string": "1.2.1",
   qs: "6.13.0",
-  "useragent-ng": "2.4.3",
+  "useragent-ng": "2.4.4",
   "tmp": "0.2.3",
 });
 


### PR DESCRIPTION
Patch update `useragent-ng` to v2.4.4 as per discussion in #13539 

I think this could also be released as a patch on its own instead of waiting for the Meteor v3.1.2 full release, if desired.