### PR TITLE
mongo-legacy: simplify error handling for MongoDB connection

### DIFF
--- a/packages/npm-mongo/wrapper.js
+++ b/packages/npm-mongo/wrapper.js
@@ -1,9 +1,10 @@
-const { MongoClient, MongoCompatibilityError } = Npm.require('mongodb');
+const { MongoClient } = Npm.require('mongodb');
 
 function connect(client) {
   return client.connect()
     .catch(error => {
-      if (error.cause instanceof MongoCompatibilityError && error.message.includes('maximum wire version')) {
+      // we just check the message since multiples errors can be catch this situation, e.g: instanceof MongoServerSelectionError or MongoCompatibilityError
+      if (error.message.includes('maximum wire version')) {
       console.warn(`[DEPRECATION] Legacy MongoDB version detected, using mongo-legacy package: ${error.message}
         Warning: MongoDB versions <= 3.6 are deprecated. Some Meteor features may not work properly with this version.
         It is recommended to use MongoDB >= 4.`);


### PR DESCRIPTION
After testing in production apps, we got the `maximum wire version` error been throung with different error instances for different mongo versions, so we now we are checking only the error message instead error intance type

This PR is pointed to 3.3.1, but maybe we can release it to 3.3.2