### PR TITLE
Meteor bundler profile command

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -73,21 +73,15 @@ const bash =
  */
 const runLiveCommand = (command, args = []) => {
   return new Promise((resolve, reject) => {
-    const childProcess = spawn(command, args, { shell: true, env: process.env });
+    const childProcess = spawn(command, args, {
+      shell: true,
+      env: { ...process.env, FORCE_COLOR: "1", TERM: "xterm-256color" },
+      stdio: "inherit",
+    });
 
     const cleanup = () => {
-      childProcess.stdout.removeAllListeners();
-      childProcess.stderr.removeAllListeners();
       childProcess.removeAllListeners();
     };
-
-    childProcess.stdout.on("data", (data) => {
-      console.log(data.toString().trim());
-    });
-
-    childProcess.stderr.on("data", (data) => {
-      Console.error(data.toString().trim());
-    });
 
     childProcess.on("close", (code) => {
       cleanup();

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3395,11 +3395,10 @@ async function doBenchmarkCommand(options) {
   const benchmarkCommand = [
     `${benchmarkPath}/scripts/monitor-bundler.sh ${projectContext.projectDir} ${new Date().getTime()} ${args.join(' ')}`,
   ].join(" && ");
-  const [okBenchmark, errBenchmark] = await bashLive`${benchmarkCommand}`;
+  const [, errBenchmark] = await bashLive`${benchmarkCommand}`;
   if (errBenchmark) {
     throw new Error(errBenchmark);
   }
-  Console.info(okBenchmark);
 }
 
 main.registerCommand(

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3383,7 +3383,7 @@ async function doBenchmarkCommand(options) {
     allowIncompatibleUpdate: options['allow-incompatible-update'],
     lintAppAndLocalPackages: !options['no-lint'],
   });
-  const profilingPath = `${projectContext.projectDir}/node_modules/.cache/meteor/benchmark`;
+  const profilingPath = `${projectContext.projectDir}/node_modules/.cache/meteor/performance`;
   await setupBenchmarkSuite(profilingPath);
 
   const profilingCommand = [

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -1156,9 +1156,15 @@ platform requirements for 'node-gyp':
 Run performance profiling for the Meteor application.
 Usage: meteor profile [<meteor-run-options>...]
 
-This command runs a performance profile for the Meteor application, monitoring the bundler process and tracking key performance metrics to help analyze the build and bundling performance.
+This command runs a performance profile for the Meteor application, monitoring the
+bundler process and tracking key performance metrics to help analyze the build and
+bundling performance.
 
-Optionally, you can set the environment variable METEOR_BUNDLE_SIZE=true to gather bundle size data, allowing you to assess the impact of changes on the overall build size.
+Optionally, you can set the environment variable METEOR_BUNDLE_SIZE=true to gather
+bundle size data, allowing you to assess the impact of changes on the overall build
+size.
 
 Options:
-The options for this command are the same as those for the meteor run command. You can pass typical runtime options (such as --settings, --exclude-archs, etc.) to customize the profiling process.
+The options for this command are the same as those for the meteor run command.
+You can pass typical runtime options (such as --settings, --exclude-archs, etc.)
+to customize the profiling process.

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -1151,3 +1151,14 @@ To see the requirements for this compilation step, consult the
 platform requirements for 'node-gyp':
 
   https://github.com/nodejs/node-gyp
+
+>>> profile
+Run performance profiling for the Meteor application.
+Usage: meteor profile [<meteor-run-options>...]
+
+This command runs a performance profile for the Meteor application, monitoring the bundler process and tracking key performance metrics to help analyze the build and bundling performance.
+
+Optionally, you can set the environment variable METEOR_BUNDLE_SIZE=true to gather bundle size data, allowing you to assess the impact of changes on the overall build size.
+
+Options:
+The options for this command are the same as those for the meteor run command. You can pass typical runtime options (such as --settings, --exclude-archs, etc.) to customize the profiling process.


### PR DESCRIPTION
Continues: https://github.com/meteor/performance/pull/9

This PR introduces the `meteor profile` command, designed to help Meteor users assess how changes in their app and tool versions impact development time and bundle size. It also supports the core team in improving the Meteor bundler and exploring modern bundler options. By providing this tool to the community, we aim to gather feedback and measure improvements on their experiences.

The initial implementation includes:

- Reporting the time metrics for your Meteor app during cold start, cache start, client rebuild, and server rebuild.
- Reporting the time to add bundle-visualizer and run the app in production mode, along with the size of Meteor app bundles and packages (using the `METEOR_BUNDLE_SIZE=true` env).
- Support only on UNIX-like systems

## Pending

- [x] Better benchmark process error handling
- [x] Better dev experience on command feedback
- [x] Better naming `meteor profile` instead of `meteor benchmark`

## Demo

### Meteor bundler profiling

![image](https://github.com/user-attachments/assets/2a1ef4ca-aa5f-46df-ad64-05eab3a7a1b1)

### Meteor bundler size

![image](https://github.com/user-attachments/assets/6125c158-f426-405f-9c51-51ffe491c16f)
