### PR TITLE
Implement redis-oplog Logic Natively to Optimize Oplog Tailing

### DIFF
--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -11,6 +11,8 @@ import { ObserveHandle } from './observe_handle';
 import { ObserveMultiplexer } from './observe_multiplex';
 import { OplogObserveDriver } from './oplog_observe_driver';
 import { OPLOG_COLLECTION, OplogHandle } from './oplog_tailing';
+import { NewOplogTailing } from './new-oplog-driver/new_oplog_tailing'
+import { NewOplogObserveDriver } from './new-oplog-driver/new_oplog_observe_driver';
 import { PollingObserveDriver } from './polling_observe_driver';
 
 const FILE_ASSET_SUFFIX = 'Asset';
@@ -86,8 +88,12 @@ export const MongoConnection = function (url, options) {
   }));
 
   if (options.oplogUrl && ! Package['disable-oplog']) {
-    self._oplogHandle = new OplogHandle(options.oplogUrl, self.db.databaseName);
-    self._docFetcher = new DocFetcher(self);
+    if(Meteor.settings?.packages?.mongo?.useNewOplogTailing){
+      self._oplogHandle = new NewOplogTailing(options.oplogUrl, self.db.databaseName);
+    } else {
+      self._oplogHandle = new OplogHandle(options.oplogUrl, self.db.databaseName);
+      self._docFetcher = new DocFetcher(self);
+    }
   }
 
 };
@@ -913,7 +919,17 @@ Object.assign(MongoConnection.prototype, {
         }
       ].every(f => f());  // invoke each function and check if all return true
 
