### PR TITLE
Retry 2: Enable modern browser support for Cordova unless explicitly disabled

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -263,6 +263,11 @@ BCp.processOneFileForTarget = function (inputFile, source) {
       features.nodeMajorVersion = parseInt(process.versions.node, 10);
     } else if (arch === "web.browser") {
       features.modernBrowsers = true;
+    } else if (arch === "web.cordova") {
+
+      if (process.env["METEOR_CORDOVA_DISABLE_MODERN_BROWSERS"] != "Y")
+        features.modernBrowsers = true;
+
     }
 
     features.topLevelAwait = inputFile.supportsTopLevelAwait &&

--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -264,10 +264,7 @@ BCp.processOneFileForTarget = function (inputFile, source) {
     } else if (arch === "web.browser") {
       features.modernBrowsers = true;
     } else if (arch === "web.cordova") {
-
-      if (process.env["METEOR_CORDOVA_DISABLE_MODERN_BROWSERS"] != "Y")
-        features.modernBrowsers = true;
-
+      features.modernBrowsers = ! getMeteorConfig()?.cordova?.disableModern;
     }
 
     features.topLevelAwait = inputFile.supportsTopLevelAwait &&

--- a/v3-docs/docs/about/cordova.md
+++ b/v3-docs/docs/about/cordova.md
@@ -266,8 +266,14 @@ After building your Cordova project with Meteor, you can use **Android Studio** 
 
 Meteor distinguishes between legacy and modern browsers - see the [modern browsers package](../packages/modern-browsers). Web apps include different code bundles for each, but Cordova apps only have a single code bundle. From Meteor 3.3.2 onwards, the default code bundle changed from legacy to modern.
 
-You can force Meteor to use the legacy browser code bundle by setting the environment variable `METEOR_CORDOVA_DISABLE_MODERN_BROWSERS` to `Y` when running or building your app. For example:
+You can force Meteor to use the legacy browser code bundle by setting the variable `cordova.disableModern` to `true` in `package.json` when running or building your app. For example:
 
-```METEOR_CORDOVA_DISABLE_MODERN_BROWSERS=Y meteor run ios```
+```
+  "meteor": {
+    "mainModule": { ... },
+    "testModule": { ... },
+    "cordova": { "disableModern":  true}
+  }
+```
 
 Both the App Store and Google Play will only publish new and updated apps for a certain minimum mobile OS version. As of 2025, these minimum OS versions support the  modern browser code bundle. 

--- a/v3-docs/docs/about/cordova.md
+++ b/v3-docs/docs/about/cordova.md
@@ -264,7 +264,7 @@ After building your Cordova project with Meteor, you can use **Android Studio** 
 
 # Legacy device support
 
-Meteor distinguishes between legacy and modern browsers - see the [modern browsers package](../packages/modern-browsers). Web apps include different code bundles for each, but Cordova apps only have a single code bundle. From Meteor 3.4 onwards, the default code bundle changed from legacy to modern.
+Meteor distinguishes between legacy and modern browsers - see the [modern browsers package](../packages/modern-browsers). Web apps include different code bundles for each, but Cordova apps only have a single code bundle. From Meteor 3.3.2 onwards, the default code bundle changed from legacy to modern.
 
 You can force Meteor to use the legacy browser code bundle by setting the environment variable `METEOR_CORDOVA_DISABLE_MODERN_BROWSERS` to `Y` when running or building your app. For example:
 

--- a/v3-docs/docs/about/cordova.md
+++ b/v3-docs/docs/about/cordova.md
@@ -261,3 +261,13 @@ After building your Cordova project with Meteor, you can use **Android Studio** 
 5. Go to **Product > Archive** to create an archive of your app
 6. In the **Organizer** window, click **Distribute App** and follow the prompts to configure signing and export the IPA file.
 7. Upload the IPA file to the App Store or distribute via TestFlight.
+
+# Legacy device support
+
+Meteor distinguishes between legacy and modern browsers - see the [modern browsers package](../packages/modern-browsers). Web apps include different code bundles for each, but Cordova apps only have a single code bundle. From Meteor 3.4 onwards, the default code bundle changed from legacy to modern.
+
+You can force Meteor to use the legacy browser code bundle by setting the environment variable `METEOR_CORDOVA_DISABLE_MODERN_BROWSERS` to `Y` when running or building your app. For example:
+
+```METEOR_CORDOVA_DISABLE_MODERN_BROWSERS=Y meteor run ios```
+
+Both the App Store and Google Play will only publish new and updated apps for a certain minimum mobile OS version. As of 2025, these minimum OS versions support the  modern browser code bundle. 


### PR DESCRIPTION
issue: https://github.com/meteor/meteor/issues/13864
pr history: https://github.com/meteor/meteor/pull/13868 -> https://github.com/meteor/meteor/pull/13889 -> [this](https://github.com/meteor/meteor/pull/13896)

