### PR TITLE
[doc] fix community-packages pages getting 404

### DIFF
--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -388,7 +388,7 @@ export default defineConfig({
             text: "Maintained Packages",
           },
           {
-            link: "packages/community-packages",
+            link: "/community-packages/index",
             text: "Community Packages",
           },
         ],
@@ -401,6 +401,30 @@ export default defineConfig({
           {
             text: "Meteor RPC",
             link: "/community-packages/meteor-rpc",
+          },
+          {
+            text: "jam:method",
+            link: "/community-packages/jam-method",
+          },
+          {
+            text: "jam:pub-sub",
+            link: "/community-packages/pub-sub",
+          },
+          {
+            text: "jam:mongo-transactions",
+            link: "/community-packages/mongo-transactions",
+          },
+          {
+            text: "jam:soft-delete",
+            link: "/community-packages/soft-delete",
+          },
+          {
+            text: "jam:archive",
+            link: "/community-packages/archive",
+          },
+          {
+            text: "jam:offline",
+            link: "/community-packages/offline",
           },
         ],
         collapsed: true,

--- a/v3-docs/docs/packages/community-packages.md
+++ b/v3-docs/docs/packages/community-packages.md
@@ -1,0 +1,9 @@
+---
+title: Community Packages
+head:
+  - - meta
+    - http-equiv: refresh
+      content: "0; url=/community-packages/index"
+---
+
+If you are not redirected automatically, open /community-packages/index


### PR DESCRIPTION
Today, when we access https://docs.meteor.com/about/what-is.html >> Go to the section Packages >> Community Packages >> we get a 404 error. 

Issue [reported via Discord](https://discord.com/channels/1247973371040239676/1250550122841116755/1409269468538077244). 