### PR TITLE
Add TypeScript type tests for check, random, email, fetch and tracker packages

### DIFF
--- a/packages/check/match_test.ts
+++ b/packages/check/match_test.ts
@@ -1,0 +1,99 @@
+import { Tinytest } from "meteor/tinytest";
+import { check, Match } from "meteor/check";
+
+Tinytest.add("Check - TypeScript types - basic check function", (test) => {
+  const value = "hello";
+  check(value, String);
+  // After check assertion, TypeScript knows value is a string
+  const upper: string = value.toUpperCase();
+  test.equal(upper, "HELLO");
+});
+
+Tinytest.add("Check - TypeScript types - Match.test with primitives", (test) => {
+  const value: unknown = 42;
+
+  if (Match.test(value, Number)) {
+    // TypeScript should narrow the type here
+    const doubled: number = value * 2;
+    test.equal(doubled, 84);
+  }
+});
+
+Tinytest.add("Check - TypeScript types - Match.Maybe", (test) => {
+  const pattern = Match.Maybe(String);
+
+  test.equal(Match.test(null, pattern), true);
+  test.equal(Match.test(undefined, pattern), true);
+  test.equal(Match.test("hello", pattern), true);
+  test.equal(Match.test(123, pattern), false);
+});
+
+Tinytest.add("Check - TypeScript types - Match.Optional", (test) => {
+  const pattern = Match.Optional(Number);
+
+  test.equal(Match.test(undefined, pattern), true);
+  test.equal(Match.test(42, pattern), true);
+  test.equal(Match.test(null, pattern), false);
+});
+
+Tinytest.add("Check - TypeScript types - Match.OneOf", (test) => {
+  const pattern = Match.OneOf(String, Number);
+
+  test.equal(Match.test("hello", pattern), true);
+  test.equal(Match.test(42, pattern), true);
+  test.equal(Match.test(true, pattern), false);
+});
+
+Tinytest.add("Check - TypeScript types - Match.ObjectIncluding", (test) => {
+  const pattern = Match.ObjectIncluding({ name: String });
+
+  test.equal(Match.test({ name: "John" }, pattern), true);
+  test.equal(Match.test({ name: "John", age: 30 }, pattern), true);
+  test.equal(Match.test({ age: 30 }, pattern), false);
+});
+
+Tinytest.add("Check - TypeScript types - Match.Where", (test) => {
+  const isPositive = Match.Where((x: any): x is number => {
+    return typeof x === "number" && x > 0;
+  });
+
+  test.equal(Match.test(42, isPositive), true);
+  test.equal(Match.test(-5, isPositive), false);
+  test.equal(Match.test("hello", isPositive), false);
+});
+
+Tinytest.add("Check - TypeScript types - Match.Integer", (test) => {
+  test.equal(Match.test(42, Match.Integer), true);
+  test.equal(Match.test(42.5, Match.Integer), false);
+  test.equal(Match.test(NaN, Match.Integer), false);
+  test.equal(Match.test(Infinity, Match.Integer), false);
+});
+
+Tinytest.add("Check - TypeScript types - Match.Any", (test) => {
+  test.equal(Match.test("hello", Match.Any), true);
+  test.equal(Match.test(42, Match.Any), true);
+  test.equal(Match.test(null, Match.Any), true);
+  test.equal(Match.test(undefined, Match.Any), true);
+});
+
+Tinytest.add("Check - TypeScript types - array patterns", (test) => {
+  const pattern = [Number];
+
+  test.equal(Match.test([1, 2, 3], pattern), true);
+  test.equal(Match.test([1, "2", 3], pattern), false);
+  test.equal(Match.test([], pattern), true);
+});
+
+Tinytest.add("Check - TypeScript types - object patterns", (test) => {
+  const pattern = { name: String, age: Number };
+
+  test.equal(Match.test({ name: "John", age: 30 }, pattern), true);
+  test.equal(Match.test({ name: "John", age: "30" }, pattern), false);
+  test.equal(Match.test({ name: "John" }, pattern), false);
+});
+
+Tinytest.add("Check - TypeScript types - check with throwAllErrors option", (test) => {
+  const value = { name: "John", age: 30 };
+  check(value, { name: String, age: Number }, { throwAllErrors: false });
+  test.equal(value.name, "John");
+});

