### PR TITLE
Fix type definition of ServerSink

### DIFF
--- a/packages/server-render/server-render.d.ts
+++ b/packages/server-render/server-render.d.ts
@@ -19,9 +19,34 @@ export interface ClientSink {
   getCookies(): { [key: string]: string };
 }
 
+/**
+ * Meteor parses the user agent string in an attempt to identify the browser.
+ * This is used, for example, to determine whether to serve the modern
+ * or the legacy bundle, in case your app uses both..
+ */
+type IdentifiedBrowser = {
+  name: string;
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/**
+ * A categorized request is an IncomingMessage with a pre-parsed URL,
+ * and additional properties added by Meteor.
+ */
+export type CategorizedRequest = Omit<http.IncomingMessage, 'url'> & {
+  browser: IdentifiedBrowser;
+  dynamicHead: string | undefined;
+  dynamicBody: string | undefined;
+  modern: boolean;
+  path: string;
+  url: URL;
+}
+
 export interface ServerSink extends ClientSink {
   // Server-only:
-  request: http.IncomingMessage;
+  request: CategorizedRequest;
   arch: string;
   head: string;
   body: string;


### PR DESCRIPTION
This is a minor PR that changes the type definition of `ServerSink` to match theimplementation.
`ServerSink`'s original type definition pointed that its `request` property was an `http.IncomingRequest`. But the `webapp` package actually [performs a transformation](https://github.com/meteor/meteor/blob/d185a3487d5390f09e06e5520bad20cecd732968/packages/webapp/webapp_server.js#L160) to the original request. It adds a few fields and parses the `url` property to generate an `URL` instance, making its type incompatible with `http.IncomingRequest`.

The result of this is confusing type errors when prototyping with server-side rendering and TypeScript.

This PR adds two new types: `IdentifiedBrowser` and `CategorizedRequest`, and slightly adjusts the type definition of `ServerSink`:

```ts
/**
 * Meteor parses the user agent string in an attempt to identify the browser.
 * This is used, for example, to determine whether to serve the modern
 * or the legacy bundle, in case your app uses both..
 */
type IdentifiedBrowser = {
  name: string;
  major: number;
  minor: number;
  patch: number;
}

/**
 * A categorized request is an IncomingMessage with a pre-parsed URL,
 * and additional properties added by Meteor.
 */
export type CategorizedRequest = Omit<http.IncomingMessage, 'url'> & {
  browser: IdentifiedBrowser;
  dynamicHead: string | undefined;
  dynamicBody: string | undefined;
  modern: boolean;
  path: string;
  url: URL;
}

export interface ServerSink extends ClientSink {
  // Server-only:
  request: CategorizedRequest;
  arch: string;
  head: string;
  body: string;
  htmlById: { [key: string]: string };
  maybeMadeChanges: boolean;
}
```

The name `CategorizedRequest` comes from the original function that transforms the request (`categorizeRequest`).