### PR TITLE
Update testing.md to show how to clean up Blaze View instances.

### DIFF
--- a/guide/source/testing.md
+++ b/guide/source/testing.md
@@ -250,7 +250,7 @@ const withDiv = function withDiv(callback) {
 export const withRenderedTemplate = function withRenderedTemplate(template, data, callback) {
   withDiv((el) => {
     const ourTemplate = isString(template) ? Template[template] : template;
-    vonst view = Blaze.renderWithData(ourTemplate, data, el);
+    const view = Blaze.renderWithData(ourTemplate, data, el);
     Tracker.flush();
     callback(el);
     return view

--- a/guide/source/testing.md
+++ b/guide/source/testing.md
@@ -238,9 +238,11 @@ import { Tracker } from 'meteor/tracker';
 const withDiv = function withDiv(callback) {
   const el = document.createElement('div');
   document.body.appendChild(el);
+  let view = null
   try {
-    callback(el);
+    view = callback(el);
   } finally {
+    if (view) Blaze.remove(view)
     document.body.removeChild(el);
   }
 };
@@ -248,9 +250,10 @@ const withDiv = function withDiv(callback) {
 export const withRenderedTemplate = function withRenderedTemplate(template, data, callback) {
   withDiv((el) => {
     const ourTemplate = isString(template) ? Template[template] : template;
-    Blaze.renderWithData(ourTemplate, data, el);
+    vonst view = Blaze.renderWithData(ourTemplate, data, el);
     Tracker.flush();
     callback(el);
+    return view
   });
 };
 ```


### PR DESCRIPTION
This adds an additional `Blaze.remove(view)` call to the sample test function to ensure the Blaze view is cleaned up properly. Additionally, this is great, even if not needed, because the Meteor AI in the new doc site answers questions about "how to render Blaze views with JavaScript" based on this `Blaze.renderWithData` example, so it is important for the AI to tell a person asking how to propertly clean up the `Blaze.View`.
