### PR TITLE
Address `meteor profile` feedback

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=22.14.0.3
+BUNDLE_VERSION=22.14.0.4
 
 
 # OS Check. Put here because here is where we download the precompiled

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3390,7 +3390,7 @@ async function doBenchmarkCommand(options) {
     !!options['only-size'] && 'METEOR_BUNDLE_SIZE_ONLY=true',
     !!options['size'] && 'METEOR_BUNDLE_SIZE=true'
   ].filter(Boolean);
-  const meteorOptions = args.filter(arg => ['--only-size', '--size'].includes(arg));
+  const meteorOptions = args.filter(arg => !['--only-size', '--size'].includes(arg));
 
   const profilingCommand = [
     `${meteorSizeEnvs.join(' ')} ${profilingPath}/scripts/monitor-bundler.sh ${projectContext.projectDir} ${new Date().getTime()} ${meteorOptions.join(' ')}`.trim(),

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3350,7 +3350,7 @@ const setupBenchmarkSuite = async (profilingPath) => {
   process.env.GIT_TERMINAL_PROMPT = 0;
 
   const repoUrl = "https://github.com/meteor/performance";
-  const branch = "profile-cmd-feedback";
+  const branch = "v3.2.0";
   const gitCommand = [
     `mkdir -p ${profilingPath}`,
     `git clone --no-checkout --depth 1 --filter=tree:0 --sparse --progress --branch ${branch} --single-branch ${repoUrl} ${profilingPath}`,

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3390,9 +3390,10 @@ async function doBenchmarkCommand(options) {
     !!options['only-size'] && 'METEOR_BUNDLE_SIZE_ONLY=true',
     !!options['size'] && 'METEOR_BUNDLE_SIZE=true'
   ].filter(Boolean);
+  const meteorOptions = args.filter(arg => ['--only-size', '--size'].includes(arg));
 
   const profilingCommand = [
-    `${meteorSizeEnvs.join(' ')} ${profilingPath}/scripts/monitor-bundler.sh ${projectContext.projectDir} ${new Date().getTime()} ${args.join(' ')}`.trim(),
+    `${meteorSizeEnvs.join(' ')} ${profilingPath}/scripts/monitor-bundler.sh ${projectContext.projectDir} ${new Date().getTime()} ${meteorOptions.join(' ')}`.trim(),
   ].join(" && ");
   const [, errBenchmark] = await bashLive`${profilingCommand}`;
   if (errBenchmark) {

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1767,6 +1767,7 @@ main.registerCommand({
   maxArgs: 1,
   options: {
     db: { type: Boolean },
+    'skip-cache': { type: Boolean },
   },
   requiresApp: true,
   catalogRefresh: new catalog.Refresh.Never()
@@ -1793,7 +1794,7 @@ main.registerCommand({
                  "MONGO_URL will NOT be reset.");
   }
 
-  const resetMeteorNmCachePromise = files.rm_recursive_async(
+  const resetMeteorNmCachePromise = options['skip-cache'] ? Promise.resolve() : files.rm_recursive_async(
     files.pathJoin(options.appDir, "node_modules", ".cache", "meteor")
   );
 

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3388,10 +3388,10 @@ async function doBenchmarkCommand(options) {
   await setupBenchmarkSuite(profilingPath);
 
   const meteorSizeEnvs = [
-    !!options['only-size'] && 'METEOR_BUNDLE_SIZE_ONLY=true',
+    !!options['size-only'] && 'METEOR_BUNDLE_SIZE_ONLY=true',
     !!options['size'] && 'METEOR_BUNDLE_SIZE=true'
   ].filter(Boolean);
-  const meteorOptions = args.filter(arg => !['--only-size', '--size'].includes(arg));
+  const meteorOptions = args.filter(arg => !['--size-only', '--size'].includes(arg));
 
   const profilingCommand = [
     `${meteorSizeEnvs.join(' ')} ${profilingPath}/scripts/monitor-bundler.sh ${projectContext.projectDir} ${new Date().getTime()} ${meteorOptions.join(' ')}`.trim(),
@@ -3409,7 +3409,7 @@ main.registerCommand(
   options: {
     ...runCommandOptions.options || {},
   'size': { type: Boolean },
-  'only-size': { type: Boolean },
+  'size-only': { type: Boolean },
   },
   catalogRefresh: new catalog.Refresh.Never(),
 }, doBenchmarkCommand);

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -1172,6 +1172,8 @@ Use METEOR_CLIENT_ENTRYPOINT=<path-to-file> to set a custom client entrypoint, a
 METEOR_SERVER_ENTRYPOINT=<path-to-file> to set a custom server entrypoint. By default,
 it uses the server and client entrypoints specified in your package.json.
 
+Use METEOR_LOG_DIR=<path-to-directory> to set a custom log directory.
+
 Options:
 The options for this command are the same as those for the meteor run command.
 You can pass typical runtime options (such as --settings, --exclude-archs, etc.)

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -1172,7 +1172,7 @@ Use METEOR_LOG_DIR=<path-to-directory> to set a custom log directory.
 
 Options:
   --size         monitor both bundle runtime and size
-  --only-size    monitor only the bundle size
+  --size-only    monitor only the bundle size
 
 The rest of options for this command are the same as those for the meteor run command.
 You can pass typical runtime options (such as --settings, --exclude-archs, etc.)

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -1168,6 +1168,10 @@ Use METEOR_IDLE_TIMEOUT=<seconds> to set a timeout for profiling. The default ti
 is usually enough for each build step to complete. If you encounter errors due to
 early exits, adjust the environment variable accordingly.
 
+Use METEOR_CLIENT_ENTRYPOINT=<path-to-file> to set a custom client entrypoint, and
+METEOR_SERVER_ENTRYPOINT=<path-to-file> to set a custom server entrypoint. By default,
+it uses the server and client entrypoints specified in your package.json.
+
 Options:
 The options for this command are the same as those for the meteor run command.
 You can pass typical runtime options (such as --settings, --exclude-archs, etc.)

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -1160,10 +1160,6 @@ This command runs a performance profile for the Meteor application, monitoring t
 bundler process and tracking key performance metrics to help analyze the build and
 bundling performance.
 
-Optionally, you can set the environment variable METEOR_BUNDLE_SIZE=true to gather
-bundle size data, allowing you to assess the impact of changes on the overall build
-size.
-
 Use METEOR_IDLE_TIMEOUT=<seconds> to set a timeout for profiling. The default time (90s)
 is usually enough for each build step to complete. If you encounter errors due to
 early exits, adjust the environment variable accordingly.
@@ -1175,6 +1171,9 @@ it uses the server and client entrypoints specified in your package.json.
 Use METEOR_LOG_DIR=<path-to-directory> to set a custom log directory.
 
 Options:
-The options for this command are the same as those for the meteor run command.
+  --size         monitor both bundle runtime and size
+  --only-size    monitor only the bundle size
+
+The rest of options for this command are the same as those for the meteor run command.
 You can pass typical runtime options (such as --settings, --exclude-archs, etc.)
 to customize the profiling process.

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -1006,3 +1006,27 @@ interface and allow you to interactively run JavaScript and see the results.
 
 Executing `meteor node -e "console.log(process.versions)"` would
 run `console.log(process.versions)` in the version of `node` bundled with Meteor.
+
+## meteor profile {meteorprofile}
+
+The `meteor profile` command runs a performance profile for the Meteor application,
+monitoring the bundler process and tracking key performance metrics to help analyze
+the build and bundling performance.
+
+The options for this command are the same as those for the `meteor run` command.
+You can pass typical runtime options (such as --settings, --exclude-archs, etc.)
+to customize the profiling process.
+
+You can use `--size` to monitor both the bundle runtime and `--only-size` to monitor
+only the bundle size, allowing you to assess the impact of changes on the overall build
+size.
+
+Use `METEOR_IDLE_TIMEOUT=<seconds>` to set a timeout for profiling. The default time (90s)
+is usually enough for each build step to complete. If you encounter errors due to
+early exits, adjust the environment variable accordingly.
+
+Use `METEOR_CLIENT_ENTRYPOINT=<path-to-file>` to set a custom client entrypoint, and
+`METEOR_SERVER_ENTRYPOINT=<path-to-file>` to set a custom server entrypoint. By default,
+it uses the server and client entrypoints specified in your package.json.
+
+Use `METEOR_LOG_DIR=<path-to-directory>` to set a custom log directory.

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -1017,7 +1017,7 @@ The options for this command are the same as those for the `meteor run` command.
 You can pass typical runtime options (such as --settings, --exclude-archs, etc.)
 to customize the profiling process.
 
-You can use `--size` to monitor both the bundle runtime and `--only-size` to monitor
+You can use `--size` to monitor both the bundle runtime and `--size-only` to monitor
 only the bundle size, allowing you to assess the impact of changes on the overall build
 size.
 


### PR DESCRIPTION
Continues: https://github.com/meteor/meteor/pull/13636 and https://github.com/meteor/performance/pull/12

This PR is latest tweaks for `meteor profile` cmd for the official 3.2 version.

- Added `--size` and `--size-only` options to meteor profile for runtime and size analysis or just bundle size.
- Introduced `METEOR_CLIENT_ENTRYPOINT` and `METEOR_SERVER_ENTRYPOINT` env vars to control Meteor endpoints.
- Added METEOR_LOG_DIR env var to set logs directory.
- Improved formatting for package and size output using `console.table`.
    - See the new [meteor packages](https://github.com/user-attachments/assets/3992c521-398a-490d-a7cd-481c59871923) and [size analysis](https://github.com/user-attachments/assets/58e7060d-b8e3-4b48-a8ef-0fe0de91beb0) output.


- Updated Meteor 3 docs to include the new command.

