### PR TITLE
Remove recursive deferred in bundler code

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1601,7 +1601,7 @@ https://guide.meteor.com/cordova.html#submitting-android
     });
   }
 
-  await files.rm_recursive(buildDir);
+  await files.rm_recursive_deferred(buildDir);
 
   const npmShrinkwrapFilePath = files.pathJoin(bundlePath, 'programs/server/npm-shrinkwrap.json');
   if (files.exists(npmShrinkwrapFilePath)) {

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -358,6 +358,20 @@ export const rm_recursive = Profile("files.rm_recursive", async (path: string) =
   }
 });
 
+export const rm_recursive_deferred = Profile("files.rm_recursive_deferred", async (path: string) => {
+  // Generate a temp path name for the old build directory
+  const oldBuildPath = path + '.old-' + Math.floor(Math.random() * 999999);
+  // If the original buildPath exists, rename it first
+  if (exists(path)) {
+    await rename(path, oldBuildPath);
+    // Start deletion of old directory asynchronously without awaiting
+    rm_recursive(oldBuildPath).catch(e => {
+      // Log error but don't fail the build
+      console.error(`Error removing old build directory ${oldBuildPath}:`, e);
+    });
+  }
+});
+
 // Returns the base64 SHA256 of the given file.
 export function fileHash(filename: string) {
   const crypto = require('crypto');

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -126,9 +126,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
   async init() {
     // Build the output from scratch
     if (this.resetBuildPath) {
-      console.time("--> (builder.js-Line: 130)\n await files.rm_recursive_deferred: ");
       await files.rm_recursive_deferred(this.buildPath);
-      console.timeEnd("--> (builder.js-Line: 130)\n await files.rm_recursive_deferred: ");
       // Create the new build directory immediately without waiting for deletion
       await files.mkdir_p(this.buildPath, 0o755);
     }

--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -1832,7 +1832,7 @@ export class PackageSourceBatch {
       if (cacheFilename) {
         // Write asynchronously.
         try {
-          await files.rm_recursive(wildcardCacheFilename);
+          await files.rm_recursive_deferred(wildcardCacheFilename);
         } finally {
           await files.writeFileAtomically(cacheFilename, retAsJSON);
         }

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -83,19 +83,19 @@ export class IsopackCache {
       // Wipe specific packages.
       for (const packageName of packages) {
         if (self.cacheDir) {
-          await files.rm_recursive(self._isopackDir(packageName));
+          await files.rm_recursive_deferred(self._isopackDir(packageName));
         }
         if (self._pluginCacheDirRoot) {
-          await files.rm_recursive(self._pluginCacheDirForPackage(packageName));
+          await files.rm_recursive_deferred(self._pluginCacheDirForPackage(packageName));
         }
       }
     } else {
       // Wipe all packages.
       if (self.cacheDir) {
-        await files.rm_recursive(self.cacheDir);
+        await files.rm_recursive_deferred(self.cacheDir);
       }
       if (self._pluginCacheDirRoot) {
-        await files.rm_recursive(self._pluginCacheDirRoot);
+        await files.rm_recursive_deferred(self._pluginCacheDirRoot);
       }
     }
   }
@@ -351,7 +351,7 @@ export class IsopackCache {
         } else {
           // Nope! Compile it again. Give it a fresh plugin cache.
           if (pluginCacheDir) {
-            await files.rm_recursive(pluginCacheDir);
+            await files.rm_recursive_deferred(pluginCacheDir);
             files.mkdir_p(pluginCacheDir);
           }
 

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -87,7 +87,7 @@ meteorNpm.updateDependencies = async function (packageName,
       // It didn't exist, which is exactly what we wanted.
       return false;
     }
-    await files.rm_recursive(newPackageNpmDir);
+    await files.rm_recursive_deferred(newPackageNpmDir);
     return false;
   }
 
@@ -102,7 +102,7 @@ meteorNpm.updateDependencies = async function (packageName,
     // proceed.
     if (files.exists(packageNpmDir) &&
         ! files.exists(files.pathJoin(packageNpmDir, 'npm-shrinkwrap.json'))) {
-      await files.rm_recursive(packageNpmDir);
+      await files.rm_recursive_deferred(packageNpmDir);
     }
 
     // with the changes on npm 8, where there were changes to how the packages metadata is given
@@ -114,7 +114,7 @@ meteorNpm.updateDependencies = async function (packageName,
           files.pathJoin(packageNpmDir, 'npm-shrinkwrap.json')
         ));
         if (shrinkwrap.lockfileVersion !== LOCK_FILE_VERSION) {
-          await files.rm_recursive(packageNpmDir);
+          await files.rm_recursive_deferred(packageNpmDir);
         }
       } catch (e) {}
     }
@@ -143,7 +143,7 @@ meteorNpm.updateDependencies = async function (packageName,
     throw e;
   } finally {
     if (files.exists(newPackageNpmDir)) {
-      await files.rm_recursive(newPackageNpmDir);
+      await files.rm_recursive_deferred(newPackageNpmDir);
     }
     tmpDirs = _.without(tmpDirs, newPackageNpmDir);
   }
@@ -384,7 +384,7 @@ Profile("meteorNpm.rebuildIfNonPortable", async function (nodeModulesDir) {
   const rebuildResult = await runNpmCommand(getRebuildArgs(), tempDir);
   if (! rebuildResult.success) {
     buildmessage.error(rebuildResult.error);
-    await files.rm_recursive(tempDir);
+    await files.rm_recursive_deferred(tempDir);
     return false;
   }
 
@@ -420,7 +420,7 @@ Profile("meteorNpm.rebuildIfNonPortable", async function (nodeModulesDir) {
     await files.renameDirAlmostAtomically(tempPkgDirs[pkgPath], pkgPath);
   }
 
-  await files.rm_recursive(tempDir);
+  await files.rm_recursive_deferred(tempDir);
 
   return true;
 });
@@ -644,7 +644,7 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
     }
 
     if (oldNodeVersion !== currentNodeCompatibilityVersion()) {
-      await files.rm_recursive(nodeModulesDir);
+      await files.rm_recursive_deferred(nodeModulesDir);
     }
   }
 

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1664,7 +1664,7 @@ Object.assign(exports.ReleaseFile.prototype, {
     if (this.isCheckout()) {
       // Only create .meteor/local/dev_bundle if .meteor/release refers to
       // an actual release, and remove it otherwise.
-      await files.rm_recursive(devBundleLink);
+      await files.rm_recursive_deferred(devBundleLink);
       return;
     }
 

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -474,7 +474,7 @@ var launchMongo = async function(options) {
     if (options.multiple) {
       // This is only for testing, so we're OK with incurring the replset
       // setup on each startup.
-      await files.rm_recursive(dbPath);
+      await files.rm_recursive_deferred(dbPath);
       files.mkdir_p(dbPath, 0o755);
     } else if (portFile) {
       var portFileExists = false;


### PR DESCRIPTION
This PR applies [a folder removal method](https://github.com/meteor/meteor/pull/13680/commits/0e97299a96bcab9c87de32d69132f2b69edd31bc) from @italojs, which only renames the folder instead of waiting for full removal. This is usually enough for caches or most file contexts.

I tested it in one spot; it's clearly faster. While it may not help much in single cases, parts of the code remove Meteor package contexts in a loop, where the speedup will be  more noticeable. I don't think we're dealing with many milliseconds of improvement, but any improvement is worth a refactor.

Just a single spot and the proof is faster:

![image](https://github.com/user-attachments/assets/00be0c96-923c-4b3c-9852-e25a211dcdf3)

---

We could apply in other parts of the code, basically replacing `rm_recursive` per `rm_recursive_deferred`, but my plan is just to focus on bundler code.
