### PR TITLE
Ensure exclude-archs options override the modern arch package.json file

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -290,7 +290,11 @@ function filterWebArchs(webArchs, excludeArchsOption, appDir, options) {
     if (!isCordovaDev) {
       const excludeArchsOptions = excludeArchsOption ? excludeArchsOption.trim().split(/\s*,\s*/) : [];
       const hasExcludeArchsOptions = (excludeArchsOptions?.length || 0) > 0;
-      const automaticallyIgnoredLegacyArchs = (appDir && !hasExcludeArchsOptions && isModernArchsOnlyEnabled(appDir)) ? ['web.browser.legacy', 'web.cordova'] : [];
+      const hasModernArchsOnlyEnabled = appDir && isModernArchsOnlyEnabled(appDir);
+      if (hasExcludeArchsOptions && hasModernArchsOnlyEnabled) {
+        console.warn('modernWebArchsOnly and --exclude-archs are both active. If both are set, --exclude-archs takes priority.');
+      }
+      const automaticallyIgnoredLegacyArchs = (!hasExcludeArchsOptions && hasModernArchsOnlyEnabled) ? ['web.browser.legacy', 'web.cordova'] : [];
       if (hasExcludeArchsOptions || automaticallyIgnoredLegacyArchs.length) {
         const excludeArchs = [...excludeArchsOptions, ...automaticallyIgnoredLegacyArchs];
         webArchs = webArchs.filter(arch => !excludeArchs.includes(arch));

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -288,9 +288,11 @@ function filterWebArchs(webArchs, excludeArchsOption, appDir, options) {
     // Dev & Test Mode
     const isCordovaDev = (options.args || []).some(arg => ['ios', 'ios-device', 'android', 'android-device'].includes(arg));
     if (!isCordovaDev) {
-      const automaticallyIgnoredLegacyArchs = (appDir && isModernArchsOnlyEnabled(appDir)) ? ['web.browser.legacy', 'web.cordova'] : [];
-      if (excludeArchsOption || automaticallyIgnoredLegacyArchs.length) {
-        const excludeArchs = [...(excludeArchsOption ? excludeArchsOption.trim().split(/\s*,\s*/) : []), ...automaticallyIgnoredLegacyArchs];
+      const excludeArchsOptions = excludeArchsOption ? excludeArchsOption.trim().split(/\s*,\s*/) : [];
+      const hasExcludeArchsOptions = (excludeArchsOptions?.length || 0) > 0;
+      const automaticallyIgnoredLegacyArchs = (appDir && !hasExcludeArchsOptions && isModernArchsOnlyEnabled(appDir)) ? ['web.browser.legacy', 'web.cordova'] : [];
+      if (hasExcludeArchsOptions || automaticallyIgnoredLegacyArchs.length) {
+        const excludeArchs = [...excludeArchsOptions, ...automaticallyIgnoredLegacyArchs];
         webArchs = webArchs.filter(arch => !excludeArchs.includes(arch));
       }
       return webArchs;


### PR DESCRIPTION
<!--OSS-707-->

Continues: https://github.com/meteor/meteor/pull/13665 and https://github.com/meteor/meteor/pull/13693

While reviewing some tests, I came across [this self-test](https://github.com/meteor/meteor/blob/48f365577743826fb532ae93e64c739754acf668/tools/tests/regressions.js#L16-L25). It uses `--exclude-archs we.browser`, so it only builds for legacy. When `modernWebArchsOnly` is enabled, it overrides other exclusions. This PR changes that to ensure `--exclude-archs` takes priority over other settings.

I add also a warning on having this two options enabled.