### PR TITLE
Fix "observeChanges - tailable" test

### DIFF
--- a/packages/mongo/tests/observe_changes_tests.js
+++ b/packages/mongo/tests/observe_changes_tests.js
@@ -519,8 +519,8 @@ if (Meteor.isServer) {
       const [resolver1, promise1] = getPromiseAndResolver();
       const [resolver2, promise2] = getPromiseAndResolver();
 
-      await self.insert({x: 2, y: 3});
       self.expects.push(resolver1, resolver2);
+      await self.insert({x: 2, y: 3});
       await self.insert({x: 3, y: 7});  // filtered out by the query
       await self.insert({x: 4});
       // Expect two added calls to happen.


### PR DESCRIPTION
the test "observeChanges - tailable" fails some times due a asyncronous operation, it was cited [here](https://github.com/meteor/meteor/pull/13787/files#r2510823348) and happenned recently [here](https://app.travis-ci.com/github/meteor/meteor/builds/276889523) 

if you call insert before add the resolver inside the self.expects array, the added callback breaks since self.expects is empty`

<img width="1009" height="176" alt="Screenshot 2025-11-21 at 12 31 23 PM" src="https://github.com/user-attachments/assets/ab2d1544-2399-4771-84dd-1ad72c943877" />
