### PR TITLE
DOCS: Fix typo in Tracker.md

### DIFF
--- a/v3-docs/docs/api/Tracker.md
+++ b/v3-docs/docs/api/Tracker.md
@@ -87,13 +87,13 @@ Tracker.autorun(async function example1(computation) {
   // Code before the first await will stay reactive.
   reactiveVar1.get(); // This will trigger a rerun.
 
-  let links = await LinksCollection.findAsync({}).fetch(); // First async call will stay reactive.
+  let links = await LinksCollection.find({}).fetchAsync(); // First async call will stay reactive.
 
   // Code after the first await looses Tracker.currentComputation: no reactivity.
   reactiveVar2.get(); // This won't trigger a rerun.
 
   // You can bring back reactivity with the Tracker.withCompuation wrapper:
-  let users = await Tracker.withComputation(computation, () => Meteor.users.findAsync({}).fetch());
+  let users = await Tracker.withComputation(computation, () => Meteor.users.find({}).fetchAsync());
 
   // Code below will again not be reactive, so you will need another Tracker.withComputation.
   const value = Tracker.withComputation(computation, () => reactiveVar3.get()); // This will trigger a rerun.


### PR DESCRIPTION
Before it was using `findAsync({}).fetch` but it should have been `find({}).fetchAsync()`

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

relates to https://forums.meteor.com/t/meteor-3-subscription-ready-not-reactive-anymore/63121/7?u=grubba