### PR TITLE
Updated parameter oders setting option = {}  and corresponding docs. #13873

### DIFF
--- a/packages/roles/roles_common_async.js
+++ b/packages/roles/roles_common_async.js
@@ -1052,14 +1052,15 @@ Object.assign(Roles, {
    * @return {Promise<Cursor>} Cursor of users in roles.
    */
   getUsersInRoleAsync: async function (roles, options = {}, queryOptions) {
+    if (!options.queryOptions) options.queryOptions = queryOptions;
     const ids = (
       await Roles.getUserAssignmentsForRole(roles, options).fetchAsync()
     ).map((a) => a.user._id)
 
     return Meteor.users.find(
       { _id: { $in: ids } },
-      (options.queryOptions) || queryOptions || {}
-    )
+      options
+    );
   },
 
   /**

--- a/packages/roles/roles_common_async.js
+++ b/packages/roles/roles_common_async.js
@@ -1051,14 +1051,14 @@ Object.assign(Roles, {
    *   - `queryOptions`: options which are passed directly through to `Meteor.users.find(query, options)`
    * @return {Promise<Cursor>} Cursor of users in roles.
    */
-  getUsersInRoleAsync: async function (roles, options, queryOptions) {
+  getUsersInRoleAsync: async function (roles, options = {}, queryOptions) {
     const ids = (
       await Roles.getUserAssignmentsForRole(roles, options).fetchAsync()
     ).map((a) => a.user._id)
 
     return Meteor.users.find(
       { _id: { $in: ids } },
-      (options && options.queryOptions) || queryOptions || {}
+      (options.queryOptions) || queryOptions || {}
     )
   },
 

--- a/v3-docs/docs/packages/roles.md
+++ b/v3-docs/docs/packages/roles.md
@@ -253,6 +253,11 @@ const legacyUsers = await (await Roles.getUsersInRoleAsync(
   { sort: { createdAt: -1 }, limit: 10 }
 )).fetchAsync();
 
+// Preferred usage with queryOptions in options
+const users = await (await Roles.getUsersInRoleAsync("manager", {
+  queryOptions: { sort: { createdAt: -1 }, limit: 10 }
+})).fetchAsync();
+
 ```
 
 ## Checking Roles

--- a/v3-docs/docs/packages/roles.md
+++ b/v3-docs/docs/packages/roles.md
@@ -234,7 +234,7 @@ const adminUsers = await (await Roles.getUsersInRoleAsync("admin")).fetchAsync()
 // Find users with specific roles in a scope
 const scopedUsers = await (await Roles.getUsersInRoleAsync(
   ["editor", "writer"],
-  "blog"
+  { scope: "blog" }
 )).fetchAsync();
 
 // Find users with custom options
@@ -245,6 +245,14 @@ const users = await (await Roles.getUsersInRoleAsync("manager", {
     limit: 10,
   },
 })).fetchAsync();
+
+// Legacy usage with separate queryOptions (not recommended)
+const legacyUsers = await (await Roles.getUsersInRoleAsync(
+  "manager",
+  {},
+  { sort: { createdAt: -1 }, limit: 10 }
+)).fetchAsync();
+
 ```
 
 ## Checking Roles


### PR DESCRIPTION
This fixes issue #13873 . 
I've fixed the parameter oders setting option = {} by default and documented it.