### PR TITLE
Replace "http-proxy" by "http-proxy-node16"

### DIFF
--- a/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
+++ b/npm-packages/eslint-plugin-meteor/scripts/dev-bundle-tool-package.js
@@ -39,7 +39,7 @@ var packageJson = {
     "source-map": "0.7.3",
     chalk: "4.1.2",
     sqlite3: "5.1.6",
-    "http-proxy": "1.18.1",
+    "http-proxy-node16": "1.0.6",
     "is-reachable": "3.1.0",
     "wordwrap": "1.0.0",
     "moment": "2.29.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "http-proxy-node16": "1.0.6",
         "prettier": "^2.8.6",
         "typescript": "^5.4.5"
       }
@@ -3010,6 +3011,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3116,6 +3123,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -3388,6 +3415,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-proxy-node16": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-node16/-/http-proxy-node16-1.0.6.tgz",
+      "integrity": "sha512-RLtYkbmbLmh+To4lmqLpiEitu0igXb/j1SOW8F6w/esXsapGT5dSShMF9vg7shtxGJSXaWiFE3wYWCoLOuiibg==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ignore": {
@@ -4372,6 +4413,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "http-proxy-node16": "1.0.6",
     "prettier": "^2.8.6",
     "typescript": "^5.4.5"
   },

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -43,7 +43,7 @@ var packageJson = {
     // TODO: maybe replace with https://www.npmjs.com/package/better-sqlite3
     sqlite3: "5.1.7",
     inquirer: "8.2.6",
-    "http-proxy": "1.18.1",
+    "http-proxy-node16": "1.0.6",
     "is-reachable": "3.1.0",
     "wordwrap": "1.0.0",
     "moment": "2.30.1",

--- a/tools/runners/run-proxy.js
+++ b/tools/runners/run-proxy.js
@@ -37,7 +37,7 @@ Object.assign(Proxy.prototype, {
 
     var http = require('http');
     var net = require('net');
-    var httpProxy = require('http-proxy');
+    var httpProxy = require('http-proxy-node16');
 
     self.proxy = httpProxy.createProxyServer({
       // agent is required to handle keep-alive, and http-proxy 1.0 is a little


### PR DESCRIPTION
This pull request addresses a deprecation warning and a potential memory leak issue by replacing the _http-proxy_ package with _http-proxy-node16_. This change is particularly relevant for Node.js versions 16 and above.

**Details**

Deprecation Warning Fix:
The util._extend API is deprecated in Node.js. By switching to http-proxy-node16, we leverage Object.assign() instead, resolving the warning:

`(node:26475) Warning: The `util._extend` API is deprecated. Please use Object.assign() instead.
`