### PR TITLE
[Rspack] Support browser tests in full app mode

### DIFF
--- a/npm-packages/meteor-rspack/lib/test.js
+++ b/npm-packages/meteor-rspack/lib/test.js
@@ -64,7 +64,7 @@ const generateEagerTestFile = ({
           extraEntry
         )}', {
     recursive: false,
-    regExp: new RegExp(\`^\\\\./${path.basename(extraEntry)}$\`),
+    include: new RegExp(\`^\\\\./${path.basename(extraEntry)}$\`),
     mode: 'eager',
   });
   extra.keys().forEach(extra);`

--- a/npm-packages/meteor-rspack/lib/test.js
+++ b/npm-packages/meteor-rspack/lib/test.js
@@ -9,6 +9,7 @@ const { createIgnoreRegex, createIgnoreGlobConfig } = require("./ignore.js");
  * @param {string} options.projectDir - The project directory
  * @param {string} options.buildContext - The build context
  * @param {string[]} options.ignoreEntries - Array of ignore patterns
+ * @param {string} options.extraEntry - Extra entry to load
  * @returns {string} The path to the generated file
  */
 const generateEagerTestFile = ({
@@ -17,6 +18,7 @@ const generateEagerTestFile = ({
   buildContext,
   ignoreEntries: inIgnoreEntries = [],
   prefix: inPrefix = '',
+  extraEntry,
 }) => {
   const distDir = path.resolve(projectDir, ".meteor/local/test");
   if (!fs.existsSync(distDir)) {
@@ -38,7 +40,7 @@ const generateEagerTestFile = ({
     createIgnoreGlobConfig(ignoreEntries)
   );
 
-  const prefix = inPrefix && `${inPrefix}-` || '';
+  const prefix = (inPrefix && `${inPrefix}-`) || "";
   const filename = isAppTest
     ? `${prefix}eager-app-tests.mjs`
     : `${prefix}eager-tests.mjs`;
@@ -47,7 +49,8 @@ const generateEagerTestFile = ({
     ? "/\\.app-(?:test|spec)s?\\.[^.]+$/"
     : "/\\.(?:test|spec)s?\\.[^.]+$/";
 
-  const content = `{
+  const content = `${extraEntry ? `import path from 'path';` : ''}
+  {
   const ctx = import.meta.webpackContext('/', {
     recursive: true,
     regExp: ${regExp},
@@ -55,6 +58,18 @@ const generateEagerTestFile = ({
     mode: 'eager',
   });
   ctx.keys().forEach(ctx);
+  ${
+    extraEntry
+      ? `const extra = import.meta.webpackContext('${path.dirname(
+          extraEntry
+        )}', {
+    recursive: false,
+    regExp: new RegExp(\`^\\\\./${path.basename(extraEntry)}$\`),
+    mode: 'eager',
+  });
+  extra.keys().forEach(extra);`
+      : ''
+  }
 }`;
 
   fs.writeFileSync(filePath, content);

--- a/npm-packages/meteor-rspack/lib/test.js
+++ b/npm-packages/meteor-rspack/lib/test.js
@@ -64,7 +64,7 @@ const generateEagerTestFile = ({
           extraEntry
         )}', {
     recursive: false,
-    include: new RegExp(\`^\\\\./${path.basename(extraEntry)}$\`),
+    regExp: ${new RegExp(`${path.basename(extraEntry)}$`).toString()},
     mode: 'eager',
   });
   extra.keys().forEach(extra);`

--- a/npm-packages/meteor-rspack/lib/test.js
+++ b/npm-packages/meteor-rspack/lib/test.js
@@ -49,8 +49,7 @@ const generateEagerTestFile = ({
     ? "/\\.app-(?:test|spec)s?\\.[^.]+$/"
     : "/\\.(?:test|spec)s?\\.[^.]+$/";
 
-  const content = `${extraEntry ? `import path from 'path';` : ''}
-  {
+  const content = `{
   const ctx = import.meta.webpackContext('/', {
     recursive: true,
     regExp: ${regExp},

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "0.2.50",
+      "version": "0.2.51",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "0.2.53",
+      "version": "0.2.54",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "0.2.52",
+      "version": "0.2.53",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "0.2.51",
+      "version": "0.2.52",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -421,6 +421,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
           buildContext,
           ignoreEntries: [...meteorIgnoreEntries, "**/server/**"],
           prefix: "client",
+          extraEntry: path.resolve(process.cwd(), Meteor.mainClientEntry),
         })
       : isTest && isTestEager
       ? generateEagerTestFile({

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -5,7 +5,7 @@
 
 export const DEFAULT_RSPACK_VERSION = '1.6.0';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.50';
+export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.51';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -5,7 +5,7 @@
 
 export const DEFAULT_RSPACK_VERSION = '1.6.5';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.53';
+export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.54';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -5,7 +5,7 @@
 
 export const DEFAULT_RSPACK_VERSION = '1.6.5';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.52';
+export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.53';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -5,7 +5,7 @@
 
 export const DEFAULT_RSPACK_VERSION = '1.6.5';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.51';
+export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.52';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -3,7 +3,7 @@
  * @description Constants and global state keys for Rspack plugin
  */
 
-export const DEFAULT_RSPACK_VERSION = '1.6.0';
+export const DEFAULT_RSPACK_VERSION = '1.6.5';
 
 export const DEFAULT_METEOR_RSPACK_VERSION = '0.2.51';
 

--- a/tools/modern-tests/apps/react-router/package.json
+++ b/tools/modern-tests/apps/react-router/package.json
@@ -28,6 +28,7 @@
     "less": "^4.4.0",
     "less-loader": "^12.3.0",
     "playwright": "^1.54.2",
+    "puppeteer": "^24.31.0",
     "typescript": "^5.9.2"
   },
   "meteor": {

--- a/tools/modern-tests/apps/react-router/server/browser-tests/browser.app-test.js
+++ b/tools/modern-tests/apps/react-router/server/browser-tests/browser.app-test.js
@@ -29,6 +29,6 @@ describe("Run browser tests", () => {
     page.goto(process.env.ROOT_URL);
     console.log("OPEN PAGE", process.env.ROOT_URL);
 
-    await page.waitForSelector("title");
+    await page.waitForSelector("#react-target");
   });
 });

--- a/tools/modern-tests/apps/react-router/server/browser-tests/browser.app-test.js
+++ b/tools/modern-tests/apps/react-router/server/browser-tests/browser.app-test.js
@@ -1,0 +1,34 @@
+import puppeteer from "puppeteer";
+
+const width = 400;
+const height = 250;
+
+describe("Run browser tests", () => {
+  it("Runs browser based integration tests", async () => {
+    console.log("STARTING BROWSER TEST");
+    const props = {
+      headless: true,
+      timeout: 15 * 1000,
+      defaultViewport: { width, height },
+      args: [
+        `--window-size=${width},${height}`,
+        "–no-sandbox",
+        "-disable-setuid-sandbox",
+        "--enable-unsafe-swiftshader"
+      ]
+    };
+    if (process.env.CHROME_COMMAND_LOCATION) {
+      props.executablePath = process.env.CHROME_COMMAND_LOCATION;
+    }
+    const browser = await puppeteer.launch(props);
+    console.log("LAUNCHED BROWSER");
+
+    const page = await browser.newPage();
+    console.log("NEW PAGE");
+
+    page.goto(process.env.ROOT_URL);
+    console.log("OPEN PAGE", process.env.ROOT_URL);
+
+    await page.waitForSelector("title");
+  });
+});

--- a/tools/modern-tests/apps/vue/package.json
+++ b/tools/modern-tests/apps/vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tools/modern-tests/apps/vue/package.json
+++ b/tools/modern-tests/apps/vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tools/modern-tests/apps/vue/package.json
+++ b/tools/modern-tests/apps/vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tools/modern-tests/apps/vue/package.json
+++ b/tools/modern-tests/apps/vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^20.0.0",
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@nx/angular-rspack": "^21.1.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^20.0.0",
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@nx/angular-rspack": "^21.1.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^20.0.0",
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@nx/angular-rspack": "^21.1.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^20.0.0",
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@nx/angular-rspack": "^21.1.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@graphql-tools/webpack-loader": "^7.0.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",
     "@rspack/plugin-react-refresh": "^1.4.3",

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@graphql-tools/webpack-loader": "^7.0.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",
     "@rspack/plugin-react-refresh": "^1.4.3",

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@graphql-tools/webpack-loader": "^7.0.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",
     "@rspack/plugin-react-refresh": "^1.4.3",

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@graphql-tools/webpack-loader": "^7.0.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",
     "@rspack/plugin-react-refresh": "^1.4.3",

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.23.3",
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.23.3",
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.23.3",
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.23.3",
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -12,7 +12,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -12,7 +12,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -12,7 +12,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -12,7 +12,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -14,7 +14,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -14,7 +14,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -14,7 +14,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -14,7 +14,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.50",
+    "@meteorjs/rspack": "^0.2.51",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.51",
+    "@meteorjs/rspack": "^0.2.52",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.53",
+    "@meteorjs/rspack": "^0.2.54",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^0.2.52",
+    "@meteorjs/rspack": "^0.2.53",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.6.0",
     "@rspack/core": "^1.6.0",

--- a/v3-docs/docs/generators/changelog/versions/3.4.0.md
+++ b/v3-docs/docs/generators/changelog/versions/3.4.0.md
@@ -118,7 +118,7 @@ If you find any issues, please report them to the [Meteor issues tracker](https:
 
 #### Bumped NPM Packages
 
-- @meteorjs/rspack@0.2.50
+- @meteorjs/rspack@0.2.51
 
 #### Special thanks to
 

--- a/v3-docs/docs/generators/changelog/versions/3.4.0.md
+++ b/v3-docs/docs/generators/changelog/versions/3.4.0.md
@@ -118,7 +118,7 @@ If you find any issues, please report them to the [Meteor issues tracker](https:
 
 #### Bumped NPM Packages
 
-- @meteorjs/rspack@0.2.52
+- @meteorjs/rspack@0.2.53
 
 #### Special thanks to
 

--- a/v3-docs/docs/generators/changelog/versions/3.4.0.md
+++ b/v3-docs/docs/generators/changelog/versions/3.4.0.md
@@ -118,7 +118,7 @@ If you find any issues, please report them to the [Meteor issues tracker](https:
 
 #### Bumped NPM Packages
 
-- @meteorjs/rspack@0.2.51
+- @meteorjs/rspack@0.2.52
 
 #### Special thanks to
 

--- a/v3-docs/docs/generators/changelog/versions/3.4.0.md
+++ b/v3-docs/docs/generators/changelog/versions/3.4.0.md
@@ -118,7 +118,7 @@ If you find any issues, please report them to the [Meteor issues tracker](https:
 
 #### Bumped NPM Packages
 
-- @meteorjs/rspack@0.2.53
+- @meteorjs/rspack@0.2.54
 
 #### Special thanks to
 


### PR DESCRIPTION
Context: https://forums.meteor.com/t/last-3-4-beta-14-release-faster-builds-smaller-bundles-and-modern-setups-with-the-rspack-integration/64124/155

This PR ensure to fix a scenario with full app tests to support load the client app entrypoint as well as the tests.

<img width="1082" height="554" alt="image" src="https://github.com/user-attachments/assets/337a8d6c-fb38-47b7-aa86-8185f1576eac" />
