### PR TITLE
Dev only and devDepends atmosphere package fixes

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1996,15 +1996,21 @@ function hashOfFiles(files) {
  */
 function getDevOnlyPackages() {
   const targets = global.meteorBundlerTargets || {};
-  return ['client', 'server'].flatMap(target => {
-    const pkgMap = targets[target]?.packageMap?._map;
-    if (!pkgMap) {
-      return [];
-    }
-    return Object.entries(pkgMap)
-      .filter(([_, pkg]) => pkg.packageSource?.devOnly)
-      .map(([name]) => name);
-  });
+  return [
+    ...new Set(
+        ['web.browser', 'server'].flatMap(target => {
+          const pkgMap = targets[target]?.unibuilds;
+
+          if (!pkgMap) {
+            return [];
+          }
+
+          return pkgMap
+              .filter(unibuild => unibuild?.pkg?.devOnly)
+              .map(unibuild => unibuild?.pkg.name);
+        })
+    )
+  ];
 }
 
 //////////////////// JsImageTarget and JsImage  ////////////////////

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -293,7 +293,9 @@ class NodeModulesDirectory {
         // Normalize .npm/package/node_modules/... paths so that they get
         // copied into the bundle as if they were in the top-level local
         // node_modules directory of the package.
-        if (relParts[1] === "package") {
+        if (relParts[1] === "devPackage") {
+          relParts.splice(0, 2, 'dev');
+        } else if (relParts[1] === "package") {
           relParts.splice(0, 2);
         } else if (relParts[1] === "plugin") {
           relParts.splice(0, 3);
@@ -2442,8 +2444,8 @@ class JsImage {
     });
 
     var devOnlySkipPackages = [];
-    const trySkipDevModule = ['build', 'deploy'].includes(global.currentCommand?.name) && buildMode === 'production';
-    if (trySkipDevModule) devOnlySkipPackages = getDevOnlyPackages();
+    const isProductionLike = ['build', 'deploy'].includes(global.currentCommand?.name) && buildMode === 'production';
+    if (isProductionLike) devOnlySkipPackages = getDevOnlyPackages();
 
     // If multiple load files share the same asset, only write one copy of
     // each. (eg, for app assets).
@@ -2588,9 +2590,25 @@ class JsImage {
       }
 
       if (nmd.sourcePath !== nmd.preferredBundlePath) {
+        const hasDevNodeModules = nmd.sourcePath.includes('npm/dev/node_modules')
+            || nmd.sourcePath.includes('devPackage/node_modules');
+        // Skip copy dev node_modules in production-like mode
+        if (isProductionLike && hasDevNodeModules) {
+          continue;
+        }
+        // Skip copy prod node_modules in dev mode when dev node_modules exist
+        if (!isProductionLike
+            && files.exists(`${nmd.sourceRoot}/npm/dev/node_modules`)
+            && nmd.sourcePath.includes('npm/node_modules')) {
+          continue;
+        }
+        // Ensure to copy dev node_modules to proper context
+        const to = hasDevNodeModules
+            ? nmd.preferredBundlePath.replace('/dev/node_modules', '/node_modules')
+            : nmd.preferredBundlePath;
         var copyOptions = {
           from: nmd.sourcePath,
-          to: nmd.preferredBundlePath,
+          to: to,
           npmDiscards: nmd.npmDiscards,
           symlink: includeNodeModules === 'symlink'
         };

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -124,6 +124,7 @@ compiler.compile = Profile(function (packageSource, options) {
   // We run this even if we have no dependencies, because we might
   // need to delete dependencies we used to have.
   var nodeModulesPath = null;
+  var devNodeModulesPath = null;
   if (packageSource.npmCacheDirectory) {
     if (await meteorNpm.updateDependencies(packageSource.name,
                                      packageSource.npmCacheDirectory,
@@ -131,6 +132,17 @@ compiler.compile = Profile(function (packageSource, options) {
       nodeModulesPath = files.pathJoin(
         packageSource.npmCacheDirectory,
         'node_modules'
+      );
+    }
+  }
+
+  if (packageSource.npmDevCacheDirectory) {
+    if (await meteorNpm.updateDependencies(packageSource.name,
+        packageSource.npmDevCacheDirectory,
+        packageSource.npmDevDependencies)) {
+      devNodeModulesPath = files.pathJoin(
+          packageSource.npmDevCacheDirectory,
+          'node_modules'
       );
     }
   }
@@ -192,6 +204,7 @@ compiler.compile = Profile(function (packageSource, options) {
         sourceArch: architecture,
         isopackCache: isopackCache,
         nodeModulesPath: nodeModulesPath,
+        devNodeModulesPath: devNodeModulesPath,
       });
 
       Object.assign(pluginProviderPackageNames,
@@ -355,6 +368,7 @@ var compileUnibuild = Profile(function (options) {
   const inputSourceArch = options.sourceArch;
   const isopackCache = options.isopackCache;
   const nodeModulesPath = options.nodeModulesPath;
+  const devNodeModulesPath = options.devNodeModulesPath;
   const isApp = ! inputSourceArch.pkg.name;
   const resources = [];
   const pluginProviderPackageNames = {};
@@ -461,6 +475,31 @@ var compileUnibuild = Profile(function (options) {
     // coffeescript package will correctly cause packages with *.coffee files
     // to be rebuilt.
     const shrinkwrapPath = nodeModulesPath.replace(
+        /node_modules$/, 'npm-shrinkwrap.json');
+    watch.readAndWatchFile(watchSet, shrinkwrapPath);
+  }
+
+  if (devNodeModulesPath) {
+    addNodeModulesDirectory({
+      packageName: inputSourceArch.pkg.name,
+      sourceRoot: inputSourceArch.sourceRoot,
+      sourcePath: devNodeModulesPath,
+      npmDiscards: isopk.npmDiscards,
+      local: false,
+    });
+
+    // If this slice has node modules, we should consider the shrinkwrap file
+    // to be part of its inputs. (This is a little racy because there's no
+    // guarantee that what we read here is precisely the version that's used,
+    // but it's better than nothing at all.)
+    //
+    // Note that this also means that npm modules used by plugins will get
+    // this npm-shrinkwrap.json in their pluginDependencies (including for all
+    // packages that depend on us)!  This is good: this means that a tweak to
+    // an indirect dependency of the coffee-script npm module used by the
+    // coffeescript package will correctly cause packages with *.coffee files
+    // to be rebuilt.
+    const shrinkwrapPath = devNodeModulesPath.replace(
         /node_modules$/, 'npm-shrinkwrap.json');
     watch.readAndWatchFile(watchSet, shrinkwrapPath);
   }

--- a/tools/isobuild/package-npm.js
+++ b/tools/isobuild/package-npm.js
@@ -125,12 +125,6 @@ export class PackageNpm {
 
     this._devDependenciesCalled = true;
 
-    // const trySkipDevModule = ['build', 'deploy'].includes(global.currentCommand?.name);
-    // if (trySkipDevModule) {
-    //   // Skip dev dependencies in production builds
-    //   return;
-    // }
-
     if (typeof devDependencies !== 'object') {
       buildmessage.error("the argument to Npm.devDepends should be an " +
         "object, like this: {jest: '29.5.0'}",

--- a/tools/isobuild/package-npm.js
+++ b/tools/isobuild/package-npm.js
@@ -16,6 +16,7 @@ export class PackageNpm {
     // the Npm.strip comment below for further usage information.
     this._discards = new NpmDiscards;
     this._dependencies = null;
+    this._devDependencies = null;
     this._dependenciesCalled = false;
     this._devDependenciesCalled = false;
   }
@@ -115,7 +116,7 @@ export class PackageNpm {
    * @locus package.js
    */
   devDepends(devDependencies) {
-    if (this._devDependenciesCalled && this._dependencies) {
+    if (this._devDependenciesCalled && this._devDependencies) {
       buildmessage.error("Npm.devDepends may only be called once per package",
                          { useMyCaller: true });
       // recover by ignoring the Npm.devDepends line
@@ -124,11 +125,11 @@ export class PackageNpm {
 
     this._devDependenciesCalled = true;
 
-    const trySkipDevModule = ['build', 'deploy'].includes(global.currentCommand?.name);
-    if (trySkipDevModule) {
-      // Skip dev dependencies in production builds
-      return;
-    }
+    // const trySkipDevModule = ['build', 'deploy'].includes(global.currentCommand?.name);
+    // if (trySkipDevModule) {
+    //   // Skip dev dependencies in production builds
+    //   return;
+    // }
 
     if (typeof devDependencies !== 'object') {
       buildmessage.error("the argument to Npm.devDepends should be an " +
@@ -155,8 +156,8 @@ export class PackageNpm {
       return;
     }
 
-    // Add dev dependencies to the main dependencies
-    this._dependencies = {
+    // Add dev dependencies mode including dependencies
+    this._devDependencies = {
       ...(this._dependencies || {}),
       ...devDependencies,
     };

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -328,6 +328,9 @@ var PackageSource = function () {
   // as a string.
   self.npmDependencies = {};
 
+  // npm packages used for development of this package.
+  self.npmDevDependencies = {};
+
   // Files to be stripped from the installed NPM dependency tree. See the
   // Npm.strip comment below for further usage information.
   self.npmDiscards = null;
@@ -437,6 +440,9 @@ Object.assign(PackageSource.prototype, {
 
     utils.ensureOnlyValidVersions(options.npmDependencies, {forCordova: false});
     self.npmDependencies = options.npmDependencies;
+
+    utils.ensureOnlyValidVersions(options.npmDevDependencies, {forCordova: false});
+    self.npmDevDependencies = options.npmDevDependencies;
 
     // If options.npmDir is a string, make sure it contains no colons.
     self.npmCacheDirectory = _.isString(options.npmDir)
@@ -772,7 +778,10 @@ Object.assign(PackageSource.prototype, {
     // dirs for use vs test?
     self.npmCacheDirectory =
       files.pathResolve(files.pathJoin(self.sourceRoot, '.npm', 'package'));
+    self.npmDevCacheDirectory =
+        files.pathResolve(files.pathJoin(self.sourceRoot, '.npm', 'devPackage'));
     self.npmDependencies = Npm._dependencies;
+    self.npmDevDependencies = Npm._devDependencies;
     self.npmDiscards = Npm._discards;
 
     self.cordovaDependencies = Cordova._dependencies;

--- a/tools/tests/old/test-bundler-devdepends.js
+++ b/tools/tests/old/test-bundler-devdepends.js
@@ -85,7 +85,7 @@ var updateTestPackageWithDevDepends = async function (
 /// HELPERS
 ///
 
-var _assertCorrectPackageNpmDir = function (projectContext, deps) {
+var _assertCorrectPackageNpmDir = function (projectContext, deps, context = 'package') {
   // test-package/.npm was generated
 
   // Get the actual npm-shrinkwrap.json content
@@ -94,7 +94,7 @@ var _assertCorrectPackageNpmDir = function (projectContext, deps) {
       files.pathJoin(
         getTestPackageDir(projectContext),
         ".npm",
-        "package",
+        context,
         "npm-shrinkwrap.json"
       ),
       "utf8"
@@ -144,20 +144,20 @@ var _assertCorrectPackageNpmDir = function (projectContext, deps) {
   var testPackageDir = getTestPackageDir(projectContext);
   assert.equal(
     files.readFile(
-      files.pathJoin(testPackageDir, ".npm", "package", ".gitignore"),
+      files.pathJoin(testPackageDir, ".npm", context, ".gitignore"),
       "utf8"
     ),
     "node_modules\n"
   );
   assert(
-    files.exists(files.pathJoin(testPackageDir, ".npm", "package", "README"))
+    files.exists(files.pathJoin(testPackageDir, ".npm", context, "README"))
   );
 
   // verify the contents of the `node_modules` dir
   var nodeModulesDir = files.pathJoin(
     testPackageDir,
     ".npm",
-    "package",
+    context,
     "node_modules"
   );
 
@@ -316,7 +316,7 @@ var runTest = async function () {
     assert.strictEqual(result.errors, false, result.errors && result.errors[0]);
 
     // In development mode, both regular and dev dependencies should be installed
-    _assertCorrectPackageNpmDir(projectContext, allDeps);
+    _assertCorrectPackageNpmDir(projectContext, allDeps, 'devPackage');
     _assertCorrectBundleNpmContents(tmpOutputDir, allDeps);
 
     // Restore the original global.currentCommand
@@ -347,7 +347,7 @@ var runTest = async function () {
     assert.strictEqual(result.errors, false, result.errors && result.errors[0]);
 
     // In production mode, only regular dependencies should be installed
-    _assertCorrectPackageNpmDir(projectContext, regularDeps);
+    _assertCorrectPackageNpmDir(projectContext, regularDeps, 'package');
     _assertCorrectBundleNpmContents(tmpOutputDir, regularDeps);
 
     // Restore the original global.currentCommand


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/pull/13797

This PR fixes an issue in the published Meteor 3.4-beta.13 where the latest production build optimizations were not taking effect. They only worked when deploying or building from a Meteor checkout.