### PR TITLE
Consider `web.cordova` as a modern architecture

### DIFF
--- a/packages/babel-compiler/babel-compiler.js
+++ b/packages/babel-compiler/babel-compiler.js
@@ -264,7 +264,7 @@ BCp.processOneFileForTarget = function (inputFile, source) {
     } else if (arch === "web.browser") {
       features.modernBrowsers = true;
     } else if (arch === "web.cordova") {
-      features.modernBrowsers = ! getMeteorConfig()?.cordova?.disableModern;
+      features.modernBrowsers = ! getMeteorConfig()?.modern?.cordova === false;
     }
 
     features.topLevelAwait = inputFile.supportsTopLevelAwait &&

--- a/tools/tool-env/meteor-config.js
+++ b/tools/tool-env/meteor-config.js
@@ -13,12 +13,14 @@ export let meteorConfig;
  * @property {boolean} minifier - Whether to use the modern minifier.
  * @property {boolean} webArchOnly - Whether to use modern features only for web architecture.
  * @property {boolean} watcher - Whether to use the modern watcher.
+ * @property {boolean} cordova - Whether to use modern bundle for Cordova.
  */
 const DEFAULT_MODERN = {
   transpiler: true,
   minifier: true,
   webArchOnly: true,
   watcher: true,
+  cordova: true,
 };
 
 /**

--- a/tools/utils/archinfo.ts
+++ b/tools/utils/archinfo.ts
@@ -245,7 +245,7 @@ function getLegacyArches(): string[] {
   try {
     const meteorConfig = getMeteorConfig();
 
-    if (meteorConfig?.cordova?.disableModern === true) {
+    if (meteorConfig?.modern?.cordova === false) {
       arches.push("web.cordova");
     }
   } catch (e) {
@@ -267,8 +267,8 @@ export function mapWhereToArches(where: string) {
   // Shorthands for common arch prefixes:
   // "server" => os.*
   // "client" => web.*
-  // "modern" => web.browser, web.cordova (unless cordova.disableModern is set)
-  // "legacy" => web.browser.legacy, web.cordova (if cordova.disableModern is true)
+  // "modern" => web.browser, web.cordova (unless modern.cordova is set to false)
+  // "legacy" => web.browser.legacy, web.cordova (if modern.cordova is false)
   if (where === "server") {
     arches.push("os");
   } else if (where === "client") {

--- a/tools/utils/archinfo.ts
+++ b/tools/utils/archinfo.ts
@@ -1,6 +1,7 @@
 import { max } from 'underscore';
 import os from 'os';
 const utils = require('./utils');
+import { getMeteorConfig } from '../tool-env/meteor-config.js';
 
 /* Meteor's current architecture scheme defines the following virtual
  * machine types, which are defined by specifying what is promised by
@@ -235,33 +236,49 @@ export function matches(host: string, program: string): boolean {
      host.substr(program.length, 1) === ".");
 }
 
-const legacyArches = [
-  "web.browser.legacy",
-  // It's important to include web.browser.legacy resources in the Cordova
-  // bundle, since Cordova bundles are built into the mobile application,
-  // rather than being downloaded from a web server at runtime. This means
-  // we can't distinguish between clients at runtime, so we have to use
-  // code that works for all clients.
-  "web.cordova",
-];
+
+function getLegacyArches(): string[] {
+  const arches = ["web.browser.legacy"];
+  
+  // Check if cordova should use legacy mode
+  // This needs to access the meteor config at runtime
+  try {
+    const meteorConfig = getMeteorConfig();
+
+    if (meteorConfig?.cordova?.disableModern === true) {
+      arches.push("web.cordova");
+    }
+  } catch (e) {
+    // If config is not available, default to modern (don't add web.cordova)
+  }
+  
+  return arches;
+}
 
 export function isLegacyArch(arch: string): boolean {
+  const legacyArches = getLegacyArches();
   return legacyArches.some(la => matches(arch, la));
 }
 
 export function mapWhereToArches(where: string) {
   const arches: string[] = [];
+  const legacyArches = getLegacyArches();
 
   // Shorthands for common arch prefixes:
   // "server" => os.*
   // "client" => web.*
-  // "legacy" => web.browser.legacy, web.cordova
+  // "modern" => web.browser, web.cordova (unless cordova.disableModern is set)
+  // "legacy" => web.browser.legacy, web.cordova (if cordova.disableModern is true)
   if (where === "server") {
     arches.push("os");
   } else if (where === "client") {
     arches.push("web");
   } else if (where === "modern") {
     arches.push("web.browser");
+    // Only add web.cordova to modern if it's not in legacy mode
+    if (!legacyArches.includes("web.cordova")) {
+      arches.push("web.cordova");
+    }
   } else if (where === "legacy") {
     arches.push(...legacyArches);
   } else {

--- a/v3-docs/docs/about/cordova.md
+++ b/v3-docs/docs/about/cordova.md
@@ -266,13 +266,13 @@ After building your Cordova project with Meteor, you can use **Android Studio** 
 
 Meteor distinguishes between legacy and modern browsers - see the [modern browsers package](../packages/modern-browsers). Web apps include different code bundles for each, but Cordova apps only have a single code bundle. From Meteor 3.3.2 onwards, the default code bundle changed from legacy to modern.
 
-You can force Meteor to use the legacy browser code bundle by setting the variable `cordova.disableModern` to `true` in `package.json` when running or building your app. For example:
+You can force Meteor to use the legacy browser code bundle by setting the variable `modern.cordova` to `false` in `package.json` when running or building your app. For example:
 
 ```
   "meteor": {
     "mainModule": { ... },
     "testModule": { ... },
-    "cordova": { "disableModern":  true}
+    "modern": { "cordova": false }
   }
 ```
 


### PR DESCRIPTION
Align with documentation and consider `web.cordova` as a modern architecture ; this will be needed for capacitor.
See discussion https://forums.meteor.com/t/migrating-from-cordova-to-capacitor/63874/19