### PR TITLE
jsAnalyze.parse optimization (acorn replacement)

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -69,7 +69,7 @@ var packageJson = {
     "ws": "7.4.5",
     "open":"8.4.2",
     "@swc/core": "1.11.11",
-    "swc-to-babel": "4.0.0",
+    "acorn": "8.14.1",
   }
 };
 

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -21,9 +21,11 @@ var AST_CACHE = new LRUCache({
 });
 
 function countLines(str) {
+  let lastIndex = str.indexOf('\n');
   let count = 0;
-  for (let i = 0; i < str.length; i++) {
-    if (str[i] === '\n') count++;
+  while (lastIndex > -1) {
+    count += 1;
+    lastIndex = str.indexOf('\n', lastIndex + 1);
   }
   return count;
 }

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -16,7 +16,7 @@ function isRegExp(value) {
 var AST_CACHE = new LRUCache({
   max: Math.pow(2, 12),
   length(ast) {
-    return ast.end;
+    return ast.loc.end.line;
   }
 });
 
@@ -37,7 +37,8 @@ function tryToParse(source, hash) {
           allowImportExportEverywhere: true,
           allowReturnOutsideFunction: true,
           allowHashBang: true,
-          checkPrivateFields: false
+          checkPrivateFields: false,
+          locations: true,
         });
       } catch (error) {
         ast = parse(source, {

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -16,19 +16,11 @@ function isRegExp(value) {
 var AST_CACHE = new LRUCache({
   max: Math.pow(2, 12),
   length(ast) {
-    return ast?.loc?.end?.line || ast?.lines || ast.end;
+    // Estimate cached lines based on average length per character
+    const avgCharsPerLine = 40;
+    return Math.ceil(ast.end / avgCharsPerLine);
   }
 });
-
-function countLines(str) {
-  let lastIndex = str.indexOf('\n');
-  let count = 0;
-  while (lastIndex > -1) {
-    count += 1;
-    lastIndex = str.indexOf('\n', lastIndex + 1);
-  }
-  return count;
-}
 
 // Like babel.parse, but annotates any thrown error with $ParseError = true.
 function tryToParse(source, hash) {
@@ -49,7 +41,6 @@ function tryToParse(source, hash) {
           allowHashBang: true,
           checkPrivateFields: false,
         });
-        Object.assign(ast, { lines: countLines(source) });
       } catch (error) {
         ast = parse(source, {
           strictMode: false,

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -20,6 +20,14 @@ var AST_CACHE = new LRUCache({
   }
 });
 
+function countLines(str) {
+  let count = 0;
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === '\n') count++;
+  }
+  return count;
+}
+
 // Like babel.parse, but annotates any thrown error with $ParseError = true.
 function tryToParse(source, hash) {
   if (hash && AST_CACHE.has(hash)) {
@@ -39,7 +47,7 @@ function tryToParse(source, hash) {
           allowHashBang: true,
           checkPrivateFields: false,
         });
-        Object.assign(ast, { lines: (source?.split('\n')?.length || 0) - 1 });
+        Object.assign(ast, { lines: countLines(source) });
       } catch (error) {
         ast = parse(source, {
           strictMode: false,

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -32,7 +32,7 @@ function tryToParse(source, hash) {
       try {
         ast = acorn.parse(source, {
           ecmaVersion: 'latest',
-          sourceType: 'module',
+          sourceType: 'script',
           allowAwaitOutsideFunction: true,
           allowImportExportEverywhere: true,
           allowReturnOutsideFunction: true,

--- a/tools/isobuild/js-analyze.js
+++ b/tools/isobuild/js-analyze.js
@@ -16,7 +16,7 @@ function isRegExp(value) {
 var AST_CACHE = new LRUCache({
   max: Math.pow(2, 12),
   length(ast) {
-    return ast.loc.end.line;
+    return ast?.loc?.end?.line || ast?.lines || ast.end;
   }
 });
 
@@ -32,14 +32,14 @@ function tryToParse(source, hash) {
       try {
         ast = acorn.parse(source, {
           ecmaVersion: 'latest',
-          sourceType: 'script',
+          sourceType: 'module',
           allowAwaitOutsideFunction: true,
           allowImportExportEverywhere: true,
           allowReturnOutsideFunction: true,
           allowHashBang: true,
           checkPrivateFields: false,
-          locations: true,
         });
+        Object.assign(ast, { lines: (source?.split('\n')?.length || 0) - 1 });
       } catch (error) {
         ast = parse(source, {
           strictMode: false,


### PR DESCRIPTION
<!-- OSS-713 -->

Continues: https://github.com/meteor/meteor/pull/13657 and https://github.com/meteor/meteor/pull/13662

This PR applies @zodern's [suggestion](https://github.com/meteor/meteor/pull/13662#issuecomment-2743938127) to use [Acorn ](https://www.npmjs.com/package/acorn) for faster code parsing in the bundler analyzer. After profiling, it does show a slight speedup during the "Build App" phases (~50-100ms extra for referenced small app and machine) .

![image](https://github.com/user-attachments/assets/8ccaaac8-bd02-4e5f-9e9f-21556d09f345)
