### PR TITLE
Fix bulk removal in LocalCollection

### DIFF
--- a/packages/minimongo/local_collection.js
+++ b/packages/minimongo/local_collection.js
@@ -265,6 +265,7 @@ export default class LocalCollection {
       if (matcher.documentMatches(doc).result) {
         remove.push(id);
       }
+      return true;
     });
 
     const queriesToRecompute = [];


### PR DESCRIPTION

This PR is a one-line fix within local_collection.js. In #13959, @arty-ms identified that the collector passed into `_eachPossiblyMatchingDocSync` by `prepareRemove` fails to return a proper semaphore value. There is only one other use of `_eachPossiblyMatchingDocSync`, and its match function does take care to return `true` or `false` based on whether it wants to continue enumeration. In `prepareRemove`, the intent is clearly to fully enumerate the items, so the match function should simply always return `true`.

I couldn't find existing tests of the `LocalCollection` class. I haven't yet looked more closely at the test suite.

Fixes: #13959 

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
