### PR TITLE
update lodash dependency in boilerplate-generator 

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -333,6 +333,30 @@ export class AccountsServer extends AccountsCommon {
     return user;
   }
 
+  /**
+   * @summary Find a user by one of their email addresses.
+   * @locus Server
+   * @param {String} email The email address to look for
+   * @param {Object} [options]
+   * @param {Object} options.fields Limit the fields to return from the user document
+   * @returns {Promise<Object>} A user if found, else null
+   * @importFromPackage accounts-base
+   */
+  findUserByEmail = async (email, options) =>
+    await this._findUserByQuery({ email }, options);
+
+  /**
+   * @summary Find a user by their username.
+   * @locus Server
+   * @param {String} username The username to look for
+   * @param {Object} [options]
+   * @param {Object} options.fields Limit the fields to return from the user document
+   * @returns {Promise<Object>} A user if found, else null
+   * @importFromPackage accounts-base
+   */
+  findUserByUsername = async (username, options) =>
+    await this._findUserByQuery({ username }, options);
+
   ///
   /// LOGIN METHODS
   ///

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -287,37 +287,6 @@ Accounts._checkPasswordAsync = checkPasswordAsync;
 ///
 
 
-/**
- * @summary Finds the user asynchronously with the specified username.
- * First tries to match username case sensitively; if that fails, it
- * tries case insensitively; but if more than one user matches the case
- * insensitive search, it returns null.
- * @locus Server
- * @param {String} username The username to look for
- * @param {Object} [options]
- * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
- * @returns {Promise<Object>} A user if found, else null
- * @importFromPackage accounts-base
- */
-Accounts.findUserByUsername =
-  async (username, options) =>
-    await Accounts._findUserByQuery({ username }, options);
-
-/**
- * @summary Finds the user asynchronously with the specified email.
- * First tries to match email case sensitively; if that fails, it
- * tries case insensitively; but if more than one user matches the case
- * insensitive search, it returns null.
- * @locus Server
- * @param {String} email The email address to look for
- * @param {Object} [options]
- * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
- * @returns {Promise<Object>} A user if found, else null
- * @importFromPackage accounts-base
- */
-Accounts.findUserByEmail =
-  async (email, options) =>
-    await Accounts._findUserByQuery({ email }, options);
 
 // XXX maybe this belongs in the check package
 const NonEmptyString = Match.Where(x => {

--- a/packages/boilerplate-generator/package.js
+++ b/packages/boilerplate-generator/package.js
@@ -5,7 +5,7 @@ Package.describe({
 
 Npm.depends({
   "combined-stream2": "1.1.2",
-  "lodash.template": "4.5.0"
+  "lodash": "4.17.21"
 });
 
 Package.onUse(api => {

--- a/packages/boilerplate-generator/template.js
+++ b/packages/boilerplate-generator/template.js
@@ -1,4 +1,4 @@
-import lodashTemplate from 'lodash.template';
+import { template as lodashTemplate } from 'lodash';
 
 // As identified in issue #9149, when an application overrides the default
 // _.template settings using _.templateSettings, those new settings are


### PR DESCRIPTION
TLDR

- [lodash.template](https://www.npmjs.com/package/lodash.template) is deprecated
- Discussed here about do not bring lodash to the core https://github.com/meteor/meteor/pull/13617
- this PR is similar to https://github.com/meteor/meteor/pull/12813 from @StorytellerCZ
