### PR TITLE
Add query selector validation to catch MongoDB errors

### DIFF
--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -58,3 +58,31 @@ Tinytest.add('minimongo - wrapTransform', test => {
   });
   handle.stop();
 });
+
+if (Meteor.isClient) {
+  Tinytest.add('minimongo - $geoIntersects should throw error', function(test) {
+    const collection = new LocalCollection();
+    collection.insert({ _id: 'a', loc: { type: 'Point', coordinates: [0, 0] } });
+
+    const query = {
+      loc: {
+        $geoIntersects: {
+          $geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]
+              ]
+            ]
+          }
+        }
+      }
+    };
+
+    test.throws(
+      () => collection.findOne(query),
+      /Unrecognized operator: \$geoIntersects/,
+      'Should throw error for $geoIntersects in Minimongo'
+    );
+  });
+}

--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -850,6 +850,9 @@ Object.assign(MongoConnection.prototype, {
     const oplogOptions = self?._oplogHandle?._oplogOptions || {};
     const { includeCollections, excludeCollections } = oplogOptions;
     if (firstHandle) {
+      // Validate query selector to catch MongoDB errors early
+      new Minimongo.Matcher(cursorDescription.selector);
+
       var matcher, sorter;
       var canUseOplog = [
         function () {
@@ -877,21 +880,6 @@ Object.assign(MongoConnection.prototype, {
             return false;
           }
           return true;
-        },
-        function () {
-          // We need to be able to compile the selector. Fall back to polling for
-          // some newfangled $selector that minimongo doesn't support yet.
-          try {
-            matcher = new Minimongo.Matcher(cursorDescription.selector);
-            return true;
-          } catch (e) {
-            // XXX make all compilation errors MinimongoError or something
-            //     so that this doesn't ignore unrelated exceptions
-            if (e instanceof MiniMongoQueryError) {
-              throw e;
-            }
-            return false;
-          }
         },
         function () {
           // ... and the selector itself needs to support oplog.

--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -888,6 +888,9 @@ Object.assign(MongoConnection.prototype, {
           } catch (e) {
             // XXX make all compilation errors MinimongoError or something
             //     so that this doesn't ignore unrelated exceptions
+            if (Meteor.isClient && e instanceof MiniMongoQueryError) {
+              throw e;
+            }
             return false;
           }
         },

--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -850,8 +850,6 @@ Object.assign(MongoConnection.prototype, {
     const oplogOptions = self?._oplogHandle?._oplogOptions || {};
     const { includeCollections, excludeCollections } = oplogOptions;
     if (firstHandle) {
-      // Validate query selector to catch MongoDB errors early
-      new Minimongo.Matcher(cursorDescription.selector);
 
       var matcher, sorter;
       var canUseOplog = [

--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -880,6 +880,18 @@ Object.assign(MongoConnection.prototype, {
           return true;
         },
         function () {
+          // We need to be able to compile the selector. Fall back to polling for
+          // some newfangled $selector that minimongo doesn't support yet.
+          try {
+            matcher = new Minimongo.Matcher(cursorDescription.selector);
+            return true;
+          } catch (e) {
+            // XXX make all compilation errors MinimongoError or something
+            //     so that this doesn't ignore unrelated exceptions
+            return false;
+          }
+        },
+        function () {
           // ... and the selector itself needs to support oplog.
           return OplogObserveDriver.cursorSupported(cursorDescription, matcher);
         },

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -4535,7 +4535,8 @@ if(Meteor.isServer) {
   Meteor.publish('testGeoPolygon', function(viewport) {
     check(viewport, Match.ObjectIncluding({ bounds: geoPolygonSchema }));
     // return an empty collection for the test
-    return new Mongo.Collection('test').find();
+    const randomId = Random.id();
+    return new Mongo.Collection(randomId).find();
   });
 }
 

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -4540,9 +4540,61 @@ if(Meteor.isServer) {
   });
 }
 
+if (Meteor.isServer) {
+  Meteor.publish('testGeoIntersects', function(viewport) {
+    check(viewport, Match.ObjectIncluding({ bounds: geoPolygonSchema }));
+    const Features = new Mongo.Collection('Features_' + this.connection.id);
+    return Features.find({
+      hull: { $geoIntersects: { $geometry: viewport.bounds } },
+    });
+  });
+}
+
+Tinytest.addAsync('mongo-livedata - publish with $geoIntersects returns correct docs', async function(test, onComplete) {
+  if (Meteor.isServer) {
+    const Features = new Mongo.Collection('Features_' + Random.id());
+    const insidePoly = {
+      _id: 'inside',
+      hull: {
+        type: 'Polygon',
+        coordinates: [
+          [ [0.2,0.2], [0.2,0.8], [0.8,0.8], [0.8,0.2], [0.2,0.2] ]
+        ]
+      }
+    };
+    const outsidePoly = {
+      _id: 'outside',
+      hull: {
+        type: 'Polygon',
+        coordinates: [
+          [ [2,2], [2,3], [3,3], [3,2], [2,2] ]
+        ]
+      }
+    };
+    await Features.insertAsync(insidePoly);
+    await Features.insertAsync(outsidePoly);
+
+    const viewport = {
+      bounds: {
+        type: 'Polygon',
+        coordinates: [
+          [ [0,0], [0,1], [1,1], [1,0], [0,0] ]
+        ]
+      }
+    };
+    const cursor = Features.find({ hull: { $geoIntersects: { $geometry: viewport.bounds } } });
+    const docs = await cursor.fetchAsync();
+    test.equal(docs.length, 1);
+    test.equal(docs[0]._id, 'inside');
+    onComplete();
+  }
+  if (Meteor.isClient) {
+    onComplete();
+  }
+});
+
 Tinytest.addAsync('mongo-livedata - publish with geoPolygonSchema does not throw', async function(test, onComplete) {
     if (Meteor.isClient) {
-      // Simulate valid viewport
       const viewport = {
         bounds: {
           type: 'Polygon',

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -4516,3 +4516,57 @@ Tinytest.addAsync(
     }
   },
 );
+
+const geoPolygonSchema = {
+  type: 'Polygon',
+  coordinates: Match.Where(coords =>
+    Array.isArray(coords) &&
+    coords.length > 0 &&
+    coords.every(
+      ring => Array.isArray(ring) && ring.every(
+        point => Array.isArray(point) && point.length === 2 &&
+          typeof point[0] === 'number' && typeof point[1] === 'number'
+      )
+    )
+  )
+};
+
+if(Meteor.isServer) {
+  Meteor.publish('testGeoPolygon', function(viewport) {
+    check(viewport, Match.ObjectIncluding({ bounds: geoPolygonSchema }));
+    // return an empty collection for the test
+    return new Mongo.Collection('test').find();
+  });
+}
+
+Tinytest.addAsync('mongo-livedata - publish with geoPolygonSchema does not throw', async function(test, onComplete) {
+    if (Meteor.isClient) {
+      // Simulate valid viewport
+      const viewport = {
+        bounds: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]
+            ]
+          ]
+        }
+      };
+      let error = null;
+      try {
+        await new Promise((resolve) => {
+          Meteor.subscribe('testGeoPolygon', viewport, {
+            onReady: resolve,
+            onError: function(e) {
+              error = e;
+              resolve();
+            }
+          });
+        });
+      } catch (e) {
+        error = e;
+      }
+      test.isNull(error, 'shouldnt throw error for valid viewport');
+    }
+    onComplete();
+});

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -4531,16 +4531,6 @@ const geoPolygonSchema = {
   )
 };
 
-if (Meteor.isServer) {
-  Meteor.publish('testGeoIntersects', function(viewport) {
-    check(viewport, Match.ObjectIncluding({ bounds: geoPolygonSchema }));
-    const Features = new Mongo.Collection('Features_' + this.connection.id);
-    return Features.find({
-      hull: { $geoIntersects: { $geometry: viewport.bounds } },
-    });
-  });
-}
-
 Tinytest.addAsync('mongo-livedata - publish with $geoIntersects returns correct docs', async function(test, onComplete) {
   if (Meteor.isServer) {
     const Features = new Mongo.Collection('Features_' + Random.id());

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -4531,15 +4531,6 @@ const geoPolygonSchema = {
   )
 };
 
-if(Meteor.isServer) {
-  Meteor.publish('testGeoPolygon', function(viewport) {
-    check(viewport, Match.ObjectIncluding({ bounds: geoPolygonSchema }));
-    // return an empty collection for the test
-    const randomId = Random.id();
-    return new Mongo.Collection(randomId).find();
-  });
-}
-
 if (Meteor.isServer) {
   Meteor.publish('testGeoIntersects', function(viewport) {
     check(viewport, Match.ObjectIncluding({ bounds: geoPolygonSchema }));
@@ -4591,35 +4582,4 @@ Tinytest.addAsync('mongo-livedata - publish with $geoIntersects returns correct 
   if (Meteor.isClient) {
     onComplete();
   }
-});
-
-Tinytest.addAsync('mongo-livedata - publish with geoPolygonSchema does not throw', async function(test, onComplete) {
-    if (Meteor.isClient) {
-      const viewport = {
-        bounds: {
-          type: 'Polygon',
-          coordinates: [
-            [
-              [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]
-            ]
-          ]
-        }
-      };
-      let error = null;
-      try {
-        await new Promise((resolve) => {
-          Meteor.subscribe('testGeoPolygon', viewport, {
-            onReady: resolve,
-            onError: function(e) {
-              error = e;
-              resolve();
-            }
-          });
-        });
-      } catch (e) {
-        error = e;
-      }
-      test.equal(error, null)
-    }
-    onComplete();
 });

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -4564,6 +4564,7 @@ Tinytest.addAsync('mongo-livedata - publish with geoPolygonSchema does not throw
           });
         });
       } catch (e) {
+        console.log('ERRO-DEBUG]', e);
         error = e;
       }
       test.isNull(error, 'shouldnt throw error for valid viewport');

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -4564,10 +4564,9 @@ Tinytest.addAsync('mongo-livedata - publish with geoPolygonSchema does not throw
           });
         });
       } catch (e) {
-        console.log('ERRO-DEBUG]', e);
         error = e;
       }
-      test.isNull(error, 'shouldnt throw error for valid viewport');
+      test.equal(error, null)
     }
     onComplete();
 });