--- a/packages/check/package.js
+++ b/packages/check/package.js
@@ -16,7 +16,8 @@ Package.onUse(api => {
 });
 
 Package.onTest(api => {
-  api.use(['check', 'tinytest', 'ejson', 'ecmascript'], ['client', 'server']);
+  api.use(['check', 'tinytest', 'ejson', 'ecmascript', 'typescript'], ['client', 'server']);
 
   api.addFiles('match_test.js', ['client', 'server']);
+  api.mainModule('match_test.ts');
 });

--- a/packages/email/email_tests.ts
+++ b/packages/email/email_tests.ts
@@ -1,0 +1,106 @@
+import { Tinytest } from "meteor/tinytest";
+import { Email, MailComposer } from "meteor/email";
+
+Tinytest.add("Email - TypeScript types - sendAsync options", (test) => {
+  // Type check that sendAsync accepts proper options
+  const options = {
+    from: "sender@example.com",
+    to: "recipient@example.com",
+    subject: "Test Email",
+    text: "This is a test email"
+  };
+
+  // This ensures the type signature is correct
+  const sendPromise: Promise<void> = Email.sendAsync(options);
+  test.equal(typeof sendPromise.then, "function");
+});
+
+Tinytest.add("Email - TypeScript types - sendAsync with html", (test) => {
+  const options = {
+    from: "sender@example.com",
+    to: "recipient@example.com",
+    subject: "Test Email",
+    html: "<p>This is a test email</p>"
+  };
+
+  const sendPromise: Promise<void> = Email.sendAsync(options);
+  test.equal(typeof sendPromise.then, "function");
+});
+
+Tinytest.add("Email - TypeScript types - sendAsync with attachments", (test) => {
+  const options = {
+    from: "sender@example.com",
+    to: "recipient@example.com",
+    subject: "Test Email",
+    text: "Email with attachment",
+    attachments: [
+      {
+        filename: "test.txt",
+        content: "Test content"
+      }
+    ]
+  };
+
+  const sendPromise: Promise<void> = Email.sendAsync(options);
+  test.equal(typeof sendPromise.then, "function");
+});
+
+Tinytest.add("Email - TypeScript types - hookSend", (test) => {
+  Email.hookSend((options) => {
+    const from: string | undefined = options.from as string | undefined;
+    test.equal(typeof options, "object");
+    return true;
+  });
+
+  test.equal(true, true);
+});
+
+Tinytest.add("Email - TypeScript types - customTransport", (test) => {
+  Email.customTransport((options) => {
+    const settings: unknown = options.packageSettings;
+    test.equal(typeof options, "object");
+  });
+
+  test.equal(true, true);
+});
+
+Tinytest.add("Email - TypeScript types - MailComposer constructor", (test) => {
+  const composer: MailComposer = new MailComposer({
+    escapeSMTP: true,
+    encoding: "utf8",
+    charset: "utf-8",
+    keepBcc: false,
+    forceEmbeddedImages: false
+  });
+
+  test.equal(typeof composer, "object");
+});
+
+Tinytest.add("Email - TypeScript types - MailComposer methods", (test) => {
+  const composer: MailComposer = new MailComposer({
+    escapeSMTP: true,
+    encoding: "utf8",
+    charset: "utf-8",
+    keepBcc: false,
+    forceEmbeddedImages: false
+  });
+
+  composer.addHeader("X-Custom-Header", "value");
+  test.equal(typeof composer.addHeader, "function");
+  test.equal(typeof composer.setMessageOption, "function");
+  test.equal(typeof composer.streamMessage, "function");
+});
+
+Tinytest.add("Email - TypeScript types - send options with multiple recipients", (test) => {
+  const options = {
+    from: "sender@example.com",
+    to: ["recipient1@example.com", "recipient2@example.com"],
+    cc: "cc@example.com",
+    bcc: ["bcc1@example.com", "bcc2@example.com"],
+    subject: "Test Email",
+    text: "Multiple recipients"
+  };
+
+  const sendPromise: Promise<void> = Email.sendAsync(options);
+  test.equal(typeof sendPromise.then, "function");
+});

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -20,6 +20,7 @@ Package.onUse(function (api) {
 
 Package.onTest(function (api) {
   api.use("email", "server");
-  api.use(["tinytest", "ecmascript"]);
+  api.use(["tinytest", "ecmascript", "typescript"]);
   api.addFiles("email_tests.js", "server");
+  api.mainModule("email_tests.ts", "server");
 });

--- a/packages/fetch/package.js
+++ b/packages/fetch/package.js
@@ -27,8 +27,10 @@ Package.onUse(function(api) {
 
 Package.onTest(function(api) {
   api.use("ecmascript");
+  api.use("typescript");
   api.use("tinytest");
   api.use("fetch");
   api.mainModule("tests/main.js");
+  api.mainModule("tests/main.ts");
   api.addAssets("tests/asset.json", ["client", "server"]);
 });

--- a/packages/fetch/tests/main.ts
+++ b/packages/fetch/tests/main.ts
@@ -1,0 +1,95 @@
+import { Tinytest } from "meteor/tinytest";
+import { fetch, Headers, Request, Response } from "meteor/fetch";
+
+Tinytest.addAsync("Fetch - TypeScript types - fetch function", async (test, done) => {
+  const response: Response = await fetch("https://httpbin.org/get");
+  const ok: boolean = response.ok;
+  const status: number = response.status;
+
+  test.equal(typeof ok, "boolean");
+  test.equal(typeof status, "number");
+  done();
+});
+
+Tinytest.add("Fetch - TypeScript types - Headers constructor", (test) => {
+  const headers: Headers = new Headers();
+  headers.append("Content-Type", "application/json");
+
+  const contentType: string | null = headers.get("Content-Type");
+  test.equal(contentType, "application/json");
+});
+
+Tinytest.add("Fetch - TypeScript types - Headers with object", (test) => {
+  const headers: Headers = new Headers({
+    "Content-Type": "application/json",
+    "X-Custom-Header": "value"
+  });
+
+  const hasHeader: boolean = headers.has("Content-Type");
+  test.equal(hasHeader, true);
+});
+
+Tinytest.add("Fetch - TypeScript types - Request constructor", (test) => {
+  const request: Request = new Request("https://example.com", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    }
+  });
+
+  const method: string = request.method;
+  const url: string = request.url;
+
+  test.equal(method, "POST");
+  test.equal(typeof url, "string");
+});
+
+Tinytest.add("Fetch - TypeScript types - Response constructor", (test) => {
+  const response: Response = new Response("body content", {
+    status: 200,
+    statusText: "OK",
+    headers: {
+      "Content-Type": "text/plain"
+    }
+  });
+
+  const status: number = response.status;
+  const statusText: string = response.statusText;
+  const ok: boolean = response.ok;
+
+  test.equal(status, 200);
+  test.equal(statusText, "OK");
+  test.equal(ok, true);
+});
+
+Tinytest.addAsync("Fetch - TypeScript types - Response methods", async (test, done) => {
+  const response: Response = new Response('{"key": "value"}');
+
+  const json: any = await response.json();
+  test.equal(json.key, "value");
+  done();
+});
+
+Tinytest.addAsync("Fetch - TypeScript types - Response text", async (test, done) => {
+  const response: Response = new Response("Hello World");
+
+  const text: string = await response.text();
+  test.equal(text, "Hello World");
+  done();
+});
+
+Tinytest.add("Fetch - TypeScript types - Headers iteration", (test) => {
+  const headers: Headers = new Headers({
+    "Content-Type": "application/json",
+    "X-Custom": "value"
+  });
+
+  let count = 0;
+  headers.forEach((value: string, key: string) => {
+    test.equal(typeof value, "string");
+    test.equal(typeof key, "string");
+    count++;
+  });
+
+  test.equal(count > 0, true);
+});

--- a/packages/random/package.js
+++ b/packages/random/package.js
@@ -14,6 +14,8 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   api.use('random');
   api.use('ecmascript');
+  api.use('typescript');
   api.use('tinytest');
   api.mainModule('random_tests.js');
+  api.mainModule('random_tests.ts');
 });

