### PR TITLE
fix/13945_oplog_tailing_grouped_operations

### DIFF
--- a/packages/mongo/oplog_tailing.ts
+++ b/packages/mongo/oplog_tailing.ts
@@ -41,6 +41,8 @@ export class OplogHandle {
     excludeCollections?: string[];
     includeCollections?: string[];
   };
+  private _includeNSRegex?: RegExp;
+  private _excludeNSRegex?: RegExp;
   private _stopped: boolean;
   private _tailHandle: any;
   private _readyPromiseResolver: (() => void) | null;
@@ -82,6 +84,18 @@ export class OplogHandle {
     }
     this._oplogOptions = { includeCollections, excludeCollections };
 
+    if (includeCollections?.length) {
+      const incAlt = includeCollections.map((c) => Meteor._escapeRegExp(c)).join('|');
+
+      this._includeNSRegex = new RegExp(`^${Meteor._escapeRegExp(this._dbName)}\\.(?:${incAlt})$`);
+    }
+
+    if (excludeCollections?.length) {
+      const excAlt = excludeCollections.map((c) => Meteor._escapeRegExp(c)).join('|');
+
+      this._excludeNSRegex = new RegExp(`^${Meteor._escapeRegExp(this._dbName)}\\.(?:${excAlt})$`);
+    }
+
     this._catchingUpResolvers = [];
     this._lastProcessedTS = null;
 
@@ -90,6 +104,15 @@ export class OplogHandle {
     });
 
     this._startTrailingPromise = this._startTailing();
+  }
+
+    private _nsAllowed(ns: string | undefined): boolean {
+    if (!ns) return false;
+    if (ns === 'admin.$cmd') return true;
+    if (this._includeNSRegex && !this._includeNSRegex.test(ns)) return false;
+    if (this._excludeNSRegex && this._excludeNSRegex.test(ns)) return false;
+
+    return true;
   }
 
   private _getOplogSelector(lastProcessedTS?: any): any {
@@ -415,6 +438,11 @@ async function handleDoc(handle: OplogHandle, doc: OplogEntry): Promise<void> {
         if (!op.ts) {
           op.ts = nextTimestamp;
           nextTimestamp = nextTimestamp.add(Long.ONE);
+        }
+        // Only forward sub-ops whose ns is allowed
+        // See https://github.com/meteor/meteor/issues/13945
+        if (!handle['_nsAllowed'](op.ns)) {
+          continue;
         }
         await handleDoc(handle, op);
       }

--- a/packages/mongo/oplog_tailing.ts
+++ b/packages/mongo/oplog_tailing.ts
@@ -166,6 +166,16 @@ export class OplogHandle {
         ],
       });
     } else {
+      const nsRegex = new RegExp(
+        "^(?:" +
+          [
+            // @ts-ignore
+            Meteor._escapeRegExp(this._dbName + "."),
+            // @ts-ignore
+            Meteor._escapeRegExp("admin.$cmd"),
+          ].join("|") +
+          ")"
+      );
       oplogCriteria.push({
         ns: nsRegex,
       });

--- a/packages/mongo/oplog_tailing.ts
+++ b/packages/mongo/oplog_tailing.ts
@@ -159,10 +159,10 @@ export class OplogHandle {
       };
       oplogCriteria.push({
         $or: [
-          { ns: /^admin\.\$cmd/, 'o.applyOps.ns': includeNs },
           {
             ns: includeNs,
           },
+          { ns: /^admin\.\$cmd/, 'o.applyOps.ns': includeNs },
         ],
       });
     } else {

--- a/packages/mongo/oplog_tailing.ts
+++ b/packages/mongo/oplog_tailing.ts
@@ -147,7 +147,7 @@ export class OplogHandle {
           { ns: excludeNs },
           {
             ns: /^admin\.\$cmd/,
-            'o.applyOps': { $elemMatch: { ns: { $nin: excludeNs.$nin } } },
+            'o.applyOps': { $elemMatch: { ns: excludeNs } },
           },
         ],
       });

--- a/packages/mongo/oplog_tailing.ts
+++ b/packages/mongo/oplog_tailing.ts
@@ -104,36 +104,41 @@ export class OplogHandle {
       },
     ];
 
