### PR TITLE
Fix for CircleCI PR branch checkout issue 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,9 +767,12 @@ jobs:
               PR_BRANCH=$(curl -s https://api.github.com/repos/meteor/meteor/pulls/$PR_NUMBER | jq -r .head.ref)
               git clone https://github.com/meteor/meteor.git ${CHECKOUT_METEOR_DOCS}
               cd ${CHECKOUT_METEOR_DOCS}
-              git fetch origin pull/$PR_NUMBER/head:$PR_BRANCH
+              git fetch origin pull/$PR_NUMBER/head:PR-$PR_NUMBER
+              git checkout PR-$PR_NUMBER
             else
-              git clone --branch $CIRCLE_BRANCH https://github.com/meteor/meteor.git ${CHECKOUT_METEOR_DOCS}
+              git clone https://github.com/meteor/meteor.git ${CHECKOUT_METEOR_DOCS}
+              cd ${CHECKOUT_METEOR_DOCS}
+              git checkout $CIRCLE_BRANCH
             fi
       # Run almost the same steps the meteor/docs repository runs, minus deploy.
       - run:


### PR DESCRIPTION

## Summary
- Fixes the CircleCI build failures by properly checking out PR branches
- Ensures correct branch checkout when building documentation

## Test plan
- CircleCI builds should now pass without errors
- PR branches should be properly checked out during the documentation build step
