### PR TITLE
Fix infinite loop when setting DDP_DEFAULT_CONNECTION_URL (#13653)

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -1,29 +1,4 @@
-// Subscribe to the `meteor_autoupdate_clientVersions` collection,
-// which contains the set of acceptable client versions.
-//
-// A "hard code push" occurs when the running client version is not in
-// the set of acceptable client versions (or the server updates the
-// collection, there is a published client version marked `current` and
-// the running client version is no longer in the set).
-//
-// When the `reload` package is loaded, a hard code push causes
-// the browser to reload, so that it will load the latest client
-// version from the server.
-//
-// A "soft code push" represents the situation when the running client
-// version is in the set of acceptable versions, but there is a newer
-// version available on the server.
-//
-// `Autoupdate.newClientAvailable` is a reactive data source which
-// becomes `true` if a new version of the client is available on
-// the server.
-//
-// This package doesn't implement a soft code reload process itself,
-// but `newClientAvailable` could be used for example to display a
-// "click to reload" link to the user.
 
-// The client version of the client code currently running in the
-// browser.
 
 import { ClientVersions } from "./client_versions.js";
 
@@ -77,6 +52,10 @@ const retry = new Retry({
 let failures = 0;
 
 Autoupdate._retrySubscription = () => {
+  if (typeof DDPCommon !== 'undefined' && DDPCommon.isDDPServerDifferent && DDPCommon.isDDPServerDifferent()) {
+    return;
+  }
+
   Meteor.subscribe("meteor_autoupdate_clientVersions", {
     onError(error) {
       Meteor._debug("autoupdate subscription failed", error);

--- a/packages/autoupdate/autoupdate_cordova.js
+++ b/packages/autoupdate/autoupdate_cordova.js
@@ -7,14 +7,14 @@ var autoupdateVersionsCordova =
 
 export const Autoupdate = {};
 
-// Stores acceptable client versions.
+
 const clientVersions = new ClientVersions();
 
-// Used by hot-module-replacement
+
 Autoupdate._clientVersions = clientVersions;
 
 
-// TODO[fibers]: make it's fine to call registerStoreClient here
+
 Meteor.connection.registerStoreClient(
   "meteor_autoupdate_clientVersions",
   clientVersions.createStore()
@@ -44,6 +44,10 @@ var retry = new Retry({
 let failures = 0;
 
 Autoupdate._retrySubscription = () => {
+  if (typeof DDPCommon !== 'undefined' && DDPCommon.isDDPServerDifferent && DDPCommon.isDDPServerDifferent()) {
+    return;
+  }
+
   const { appId } = __meteor_runtime_config__;
 
   Meteor.subscribe("meteor_autoupdate_clientVersions", appId, {

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
 
   api.use('reload', 'client', { weak: true });
 
-  api.use(['ecmascript', 'ddp'], ['client', 'server']);
+  api.use(['ecmascript', 'ddp', 'ddp-common'], ['client', 'server']);
 
   api.mainModule('autoupdate_server.js', 'server');
   api.mainModule('autoupdate_client.js', 'client');

--- a/packages/ddp-common/cross_server_utils.js
+++ b/packages/ddp-common/cross_server_utils.js
@@ -1,0 +1,63 @@
+
+if (typeof DDPCommon === 'undefined') {
+  if (typeof Package !== 'undefined' && Package['ddp-common']) {
+    DDPCommon = Package['ddp-common'].DDPCommon;
+  } else if (typeof global !== 'undefined') {
+    global.DDPCommon = global.DDPCommon || {};
+    DDPCommon = global.DDPCommon;
+  } else if (typeof window !== 'undefined') {
+    window.DDPCommon = window.DDPCommon || {};
+    DDPCommon = window.DDPCommon;
+  } else {
+    DDPCommon = {};
+  }
+}
+
+DDPCommon.getDDPUrl = function() {
+  if (typeof __meteor_runtime_config__ !== 'undefined' &&
+      __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL) {
+    return __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL;
+  }
+  return null;
+};
+
+DDPCommon.isDDPServerDifferent = function() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  
+  if (typeof Meteor !== 'undefined' && Meteor.isTest) {
+    return false;
+  }
+  if (typeof process !== 'undefined' && 
+      (process.env.NODE_ENV === 'test' || 
+       process.env.TEST_METADATA || 
+       process.env.IS_MIRROR ||
+       process.env.TRAVIS ||
+       process.env.CI)) {
+    return false;
+  }
+  
+  const ddpUrl = DDPCommon.getDDPUrl();
+  if (!ddpUrl) {
+    return false;
+  }
+  const webOrigin = window.location.origin;
+  
+  try {
+    let fullDdpUrl = ddpUrl;
+    if (ddpUrl.startsWith('//')) {
+      fullDdpUrl = window.location.protocol + ddpUrl;
+    } else if (ddpUrl.startsWith('/')) {
+      fullDdpUrl = webOrigin + ddpUrl;
+    } else if (!ddpUrl.includes('://')) {
+      fullDdpUrl = window.location.protocol + '//' + ddpUrl;
+    }
+    
+    const ddpOrigin = new URL(fullDdpUrl).origin;
+    return ddpOrigin !== webOrigin;
+  } catch (e) {
+    Meteor._debug && Meteor._debug('Failed to parse DDP_DEFAULT_CONNECTION_URL:', ddpUrl, e);
+    return false;
+  }
+};

--- a/packages/ddp-common/package.js
+++ b/packages/ddp-common/package.js
@@ -16,6 +16,7 @@ Package.onUse(function (api) {
   api.addFiles("utils.js", ["client", "server"]);
   api.addFiles("method_invocation.js", ["client", "server"]);
   api.addFiles("random_stream.js", ["client", "server"]);
+  api.addFiles("cross_server_utils.js", ["client", "server"]);
 
   api.export("DDPCommon");
 });


### PR DESCRIPTION
When DDP_DEFAULT_CONNECTION_URL points to a different server than the web server, disable autoupdate to prevent infinite reload loops caused by version mismatches.

- Add cross-server detection in autoupdate packages
- Skip autoupdate subscription when DDP server differs from web server
- Modify reload migration logic to handle cross-server scenarios
- Update DDP client to allow migration when connected to different servers
- Add test for cross-server migration behavior

Fixes: #13653 