### PR TITLE
Bump postcss in minifier-css to fix vulnerabilities

### DIFF
--- a/packages/minifier-css/package.js
+++ b/packages/minifier-css/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: 'CSS minifier',
-  version: '2.0.0',
+  version: '2.0.1',
 });
 
 Npm.depends({
-  postcss: '8.4.21',
+  postcss: '8.5.1',
   cssnano: '5.1.15'
 });
 


### PR DESCRIPTION
`postcss` before 8.4.31 is vulnerable (https://nvd.nist.gov/vuln/detail/cve-2023-44270). This PR bumps the version being used by `minifier-css`.