### PR TITLE
Wait on Mongo replication of hashedToken; before closing connection

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1014,14 +1014,18 @@ export class AccountsServer extends AccountsCommon {
 
         this._userObservesForConnections[connection.id] = observe;
 
-        if (! foundMatchingUser) {
-          // We've set up an observe on the user associated with `newToken`,
-          // so if the new token is removed from the database, we'll close
-          // the connection. But the token might have already been deleted
-          // before we set up the observe, which wouldn't have closed the
-          // connection because the observe wasn't running yet.
-          connection.close();
-        }
+        Meteor.setTimeout(() => {
+          if (! foundMatchingUser) {
+            // We've set up an observe on the user associated with `newToken`,
+            // so if the new token is removed from the database, we'll close
+            // the connection. But the token might have already been deleted
+            // before we set up the observe, which wouldn't have closed the
+            // connection because the observe wasn't running yet.
+            // Check this after one second to give Mongo time to replicate 
+            // the added hashedToken to other (read) replicas.
+            connection.close();
+          }
+        }, 1000);
       });
     }
   };


### PR DESCRIPTION
We have our Mongo database set up with read replication in a different continent. Users on that continent were sometimes experiencing issues when logging in. Meteor would close the connection.

We found that the root cause was in the accounts-base package.

It adds an observer, which listens to the hashedToken being added. If the token is added the `foundMatchingUser` is set to true. If foundMatchingUser is false however it closes the connection.

This foundMatchingUser is immediately evaluated, sometimes not giving Mongo enough time to replicate the write of the hashedToken to the other continent.

Now I just simply added a 1 second wait before evaluating foundMatchingUser.

p.s. We're using Meteor 2.16, and I branched of from release-2.16 because of that.
