### PR TITLE
Fix for Issue #13652 caused by MongoDB Node.js Driver

### DIFF
--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -8,7 +8,7 @@ Package.describe({
 });
 
 Npm.depends({
-  mongodb: "6.9.0"
+  mongodb: "6.16.0"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
This PR primarily addresses the bug reported in #13652. The issue was caused by the MongoDB Node.js Driver and has been fixed in version v6.16.0.

In Commit 3dac12a, I noticed a temporary version downgrade from 6.10.0 to 6.9.0 due to legacy database connection issues.  However, after reviewing the 6.10.0 changelog, the only documented breaking change was the dropped compatibility with MongoDB 3.6.  No other critical issues were mentioned in the release notes.

If the issue was solely related to pre-MongoDB 4.x compatibility, I believe we should proceed with the upgrade. According to MongoDB's official support policy ([MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles)), versions below 4.x are already end-of-life (EOL) and no longer supported. Maintaining compatibility with deprecated database versions would introduce unnecessary technical debt and potential security risks.