### PR TITLE
Ci/removing travis

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -49,5 +49,8 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
+      - name: Install Puppeteer
+        run: ./meteor npm install -g puppeteer@23.6.0
+
       - name: Run test-in-console suite (Travis parity)
         run: ./packages/test-in-console/run.sh

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -18,7 +18,8 @@ jobs:
       PUPPETEER_DOWNLOAD_PATH: /home/runner/.npm/chromium
       TEST_PACKAGES_EXCLUDE: stylus
       METEOR_MODERN: true
-      TINYTEST_FILTER: "email"
+      TINYTEST_FILTER: email
+      NODE_ENV: CI
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -18,7 +18,6 @@ jobs:
       PUPPETEER_DOWNLOAD_PATH: /home/runner/.npm/chromium
       TEST_PACKAGES_EXCLUDE: stylus
       METEOR_MODERN: true
-      TINYTEST_FILTER: email
       NODE_ENV: CI
 
     steps:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -1,0 +1,53 @@
+name: Meteor test packages
+
+on:
+  push:
+    branches:
+      - ci/removing-travis
+
+jobs:
+  travis-compat:
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    timeout-minutes: 90
+    env:
+      CXX: g++-12
+      phantom: false
+      PUPPETEER_DOWNLOAD_PATH: /home/runner/.npm/chromium
+      TEST_PACKAGES_EXCLUDE: stylus
+      METEOR_MODERN: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.17.0
+
+      - name: Restore caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            .meteor
+            .babel-cache
+            dev_bundle
+            /home/runner/.npm/chromium
+          key: ${{ runner.os }}-node-22.17-${{ hashFiles('meteor', '**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-22.17-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-12 libnss3
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Run test-in-console suite (Travis parity)
+        run: ./packages/test-in-console/run.sh

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -6,7 +6,7 @@ on:
       - ci/removing-travis
 
 jobs:
-  travis-compat:
+  test-packages:
     runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +18,7 @@ jobs:
       PUPPETEER_DOWNLOAD_PATH: /home/runner/.npm/chromium
       TEST_PACKAGES_EXCLUDE: stylus
       METEOR_MODERN: true
+      TINYTEST_FILTER: "email"
 
     steps:
       - name: Checkout repository
@@ -49,8 +50,5 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
-      - name: Install Puppeteer
-        run: ./meteor npm install -g puppeteer@23.6.0
-
-      - name: Run test-in-console suite (Travis parity)
+      - name: Run test-in-console suite 
         run: ./packages/test-in-console/run.sh

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1,4 +1,6 @@
 Accounts._connectionCloseDelayMsForTests = 1000;
+Accounts._options.ambiguousErrorMessages = false;
+
 const makeTestConnAsync =
   (test) =>
     new Promise((resolve, reject) => {

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -251,14 +251,14 @@ Email.sendAsync = async function (options) {
   const mailUrlEnv = process.env.MAIL_URL;
   const mailUrlSettings = Meteor.settings.packages?.email;
 
-  console.log('MAIL_URL env:', mailUrlEnv);
-  console.log('MAIL_URL settings:', mailUrlSettings);
-  console.log('Meteor.isProduction:', Meteor.isProduction);
   if (Meteor.isProduction && !mailUrlEnv && !mailUrlSettings) {
     // This check is mostly necessary when using the flag --production when running locally.
     // And it works as a reminder to properly set the mail URL when running locally.
     throw new Error(
-      'You have not provided a mail URL. You can provide it by using the environment variable MAIL_URL or your settings. You can read more about it here: https://docs.meteor.com/api/email.html.'
+      `You have not provided a mail URL. You can provide it by using the environment variable MAIL_URL or your settings. You can read more about it here: https://docs.meteor.com/api/email.html. 
+      MAIL_URL env: ${mailUrlEnv}
+      MAIL_URL settings: ${JSON.stringify(mailUrlSettings)}
+      Meteor.isProduction: ${Meteor.isProduction}`
     );
   }
 

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -255,10 +255,7 @@ Email.sendAsync = async function (options) {
     // This check is mostly necessary when using the flag --production when running locally.
     // And it works as a reminder to properly set the mail URL when running locally.
     throw new Error(
-      `You have not provided a mail URL. You can provide it by using the environment variable MAIL_URL or your settings. You can read more about it here: https://docs.meteor.com/api/email.html. 
-      MAIL_URL env: ${mailUrlEnv}
-      MAIL_URL settings: ${JSON.stringify(mailUrlSettings)}
-      Meteor.isProduction: ${Meteor.isProduction}`
+      'You have not provided a mail URL. You can provide it by using the environment variable MAIL_URL or your settings. You can read more about it here: https://docs.meteor.com/api/email.html.'
     );
   }
 

--- a/packages/email/email.js
+++ b/packages/email/email.js
@@ -251,6 +251,9 @@ Email.sendAsync = async function (options) {
   const mailUrlEnv = process.env.MAIL_URL;
   const mailUrlSettings = Meteor.settings.packages?.email;
 
+  console.log('MAIL_URL env:', mailUrlEnv);
+  console.log('MAIL_URL settings:', mailUrlSettings);
+  console.log('Meteor.isProduction:', Meteor.isProduction);
   if (Meteor.isProduction && !mailUrlEnv && !mailUrlSettings) {
     // This check is mostly necessary when using the flag --production when running locally.
     // And it works as a reminder to properly set the mail URL when running locally.

--- a/packages/test-in-console/package.js
+++ b/packages/test-in-console/package.js
@@ -6,6 +6,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.use(['tinytest', 'random', 'ejson', 'check', 'ecmascript']);
   api.use('fetch', 'server');
+  api.use('jquery', 'client');
 
   api.export('TEST_STATUS', 'client');
 

--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -15,6 +15,7 @@ export PATH=$METEOR_HOME:$PATH
 
 export URL='http://127.0.0.1:4096/'
 export METEOR_PACKAGE_DIRS='packages/deprecated'
+export METEOR_NO_DEPRECATION=true
 
 exec 3< <(./meteor test-packages --driver-package test-in-console -p 4096 --exclude ${TEST_PACKAGES_EXCLUDE:-''} $1)
 EXEC_PID=$!

--- a/packages/webapp/socket_file_tests.js
+++ b/packages/webapp/socket_file_tests.js
@@ -26,6 +26,49 @@ const isMacOS = () => {
   return platform() === 'darwin';
 };
 
+const getGroupNameForGid = (gid) => {
+  try {
+    const data = readFileSync('/etc/group', 'utf8');
+    const line = data
+      .trim()
+      .split('\n')
+      .find((groupLine) => {
+        const [, , groupGid] = groupLine.trim().split(':');
+        return Number(groupGid) === gid;
+      });
+
+    if (!line) return null;
+    const [name] = line.trim().split(':');
+    return name || null;
+  } catch {
+    return null;
+  }
+};
+
+const getWritableGroupName = () => {
+  const { gid, uid } = userInfo();
+  const gidsToTry = new Set();
+
+  if (typeof gid === 'number') {
+    gidsToTry.add(gid);
+  }
+
+  if (typeof process.getgroups === 'function') {
+    process.getgroups().forEach((groupId) => gidsToTry.add(groupId));
+  }
+
+  for (const groupId of gidsToTry) {
+    const groupName = getGroupNameForGid(groupId);
+    if (groupName) {
+      return groupName;
+    }
+  }
+
+  if (Boolean(process.env.TRAVIS)) return 'travis';
+  if (isMacOS()) return 'staff';
+  return uid === 0 ? 'root' : null;
+};
+
 const removeTestSocketFile = () => {
   try {
     unlinkSync(testSocketFile);
@@ -131,9 +174,16 @@ testAsyncMulti(
     },
     async (test) => {
       // use UNIX_SOCKET_PATH and UNIX_SOCKET_GROUP
+      const groupToUse = getWritableGroupName();
+
+      if (!groupToUse) {
+        // Skip when no writable group could be determined for the current user.
+        test.isTrue(true);
+        return;
+      }
+
       const { httpServer, server } = prepareServer();
 
-      const groupToUse = Boolean(process.env.TRAVIS) && 'travis' || (isMacOS() ? 'staff' : 'root');
       process.env.UNIX_SOCKET_PATH = testSocketFile;
       process.env.UNIX_SOCKET_GROUP = groupToUse;
       process.env.UNIX_SOCKET_PERMISSIONS = '777';

--- a/v3-docs/docs/api/app.md
+++ b/v3-docs/docs/api/app.md
@@ -57,7 +57,7 @@ App.launchScreens({
 });
 
 // Set PhoneGap/Cordova preferences.
-App.setPreference('BackgroundColor', '0xff0000ff');
+App.setPreference('BackgroundColor', '#000000ff');
 App.setPreference('HideKeyboardFormAccessoryBar', true);
 App.setPreference('Orientation', 'default');
 App.setPreference('Orientation', 'all', 'ios');


### PR DESCRIPTION
Moving travisCI to github actions:

Issues and fixes:

### **issue**: 
`jquery not found`

I dont know how it pass inside travisCI but if you run `./packages/test-in-console/run.sh`or `METEOR_PACKAGE_DIRS='packages/deprecated'   METEOR_NO_DEPRECATION=true TINYTEST_FILTER="logging in with case insensitive email should escape regex special characters" ./meteor test-packages --driver-package test-in-console -p 4096` locally you will se the ...:4096 aplication have an error saying: `jquery not found`
### **Fix**: 
addressed the jquery  inside `test-in-console` app

----------------


### **issue**: 

`EPERM: operation not permitted, chown '/tmp/socket_file_tests'` 


`chownSync` in [main](https://github.com/meteor/meteor/blob/fcb317a31f6e6b9d68a69f6bc9253b60f60d1d70/packages/webapp/webapp_server.js#L1394) fail with `EPERM` on GitHub Actions, because we have a root as default user to handle the files, what isnt allowed in github actions enviroment.

### **Fix**: 

`getWritableGroupName()` picks a real group the current process actually belongs to (via userInfo/getgroups) and uses that for `UNIX_SOCKET_GROUP`, or skips if none is writable.



This PR depends of https://github.com/meteor/meteor/pull/14027 to pass the tests