### PR TITLE
Update elliptic in node-stubs

### DIFF
--- a/npm-packages/meteor-node-stubs/package-lock.json
+++ b/npm-packages/meteor-node-stubs/package-lock.json
@@ -41,7 +41,7 @@
         "console-browserify": "^1.2.0",
         "constants-browserify": "^1.0.0",
         "domain-browser": "^4.23.0",
-        "elliptic": "^6.6.0",
+        "elliptic": "^6.6.1",
         "events": "^3.3.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",
@@ -520,10 +520,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -614,10 +615,11 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
-      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/npm-packages/meteor-node-stubs/package.json
+++ b/npm-packages/meteor-node-stubs/package.json
@@ -18,7 +18,7 @@
     "console-browserify": "^1.2.0",
     "constants-browserify": "^1.0.0",
     "domain-browser": "^4.23.0",
-    "elliptic": "^6.6.0",
+    "elliptic": "^6.6.1",
     "events": "^3.3.0",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",


### PR DESCRIPTION
Updated elliptic to 6.6.1 and run `npm audit fix` to fix anything else.

There are few other major version updates that can be made:
```
buffer            ^5.7.1  →  ^6.0.3
 domain-browser   ^4.23.0  →  ^5.7.0
 punycode          ^1.4.1  →  ^2.3.1
 readable-stream   ^3.6.2  →  ^4.7.0
 rimraf           ^5.0.10  →  ^6.0.1
```