### PR TITLE
Use `_.template` from `lodash` instead of vulnerable `lodash.template`

### DIFF
--- a/packages/boilerplate-generator/package.js
+++ b/packages/boilerplate-generator/package.js
@@ -1,11 +1,11 @@
 Package.describe({
   summary: "Generates the boilerplate html from program's manifest",
-  version: '2.0.0',
+  version: '2.0.1',
 });
 
 Npm.depends({
   "combined-stream2": "1.1.2",
-  "lodash.template": "4.5.0"
+  "lodash": "4.17.21"
 });
 
 Package.onUse(api => {

--- a/packages/boilerplate-generator/template.js
+++ b/packages/boilerplate-generator/template.js
@@ -1,4 +1,4 @@
-import lodashTemplate from 'lodash.template';
+import _ from 'lodash';
 
 // As identified in issue #9149, when an application overrides the default
 // _.template settings using _.templateSettings, those new settings are
@@ -6,7 +6,7 @@ import lodashTemplate from 'lodash.template';
 // boilerplate-generator. To handle this, _.template settings that have
 // been verified to work are overridden here on each _.template call.
 export default function template(text) {
-  return lodashTemplate(text, null, {
+  return _.template(text, null, {
     evaluate    : /<%([\s\S]+?)%>/g,
     interpolate : /<%=([\s\S]+?)%>/g,
     escape      : /<%-([\s\S]+?)%>/g,


### PR DESCRIPTION
`lodash.template` is a package that has been outdated for 6 years. As seen in the following Snyk page, the latest published version has a high-severity vulnerability (https://security.snyk.io/package/npm/lodash.template) - which is a code injection issue.

Instead of using the standalone `lodash.template` package, we can use the full `lodash` package, which contains no known vulnerability as of now (https://security.snyk.io/package/npm/lodash).