### PR TITLE
Broader app modernization support

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3507,6 +3507,7 @@ main.registerCommand(
   name: 'profile',
   maxArgs: Infinity,
   options: {
+    ...buildCommands.options || {},
     ...runCommandOptions.options || {},
     'size': { type: Boolean },
     'size-only': { type: Boolean },

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1819,14 +1819,16 @@ export class MeteorConfig {
   // TODO Implement an API for setting these values?
   get(...keys) {
     let config = this._ensureInitialized();
+    let filteredConfig = keys.length ? undefined : config;
     if (config) {
       keys.every(key => {
         if (config && _.has(config, key)) {
-          config = config[key];
+          filteredConfig = config[key];
           return true;
         }
+        return false;
       });
-      return config;
+      return filteredConfig;
     }
   }
 
@@ -1908,6 +1910,8 @@ export class MeteorConfig {
 
   _getEntryModulesByArch(...keys) {
     const configEntryModule = this.get(...keys);
+    console.log("--> (project-context.js-Line: 1911)\n configEntryModule: ", configEntryModule);
+    console.log("--> (project-context.js-Line: 1911)\n keys: ", keys);
     const entryModulesByArch = Object.create(null);
 
     if (typeof configEntryModule === "string" ||
@@ -1927,6 +1931,7 @@ export class MeteorConfig {
       });
     }
 
+    console.log("--> (project-context.js-Line: 1931)\n entryModulesByArch: ", entryModulesByArch);
     return entryModulesByArch;
   }
 
@@ -1936,9 +1941,13 @@ export class MeteorConfig {
   ) {
     const entryMatch = archinfo.mostSpecificMatch(
       arch, Object.keys(entryModulesByArch));
+    // console.log("--> (project-context.js-Line: 1939)\n archinfo: ", archinfo);
+    // console.log("--> (project-context.js-Line: 1939)\n Object.keys(entryModulesByArch): ", Object.keys(entryModulesByArch));
 
     if (entryMatch) {
       const entryModule = entryModulesByArch[entryMatch];
+      console.log("--> (project-context.js-Line: 1944)\n entryModulesByArch: ", entryModulesByArch);
+      console.log("--> (project-context.js-Line: 1942)\n entryModule: ", entryModule);
 
       if (entryModule === false) {
         // If meteor.{main,test}Module.{client,server,...} === false, no
@@ -1967,6 +1976,7 @@ export class MeteorConfig {
         "./" + files.pathNormalize(entryModule),
         this.packageJsonPath
       );
+      console.log("--> (project-context.js-Line: 1970)\n res: ", res);
 
       if (res && typeof res === "object") {
         return files.pathRelative(this.appDirectory, res.path);

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1910,8 +1910,6 @@ export class MeteorConfig {
 
   _getEntryModulesByArch(...keys) {
     const configEntryModule = this.get(...keys);
-    console.log("--> (project-context.js-Line: 1911)\n configEntryModule: ", configEntryModule);
-    console.log("--> (project-context.js-Line: 1911)\n keys: ", keys);
     const entryModulesByArch = Object.create(null);
 
     if (typeof configEntryModule === "string" ||
@@ -1931,7 +1929,6 @@ export class MeteorConfig {
       });
     }
 
-    console.log("--> (project-context.js-Line: 1931)\n entryModulesByArch: ", entryModulesByArch);
     return entryModulesByArch;
   }
 
@@ -1941,13 +1938,9 @@ export class MeteorConfig {
   ) {
     const entryMatch = archinfo.mostSpecificMatch(
       arch, Object.keys(entryModulesByArch));
-    // console.log("--> (project-context.js-Line: 1939)\n archinfo: ", archinfo);
-    // console.log("--> (project-context.js-Line: 1939)\n Object.keys(entryModulesByArch): ", Object.keys(entryModulesByArch));
 
     if (entryMatch) {
       const entryModule = entryModulesByArch[entryMatch];
-      console.log("--> (project-context.js-Line: 1944)\n entryModulesByArch: ", entryModulesByArch);
-      console.log("--> (project-context.js-Line: 1942)\n entryModule: ", entryModule);
 
       if (entryModule === false) {
         // If meteor.{main,test}Module.{client,server,...} === false, no
@@ -1976,7 +1969,6 @@ export class MeteorConfig {
         "./" + files.pathNormalize(entryModule),
         this.packageJsonPath
       );
-      console.log("--> (project-context.js-Line: 1970)\n res: ", res);
 
       if (res && typeof res === "object") {
         return files.pathRelative(this.appDirectory, res.path);

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1819,7 +1819,7 @@ export class MeteorConfig {
   // TODO Implement an API for setting these values?
   get(...keys) {
     let config = this._ensureInitialized();
-    let filteredConfig = keys.length ? undefined : config;
+    let filteredConfig = keys.length ? {} : config;
     if (config) {
       keys.every(key => {
         if (config && _.has(config, key)) {

--- a/v3-docs/docs/about/modern-build-stack/modern-transpiler-swc.md
+++ b/v3-docs/docs/about/modern-build-stack/modern-transpiler-swc.md
@@ -142,7 +142,7 @@ This overrides Meteor's internal SWC config to apply your settings, ensuring SWC
 - `modern.transpiler.verbose: [true|false]`
   If true, the transpilation process for files is shown when running the app. This helps understand which transpiler is used for each file, what fallbacks are applied, and gives a chance to either exclude files to always use Babel or migrate fully to SWC.
 
-## Migration guide
+## Migration Topics
 
 ### Nested imports
 

--- a/v3-docs/docs/about/modern-build-stack/modern-transpiler-swc.md
+++ b/v3-docs/docs/about/modern-build-stack/modern-transpiler-swc.md
@@ -144,7 +144,7 @@ This overrides Meteor's internal SWC config to apply your settings, ensuring SWC
 
 ## Migration Topics
 
-### Nested imports
+### Nested Imports
 
 Nested imports are a Meteor-specific feature in its bundler, unlike standard bundlers. Meteor introduced them during a time when bundling standards were still evolving and experimented with its own approach. This feature comes from the [`reify` module](https://github.com/benjamn/reify/tree/main) and works with Babel transpilation. SWC doesn't support them since they were never standardized.
 
@@ -190,7 +190,7 @@ To use the same aliases in SWC, add them to your [.swcrc](#custom-swcrc):
 
 This enables you to use `@ui/components` instead of `./ui/components` in your imports.
 
-### React runtime
+### React Runtime
 
 Meteor Babel lets you skip importing React in your files by using the [`@babel/plugin-transform-react-jsx`](https://www.npmjs.com/package/@babel/plugin-transform-react-jsx) runtime config.
 

--- a/v3-docs/docs/about/modern-build-stack/modern-transpiler-swc.md
+++ b/v3-docs/docs/about/modern-build-stack/modern-transpiler-swc.md
@@ -48,7 +48,7 @@ This shows each file being processed, its context, cache usage, and whether it f
 
 ## Adapt your code to benefit from SWC
 
-If all your code uses SWC, you're good and can turn off verbosity. But if you see logs like:
+If all your code uses SWC, you're good and can turn off verbosity. But if you [see logs like](https://forums.meteor.com/uploads/default/original/3X/e/1/e1a2c285284f82ab736bcada647d88bd4fa8d3ec.png):
 
 ``` shell
 [Transpiler] Used Babel for <file>     (<context>)     Fallback

--- a/v3-docs/docs/about/modern-build-stack/modern-transpiler-swc.md
+++ b/v3-docs/docs/about/modern-build-stack/modern-transpiler-swc.md
@@ -142,7 +142,7 @@ This overrides Meteor's internal SWC config to apply your settings, ensuring SWC
 - `modern.transpiler.verbose: [true|false]`
   If true, the transpilation process for files is shown when running the app. This helps understand which transpiler is used for each file, what fallbacks are applied, and gives a chance to either exclude files to always use Babel or migrate fully to SWC.
 
-## Related Topics
+## Migration guide
 
 ### Nested imports
 
@@ -170,6 +170,43 @@ if (condition) {
 For background, see: [Why nested import](https://github.com/benjamn/reify/blob/main/WHY_NEST_IMPORTS.md).
 
 With `"modern.transpiler": true`, if SWC finds one, it silently falls back to Babel (only shows in `"verbose": true`). Nested imports isn’t standard, most modern projects use other deferred loading methods. You might want to move imports to the top or use require instead, letting SWC handle the file and speeding up builds. Still, this decision is up to the devs, some Meteor devs use them for valid reasons.
+
+### Import Aliases
+
+Meteor Babel lets you define aliases for import paths with [babel-plugin-module-resolver](https://www.npmjs.com/package/babel-plugin-module-resolver).
+
+To use the same aliases in SWC, add them to your [.swcrc](#custom-swcrc):
+
+```json
+{
+  "jsc": {
+    "baseUrl": "./",
+    "paths": {
+      "@ui/*": ["ui/*"]
+    }
+  }
+}
+```
+
+This enables you to use `@ui/components` instead of `./ui/components` in your imports.
+
+### React runtime
+
+Meteor Babel lets you skip importing React in your files by using the [`@babel/plugin-transform-react-jsx`](https://www.npmjs.com/package/@babel/plugin-transform-react-jsx) runtime config.
+
+To use the same config in SWC, add it to your [.swcrc](#custom-swcrc):
+
+```json
+{
+  "jsc": {
+    "transform": {
+      "react": {
+        "runtime": "automatic"
+      }
+    }
+  }
+}
+```
 
 ## Troubleshotting
 


### PR DESCRIPTION
This PR updates 3.3 for better compatibility with Meteor apps. While adapting a few examples, I encountered edge cases that need fixing. I also updated docs to explain further migration quick guiding.

## Meteor config fix

Meteor config breaks if mainModule is missing but testModule is set and modern config is added. I fixed the utility to output as expected and prevent the error. If tests still fail, I’ll explore another approach.