### PR TITLE
DEV: update node-stubs version and remove elliptic dependency

### DIFF
--- a/npm-packages/meteor-node-stubs/package-lock.json
+++ b/npm-packages/meteor-node-stubs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meteor-node-stubs",
-  "version": "1.2.12",
+  "version": "1.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meteor-node-stubs",
-      "version": "1.2.12",
+      "version": "1.2.18",
       "bundleDependencies": [
         "@meteorjs/crypto-browserify",
         "assert",
@@ -41,7 +41,6 @@
         "console-browserify": "^1.2.0",
         "constants-browserify": "^1.0.0",
         "domain-browser": "^4.23.0",
-        "elliptic": "^6.6.1",
         "events": "^3.3.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",

--- a/npm-packages/meteor-node-stubs/package.json
+++ b/npm-packages/meteor-node-stubs/package.json
@@ -2,7 +2,7 @@
   "name": "meteor-node-stubs",
   "author": "Ben Newman <ben@meteor.com>",
   "description": "Stub implementations of Node built-in modules, a la Browserify",
-  "version": "1.2.13",
+  "version": "1.2.18",
   "main": "index.js",
   "license": "MIT",
   "homepage": "https://github.com/meteor/meteor/blob/devel/npm-packages/meteor-node-stubs/README.md",
@@ -18,7 +18,6 @@
     "console-browserify": "^1.2.0",
     "constants-browserify": "^1.0.0",
     "domain-browser": "^4.23.0",
-    "elliptic": "^6.6.1",
     "events": "^3.3.0",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",
@@ -81,5 +80,30 @@
   ],
   "bugs": {
     "url": "https://github.com/meteor/node-stubs/issues"
-  }
+  },
+  "bundleDependencies": [
+    "@meteorjs/crypto-browserify",
+    "assert",
+    "browserify-zlib",
+    "buffer",
+    "console-browserify",
+    "constants-browserify",
+    "domain-browser",
+    "events",
+    "https-browserify",
+    "os-browserify",
+    "path-browserify",
+    "process",
+    "punycode",
+    "querystring-es3",
+    "readable-stream",
+    "stream-browserify",
+    "stream-http",
+    "string_decoder",
+    "timers-browserify",
+    "tty-browserify",
+    "url",
+    "util",
+    "vm-browserify"
+  ]
 }


### PR DESCRIPTION
We don't have any reference from elliptic in the meteor-node-stub pkg
https://www.npmjs.com/package/meteor-node-stubs

<img width="575" alt="Screenshot 2025-05-21 at 15 06 06" src="https://github.com/user-attachments/assets/9a45bf3f-7429-4772-8aa8-06ab8e6682af" />
