### PR TITLE
Support swc.config.js file for dynamic config

### DIFF
--- a/v3-docs/docs/about/modern-build-stack/transpiler-swc.md
+++ b/v3-docs/docs/about/modern-build-stack/transpiler-swc.md
@@ -210,7 +210,7 @@ var adminAliases = {
 module.exports = {
     jsc: {
         baseUrl: "./",
-        paths: mode === "USER" ? uiAliases : adminAliases,
+        paths: mode === "USER" ? userAliases : adminAliases,
     },
 };
 ```

--- a/v3-docs/docs/about/modern-build-stack/transpiler-swc.md
+++ b/v3-docs/docs/about/modern-build-stack/transpiler-swc.md
@@ -200,11 +200,11 @@ You can use `swc.config.js` to define different aliases based on an environment 
 var mode = process.env.MODE_ENV;
 
 var userAliases = {
-  "@user/*": ["user/*"],
+  "@ui/*": ["user/*"],
 };
 
 var adminAliases = {
-  "@admin/*": ["admin/*"],
+  "@ui/*": ["admin/*"],
 };
 
 module.exports = {

--- a/v3-docs/docs/about/modern-build-stack/transpiler-swc.md
+++ b/v3-docs/docs/about/modern-build-stack/transpiler-swc.md
@@ -121,6 +121,10 @@ You can also configure other options using the `.swcrc` format. One common case 
 
 This overrides Meteor's internal SWC config to apply your settings, ensuring SWC processes `.js` or `.ts` files with React components without falling back to Babel.
 
+Use `swc.config.js` in your project root for dynamic configuration. Meteor will import and apply the SWC config automatically. This lets you choose a config based on environment variables or other runtime factors.
+
+Explore additional custom SWC configs, including ["Import Aliases"](#import-aliases) and ["React Runtime"](#react-runtime).
+
 ## Config API
 
 - `modern.transpiler: [true|false]` - Default: `true`
@@ -188,6 +192,27 @@ To use the same aliases in SWC, add them to your [.swcrc](#custom-swcrc):
     }
   }
 }
+```
+
+You can use `swc.config.js` to define different aliases based on an environment variable.
+
+``` js
+var mode = process.env.MODE_ENV;
+
+var userAliases = {
+  "@user/*": ["user/*"],
+};
+
+var adminAliases = {
+  "@admin/*": ["admin/*"],
+};
+
+module.exports = {
+    jsc: {
+        baseUrl: "./",
+        paths: mode === "USER" ? uiAliases : adminAliases,
+    },
+};
 ```
 
 This enables you to use `@ui/components` instead of `./ui/components` in your imports.


### PR DESCRIPTION
<!-- OSS-767 -->
<!-- OSS-768) -->

Context: https://forums.meteor.com/t/weekly-update-april-16-2025-faster-bundle-times-with-3-3-beta-0/63494/35

This PR adds support for dynamic `swc.config.js`, so Meteor projects can define configs that change based on environment variables or other factors. It also ensures that the cache key includes the generated config, so restarting the app with new variables recompiles with the new config.

I verified that METEOR_LOCAL_DIR is respected and the SWC cache still uses the configured directory.