--- a/packages/random/random_tests.ts
+++ b/packages/random/random_tests.ts
@@ -1,0 +1,38 @@
+import { Tinytest } from "meteor/tinytest";
+import { Random } from "meteor/random";
+
+Tinytest.add("Random - TypeScript types - id", (test) => {
+  const id1: string = Random.id();
+  const id2: string = Random.id(10);
+  test.equal(typeof id1, "string");
+  test.equal(typeof id2, "string");
+});
+
+Tinytest.add("Random - TypeScript types - secret", (test) => {
+  const secret1: string = Random.secret();
+  const secret2: string = Random.secret(10);
+  test.equal(typeof secret1, "string");
+  test.equal(typeof secret2, "string");
+});
+
+Tinytest.add("Random - TypeScript types - fraction", (test) => {
+  const frac: number = Random.fraction();
+  test.equal(typeof frac, "number");
+});
+
+Tinytest.add("Random - TypeScript types - hexString", (test) => {
+  const hex: string = Random.hexString(10);
+  test.equal(typeof hex, "string");
+});
+
+Tinytest.add("Random - TypeScript types - choice with array", (test) => {
+  const numbers = [1, 2, 3, 4, 5];
+  const chosen: number | undefined = Random.choice(numbers);
+  test.equal(typeof chosen === "number" || chosen === undefined, true);
+});
+
+Tinytest.add("Random - TypeScript types - choice with string", (test) => {
+  const str = "abcdef";
+  const chosen: string = Random.choice(str);
+  test.equal(typeof chosen, "string");
+});

