### PR TITLE
Fix modern transpiler config

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -329,7 +329,7 @@ BCp.processOneFileForTarget = function (inputFile, source) {
         const isLegacyWebArch = arch.includes('legacy');
 
         const config = lastModifiedMeteorConfig?.modern?.transpiler;
-        const hasModernTranspiler = lastModifiedMeteorConfig?.modern?.transpiler !== false;
+        const hasModernTranspiler = config != null && config !== false;
         const shouldSkipSwc =
           !hasModernTranspiler ||
           (isAppCode && config?.excludeApp === true) ||


### PR DESCRIPTION
This PR solves an issue that caused the SWC modern config enabled when not provided.

This explains why some scenarios with compiler plugins caused breaks, as it tried to use SWC even when disabled. Meteor 3.3 shouldn’t introduce breaking changes, and you should still be able to use Babel when modern not set.