### PR TITLE
FEATURE: add `shouldShowTime` to `logging` package

### DIFF
--- a/packages/logging/logging.d.ts
+++ b/packages/logging/logging.d.ts
@@ -24,6 +24,7 @@ export declare function Log(input: LogInput, ...optionalParams: any[]): void;
 
 export declare namespace Log {
   var outputFormat: 'json' | 'colored-text';
+  var shouldShowTime: boolean;
   function _intercept(count: number): void;
   function _suppress(count: number): void;
   function _intercepted(): string[];

--- a/packages/logging/logging.d.ts
+++ b/packages/logging/logging.d.ts
@@ -24,7 +24,7 @@ export declare function Log(input: LogInput, ...optionalParams: any[]): void;
 
 export declare namespace Log {
   var outputFormat: 'json' | 'colored-text';
-  var shouldShowTime: boolean;
+  var showTime: boolean;
   function _intercept(count: number): void;
   function _suppress(count: number): void;
   function _intercepted(): string[];

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -47,7 +47,7 @@ Log.outputFormat = 'json';
 // Defaults to true for local development and for backwards compatibility.
 // for cloud environments is interesting to leave it false as most of them have the timestamp in the console.
 // Only works in server with colored-text
-Log.shouldShowTime = true;
+Log.showTime = true;
 
 const LEVEL_COLORS = {
   debug: 'green',
@@ -301,7 +301,7 @@ Log.format = (obj, options = {}) => {
 
   const stderrIndicator = stderr ? '(STDERR) ' : '';
 
-  const timeString = Log.shouldShowTime
+  const timeString = Log.showTime
     ? `${dateStamp}-${timeStamp}${utcOffsetStr}${timeInexact ? '? ' : ' '}`
     : ' ';
 

--- a/packages/logging/logging.js
+++ b/packages/logging/logging.js
@@ -44,6 +44,11 @@ Log._intercepted = () => {
 // other process that will be reading its standard output.
 Log.outputFormat = 'json';
 
+// Defaults to true for local development and for backwards compatibility.
+// for cloud environments is interesting to leave it false as most of them have the timestamp in the console.
+// Only works in server with colored-text
+Log.shouldShowTime = true;
+
 const LEVEL_COLORS = {
   debug: 'green',
   // leave info as the default color
@@ -296,13 +301,15 @@ Log.format = (obj, options = {}) => {
 
   const stderrIndicator = stderr ? '(STDERR) ' : '';
 
+  const timeString = Log.shouldShowTime
+    ? `${dateStamp}-${timeStamp}${utcOffsetStr}${timeInexact ? '? ' : ' '}`
+    : ' ';
+
+
+
   const metaPrefix = [
     level.charAt(0).toUpperCase(),
-    dateStamp,
-    '-',
-    timeStamp,
-    utcOffsetStr,
-    timeInexact ? '? ' : ' ',
+    timeString,
     appInfo,
     sourceInfo,
     stderrIndicator].join('');

--- a/packages/logging/logging_test.js
+++ b/packages/logging/logging_test.js
@@ -1,57 +1,58 @@
-import { Meteor  } from 'meteor/meteor';
-import { Log } from 'meteor/logging';
+import { Log } from "meteor/logging";
+import { Meteor } from "meteor/meteor";
 
-Tinytest.add('logging - _getCallerDetails', function (test) {
+Tinytest.add("logging - _getCallerDetails", function (test) {
   const details = Log._getCallerDetails();
   // Ignore this test for Opera, IE, Safari since this test would work only
   // in Chrome and Firefox, other browsers don't give us an ability to get
   // stacktrace.
-  if ((new Error).stack) {
+  if (new Error().stack) {
     if (Meteor.isServer) {
-      test.equal(details.file, 'tinytest.js');
+      test.equal(details.file, "tinytest.js");
     } else {
       // Note that we want this to work in --production too, so we need to allow
       // for the minified filename.
-      test.matches(details.file,
-                   /^(?:tinytest\.js|[a-f0-9]{40}\.js)$/);
+      test.matches(details.file, /^(?:tinytest\.js|[a-f0-9]{40}\.js)$/);
     }
 
     // evaled statements shouldn't crash
-    const code = 'Log._getCallerDetails().file';
+    const code = "Log._getCallerDetails().file";
     // Note that we want this to work in --production too, so we need to allow
     // for the minified filename
-    test.matches(eval(code),
-                 /^(?:eval|local-test_logging\.js|[a-f0-9]{40}\.js)/);
+    test.matches(
+      eval(code),
+      /^(?:eval|local-test_logging\.js|[a-f0-9]{40}\.js)/
+    );
   }
 });
 
-Tinytest.add('logging - log', function (test) {
+Tinytest.add("logging - log", function (test) {
   const logBothMessageAndObject = function (log, level) {
     Log._intercept(3);
     // Tests for correctness
-    log('message');
-    log({property1: 'foo', property2: 'bar'});
-    log({message: 'mixed', property1: 'foo', property2: 'bar'});
+    log("message");
+    log({ property1: "foo", property2: "bar" });
+    log({ message: "mixed", property1: "foo", property2: "bar" });
 
     let intercepted = Log._intercepted();
     test.equal(intercepted.length, 3);
 
     const obj1 = EJSON.parse(intercepted[0]);
-    test.equal(obj1.message, 'message');
+    test.equal(obj1.message, "message");
     test.equal(obj1.level, level);
     test.instanceOf(obj1.time, Date);
 
     const obj2 = EJSON.parse(intercepted[1]);
     test.isFalse(obj2.message);
-    test.equal(obj2.property1, 'foo');
-    test.equal(obj2.property2, 'bar');
+    test.equal(obj2.property1, "foo");
+    test.equal(obj2.property2, "bar");
     test.equal(obj2.level, level);
     test.instanceOf(obj2.time, Date);
 
     const obj3 = EJSON.parse(intercepted[2]);
-    test.equal(obj3.message, 'mixed');
-    test.equal(obj3.property1, 'foo');
-    test.equal(obj3.property2, 'bar');
+    test.equal(obj3.message, "mixed");
+    test.equal(obj3.property1, "foo");
+    test.equal(obj3.property2, "bar");
     test.equal(obj3.level, level);
     test.instanceOf(obj3.time, Date);
 
@@ -59,15 +60,20 @@ Tinytest.add('logging - log', function (test) {
     // and some other non-stringy things
     // In a format of testcase, expected result, name of the test.
     const testcases = [
-          [1, '1', 'single digit'],
-          [0, '0', 'falsy - 0'],
-          [null, 'null', 'falsy - null'],
-          [undefined, 'undefined', 'falsy - undefined'],
-          [new Date('2013-06-13T01:15:16.000Z'), new Date('2013-06-13T01:15:16.000Z'), 'date'],
-          [/[^regexp]{0,1}/g, '/[^regexp]{0,1}/g', 'regexp'],
-          [true, 'true', 'boolean - true'],
-          [false, 'false', 'boolean - false'],
-          [-Infinity, '-Infinity', 'number - -Infinity']];
+      [1, "1", "single digit"],
+      [0, "0", "falsy - 0"],
+      [null, "null", "falsy - null"],
+      [undefined, "undefined", "falsy - undefined"],
+      [
+        new Date("2013-06-13T01:15:16.000Z"),
+        new Date("2013-06-13T01:15:16.000Z"),
+        "date",
+      ],
+      [/[^regexp]{0,1}/g, "/[^regexp]{0,1}/g", "regexp"],
+      [true, "true", "boolean - true"],
+      [false, "false", "boolean - false"],
+      [-Infinity, "-Infinity", "number - -Infinity"],
+    ];
 
     Log._intercept(testcases.length);
     testcases.forEach((testcase) => {
@@ -79,18 +85,20 @@ Tinytest.add('logging - log', function (test) {
     test.equal(intercepted.length, testcases.length);
 
     testcases.forEach((testcase, index) => {
-      var expected = testcase[1];
-      var testName = testcase[2];
-      var recieved = intercepted[index];
-      var obj = EJSON.parse(recieved);
+      const expected = testcase[1];
+      const testName = testcase[2];
+      const recieved = intercepted[index];
+      const obj = EJSON.parse(recieved);
 
       // IE8 and old Safari don't support this date format. Skip it.
-      if (expected && expected.toString &&
-          (expected.toString() === 'NaN' ||
-           expected.toString() === 'Invalid Date')) {
-            return;
+      if (
+        expected &&
+        expected.toString &&
+        (expected.toString() === "NaN" ||
+          expected.toString() === "Invalid Date")
+      ) {
+        return;
       }
-
 
       if (testcase[0] instanceof Date) {
         obj.message = new Date(obj.message);
@@ -103,24 +111,35 @@ Tinytest.add('logging - log', function (test) {
     Log._intercept(6);
 
     test.throws(function () {
-      log({time: 'not the right time'});
+      log({ time: "not the right time" });
     });
     test.throws(function () {
-      log({level: 'not the right level'});
+      log({ level: "not the right level" });
     });
-    ['file', 'line', 'program', 'originApp', 'satellite'].forEach(
-      function (restrictedKey) {
+    ["file", "line", "program", "originApp", "satellite"].forEach(function (
+      restrictedKey
+    ) {
       test.throws(function () {
-        var obj = {};
-        obj[restrictedKey] = 'usage of restricted key';
+        const obj = {};
+        obj[restrictedKey] = "usage of restricted key";
         log(obj);
       });
     });
 
     // Can't pass numbers, objects, arrays, regexps or functions as message
-    var throwingTestcases = [1, NaN, {foo:'bar'}, ['a', 'r', 'r'], null,
-                             undefined, new Date, function () { return 42; },
-                             /[regexp]/ ];
+    const throwingTestcases = [
+      1,
+      NaN,
+      { foo: "bar" },
+      ["a", "r", "r"],
+      null,
+      undefined,
+      new Date(),
+      function () {
+        return 42;
+      },
+      /[regexp]/,
+    ];
     Log._intercept(throwingTestcases.length);
     throwingTestcases.forEach(function (testcase) {
       test.throws(function () {
@@ -133,75 +152,266 @@ Tinytest.add('logging - log', function (test) {
     test.equal(Log._intercepted().length, 0);
   };
 
-  logBothMessageAndObject(Log, 'info');
-  ['info', 'warn', 'error'].forEach((level) => {
+  logBothMessageAndObject(Log, "info");
+  ["info", "warn", "error"].forEach((level) => {
     logBothMessageAndObject(Log[level], level);
   });
 });
 
-Tinytest.add('logging - parse', function (test) {
+Tinytest.add("logging - parse", function (test) {
   test.equal(Log.parse("message"), null);
   test.equal(Log.parse('{"foo": "bar"}'), null);
-  var time = new Date;
-  test.equal(Log.parse(`{"foo": "bar", "time": ${EJSON.stringify(time)}}`),
-                        { foo: "bar", time: time });
+  const time = new Date();
+  test.equal(Log.parse(`{"foo": "bar", "time": ${EJSON.stringify(time)}}`), {
+    foo: "bar",
+    time,
+  });
   test.equal(Log.parse('{"foo": not json "bar"}'), null);
   test.equal(Log.parse('{"time": "not a date object"}'), null);
 });
 
-Tinytest.add('logging - format', function (test) {
-  var time = new Date(2012, 9 - 1/*0-based*/, 8, 7, 6, 5, 4);
-  var utcOffsetStr = '(' + (-(new Date().getTimezoneOffset() / 60)) + ')';
+Tinytest.add("logging - format", function (test) {
+  const time = new Date(2012, 9 - 1 /*0-based*/, 8, 7, 6, 5, 4);
+  const utcOffsetStr = "(" + -(new Date().getTimezoneOffset() / 60) + ")";
 
-  ['debug', 'info', 'warn', 'error'].forEach(function (level) {
+  ["debug", "info", "warn", "error"].forEach(function (level) {
     test.equal(
-      Log.format({message: 'message', time: time, level: level}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} message`);
-
-    test.equal(
-      Log.format({message: 'message', time: time, timeInexact: true, level: level}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr}? message`);
-
-    test.equal(
-      Log.format({foo1: 'bar1', foo2: 'bar2', time: time, level: level}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} {"foo1":"bar1","foo2":"bar2"}`);
+      Log.format({ message: "message", time, level }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} message`
+    );
 
     test.equal(
-      Log.format({message: 'message', foo: 'bar', time: time, level: level}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} message {"foo":"bar"}`);
+      Log.format({
+        message: "message",
+        time,
+        timeInexact: true,
+        level,
+      }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr}? message`
+    );
+
+    test.equal(
+      Log.format({ foo1: "bar1", foo2: "bar2", time, level }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} {"foo1":"bar1","foo2":"bar2"}`
+    );
+
+    test.equal(
+      Log.format({ message: "message", foo: "bar", time, level }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} message {"foo":"bar"}`
+    );
 
     // Has everything except stderr field
     test.equal(
-      Log.format({message: 'message', foo: 'bar', time: time, level: level, file: 'app.js', line:42, app: 'myApp', originApp: 'proxy', program: 'server'}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} [myApp via proxy] (server:app.js:42) message {\"foo\":\"bar\"}`);
+      Log.format({
+        message: "message",
+        foo: "bar",
+        time,
+        level,
+        file: "app.js",
+        line: 42,
+        app: "myApp",
+        originApp: "proxy",
+        program: "server",
+      }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} [myApp via proxy] (server:app.js:42) message {\"foo\":\"bar\"}`
+    );
 
     // stderr
     test.equal(
-      Log.format({message: 'message from stderr', time: time, level: level, stderr: true}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} (STDERR) message from stderr`);
+      Log.format({
+        message: "message from stderr",
+        time,
+        level,
+        stderr: true,
+      }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} (STDERR) message from stderr`
+    );
 
     // app/originApp
     test.equal(
-      Log.format({message: 'message', time: time, level: level, app: 'app', originApp: 'app'}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} [app] message`);
+      Log.format({
+        message: "message",
+        time,
+        level,
+        app: "app",
+        originApp: "app",
+      }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} [app] message`
+    );
     test.equal(
-      Log.format({message: "message", time: time, level: level, app: 'app', originApp: 'proxy'}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} [app via proxy] message`);
+      Log.format({
+        message: "message",
+        time,
+        level,
+        app: "app",
+        originApp: "proxy",
+      }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} [app via proxy] message`
+    );
 
     // source info
     test.equal(
-      Log.format({message: 'message', time: time, level: level, file: 'app.js', line: 42, program: 'server'}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} (server:app.js:42) message`);
+      Log.format({
+        message: "message",
+        time,
+        level,
+        file: "app.js",
+        line: 42,
+        program: "server",
+      }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} (server:app.js:42) message`
+    );
     test.equal(
-      Log.format({message: 'message', time: time, level: level, file: 'app.js', line: 42}),
-      `${level.charAt(0).toUpperCase()}20120908-07:06:05.004${utcOffsetStr} (app.js:42) message`);
+      Log.format({
+        message: "message",
+        time,
+        level,
+        file: "app.js",
+        line: 42,
+      }),
+      `${level
+        .charAt(0)
+        .toUpperCase()}20120908-07:06:05.004${utcOffsetStr} (app.js:42) message`
+    );
   });
 
-  test.matches(Log.format({
-    message: 'oyez',
-    time: new Date,
-    level: 'error'
-  }, {
-    color: true
-  }), /oyez/);
+  test.matches(
+    Log.format(
+      {
+        message: "oyez",
+        time: new Date(),
+        level: "error",
+      },
+      {
+        color: true,
+      }
+    ),
+    /oyez/
+  );
+});
+
+Tinytest.add("logging - formats - without time", function (test) {
+  const time = new Date(2012, 9 - 1 /*0-based*/, 8, 7, 6, 5, 4);
+  // even tho time and offset are provided they should not be included in the output
+  Log.shouldShowTime = false;
+  const levels = ["debug", "info", "warn", "error"];
+  for (const level of levels) {
+    test.equal(
+      Log.format({ message: "message", time, level }),
+      `${level.charAt(0).toUpperCase()} message`
+    );
+
+    test.equal(
+      Log.format({
+        message: "message",
+        time,
+        timeInexact: true,
+        level,
+      }),
+      `${level.charAt(0).toUpperCase()} message`
+    );
+
+    test.equal(
+      Log.format({ foo1: "bar1", foo2: "bar2", time, level }),
+      `${level.charAt(0).toUpperCase()} {"foo1":"bar1","foo2":"bar2"}`
+    );
+
+    test.equal(
+      Log.format({ message: "message", foo: "bar", time, level }),
+      `${level.charAt(0).toUpperCase()} message {"foo":"bar"}`
+    );
+
+    // Has everything except stderr field
+    test.equal(
+      Log.format({
+        message: "message",
+        foo: "bar",
+        time,
+        level,
+        file: "app.js",
+        line: 42,
+        app: "myApp",
+        originApp: "proxy",
+        program: "server",
+      }),
+      `${level
+        .charAt(0)
+        .toUpperCase()} [myApp via proxy] (server:app.js:42) message {\"foo\":\"bar\"}`
+    );
+
+    // stderr
+    test.equal(
+      Log.format({
+        message: "message from stderr",
+        time,
+        level,
+        stderr: true,
+      }),
+      `${level.charAt(0).toUpperCase()} (STDERR) message from stderr`
+    );
+
+    // app/originApp
+    test.equal(
+      Log.format({
+        message: "message",
+        time,
+        level,
+        app: "app",
+        originApp: "app",
+      }),
+      `${level.charAt(0).toUpperCase()} [app] message`
+    );
+    test.equal(
+      Log.format({
+        message: "message",
+        time,
+        level,
+        app: "app",
+        originApp: "proxy",
+      }),
+      `${level.charAt(0).toUpperCase()} [app via proxy] message`
+    );
+
+    // source info
+    test.equal(
+      Log.format({
+        message: "message",
+        time,
+        level,
+        file: "app.js",
+        line: 42,
+        program: "server",
+      }),
+      `${level.charAt(0).toUpperCase()} (server:app.js:42) message`
+    );
+    test.equal(
+      Log.format({
+        message: "message",
+        time,
+        level,
+        file: "app.js",
+        line: 42,
+      }),
+      `${level.charAt(0).toUpperCase()} (app.js:42) message`
+    );
+  }
+  Log.shouldShowTime = true; // reset
 });

--- a/packages/logging/logging_test.js
+++ b/packages/logging/logging_test.js
@@ -311,7 +311,7 @@ Tinytest.add("logging - format", function (test) {
 Tinytest.add("logging - formats - without time", function (test) {
   const time = new Date(2012, 9 - 1 /*0-based*/, 8, 7, 6, 5, 4);
   // even tho time and offset are provided they should not be included in the output
-  Log.shouldShowTime = false;
+  Log.showTime = false;
   const levels = ["debug", "info", "warn", "error"];
   for (const level of levels) {
     test.equal(
@@ -413,5 +413,5 @@ Tinytest.add("logging - formats - without time", function (test) {
       `${level.charAt(0).toUpperCase()} (app.js:42) message`
     );
   }
-  Log.shouldShowTime = true; // reset
+  Log.showTime = true; // reset
 });

--- a/v3-docs/docs/api/packages-listing.md
+++ b/v3-docs/docs/api/packages-listing.md
@@ -105,7 +105,6 @@
 ### [mongo-dev-server](https://github.com/meteor/meteor/tree/devel/packages/mongo-dev-server) {#mongo-dev-server}
 ### [mongo-id](https://github.com/meteor/meteor/tree/devel/packages/mongo-id) {#mongo-id}
 ### [mongo-livedata](https://github.com/meteor/meteor/tree/devel/packages/mongo-livedata) {#mongo-livedata}
-### [npm-bcrypt](https://github.com/meteor/meteor/tree/devel/packages/npm-bcrypt) {#npm-bcrypt}
 ### [npm-mongo](https://github.com/meteor/meteor/tree/devel/packages/npm-mongo) {#npm-mongo}
 ### [oauth](https://github.com/meteor/meteor/tree/devel/packages/oauth) {#oauth}
 ### [oauth-encryption](https://github.com/meteor/meteor/tree/devel/packages/oauth-encryption) {#oauth-encryption}

--- a/v3-docs/docs/generators/meteor-versions/metadata.generated.js
+++ b/v3-docs/docs/generators/meteor-versions/metadata.generated.js
@@ -22,9 +22,13 @@ export default {
     },
     {
       "version": "v3.1.1",
-      "url": "https://release-3-1-1.docs.meteor.com/",
+      "url": "https://release-3-1-1.docs.meteor.com/"
+    },
+    {
+      "version": "v3.1.2",
+      "url": "https://release-3-1-2.docs.meteor.com/",
       "isCurrent": true
     }
   ],
-  "currentVersion": "v3.1.1"
+  "currentVersion": "v3.1.2"
 }

--- a/v3-docs/docs/history.md
+++ b/v3-docs/docs/history.md
@@ -10,6 +10,8 @@ This is a complete history of changes for Meteor releases.
 
 [//]: # (go to meteor/docs/generators/changelog/docs)
 
+
+
 ## v3.1.2, 2025-02-06
 
 ### Highlights
@@ -59,7 +61,6 @@ N/A
 - [@julio-rocketchat](https://github.com/julio-rocketchat)
 
 ✨✨✨
-
 ## v3.1.1, 2025-01-15
 
 ### Highlights
@@ -131,7 +132,6 @@ N/A
 - [@quyetdgroup](https://github.com/quyetdgroup)
 
 ✨✨✨
-
 ## v3.1.0, 2024-11-20
 
 ### Highlights

--- a/v3-docs/docs/packages/logging.md
+++ b/v3-docs/docs/packages/logging.md
@@ -29,7 +29,7 @@ Besides passing in strings, you can also pass in objects. This has few exception
 First in the root of the object the following keys are not allowed:
 
 ```javascript
-"time",
+  "time",
   "timeInexact",
   "level",
   "file",

--- a/v3-docs/docs/packages/logging.md
+++ b/v3-docs/docs/packages/logging.md
@@ -78,5 +78,5 @@ Log.outputFormat = "json";
 // Boolean. Defaults to true.
 // for cloud environments is interesting to leave it false as most of them have the timestamp in the console.
 // Only works in server with colored-text output format.
-Log.shouldShowTime = true;
+Log.showTime = true;
 ```

--- a/v3-docs/docs/packages/logging.md
+++ b/v3-docs/docs/packages/logging.md
@@ -11,29 +11,47 @@ meteor add logging
 ```
 
 You can then import the utility anywhere in you code like this:
+
 ```javascript
-import { Log } from 'meteor/logging'
+import { Log } from "meteor/logging";
 ```
 
 You can then call the logging functions in one of the following ways:
+
 ```javascript
-Log('starting up') // or Log.info('starting up')
-Log.error('error message')
-Log.warn('warning')
-Log.debug('this will show only in development')
+Log("starting up"); // or Log.info('starting up')
+Log.error("error message");
+Log.warn("warning");
+Log.debug("this will show only in development");
 ```
 
 Besides passing in strings, you can also pass in objects. This has few exceptions and special functions associated.
 First in the root of the object the following keys are not allowed:
+
 ```javascript
-'time', 'timeInexact', 'level', 'file', 'line', 'program', 'originApp', 'satellite', 'stderr'
+"time",
+  "timeInexact",
+  "level",
+  "file",
+  "line",
+  "program",
+  "originApp",
+  "satellite",
+  "stderr";
 ```
 
 On the other hand there is `message` and `app`, which are also reserved, but they will display in more prominent manner:
+
 ```javascript
-Log.info({message: 'warning', app: 'DESKTOP', error: { property1: 'foo', property2: 'bar', property3: { foo: 'bar' }} })
+Log.info({
+  message: "warning",
+  app: "DESKTOP",
+  error: { property1: "foo", property2: "bar", property3: { foo: "bar" } },
+});
 ```
+
 will turn into:
+
 ```shell
 E20200519-17:57:41.655(9) [DESKTOP] (main.js:36) warning {"error":{"property1":"foo","property2":"bar","property3":{"foo":"bar"}}}
 ```
@@ -41,4 +59,24 @@ E20200519-17:57:41.655(9) [DESKTOP] (main.js:36) warning {"error":{"property1":"
 The display of each log is color coded. Info is `blue`, warn is `magenta`, debug is `green` and error is in `red`.
 
 ### Log.debug
+
 The `Log.debug()` logging is different from the other calls as these messages will not be displayed in production.
+
+### Options
+
+You can set the following options:
+
+```javascript
+// Either 'json' or 'colored-text'. Defaults to 'json'.
+//
+// When this is set to 'json', print JSON documents to the console.
+//
+// When this is set to 'colored-text', call 'Log.format' before printing.
+// This should be used for logging to the console in a human-readable format.
+Log.outputFormat = "json";
+
+// Boolean. Defaults to true.
+// for cloud environments is interesting to leave it false as most of them have the timestamp in the console.
+// Only works in server with colored-text output format.
+Log.shouldShowTime = true;
+```


### PR DESCRIPTION
Relates to [this forum request](https://forums.meteor.com/t/suggestions-for-logging-in-galaxy/63119/6?u=grubba).

Those that use `colored-text` output format can now decide if they want the timestamp or can rely on their server/cloud environments info.