### PR TITLE
fix uninstall commands

### DIFF
--- a/v3-docs/docs/about/install.md
+++ b/v3-docs/docs/about/install.md
@@ -141,5 +141,7 @@ npx meteor uninstall
 
 If you installed Meteor using curl or as a fallback solution, run:
 
-`rm -rf ~/.meteor`
-`sudo rm /usr/local/bin/meteor`
+```bash
+rm -rf ~/.meteor
+sudo rm /usr/local/bin/meteor
+```


### PR DESCRIPTION
The way the uninstall commands are currently formatted, they run together into a single line, which could in some rare cases (i.e. there are files in the current directory named "sudo" or "rm") cause data loss. Reformatting fixes this issue.