### PR TITLE
Ignore meteor/mongo to avoid annoying non-critical waring

### DIFF
--- a/tools/static-assets/skel-solid/vite.config.js
+++ b/tools/static-assets/skel-solid/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
       serverEntry: 'server/main.js',
       enableExperimentalFeatures: true,
       stubValidation: {
-        ignorePackages: ['mongo'],
+        ignorePackages: ['meteor/mongo'],
       },
     }),
   ],

--- a/tools/static-assets/skel-solid/vite.config.js
+++ b/tools/static-assets/skel-solid/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
       serverEntry: 'server/main.js',
       enableExperimentalFeatures: true,
       stubValidation: {
-        warnOnly: true,
+        ignorePackages: ['mongo'],
       },
     }),
   ],

--- a/tools/static-assets/skel-vue/vite.config.js
+++ b/tools/static-assets/skel-vue/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
       serverEntry: 'server/main.js',
       enableExperimentalFeatures: true,
       stubValidation: {
-        warnOnly: true,
+        ignorePackages: ['mongo'],
       },
     }),
   ],

--- a/tools/static-assets/skel-vue/vite.config.js
+++ b/tools/static-assets/skel-vue/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
       serverEntry: 'server/main.js',
       enableExperimentalFeatures: true,
       stubValidation: {
-        ignorePackages: ['mongo'],
+        ignorePackages: ['meteor/mongo'],
       },
     }),
   ],


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/issues/13530

Ignore annoying warning as part of the meteor-vite setup on related skeletons.

![image](https://github.com/user-attachments/assets/88924fc4-fb70-4c6e-9358-0a199f604ff9)
