### PR TITLE
FIX: add in development label

### DIFF
--- a/.github/scripts/__tests__/inactive-issues.test.js
+++ b/.github/scripts/__tests__/inactive-issues.test.js
@@ -127,6 +127,29 @@ test('90 days inactivity -> label + comment', async () => {
   assert.match(botComments[0].body, /90 days/i);
 });
 
+test('90 days inactivity but already labeled -> no action', async () => {
+  const issue = makeIssue({ daysSinceHumanActivity: 100, labels: ['idle'] });
+  const issues = [issue];
+  const commentsByIssue = { [issue.number]: [] };
+
+  await runScript({ issues, commentsByIssue });
+
+  const botComments = commentsByIssue[issue.number].filter(c => c.user.login === 'github-actions[bot]');
+  assert.equal(botComments.length, 0, 'Should not comment again');
+});
+
+test('90 days inactivity but already labeled `in-development` -> no action', async () => {
+  const issue = makeIssue({ daysSinceHumanActivity: 100, labels: ['in-development'] });
+  const issues = [issue];
+  const commentsByIssue = { [issue.number]: [] };
+
+  await runScript({ issues, commentsByIssue });
+
+  const botComments = commentsByIssue[issue.number].filter(c => c.user.login === 'github-actions[bot]');
+  assert.equal(botComments.length, 0, 'Should not comment again');
+});
+
+
 test('Human reply after reminder resets cycle (no immediate labeling)', async () => {
   // Scenario: last human activity 10 days ago, bot commented 40 days ago (which was 50 days after original). Should NOT comment again or label.
   const issue = makeIssue({ daysSinceHumanActivity: 10 });

--- a/.github/scripts/inactive-issues.js
+++ b/.github/scripts/inactive-issues.js
@@ -24,7 +24,7 @@ module.exports = async ({ github, context }) => {
     `👋 @${login} This issue has been open with no human activity for ${daysToComment} days. Is this issue still relevant? If there is no human response or activity within the next ${daysToLabel - daysToComment} days, this issue will be labeled as \`idle\`.`;
 
   const COMMENT_90_TEXT =
-    'This issue has been automatically labeled as `idle` due to 90 days of inactivity (no human interaction). If this is still relevant, please comment to reactivate it.';
+    'This issue has been automatically labeled as `idle` due to 90 days of inactivity (no human interaction). If this is still relevant or if someone is working on it, please comment or add `in-development` label.';
 
   // Fetch all open issues
   async function fetchAllIssues() {
@@ -106,7 +106,7 @@ module.exports = async ({ github, context }) => {
       continue;
     }
 
-    if (issue.labels.some((l) => l.name === 'idle')) {
+    if (issue.labels.some((l) => l.name === 'idle' || l.name === 'in-development')) {
       continue;
     }
 


### PR DESCRIPTION
Sometimes we are working on an issue, and the bot tries to label it as idle – this should not happen

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
