### PR TITLE
Support async profiler actions

### DIFF
--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -500,7 +500,7 @@ var runMain = Profile("Run main()", async function () {
 
   await Profile.run('Server startup', async function() {
     const asyncLocalStorage = global.__METEOR_ASYNC_LOCAL_STORAGE;
-    let existingStore = asyncLocalStorage.getStore();
+    const existingStore = asyncLocalStorage.getStore();
     return global.__METEOR_ASYNC_LOCAL_STORAGE.run(existingStore || {}, async () => {
       await loadServerBundles();
       await callStartupHooks();

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -499,13 +499,9 @@ var runMain = Profile("Run main()", async function () {
   }
 
   await Profile.run('Server startup', async function() {
-    const asyncLocalStorage = global.__METEOR_ASYNC_LOCAL_STORAGE;
-    const existingStore = asyncLocalStorage.getStore();
-    return global.__METEOR_ASYNC_LOCAL_STORAGE.run(existingStore || {}, async () => {
-      await loadServerBundles();
-      await callStartupHooks();
-      await runMain();
-    });
+    await loadServerBundles();
+    await callStartupHooks();
+    await runMain();
   });
 })().catch(e => {
   console.log('error on boot.js',  e )

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -498,8 +498,10 @@ var runMain = Profile("Run main()", async function () {
     global.__METEOR_ASYNC_LOCAL_STORAGE = new AsyncLocalStorage();
   }
 
-  await Profile.run('Server startup', function() {
-    return global.__METEOR_ASYNC_LOCAL_STORAGE.run({}, async () => {
+  await Profile.run('Server startup', async function() {
+    const asyncLocalStorage = global.__METEOR_ASYNC_LOCAL_STORAGE;
+    let existingStore = asyncLocalStorage.getStore();
+    return global.__METEOR_ASYNC_LOCAL_STORAGE.run(existingStore || {}, async () => {
       await loadServerBundles();
       await callStartupHooks();
       await runMain();

--- a/tools/tool-env/profile.ts
+++ b/tools/tool-env/profile.ts
@@ -160,7 +160,6 @@
 //     B: 250.0
 //
 // In both reports the grand total is 600ms.
-const { makeGlobalAsyncLocalStorage } = require("../utils/fiber-helpers");
 
 const filter = parseFloat(process.env.METEOR_PROFILE || "100"); // ms
 
@@ -250,7 +249,7 @@ export function Profile<
       return f.apply(this, args);
     }
 
-    const asyncLocalStorage = makeGlobalAsyncLocalStorage();
+    const asyncLocalStorage = global.__METEOR_ASYNC_LOCAL_STORAGE;
     let existingStore = asyncLocalStorage.getStore();
 
     // Ensure `existingStore` is an object, initialize it if not present

--- a/tools/tool-env/profile.ts
+++ b/tools/tool-env/profile.ts
@@ -280,8 +280,9 @@ function runWithContext<TArgs extends any[], TResult>(
   const key = encodeEntryKey(store.currentEntry);
   const start = process.hrtime();
 
+  let result: TResult | Promise<TResult>;
   try {
-    const result = f.apply(context, args);
+    result = f.apply(context, args);
 
     if (result instanceof Promise) {
       // Return a promise if async
@@ -291,9 +292,7 @@ function runWithContext<TArgs extends any[], TResult>(
     // Return directly if sync
     return result;
   } finally {
-    if (!(f.apply(context, args) instanceof Promise)) {
-      finalizeProfiling(key, start, store.currentEntry);
-    }
+    finalizeProfiling(key, start, store.currentEntry);
   }
 }
 

--- a/tools/tool-env/profile.ts
+++ b/tools/tool-env/profile.ts
@@ -292,7 +292,9 @@ function runWithContext<TArgs extends any[], TResult>(
     // Return directly if sync
     return result;
   } finally {
-    finalizeProfiling(key, start, store.currentEntry);
+    if (!(result instanceof Promise)) {
+      finalizeProfiling(key, start, store.currentEntry);
+    }
   }
 }
 

--- a/tools/tool-env/profile.ts
+++ b/tools/tool-env/profile.ts
@@ -275,7 +275,7 @@ function runWithContext<TArgs extends any[], TResult>(
     args: IArguments,
 ): TResult | Promise<TResult> {
   const name = typeof bucketName === "function" ? bucketName.apply(context, args) : bucketName;
-  store.currentEntry.push(name);
+  store.currentEntry = [...store.currentEntry || [], name];
   const key = encodeEntryKey(store.currentEntry);
   const start = process.hrtime();
 


### PR DESCRIPTION
<!-- OSS-692 -->

Continues: https://github.com/meteor/meteor/pull/13615 and https://github.com/meteor/performance/pull/9

## Issue

There are scenarios where profiler can't get properly the timing due to the lack of support of async flows.

![image](https://github.com/user-attachments/assets/8cbb8627-c9d7-44cc-850c-2bc7296004c1)

## Fix

![image](https://github.com/user-attachments/assets/20eabf89-109a-4f58-a077-52d5084f58f6)

## Pending issue


Server profiling outputing 0ms suddenly

![image](https://github.com/user-attachments/assets/4e9bd4bd-b8a7-4f95-93d7-42544d4ec4cb)

