### PR TITLE
New envs for package development

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -596,7 +596,8 @@ async function doRunCommand(options) {
   const buildMode = options.production ? 'production' : 'development';
 
   let cordovaRunner;
-  if (!_.isEmpty(runTargets)) {
+  const shouldDisableCordova =  Boolean(JSON.parse(process.env.METEOR_CORDOVA_DISABLE || 'false'));
+  if (!shouldDisableCordova && !_.isEmpty(runTargets)) {
 
     async function prepareCordovaProject() {
       import { CordovaProject } from '../cordova/project.js';

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -332,9 +332,21 @@ function filterWebArchs(webArchs, excludeArchsOption, appDir, options) {
         const excludeArchs = [...excludeArchsOptions, ...automaticallyIgnoredLegacyArchs];
         webArchs = webArchs.filter(arch => !excludeArchs.includes(arch));
       }
-      return webArchs;
     }
   }
+
+  const forcedInclArchs = process.env.METEOR_FORCE_INCLUDE_ARCHS;
+  if (forcedInclArchs != null) {
+    const nextInclArchs = forcedInclArchs.trim().split(/\s*,\s*/);
+    webArchs = Array.from(new Set([...webArchs, ...nextInclArchs]));
+  }
+
+  const forcedExclArchs = process.env.METEOR_FORCE_EXCLUDE_ARCHS;
+  if (forcedExclArchs != null) {
+    const nextExclArchs = forcedExclArchs.trim().split(/\s*,\s*/);
+    webArchs = webArchs.filter(_webArch => !nextExclArchs.includes(_webArch));
+  }
+
   return webArchs;
 }
 

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -1544,6 +1544,9 @@ makeGlobalAsyncLocalStorage().run({}, async function () {
       });
     }
 
+    // Set the currentCommand in the global object to spread context
+    global.currentCommand = { name: command.name, options };
+
     var ret = await command.func(options, { rawOptions });
 
   } catch (e) {


### PR DESCRIPTION
This PR prepares environment variables for upcoming dynamic atmosphere packages that enable specific features. They can be used in pre, during, or post build phases to adjust project behavior.

- `global.currentCommand`: the context of the running command.

- `METEOR_FORCE_INCLUDE_ARCHS` and `METEOR_FORCE_EXCLUDE_ARCHS`: include or exclude web.archs.

- `METEOR_CORDOVA_DISABLE`: skip the Cordova setup and running in `meteor run android` and `meteor run ios` commands, and alike.

These variables [hint at upcoming features](https://forums.meteor.com/t/building-capacitor-mobile-app-from-meteor-react/63560/4). 😁