### PR TITLE
Fix(docs): always render options table for improved search UX (#13937)

### DIFF
--- a/v3-docs/docs/components/helpers/ParamTable.vue
+++ b/v3-docs/docs/components/helpers/ParamTable.vue
@@ -44,6 +44,9 @@ const sourceCode = `https://github.com/meteor/meteor/blob/devel/packages/${props
 
 </script>
 
+
+
+
 <template>
   <div v-if="localArr.length > 0">
     <header>
@@ -81,8 +84,9 @@ const sourceCode = `https://github.com/meteor/meteor/blob/devel/packages/${props
         </tr>
       </tbody>
     </table>
-    <Collapse v-if="hasOptions(props) && props.options && props.options?.length > 0" :when="isOptionsTableOpen"
-      class="options-table">
+
+
+    <Collapse :when ="isOptionsTableOpen" class ="options-table" v-show="hasOptions(props) && props.options && props.options?.length>0">
       <h4>Options:</h4>
       <table>
         <thead>
@@ -103,6 +107,7 @@ const sourceCode = `https://github.com/meteor/meteor/blob/devel/packages/${props
         </tbody>
       </table>
     </Collapse>
+
   </div>
 </template>
 


### PR DESCRIPTION

Hi Maintainer,

I noticed that some important configuration options in the docs were hard to find using browser search, especially when they were tucked away inside collapsed tables in ParamTable.vue (under v3-docs). This was frustrating for new developers (and me!) because Ctrl+F or AI search couldn’t discover those options unless you manually expanded everything first.

With this PR, the options table is always present in the DOM—even when it’s collapsed—so all those hidden config options are now searchable right from the browser or using AI tools.

Hope this helps !
Fixes #13937

