### PR TITLE
Update 7.adding-user-accounts.md

### DIFF
--- a/v3-docs/docs/tutorials/react/7.adding-user-accounts.md
+++ b/v3-docs/docs/tutorials/react/7.adding-user-accounts.md
@@ -271,7 +271,7 @@ import { Accounts } from "meteor/accounts-base";
 import { TasksCollection } from "/imports/api/TasksCollection";
 
 const insertTask = (taskText, user) =>
-  TasksCollection.insert({
+  TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),


### PR DESCRIPTION
use `insertAsync` as introduced in Step 2 instead of `insert`.
Blindly copy pasting the code will result in an unnecessary error for new developers.
