### PR TITLE
[Rspack] Install tools dependencies as part of `meteor update` and improve messaging

### DIFF
--- a/packages/rspack/lib/dependencies.js
+++ b/packages/rspack/lib/dependencies.js
@@ -19,6 +19,7 @@ const {
   logError,
 } = require('meteor/tools-core/lib/log');
 const {
+  isMeteorAppUpdate,
   getMeteorAppDir,
 } = require('meteor/tools-core/lib/meteor');
 const {
@@ -142,6 +143,20 @@ async function ensureDependenciesInstalled(dependencies, globalStateKey, package
     }
 
     logSuccess(`✅ ${packageName} dependencies installed`);
+
+    if (isMeteorAppUpdate()) {
+      const isYarnProj = process.env.YARN_ENABLED === 'true';
+      const installCommand = isYarnProj ? 'yarn install' : 'npm install';
+
+      logInfo(`\n┌───────────────────────────────────────────────────────────────────────┐`);
+      logInfo(`│ 🔔 IMPORTANT: Project Stability Reminder                              │`);
+      logInfo(`├───────────────────────────────────────────────────────────────────────┤`);
+      logInfo(`│ After the Meteor update finishes, please run \`${installCommand}\` in your    │`);
+      logInfo(`│ project directory.                                                    │`);
+      logInfo(`│                                                                       │`);
+      logInfo(`│ This helps keep your dependencies correct and your project stable.    │`);
+      logInfo(`└───────────────────────────────────────────────────────────────────────┘`);
+    }
   }
 
   // Mark as checked

--- a/packages/rspack/lib/processes.js
+++ b/packages/rspack/lib/processes.js
@@ -163,8 +163,14 @@ export function getConfigFilePath() {
     }
   }
 
-  // If no config file is found, throw an error
-  throw new Error('Could not find rspack.config.js, rspack.config.ts, rspack.config.mjs, or rspack.config.cjs. Make sure @meteorjs/rspack is installed correctly.');
+  // If no config file is found, throw an error with suggestion to run npm install
+  const isYarnProj = process.env.YARN_ENABLED === 'true';
+  const installCommand = isYarnProj ? 'yarn install' : 'npm install';
+  throw new Error(
+    `Could not find rspack.config.js, rspack.config.ts, rspack.config.mjs, or rspack.config.cjs.\n\n` +
+    `Try running \`${installCommand}\` in your project directory and then re-run the build.\n` +
+    `This will ensure @meteorjs/rspack is installed correctly.`
+  );
 }
 
 /**

--- a/packages/rspack/rspack_plugin.js
+++ b/packages/rspack/rspack_plugin.js
@@ -62,6 +62,7 @@ const {
 const {
   isMeteorAppRun,
   isMeteorAppBuild,
+  isMeteorAppUpdate,
   getMeteorInitialAppEntrypoints,
   getMeteorAppEntrypoints,
   isMeteorAppTest,
@@ -86,9 +87,9 @@ const {
   getYarnCommand,
   isYarnProject,
 } = require('meteor/tools-core/lib/npm');
-const { getMeteorAppConfig, hasMeteorAppConfigAutoInstallDeps } = require("../tools-core/lib/meteor");
+const { hasMeteorAppConfigAutoInstallDeps } = require("../tools-core/lib/meteor");
 
-if (isMeteorAppRun() || isMeteorAppBuild() || isMeteorAppTest()) {
+if (isMeteorAppRun() || isMeteorAppBuild() || isMeteorAppTest() || isMeteorAppUpdate()) {
   // Get entry points from Meteor configuration
   setGlobalState(GLOBAL_STATE_KEYS.INITIAL_ENTRYPONTS, getMeteorAppEntrypoints());
 
@@ -127,7 +128,14 @@ if (isMeteorAppRun() || isMeteorAppBuild() || isMeteorAppTest()) {
         await ensureRspackReactInstalled();
       }
     }
+  } catch (error) {
+    logError(`Rspack plugin error: ${error.message}`);
+    throw error;
+  }
+}
 
+if (isMeteorAppRun() || isMeteorAppBuild() || isMeteorAppTest()) {
+  try {
     // Check if Angular is installed
     checkAngularInstalled();
 

--- a/packages/tools-core/lib/meteor.js
+++ b/packages/tools-core/lib/meteor.js
@@ -203,6 +203,14 @@ export function isMeteorAppBuild() {
 }
 
 /**
+ * Checks if the current Meteor command is 'update'.
+ * @returns {boolean} True if the current command is 'update', false otherwise.
+ */
+export function isMeteorAppUpdate() {
+  return Package?.meteor?.global?.currentCommand?.name === 'update';
+}
+
+/**
  * Checks if the current Meteor command is 'test'.
  * @returns {boolean} True if the current command is 'test', false otherwise.
  */


### PR DESCRIPTION
This PR ensures the rspack tool dependencies can be installed as part of `meteor update`, suggesting a manual `npm install` later. The reason is that the `npm install` made within the Meteor Node tool process doesn't install properly dependencies, even getting make of them empty within node_modules.