### PR TITLE
Bump nodemailer-openpgp to fix vulnerabilities

### DIFF
--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -7,7 +7,7 @@ Npm.depends({
   nodemailer: "6.9.10",
   "stream-buffers": "3.0.2",
   "@types/nodemailer": "6.4.14",
-  "nodemailer-openpgp": "2.2.0",
+  "nodemailer-openpgp": "2.2.1",
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
OpenPGP 5.9.0 has a medium-severity CVE (https://security.snyk.io/package/npm/openpgp/5.9.0). node-mailer-openpgp version 2.2.1 bumps the OpenPGP library to a version that fixes this vulnerability (https://github.com/nodemailer/nodemailer-openpgp/commit/fa6ff1bf638903550ae433e90158e7ea4cec2c89#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26).

Meteor is currently using version 2.2.0 and this PR bumps it to 2.2.1.