### PR TITLE
Skip error saying events were dropped since watcher still is alive

### DIFF
--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -301,10 +301,13 @@ async function ensureWatchRoot(dirPath: string): Promise<void> {
         osDirPath,
         (err, events) => {
           if (err) {
-            console.error(`Parcel watcher error on ${osDirPath}:`, err);
+            if (/Events were dropped/.test(err.message)) {
+              return;
+            }
             // Only disable native watching for critical errors (like ENOSPC).
             // @ts-ignore
             if (err.code === "ENOSPC" || err.errno === require("constants").ENOSPC) {
+              console.log('fallbackToPolling');
               fallbackToPolling();
             }
             watchRoots.delete(dirPath);

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -304,6 +304,7 @@ async function ensureWatchRoot(dirPath: string): Promise<void> {
             if (/Events were dropped/.test(err.message)) {
               return;
             }
+            console.error(`Parcel watcher error on ${osDirPath}:`, err);
             // Only disable native watching for critical errors (like ENOSPC).
             // @ts-ignore
             if (err.code === "ENOSPC" || err.errno === require("constants").ENOSPC) {

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -307,7 +307,6 @@ async function ensureWatchRoot(dirPath: string): Promise<void> {
             // Only disable native watching for critical errors (like ENOSPC).
             // @ts-ignore
             if (err.code === "ENOSPC" || err.errno === require("constants").ENOSPC) {
-              console.log('fallbackToPolling');
               fallbackToPolling();
             }
             watchRoots.delete(dirPath);


### PR DESCRIPTION
<!-- OSS-766 -->

This PR filters `"Events were dropped by the FSEvents client. File system must be re-scanned"` error since is non-fatal and doesn't end the watcher when it happens. `@parcel/watcher` never closes the stream on an FSEvents overflow, it just invokes thecallback with an err, then keeps on going. By checking for the “Events were dropped” substring and returning early, we skip just the overflow notices and continue receiving subsequent events.

