### PR TITLE
Fix Windows build issue by adding node-gyp-build dependency

### DIFF
--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -11,6 +11,7 @@ Package.describe({
 Npm.depends({
   bcrypt: "5.0.1",
   argon2: "0.41.1",
+  "node-gyp-build": "4.8.4",
 });
 
 Package.onUse((api) => {

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -12,6 +12,7 @@ var packageJson = {
     // and we want to make sure there are no dependencies on a higher version
     npm: "10.9.3",
     "node-gyp": "10.2.0",
+    "node-gyp-build": "4.8.4",
     "@mapbox/node-pre-gyp": "1.0.11",
     typescript: "5.6.3",
     "@meteorjs/babel": "7.20.0",


### PR DESCRIPTION
<!-- OSS-720 -->

# Fix Windows Build Issue in accounts-password Package

## Problem
After upgrading to Meteor 3.2+, Windows users encounter build failures when using the `accounts-password` package:

```
npm error 'node-gyp-build' is not recognized as an internal or external command
```

This occurs because the `argon2` dependency requires `node-gyp-build` for native compilation, but this transitive dependency isn't being properly resolved on Windows during Meteor's npm build process.

## Root Cause
- `argon2@0.41.1` depends on `node-gyp-build@^4.8.1`
- Meteor's Windows build process fails to resolve this transitive dependency
- Results in missing `node-gyp-build` command during argon2 compilation

## Solution
Add explicit `node-gyp-build` dependency to the `accounts-password` package to ensure it's available during the build process.

## Changes Made
- Added `"node-gyp-build": "4.8.4"` to `Npm.depends()` in `packages/accounts-password/package.js`
- Uses latest compatible version that satisfies argon2's requirement (`^4.8.1`)

## Verification
- Matches the working solution confirmed by multiple users in the issue
- Version 4.8.4 is the latest in the 4.8.x series and compatible with argon2@0.41.1
- No breaking changes to existing functionality

Fixes #13663