### PR TITLE
Enable modern browser support for Cordova unless explicitly disabled

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -249,6 +249,11 @@ BCp.processOneFileForTarget = function (inputFile, source) {
       features.nodeMajorVersion = parseInt(process.versions.node, 10);
     } else if (arch === "web.browser") {
       features.modernBrowsers = true;
+    } else if (arch === "web.cordova") {
+
+      if (process.env["METEOR_CORDOVA_DISABLE_MODERN_BROWSERS"] != "Y")
+        features.modernBrowsers = true;
+
     }
 
     features.topLevelAwait = inputFile.supportsTopLevelAwait &&

--- a/v3-docs/docs/about/cordova.md
+++ b/v3-docs/docs/about/cordova.md
@@ -261,3 +261,13 @@ After building your Cordova project with Meteor, you can use **Android Studio** 
 5. Go to **Product > Archive** to create an archive of your app
 6. In the **Organizer** window, click **Distribute App** and follow the prompts to configure signing and export the IPA file.
 7. Upload the IPA file to the App Store or distribute via TestFlight.
+
+# Legacy device support
+
+Meteor distinguishes between legacy and modern browsers - see the [modern browsers package](../packages/modern-browsers). Web apps include different code bundles for each, but Cordova apps only have a single code bundle. From Meteor 3.4 onwards, the default code bundle changed from legacy to modern.
+
+You can force Meteor to use the legacy browser code bundle by setting the environment variable `METEOR_CORDOVA_DISABLE_MODERN_BROWSERS` to `Y` when running or building your app. For example:
+
+```METEOR_CORDOVA_DISABLE_MODERN_BROWSERS=Y meteor run ios```
+
+Both the App Store and Google Play will only publish new and updated apps for a certain minimum mobile OS version. As of 2025, these minimum OS versions support the  modern browser code bundle. 


### PR DESCRIPTION
Modern mobile devices have qualified as "modern browsers" for a long while now, so we can drop the transpiling we needed to do in the early days. 

Apps built to older API specifications do not meet the requirements to be published in the app stores anymore anyway. 

This new behavior can be disabled by setting the environment variable `METEOR_CORDOVA_DISABLE_MODERN_BROWSERS` to `Y`. 

This was discussed with @italojs in this issue https://github.com/meteor/meteor/issues/13864#issuecomment-3119736349

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