--- a/packages/mongo/tests/observe_changes_tests.js
+++ b/packages/mongo/tests/observe_changes_tests.js
@@ -545,6 +545,7 @@ if (Meteor.isServer) {
 }
 
 
+// Those errors should throw since mongo doent support {$in: null}
 testAsyncMulti("observeChanges - bad query", [
   async function (test, expect) {
     var c = makeCollection();
@@ -563,15 +564,9 @@ testAsyncMulti("observeChanges - bad query", [
       return;
     }
 
-    const p1 = new Promise(r => {
-      observeThrows().finally(() => r());
-    });
-    const p2 = new Promise(r => {
-      observeThrows().finally(() => r());
-    });
-
-    await p1;
-    await p2;
+    await test.throwsAsync(async function () {
+        await c.find({__id: {$in: null}}).countAsync();
+    }, '$in needs an array');
   }
 ]);
 


### PR DESCRIPTION
fix for https://forums.meteor.com/t/meteor-3-3-1-geointersects-inside-publication-throws-error/63842

The main changes ensure that query errors are thrown correctly in the client and the server.

**Error handling improvements:**

* In `mongo_connection.js`, updated the error handling logic so that `MiniMongoQueryError` is only re-thrown on the client, preventing unrelated exceptions from being ignored on the server.

**Test improvements:**

The error `$in needs an array` should come from Mongo since Mongo itself doesn't support that operation, it wasn't being thrown via observeChanges

Note: `MiniMongo` is already covered by `minimongo - selector_compiler` test.