### PR TITLE
SWC resolves custom base url properly

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -153,6 +153,11 @@ BCp.initializeMeteorAppSwcrc = function () {
     lastModifiedSwcConfigTime = currentLastModifiedConfigTime;
     lastModifiedSwcConfig = getMeteorAppSwcrc();
 
+    // Resolve custom baseUrl to an absolute path pointing to the project root
+    if (lastModifiedSwcConfig.jsc && lastModifiedSwcConfig.jsc.baseUrl) {
+      lastModifiedSwcConfig.jsc.baseUrl = path.resolve(process.cwd(), lastModifiedSwcConfig.jsc.baseUrl);
+    }
+
     if (lastModifiedMeteorConfig?.modern?.transpiler?.verbose) {
       logConfigBlock('SWC Config', lastModifiedSwcConfig);
     }


### PR DESCRIPTION
<!--OSS-735-->

Context: https://forums.meteor.com/t/weekly-update-april-16-2025-faster-bundle-times-with-3-3-beta-0/63494/29

This PR fixes an issue where using a custom `baseDir` for alias definitions causes failures. The fix ensures that the absolute path is correctly resolved when a `baseDir` is provided in the custom `.swcrc` configuration.

![image](https://github.com/user-attachments/assets/f91f3daf-a691-4c35-83d4-b9bf2e0331fe)
