### PR TITLE
Use forked Cordova android and ios platforms with cordova-common fixed

### DIFF
--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -13,7 +13,7 @@ export const CORDOVA_ARCH = "web.cordova";
 
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
-const CORDOVA_ANDROID_VERSION = "12.0.1";
+const CORDOVA_ANDROID_VERSION = "https://github.com/meteor/cordova-android.git#meteor-2.16.1";
 
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
   'cordova-lib': '10.0.0',
@@ -25,7 +25,7 @@ export const CORDOVA_DEV_BUNDLE_VERSIONS = {
 
 export const CORDOVA_PLATFORM_VERSIONS = {
   'android': CORDOVA_ANDROID_VERSION,
-  'ios': '7.0.1',
+  'ios': 'https://github.com/meteor/cordova-ios.git#meteor-2.16.1',
 };
 
 export const SWIFT_VERSION = 5;


### PR DESCRIPTION
<!--OSS-688--->

Continues: https://github.com/meteor/meteor/pull/13619

Context: https://forums.meteor.com/t/error-building-cordova-project/63140

Existing workaround so far: https://forums.meteor.com/t/error-building-cordova-project/63140/11

Fixed cordova-common at `5.0.0` for [cordova-android](https://github.com/meteor/cordova-android/blob/meteor-2.16.1/package.json#L34) and [cordova-ios](https://github.com/meteor/cordova-ios/blob/meteor-2.16.1/package.json#L49) by using a fork pointing used versions in Meteor 2.x version.

I used GitHub links because publishing under our `@meteorjs/*` scope made Cordova misidentify platform locations in the build. Cordova relies on package names for this.