### PR TITLE
Release 2.16.2

### DIFF
--- a/meteor
+++ b/meteor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUNDLE_VERSION=14.21.4.14
+BUNDLE_VERSION=14.21.4.15
 
 
 # OS Check. Put here because here is where we download the precompiled

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'The Meteor command-line tool',
-  version: '2.16.1-beta.0',
+  version: '2.16.2-beta.0',
 });
 
 Package.includeTool();

--- a/packages/minifier-js/.npm/package/npm-shrinkwrap.json
+++ b/packages/minifier-js/.npm/package/npm-shrinkwrap.json
@@ -2,39 +2,34 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A=="
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg=="
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
-    },
-    "@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
     },
     "@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw=="
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
+      "integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q=="
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g=="
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -57,9 +52,9 @@
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="
     },
     "terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA=="
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
+      "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg=="
     }
   }
 }

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "2.16.1-beta.0",
+  "version": "2.16.2-beta.0",
   "recommended": false,
   "official": false,
   "description": "Meteor experimental release"

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -13,7 +13,7 @@ export const CORDOVA_ARCH = "web.cordova";
 
 export const CORDOVA_PLATFORMS = ['ios', 'android'];
 
-const CORDOVA_ANDROID_VERSION = "https://github.com/meteor/cordova-android.git#meteor-2.16.1";
+const CORDOVA_ANDROID_VERSION = "https://github.com/meteor/cordova-android.git#meteor-2.16.2";
 
 export const CORDOVA_DEV_BUNDLE_VERSIONS = {
   'cordova-lib': '10.0.0',


### PR DESCRIPTION
<!-- OSS-833 -->

This PR includes the needed changes to ensure compatibility of Cordova 14 in Meteor 2.x, so that Meteor 2 apps can still fulfil Android SDK 35 minimum requirement.

As I was afraid of Cordova 14 now uses modern Node APIs like [cpSync](https://github.com/user-attachments/assets/d4379884-30ef-47ef-a886-7438f1ad8b26) and [fsp.copy](https://github.com/user-attachments/assets/b9b2312d-0e09-4b01-8153-e4556b85df8c), which require Node 16.x or newer (Meteor 2.x limited to Node 14). Here’s what I did:

- Created branch `release-2.16.2` from `release-2.16.1`, with our custom forks of cordova-android and cordova-ios already set.

- Updated our `cordova-android` fork’s [`meteor-2.16.2` branch](https://github.com/meteor/cordova-android/tree/meteor-2.16.2) to [Cordova 14.0.0](https://github.com/meteor/cordova-android/blob/meteor-2.16.2/package.json#L3) and linked it in the Meteor tool.

- Added `fs-extra` and rewrote copy operations to use Node 14–compatible methods, [a90f936](https://github.com/meteor/cordova-android/commit/a90f9368a2977963d833291f8d38e2f95d61517d) and [
395727e](https://github.com/meteor/cordova-android/commit/395727e9db6788779a5d08f56f4a9f7bb55cc0e2)

- [Downgraded `cordova-common` to v4.0.2](https://github.com/meteor/cordova-android/commit/d5273835e76498a61230251a564d62bdd0e3453f), since v5.0.1 causes copy issues and only includes refactors, patch bumps, and CI updates.

With these changes I got the Cordova app running on SDK 35.

<img width="3298" height="1852" alt="cordova-14" src="https://github.com/user-attachments/assets/ce7238af-7a98-49cd-ab84-c194be6c5c69" />

Next, we’ll publish the new version and have developers verify successful store submissions.

Our release procedure for Meteor 2 is slower and may take longer. If you’re still on Meteor 2, run your project from the `release-2.16.1` branch: clone the meteor/meteor repo, switch to release-2.16.1, then use `<path-to-meteor-clone>/meteor run` as your CLI to work with your Meteor app.