### PR TITLE
fix: Update TypeScript definitions for async support in accounts-base

### DIFF
--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -362,11 +362,11 @@ export namespace Accounts {
    * - a login method result object
    **/
   function registerLoginHandler(
-    handler: (options: any) => undefined | LoginMethodResult
+    handler: (options: any) => undefined | LoginMethodResult | Promise<undefined | LoginMethodResult>
   ): void;
   function registerLoginHandler(
     name: string,
-    handler: (options: any) => undefined | LoginMethodResult
+    handler: (options: any) => undefined | LoginMethodResult | Promise<undefined | LoginMethodResult>
   ): void;
 
   type Password =
@@ -387,8 +387,7 @@ export namespace Accounts {
   function _checkPasswordAsync(
     user: Meteor.User,
     password: Password
-  ): Promise<{ userId: string; error?: any }>
-}
+  ): Promise<{ userId: string; error?: any }>;
 
 export namespace Accounts {
   type StampedLoginToken = {


### PR DESCRIPTION
- Add Promise support to registerLoginHandler callback return type
- Fix _checkPasswordAsync return type to Promise<...>
- Allows both sync and async callbacks in login handlers

Fixes #13248 