### PR TITLE
Support option to profile `meteor build`

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3362,7 +3362,7 @@ const setupBenchmarkSuite = async (profilingPath) => {
   process.env.GIT_TERMINAL_PROMPT = 0;
 
   const repoUrl = "https://github.com/meteor/performance";
-  const branch = "v3.2.0";
+  const branch = "v3.3.0";
   const gitCommand = [
     `mkdir -p ${profilingPath}`,
     `git clone --no-checkout --depth 1 --filter=tree:0 --sparse --progress --branch ${branch} --single-branch ${repoUrl} ${profilingPath}`,
@@ -3401,9 +3401,10 @@ async function doBenchmarkCommand(options) {
 
   const meteorSizeEnvs = [
     !!options['size-only'] && 'METEOR_BUNDLE_SIZE_ONLY=true',
-    !!options['size'] && 'METEOR_BUNDLE_SIZE=true'
+    !!options['size'] && 'METEOR_BUNDLE_SIZE=true',
+    !!options['build'] && 'METEOR_BUNDLE_BUILD=true',
   ].filter(Boolean);
-  const meteorOptions = args.filter(arg => !['--size-only', '--size'].includes(arg));
+  const meteorOptions = args.filter(arg => !['--size-only', '--size', '--build'].includes(arg));
 
   const profilingCommand = [
     `${meteorSizeEnvs.join(' ')} ${profilingPath}/scripts/monitor-bundler.sh ${projectContext.projectDir} ${new Date().getTime()} ${meteorOptions.join(' ')}`.trim(),
@@ -3420,8 +3421,9 @@ main.registerCommand(
   maxArgs: Infinity,
   options: {
     ...runCommandOptions.options || {},
-  'size': { type: Boolean },
-  'size-only': { type: Boolean },
+    'size': { type: Boolean },
+    'size-only': { type: Boolean },
+    'build': { type: Boolean },
   },
   catalogRefresh: new catalog.Refresh.Never(),
 }, doBenchmarkCommand);

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -1173,6 +1173,7 @@ Use METEOR_LOG_DIR=<path-to-directory> to set a custom log directory.
 Options:
   --size         monitor both bundle runtime and size
   --size-only    monitor only the bundle size
+  --build        monitor build time
 
 The rest of options for this command are the same as those for the meteor run command.
 You can pass typical runtime options (such as --settings, --exclude-archs, etc.)

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -175,13 +175,15 @@ This command monitors the bundler process and tracks key performance metrics to 
 
 ### Options
 
-| Option | Description |
-|--------|-------------|
-| `--size` | Monitor both bundle runtime and size |
-| `--size-only` | Monitor only the bundle size |
+| Option        | Description                          |
+|---------------|--------------------------------------|
+| `--size`      | Monitor both bundle runtime and size |
+| `--size-only` | Monitor only the bundle size         |
+| `--build`     | Monitor build time                   |
 
 ::: info
 All other options from `meteor run` are also supported (e.g., `--settings`, `--exclude-archs`).
+If you use the --build option, it also accepts meteor build flags (e.g. `--mobile-settings`, `--architecture`).
 :::
 
 ### Environment Variables
@@ -211,6 +213,9 @@ METEOR_IDLE_TIMEOUT=120 meteor profile --settings settings.json
 
 # Profile with custom entrypoints
 METEOR_CLIENT_ENTRYPOINT=client/main.js METEOR_SERVER_ENTRYPOINT=server/main.js meteor profile
+
+# Monitor build time
+meteor profile --build
 ```
 
 ::: details Customizing the Profiling Process

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -208,14 +208,14 @@ meteor profile
 # Monitor bundle size only
 meteor profile --size-only
 
+# Monitor build time
+meteor profile --build
+
 # Profile with custom settings and timeout
 METEOR_IDLE_TIMEOUT=120 meteor profile --settings settings.json
 
 # Profile with custom entrypoints
 METEOR_CLIENT_ENTRYPOINT=client/main.js METEOR_SERVER_ENTRYPOINT=server/main.js meteor profile
-
-# Monitor build time
-meteor profile --build
 ```
 
 ::: details Customizing the Profiling Process

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -219,7 +219,7 @@ METEOR_CLIENT_ENTRYPOINT=client/main.js METEOR_SERVER_ENTRYPOINT=server/main.js 
 ```
 
 ::: details Customizing the Profiling Process
-You can pass any option that works with `meteor run` to customize the profiling process. This allows you to profile your application under specific conditions that match your deployment environment.
+You can pass any option that works with `meteor run` to customize the profiling process. This allows you to profile your application under specific conditions that match your deployment environment. The same applies to the `--build` option, which matches `meteor build` options.
 :::
 
 ## meteor create _app-name_ {#meteorcreate}


### PR DESCRIPTION
<!--OSS-724-->

Continues: https://github.com/meteor/performance/pull/14

This PR adds the `meteor profile --build` option to the Meteor tool. It profiles the `meteor build` command across cold, cached, and final scenarios to allow performance comparisons and generate complete profiles.

![image](https://github.com/user-attachments/assets/b854ce7c-eb04-4e11-8461-f5eca0b144c1)


