### PR TITLE
Ensure @swc/helpers usage to optimize bundle size and performance

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -324,7 +324,11 @@ BCp.processOneFileForTarget = function (inputFile, source) {
             jsx: hasJSXSupport,
             tsx: hasTSXSupport,
           },
-          ...(hasSwcHelpersAvailable && { externalHelpers: true }),
+          ...(hasSwcHelpersAvailable &&
+            (packageName == null ||
+              !['modules-runtime'].includes(packageName)) && {
+              externalHelpers: true,
+            }),
         },
         module: { type: 'es6' },
         minify: false,

--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -34,6 +34,9 @@ BCp.isVerbose = function(config = getMeteorConfig()) {
   if (config?.modern?.transpiler?.verbose) {
     return true;
   }
+  if (config?.modern?.verbose) {
+    return true;
+  }
   if (config?.verbose) {
     return true;
   }
@@ -129,7 +132,7 @@ BCp.initializeMeteorAppSwcrc = function () {
     lastModifiedSwcConfig = getMeteorAppSwcrc(swcFile);
 
     if (this.isVerbose()) {
-      logConfigBlock('SWC Config', lastModifiedSwcConfig);
+      logConfigBlock('SWC Custom Config', lastModifiedSwcConfig);
     }
   }
   return lastModifiedSwcConfig;
@@ -145,6 +148,42 @@ BCp.initializeMeteorAppLegacyConfig = function () {
   return lastModifiedSwcConfig;
 };
 
+// Helper function to check if @swc/helpers is available
+function hasSwcHelpers() {
+  return fs.existsSync(`${getMeteorAppDir()}/node_modules/@swc/helpers`);
+}
+
+// Helper function to log friendly messages about SWC helpers
+function logSwcHelpersStatus(isAvailable) {
+  const label = color('[SWC Helpers]', 36);
+
+  if (isAvailable) {
+    // Green message for when helpers are available
+    console.log(`${label} ${color('✓ @swc/helpers is available in your project!', 32)}`);
+    console.log(`  ${color('Benefits:', 32)}`);
+    console.log(`  ${color('• Smaller bundle size: External helpers reduce code duplication', 32)}`);
+    console.log(`  ${color('• Faster loads: less code to parse on first download', 32)}`);
+    console.log(`  ${color('• Optional caching: separate vendor chunk can be cached by browsers', 32)}`);
+  } else {
+    // Yellow message for when helpers are not available
+    console.log(`${label} ${color('⚠ @swc/helpers is not available in your project', 33)}`);
+    console.log(`  ${color('Suggestion:', 33)}`);
+    console.log(`  ${color('• Add @swc/helpers to your project:', 33)}`);
+    console.log(`    ${color('meteor npm install --save @swc/helpers', 33)}`);
+    console.log(`  ${color('• This will reduce bundle size and improve performance', 33)}`);
+  }
+  console.log();
+}
+
+let hasSwcHelpersAvailable = false;
+BCp.initializeMeteorAppSwcHelpersAvailable = function () {
+  hasSwcHelpersAvailable = hasSwcHelpers();
+  if (this.isVerbose()) {
+    logSwcHelpersStatus(hasSwcHelpersAvailable);
+  }
+  return hasSwcHelpersAvailable;
+};
+
 BCp.processFilesForTarget = function (inputFiles) {
   var compiler = this;
 
@@ -154,6 +193,7 @@ BCp.processFilesForTarget = function (inputFiles) {
   this.initializeMeteorAppConfig();
   this.initializeMeteorAppSwcrc();
   this.initializeMeteorAppLegacyConfig();
+  this.initializeMeteorAppSwcHelpersAvailable();
 
   inputFiles.forEach(function (inputFile) {
     if (inputFile.supportsLazyCompilation) {
@@ -284,6 +324,7 @@ BCp.processOneFileForTarget = function (inputFile, source) {
             jsx: hasJSXSupport,
             tsx: hasTSXSupport,
           },
+          ...(hasSwcHelpersAvailable && { externalHelpers: true }),
         },
         module: { type: 'es6' },
         minify: false,
@@ -356,6 +397,7 @@ BCp.processOneFileForTarget = function (inputFile, source) {
           toBeAdded.hash,
           lastModifiedSwcConfigTime,
           isLegacyWebArch ? 'legacy' : '',
+          hasSwcHelpersAvailable,
         ]
           .filter(Boolean)
           .join('-');

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -11,6 +11,7 @@
     "@apollo/client": "^3.9.2",
     "@apollo/server": "^4.10.0",
     "@babel/runtime": "^7.23.9",
+    "@swc/helpers": "^0.5.17",
     "graphql": "^16.8.1",
     "meteor-node-stubs": "^1.2.12",
     "react": "^18.2.0",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "jquery": "^3.7.1",
     "meteor-node-stubs": "^1.2.12"
   },

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "@chakra-ui/icons": "^1.1.7",
     "@chakra-ui/react": "^1.8.8",
     "@emotion/react": "^11.9.3",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -7,10 +7,18 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "jquery": "^3.7.1",
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
     "chai": "^4.2.0"
+  },
+  "meteor": {
+    "mainModule": {
+      "client": "client/main.js",
+      "server": "server/main.js"
+    },
+    "modern": true
   }
 }

--- a/tools/static-assets/skel-minimal/package.json
+++ b/tools/static-assets/skel-minimal/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "meteor-node-stubs": "^1.2.12"
   },
   "meteor": {

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "meteor-node-stubs": "^1.2.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.9",
+    "@swc/helpers": "^0.5.17",
     "meteor-node-stubs": "^1.2.12",
     "picocolors": "^1.1.1",
     "solid-js": "^1.9.4"

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "meteor-node-stubs": "^1.2.12",
     "svelte": "^3.59.2"
   },

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "autoprefixer": "^10.4.4",
     "meteor-node-stubs": "^1.2.12",
     "postcss": "^8.4.12",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "meteor-node-stubs": "^1.2.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@swc/helpers": "^0.5.17",
     "meteor-node-stubs": "^1.2.12",
     "vue": "^3.3.9",
     "vue-meteor-tracker": "^3.0.0-beta.7",

--- a/tools/tests/modern.js
+++ b/tools/tests/modern.js
@@ -234,7 +234,7 @@ selftest.define("modern build stack - transpiler boolean-like options", async fu
   await run.match(/Loaded NPM package "config"/, false, true);
 
   /* check verbose logs */
-  await run.match(/SWC Config/, false, true);
+  await run.match(/SWC Custom Config/, false, true);
   await run.match(/SWC Legacy Config/, false, true);
   await run.match(/Meteor Config/, false, true);
 
@@ -330,7 +330,7 @@ console.log('Loaded NPM package "config"', require('config').id);`);
   await run.match(/Loaded NPM package "config"/, false, true);
 
   /* check verbose logs */
-  await run.match(/SWC Config/, false, true);
+  await run.match(/SWC Custom Config/, false, true);
   await run.match(/SWC Legacy Config/, false, true);
   await run.match(/Meteor Config/, false, true);
 

--- a/v3-docs/docs/about/modern-build-stack/transpiler-swc.md
+++ b/v3-docs/docs/about/modern-build-stack/transpiler-swc.md
@@ -100,6 +100,20 @@ Most apps will benefit just by enabling `modern: true`. Most Meteor packages sho
 
 > Remember to turn off verbosity when you're done with optimizations.
 
+## Externalize SWC Helpers
+
+By default, SWC inlines transformation helpers (e.g. _extends, _objectSpread) into every file that uses them. While this ensures compatibility out of the box, it can lead to duplicated code across your bundles increasing bundle size.
+
+To centralize these helpers and keep your client builds lean, you can add the `@swc/helpers` in your app project.
+
+``` bash
+meteor npm install --save @swc/helpers
+```
+
+> This package is installed by default for new apps.
+
+Meteor’s build tool comes pre-configured to externalize SWC helpers for you, no extra setup or .swcrc tweaks are needed. As soon as you install @swc/helpers, Meteor’s SWC pipeline will automatically emit imports for shared helper functions rather than inlining them, ensuring your app ships each helper just once.
+
 ## Custom .swcrc
 
 You can use `.swcrc` config in the root of your project to describe specific [SWC plugins](https://github.com/swc-project/plugins) there, that will be applied to compile the entire files of your project.


### PR DESCRIPTION
<!-- OSS-806 -->

This PR adopts [`@swc/helpers` as a project dependency](https://swc.rs/docs/configuration/compilation#jscexternalhelpers) and configures SWC to load shared helper functions from that package instead of inlining them. This will reduce the bundle size and improve JS loading.

## Issue

Deploying a Meteor 3.3 app ([fredmaiaarantes/simpletasks](https://github.com/fredmaiaarantes/simpletasks)) to Galaxy increases the client bundle size by about 20 KB (~1.7 MB), due to inline SWC helpers being duplicated in each file.

![image](https://github.com/user-attachments/assets/72dca798-3155-435f-85c7-381714c2c627)

Installing @swc/helpers in your project returns the size to about 1.5 MB.

![image](https://github.com/user-attachments/assets/1d3f89a3-c469-4f76-9ced-fd73ca4244ef)

To promote its usage by default any new Meteor app will include @swc/helpers. Besides, as part of [modern.transpiler.verbose](https://docs.meteor.com/about/modern-build-stack/transpiler-swc.html#verbose-transpilation-process) mode, it will be a warning to add it for existing projects.

![image](https://github.com/user-attachments/assets/ed1b03a2-fb3d-4a30-96b6-b8377263d8c7)

This is a regression likely to be introduced in Meteor 3.3.1. Total size on server bundle is also affected by the addition of SWC and only devOnly deps on final bundle, **but that will be covered on [a new feature of dev only packages later](https://github.com/meteor/meteor/pull/13797)**.