### PR TITLE
Fix `meteor profile` cloning in some volume

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=22.16.0.1
+BUNDLE_VERSION=22.16.0.2
 
 # OS Check. Put here because here is where we download the precompiled
 # bundles that are arch specific.

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -3439,7 +3439,7 @@ const setupBenchmarkSuite = async (profilingPath) => {
       `git sparse-checkout set scripts`,
       `git checkout ${branch}`,
       `mkdir -p ${profilingPath}/scripts`,
-      `tar --exclude=".*" -czf /tmp/scripts.tar.gz -C ./scripts .`,
+      `tar -czf /tmp/scripts.tar.gz -C ./scripts .`,
       `tar -xzf /tmp/scripts.tar.gz -C ${profilingPath}/scripts`,
       `rm -rf ${tempDir}`,
       `rm -f /tmp/scripts.tar.gz`


### PR DESCRIPTION
<!-- OSS-800 -->

This PR fixes an issue when running `meteor profile` on certain volumes. Git can’t clone directly there, so it now clone to /tmp folder and uses tar to move it into the volumes. Only if tar is available this approach is more robust and preferable, otherwise the current git clone will be used.