--- a/packages/tracker/package.js
+++ b/packages/tracker/package.js
@@ -15,5 +15,8 @@ Package.onTest(function (api) {
   api.use('tinytest');
   api.use('test-helpers');
   api.use('tracker');
+  api.use('ecmascript');
+  api.use('typescript');
   api.addFiles('tracker_tests.js', 'client');
+  api.mainModule('tracker_tests.ts');
 });

--- a/packages/tracker/tracker_tests.ts
+++ b/packages/tracker/tracker_tests.ts
@@ -1,0 +1,185 @@
+import { Tinytest } from "meteor/tinytest";
+import { Tracker } from "meteor/tracker";
+
+Tinytest.add("Tracker - TypeScript types - autorun returns Computation", (test) => {
+  const computation: Tracker.Computation = Tracker.autorun((c) => {
+    const comp: Tracker.Computation = c;
+    test.equal(typeof comp.firstRun, "boolean");
+  });
+
+  computation.stop();
+  test.equal(computation.stopped, true);
+});
+
+Tinytest.add("Tracker - TypeScript types - Computation properties", (test) => {
+  const computation = Tracker.autorun((c) => {
+    const firstRun: boolean = c.firstRun;
+    const invalidated: boolean = c.invalidated;
+    const stopped: boolean = c.stopped;
+    const promise: Promise<unknown> = c.firstRunPromise;
+
+    test.equal(typeof firstRun, "boolean");
+    test.equal(typeof invalidated, "boolean");
+    test.equal(typeof stopped, "boolean");
+    test.equal(promise instanceof Promise, true);
+  });
+
+  computation.stop();
+});
+
+Tinytest.add("Tracker - TypeScript types - Computation methods", (test) => {
+  const computation = Tracker.autorun(() => {});
+
+  computation.invalidate();
+  test.equal(computation.invalidated, true);
+
+  computation.onInvalidate((c: Tracker.Computation) => {
+    test.equal(typeof c, "object");
+  });
+
+  computation.onStop((c: Tracker.Computation) => {
+    test.equal(typeof c, "object");
+  });
+
+  computation.stop();
+});
+
+Tinytest.add("Tracker - TypeScript types - Dependency", (test) => {
+  const dep: Tracker.Dependency = new Tracker.Dependency();
+
+  const hasDeps: boolean = dep.hasDependents();
+  test.equal(typeof hasDeps, "boolean");
+
+  const computation = Tracker.autorun(() => {
+    const didDepend: boolean = dep.depend();
+    test.equal(typeof didDepend, "boolean");
+  });
+
+  dep.changed();
+  computation.stop();
+});
+
+Tinytest.add("Tracker - TypeScript types - currentComputation", (test) => {
+  const outsideComp: Tracker.Computation | null = Tracker.currentComputation;
+  test.equal(outsideComp, null);
+
+  Tracker.autorun(() => {
+    const insideComp: Tracker.Computation | null = Tracker.currentComputation;
+    test.equal(insideComp !== null, true);
+  });
+});
+
+Tinytest.add("Tracker - TypeScript types - active", (test) => {
+  const outsideActive: boolean = Tracker.active;
+  test.equal(outsideActive, false);
+
+  Tracker.autorun(() => {
+    const insideActive: boolean = Tracker.active;
+    test.equal(insideActive, true);
+  });
+});
+
+Tinytest.add("Tracker - TypeScript types - afterFlush", (test) => {
+  let called = false;
+
+  Tracker.afterFlush(() => {
+    called = true;
+  });
+
+  Tracker.flush();
+  test.equal(called, true);
+});
+
+Tinytest.add("Tracker - TypeScript types - flush", (test) => {
+  const dep = new Tracker.Dependency();
+  let runCount = 0;
+
+  Tracker.autorun(() => {
+    dep.depend();
+    runCount++;
+  });
+
+  dep.changed();
+  test.equal(runCount, 1); // Not flushed yet
+
+  Tracker.flush();
+  test.equal(runCount, 2); // Now flushed
+});
+
+Tinytest.add("Tracker - TypeScript types - nonreactive", (test) => {
+  const dep = new Tracker.Dependency();
+  let runCount = 0;
+
+  Tracker.autorun(() => {
+    runCount++;
+    const result: number = Tracker.nonreactive(() => {
+      dep.depend(); // This should NOT create a dependency
+      return 42;
+    });
+    test.equal(result, 42);
+  });
+
+  dep.changed();
+  Tracker.flush();
+  test.equal(runCount, 1); // Should not have rerun
+});
+
+Tinytest.add("Tracker - TypeScript types - onInvalidate", (test) => {
+  const dep = new Tracker.Dependency();
+  let invalidateCount = 0;
+
+  const computation = Tracker.autorun(() => {
+    dep.depend();
+    Tracker.onInvalidate(() => {
+      invalidateCount++;
+    });
+  });
+
+  dep.changed();
+  Tracker.flush();
+  test.equal(invalidateCount, 1);
+
+  computation.stop();
+});
+
+Tinytest.add("Tracker - TypeScript types - autorun with onError option", (test) => {
+  let errorCaught = false;
+
+  const computation = Tracker.autorun(
+    () => {
+      throw new Error("Test error");
+    },
+    {
+      onError: (err: Error) => {
+        errorCaught = true;
+        test.equal(err.message, "Test error");
+      },
+    }
+  );
+
+  test.equal(errorCaught, true);
+  computation.stop();
+});
+
+Tinytest.addAsync("Tracker - TypeScript types - withComputation", async (test, done) => {
+  const computation = Tracker.autorun(() => {});
+
+  const result: string = await Tracker.withComputation(computation, async () => {
+    return "async result";
+  });
+
+  test.equal(result, "async result");
+  computation.stop();
+  done();
+});
+
+Tinytest.addAsync("Tracker - TypeScript types - firstRunPromise", async (test, done) => {
+  const computation = Tracker.autorun((c) => {});
+
+  const promise: Promise<unknown> = computation.firstRunPromise;
+  await promise;
+
+  test.equal(computation.firstRun, false);
+  computation.stop();
+  done();
+});


### PR DESCRIPTION
## Summary
- Addresses issue #13676 by adding TypeScript type tests to verify type definitions work correctly
- Establishes a pattern for adding type tests to other packages with `.d.ts` files
- Added comprehensive type tests for 5 packages: `check`, `random`, `tracker`, `fetch`, and `email`

## Changes
- **check**: Added type tests for Match patterns (Maybe, Optional, OneOf, ObjectIncluding, Where, Integer, Any) and check() assertions
- **random**: Added type tests for all Random methods (id, secret, fraction, hexString, choice)
- **tracker**: Added type tests for Tracker.autorun, Computation interface, Dependency class, and reactive utilities
- **fetch**: Added type tests for fetch(), Headers, Request, and Response APIs
- **email**: Added type tests for Email.sendAsync(), hookSend(), customTransport(), and MailComposer

## Pattern for other packages
Each package now follows this pattern:
1. Add `'typescript'` to `Package.onTest()` dependencies
2. Create a `*_test.ts` file with type tests using `api.mainModule()`
3. Import APIs and verify type signatures, return types, and type narrowing

Fixes #13676