### PR TITLE
Fix/accounts base docs

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -340,6 +340,7 @@ export class AccountsServer extends AccountsCommon {
    * @param {Object} [options]
    * @param {Object} options.fields Limit the fields to return from the user document
    * @returns {Promise<Object>} A user if found, else null
+   * @memberof Accounts
    * @importFromPackage accounts-base
    */
   findUserByEmail = async (email, options) =>
@@ -352,6 +353,7 @@ export class AccountsServer extends AccountsCommon {
    * @param {Object} [options]
    * @param {Object} options.fields Limit the fields to return from the user document
    * @returns {Promise<Object>} A user if found, else null
+   * @memberof Accounts
    * @importFromPackage accounts-base
    */
   findUserByUsername = async (username, options) =>

--- a/packages/accounts-base/server_main.js
+++ b/packages/accounts-base/server_main.js
@@ -8,29 +8,6 @@ Accounts = new AccountsServer(Meteor.server, { ...Meteor.settings.packages?.acco
 // TODO[FIBERS]: I need TLA
 Accounts.init().then();
 
-/**
- * @summary Find a user by one of their email addresses.
- * @locus Server
- * @param {String} email The email address to look for
- * @param {Object} [options]
- * @param {Object} options.fields Limit the fields to return from the user document
- * @returns {Promise<Object>} A user if found, else null
- * @memberof Accounts
- * @importFromPackage accounts-base
- */
-Accounts.findUserByEmail = AccountsServer.findUserByEmail;
-
-/**
- * @summary Find a user by their username.
- * @locus Server
- * @param {String} username The username to look for
- * @param {Object} [options]
- * @param {Object} options.fields Limit the fields to return from the user document
- * @returns {Promise<Object>} A user if found, else null
- * @memberof Accounts
- * @importFromPackage accounts-base
- */
-Accounts.findUserByUsername = Accounts.findUserByUsername;
 // Users table. Don't use the normal autopublish, since we want to hide
 // some fields. Code to autopublish this is in accounts_server.js.
 // XXX Allow users to configure this collection name.

--- a/packages/accounts-base/server_main.js
+++ b/packages/accounts-base/server_main.js
@@ -18,7 +18,7 @@ Accounts.init().then();
  * @memberof Accounts
  * @importFromPackage accounts-base
  */
-Accounts.findUserByEmail = Accounts.findUserByEmail;
+Accounts.findUserByEmail = AccountsServer.findUserByEmail;
 
 /**
  * @summary Find a user by their username.

--- a/packages/accounts-base/server_main.js
+++ b/packages/accounts-base/server_main.js
@@ -7,6 +7,30 @@ import { AccountsServer } from "./accounts_server.js";
 Accounts = new AccountsServer(Meteor.server, { ...Meteor.settings.packages?.accounts, ...Meteor.settings.packages?.['accounts-base'] });
 // TODO[FIBERS]: I need TLA
 Accounts.init().then();
+
+/**
+ * @summary Find a user by one of their email addresses.
+ * @locus Server
+ * @param {String} email The email address to look for
+ * @param {Object} [options]
+ * @param {Object} options.fields Limit the fields to return from the user document
+ * @returns {Promise<Object>} A user if found, else null
+ * @memberof Accounts
+ * @importFromPackage accounts-base
+ */
+Accounts.findUserByEmail = Accounts.findUserByEmail;
+
+/**
+ * @summary Find a user by their username.
+ * @locus Server
+ * @param {String} username The username to look for
+ * @param {Object} [options]
+ * @param {Object} options.fields Limit the fields to return from the user document
+ * @returns {Promise<Object>} A user if found, else null
+ * @memberof Accounts
+ * @importFromPackage accounts-base
+ */
+Accounts.findUserByUsername = Accounts.findUserByUsername;
 // Users table. Don't use the normal autopublish, since we want to hide
 // some fields. Code to autopublish this is in accounts_server.js.
 // XXX Allow users to configure this collection name.


### PR DESCRIPTION
After [this PR](https://github.com/meteor/meteor/pull/13859) we are getting an error when we try to test docs

``` shell
italojose@italo-machine: ~/dev/meteor-dev/meteor/docs release-3.3.2 ⚡
$ npm run test                                                                                                                                                                                   [18:59:21]

> hexo-site@0.0.0 test
> npm run clean; npm run build


> hexo-site@0.0.0 clean
> hexo clean; rm data/data.js data/names.json

INFO  Deleted database.
INFO  Deleted public folder.

> hexo-site@0.0.0 build
> npm run list-core-packages && jsdoc/jsdoc.sh && chexo @meteorjs/meteor-hexo-config -- generate


> hexo-site@0.0.0 list-core-packages
> node ./generators/packages-listing/script.js

🚂 Started listing 🚂
📝 Writing to file 📝
🚀 Done 🚀
/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/.bin/jsdoc -t /Users/italojose/dev/meteor-dev/meteor/docs/jsdoc/docdata-jsdoc-template -c /Users/italojose/dev/meteor-dev/meteor/docs/jsdoc/jsdoc-conf.json docs/jsdoc/docdata-jsdoc-template/publish.js npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/bundled_www/application/packages/meteor.js npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/bundled_www/application/packages/meteor.js.map npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version1/packages/57d11a30155349aa5106f8150cee35eac5f4764c.map npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version1/packages/meteor.js npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version2/packages/57d11a30155349aa5106f8150cee35eac5f4764c.map npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version2/packages/meteor.js npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version2_with_invalid_asset/packages/57d11a30155349aa5106f8150cee35eac5f4764c.map npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version2_with_invalid_asset/packages/meteor.js npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version2_with_missing_asset/packages/57d11a30155349aa5106f8150cee35eac5f4764c.map npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version2_with_missing_asset/packages/meteor.js npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version2_with_version_mismatch/packages/57d11a30155349aa5106f8150cee35eac5f4764c.map npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version2_with_version_mismatch/packages/meteor.js npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version3/packages/57d11a30155349aa5106f8150cee35eac5f4764c.map npm-packages/cordova-plugin-meteor-webapp/tests/fixtures/downloadable_versions/version3/packages/meteor.js npm-packages/eslint-plugin-meteor/scripts/admin/jsdoc/docdata-jsdoc-template/publish.js npm-packages/eslint-plugin-meteor/scripts/admin/jsdoc/jsdoc.sh npm-packages/meteor-babel/test/mocha.js packages/accounts-2fa/2fa-client.js packages/accounts-base/accounts_client.js packages/accounts-base/accounts_common.js packages/accounts-base/accounts_server.js packages/accounts-base/client_main.js packages/accounts-base/server_main.js packages/accounts-oauth/oauth_client.js packages/accounts-password/email_templates.js packages/accounts-password/password_client.js packages/accounts-password/password_server.js packages/accounts-passwordless/email_templates.js packages/accounts-passwordless/passwordless_client.js packages/accounts-passwordless/passwordless_server.js packages/accounts-ui-unstyled/accounts_ui.js packages/allow-deny/allow-deny.js packages/check/match.js packages/ddp-client/common/document_processors.js packages/ddp-client/common/livedata_connection.js packages/ddp-client/common/message_processors.js packages/ddp-client/common/namespace.js packages/ddp-common/method_invocation.js packages/ddp-common/namespace.js packages/ddp-rate-limiter/ddp-rate-limiter.js packages/ddp-server/livedata_server.js packages/deprecated/http/httpcall_client.js packages/deprecated/http/httpcall_common.js packages/ejson/ejson.js packages/email/email.js packages/hot-module-replacement/hot-api.js packages/meteor/asl-helpers-client.js packages/meteor/client_environment.js packages/meteor/cordova_environment.js packages/meteor/dynamics_browser.js packages/meteor/dynamics_nodejs.js packages/meteor/errors.js packages/meteor/helpers.js packages/meteor/startup_client.js packages/meteor/test_environment.js packages/meteor/timers.js packages/meteor/url_common.js packages/minimongo/constants.js packages/minimongo/cursor.js packages/modern-browsers/modern.js packages/mongo/collection/collection.js packages/mongo/collection/methods_async.js packages/mongo/collection/methods_index.js packages/mongo/collection/methods_sync.js packages/mongo/connection_options.ts packages/random/AbstractRandomGenerator.js packages/random/AleaRandomGenerator.js packages/random/BrowserRandomGenerator.js packages/random/NodeRandomGenerator.js packages/reactive-dict/reactive-dict.js packages/reactive-var/reactive-var.js packages/roles/roles_common_async.js packages/session/session.js packages/tracker/tracker.d.ts packages/tracker/tracker.js packages/webapp/webapp_server.js scripts/admin/jsdoc/docdata-jsdoc-template/publish.js scripts/admin/jsdoc/jsdoc.sh tools/cordova/builder.js tools/isobuild/build-plugin.js tools/isobuild/bundler.js tools/isobuild/compiler-deprecated-compile-step.js tools/isobuild/compiler-plugin.js tools/isobuild/isopack.js tools/isobuild/minifier-plugin.js tools/isobuild/package-api.js tools/isobuild/package-cordova.js tools/isobuild/package-namespace.js tools/isobuild/package-npm.js tools/isobuild/package-source.js tools/static-assets/server/boot.js tools/utils/fiber-helpers.js tools/utils/processes.ts v3-docs/docs/jsdoc/docdata-jsdoc-template/publish.js
INFO  Config based on 2 files
INFO  Start processing
API Data not found: Accounts.findUserByUsername
FATAL Something's wrong. Maybe you can find the solution here: https://hexo.io/docs/troubleshooting.html
Template render error: (unknown path)
  Error: Cannot render apibox without API data: Accounts.findUserByUsername
    at Object._prettifyError (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/nunjucks/src/lib.js:32:11)
    at /Users/italojose/dev/meteor-dev/meteor/docs/node_modules/nunjucks/src/environment.js:464:19
    at Template.root [as rootRenderFunc] (eval at _compile (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/nunjucks/src/environment.js:527:18), <anonymous>:63:3)
    at Template.render (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/nunjucks/src/environment.js:454:10)
    at Environment.renderString (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/nunjucks/src/environment.js:313:17)
    at /Users/italojose/dev/meteor-dev/meteor/docs/node_modules/hexo/lib/extend/tag.js:123:48
    at tryCatcher (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/util.js:16:23)
    at Promise.fromNode.Promise.fromCallback (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/promise.js:209:30)
    at Tag.render (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/hexo/lib/extend/tag.js:123:18)
    at Object.onRenderEnd (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/hexo/lib/hexo/post.js:280:20)
    at /Users/italojose/dev/meteor-dev/meteor/docs/node_modules/hexo/lib/hexo/render.js:64:19
    at tryCatcher (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/promise.js:729:18)
    at _drainQueueStep (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/async.js:102:5)
    at Async.drainQueues (/Users/italojose/dev/meteor-dev/meteor/docs/node_modules/bluebird/js/release/async.js:15:14)
    at process.processImmediate (node:internal/timers:505:21)
FAIL: 2
```

This PR fixes it by adding the JSDocs into accounts-base for  `findUserByEmail` and `findUserByUsername`