### PR TITLE
Add Accounts.replaceEmailAsync

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -213,6 +213,7 @@ redirects:
   /#/full/accounts-setusername: 'api/passwords.html#accounts-setusername'
   /#/full/accounts-addemail: 'api/passwords.html#accounts-addemail'
   /#/full/accounts-removeemail: 'api/passwords.html#accounts-removeemail'
+  /#/full/accounts_replaceemail: 'api/passwords.html#Accounts-replaceEmail'
   /#/full/accounts_verifyemail: 'api/passwords.html#Accounts-verifyEmail'
   /#/full/accounts-finduserbyusername: 'api/passwords.html#accounts-finduserbyusername'
   /#/full/accounts-finduserbyemail: 'api/passwords.html#accounts-finduserbyemail'

--- a/docs/generators/changelog/versions/3.0.0.md
+++ b/docs/generators/changelog/versions/3.0.0.md
@@ -55,6 +55,7 @@
   - `Accounts.sendVerificationEmail`
   - `Accounts.addEmail`
   - `Accounts.removeEmail`
+  - `Accounts.replaceEmailAsync`
   - `Accounts.verifyEmail`
   - `Accounts.createUserVerifyingEmail`
   - `Accounts.createUser`

--- a/docs/source/api/passwords.md
+++ b/docs/source/api/passwords.md
@@ -59,6 +59,8 @@ By default, an email address is added with `{ verified: false }`. Use
 [`Accounts.sendVerificationEmail`](#Accounts-sendVerificationEmail) to send an
 email with a link the user can use to verify their email address.
 
+{% apibox "Accounts.replaceEmailAsync" %}
+
 {% apibox "Accounts.removeEmail" %}
 
 {% apibox "Accounts.verifyEmail" %}

--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -188,6 +188,8 @@ export namespace Accounts {
 
   function removeEmail(userId: string, email: string): Promise<void>;
 
+  function replaceEmailAsync(userId: string, oldEmail: string, newEmail: string, verified?: boolean): Promise<void>;
+
   function onCreateUser(
     func: (options: { profile?: {} | undefined }, user: Meteor.User) => void
   ): void;

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1789,6 +1789,32 @@ if (Meteor.isServer) (() => {
       ]);
     });
 
+    Tinytest.addAsync("passwords, replace email", async test => {
+      const origEmail = `${ Random.id() }@turing.com`;
+      const userId = await Accounts.createUser({
+        email: origEmail
+      });
+
+      const newEmail = `${ Random.id() }@turing.com`;
+      await Accounts.addEmailAsync(userId, newEmail);
+
+      const thirdEmail = `${ Random.id() }@turing.com`;
+      await Accounts.addEmailAsync(userId, thirdEmail, true);
+      const u1 = await Accounts._findUserByQuery({ id: userId })
+      test.equal(u1.emails, [
+        { address: origEmail, verified: false },
+        { address: newEmail, verified: false },
+        { address: thirdEmail, verified: true }
+      ]);
+
+      await Accounts.replaceEmailAsync(userId, newEmail, thirdEmail);
+      const u2 = await Accounts._findUserByQuery({ id: userId })
+      test.equal(u2.emails, [
+        { address: origEmail, verified: false },
+        { address: thirdEmail, verified: true }
+      ]);
+    })
+
   Tinytest.addAsync("passwords - remove email",
     async test => {
       const origEmail = `${ Random.id() }@turing.com`;

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1789,27 +1789,30 @@ if (Meteor.isServer) (() => {
       ]);
     });
 
