### PR TITLE
Favor Reify transpile in SWC all time

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -91,9 +91,7 @@ function compileWithSwc(source, swcOptions = {}, { inputFilePath, features, arch
         generateLetDeclarations: true,
       }),
     });
-    if (!result.identical) {
-      content = result.code;
-    }
+    content = result.code;
 
     return {
       code: content,


### PR DESCRIPTION
<!--OSS-735-->

Fixes: https://forums.meteor.com/t/weekly-update-april-16-2025-faster-bundle-times-with-3-3-beta-0/63494/20

This PR ensures the reify output on SWC transpilation is always favored to ensure top-level await works as expected in all scenarios.