-    const nsRegex = new RegExp(
-      "^(?:" +
-        [
-          // @ts-ignore
-          Meteor._escapeRegExp(this._dbName + "."),
-          // @ts-ignore
-          Meteor._escapeRegExp("admin.$cmd"),
-        ].join("|") +
-        ")"
-    );
-
     if (this._oplogOptions.excludeCollections?.length) {
-      oplogCriteria.push({
-        ns: {
-          $regex: nsRegex,
-          $nin: this._oplogOptions.excludeCollections.map(
-            (collName: string) => `${this._dbName}.${collName}`
-          ),
-        },
-      });
-    } else if (this._oplogOptions.includeCollections?.length) {
+      const nsRegex = new RegExp(
+        '^(?:' +
+          [
+            // @ts-ignore
+            Meteor._escapeRegExp(this._dbName + '.'),
+          ].join('|') +
+          ')'
+      );
+      const excludeNs = {
+        $regex: nsRegex,
+        $nin: this._oplogOptions.excludeCollections.map(
+          (collName: string) => `${this._dbName}.${collName}`
+        ),
+      };
       oplogCriteria.push({
         $or: [
-          { ns: /^admin\.\$cmd/ },
+          { ns: excludeNs },
           {
-            ns: {
-              $in: this._oplogOptions.includeCollections.map(
-                (collName: string) => `${this._dbName}.${collName}`
-              ),
-            },
+            ns: /^admin\.\$cmd/,
+            'o.applyOps': { $elemMatch: { ns: { $nin: excludeNs.$nin } } },
+          },
+        ],
+      });
+    } else if (this._oplogOptions.includeCollections?.length) {
+      const includeNs = {
+        $in: this._oplogOptions.includeCollections.map(
+          (collName: string) => `${this._dbName}.${collName}`
+        ),
+      };
+      oplogCriteria.push({
+        $or: [
+          { ns: /^admin\.\$cmd/, 'o.applyOps.ns': includeNs },
+          {
+            ns: includeNs,
           },
         ],
       });

--- a/packages/mongo/tests/oplog_tests.js
+++ b/packages/mongo/tests/oplog_tests.js
@@ -181,11 +181,46 @@ process.env.MONGO_OPLOG_URL &&
 const defaultOplogHandle = MongoInternals.defaultRemoteCollectionDriver().mongo._oplogHandle;
 let previousMongoPackageSettings = {};
 
+async function oplogSimpleInsertion(IncludeCollection, ExcludeCollection) {
+  await IncludeCollection.rawCollection().insertOne({ include: 'yes', foo: 'bar' });
+  await ExcludeCollection.rawCollection().insertOne({ include: 'no', foo: 'bar' });
+}
+
+async function oplogInsertionTransaction(IncludeCollection, ExcludeCollection) {
+  const client = MongoInternals.defaultRemoteCollectionDriver().mongo.client;
+  const session = client.startSession();
+
+  try {
+    await session.withTransaction(async () => {
+      await IncludeCollection.rawCollection().insertOne({ include: 'yes', foo: 'bar' }, { session });
+      await ExcludeCollection.rawCollection().insertOne({ include: 'no', foo: 'bar' }, { session });
+    });
+  } finally {
+    await session.endSession();
+  }
+}
+
+async function oplogMassiveInsertion(IncludeCollection, ExcludeCollection) {
+  const totalDocuments = 10000;
+  const documentInclude = Array.from(
+    { length: totalDocuments },
+    (_, index) => ({ include: "yes", foo: "bar" + index })
+  );
+  const documentExclude = Array.from(
+    { length: totalDocuments },
+    (_, index) => ({ include: "no", foo: "bar" + index })
+  );
+
+  await IncludeCollection.rawCollection().insertMany(documentInclude);
+  await ExcludeCollection.rawCollection().insertMany(documentExclude);
+}
+
 async function oplogOptionsTest({
   test,
   includeCollectionName,
   excludeCollectionName,
-  mongoPackageSettings = {}
+  mongoPackageSettings = {},
+  functionToRun
 }) {
   try {
     previousMongoPackageSettings = { ...(Meteor.settings?.packages?.mongo || {}) };
@@ -199,9 +234,11 @@ async function oplogOptionsTest({
     const IncludeCollection = new Mongo.Collection(includeCollectionName);
     const ExcludeCollection = new Mongo.Collection(excludeCollectionName);
 
-    const shouldBeTracked = new Promise((resolve) => {
-      IncludeCollection.find({ include: 'yes' }).observeChanges({
-        added(id, fields) { resolve(true) }
+    const shouldBeTracked = new Promise((resolve, reject) => {
+      IncludeCollection.find({ include: "yes" }).observeChanges({
+        added(id, fields) {
+          resolve(true);
+        },
       });
     });
     const shouldBeIgnored = new Promise((resolve, reject) => {
@@ -218,12 +255,80 @@ async function oplogOptionsTest({
     });
 
     // do the inserts:
-    await IncludeCollection.rawCollection().insertOne({ include: 'yes', foo: 'bar' });
-    await ExcludeCollection.rawCollection().insertOne({ include: 'no', foo: 'bar' });
+    await functionToRun(IncludeCollection, ExcludeCollection);
 
     test.equal(await shouldBeTracked, true);
     test.equal(await shouldBeIgnored, true);
   } finally {
+    // Reset:
+    Meteor.settings.packages.mongo = { ...previousMongoPackageSettings };
+    MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(defaultOplogHandle);
+  }
+}
+async function oplogTailingOptionsTest({
+  test,
+  includeCollectionName,
+  excludeCollectionName,
+  mongoPackageSettings = {},
+  functionToRun
+}) {
+  let stopRaw;
+  try {
+    previousMongoPackageSettings = { ...(Meteor.settings?.packages?.mongo || {}) };
+    if (!Meteor.settings.packages) Meteor.settings.packages = {};
+    Meteor.settings.packages.mongo = mongoPackageSettings;
+
+    const myOplogHandle = new MongoInternals.OplogHandle(process.env.MONGO_OPLOG_URL, 'meteor');
+    await myOplogHandle._startTrailingPromise;
+    MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(myOplogHandle);
+
+    const IncludeCollection = new Mongo.Collection(includeCollectionName);
+    const ExcludeCollection = new Mongo.Collection(excludeCollectionName);
+
+    // Listen for INCLUDE collection oplog entries
+    const includeSeen = new Promise(async (resolve, reject) => {
+      const includeStop = await myOplogHandle.onOplogEntry(
+        { dropCollection: false, dropDatabase: false, collection: includeCollectionName },
+        ({ op, collection, id }) => {
+          try {
+            // Only accept actual inserts for the include collection
+            if (op?.op === 'i' && collection === includeCollectionName && op?.o?.include === 'yes') {
+              includeStop.stop();
+              resolve(true);
+            }
+          } catch (e) {
+            includeStop.stop();
+            reject(e);
+          }
+        }
+      );
+    });
+
+  // Ensure EXCLUDE collection does NOT get processed
+  const excludeNotSeen = new Promise(async (resolve, reject) => {
+    const excludeStop = await myOplogHandle.onOplogEntry(
+      { dropCollection: false, dropDatabase: false, collection: excludeCollectionName },
+      ({ op, collection, id }) => {
+        // If anything for excluded collection arrives, fail
+        excludeStop.stop();
+        reject("Recieved a document in a excluded collection");
+      }
+    );
+    // Resolve after 2s if nothing arrived
+    setTimeout(() => {
+      excludeStop.stop();
+      resolve(true);
+    }, 2000);
+  });
+
+  // Do the inserts (e.g., oplogInsertionTransaction or your chosen function)
+  await functionToRun(IncludeCollection, ExcludeCollection);
+
+  // Await raw-oplog assertions
+  test.equal(await includeSeen, true);
+  test.equal(await excludeNotSeen, true);
+  } finally {
+    if (stopRaw?.stop) await stopRaw.stop();
     // Reset:
     Meteor.settings.packages.mongo = { ...previousMongoPackageSettings };
     MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(defaultOplogHandle);
@@ -242,7 +347,8 @@ process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
       test,
       includeCollectionName: collectionNameA,
       excludeCollectionName: collectionNameB,
-      mongoPackageSettings
+      mongoPackageSettings,
+      functionToRun: oplogSimpleInsertion
     });
   }
 );
@@ -259,7 +365,8 @@ process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
       test,
       includeCollectionName: collectionNameB,
       excludeCollectionName: collectionNameA,
-      mongoPackageSettings
+      mongoPackageSettings,
+      functionToRun: oplogSimpleInsertion
     });
   }
 );
@@ -279,7 +386,8 @@ process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
         test,
         includeCollectionName: collectionNameA,
         excludeCollectionName: collectionNameB,
-        mongoPackageSettings
+        mongoPackageSettings,
+        functionToRun: oplogSimpleInsertion
       });
       test.fail();
     } catch (err) {
@@ -350,6 +458,60 @@ process.env.MONGO_OPLOG_URL &&
     }
   );
 
