### PR TITLE
Update and match SWC 1.12.14 version

### DIFF
--- a/packages/babel-compiler/package.js
+++ b/packages/babel-compiler/package.js
@@ -8,7 +8,7 @@ Npm.depends({
   '@meteorjs/babel': '7.20.1',
   'json5': '2.2.3',
   'semver': '7.6.3',
-  "@meteorjs/swc-core": "1.1.3",
+  "@meteorjs/swc-core": "1.12.14",
 });
 
 Package.onUse(function (api) {

--- a/packages/standard-minifier-js/package.js
+++ b/packages/standard-minifier-js/package.js
@@ -12,7 +12,7 @@ Package.registerBuildPlugin({
     'ecmascript'
   ],
   npmDependencies: {
-    '@meteorjs/swc-core': '1.1.3',
+    '@meteorjs/swc-core': '1.12.14',
     'acorn': '8.10.0',
     "@babel/runtime": "7.18.9",
     '@babel/parser': '7.22.7',


### PR DESCRIPTION
<!-- OSS-820 -->

This PR updates SWC to version 1.12.14 (from 1.11.24) and ensures the [@meteorjs/swc-core](https://github.com/meteor/meteor-package-install-swc/tree/core) npm package matches the swc-core version, so the current SWC release is correctly recognized.