### PR TITLE
update `Accounts.onCreateUser` callback return type

### DIFF
--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -188,9 +188,9 @@ export namespace Accounts {
 
   function removeEmail(userId: string, email: string): Promise<void>;
 
-  function onCreateUser(
-    func: (options: { profile?: {} | undefined }, user: Meteor.User) => void
-  ): void;
+  type CreateUserCallback = (options: { profile?: {} | undefined }, user: Meteor.User) => Meteor.User
+
+  function onCreateUser(func: CreateUserCallback): void;
 
   function findUserByEmail(
     email: string,


### PR DESCRIPTION
The [`Accounts.onCreateUser` docs](https://docs.meteor.com/api/accounts.html#AccountsServer-onCreateUser) mention that the callback must return the user object, or throw, however the type definition had a return type of `void`.