### PR TITLE
DOCS: add import type to api box

### DIFF
--- a/v3-docs/docs/components/ApiBox.vue
+++ b/v3-docs/docs/components/ApiBox.vue
@@ -117,12 +117,12 @@ const debug = (name) => {
         <slot />
         <ParamTable v-if="isFunction || isClass" :params="ui.params" :options="ui.options" :from="gitHubSource" />
         <template v-if="!hasCustomExample">
-            <Booleans v-if="isBoolean" :memberof="ui.memberof" :from="ui.module" :is-default-import="ui.isDefaultImport"
+            <Booleans v-if="isBoolean" :memberof="ui.memberof" :from="ui.module" :is-default-import="isDefaultImport"
                 :longname="ui.longname" />
-            <Functions v-if="isFunction" :from="ui.module" :is-default-import="ui.isDefaultImport"
+            <Functions v-if="isFunction" :from="ui.module" :is-default-import="isDefaultImport"
                 :longname="ui.longname" :params="ui.params" :fnName="ui.name"
                 :memberof="isInstance ? instanceName : ui.memberof" :scope="ui.scope" :returns="ui.returns" />
-            <Classes v-if="isClass" :params="ui.params" :from="ui.module" :is-default-import="ui.isDefaultImport"
+            <Classes v-if="isClass" :params="ui.params" :from="ui.module" :is-default-import="isDefaultImport"
                 :longname="ui.longname" />
 
         </template>

--- a/v3-docs/docs/components/ApiBox.vue
+++ b/v3-docs/docs/components/ApiBox.vue
@@ -27,6 +27,10 @@ const props = defineProps({
     from: {
         type: String,
         default: ''
+    },
+    isDefaultImport: {
+        type: Boolean,
+        default: false
     }
 })
 
@@ -99,7 +103,8 @@ const debug = (name) => {
 <template>
     <div>
         <h2 :id="link">
-            <a class="header-anchor" :href="'#' + link" :aria-label="'Permalink to &quot;' + ui.longname + '&quot;'">​</a>
+            <a class="header-anchor" :href="'#' + link"
+                :aria-label="'Permalink to &quot;' + ui.longname + '&quot;'">​</a>
 
             {{ showName(ui.longname) }}
             <Locus v-if="ui.locus && ui.locus !== 'Anywhere'" :locus="ui.locus" />
@@ -112,10 +117,13 @@ const debug = (name) => {
         <slot />
         <ParamTable v-if="isFunction || isClass" :params="ui.params" :options="ui.options" :from="gitHubSource" />
         <template v-if="!hasCustomExample">
-            <Booleans v-if="isBoolean" :memberof="ui.memberof" :from="ui.module" :longname="ui.longname" />
-            <Functions v-if="isFunction" :from="ui.module" :longname="ui.longname" :params="ui.params" :fnName="ui.name"
+            <Booleans v-if="isBoolean" :memberof="ui.memberof" :from="ui.module" :is-default-import="ui.isDefaultImport"
+                :longname="ui.longname" />
+            <Functions v-if="isFunction" :from="ui.module" :is-default-import="ui.isDefaultImport"
+                :longname="ui.longname" :params="ui.params" :fnName="ui.name"
                 :memberof="isInstance ? instanceName : ui.memberof" :scope="ui.scope" :returns="ui.returns" />
-            <Classes v-if="isClass" :params="ui.params" :from="ui.module" :longname="ui.longname" />
+            <Classes v-if="isClass" :params="ui.params" :from="ui.module" :is-default-import="ui.isDefaultImport"
+                :longname="ui.longname" />
 
         </template>
 

--- a/v3-docs/docs/components/helpers/Booleans.vue
+++ b/v3-docs/docs/components/helpers/Booleans.vue
@@ -4,14 +4,17 @@
 <script setup lang="ts">
 const props = defineProps<{
   from: string;
+  isDefaultImport: boolean;
   longname: string;
   memberof: string;
-}>()
+}>();
+import ImportStatement from './Import.vue';
+
 </script>
 
 <template>
   <div class="language-js vp-adaptive-theme"><button title="Copy Code" class="copy"></button><span class="lang">js</span>
-    <pre class="shiki shiki-themes github-light github-dark vp-code"><code><span class="line"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">import</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;"> { {{ props.memberof }} } </span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">from</span><span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> 'meteor/{{ props.from }}'</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">;</span></span>
+    <pre class="shiki shiki-themes github-light github-dark vp-code"><code><ImportStatement :what="props.memberof" :is-default-import="props.isDefaultImport" :from="props.from" :scope="'static'"/>
 <span class="line"></span>
 <span class="line"><span style="--shiki-light:#6A737D;--shiki-dark:#6A737D;">/** </span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">@type</span><span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;"> {Boolean}</span><span style="--shiki-light:#6A737D;--shiki-dark:#6A737D;"> */</span></span>
 <span class="line"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">if</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;"> ({{ props.longname }}) {</span></span>
@@ -19,6 +22,3 @@ const props = defineProps<{
 <span class="line"><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">}</span></span></code></pre>
   </div>
 </template>
-
-
-

--- a/v3-docs/docs/components/helpers/Classes.vue
+++ b/v3-docs/docs/components/helpers/Classes.vue
@@ -3,9 +3,11 @@
 
 <script setup lang="ts">
 import { makePrimitiveHTML } from '../scripts/make-primitive-html';
+import ImportStatement from './Import.vue';
 
 const props = defineProps<{
   from: string;
+  isDefaultImport: boolean;
   longname: string;
   params: {
     name: string;
@@ -29,7 +31,7 @@ const isOneLiner = props?.params?.length === 0;
 </script>
 
 <template>
-  <div class="language-js vp-adaptive-theme"><button title="Copy Code" class="copy"></button><span class="lang">js</span> <pre class="shiki shiki-themes github-light github-dark vp-code"><code><span class="line"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">import</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;"> { {{ props.longname.split(".")[0] }} } </span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">from</span><span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> "meteor/{{ props.from }}""</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">;</span></span>
+  <div class="language-js vp-adaptive-theme"><button title="Copy Code" class="copy"></button><span class="lang">js</span> <pre class="shiki shiki-themes github-light github-dark vp-code"><code><ImportStatement :what="props.longname.split('.')[0]"  :is-default-import="props.isDefaultImport" :from="props.from" :scope="'static'"/>
 <span class="line"></span>
 <span class="line"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">const</span><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF;"> {{ toCamelCase(props.longname) }}</span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;"> =</span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;"> new</span><span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;"> {{ props.longname }}</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">(<span v-show="isOneLiner">);</span></span>
 <span class="line" v-for="(param, index) in props.params" :key="param.name"><span v-html="makePrimitiveHTML({ primitive: [param.type.names[0]], arr: props.params, index, isOptional: param.optional, name: param.name })"/></span>
@@ -37,6 +39,3 @@ const isOneLiner = props?.params?.length === 0;
 </code></pre>
   </div>
 </template>
-
-
-

--- a/v3-docs/docs/components/helpers/Functions.vue
+++ b/v3-docs/docs/components/helpers/Functions.vue
@@ -3,8 +3,10 @@
 
 <script setup lang="ts">
 import { makePrimitiveHTML, comment, typeComment } from '../scripts/make-primitive-html';
+import ImportStatement from './Import.vue';
 const props = defineProps<{
   from: string;
+  isDefaultImport: boolean;
   longname: string;
   memberof: string;
   fnName: string;
@@ -43,7 +45,7 @@ function getReturnType(returns: typeof props.returns) {
 <template>
   <div class="language-js vp-adaptive-theme"><button title="Copy Code" class="copy"></button><span class="lang">js</span>
     <pre
-      class="shiki shiki-themes github-light github-dark vp-code"><code><span class="line" v-if="props.scope !== 'instance' && props.from"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">import</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;"> { {{ props.memberof.split(".")[0] }} } </span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">from</span><span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> "meteor/{{ props.from }}"</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">;</span></span>
+      class="shiki shiki-themes github-light github-dark vp-code"><code><ImportStatement :what="props.memberof.split('.')[0]" :is-default-import="props.isDefaultImport" :from="props.from" :scope="props.scope"/>
 <span class="line" v-if="props.scope === 'instance'" v-html="comment(`// ${props.memberof} is an instance of ${getInstanceName(props.longname)}`)"></span>
 <span class="line" v-if="props.returns !== undefined" v-html="typeComment(getReturnType(props.returns))"></span>
 <span class="line"><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;"><span :style="{'display': props.returns === undefined ? 'none' : ''}"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">const </span>result = </span>{{ props.memberof }}.</span><span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;">{{ trimFnName(props.fnName) }}</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">(<span v-show="isOneLiner">);</span></span></span>
@@ -51,6 +53,3 @@ function getReturnType(returns: typeof props.returns) {
 <span v-show="!isOneLiner" class="line"><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">);</span></span></code></pre>
   </div>
 </template>
-
-
-

--- a/v3-docs/docs/components/helpers/Import.vue
+++ b/v3-docs/docs/components/helpers/Import.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+const props = defineProps<{
+  scope: string;
+  what: string;
+  from: string;
+  isDefaultImport: boolean;
+}>()
+
+const exportName = (what: string) => props.isDefaultImport ? ` ${what} ` : ` { ${what} } `
+</script>
+
+
+<template>
+  <span class="line" v-if="props.scope !== 'instance' && props.from">
+    <span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">import</span>
+    <span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;"> {{ exportName(what) }} </span>
+    <span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">from</span>
+    <span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> "meteor/{{ props.from }}"</span>
+    <span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">;</span>
+  </span>
+</template>

--- a/v3-docs/docs/packages/modern-browsers.md
+++ b/v3-docs/docs/packages/modern-browsers.md
@@ -1,6 +1,5 @@
 # Modern-browsers
 
-
 API for defining the boundary between modern and legacy JavaScript clients.
 
 You can use this package to define the minimum browser versions for which
@@ -10,13 +9,13 @@ on using modern features that you need.
 
 You can read more about this in [Meteor 1.7 announcement blog](https://blog.meteor.com/meteor-1-7-and-the-evergreen-dream-a8c1270b0901).
 
-<ApiBox name="ModernBrowsers.isModern" />
+<ApiBox name="ModernBrowsers.isModern" isDefaultImport/>
 
-<ApiBox name="ModernBrowsers.setMinimumBrowserVersions" />
+<ApiBox name="ModernBrowsers.setMinimumBrowserVersions" isDefaultImport/>
 
-<ApiBox name="ModernBrowsers.getMinimumBrowserVersions" />
+<ApiBox name="ModernBrowsers.getMinimumBrowserVersions" isDefaultImport/>
 
-<ApiBox name="ModernBrowsers.calculateHashOfMinimumVersions" />
+<ApiBox name="ModernBrowsers.calculateHashOfMinimumVersions" isDefaultImport/>
 
 ## Configure Unknown Browsers to default to Modern
 
@@ -24,10 +23,10 @@ Browsers not explicitly listed in `setMinimumBrowserVersions` are considered "le
 
 To change this and treat unknown browsers as "modern," update the relevant option in your settings file:
 
-``` js
+```js
 Meteor.settings.packages = {
-    "modern-browsers": {
-        "unknownBrowsersAssumedModern": true
-    }
+  "modern-browsers": {
+    unknownBrowsersAssumedModern: true,
+  },
 };
 ```


### PR DESCRIPTION
It should fix https://github.com/meteor/meteor/issues/13925;

This snippet:
```md
<ApiBox name="Random.id" isDefaultImport/>
```
should generate this in the UI:
<img width="556" height="193" alt="Screenshot 2025-09-15 at 11 49 51" src="https://github.com/user-attachments/assets/6b4ff6aa-981a-4685-a58e-c588d3291df5" />


We can also check the Netlify preview deploy:
https://deploy-preview-13931.docs.meteor.com/