### PR TITLE
SQLite 3 improvements for offline catalog

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -473,7 +473,6 @@ main.registerCommand(Object.assign(
 
 async function doRunCommand(options) {
   Console.setVerbose(!!options.verbose);
-
   // Additional args are interpreted as run targets
   const runTargets = parseRunTargets(options.args);
 

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -473,6 +473,7 @@ main.registerCommand(Object.assign(
 
 async function doRunCommand(options) {
   Console.setVerbose(!!options.verbose);
+
   // Additional args are interpreted as run targets
   const runTargets = parseRunTargets(options.args);
 

--- a/tools/packaging/catalog/catalog-remote.js
+++ b/tools/packaging/catalog/catalog-remote.js
@@ -441,9 +441,9 @@ Object.assign(Table.prototype, {
     return "(" + _.times(n, function () { return "?" }).join(",") + ")";
   },
 
-  find: async function (txn, id) {
+  find: async function (id) {
     var self = this;
-    var rows = await txn.query(self._selectQuery, [ id ]);
+    var rows = await self.db._query(self._selectQuery, [ id ]);
     if (rows.length !== 0) {
       if (rows.length !== 1) {
         throw new Error("Corrupt database (PK violation)");
@@ -812,24 +812,44 @@ Object.assign(RemoteCatalog.prototype, {
   // Given a release track, returns all recommended version *records* for this
   // track, sorted by their orderKey. Returns the empty array if the release
   // track does not exist or does not have any recommended versions.
+  // getSortedRecommendedReleaseRecords: async function (track, laterThanOrderKey) {
+  //   var self = this;
+  //   // XXX releaseVersions content objects are kinda big; if we put
+  //   // 'recommended' and 'orderKey' in their own columns this could be faster
+  //   var result = await self._contentQuery(
+  //     "SELECT content FROM releaseVersions WHERE track=?", track);
+  //
+  //   var recommended = _.filter(result, function (v) {
+  //     if (!v.recommended)
+  //       return false;
+  //     return !laterThanOrderKey || v.orderKey > laterThanOrderKey;
+  //   });
+  //
+  //   var recSort = _.sortBy(recommended, function (rec) {
+  //     return rec.orderKey;
+  //   });
+  //   recSort.reverse();
+  //   return recSort;
+  // },
+
   getSortedRecommendedReleaseRecords: async function (track, laterThanOrderKey) {
-    var self = this;
-    // XXX releaseVersions content objects are kinda big; if we put
-    // 'recommended' and 'orderKey' in their own columns this could be faster
-    var result = await self._contentQuery(
-      "SELECT content FROM releaseVersions WHERE track=?", track);
+    const hasMinKey = laterThanOrderKey != null;
 
-    var recommended = _.filter(result, function (v) {
-      if (!v.recommended)
-        return false;
-      return !laterThanOrderKey || v.orderKey > laterThanOrderKey;
-    });
+    // Always use JSON1 to filter & sort directly in SQL
+    const sql = `
+    SELECT content
+    FROM releaseVersions
+    WHERE track = ?
+      AND json_extract(content, '$.recommended') = 1
+      ${hasMinKey ? "AND json_extract(content, '$.orderKey') > ?" : ""}
+    ORDER BY json_extract(content, '$.orderKey') DESC
+  `;
+    const params = hasMinKey
+        ? [track, laterThanOrderKey]
+        : [track];
 
-    var recSort = _.sortBy(recommended, function (rec) {
-      return rec.orderKey;
-    });
-    recSort.reverse();
-    return recSort;
+    // _contentQuery will JSON.parse(content) for you
+    return this._contentQuery(sql, params);
   },
 
   // Given a release track, returns all version records for this track.
@@ -881,9 +901,9 @@ Object.assign(RemoteCatalog.prototype, {
   },
 
   // Executes a query, returning an array of each content column parsed as JSON
-  _contentQuery: async function (query, params) {
+  _contentQuery: async function (query, params, transaction = false) {
     var self = this;
-    var rows = await self._columnsQuery(query, params);
+    var rows = await self._columnsQuery(query, params, transaction);
     return _.map(rows, function(entity) {
       return JSON.parse(entity.content);
     });
@@ -893,9 +913,7 @@ Object.assign(RemoteCatalog.prototype, {
   // No JSON parsing is performed.
   _columnsQuery: async function (query, params) {
     var self = this;
-    var rows = await self.db.runInTransaction(function (txn) {
-      return txn.query(query, params);
-    });
+    var rows = await self.db._query(query, params);
     return rows;
   },
 
@@ -946,9 +964,7 @@ Object.assign(RemoteCatalog.prototype, {
 
   getMetadata: async function(key) {
     var self = this;
-    var row = await self.db.runInTransaction(function (txn) {
-      return self.tableMetadata.find(txn, key);
-    });
+    var row = await self.tableMetadata.find(key);
     if (row) {
       return JSON.parse(row['content']);
     }
@@ -970,9 +986,7 @@ Object.assign(RemoteCatalog.prototype, {
 
   shouldShowBanner: async function (releaseName, bannerDate) {
     var self = this;
-    var row = await self.db.runInTransaction(function (txn) {
-      return self.tableBannersShown.find(txn, releaseName);
-    });
+    var row = await self.tableBannersShown.find(releaseName);
     // We've never printed a banner for this release.
     if (! row)
       return true;

--- a/tools/packaging/catalog/catalog-remote.js
+++ b/tools/packaging/catalog/catalog-remote.js
@@ -441,9 +441,9 @@ Object.assign(Table.prototype, {
     return "(" + _.times(n, function () { return "?" }).join(",") + ")";
   },
 
-  find: async function (id) {
+  find: async function (db, id) {
     var self = this;
-    var rows = await self.db._query(self._selectQuery, [ id ]);
+    var rows = await db._query(self._selectQuery, [ id ]);
     if (rows.length !== 0) {
       if (rows.length !== 1) {
         throw new Error("Corrupt database (PK violation)");
@@ -944,7 +944,7 @@ Object.assign(RemoteCatalog.prototype, {
 
   getMetadata: async function(key) {
     var self = this;
-    var row = await self.tableMetadata.find(key);
+    var row = await self.tableMetadata.find(self.db, key);
     if (row) {
       return JSON.parse(row['content']);
     }
@@ -966,7 +966,7 @@ Object.assign(RemoteCatalog.prototype, {
 
   shouldShowBanner: async function (releaseName, bannerDate) {
     var self = this;
-    var row = await self.tableBannersShown.find(releaseName);
+    var row = await self.tableBannersShown.find(self.db, releaseName);
     // We've never printed a banner for this release.
     if (! row)
       return true;

--- a/tools/packaging/catalog/catalog-remote.js
+++ b/tools/packaging/catalog/catalog-remote.js
@@ -812,26 +812,6 @@ Object.assign(RemoteCatalog.prototype, {
   // Given a release track, returns all recommended version *records* for this
   // track, sorted by their orderKey. Returns the empty array if the release
   // track does not exist or does not have any recommended versions.
-  // getSortedRecommendedReleaseRecords: async function (track, laterThanOrderKey) {
-  //   var self = this;
-  //   // XXX releaseVersions content objects are kinda big; if we put
-  //   // 'recommended' and 'orderKey' in their own columns this could be faster
-  //   var result = await self._contentQuery(
-  //     "SELECT content FROM releaseVersions WHERE track=?", track);
-  //
-  //   var recommended = _.filter(result, function (v) {
-  //     if (!v.recommended)
-  //       return false;
-  //     return !laterThanOrderKey || v.orderKey > laterThanOrderKey;
-  //   });
-  //
-  //   var recSort = _.sortBy(recommended, function (rec) {
-  //     return rec.orderKey;
-  //   });
-  //   recSort.reverse();
-  //   return recSort;
-  // },
-
   getSortedRecommendedReleaseRecords: async function (track, laterThanOrderKey) {
     const hasMinKey = laterThanOrderKey != null;
 
@@ -901,9 +881,9 @@ Object.assign(RemoteCatalog.prototype, {
   },
 
   // Executes a query, returning an array of each content column parsed as JSON
-  _contentQuery: async function (query, params, transaction = false) {
+  _contentQuery: async function (query, params) {
     var self = this;
-    var rows = await self._columnsQuery(query, params, transaction);
+    var rows = await self._columnsQuery(query, params);
     return _.map(rows, function(entity) {
       return JSON.parse(entity.content);
     });


### PR DESCRIPTION
<!-- OSS-736 -->

This PR addresses an issue [reported here](https://forums.meteor.com/t/join-the-effort-to-speed-up-meteor-bundler/63406/38).

The problem is that in published Meteor versions, we run an extra SQLite query to check the latest recommended Meteor version in the offline SQLite catalog. This doesn't happen when running Meteor from a checkout. This extra query exposed performance issues, as it ran a SQLite query with unnecessary overhead.

The fix is to avoid creating controlled transactions for single read-only SQLite queries. These aren't needed, SQLite already uses auto-commit for single operations. Transactions are mainly useful for writes or grouped queries. Removing them saved around ~2 seconds in build time. Also, the query was refactored to handle filtering and sorting directly in SQLite instead of JS. While query time stayed similar, the JS context does less work now. Anyway, the key improvement is removing the transaction.

![image](https://github.com/user-attachments/assets/57bcd898-71c4-45e4-b3c8-6b10f3475e4b)

Below is the updated meteor profile output showing the overall performance gain. To do this, I manually located the catalog-remote.js file in the published Meteor 3.3-beta.0 (`find ~/.meteor -type f -name catalog-remote.js`) and applied the PR changes there. Then I re-ran profiling to confirm the improvements (`meteor profile`). This was done to simulate the new changes on a published version, avoiding for us to require to publish a new beta to test these changes.

![image](https://github.com/user-attachments/assets/f5dda64e-c36c-4270-813b-f92ac028a265)

---

While we could remove more transactions for single write operations, I didn’t touch them since most aren’t part of the app build time. They run when using Meteor commands with packages, fetching the catalog, and similar tasks. Other refactors touch different parts of the Meteor CLI, and right now we’re focused only on `meteor run` and `meteor build`, so I left those out. We’ll keep this in mind for the future.

Another possible optimization is using [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) with sync operations. In theory, it could improve response time, but I’m not fully sure in our case. Also, sqlite isn’t deeply involved in `meteor run` or `meteor build`, so it makes sense to postpone this.

Lastly, sqlite seems slower on published Meteor versions when running queries. This might be related to version mismatches during CI publishing or missing dependencies, like a specific Node version.