### PR TITLE
fix: typo in link to Mongo-Cursor-forEachAsync

### DIFF
--- a/v3-docs/docs/api/collections.md
+++ b/v3-docs/docs/api/collections.md
@@ -698,7 +698,7 @@ topPosts.forEach((post) => {
 
 ::: warning
 Client only.
-For server/isomorphic usage see [removeAsync](#Mongo-Cursor-forEachAsync).
+For server/isomorphic usage see [forEachAsync](#Mongo-Cursor-forEachAsync).
 :::
 
 <ApiBox name="Mongo.Cursor#forEachAsync" instanceName="Cursor"/>


### PR DESCRIPTION
Fix typo in link from `Cursor#forEach` section to `Mongo-Cursor-forEachAsync` section