### PR TITLE
fix(webapp): prevent truncated agent string in lookupUserAgent

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -132,7 +132,7 @@ var identifyBrowser = function(userAgentString) {
       patch: 0
     };
   }
-  var userAgent = lookupUserAgent(userAgentString.substring(0, 150));
+  var userAgent = lookupUserAgent(userAgentString);
   return {
     name: camelCase(userAgent.family),
     major: +userAgent.major,

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -153,6 +153,25 @@ Tinytest.addAsync("webapp - modern/legacy static files", test => {
   return Promise.all(promises);
 });
 
+const specialUserAgent =
+  "Mozilla/5.0 (Linux; Android 5.1.1; MI NOTE Pro Build/LMY47V; wv) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 " +
+  "Mobile Safari/537.36 baidubrowser/7.7.13.0 (Baidu; P1 5.1.1)"
+
+Tinytest.addAsync("webapp - agent identification", async function (test) {
+  const modernBrowser = WebAppInternals.identifyBrowser(modernUserAgent);
+  test.equal(modernBrowser.name, "chrome");
+  test.equal(modernBrowser.major, 68);
+  test.equal(modernBrowser.minor, 0);
+  test.equal(modernBrowser.patch, 3440);
+
+  const specialBrowser = WebAppInternals.identifyBrowser(specialUserAgent);
+  test.equal(specialBrowser.name, "baiduBrowser");
+  test.equal(specialBrowser.major, 7);
+  test.equal(specialBrowser.minor, 7);
+  test.equal(specialBrowser.patch, 13);
+})
+
 Tinytest.addAsync(
   "webapp - additional static javascript",
   async function (test) {


### PR DESCRIPTION
In useragent-ng's lookup function implementation, there are security validations and truncation checks for useragent length.  For certain useragent use cases where the length exceeds 150 characters, premature truncation before being passed to the lookup function results in incorrect agent identification.

**in useragent-ng parse:**

https://github.com/schmod/useragent-ng/blob/9d22aab904b8134f7680102415539b0570fc7405/index.js#L414

```js
exports.parse = function parse(userAgent, jsAgent) {
  if (userAgent && userAgent.length > 1000) {
    userAgent = userAgent.substring(0, 1000);
  }

  if (!userAgent || !isSafe(userAgent)) return new Agent();

  var length = agentparserslength
    , parsers = agentparsers
    , i = 0
    , parser
    , res;
```

**in lookup**

https://github.com/schmod/useragent-ng/blob/9d22aab904b8134f7680102415539b0570fc7405/index.js#L482

```js
exports.lookup = function lookup(userAgent, jsAgent) {
  if (!LRU) {
    LRU = new (require('lru-cache'))({ max: 5000 });
  }
  var key = (userAgent || '')+(jsAgent || '')
    , cached = LRU.get(key);

  if (cached) return cached;
  LRU.set(key, (cached = exports.parse(userAgent, jsAgent)));

  return cached;
};
```

