### PR TITLE
Add TypeScript declarations for isModern and getMinimumBrowserVersions functions

### DIFF
--- a/packages/modern-browsers/modern.d.ts
+++ b/packages/modern-browsers/modern.d.ts
@@ -1,4 +1,12 @@
+export declare function isModern(
+  browser: { name: string, major: number, minor?: number, patch?: number }
+): boolean;
+
 export declare function setMinimumBrowserVersions(
   versions: Record<string, number | number[]>,
-  source: string
+  source?: string
 ): void;
+
+export declare function getMinimumBrowserVersions(): Record<string, Record<string, number | number[]>>;
+
+export declare function calculateHashOfMinimumVersions(): string;


### PR DESCRIPTION
This PR supplements the TypeScript definitions in the module. Currently, the TS definitions only include `setMinimumBrowserVersions`, but lack the following:

- isModern
- getMinimumBrowserVersions
- calculateHashOfMinimumVersions

The changes focus **solely on adding the missing type declarations** without modifying any existing logic or behavior.