### PR TITLE
DEV: Flip `--raw-logs` to default true and add `--timestamps` option.

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -536,7 +536,7 @@ async function doRunCommand(options) {
     );
   }
 
-  runLog.setRawLogs(!options['raw-logs'] && options.timestamps);
+  runLog.setRawLogs(options['raw-logs'] && !options.timestamps);
 
   let webArchs = projectContext.platformList.getWebArchs();
   if (! _.isEmpty(runTargets) ||
@@ -2259,7 +2259,8 @@ async function doTestCommand(options) {
     serverArchitectures.push(DEPLOY_ARCH);
   }
 
-  runLog.setRawLogs(!options['raw-logs'] && options.timestamps);
+  runLog.setRawLogs(options['raw-logs'] && !options.timestamps);
+
 
   var includePackages = [];
   if (options['extra-packages']) {

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -451,7 +451,8 @@ var runCommandOptions = {
     ...inspectOptions,
     'no-release-check': { type: Boolean },
     production: { type: Boolean },
-    'raw-logs': { type: Boolean },
+    'raw-logs': { type: Boolean, default: true },
+    timestamps: { type: Boolean, default: false }, // opposite of --raw-logs
     settings: { type: String, short: "s" },
     verbose: { type: Boolean, short: "v" },
     // With --once, meteor does not re-run the project if it crashes
@@ -535,10 +536,7 @@ async function doRunCommand(options) {
     );
   }
 
-  if (options['raw-logs']) {
-    runLog.setRawLogs(true);
-  }
-
+  runLog.setRawLogs(!options['raw-logs'] && options.timestamps);
 
   let webArchs = projectContext.platformList.getWebArchs();
   if (! _.isEmpty(runTargets) ||
@@ -2125,7 +2123,8 @@ testCommandOptions = {
     // like progress bars and spinners are unimportant.
     headless: { type: Boolean },
     verbose: { type: Boolean, short: "v" },
-    'raw-logs': { type: Boolean },
+    'raw-logs': { type: Boolean, default: true },
+    timestamps: { type: Boolean, default: false }, // opposite of --raw-logs
 
     // Undocumented. See #Once
     once: { type: Boolean },
@@ -2176,7 +2175,7 @@ testCommandOptions = {
     'extra-packages': { type: String },
 
     'exclude-archs': { type: String },
-    
+
     // Same as TINYTEST_FILTER
     filter: { type: String, short: 'f' },
   }
@@ -2260,9 +2259,7 @@ async function doTestCommand(options) {
     serverArchitectures.push(DEPLOY_ARCH);
   }
 
-  if (options['raw-logs']) {
-    runLog.setRawLogs(true);
-  }
+  runLog.setRawLogs(!options['raw-logs'] && options.timestamps);
 
   var includePackages = [];
   if (options['extra-packages']) {

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -90,7 +90,8 @@ Options:
                    Meteor app source code as by default the port is generated
                    using the id inside .meteor/.id file.
   --production     Simulate production mode. Minify and bundle CSS and JS files.
-  --raw-logs       Run without parsing logs from stdout and stderr.
+  --raw-logs       Run without parsing logs from stdout and stderr (default: true).
+  --timestamps     Run with timestamps in logs, the same as passing `--raw-logs=false`.
   --settings, -s   Set optional data for Meteor.settings on the server.
   --release        Specify the release of Meteor to use.
   --verbose        Print all output from builds logs.
@@ -747,7 +748,9 @@ Options:
                     important when multiple Cordova apps are build from the same
                     Meteor app source code as by default the port is generated
                     using the id inside .meteor/.id file.
-  --raw-logs        Run without parsing logs from stdout and stderr.
+  --raw-logs        Run without parsing logs from stdout and stderr (default: true).
+  --timestamps      Run with timestamps in logs, the same as passing `--raw-logs=false`.
+
   --settings, -s    Set optional data for Meteor.settings on the server
 
   --ios,            Run tests in an emulator or on a mobile device. All of

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -403,7 +403,7 @@ selftest.define("run and SIGKILL parent process", ["yet-unsolved-windows-failure
   await s.createApp("myapp", "app-prints-pid");
   s.cd("myapp");
 
-  run = s.run();
+  run = s.run("run", "--timestamps");
   run.waitSecs(30);
   var match = await run.match(/My pid is (\d+)/);
   var childPid;

--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -434,7 +434,8 @@ selftest.define("run and SIGKILL parent process", ["yet-unsolved-windows-failure
   // Test that passing a bad pid in $METEOR_PARENT_PID logs an error and exits
   // immediately.
   s.set("METEOR_BAD_PARENT_PID_FOR_TEST", "t");
-  run = s.run();
+  run = s.run("run", "--timestamps");
+
   run.waitSecs(120);
   await run.match("must be a valid process ID");
   await run.match("Your application is crashing");

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -53,7 +53,8 @@ This is the default command. Simply running `meteor` is the same as `meteor run`
 | `--mobile-server <url>` | Location where mobile builds connect (defaults to local IP and port). Can include URL scheme (e.g., https://example.com:443) |
 | `--cordova-server-port <port>` | Local port where Cordova will serve content |
 | `--production` | Simulate production mode. Minify and bundle CSS and JS files |
-| `--raw-logs` | Run without parsing logs from stdout and stderr |
+| `--raw-logs` | Run without parsing logs from stdout and stderr (default: true) |
+| `--timestamps` | Run with timestamps in logs, the same as passing `--raw-logs=false`. |
 | `--settings`, `-s <file>` | Set optional data for Meteor.settings on the server |
 | `--release <version>` | Specify the release of Meteor to use |
 | `--verbose` | Print all output from builds logs |
@@ -247,10 +248,10 @@ If you run `meteor create` without arguments, Meteor will launch an interactive 
   Typescript # To create an app using TypeScript and React
   Vue       # To create a basic Vue3-based app
   Svelte    # To create a basic Svelte app
-  Tailwind # To create an app using React and Tailwind 
-  Chakra-ui # To create an app Chakra UI and React 
-  Solid # To create a basic Solid app 
-  Apollo # To create a basic Apollo + React app 
+  Tailwind # To create an app using React and Tailwind
+  Chakra-ui # To create an app Chakra UI and React
+  Solid # To create a basic Solid app
+  Apollo # To create a basic Apollo + React app
   Bare # To create an empty app
 ```
 :::
@@ -359,7 +360,7 @@ To learn more about the recommended file structure for Meteor apps, check the [M
 
 ##  meteor generate  {meteorgenerate}
 
-``meteor generate`` is a command to generate boilerplate for your current project. `meteor generate` receives a name as a parameter, and generates files containing code to create a [Collection](https://docs.meteor.com/api/collections.html) with that name, [Methods](https://docs.meteor.com/api/meteor.html#methods) to perform basic CRUD operations on that Collection, and a [Subscription](https://docs.meteor.com/api/meteor.html#Meteor-publish) to read its data with reactivity from the client. 
+``meteor generate`` is a command to generate boilerplate for your current project. `meteor generate` receives a name as a parameter, and generates files containing code to create a [Collection](https://docs.meteor.com/api/collections.html) with that name, [Methods](https://docs.meteor.com/api/meteor.html#methods) to perform basic CRUD operations on that Collection, and a [Subscription](https://docs.meteor.com/api/meteor.html#Meteor-publish) to read its data with reactivity from the client.
 
 If you run ``meteor generate``  without arguments, it will ask you for a name, and name the auto-generated Collection accordingly. It will also ask if you do want Methods for your API and Publications to be generated as well.
 


### PR DESCRIPTION
<img width="796" height="650" alt="Screenshot 2025-09-29 at 22 30 40" src="https://github.com/user-attachments/assets/7677a942-1e92-460d-979d-c2c03bb6dd71" />

This _for_ sure will make the regular dev xp better; this could arguably be a breaking change _but_ I really want to believe that people did not rely on this timestamp for their logs (I assume people are using [the logging package](https://docs.meteor.com/packages/logging.html))

<img width="567" height="311" alt="Screenshot 2025-09-29 at 22 34 33" src="https://github.com/user-attachments/assets/70d840b6-deec-441a-8baa-da169899a839" />
<img width="790" height="328" alt="Screenshot 2025-09-29 at 22 35 12" src="https://github.com/user-attachments/assets/5b2dfd90-5909-4039-a8ef-758259128992" />


relates to: https://forums.meteor.com/t/meteor-development-tiny-tip-that-helped-me-a-lot/64156/4?u=grubba