### PR TITLE
Upgrade Cordova 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ run_save_node_bin: &run_save_node_bin
 build_machine_environment:
   &build_machine_environment # Specify that we want an actual machine (ala Circle 1.0), not a Docker image.
   docker:
-    - image: meteor/circleci:android-35-node-22
+    - image: meteor/circleci:2025.07.7-android-35-node-22
   resource_class: large
   environment:
     # This multiplier scales the waitSecs for selftests.
@@ -756,7 +756,7 @@ jobs:
   Docs:
     docker:
       # This Node version should match that in the meteor/docs CircleCI config.
-      - image: meteor/circleci:android-35-node-22
+      - image: meteor/circleci:2025.07.7-android-35-node-22
     resource_class: large
     environment:
       CHECKOUT_METEOR_DOCS: /home/circleci/test_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ run_save_node_bin: &run_save_node_bin
 build_machine_environment:
   &build_machine_environment # Specify that we want an actual machine (ala Circle 1.0), not a Docker image.
   docker:
-    - image: meteor/circleci:2025.07.7-android-35-node-22
+    - image: meteor/circleci:2025.07.8-android-35-node-22
   resource_class: large
   environment:
     # This multiplier scales the waitSecs for selftests.
@@ -756,7 +756,7 @@ jobs:
   Docs:
     docker:
       # This Node version should match that in the meteor/docs CircleCI config.
-      - image: meteor/circleci:2025.07.7-android-35-node-22
+      - image: meteor/circleci:2025.07.8-android-35-node-22
     resource_class: large
     environment:
       CHECKOUT_METEOR_DOCS: /home/circleci/test_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ run_save_node_bin: &run_save_node_bin
 build_machine_environment:
   &build_machine_environment # Specify that we want an actual machine (ala Circle 1.0), not a Docker image.
   docker:
-    - image: meteor/circleci:2024.09.11-android-34-node-20
+    - image: meteor/circleci:2024.09.11-android-35-node-22
   resource_class: large
   environment:
     # This multiplier scales the waitSecs for selftests.
@@ -756,7 +756,7 @@ jobs:
   Docs:
     docker:
       # This Node version should match that in the meteor/docs CircleCI config.
-      - image: meteor/circleci:2024.09.11-android-34-node-20
+      - image: meteor/circleci:2024.09.11-android-35-node-22
     resource_class: large
     environment:
       CHECKOUT_METEOR_DOCS: /home/circleci/test_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ run_save_node_bin: &run_save_node_bin
 build_machine_environment:
   &build_machine_environment # Specify that we want an actual machine (ala Circle 1.0), not a Docker image.
   docker:
-    - image: meteor/circleci:2024.09.11-android-35-node-22
+    - image: meteor/circleci:android-35-node-22
   resource_class: large
   environment:
     # This multiplier scales the waitSecs for selftests.
@@ -756,7 +756,7 @@ jobs:
   Docs:
     docker:
       # This Node version should match that in the meteor/docs CircleCI config.
-      - image: meteor/circleci:2024.09.11-android-35-node-22
+      - image: meteor/circleci:android-35-node-22
     resource_class: large
     environment:
       CHECKOUT_METEOR_DOCS: /home/circleci/test_docs

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -13,11 +13,11 @@ export const CORDOVA_ARCH = "web.cordova";
 
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
-const CORDOVA_ANDROID_VERSION = "13.0.0";
+const CORDOVA_ANDROID_VERSION = "14.0.1";
 
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
-  'cordova-lib': '12.0.1',
-  'cordova-common': '5.0.0',
+  'cordova-lib': '12.0.2',
+  'cordova-common': '5.0.1',
   'cordova-create': '2.0.0',
   'cordova-registry-mapper': '1.1.15',
   'cordova-android': CORDOVA_ANDROID_VERSION,

--- a/v3-docs/docs/about/cordova.md
+++ b/v3-docs/docs/about/cordova.md
@@ -73,7 +73,7 @@ $env:PATH += ";%JAVA_HOME%\bin"
 
 For Android builds, you will need the Android SDK. You can install it via [Android Studio](https://developer.android.com/studio).
 
-Once Android Studio is installed, go to **SDK Manager** and install the required SDK packages. The minimum required version is Android SDK 34. Install the `Android SDK Command-line Tools (latest)` as well.
+Once Android Studio is installed, go to **SDK Manager** and install the required SDK packages. The minimum required version is Android SDK 35. Install the `Android SDK Command-line Tools (latest)` as well.
 
 Ensure `ANDROID_HOME` environment variable is set by adding it to `~/.bashrc` or `~/.zshrc` :
 


### PR DESCRIPTION
<!-- OSS-815 -->

This PR upgrades Cordova deps, mainly for cordova-android and its support with API 35.

After install API 35 SDK the app loaded properly. It should work well, but we should hightlight the changelog for each app specifics migrations, https://cordova.apache.org/announcements/2025/03/26/cordova-android-14.0.0.html

![image](https://github.com/user-attachments/assets/b18449cb-155c-466d-9262-31dc3f423754)

