### PR TITLE
Release 2.16.1

### DIFF
--- a/docs/generators/changelog/versions/2.16.1.md
+++ b/docs/generators/changelog/versions/2.16.1.md
@@ -1,0 +1,36 @@
+````## v2.16.1, <date>
+
+### Highlights
+
+- Fix Cordova after the latest breaking change in common dependencies. [PR](https://github.com/meteor/meteor/pull/13620)
+
+#### Migration Steps
+
+To update from 2.16.0 to this one, you can run:
+
+```
+meteor update --release 2.16.1
+```
+
+If you're coming from an older version, please check our [Migration Guides](https://guide.meteor.com/2.14-migration).
+
+#### Breaking Changes
+
+N/A
+
+#### Internal API changes
+
+N/A
+
+#### Meteor Version Release
+
+* meteor-tool@2.16.1
+
+#### Independent releases
+
+N/A
+
+#### Contributors
+
+- [GH nachocodoner]
+````

--- a/docs/history.md
+++ b/docs/history.md
@@ -8,7 +8,41 @@
 
 [//]: # (go to meteor/docs/generators/changelog/docs)
 
+## v2.16.1, <date>
 
+### Highlights
+
+- Fix Cordova after the latest breaking change in common dependencies. [PR](https://github.com/meteor/meteor/pull/13620)
+
+#### Migration Steps
+
+To update from 2.16.0 to this one, you can run:
+
+```
+meteor update --release 2.16.1
+```
+
+If you're coming from an older version, please check our [Migration Guides](https://guide.meteor.com/2.14-migration).
+
+#### Breaking Changes
+
+N/A
+
+#### Internal API changes
+
+N/A
+
+#### Meteor Version Release
+
+* meteor-tool@2.16.1
+
+#### Independent releases
+
+N/A
+
+#### Contributors
+
+- [GH nachocodoner]
 
 ## v2.16.0, 2024-05-14
 

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.21.4.9
+BUNDLE_VERSION=14.21.4.10
 
 
 # OS Check. Put here because here is where we download the precompiled

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.21.4.11
+BUNDLE_VERSION=14.21.4.12
 
 
 # OS Check. Put here because here is where we download the precompiled

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.21.4.10
+BUNDLE_VERSION=14.21.4.11
 
 
 # OS Check. Put here because here is where we download the precompiled

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.21.4.12
+BUNDLE_VERSION=14.21.4.13
 
 
 # OS Check. Put here because here is where we download the precompiled

--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.21.4.13
+BUNDLE_VERSION=14.21.4.14
 
 
 # OS Check. Put here because here is where we download the precompiled

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'The Meteor command-line tool',
-  version: '2.16.0',
+  version: '2.16.1-beta.0',
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "2.16-rc.0",
+  "version": "2.16.1-beta.0",
   "recommended": false,
   "official": false,
   "description": "Meteor experimental release"

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -13,7 +13,7 @@ export const CORDOVA_ARCH = "web.cordova";
 
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
-const CORDOVA_ANDROID_VERSION = "12.0.1";
+const CORDOVA_ANDROID_VERSION = "https://github.com/meteor/cordova-android.git#meteor-2.16.1";
 
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
   'cordova-lib': '10.0.0',
@@ -25,7 +25,7 @@ export const CORDOVA_DEV_BUNDLE_VERSIONS = {
 
 export const CORDOVA_PLATFORM_VERSIONS = {
   'android': CORDOVA_ANDROID_VERSION,
-  'ios': '7.0.1',
+  'ios': 'https://github.com/meteor/cordova-ios.git#meteor-2.16.1',
 };
 
 export const SWIFT_VERSION = 5;


### PR DESCRIPTION
## Still in development

Current released version: 2.16.1-beta.0

To use it, please do a

``` sh
meteor update --release 2.16.1-beta.0
```

``` sh
meteor create --release 2.16.1-beta.0
```

## Includes

- Provide a fix on Cordova since was completely failing from Meteor 2.14+, https://github.com/meteor/meteor/pull/13620