### PR TITLE
Fix linter issue triggering full server refreshes for client-only entrypoint

### DIFF
--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -796,8 +796,9 @@ async function runLinters({inputSourceArch, isopackCache, sources,
 
     const absPath = files.pathResolve(inputSourceArch.sourceRoot, relPath);
     const hash = optimisticHashOrNull(absPath);
-    const contents = optimisticReadFile(absPath);
-    watchSet.addFile(absPath, hash);
+    if (!watchSet.hasFile(absPath)) {
+      watchSet.addFile(absPath, hash);
+    }
 
     if (classification.type === "meteor-ignore") {
       // Return after watching .meteorignore files but before adding them
@@ -806,6 +807,7 @@ async function runLinters({inputSourceArch, isopackCache, sources,
       return;
     }
 
+    const contents = optimisticReadFile(absPath);
     const wrappedSource = {
       relPath, contents, hash, fileOptions,
       arch: inputSourceArch.arch,


### PR DESCRIPTION
<!--OSS-757-->

Context: https://github.com/zodern/meteor-types/issues/24

This PR fixes a core-level linter issue. When registering a lint (for example via [`zodern:types`](https://github.com/zodern/meteor-types)) and triggering a rebuild, we end up re-adding an existing watcher to the watchSet. That extra registration causes a full recompile and server refresh.

The problem only occurs on the `mainModule.client` entry point. We saw it with `meteor profile` on apps using `zodern:types`, since the profiler expects only a client refresh. Adding a pre-check to skip files already in the watchSet resolves the issue.