### PR TITLE
Update v3-docs to point to docs to reduce confusion

### DIFF
--- a/guide/source/index.md
+++ b/guide/source/index.md
@@ -3,7 +3,7 @@ title: Introduction
 description: This is the guide for using Meteor, a full-stack JavaScript platform for developing modern web and mobile applications.
 ---
 
-> Meteor 2.x runs on a deprecated Node.js version (14). Meteor 3 has been released with support for the latest Node.js LTS version. For more information, please consult our [migration guide](https://v3-migration-docs.meteor.com/) and the [latest docs](https://v3-docs.meteor.com).
+> Meteor 2.x runs on a deprecated Node.js version (14). Meteor 3.x has been released with support for the latest Node.js LTS version. For more information, please consult our [migration guide](https://v3-migration-docs.meteor.com/) and the [latest docs](https://docs.meteor.com).
 
 <!--  XXX: note that this content is somewhat duplicated on the docs, and should be updated in parallel -->
 <h2 id="what-is-meteor">What is Meteor?</h2>


### PR DESCRIPTION
This PR is one contribution of many sparked from the discussion here: https://forums.meteor.com/t/meteor-phoenix-rising-from-the-ashes-to-spark-new-developer-passion/63339/1

This should be paired with my change here: https://github.com/meteor/meteor-theme-hexo/pull/99


## Before 

https://github.com/user-attachments/assets/7b5ef3c3-1902-4031-89ac-82d4437b32fb

## After

https://github.com/user-attachments/assets/0e7905ef-461b-4e55-b97f-8cb9da4f0764