-      var driverClass = canUseOplog ? OplogObserveDriver : PollingObserveDriver;
+      const useNewOplogTailing = Meteor.settings?.packages?.mongo?.useNewOplogTailing;
+      let driverClass;
+      if(canUseOplog && useNewOplogTailing) {
+        driverClass = NewOplogObserveDriver;
+      }
+      else if (canUseOplog) {
+        driverClass = OplogObserveDriver;
+      } else {
+        driverClass = PollingObserveDriver;
+      }
+
       observeDriver = new driverClass({
         cursorDescription: cursorDescription,
         mongoHandle: self,

--- a/packages/mongo/mongo_driver.js
+++ b/packages/mongo/mongo_driver.js
@@ -1,4 +1,5 @@
 import { OplogHandle } from './oplog_tailing';
+import { NewOplogTailing } from './new-oplog-driver/new_oplog_tailing'
 import { MongoConnection } from './mongo_connection';
 import { OplogObserveDriver } from './oplog_observe_driver';
 import { MongoDB } from './mongo_common';
@@ -31,6 +32,7 @@ MongoInternals.NpmModule = new Proxy(MongoDB, {
 });
 
 MongoInternals.OplogHandle = OplogHandle;
+MongoInternals.NewOplogHandle = NewOplogTailing
 
 MongoInternals.Connection = MongoConnection;
 

--- a/packages/mongo/new-oplog-driver/mongo_id_map.ts
+++ b/packages/mongo/new-oplog-driver/mongo_id_map.ts
@@ -1,0 +1,97 @@
+import { MongoID } from 'meteor/mongo-id';
+
+export class MongoIDMap {
+  _internal: Map<any, any>;
+  private _idStringify: any;
+  private _idParse: any;
+  constructor() {
+    this._internal = new Map();
+    this._idStringify = MongoID.idStringify;
+    this._idParse = MongoID.idParse;
+  }
+
+  get(id: any) {
+    const key = this._idStringify(id);
+    return this._internal.get(key);
+  }
+
+  pop(id: any) {
+    const key = this._idStringify(id);
+    const ret = this._internal.get(key);
+    this._internal.delete(key);
+    return ret;
+  }
+
+  set(id: any, value: any) {
+    const key = this._idStringify(id);
+    this._internal.set(key, value);
+  }
+
+  setDefault(id: any, def: any) {
+    const key = this._idStringify(id);
+    if (this._internal.has(key)) {
+      return this._internal.get(key);
+    }
+    this._internal.set(key, def);
+    return def;
+  }
+
+  remove(id: any) {
+    const key = this._idStringify(id);
+    this._internal.delete(key);
+  }
+
+  has(id: any) {
+    const key = this._idStringify(id);
+    return this._internal.has(key);
+  }
+
+  size() {
+    return this._internal.size;
+  }
+
+  empty() {
+    return this._internal.size === 0;
+  }
+
+  clear() {
+    this._internal.clear();
+  }
+
+  keys() {
+    return Array.from(this._internal.keys()).map((key) => this._idParse(key));
+  }
+
+  forEach(iterator: (value: any, key: any) => void) {
+    this._internal.forEach((value, key) => {
+      iterator(value, this._idParse(key));
+    });
+  }
+
+  async compareWith(other:MongoIDMap, callbacks: {
+    both?: (id: any, leftValue: any, rightValue: any) => Promise<void>;
+    leftOnly?: (id: any, leftValue: any) => Promise<void>;
+    rightOnly?: (id: any, rightValue: any) => Promise<void>;
+  }) {
+    // operate on the _internal maps to avoid overhead of parsing id's.
+    const leftMap = this._internal;
+    const rightMap = other._internal;
+
+    for (const [key, leftValue] of leftMap) {
+      const rightValue = rightMap.get(key);
+      if (rightValue)
+        callbacks.both &&
+          (await callbacks.both(this._idParse(key), leftValue, rightValue));
+      else
+        callbacks.leftOnly &&
+          (await callbacks.leftOnly(this._idParse(key), leftValue));
+    }
+
+    if (callbacks.rightOnly) {
+      for (const [key, rightValue] of rightMap) {
+        if (!leftMap.has(key))
+          await callbacks.rightOnly(this._idParse(key), rightValue);
+      }
+    }
+  }
+}

--- a/packages/mongo/new-oplog-driver/new_oplog_observe_driver.ts
+++ b/packages/mongo/new-oplog-driver/new_oplog_observe_driver.ts
@@ -1,0 +1,284 @@
+import { LocalCollection } from 'meteor/minimongo';
+import { Tracker } from 'meteor/tracker';
+
+import { MongoIDMap } from './mongo_id_map';
+import ObservableCollection from './observable_collection';
+import { NewOplogTailing } from './new_oplog_tailing';
+import { getDedicatedChannel, extractIdsFromSelector } from './utils';
+import { EJSON } from '../../ejson/ejson';
+import { listenAll } from '../mongo_driver';
+
+let currentId = 0;
+
+type StrategyType = 'DEFAULT' | 'LIMIT_SORT' | 'DEDICATED_CHANNELS';
+export type OplogEventType = 'INSERT' | 'UPDATE' | 'REMOVE';
+
+export class NewOplogObserveDriver {
+  options: {
+    multiplexer: any;
+    matcher: any;
+    sorter: any;
+    cursorDescription: any;
+    limit?: number;
+    sort?: any;
+  };
+  oplogHandle: NewOplogTailing;
+  observableCollection: ObservableCollection | null = null;
+  private _id: number;
+  private _cursorDescription: any;
+  _multiplexer: any;
+  private _onlyContainsDirectIdSelector = false;
+  private _invalidationCrossbarListener?: { stop: () => void };
+  _stopped = false;
+  strategy: StrategyType;
+  channels: string[];
+
+  constructor(options: any) {
+    this._id = currentId;
+    currentId++;
+
+    this.options = options;
+    const { cursorDescription } = options;
+    this.oplogHandle = options.mongoHandle._oplogHandle;
+
+    this._cursorDescription = options.cursorDescription;
+    this._multiplexer = options.multiplexer;
+
+    if (options.limit && !options.sort) {
+      options.sort = { _id: 1 };
+    }
+    if (cursorDescription.options.limit && cursorDescription.options.sort) {
+      this.strategy = 'LIMIT_SORT';
+      this.channels = [cursorDescription.collectionName];
+    } else if (cursorDescription.selector?._id) {
+      this.strategy = 'DEDICATED_CHANNELS';
+      const ids = extractIdsFromSelector(cursorDescription.selector);
+      this.channels = ids.map((id) =>
+        getDedicatedChannel(cursorDescription.collectionName, id)
+      );
+      this._onlyContainsDirectIdSelector =
+        Object.keys(cursorDescription.selector).length === 1;
+    } else {
+      this.strategy = 'DEFAULT';
+      this.channels = [cursorDescription.collectionName];
+    }
+  }
+
+  async _init() {
+    this.observableCollection = new ObservableCollection(this.options);
+    await this.observableCollection.setupCollection();
+
+    // This is to mitigate the issue when we run init the first time on a subscription
+    // And if you are using packages like reactive-publish
+    // Because inside here we do a .find().fetch(), and that's considered reactive
+    await Tracker.nonreactive(async () => {
+      await this.observableCollection!.init();
+    });
+
+    this.oplogHandle.attach(this);
+
+    this._invalidationCrossbarListener = await listenAll(this._cursorDescription, () => {
+      // If we're not in a pre-fire write fence, we don't have to do anything.
+      const fence = DDPServer._getCurrentFence();
+      if (!fence || fence.fired) return;
+
+      if (fence._oplogObserveDrivers) {
+        fence._oplogObserveDrivers[this._id] = this;
+        return;
+      }
+
+      fence._oplogObserveDrivers = {};
+      fence._oplogObserveDrivers[this._id] = this;
+
+      fence.onBeforeFire(async () => {
+        const drivers = fence._oplogObserveDrivers;
+        delete fence._oplogObserveDrivers;
+
+        // This fence cannot fire until we've caught up to "this point" in the
+        // oplog, and all observers made it back to the steady state.
+        await this.oplogHandle.waitUntilCaughtUp();
+
+        for (const driver of Object.values(drivers)) {
+          if (driver._stopped) continue;
+
+          const write = await fence.beginWrite();
+          await driver._multiplexer.onFlush(write.committed);
+        }
+      });
+    });
+  }
+
+  stop() {
+    this._stopped = true;
+    this.oplogHandle.detach(this);
+    this.observableCollection = null;
+    this._invalidationCrossbarListener?.stop();
+    Package['facts-base'] &&
+      Package['facts-base'].Facts.incrementServerFact(
+        'mongo-livedata',
+        'observe-drivers-oplog',
+        -1
+      );
+  }
+
+  async reload() {
+    const { store, cursor } = this.observableCollection!;
+    const freshData = await cursor.fetchAsync();
+    const newStore = new MongoIDMap();
+    freshData.forEach((doc: any) => newStore.set(doc._id, doc));
+
+    await store.compareWith(newStore, {
+      both: async (docId, oldDoc, newDoc) => {
+        await this.observableCollection!.change(newDoc);
+      },
+      leftOnly: async (docId) => {
+        await this.observableCollection!.remove(docId);
+      },
+      rightOnly: async (docId, newDoc) => {
+        await this.observableCollection!.add(newDoc);
+      },
+    });
+  }
+
+  processFromOplog(eventType: OplogEventType, doc: any) {
+    if (this._stopped) {
+      return;
+    }
+    if (this.strategy === 'LIMIT_SORT') {
+      return this.processLimitSort(eventType, doc);
+    }
+    const observableCollection = this.observableCollection!;
+
+    if (eventType === 'INSERT' || eventType === 'UPDATE') {
+      if (this._onlyContainsDirectIdSelector || observableCollection.isEligible(doc)) {
+        if (observableCollection.contains(doc._id)) {
+          return observableCollection.change(doc);
+        } else {
+          return observableCollection.add(doc);
+        }
+      } else if (observableCollection.contains(doc._id)) {
+        return observableCollection.remove(doc._id);
+      }
+    } else if (eventType === 'REMOVE') {
+      return this.observableCollection!.remove(doc._id);
+    }
+  }
+
+  processLimitSort(event: OplogEventType, doc: any) {
+    const observableCollection = this.observableCollection!;
+    let needToRequery = false;
+    if (event === 'INSERT' && observableCollection.isEligible(doc)) {
+      needToRequery = true;
+    } else if (event === 'UPDATE') {
+      if (
+        observableCollection.isEligible(doc) ||
+        observableCollection.contains(doc._id)
+      ) {
+        needToRequery = true;
+      }
+    } else if (
+      event === 'REMOVE' &&
+      (observableCollection.contains(doc._id) || observableCollection.options.skip)
+    ) {
+      needToRequery = true;
+    }
+
+    if (!needToRequery) {
+      return;
+    }
+    this.requeryToProcess.push(doc);
+    this.requeryPromise = this.requeryPromise.then(() => {
+      if (this.requeryToProcess.length > 0) {
+        const requeryToProcess = this.requeryToProcess;
+        this.requeryToProcess = [];
+        return this.requeryForLimitSort(requeryToProcess);
+      }
+    });
+    return this.requeryPromise;
+  }
+
+  requeryPromise = Promise.resolve();
+  requeryToProcess: any[] = [];
+  async requeryForLimitSort(docs: any) {
+    if (this._stopped) {
+      return;
+    }
+    const observableCollection = this.observableCollection!;
+    const { store, selector, options } = observableCollection;
+
+    const newStore = new MongoIDMap();
+    const freshIds = await observableCollection.collection
+      .find(selector, { ...options, fields: { _id: 1 } })
+      .fetchAsync();
+
+    freshIds.forEach((d: any) => newStore.set(d._id, d));
+    const actionOnDocIds: string[] = [];
+    const idsToAdd: any[] = [];
+    await store.compareWith(newStore, {
+      async leftOnly(docId) {
+        if (docs.find((doc: any) => EJSON.equals(docId, doc._id))) {
+          actionOnDocIds.push(docId);
+        }
+        await observableCollection.remove(docId);
+      },
+      async rightOnly(docId) {
+        for (const doc of docs) {
+          if (EJSON.equals(docId, doc._id)) {
+            actionOnDocIds.push(docId);
+            await observableCollection.add(doc);
+            return;
+          }
+        }
+        idsToAdd.push(docId);
+      },
+    });
+    if (idsToAdd.length > 0) {
+      await observableCollection.addByIds(idsToAdd);
+    }
+
+    for (const doc of docs) {
+      if (!actionOnDocIds.includes(doc._id) && store.has(doc._id)) {
+        await observableCollection.change(doc);
+      }
+    }
+  }
+
+  static cursorSupported(cursorDescription: any, matcher: any) {
+    // First, check the options.
+    const options = cursorDescription.options;
+
+    // Did the user say no explicitly?
+    // underscored version of the option is COMPAT with 1.2
+    if (options.disableOplog || options._disableOplog) return false;
+
+    // If a fields projection option is given check if it is supported by
+    // minimongo (some operators are not supported).
+
+    const fields = options.projection || options.fields;
+
+    if (fields) {
+      try {
+        LocalCollection._checkSupportedProjection(fields);
+      } catch (e: any) {
+        if (e.name === 'MinimongoError') {
+          return false;
+        }
+        throw e;
+      }
+    }
+
+    // We don't allow the following selectors:
+    //   - $where (not confident that we provide the same JS environment
+    //             as Mongo, and can yield!)
+    //   - $near (has "interesting" properties in MongoDB, like the possibility
+    //            of returning an ID multiple times, though even polling maybe
+    //            have a bug there)
+    //           XXX: once we support it, we would need to think more on how we
+    //           initialize the comparators when we create the driver.
+    return !matcher.hasWhere() && !matcher.hasGeoQuery();
+  }
+
+  getFieldsOfInterest() {
+    return this.observableCollection!.fieldsOfInterest;
+  }
+}

--- a/packages/mongo/new-oplog-driver/new_oplog_tailing.ts
+++ b/packages/mongo/new-oplog-driver/new_oplog_tailing.ts
@@ -171,6 +171,20 @@ export class NewOplogTailing {
       return;
     }
     const collectionName = oplogDocument.ns.slice(this._dbName.length + 1);
+    if (oplogDocument.o.drop) {
+      for (const subscribers of Object.values(this.store)) {
+        for (const subscriber of subscribers) {
+          if (
+            !subscriber._stopped &&
+            subscriber.observableCollection?.collectionName ===
+              oplogDocument.o.drop
+          ) {
+            await subscriber.reload();
+          }
+        }
+      }
+      return;
+    }
 
     const id = oplogDocument.o?._id ?? oplogDocument.o2?._id;
     if (!collectionName || !id) {
@@ -200,9 +214,8 @@ export class NewOplogTailing {
       return;
     }
 
-    const collection = subscribers[0].observableCollection!.collection;
 
-    const doc = await this.getDoc(collection, subscribers, id, eventType);
+    const doc = await this.getDoc( subscribers, id, eventType);
     if (!doc) {
       return;
     }
@@ -230,7 +243,6 @@ export class NewOplogTailing {
 
   queueGetDoc: Promise<any> = Promise.resolve();
   async getDoc(
-    collection: any,
     subscribers: NewOplogObserveDriver[],
     id: any,
     eventType: OplogEventType
@@ -238,12 +250,14 @@ export class NewOplogTailing {
     const stringifiedId = MongoID.idStringify(id);
     if (eventType === "REMOVE") {
       this.queueGetDoc = this.queueGetDoc.then(() => {
-        return { _id: stringifiedId };
+        return { _id: id };
       });
       return this.queueGetDoc;
     }
+    const observableCollection = subscribers[0].observableCollection!;
+    const mongoHandle = observableCollection.mongoHandle
 
-    const collectionName = collection._name;
+    const collectionName = observableCollection.collectionName;
 
     const fieldsOfInterest = getFieldsOfInterestFromAll(subscribers);
     this.documentsToFetch.set(stringifiedId, {
@@ -276,8 +290,8 @@ export class NewOplogTailing {
           count++;
         }
       }
-      const items = await collection
-        .find(
+      const items = await mongoHandle.
+        find(collectionName,
           { _id: { $in: documentIds } },
           {
             projection:

--- a/packages/mongo/new-oplog-driver/new_oplog_tailing.ts
+++ b/packages/mongo/new-oplog-driver/new_oplog_tailing.ts
@@ -1,0 +1,438 @@
+import isEmpty from "lodash.isempty";
+import { Meteor } from "meteor/meteor";
+import { NpmModuleMongodb } from "meteor/npm-mongo";
+import { isDeepStrictEqual } from "node:util";
+import { MongoID } from 'meteor/mongo-id';
+
+import type {
+  NewOplogObserveDriver,
+  OplogEventType,
+} from "./new_oplog_observe_driver";
+import { getDedicatedChannel, getFieldsOfInterestFromAll } from "./utils";
+import { MongoConnection } from "../mongo_connection";
+import type { CatchingUpResolver, OplogEntry } from "../oplog_tailing";
+
+const { Long } = NpmModuleMongodb;
+
+const OPLOG_COLLECTION = "oplog.rs";
+
+const TAIL_TIMEOUT = +(process.env.METEOR_OPLOG_TAIL_TIMEOUT || 30000);
+
+export class NewOplogTailing {
+  queue: any;
+  store: { [key: string]: NewOplogObserveDriver[] };
+  private _oplogLastEntryConnection: MongoConnection | null;
+  private _oplogUrl: string;
+  private _dbName: string;
+  private _oplogOptions: {
+    excludeCollections?: string[];
+    includeCollections?: string[];
+  };
+  private _lastProcessedTS: any;
+  private _tailHandle: any;
+  private _readyPromiseResolver!: () => void;
+  private _readyPromise = new Promise<void>(
+    (r) => (this._readyPromiseResolver = r)
+  );
+  private _catchingUpResolvers: CatchingUpResolver[] = [];
+  private _stopped = false;
+  _startTrailingPromise: Promise<void> | null = null;
+
+  constructor(oplogUrl: string, dbName: string) {
+    this._oplogUrl = oplogUrl;
+    this._dbName = dbName;
+    this.queue = new Meteor._AsynchronousQueue();
+    this.store = {};
+    const includeCollections =
+      Meteor.settings?.packages?.mongo?.oplogIncludeCollections;
+    const excludeCollections =
+      Meteor.settings?.packages?.mongo?.oplogExcludeCollections;
+    if (includeCollections?.length && excludeCollections?.length) {
+      throw new Error(
+        "Can't use both mongo oplog settings oplogIncludeCollections and oplogExcludeCollections at the same time."
+      );
+    }
+    this._oplogOptions = { includeCollections, excludeCollections };
+    this._startTrailingPromise = this._startTailing();
+  }
+
+  async stop(): Promise<void> {
+    if (this._stopped) return;
+    this._stopped = true;
+    if (this._tailHandle) {
+      await this._tailHandle.stop();
+    }
+  }
+
+  getAllSubscribers() {
+    const subscribers: NewOplogObserveDriver[] = [];
+    for (const observers of Object.values(this.store)) {
+      subscribers.push(...observers);
+    }
+    return subscribers;
+  }
+
+  attach(subscriber: NewOplogObserveDriver) {
+    for (const channel of subscriber.channels) {
+      if (!this.store[channel]) {
+        this.store[channel] = [];
+      }
+      this.store[channel].push(subscriber);
+    }
+  }
+
+  detach(subscriber: NewOplogObserveDriver) {
+    for (const channel of subscriber.channels) {
+      this.store[channel] = this.store[channel]?.filter((s) => s !== subscriber);
+      if (this.store[channel] && this.store[channel].length === 0) {
+        delete this.store[channel];
+      }
+    }
+  }
+
+  async _startTailing() {
+    const oplogTailConnection = new MongoConnection(this._oplogUrl, {
+      maxPoolSize: 1,
+      minPoolSize: 1,
+    });
+    this._oplogLastEntryConnection = new MongoConnection(this._oplogUrl, {
+      maxPoolSize: 1,
+      minPoolSize: 1,
+    });
+
+    const lastOplogEntry = await this._oplogLastEntryConnection.findOneAsync(
+      OPLOG_COLLECTION,
+      {},
+      { sort: { $natural: -1 }, projection: { ts: 1 } }
+    );
+    const oplogSelector = this._getOplogSelector(lastOplogEntry?.ts);
+
+    if (lastOplogEntry) {
+      this._lastProcessedTS = lastOplogEntry.ts;
+    }
+
+    const cursorDescription = {
+      collectionName: OPLOG_COLLECTION,
+      selector: oplogSelector,
+      options: {
+        tailable: true,
+        projection: {
+          op: 1,
+          ts: 1,
+          ns: 1,
+          "o._id": 1,
+          "o2._id": 1,
+          "o.drop": 1,
+          "o.applyOps": 1,
+        },
+      },
+    };
+
+    this._tailHandle = oplogTailConnection.tail(
+      cursorDescription,
+      async (doc: any) => {
+        const promise = this.processOplogDocument(doc);
+        //When there is a lot of oplog entries, some processing is done in parallel.
+        //This queue ensure that the timestamp is set only after all preceding entries are processed.
+        //This guarantees that after an await myCollection.updateAsync(docId, ...), all prior oplog entries have been processed.
+        this.tailingQueue = this.tailingQueue.then(() => promise);
+        await this.tailingQueue;
+        this._setLastProcessedTS(doc.ts);
+      },
+      TAIL_TIMEOUT
+    );
+    this._readyPromiseResolver!();
+  }
+
+  private async processOplogDocument(oplogDocument: any) {
+    if (oplogDocument.ns === "admin.$cmd") {
+      if (oplogDocument.o.applyOps) {
+        // This was a successful transaction, so we need to apply the
+        // operations that were involved.
+        let nextTimestamp = oplogDocument.ts;
+        return Promise.all(
+          oplogDocument.o.applyOps.map((op) => {
+            // See https://github.com/meteor/meteor/issues/10420.
+            if (!op.ts) {
+              op.ts = nextTimestamp;
+              nextTimestamp = nextTimestamp.add(Long.ONE);
+            }
+            return this.processOplogDocument(op);
+          })
+        );
+      }
+      throw new Error("Unknown command " + JSON.stringify(oplogDocument));
+    }
+
+    if (
+      typeof oplogDocument.ns !== "string" ||
+      !oplogDocument.ns.startsWith(this._dbName + ".")
+    ) {
+      return;
+    }
+    const collectionName = oplogDocument.ns.slice(this._dbName.length + 1);
+
+    const id = oplogDocument.o?._id ?? oplogDocument.o2?._id;
+    if (!collectionName || !id) {
+      return;
+    }
+
+    let eventType: OplogEventType;
+    if (oplogDocument.op === "i") {
+      eventType = "INSERT";
+    } else if (oplogDocument.op === "u") {
+      eventType = "UPDATE";
+    } else if (oplogDocument.op === "d") {
+      eventType = "REMOVE";
+    } else {
+      throw new Meteor.Error(
+        `Unknown oplog event type "${
+          oplogDocument.op
+        }" for document ${JSON.stringify(oplogDocument)}`
+      );
+    }
+
+    const subscribers = [
+      ...(this.store[collectionName] ?? []),
+      ...(this.store[getDedicatedChannel(collectionName, id)] ?? []),
+    ].filter((s) => !s._stopped);
+    if (subscribers.length === 0) {
+      return;
+    }
+
+    const collection = subscribers[0].observableCollection!.collection;
+
+    const doc = await this.getDoc(collection, subscribers, id, eventType);
+    if (!doc) {
+      return;
+    }
+    for (const subscriber of subscribers) {
+      try {
+        await subscriber.processFromOplog(eventType, doc);
+      } catch (e) {
+        Meteor._debug(`Exception while processing event`, e);
+      }
+    }
+  }
+
+  documentsToFetch = new Map<
+    string,
+    {
+      doc: any;
+      collectionName: string;
+      fieldsOfInterest:
+        | true
+        | {
+            [key: string]: 1;
+          };
+    }
+  >();
+
+  queueGetDoc: Promise<any> = Promise.resolve();
+  async getDoc(
+    collection: any,
+    subscribers: NewOplogObserveDriver[],
+    id: any,
+    eventType: OplogEventType
+  ) {
+    const stringifiedId = MongoID.idStringify(id);
+    if (eventType === "REMOVE") {
+      this.queueGetDoc = this.queueGetDoc.then(() => {
+        return { _id: stringifiedId };
+      });
+      return this.queueGetDoc;
+    }
+
+    const collectionName = collection._name;
+
+    const fieldsOfInterest = getFieldsOfInterestFromAll(subscribers);
+    this.documentsToFetch.set(stringifiedId, {
+      fieldsOfInterest,
+      doc: null,
+      collectionName,
+    });
+    this.queueGetDoc = this.queueGetDoc.then(async () => {
+      const documentsToFetch = this.documentsToFetch.get(stringifiedId);
+      if (!documentsToFetch) {
+        return;
+      }
+      this.documentsToFetch.delete(stringifiedId);
+      if (documentsToFetch.doc) {
+        return documentsToFetch.doc;
+      }
+
+      const documentIds = [MongoID.idParse(stringifiedId)];
+      let count = 0;
+      const limit = 1000;
+      for (const [key, value] of this.documentsToFetch) {
+        if (count >= limit) {
+          break;
+        }
+        if (
+          value.collectionName === collectionName &&
+          isDeepStrictEqual(value.fieldsOfInterest, fieldsOfInterest)
+        ) {
+          documentIds.push(MongoID.idParse(key));
+          count++;
+        }
+      }
+      const items = await collection
+        .find(
+          { _id: { $in: documentIds } },
+          {
+            projection:
+              fieldsOfInterest === true ? undefined : fieldsOfInterest,
+          }
+        )
+        .fetchAsync();
+
+      let result: any;
+      for (const item of items) {
+        const itemId = MongoID.idStringify(item._id);
+        if (itemId === stringifiedId) {
+          result = item;
+        } else {
+          const docToFetch = this.documentsToFetch.get(itemId);
+          if (docToFetch) {
+            docToFetch.doc = item;
+          }
+        }
+      }
+      return result;
+    });
+    return this.queueGetDoc;
+  }
+  tailingQueue: Promise<any> = Promise.resolve();
+
+  _getOplogSelector(lastProcessedTS?: Date) {
+    const oplogCriteria: any[] = [
+      {
+        $or: [
+          { op: { $in: ["i", "u", "d"] } },
+          { op: "c", "o.drop": { $exists: true } },
+          { op: "c", "o.dropDatabase": 1 },
+          { op: "c", "o.applyOps": { $exists: true } },
+        ],
+      },
+    ];
+
+    const nsRegex = new RegExp(
+      "^(?:" +
+        [
+          // @ts-ignore
+          Meteor._escapeRegExp(this._dbName + "."),
+          // @ts-ignore
+          Meteor._escapeRegExp("admin.$cmd"),
+        ].join("|") +
+        ")"
+    );
+
+    if (this._oplogOptions.excludeCollections?.length) {
+      oplogCriteria.push({
+        ns: {
+          $regex: nsRegex,
+          $nin: this._oplogOptions.excludeCollections.map(
+            (collName: string) => `${this._dbName}.${collName}`
+          ),
+        },
+      });
+    } else if (this._oplogOptions.includeCollections?.length) {
+      oplogCriteria.push({
+        $or: [
+          { ns: /^admin\.\$cmd/ },
+          {
+            ns: {
+              $in: this._oplogOptions.includeCollections.map(
+                (collName: string) => `${this._dbName}.${collName}`
+              ),
+            },
+          },
+        ],
+      });
+    } else {
+      oplogCriteria.push({
+        ns: nsRegex,
+      });
+    }
+
+    if (lastProcessedTS) {
+      oplogCriteria.push({
+        ts: { $gt: lastProcessedTS },
+      });
+    }
+
+    return {
+      $and: oplogCriteria,
+    };
+  }
+
+  async waitUntilCaughtUp(): Promise<void> {
+    if (this._stopped) {
+      throw new Error("Called waitUntilCaughtUp on stopped handle!");
+    }
+
+    await this._readyPromise;
+
+    let lastEntry: OplogEntry | null = null;
+
+    while (!this._stopped) {
+      const oplogSelector = this._getOplogSelector();
+      try {
+        lastEntry = await this._oplogLastEntryConnection.findOneAsync(
+          OPLOG_COLLECTION,
+          oplogSelector,
+          { projection: { ts: 1 }, sort: { $natural: -1 } }
+        );
+        break;
+      } catch (e) {
+        Meteor._debug("Got exception while reading last entry", e);
+        // @ts-ignore
+        await Meteor.sleep(100);
+      }
+    }
+
+    if (this._stopped) return;
+
+    if (!lastEntry) return;
+
+    const ts = lastEntry.ts;
+    if (!ts) {
+      throw Error("oplog entry without ts: " + JSON.stringify(lastEntry));
+    }
+
+    if (this._lastProcessedTS && ts.lessThanOrEqual(this._lastProcessedTS)) {
+      return;
+    }
+
+    let insertAfter = this._catchingUpResolvers.length;
+
+    while (
+      insertAfter - 1 > 0 &&
+      this._catchingUpResolvers[insertAfter - 1].ts.greaterThan(ts)
+    ) {
+      insertAfter--;
+    }
+
+    let promiseResolver = null;
+
+    const promiseToAwait = new Promise((r) => (promiseResolver = r));
+
+    this._catchingUpResolvers.splice(insertAfter, 0, {
+      ts,
+      resolver: promiseResolver!,
+    });
+
+    await promiseToAwait;
+  }
+
+  _setLastProcessedTS(ts: any): void {
+    this._lastProcessedTS = ts;
+    while (
+      !isEmpty(this._catchingUpResolvers) &&
+      this._catchingUpResolvers[0].ts.lessThanOrEqual(this._lastProcessedTS)
+    ) {
+      const sequencer = this._catchingUpResolvers.shift()!;
+      sequencer.resolver();
+    }
+  }
+}

--- a/packages/mongo/new-oplog-driver/observable_collection.ts
+++ b/packages/mongo/new-oplog-driver/observable_collection.ts
@@ -1,0 +1,289 @@
+import isEmpty from 'lodash.isempty';
+import { DiffSequence } from 'meteor/diff-sequence';
+import { EJSON } from 'meteor/ejson';
+import { Meteor } from 'meteor/meteor';
+import { LocalCollection } from 'meteor/minimongo';
+import { MongoIDMap } from './mongo_id_map';
+
+const allowedOptions = ['limit', 'skip', 'sort', 'fields', 'projection'];
+
+export default class ObservableCollection {
+  multiplexer: any;
+  matcher: any;
+  sorter: any;
+  cursorDescription: any;
+  collectionName: string;
+  collection: Mongo.Collection;
+  cursor: Mongo.Cursor;
+  store!: MongoIDMap;
+  selector: any;
+  options: any;
+  fieldsArray?: string[];
+  projectFieldsOnDoc: any;
+  isFieldsProjectionByExclusion: boolean | undefined;
+  fieldsOfInterest?: true | string[];
+  private __isInitialized = false;
+  private _projectionFn: any;
+  private _sharedProjection: any;
+  private _sharedProjectionFn: any;
+
+  constructor({
+    multiplexer,
+    matcher,
+    sorter,
+    cursorDescription,
+  }: {
+    multiplexer: any;
+    matcher: any;
+    sorter: any;
+    cursorDescription: any;
+  }) {
+    this.multiplexer = multiplexer;
+    this.matcher = matcher;
+    this.sorter = sorter;
+    this.cursorDescription = cursorDescription;
+
+    this.collectionName = this.cursorDescription.collectionName;
+    this.collection = Mongo.getCollection(cursorDescription.collectionName);
+
+    if (!this.collection) {
+      throw new Meteor.Error(
+        `We could not find the collection instance by name: "${
+          this.collectionName
+        }", the cursor description was: ${JSON.stringify(cursorDescription)}`
+      );
+    }
+  }
+
+  setupCollection() {
+    if (!this.collection) {
+      throw new Meteor.Error(
+        'We could not properly identify the collection by its name: ' +
+          this.collectionName +
+          '. Make sure you added redis-oplog package before any package that instantiates a collection.'
+      );
+    }
+
+    this.cursor = this.collection.find(
+      this.cursorDescription.selector,
+      this.cursorDescription.options
+    );
+
+    this.store = new MongoIDMap();
+    this.selector = this.cursorDescription.selector || {};
+
+    if (typeof this.selector === 'string') {
+      this.selector = { _id: this.selector };
+    }
+
+    if (this.cursorDescription.options) {
+      this.options = allowedOptions.reduce((acc, option) => {
+        if (this.cursorDescription.options[option]) {
+          acc[option] = this.cursorDescription.options[option];
+        }
+        return acc;
+      }, {} as any);
+    } else {
+      this.options = {};
+    }
+
+    const fields = this.options.projection || this.options.fields;
+
+    // check for empty projector object and delete.
+    if (fields && isEmpty(fields)) {
+      delete this.options.projection;
+      delete this.options.fields;
+    }
+
+    if (fields) {
+      this.fieldsArray = Object.keys(fields);
+
+      if (!Array.isArray(this.fieldsArray)) {
+        throw new Meteor.Error(
+          'We could not properly extract any fields. "projection" or "fields" must be an object. This was provided: ' +
+            JSON.stringify(fields)
+        );
+      }
+
+      this.projectFieldsOnDoc = LocalCollection._compileProjection(fields);
+      this.isFieldsProjectionByExclusion = this.fieldProjectionIsExclusion(fields);
+    }
+
+    this.fieldsOfInterest = this._getFieldsOfInterest();
+    this.__isInitialized = false;
+
+    const projection = fields || {};
+    this._projectionFn = LocalCollection._compileProjection(projection); // Projection function, result of combining important fields for selector and
+    // existing fields projection
+
+    this._sharedProjection = this.matcher.combineIntoProjection(projection);
+    if (this.sorter) {
+      this._sharedProjection = this.sorter.combineIntoProjection(this._sharedProjection);
+    }
+    this._sharedProjectionFn = LocalCollection._compileProjection(this._sharedProjection);
+  }
+
+  isEligible(doc: any) {
+    if (this.matcher) {
+      return this.matcher.documentMatches(doc).result;
+    }
+
+    return true;
+  }
+
+  async isEligibleByDB(_id: any) {
+    if (this.matcher) {
+      return !!(await this.collection.findOneAsync(
+        Object.assign({}, this.selector, { _id }),
+        { fields: { _id: 1 } }
+      ));
+    }
+
+    return true;
+  }
+
+  async init() {
+    if (this.__isInitialized) {
+      return; // silently do nothing.
+    }
+
+    this.__isInitialized = true;
+    const data = await this.cursor.fetchAsync();
+
+    for (const doc of data) {
+      await this.add(doc, true);
+    }
+    // This has too much control over multiplexer..
+    this.multiplexer.ready();
+  }
+
+  contains(docId: string) {
+    return this.store.has(docId);
+  }
+
+  async add(doc: any, safe = false) {
+    if (!safe) {
+      if (this.fieldsArray) {
+        // projection function clones the document already.
+        doc = this.projectFieldsOnDoc(doc);
+      } else {
+        doc = EJSON.clone(doc);
+      }
+    }
+    this.store.set(doc._id, doc);
+    const fields = {...doc};
+    delete fields._id;
+    await this.multiplexer.added(doc._id, fields);
+  }
+
+  /* We use this method when we receive updates for a document that is not yet in the observable collection store */
+  async addByIds(docIds: string[]) {
+    const { limit, skip, ...cleanedOptions } = this.options;
+    const docs = await this.collection
+      .find({ _id: { $in: docIds } }, cleanedOptions)
+      .fetchAsync();
+
+    for (const docId of docIds) {
+      const doc = docs.find((d) => d._id === docId);
+      this.store.set(docId, doc);
+      if (doc) {
+        const fields = {...doc};
+        delete fields._id;
+        await this.multiplexer.added(doc._id, fields);
+      }
+    }
+  }
+
+  /* Sends over the wire only the top fields of changes, because DDP client doesnt do deep merge.*/
+  async change(doc: any) {
+    const docId = doc._id;
+    const oldDoc = this.store.get(docId);
+    if (!oldDoc) {
+      return;
+    }
+
+    this.store.set(docId, this._sharedProjectionFn(doc));
+
+    const projectedNew = this._projectionFn(doc);
+    const projectedOld = this._projectionFn(oldDoc);
+
+    const changed = DiffSequence.makeChangedFields(projectedNew, projectedOld);
+
+    if (!isEmpty(changed)) {
+      await this.multiplexer.changed(docId, changed);
+    }
+  }
+
+  async remove(docId: string) {
+    const doc = this.store.pop(docId);
+    if (doc) {
+      await this.multiplexer.removed(docId);
+    }
+  }
+
+  clearStore() {
+    this.store.clear();
+  }
+
+  isLimitReached() {
+    if (this.options.limit) {
+      const size = this.store.size();
+      return size >= this.options.limit;
+    }
+
+    return false;
+  }
+
+  _getFieldsOfInterest() {
+    const fields = this.options.projection || this.options.fields;
+
+    if (!fields) {
+      return true;
+    }
+
+    // if you have some fields excluded (high chances you don't, but we query for all fields either way)
+    // because it can get very tricky with future subscribers that may need some fields
+    if (this.isFieldsProjectionByExclusion) {
+      return true;
+    }
+
+    // if we have options, we surely have fields array
+    let fieldsArray = this.fieldsArray!.slice();
+    if (Object.keys(this.selector).length > 0) {
+      fieldsArray = Array.from(
+        new Set([...fieldsArray, ...this.extractFieldsFromFilters(this.selector)])
+      );
+    }
+
+    return fieldsArray;
+  }
+  private fieldProjectionIsExclusion(fields: any) {
+    return Object.values(fields)[0] !== 1;
+  }
+  private extractFieldsFromFilters(filters: any) {
+    const deepFilterFieldsArray = ['$and', '$or', '$nor'];
+    const deepFilterFieldsObject = ['$not'];
+    const filterFields: string[] = [];
+    Object.keys(filters).forEach((key) => {
+      if (key[0] !== '$') {
+        filterFields.push(key);
+      }
+    });
+
+    deepFilterFieldsArray.forEach((field) => {
+      if (filters[field]) {
+        filters[field].forEach((element: any) => {
+          filterFields.push(...this.extractFieldsFromFilters(element));
+        });
+      }
+    });
+
+    deepFilterFieldsObject.forEach((field) => {
+      if (filters[field]) {
+        filterFields.push(...this.extractFieldsFromFilters(filters[field]));
+      }
+    });
+
+    return filterFields;
+  }
+}

--- a/packages/mongo/new-oplog-driver/observable_collection.ts
+++ b/packages/mongo/new-oplog-driver/observable_collection.ts
@@ -4,6 +4,8 @@ import { EJSON } from 'meteor/ejson';
 import { Meteor } from 'meteor/meteor';
 import { LocalCollection } from 'meteor/minimongo';
 import { MongoIDMap } from './mongo_id_map';
+import  { MongoConnection } from '../mongo_connection';
+import { CursorDescription } from '../cursor_description';
 
 const allowedOptions = ['limit', 'skip', 'sort', 'fields', 'projection'];
 
@@ -13,7 +15,6 @@ export default class ObservableCollection {
   sorter: any;
   cursorDescription: any;
   collectionName: string;
-  collection: Mongo.Collection;
   cursor: Mongo.Cursor;
   store!: MongoIDMap;
   selector: any;
@@ -26,47 +27,42 @@ export default class ObservableCollection {
   private _projectionFn: any;
   private _sharedProjection: any;
   private _sharedProjectionFn: any;
+  mongoHandle: MongoConnection
 
   constructor({
     multiplexer,
     matcher,
     sorter,
     cursorDescription,
+    mongoHandle,
   }: {
     multiplexer: any;
     matcher: any;
     sorter: any;
     cursorDescription: any;
+    mongoHandle:any
   }) {
     this.multiplexer = multiplexer;
     this.matcher = matcher;
     this.sorter = sorter;
     this.cursorDescription = cursorDescription;
+    this.mongoHandle = mongoHandle
 
     this.collectionName = this.cursorDescription.collectionName;
-    this.collection = Mongo.getCollection(cursorDescription.collectionName);
-
-    if (!this.collection) {
-      throw new Meteor.Error(
-        `We could not find the collection instance by name: "${
-          this.collectionName
-        }", the cursor description was: ${JSON.stringify(cursorDescription)}`
-      );
-    }
   }
 
   setupCollection() {
-    if (!this.collection) {
-      throw new Meteor.Error(
-        'We could not properly identify the collection by its name: ' +
-          this.collectionName +
-          '. Make sure you added redis-oplog package before any package that instantiates a collection.'
+      const  options = Object.assign({}, this.cursorDescription.options);
+      delete options.transform;
+      const  description = new CursorDescription(
+        this.cursorDescription.collectionName,
+        this.cursorDescription.selector,
+        options
       );
-    }
 
-    this.cursor = this.collection.find(
-      this.cursorDescription.selector,
-      this.cursorDescription.options
+    this.cursor = this.mongoHandle.find(this.collectionName,
+      description.selector,
+      description.options
     );
 
     this.store = new MongoIDMap();
@@ -133,7 +129,7 @@ export default class ObservableCollection {
 
   async isEligibleByDB(_id: any) {
     if (this.matcher) {
-      return !!(await this.collection.findOneAsync(
+      return !!(await this.mongoHandle.findOneAsync(this.collectionName,
         Object.assign({}, this.selector, { _id }),
         { fields: { _id: 1 } }
       ));
@@ -179,12 +175,12 @@ export default class ObservableCollection {
   /* We use this method when we receive updates for a document that is not yet in the observable collection store */
   async addByIds(docIds: string[]) {
     const { limit, skip, ...cleanedOptions } = this.options;
-    const docs = await this.collection
-      .find({ _id: { $in: docIds } }, cleanedOptions)
+    const docs = await this.mongoHandle
+      .find(this.collectionName, { _id: { $in: docIds } }, cleanedOptions)
       .fetchAsync();
-
+      
     for (const docId of docIds) {
-      const doc = docs.find((d) => d._id === docId);
+      const doc = docs.find((d) => EJSON.equals(docId, d._id));
       this.store.set(docId, doc);
       if (doc) {
         const fields = {...doc};

--- a/packages/mongo/new-oplog-driver/utils.ts
+++ b/packages/mongo/new-oplog-driver/utils.ts
@@ -1,0 +1,77 @@
+import { Meteor } from 'meteor/meteor';
+import { MongoID } from 'meteor/mongo-id';
+import isObject from 'lodash.isobject';
+
+import type { NewOplogObserveDriver } from './new_oplog_observe_driver';
+
+export function extractIdsFromSelector(selector: any) {
+  const filter = selector._id;
+  let ids: any[] = [];
+
+  if (isObject(filter) && !filter._str) {
+    if (!filter.$in) {
+      throw new Meteor.Error(
+        `When you subscribe directly, you can't have other specified fields rather than $in`
+      );
+    }
+
+    ids = filter.$in;
+  } else {
+    ids.push(filter);
+  }
+
+  return ids;
+}
+
+export function getDedicatedChannel(collectionName: string, docId: any) {
+  return `${collectionName}::${MongoID.idStringify(docId)}`;
+}
+
+export function getFieldsOfInterestFromAll(subscribers: NewOplogObserveDriver[]) {
+  let allFields = [];
+  for (let i = 0; i < subscribers.length; i++) {
+    const subscriber = subscribers[i];
+    const fields = subscriber.getFieldsOfInterest()!;
+
+    if (fields === true) {
+      // end of story, there is an observableCollection that needs all fields
+      // therefore we will query for all fields
+      return true;
+    }
+    allFields.push(...fields);
+  }
+
+  allFields = Array.from(new Set(allFields));
+
+  // this should not happen, but as a measure of safety
+  if (allFields.length === 0) {
+    return true;
+  }
+
+  allFields = removeChildrenOfParents(allFields);
+
+  const fieldsObject: { [key: string]: 1 } = {};
+
+  allFields.forEach((field) => {
+    fieldsObject[field] = 1;
+  });
+
+  return fieldsObject;
+}
+
+export function removeChildrenOfParents(array: string[]) {
+  const freshArray: string[] = [];
+
+  array.forEach((element, idxe) => {
+    // add it to freshArray only if there's no field starting with {me} + '.' inside the array
+    const foundParent = array.find((subelement, idxs) => {
+      return idxe !== idxs && element.indexOf(`${subelement}.`) === 0;
+    });
+
+    if (!foundParent) {
+      freshArray.push(element);
+    }
+  });
+
+  return freshArray;
+}

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -131,6 +131,7 @@ Package.onTest(function (api) {
   api.addFiles("tests/collection_async_tests.js", ["client", "server"]);
   api.addFiles("tests/observe_changes_tests.js", ["client", "server"]);
   api.addFiles("tests/oplog_tests.js", "server");
+  api.addFiles("tests/new_oplog_tests.js", "server");
   api.addFiles("tests/oplog_v2_converter_tests.js", "server");
   api.addFiles("tests/doc_fetcher_tests.js", "server");
 });

--- a/packages/mongo/tests/new_oplog_tests.js
+++ b/packages/mongo/tests/new_oplog_tests.js
@@ -1,0 +1,305 @@
+import { oplogOptionsTest } from "./oplog_tests.js";
+
+process.env.MONGO_OPLOG_URL &&
+  Tinytest.addAsync(
+    "mongo-livedata - newOplog - oplogIncludeCollections",
+    async (test) => {
+      const collectionNameA = "oplog-a-" + Random.id();
+      const collectionNameB = "oplog-b-" + Random.id();
+      const mongoPackageSettings = {
+        oplogIncludeCollections: [collectionNameB],
+        useNewOplogTailing: true,
+      };
+      await oplogOptionsTest({
+        test,
+        includeCollectionName: collectionNameB,
+        excludeCollectionName: collectionNameA,
+        mongoPackageSettings,
+      });
+    }
+  );
+
+process.env.MONGO_OPLOG_URL &&
+  Tinytest.addAsync(
+    "mongo-livedata - newOplog - oplogExcludeCollections",
+    async (test) => {
+      const collectionNameA = "oplog-a-" + Random.id();
+      const collectionNameB = "oplog-b-" + Random.id();
+      const mongoPackageSettings = {
+        oplogExcludeCollections: [collectionNameB],
+        useNewOplogTailing: true,
+      };
+      await oplogOptionsTest({
+        test,
+        includeCollectionName: collectionNameA,
+        excludeCollectionName: collectionNameB,
+        mongoPackageSettings,
+      });
+    }
+  );
+
+const withNewOplog = async (callback) => {
+  const previousMongoPackageSettings = {
+    ...(Meteor.settings?.packages?.mongo || {}),
+  };
+  Meteor.settings.packages.mongo = {
+    ...previousMongoPackageSettings,
+    useNewOplogTailing: true,
+  };
+  const defaultOplogHandle =
+    MongoInternals.defaultRemoteCollectionDriver().mongo._oplogHandle;
+
+  try {
+    const myOplogHandle = new MongoInternals.NewOplogHandle(
+      process.env.MONGO_OPLOG_URL,
+      "meteor"
+    );
+    await myOplogHandle._startTrailingPromise;
+    MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(
+      myOplogHandle
+    );
+
+    return await callback();
+  } finally {
+    Meteor.settings.packages.mongo = previousMongoPackageSettings;
+    MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(
+      defaultOplogHandle
+    );
+  }
+};
+
+Tinytest.addAsync(
+  "mongo-livedata - newOplog - unordered - basics",
+  async function (test, onComplete) {
+    await withNewOplog(async () => {
+      const c = new Mongo.Collection(Random.id());
+      await withCallbackLogger(
+        test,
+        ["added", "changed", "removed"],
+        Meteor.isServer,
+        async function (logger) {
+          const handle = await c.find().observeChanges(logger);
+          const barid = await c.insertAsync({ thing: "stuff" });
+          await logger.expectResultOnly("added", [barid, { thing: "stuff" }]);
+
+          let fooid = await c.insertAsync({
+            noodles: "good",
+            bacon: "bad",
+            apples: "ok",
+          });
+
+          await logger.expectResultOnly("added", [
+            fooid,
+            { noodles: "good", bacon: "bad", apples: "ok" },
+          ]);
+
+          await c.updateAsync(fooid, {
+            noodles: "alright",
+            potatoes: "tasty",
+            apples: "ok",
+          });
+          await c.updateAsync(fooid, {
+            noodles: "alright",
+            potatoes: "tasty",
+            apples: "ok",
+          });
+          await logger.expectResultOnly("changed", [
+            fooid,
+            { noodles: "alright", potatoes: "tasty", bacon: undefined },
+          ]);
+          await c.removeAsync(fooid);
+          await logger.expectResultOnly("removed", [fooid]);
+          await c.removeAsync(barid);
+          await logger.expectResultOnly("removed", [barid]);
+
+          fooid = await c.insertAsync({
+            noodles: "good",
+            bacon: "bad",
+            apples: "ok",
+          });
+
+          await logger.expectResult("added", [
+            fooid,
+            { noodles: "good", bacon: "bad", apples: "ok" },
+          ]);
+          await logger.expectNoResult();
+          handle.stop();
+          onComplete();
+        }
+      );
+    });
+  }
+);
+
+Tinytest.addAsync(
+  "mongo-livedata - newOplog - dedicatedChannel",
+  async function (test, onComplete) {
+    await withNewOplog(async () => {
+      const c = new Mongo.Collection(Random.id());
+      await withCallbackLogger(
+        test,
+        ["added", "changed", "removed"],
+        Meteor.isServer,
+        async function (logger) {
+          const observedId = Random.id();
+
+          const handle = await c.find({ _id: observedId }).observeChanges(logger);
+          const nonObeservedId = await c.insertAsync({ thing: "uselessStuff" });
+          await logger.expectNoResult();
+          await c.insertAsync({ _id: observedId, thing: "importantStuff" });
+          await logger.expectResultOnly("added", [
+            observedId,
+            { thing: "importantStuff" },
+          ]);
+          await c.updateAsync(nonObeservedId, {
+            $set: { thing: "updatedUselessStuff" },
+          });
+          await logger.expectNoResult();
+          await c.updateAsync(observedId, {
+            $set: { thing: "updatedImportantStuff" },
+          });
+          await logger.expectResultOnly("changed", [
+            observedId,
+            { thing: "updatedImportantStuff" },
+          ]);
+          await c.removeAsync(nonObeservedId);
+          await logger.expectNoResult();
+          await c.removeAsync(observedId);
+          await logger.expectResultOnly("removed", [observedId]);
+          handle.stop();
+          onComplete();
+        }
+      );
+    });
+  }
+);
+Tinytest.addAsync(
+  "mongo-livedata - newOplog - default",
+  async function (test, onComplete) {
+    await withNewOplog(async () => {
+      const c = new Mongo.Collection(Random.id());
+      await withCallbackLogger(
+        test,
+        ["added", "changed", "removed"],
+        Meteor.isServer,
+        async function (logger) {
+          const observedId = Random.id();
+
+          const handle = await c
+            .find({ type: "important" })
+            .observeChanges(logger);
+          const nonObeservedId = await c.insertAsync({
+            name: "test1",
+            type: "useless",
+          });
+          await logger.expectNoResult();
+          await c.insertAsync({
+            _id: observedId,
+            name: "test2",
+            type: "important",
+          });
+          await logger.expectResultOnly("added", [
+            observedId,
+            { name: "test2", type: "important" },
+          ]);
+          await c.updateAsync(nonObeservedId, {
+            $set: { type: "still-useless" },
+          });
+          await logger.expectNoResult();
+          await c.updateAsync(nonObeservedId, { $set: { type: "important" } });
+          await logger.expectResultOnly("added", [
+            nonObeservedId,
+            { name: "test1", type: "important" },
+          ]);
+          await c.updateAsync(observedId, { $set: { name: "test2-updated" } });
+          await logger.expectResultOnly("changed", [
+            observedId,
+            { name: "test2-updated" },
+          ]);
+          await c.updateAsync(nonObeservedId, { $set: { type: "useless" } });
+          await logger.expectResultOnly("removed", [nonObeservedId]);
+          await c.removeAsync(nonObeservedId);
+          await logger.expectNoResult();
+          await c.removeAsync(observedId);
+          await logger.expectResultOnly("removed", [observedId]);
+          handle.stop();
+          onComplete();
+        }
+      );
+    });
+  }
+);
+Tinytest.addAsync(
+  "mongo-livedata - newOplog - limit",
+  async function (test, onComplete) {
+    await withNewOplog(async () => {
+      const c = new Mongo.Collection(Random.id());
+      await withCallbackLogger(
+        test,
+        ["added", "changed", "removed"],
+        Meteor.isServer,
+        async function (logger) {
+          const handle = await c
+            .find({ type: "important" }, { sort: { name: 1 }, limit:3 })
+            .observeChanges(logger);
+          const test1Id = await c.insertAsync({
+            name: "test1",
+            type: "useless",
+          });
+
+          await logger.expectNoResult();
+          const test2Id = await c.insertAsync({
+            name: "test2",
+            type: "important",
+          });
+          await logger.expectResultOnly("added", [
+            test2Id,
+            { name: "test2", type: "important" },
+          ]);
+          await c.updateAsync(test1Id, {
+            $set: { type: "still-useless" },
+          });
+          await logger.expectNoResult();
+          await c.updateAsync(test1Id, { $set: { type: "important" } });
+          await logger.expectResultOnly("added", [
+            test1Id,
+            { name: "test1", type: "important" },
+          ]);
+          await c.updateAsync(test2Id, { $set: { name: "test2-updated" } });
+          await logger.expectResultOnly("changed", [
+            test2Id,
+            { name: "test2-updated" },
+          ]);
+          const test3Id = await c.insertAsync({
+            name: "test3",
+            type: "important",
+          });
+          await logger.expectResultOnly("added", [
+            test3Id,
+            { name: "test3", type: "important" },
+          ]);
+          const test4Id = await c.insertAsync({
+            name: "test4",
+            type: "important",
+          });
+          await logger.expectNoResult();
+          await c.updateAsync(test4Id, { $set: { name: "test0" } });
+          await logger.expectResult("removed", [test3Id]);
+          await logger.expectResult("added", [
+            test4Id,
+            { name: "test0", type: "important" },
+          ]);
+          await c.updateAsync(test1Id, { $set: { type: "useless" } });
+          await logger.expectResult("removed", [test1Id]);
+          await logger.expectResult("added", [test3Id, {name: "test3", type: "important"}]);
+          await c.removeAsync(test1Id);
+          await logger.expectNoResult();
+          await c.removeAsync(test2Id);
+          await logger.expectResultOnly("removed", [test2Id]);
+          handle.stop();
+          onComplete();
+        }
+      );
+    });
+  }
+);

--- a/packages/mongo/tests/observe_changes_tests.js
+++ b/packages/mongo/tests/observe_changes_tests.js
@@ -518,9 +518,8 @@ if (Meteor.isServer) {
 
       const [resolver1, promise1] = getPromiseAndResolver();
       const [resolver2, promise2] = getPromiseAndResolver();
-
-      await self.insert({x: 2, y: 3});
       self.expects.push(resolver1, resolver2);
+      await self.insert({x: 2, y: 3});
       await self.insert({x: 3, y: 7});  // filtered out by the query
       await self.insert({x: 4});
       // Expect two added calls to happen.

--- a/packages/mongo/tests/oplog_tests.js
+++ b/packages/mongo/tests/oplog_tests.js
@@ -181,7 +181,7 @@ process.env.MONGO_OPLOG_URL &&
 const defaultOplogHandle = MongoInternals.defaultRemoteCollectionDriver().mongo._oplogHandle;
 let previousMongoPackageSettings = {};
 
-async function oplogOptionsTest({
+export async function oplogOptionsTest({
   test,
   includeCollectionName,
   excludeCollectionName,
@@ -192,7 +192,9 @@ async function oplogOptionsTest({
     if (!Meteor.settings.packages) Meteor.settings.packages = {};
     Meteor.settings.packages.mongo = mongoPackageSettings;
 
-    const myOplogHandle = new MongoInternals.OplogHandle(process.env.MONGO_OPLOG_URL, 'meteor');
+    const OplogHandle = mongoPackageSettings.useNewOplogTailing ? MongoInternals.NewOplogHandle : MongoInternals.OplogHandle;
+    const myOplogHandle = new OplogHandle(process.env.MONGO_OPLOG_URL, 'meteor');
+
     await myOplogHandle._startTrailingPromise;
     MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(myOplogHandle);
 


### PR DESCRIPTION
### Context & Motivation
Many large-scale Meteor applications turn to redis-oplog to solve performance bottlenecks related to high-volume writes and oplog tailing. Our application faced these exact issues: high latency during bulk operations, server instability, and OOM crashes under load.
While redis-oplog was a potential solution, it introduces significant operational complexity: managing a highly-available Redis cluster and ensuring external database writes are also piped to Redis. We sought to achieve the same performance gains without this added architectural dependency.
Our investigation confirmed the bottleneck is the expensive BSON-to-JavaScript transformation of every document in the oplog, even for documents that don't match active publications. redis-oplog solves this by deferring the full document fetch. This PR brings that same core logic directly into Meteor's native oplog driver.

### Proposed Solution
This PR refactors the oplog driver to mirror the two-stage process used by redis-oplog when used with something like oplogtoredis:
1. Initial Fetch (ID-Only): The oplog query is modified to only retrieve the document's _id. This avoids the costly BSON parsing of the full object for every change event.
2. Deferred Document Load: The full document is only fetched from MongoDB if the change is relevant to an active publication. This fetch uses a projection to retrieve only the fields required by those publications.
Advantages
This implementation avoids the processing of the irrelevant oplog entries without requiring a Redis instance. It offers the same performance trade-off: a small increase in latency for a relevant document change (due to the second DB hit) in exchange for a massive reduction in server load and processing during high-volume writes.
By integrating this pattern into meteor, we achieve these benefits while simplifying the application's architecture.
### Observed Results
This change has been running in our production application for a month and has been validated with targeted load tests.
In Production:
* A massive and sustained improvement in CPU usage, 95th percentile Event Loop Latency, and Garbage Collection duration.
* The application is noticeably more responsive and resilient during peak usage times.
In Load Testing:
* Mass Insertion (Publications filtered by ID): An operation that previously made the application unresponsive for ~10 minutes now completes while the application remains fully responsive.
* Mass Insertion (Publications without an ID filter): An operation that previously caused a server crash (OOM) now results in a brief period of high load, but the server remains stable, does not crash, and fully recovers.
Relation to Change Streams
I am aware there is ongoing work to support MongoDB Change Streams but I'm unsure if this would address the same performance issues.

Looking forward to feedback on this approach.