### PR TITLE
Fix regression on recompile behavior

### DIFF
--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1821,13 +1821,17 @@ export class MeteorConfig {
     let config = this._ensureInitialized();
     let filteredConfig = keys.length ? {} : config;
     if (config) {
-      keys.every(key => {
-        if (config && _.has(config, key)) {
-          filteredConfig = config[key];
-          return true;
-        }
-        return false;
-      });
+      const subConfig = config[keys[0]];
+      if (subConfig) {
+        filteredConfig = subConfig;
+        const [, ...subConfigKeys] = keys;
+        subConfigKeys.every(key => {
+          if (filteredConfig && _.has(filteredConfig, key)) {
+            filteredConfig = filteredConfig[key];
+            return true;
+          }
+        });
+      }
       return filteredConfig;
     }
   }

--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1818,22 +1818,14 @@ export class MeteorConfig {
   // General utility for querying the "meteor" section of package.json.
   // TODO Implement an API for setting these values?
   get(...keys) {
-    let config = this._ensureInitialized();
-    let filteredConfig = keys.length ? {} : config;
-    if (config) {
-      const subConfig = config[keys[0]];
-      if (subConfig) {
-        filteredConfig = subConfig;
-        const [, ...subConfigKeys] = keys;
-        subConfigKeys.every(key => {
-          if (filteredConfig && _.has(filteredConfig, key)) {
-            filteredConfig = filteredConfig[key];
-            return true;
-          }
-        });
-      }
-      return filteredConfig;
-    }
+    const config = this._ensureInitialized();
+    if (!config) return undefined;
+
+    return keys.reduce((cur, key) => {
+      return (cur != null && _.has(cur, key))
+        ? cur[key]
+        : undefined;
+    }, config);
   }
 
   getNodeModulesToRecompileByArch() {

--- a/tools/tests/apps/modern/package.json
+++ b/tools/tests/apps/modern/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "config": "file:../config-package",
     "meteor-node-stubs": "^1.2.12",
     "react": "^18.3.1"
   },

--- a/tools/tests/modern.js
+++ b/tools/tests/modern.js
@@ -188,8 +188,34 @@ selftest.define("modern build stack - transpiler boolean-like options", async fu
   const s = new Sandbox();
   await s.init();
 
+  s.mkdir("config-package");
+  s.cd("config-package");
+
+  s.write(
+    "package.json",
+    JSON.stringify({
+      name: "config",
+      version: "1.2.3",
+      "private": true,
+      main: "index.js"
+    }, null, 2) + "\n"
+  );
+
+  s.write(
+    "index.js",
+    "exports.id = module.id;\n"
+  );
+
+  s.cd(s.home);
+
   await s.createApp("modern", "modern");
   await s.cd("modern");
+
+  s.append(
+    "server/main.js",
+    `if (require('config')) {
+  console.log('Loaded NPM package "config"', require('config').id);
+}`);
 
   process.env.METEOR_DISABLE_COLORS = true;
 
@@ -204,6 +230,9 @@ selftest.define("modern build stack - transpiler boolean-like options", async fu
   run.waitSecs(waitToStart);
   await run.match("App running at");
 
+  /* check appended NPM package require */
+  await run.match(/Loaded NPM package "config"/, false, true);
+
   /* check verbose logs */
   await run.match(/SWC Config/, false, true);
   await run.match(/SWC Legacy Config/, false, true);
@@ -212,6 +241,7 @@ selftest.define("modern build stack - transpiler boolean-like options", async fu
   /* check transpiler options */
   await run.match(/\[Transpiler] Used SWC.*\(app\)/, false, true);
   await run.match(/\[Transpiler] Used SWC.*\(package\)/, false, true);
+  run.forbid(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
 
   await writeModernConfig(s, {
     transpiler: {
@@ -229,6 +259,20 @@ selftest.define("modern build stack - transpiler boolean-like options", async fu
   });
   await run.match(/\[Transpiler] Used Babel.*\(package\)/, false, true);
 
+  await writeConfig(s, {
+    modern: {
+      transpiler: {
+        verbose: true,
+      },
+    },
+    nodeModules: {
+      recompile: {
+        config: true,
+      },
+    },
+  });
+  await run.match(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
+
   await run.stop();
 
   process.env.METEOR_MODERN = currentMeteorModern;
@@ -241,8 +285,33 @@ selftest.define("modern build stack - transpiler string-like options", async fun
   const s = new Sandbox();
   await s.init();
 
+  s.mkdir("config-package");
+  s.cd("config-package");
+
+  s.write(
+    "package.json",
+    JSON.stringify({
+      name: "config",
+      version: "1.2.3",
+      "private": true,
+      main: "index.js"
+    }, null, 2) + "\n"
+  );
+
+  s.write(
+    "index.js",
+    "exports.id = module.id;\n"
+  );
+
+  s.cd(s.home);
+
   await s.createApp("modern", "modern");
   await s.cd("modern");
+
+  s.append(
+    "server/main.js",
+    `import { id } from 'config';
+console.log('Loaded NPM package "config"', require('config').id);`);
 
   process.env.METEOR_DISABLE_COLORS = true;
 
@@ -257,6 +326,9 @@ selftest.define("modern build stack - transpiler string-like options", async fun
   run.waitSecs(waitToStart);
   await run.match("App running at");
 
+  /* check appended NPM package imported */
+  await run.match(/Loaded NPM package "config"/, false, true);
+
   /* check verbose logs */
   await run.match(/SWC Config/, false, true);
   await run.match(/SWC Legacy Config/, false, true);
@@ -265,6 +337,7 @@ selftest.define("modern build stack - transpiler string-like options", async fun
   /* check transpiler options */
   await run.match(/\[Transpiler] Used SWC.*\(app\)/, false, true);
   await run.match(/\[Transpiler] Used SWC.*\(package\)/, false, true);
+  run.forbid(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
 
   await writeModernConfig(s, {
     transpiler: {
@@ -281,6 +354,20 @@ selftest.define("modern build stack - transpiler string-like options", async fun
     },
   });
   await run.match(/\[Transpiler] Used Babel.*\(package\)/, false, true);
+
+  await writeConfig(s, {
+    modern: {
+      transpiler: {
+        verbose: true,
+      },
+    },
+    nodeModules: {
+      recompile: {
+        config: true,
+      },
+    },
+  });
+  await run.match(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
 
   await run.stop();
 

--- a/v3-docs/docs/about/install.md
+++ b/v3-docs/docs/about/install.md
@@ -141,5 +141,7 @@ npx meteor uninstall
 
 If you installed Meteor using curl or as a fallback solution, run:
 
-`rm -rf ~/.meteor`
-`sudo rm /usr/local/bin/meteor`
+```bash
+rm -rf ~/.meteor
+sudo rm /usr/local/bin/meteor
+```


### PR DESCRIPTION
<!-- OSS-801 -->

This PR fixes a regression in Meteor config recompile behavior.

When adding support for the modern option in Meteor 3.3, the config reader was changed and `nodeModules.recompile` stopped being picked up. No existing tests covered this case.

This update restores correct handling of both modern and nodeModules.recompile without errors.

## Regression vs fix

``` json

"meteor": {
    "mainModule": {
      "client": "ui/main.jsx",
      "server": "api/main.js"
    },
    "testModule":  "tests/main.js",
    "modern": true,
    "nodeModules": {
      "recompile": {
        "pdfjs-dist": true
      }
    }
  },
```

![image](https://github.com/user-attachments/assets/b7e0ebe0-531a-48fd-b9b5-31ab243cc6b3)

## Pending

- [x] Add a regression test to verify nodeModules.recompile options in various configs
- [x] Verify how nodeModules.recompile behaves in SWC