### PR TITLE
Handle all-zero version cases in modern browser detection

### DIFF
--- a/packages/modern-browsers/modern-tests.js
+++ b/packages/modern-browsers/modern-tests.js
@@ -49,6 +49,13 @@ Tinytest.add('modern-browsers - versions - basic', function (test) {
     patch: 0,
   }));
 
+  test.isFalse(isModern({
+    name: "mobileSafariUI/WKWebView", 
+    major: 0, 
+    minor: 0,
+    patch: 0,
+  }));
+
   const oldPackageSettings = Meteor.settings.packages;
   
   Meteor.settings.packages = {
@@ -61,6 +68,13 @@ Tinytest.add('modern-browsers - versions - basic', function (test) {
     name: "unknownBrowser", 
     major: 10, 
     minor: 1,
+    patch: 0,
+  }));
+
+  test.isTrue(isModern({
+    name: "mobileSafariUI/WKWebView", 
+    major: 0, 
+    minor: 0,
     patch: 0,
   }));
 

--- a/packages/modern-browsers/modern.js
+++ b/packages/modern-browsers/modern.js
@@ -93,7 +93,13 @@ function isModern(browser) {
   const entry = hasOwn.call(minimumVersions, lowerCaseName)
     ? minimumVersions[lowerCaseName]
     : undefined;
-  if (!entry) {
+    if (
+      !entry ||
+      // When all version numbers are 0, this typically comes from in-app WebView UAs (e.g., iOS WKWebView).
+      // We can let users decide whether to treat it as a modern browser
+      // via the packageSettings.unknownBrowsersAssumedModern option.
+      (browser.major === 0 && browser.minor === 0 && browser.patch === 0)
+    ) {
     const packageSettings = Meteor.settings.packages
       ? Meteor.settings.packages['modern-browsers']
       : undefined;


### PR DESCRIPTION
When all version numbers are 0, this typically comes from in-app WebView UAs (e.g., iOS WKWebView).
We can let users decide whether to treat it as a modern browser
via the packageSettings.unknownBrowsersAssumedModern option.