### PR TITLE
feat: add native Node Inspector profiling to meteor profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ packages/**/.npm
 
 # doc files should not be committed
 packages/**/*.docs.js
+
+#cursor
+.cursorignore
+.cursorrules

--- a/tools/PERFORMANCE.md
+++ b/tools/PERFORMANCE.md
@@ -167,6 +167,94 @@ The Profiler is activated using `Profile.run(.)`, which will cause a report to b
 
 In addition to tool code, you can also use `Profile` in compiler plugins.  If you want to use `Profile` in packages that are loaded into the tool (e.g. packages depended on by compiler plugins, or specially loaded into the tool as isopackets), you should always test `(typeof Profile !== 'undefined')` before accessing `Profile`, or pass it in from the tool as an option.
 
+## Inspector Profiling
+
+In addition to the standard profiler, Meteor includes a more advanced profiling system based on Node.js's `inspector` module. This system generates `.cpuprofile` files that provide much more detailed performance data.
+
+### How to Use Inspector Profiling
+
+To enable inspector profiling, you need to specify which functions you want to profile through the `METEOR_INSPECT` environment variable:
+
+```bash
+# Profile multiple functions
+METEOR_INSPECT=bundler.bundle,compiler.compile meteor build ./output-build
+```
+
+Complete list for METEOR_INSPECT:
+- bundler.bundle
+- compiler.compile
+- Babel.compile
+- _readProjectMetadata
+- initializeCatalog
+- _downloadMissingPackages
+- _saveChangeMetadata
+- _realpath
+- package-client
+
+
+### Additional Configuration Options
+
+You can customize the inspector profiling behavior with the following environment variables:
+
+```bash
+# Identifier for profile files
+METEOR_INSPECT_CONTEXT=context_name
+
+# Directory where .cpuprofile files will be saved (default: ./profiling)
+METEOR_INSPECT_OUTPUT=/path/to/directory
+
+# Sampling interval in ms - lower values = more details but uses more memory
+METEOR_INSPECT_INTERVAL=500
+
+# Maximum profile size in MB (default: 2000)
+METEOR_INSPECT_MAX_SIZE=1000
+```
+
+### Viewing the Results
+
+#### Chrome DevTools
+The generated `.cpuprofile` files can be visualized in Chrome DevTools:
+
+1. Open Chrome DevTools
+2. Go to the "Performance" or "Profiler" tab
+3. Click "Load Profile" and select the generated .cpuprofile file
+
+#### Discoveryjs cpupro 
+
+For a opensource interactive analysis of your `.cpuprofile` files, you can use [cpupro](https://discoveryjs.github.io/cpupro/), an open-source CPU profile viewer:
+
+1. Visit https://discoveryjs.github.io/cpupro/ in your browser
+2. Drag and drop your `.cpuprofile` file onto the interface
+3. Use the interactive visualization to explore your profile data
+
+cpupro offers several advantages over Chrome DevTools:
+- Better handling of large profiles
+- More flexible filtering options
+- Advanced search capabilities
+- Multiple visualization modes
+- Ability to compare different profiles
+
+You can also run cpupro locally by installing it via npm:
+
+
+### Important Considerations
+
+- Inspector profiling consumes more memory than the standard profiler
+- To avoid out-of-memory (OOM) errors, consider increasing Node's memory limit:
+  ```bash
+  NODE_OPTIONS="--max-old-space-size=4096" METEOR_INSPECT=bundler.bundle meteor ...
+  ```
+- Very large profiles (>2GB) will be automatically truncated to avoid OOM errors
+
+### When to Use Inspector Profiling
+
+Use inspector profiling when:
+- You need more detailed analysis than the standard profiler provides
+- You're investigating complex performance issues
+- You want to identify specific bottlenecks in heavy functions like bundler or compiler
+
+The standard profiler (`METEOR_PROFILE`) remains the best option for quick and general analyses, while inspector profiling is more suitable for detailed diagnostics.
+
 ## Known Areas for Improvement
 
 These are areas to improve or investigate, along with what's known, in no

--- a/tools/README.md
+++ b/tools/README.md
@@ -105,6 +105,34 @@ Internally, every profiled function should be wrapped into a `Profile(fn)` call.
 The entry point should be started explicitly with the `Profile.run()`
 call. Otherwise, it won't start measuring anything.
 
+### Inspector Profiling
+
+In addition to the standard profiler, you can use the more advanced inspector profiling:
+
+```bash
+# Profile a specific function (e.g. bundler.bundle)
+METEOR_INSPECT=bundler.bundle meteor run
+
+# Profile multiple functions
+METEOR_INSPECT=bundler.bundle,compiler.compile meteor build
+```
+
+Additional options:
+```bash
+# Output directory for .cpuprofile files
+METEOR_INSPECT_OUTPUT=/path/to/directory
+
+# Name to identify profile files
+METEOR_INSPECT_CONTEXT=project_xyz
+
+# Sampling interval (lower = more details, more memory)
+METEOR_INSPECT_INTERVAL=500
+```
+
+The generated `.cpuprofile` files can be opened in Chrome DevTools through the "Performance" or "Profiler" tab.
+
+For more details, see the `PERFORMANCE.md` file.
+
 ## Debugging
 
 Currently, to debug the tool with `node-inspector`, you can set the `

--- a/tools/tool-env/profile.ts
+++ b/tools/tool-env/profile.ts
@@ -413,7 +413,7 @@ function startInspectorProfiling(name: string): boolean {
     
     // Adjust the heap limit to avoid OOM
     if (process.env.NODE_OPTIONS && !process.env.NODE_OPTIONS.includes('--max-old-space-size')) {
-      process.stdout.write('[PROFILING_START] WARN: Recommended to set NODE_OPTIONS="--max-old-space-size=4096" to avoid OOM\n');
+      process.stdout.write('[PROFILING_START] WARN: Recommended to set TOOL_NODE_FLAGS="–max_old_space_size=4096" to avoid OOM\n');
     }
     
     profileStartTime = Date.now();


### PR DESCRIPTION
## description
This PR introduces the creation of the .cpuprofiling fileS inside [Profile function](https://github.com/meteor/meteor/blob/f8a7e448eed50a51bebad6500a64592a9d95136b/tools/tool-env/profile.ts#L292)

Each time we call Profile we will be able to inspect that function execution and name that with the Profile's name + METEOR_INSPECT_CONTEXT env

## Usage
Current usage in [meteor performance ](https://github.com/italojs/performance/tree/monitor-bundler) monitor-bundler branch:
``` shell
METEOR_INSPECT_OUTPUT="/Users/italojs/dev/meteor/performance/profiles" \
METEOR_INSPECT="bundler.bundle" \
METEOR_CHECKOUT_PATH="/Users/italojs/dev/meteor/meteor" \
METEOR_BUNDLE_SIZE=true \ 
sh '/Users/italojs/dev/meteor/performance/scripts/monitor-bundler.sh' '/Users/italojs/dev/meteor/performance/apps/app-3.2'
```

Output files: 
``` shell
372K    ./bundler.bundle-rebuild-client-2025-03-13T15-50-38-301Z.cpuprofile
832K    ./bundler.bundle-rebuild-server-2025-03-13T15-50-55-747Z.cpuprofile
1.1M    ./bundler.bundle-rebuild-client-2025-03-13T15-50-36-542Z.cpuprofile
1.5M    ./bundler.bundle-rebuild-server-2025-03-13T15-50-53-283Z.cpuprofile
5.3M    ./bundler.bundle-rebuild-client-2025-03-13T15-50-31-331Z.cpuprofile
5.4M    ./bundler.bundle-rebuild-server-2025-03-13T15-50-48-255Z.cpuprofile
7.0M    ./bundler.bundle-cache-start-2025-03-13T15-50-18-255Z.cpuprofile
 23M    ./bundler.bundle-cold-start-2025-03-13T15-50-03-055Z.cpuprofile
 60M    ./bundler.bundle-visualize-bundle-2025-03-13T15-51-21-410Z.cpuprofile
104M    .
```

Then, we can open it on https://discoveryjs.github.io/cpupro/
![Screenshot 2025-03-13 at 12 57 00](https://github.com/user-attachments/assets/a5159823-21df-47e9-b5e4-1be13cd149b5)

###  new environment variables

| Variable                        | Description                                                                                               | Default value                |
|---------------------------------|-----------------------------------------------------------------------------------------------------------|------------------------------|
| `METEOR_INSPECT`                 | Enables or disables the Inspector. Can be a comma-separated list of event names to inspect. **The values must match the ones currently used inside the `Profile` wrapper.** If set, the inspector will be active. | `undefined` (disabled)        |
| `METEOR_INSPECT_CONTEXT`         | Sets the name or context for this inspector run, used to identify the profiling output.                   | `'unknown'`                  |
| `METEOR_INSPECT_OUTPUT`          | Directory path where profiling output files will be stored.                                               | `<project folder>/profiling` |
| `METEOR_INSPECT_INTERVAL`        | Sampling interval in milliseconds. Lower values give more detail but consume more memory.                  | `undefined` (optional)        |
| `METEOR_INSPECT_MAX_SIZE`        | Maximum profile file size in MB.                                                                          | `2000`                       |

METEOR_INSPECT_INTERVAL and METEOR_INSPECT_MAX_SIZE is important to handle OOM errors

Note: this PR depends of https://github.com/meteor/performance/pull/11
