### PR TITLE
fixed Navbar added

### DIFF
--- a/guide/source/flowbite.md
+++ b/guide/source/flowbite.md
@@ -131,12 +131,12 @@ import { Dropdown } from 'flowbite-react';
 </Dropdown>;
 ```
 
-Finally, another example on how you can use the navbar component:
+Finally, another example on how you can use the navbar component with a fixed position:
 
 ```javascript
 import { Navbar } from 'flowbite-react';
 
-<Navbar fluid={true} rounded={true}>
+<Navbar fluid={true} className="fixed top-0 left-0 right-0 z-50 bg-white dark:bg-gray-900">
   <Navbar.Brand href="https://flowbite.com/">
     <img
       src="https://flowbite.com/docs/images/logo.svg"
@@ -159,6 +159,8 @@ import { Navbar } from 'flowbite-react';
   </Navbar.Collapse>
 </Navbar>;
 ```
+
+Note: When using a fixed navbar, make sure to add `padding-top` to your main content container to prevent it from being hidden behind the navbar. For example, add `pt-16` (or the height of your navbar) to the body or main element.
 
 To learn more about Flowbite React make sure to check out to the [repository](https://github.com/themesberg/flowbite-react) and the [main website](https://flowbite-react.com/).
 


### PR DESCRIPTION
<!--
Update Flowbite navbar example to demonstrate fixed positioning

This PR updates the navbar component example in the Flowbite guide (guide/source/flowbite.md) to show how to make the navbar fixed at the top of the page when scrolling.

Changes:

Added className="fixed top-0 left-0 right-0 z-50 bg-white dark:bg-gray-900" to the <Navbar> component for fixed positioning.
Removed the rounded prop as it doesn't work well with full-width fixed navbars.
Added a note explaining the need to add padding-top to main content to prevent it from being hidden behind the fixed navbar.
Why this change:

Provides a practical example for users who want a sticky/fixed navbar in their Meteor.js + Flowbite projects.
Improves the documentation by addressing a common UI requirement (fixed navigation on scroll).
Ensures the example is functional and includes best practices for implementation.
Testing:

Verified the updated code block renders correctly in the markdown.
The example can be directly copied and used in a Flowbite React setup.
-->
