### PR TITLE
Symlink support on new watcher

### DIFF
--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -153,24 +153,25 @@ function shouldIgnorePath(absPath: string): boolean {
   }
 
   // For project node_modules: check if it's a direct node_modules/<package>
-  if (isWithinCwd && absPath.includes(`${cwd}/node_modules`)) {
-    // Check if it's a direct node_modules/<package> path
-    const relPath = absPath.substring(cwd.length + 1); // +1 for the slash
-    const relParts = relPath.split('/');
-    if (relParts.length >= 2 && relParts[0] === 'node_modules') {
-      // If it's a direct node_modules/<package>, check if it's a symlink
-      // We'll return false here (don't ignore) so that the code can later decide to use polling
-      // based on isSymbolicLink check in the watch function
-      if (relParts.length === 2 && isSymbolicLink(absPath)) {
-        return false;
+  if (isWithinCwd) {
+    if (absPath.includes(`${cwd}/node_modules`)) {
+      // Check if it's a direct node_modules/<package> path
+      const relPath = absPath.substring(cwd.length + 1); // +1 for the slash
+      const relParts = relPath.split('/');
+      if (relParts.length >= 2 && relParts[0] === 'node_modules') {
+        // If it's a direct node_modules/<package>, check if it's a symlink
+        // We'll return false here (don't ignore) so that the code can later decide to use polling
+        // based on isSymbolicLink check in the watch function
+        if (relParts.length === 2 && isSymbolicLink(absPath)) {
+          return false;
+        }
+        // Check if it's within a symlink root to not ignore
+        if (isWithinSymlinkRoot(absPath)) {
+          return false;
+        }
       }
-      // Check if it's within a symlink root to not ignore
-      if (isWithinSymlinkRoot(absPath)) {
-        return false;
-      }
-      return true;
     }
-    return true;
+    return false;
   }
 
   // For external node_modules: check if it's a direct node_modules/<package>

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -170,8 +170,10 @@ function shouldIgnorePath(absPath: string): boolean {
           return false;
         }
       }
+      return true;
+    } else {
+      return false;
     }
-    return false;
   }
 
   // For external node_modules: check if it's a direct node_modules/<package>

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -161,7 +161,7 @@ function shouldIgnorePath(absPath: string): boolean {
       // If it's a direct node_modules/<package>, check if it's a symlink
       // We'll return false here (don't ignore) so that the code can later decide to use polling
       // based on isSymbolicLink check in the watch function
-      if (relParts.length === 2 && isSymbolicLink(absPath, false)) {
+      if (relParts.length === 2 && isSymbolicLink(absPath)) {
         return false;
       }
       // Check if it's within a symlink root to not ignore

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -154,6 +154,7 @@ function shouldIgnorePath(absPath: string): boolean {
 
   // For project node_modules: check if it's a direct node_modules/<package>
   if (isWithinCwd) {
+    // Check if it's the project node_modules
     if (absPath.includes(`${cwd}/node_modules`)) {
       // Check if it's a direct node_modules/<package> path
       const relPath = absPath.substring(cwd.length + 1); // +1 for the slash
@@ -172,6 +173,7 @@ function shouldIgnorePath(absPath: string): boolean {
       }
       return true;
     } else {
+      // Otherwise, don't ignore non-npm node_modules
       return false;
     }
   }
@@ -179,6 +181,12 @@ function shouldIgnorePath(absPath: string): boolean {
   // For external node_modules: check if it's a direct node_modules/<package>
   const nmIndex = parts.indexOf("node_modules");
   if (nmIndex !== -1) {
+    // Don't ignore node_modules within .npm/package/ paths
+    const npmPackageIndex = parts.indexOf(".npm");
+    if (npmPackageIndex !== -1 && parts[npmPackageIndex + 1] === "package" && 
+        nmIndex > npmPackageIndex && parts[nmIndex - 1] === "package") {
+      return false;
+    }
     return true;
   }
 

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -2,7 +2,7 @@ import { Stats } from 'fs';
 import ParcelWatcher from "@parcel/watcher";
 
 import { Profile } from "../tool-env/profile";
-import { statOrNull, lstat, toPosixPath, convertToOSPath, pathRelative, watchFile, unwatchFile, pathResolve, pathDirname, realpathOrNull, readdir, pathJoin } from "./files";
+import { statOrNull, lstat, toPosixPath, convertToOSPath, pathRelative, watchFile, unwatchFile, pathResolve, pathDirname } from "./files";
 
 // Register process exit handlers to ensure subscriptions are properly cleaned up
 const registerExitHandlers = () => {


### PR DESCRIPTION
<!--OSS-715-->

Continues: https://github.com/meteor/meteor/pull/13699

This PR addresses part of the feedback from @zodern in the previous PR. It improves support for symbolic links by detecting symlinks and all traversed files, using a polling strategy to reliably watch for changes. I also enabled support for direct packages linked with npm link in the project's node_modules. I tested these and they work well.

Polling is used because native recursive watching isn't supported consistently across all OS when using symlinks, so polling is applied in these cases. Tools like [chokidar ](https://github.com/paulmillr/chokidar) could handle this more smartly, but for now this approach works well enough.

I considered enabling native watching and polling for all project files simultanously, not just symlinks. However, polling puts significant load on the CPU and impacts performance. So for now, polling remains opt-in via an environment variable (`METEOR_WATCH_FORCE_POLLING` and `METEOR_WATCH_POLLING_INTERVAL_MS`).

Most modern bundlers rely on native watchers, and for edge cases like working with volumes or network files, you can opt into polling. See [Vite](https://v2.vitejs.dev/config/#server-watch) and [rspack](https://rspack.dev/config/watch#watchoptionspoll) as examples. This favors performance in common scenarios while keeping compatibility available when needed.

Since Meteor 3.4 will favor using a modern bundler for app and node_modules code, it makes sense to align with how they handle things. As app code will be managed by the bundler, its options will become the new configuration standard for modern Meteor apps, including watching. Using `@parcel/watcher` still makes sense on Meteor core, as it improves file change detection for atmosphere packages code and intermediate outputs from the modern bundler.

---

We'll mention in Meteor 3.3 that this could be a breaking change in cases like using WSL2 from host machine, working with volumes, or over network setups, where polling needs to be enabled manually. I'll test some of these cases too. It’s also a chance to collect feedback, but since performance is the priority, and this aligns with other modern tools, this seems like the right path.