### PR TITLE
Fix for Issue #13652 caused by MongoDB Node.js Driver (reopened)

### DIFF
--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -8,7 +8,7 @@ Package.describe({
 });
 
 Npm.depends({
-  mongodb: "6.9.0"
+  mongodb: "6.16.0"
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
This PR primarily addresses the bug reported in https://github.com/meteor/meteor/issues/13652. The issue was caused by the MongoDB Node.js Driver and has been fixed in version v6.16.0.

This PR is a reopened version of #13710 with identical changes. It upgrades the MongoDB npm package to a newer version.