-    Tinytest.addAsync("passwords, replace email", async test => {
-      const origEmail = `originalemail@test.com`;
-      const userId = await Accounts.createUser({
-        email: origEmail
-      });
+    
 
-      const newEmail = `newemail@test.com`;
+Tinytest.addAsync("accounts emails - replace email", async test => {
+  const origEmail = `originalemail@test.com`;
+  const userId = await Accounts.createUserAsync({
+    email: origEmail,
+    password: 'password'
+  });
 
-      const u1 = await Accounts._findUserByQuery({ id: userId })
-      test.equal(u1.emails, [
-        { address: origEmail, verified: false }
-      ]);
+  const newEmail = `newemail@test.com`;
 
-      await Accounts.replaceEmailAsync(userId, origEmail, newEmail);
-      const u2 = await Accounts._findUserByQuery({ id: userId })
-      test.equal(u2.emails, [
-        { address: newEmail, verified: false }
-      ]);
-    })
+  const u1 = await Accounts._findUserByQuery({ id: userId })
+  test.equal(u1.emails, [
+    { address: origEmail, verified: false }
+  ]);
 
-  Tinytest.addAsync("passwords - remove email",
+  await Accounts.replaceEmailAsync(userId, origEmail, newEmail);
+  const u2 = await Accounts._findUserByQuery({ id: userId })
+  test.equal(u2.emails, [
+    { address: newEmail, verified: false }
+  ]);
+})
+  
+    Tinytest.addAsync("passwords - remove email",
     async test => {
       const origEmail = `${ Random.id() }@turing.com`;
       const userId = await Accounts.createUser({

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1790,28 +1790,22 @@ if (Meteor.isServer) (() => {
     });
 
     Tinytest.addAsync("passwords, replace email", async test => {
-      const origEmail = `${ Random.id() }@turing.com`;
+      const origEmail = `originalemail@test.com`;
       const userId = await Accounts.createUser({
         email: origEmail
       });
 
-      const newEmail = `${ Random.id() }@turing.com`;
-      await Accounts.addEmailAsync(userId, newEmail);
+      const newEmail = `newemail@test.com`;
 
-      const thirdEmail = `${ Random.id() }@turing.com`;
-      await Accounts.addEmailAsync(userId, thirdEmail, true);
       const u1 = await Accounts._findUserByQuery({ id: userId })
       test.equal(u1.emails, [
-        { address: origEmail, verified: false },
-        { address: newEmail, verified: false },
-        { address: thirdEmail, verified: true }
+        { address: origEmail, verified: false }
       ]);
 
-      await Accounts.replaceEmailAsync(userId, newEmail, thirdEmail);
+      await Accounts.replaceEmailAsync(userId, origEmail, newEmail);
       const u2 = await Accounts._findUserByQuery({ id: userId })
       test.equal(u2.emails, [
-        { address: origEmail, verified: false },
-        { address: thirdEmail, verified: true }
+        { address: newEmail, verified: false }
       ]);
     })
 

--- a/v3-docs/docs/api/accounts.md
+++ b/v3-docs/docs/api/accounts.md
@@ -888,7 +888,7 @@ email with a link the user can use to verify their email address.
 
 <ApiBox name="Accounts.removeEmail" />
 
-<ApiBox name="Accounts.replaceEmail" />
+<ApiBox name="Accounts.replaceEmailAsync" />
 
 <ApiBox name="Accounts.verifyEmail" />
 

--- a/v3-docs/docs/api/accounts.md
+++ b/v3-docs/docs/api/accounts.md
@@ -888,6 +888,8 @@ email with a link the user can use to verify their email address.
 
 <ApiBox name="Accounts.removeEmail" />
 
+<ApiBox name="Accounts.replaceEmail" />
+
 <ApiBox name="Accounts.verifyEmail" />
 
 If the user trying to verify the email has 2FA enabled, this error will be thrown:

--- a/v3-docs/docs/generators/changelog/versions/3.0.0.md
+++ b/v3-docs/docs/generators/changelog/versions/3.0.0.md
@@ -58,7 +58,7 @@
   - `Accounts.sendVerificationEmail`
   - `Accounts.addEmail`
   - `Accounts.removeEmail`
-  - `Accounts.replaceEmail`
+  - `Accounts.replaceEmailAsync`
   - `Accounts.verifyEmail`
   - `Accounts.createUserVerifyingEmail`
   - `Accounts.createUser`

--- a/v3-docs/docs/generators/changelog/versions/3.0.0.md
+++ b/v3-docs/docs/generators/changelog/versions/3.0.0.md
@@ -58,6 +58,7 @@
   - `Accounts.sendVerificationEmail`
   - `Accounts.addEmail`
   - `Accounts.removeEmail`
+  - `Accounts.replaceEmail`
   - `Accounts.verifyEmail`
   - `Accounts.createUserVerifyingEmail`
   - `Accounts.createUser`


### PR DESCRIPTION
I was recently working on application where we had wanted to replace the user email and I was surprised the Meteor accounts offers no such utility. Although Meteor does offer a way to [add emails](https://docs.meteor.com/api/accounts#Accounts-addEmailAsync) and [remove them](https://docs.meteor.com/api/accounts#Accounts-removeEmail) and they may be combined to allow you to replace an email, that wouldn't be the best solution as it entails two different email operations instead of one.  

Accounts.replaceEmailAsync aims to help fix this problem, it checks first if such email collides with another user email before adding, it also notifies you in case it hadn't been able to find a user with the old email you provided instead of failing silently.  