### PR TITLE
Return insertedId on client upsert to match Meteor 2.x behavior

### DIFF
--- a/packages/minimongo/local_collection.js
+++ b/packages/minimongo/local_collection.js
@@ -678,6 +678,7 @@ export default class LocalCollection {
 
     return this.finishUpdate({
       options,
+      insertedId,
       updateCount,
       callback,
       selector,

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -4010,3 +4010,55 @@ Tinytest.addAsync('minimongo - asyncIterator', async (test) => {
   test.equal(itemIds.length, 2);
   test.equal(itemIds, ['a', 'b']);
 });
+
+Tinytest.add('minimongo - operation result fields (sync)', test => {
+  const c = new LocalCollection();
+
+  // Test insert
+  const insertedId = c.insert({name: 'doc1'});
+  test.isTrue(insertedId !== undefined, 'insert should return an ID');
+
+  // Test update
+  const updateResult = c.update({name: 'doc1'}, {$set: {value: 1}});
+  test.equal(updateResult, 1, 'update should return affected count');
+
+  // Test upsert (update case)
+  const upsertUpdateResult = c.upsert({name: 'doc1'}, {$set: {value: 2}});
+  test.equal(upsertUpdateResult.numberAffected, 1);
+  test.isFalse(upsertUpdateResult.hasOwnProperty('insertedId'));
+
+  // Test upsert (insert case)
+  const upsertInsertResult = c.upsert({name: 'doc2'}, {$set: {value: 3}});
+  test.equal(upsertInsertResult.numberAffected, 1);
+  test.isTrue(upsertInsertResult.hasOwnProperty('insertedId'));
+
+  // Test remove
+  const removeResult = c.remove({name: 'doc1'});
+  test.equal(removeResult, 1, 'remove should return removed count');
+});
+
+Tinytest.addAsync('minimongo - operation result fields (async)', async test => {
+  const c = new LocalCollection();
+
+  // Test insert
+  const insertedId = await c.insertAsync({name: 'doc1'});
+  test.isTrue(insertedId !== undefined, 'insert should return an ID');
+
+  // Test update
+  const updateResult = await c.updateAsync({name: 'doc1'}, {$set: {value: 1}});
+  test.equal(updateResult, 1, 'update should return affected count');
+
+  // Test upsert (update case)
+  const upsertUpdateResult = await c.upsertAsync({name: 'doc1'}, {$set: {value: 2}});
+  test.equal(upsertUpdateResult.numberAffected, 1);
+  test.isFalse(upsertUpdateResult.hasOwnProperty('insertedId'));
+
+  // Test upsert (insert case)
+  const upsertInsertResult = await c.upsertAsync({name: 'doc2'}, {$set: {value: 3}});
+  test.equal(upsertInsertResult.numberAffected, 1);
+  test.isTrue(upsertInsertResult.hasOwnProperty('insertedId'));
+
+  // Test remove
+  const removeResult = await c.removeAsync({name: 'doc1'});
+  test.equal(removeResult, 1, 'remove should return removed count');
+});


### PR DESCRIPTION
This PR fixes an issue found when migrating apps from Meteor 2.x to 3.x. The MongoDB upsert behavior changed: on the client side it no longer returns the insertedId when creating a new record.

<img width="5091" height="523" alt="image" src="https://github.com/user-attachments/assets/3f9e4e30-1f0f-473d-bc56-734a8b72b8f5" />
