### PR TITLE
Fix edges cases on swc config cache invalidation

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -139,7 +139,9 @@ BCp.initializeMeteorAppSwcrc = function () {
   let currentLastModifiedConfigTime;
   if (hasSwcJs) {
     // For dynamic JS files, first get the resolved configuration
-    const resolvedConfig = lastModifiedSwcConfig || getMeteorAppSwcrc(swcFile);
+    const resolvedConfig = lastModifiedSwcConfigTime?.includes(`${fileModTime}`)
+      ? lastModifiedSwcConfig || getMeteorAppSwcrc(swcFile)
+      : getMeteorAppSwcrc(swcFile);
     // Calculate a hash of the resolved configuration to detect changes
     const contentHash = crypto
       .createHash('sha256')
@@ -161,6 +163,8 @@ BCp.initializeMeteorAppSwcrc = function () {
     if (this.isVerbose(lastModifiedMeteorConfig)) {
       logConfigBlock('SWC Config', lastModifiedSwcConfig);
     }
+
+    this._swcIncompatible = {};
   }
   return lastModifiedSwcConfig;
 };


### PR DESCRIPTION
<!-- OSS-799 -->

Context: https://github.com/meteor/meteor/issues/13796

This PR fixes cache invalidation edge cases when modifying the .swcrc or swc.config.js files.