### PR TITLE
fix loggingIn flag stuck on true for DDP connections to different hosts

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -384,7 +384,7 @@ export class AccountsClient extends AccountsCommon {
       // use Tracker to make we sure have a user before calling the callbacks
       Tracker.autorun(async (computation) => {
         const user = await Tracker.withComputation(computation, () =>
-          Meteor.userAsync(),
+          this.userAsync(),
         );
 
         if (user) {

--- a/packages/accounts-base/accounts_client_ddp_tests.js
+++ b/packages/accounts-base/accounts_client_ddp_tests.js
@@ -1,0 +1,53 @@
+if (Meteor.isClient) {
+  Tinytest.addAsync(
+    'accounts - loggingIn flag works correctly with DDP.connect to different host',
+    (test, done) => {
+      const username = `testuser-${Random.id()}`;
+      const password = `password-${Random.id()}`;
+      Accounts.createUser({
+        username: username,
+        password: password
+      }, (err) => {
+        if (err) {
+          test.fail('Failed to create user: ' + err.message);
+          return done();
+        }
+        
+        Meteor.logout(() => {
+          const ddpConnection = DDP.connect(Meteor.absoluteUrl());
+          const accountsClient = new AccountsClient({ connection: ddpConnection });
+          test.isFalse(accountsClient.loggingIn(), 'loggingIn should start as false');
+          
+          accountsClient.loginWithPassword(username, password, (loginErr) => {
+            if (loginErr) {
+              test.fail('Login failed: ' + loginErr.message);
+              ddpConnection.close();
+              return done();
+            }
+            
+            Meteor.setTimeout(() => {
+              test.isFalse(accountsClient.loggingIn(), 'loggingIn should be false after successful login');
+              test.isNotNull(accountsClient.userId(), 'User should be logged in on new connection');
+              accountsClient.logout(() => {
+                ddpConnection.close();
+                Meteor.call('removeTestUser', username, () => {
+                  done();
+                });
+              });
+            }, 100);
+          });
+          
+          test.isTrue(accountsClient.loggingIn(), 'loggingIn should be true during login');
+        });
+      });
+    }
+  );
+}
+
+if (Meteor.isServer) {
+  Meteor.methods({
+    removeTestUser: function(username) {
+      Meteor.users.remove({ username: username });
+    }
+  });
+}


### PR DESCRIPTION
### Fix loggingIn flag stuck on true for DDP connections to different hosts

fixes: #13492 

**Problem:** `loggingIn()` flag gets stuck on `true` when using `DDP.connect()` to login on different host.

**Root Cause:** `Meteor.userAsync()` checks default connection instead of the specific DDP connection used for login.

**Solution:** Changed `Meteor.userAsync()` to `this.userAsync()` to check the correct connection.