### PR TITLE
Allow mutation of file content in version bump script

### DIFF
--- a/scripts/admin/bump-all-version-numbers.js
+++ b/scripts/admin/bump-all-version-numbers.js
@@ -7,7 +7,7 @@ const packageNames = process.argv.slice(2);
 packageNames.forEach(name => {
   // name = "packages/" + name + "/package.js";
 
-  const content = fs.readFileSync(name, {encoding: "utf-8"});
+  let content = fs.readFileSync(name, {encoding: "utf-8"});
 
   const match = content.match(/\d+\.\d+\.\d+-winr.\d+/);
   if (match) {

--- a/v3-docs/docs/tutorials/react/9.next-steps.md
+++ b/v3-docs/docs/tutorials/react/9.next-steps.md
@@ -2,7 +2,7 @@
 
 You have completed the tutorial!
 
-By now, you should have a good understanding of working with Meteor and Vue.
+By now, you should have a good understanding of working with Meteor and React.
 
 ::: info
 You can find the final version of this app in our [GitHub repository](https://github.com/meteor/meteor3-react).


### PR DESCRIPTION
## PR Summary
This small PR updates the `bump-all-version-numbers.js` script to use `let` instead of `const` for the content variable. Since the file content is modified after being read, using `const` caused a reassignment error. This change allows safe in-place modification of the file content before writing it back.