+process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
+  'mongo-livedata - oplog - oplogSettings - massiveInsertion - oplogIncludeCollections',
+  async test => {
+    const collectionNameA = "oplog-a-massive-" + Random.id();
+    const collectionNameB = "oplog-b-massive-" + Random.id();
+    const mongoPackageSettings = {
+      oplogIncludeCollections: [collectionNameA]
+    };
+    await oplogTailingOptionsTest({
+      test,
+      includeCollectionName: collectionNameA,
+      excludeCollectionName: collectionNameB,
+      mongoPackageSettings,
+      functionToRun: oplogMassiveInsertion
+    });
+  }
+);
+
+process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
+  'mongo-livedata - oplog - oplogSettings - massiveInsertion - oplogExcludeCollections',
+  async test => {
+    const collectionNameA = "oplog-a-massive-" + Random.id();
+    const collectionNameB = "oplog-b-massive-" + Random.id();
+    const mongoPackageSettings = {
+      oplogExcludeCollections: [collectionNameA]
+    };
+    await oplogTailingOptionsTest({
+      test,
+      includeCollectionName: collectionNameB,
+      excludeCollectionName: collectionNameA,
+      mongoPackageSettings,
+      functionToRun: oplogMassiveInsertion
+    });
+  }
+);
+
+process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
+  'mongo-livedata - oplog - oplogSettings - transaction - oplogExcludeCollections',
+  async test => {
+    const collectionNameA = "oplog-a-massive-" + Random.id();
+    const collectionNameB = "oplog-b-massive-" + Random.id();
+    const mongoPackageSettings = {
+      oplogExcludeCollections: [collectionNameA]
+    };
+    await oplogTailingOptionsTest({
+      test,
+      includeCollectionName: collectionNameB,
+      excludeCollectionName: collectionNameA,
+      mongoPackageSettings,
+      functionToRun: oplogInsertionTransaction
+    });
+  }
+);
+  
 // TODO this is commented for now, but we need to find out the cause
 // PR: https://github.com/meteor/meteor/pull/12057
 // Meteor.isServer && Tinytest.addAsync(

