### PR TITLE
Disable ambiguous error messages in password tests

### DIFF
--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1,4 +1,6 @@
 Accounts._connectionCloseDelayMsForTests = 1000;
+Accounts._options.ambiguousErrorMessages = false;
+
 const makeTestConnAsync =
   (test) =>
     new Promise((resolve, reject) => {


### PR DESCRIPTION
I'm passing the meteor test-packages from travisCI to GitHub Actions, but a few tests that fail locally is failling into github CI as well. While investing, I got the issue and I dont know how it was working inside travisCI, IMO it should fail there too

All tests below expect a "not found error", but `ambiguousErrorMessages` isnt configured (undefined) inside Accounts, so the [_handleError](https://github.com/meteor/meteor/blob/f90b37c9bbb408bd2ab462f7ed0cc39ebda59f51/packages/accounts-base/accounts_server.js#L1552) returns a default error message (different from the expected "Not Found Error")

❌ passwords - logging in with case insensitive email should escape regex special characters  
❌ passwords - logging in with case insensitive email should require a match of the full string
❌ passwords - logging in with case insensitive email when there are multiple matches  
❌ passwords - creating users with the same case insensitive email  

[Reproduction]
You can give a look in the failing tests at GitHub CI [here](https://github.com/meteor/meteor/actions/runs/19713436074/job/56479739590) from[ this PR](https://github.com/meteor/meteor/pull/14026) 
Also, you can run: 
- `TINYTEST_FILTER="passwords - "  METEOR_NO_DEPRECATION=true mymeteor test-packages ` -> then open `localhost:3000` 
or 
- ` METEOR_PACKAGE_DIRS='packages/deprecated'   METEOR_NO_DEPRECATION=true TINYTEST_FILTER="passwords" ./meteor test-packages --driver-package test-in-console -p 4096 ` -> then open the `localhost:4096` and check the console

Solved it by adding the config on top of the file, since all those tests happen in the client, we should to configure it when we run the server tests