--- a/packages/mongo/tests/oplog_tests.js
+++ b/packages/mongo/tests/oplog_tests.js
@@ -280,7 +280,6 @@ async function oplogTailingOptionsTest({
 
     const myOplogHandle = new MongoInternals.OplogHandle(process.env.MONGO_OPLOG_URL, 'meteor');
     await myOplogHandle._startTrailingPromise;
-    MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(myOplogHandle);
 
     const IncludeCollection = new Mongo.Collection(includeCollectionName);
     const ExcludeCollection = new Mongo.Collection(excludeCollectionName);
@@ -331,7 +330,6 @@ async function oplogTailingOptionsTest({
     if (stopRaw?.stop) await stopRaw.stop();
     // Reset:
     Meteor.settings.packages.mongo = { ...previousMongoPackageSettings };
-    MongoInternals.defaultRemoteCollectionDriver().mongo._setOplogHandle(defaultOplogHandle);
   }
 }
 
@@ -497,8 +495,8 @@ process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
 process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
   'mongo-livedata - oplog - oplogSettings - transaction - oplogExcludeCollections',
   async test => {
-    const collectionNameA = "oplog-a-massive-" + Random.id();
-    const collectionNameB = "oplog-b-massive-" + Random.id();
+    const collectionNameA = "oplog-a-transaction-" + Random.id();
+    const collectionNameB = "oplog-b-transaction-" + Random.id();
     const mongoPackageSettings = {
       oplogExcludeCollections: [collectionNameA]
     };
@@ -506,6 +504,24 @@ process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
       test,
       includeCollectionName: collectionNameB,
       excludeCollectionName: collectionNameA,
+      mongoPackageSettings,
+      functionToRun: oplogInsertionTransaction
+    });
+  }
+);
+
+process.env.MONGO_OPLOG_URL && Tinytest.addAsync(
+  'mongo-livedata - oplog - oplogSettings - transaction - oplogIncludeCollections',
+  async test => {
+    const collectionNameA = "oplog-a-transaction-" + Random.id();
+    const collectionNameB = "oplog-b-transaction-" + Random.id();
+    const mongoPackageSettings = {
+      oplogIncludeCollections: [collectionNameA]
+    };
+    await oplogTailingOptionsTest({
+      test,
+      includeCollectionName: collectionNameA,
+      excludeCollectionName: collectionNameB,
       mongoPackageSettings,
       functionToRun: oplogInsertionTransaction
     });

--- a/packages/mongo/tests/oplog_tests.js
+++ b/packages/mongo/tests/oplog_tests.js
@@ -304,29 +304,29 @@ async function oplogTailingOptionsTest({
       );
     });
 
-  // Ensure EXCLUDE collection does NOT get processed
-  const excludeNotSeen = new Promise(async (resolve, reject) => {
-    const excludeStop = await myOplogHandle.onOplogEntry(
-      { dropCollection: false, dropDatabase: false, collection: excludeCollectionName },
-      ({ op, collection, id }) => {
-        // If anything for excluded collection arrives, fail
+    // Ensure EXCLUDE collection does NOT get processed
+    const excludeNotSeen = new Promise(async (resolve, reject) => {
+      const excludeStop = await myOplogHandle.onOplogEntry(
+        { dropCollection: false, dropDatabase: false, collection: excludeCollectionName },
+        ({ op, collection, id }) => {
+          // If anything for excluded collection arrives, fail
+          excludeStop.stop();
+          reject("Recieved a document in a excluded collection");
+        }
+      );
+      // Resolve after 2s if nothing arrived
+      setTimeout(() => {
         excludeStop.stop();
-        reject("Recieved a document in a excluded collection");
-      }
-    );
-    // Resolve after 2s if nothing arrived
-    setTimeout(() => {
-      excludeStop.stop();
-      resolve(true);
-    }, 2000);
-  });
+        resolve(true);
+      }, 2000);
+    });
 
-  // Do the inserts (e.g., oplogInsertionTransaction or your chosen function)
-  await functionToRun(IncludeCollection, ExcludeCollection);
+    // Do the inserts (e.g., oplogInsertionTransaction or your chosen function)
+    await functionToRun(IncludeCollection, ExcludeCollection);
 
-  // Await raw-oplog assertions
-  test.equal(await includeSeen, true);
-  test.equal(await excludeNotSeen, true);
+    // Await raw-oplog assertions
+    test.equal(await includeSeen, true);
+    test.equal(await excludeNotSeen, true);
   } finally {
     if (stopRaw?.stop) await stopRaw.stop();
     // Reset:


### PR DESCRIPTION
As discussed here https://github.com/meteor/meteor/issues/13945 , the current oplog tailing filter does not correctly handle grouped operations. We need to update the query accordingly.

We can receive documents like the following:
```
{
  "txnNumber": 1,
  "op": "c",
  "ns": "admin.$cmd",
  applyOps: [
    { op: "i", ns: "db1.collection1", o: { _id: 1, name: "Alice" } },
    { op: "u", ns: "db2.collection2", o: { $set: { age: 30 } }, o2: { _id: 1 } },
    { op: "d", ns: "db3.collection3", o2: { _id: 1 } }
  ]
```
The idea is to apply the filtering first in the listener.
For mixed operations (e.g. transactions where multiple collections are grouped inside applyOps), we should **not** filter out the document if at least one of the collections should be processed. Later, during document analysis, the filtering will be applied more precisely, so the unwanted operations won’t be sent through DDP.