### PR TITLE
Windows CI check optimizations

### DIFF
--- a/.github/workflows/meteor-selftest-windows.yml
+++ b/.github/workflows/meteor-selftest-windows.yml
@@ -6,10 +6,20 @@ on:
       - opened
       - reopened
       - synchronize
+    paths:
+      - 'meteor'
+      - 'meteor.bat'
+      - 'tools/**'
+      - 'packages/babel-compiler/**'
+      - 'packages/dynamic-import/**'
+      - 'packages/meteor/**'
+      - 'packages/meteor-tool/**'
+      - '.github/workflows/windows-selftest.yml'
+
   push:
     branches:
       - devel
-      - 2.x.x
+      - release-**
 
 env:
   METEOR_PRETTY_OUTPUT: 0
@@ -37,6 +47,7 @@ jobs:
           node-version: 22.x
 
       - name: Cache dependencies
+        id: meteor-cache
         uses: actions/cache@v4
         with:
           path: |
@@ -49,6 +60,14 @@ jobs:
           key: ${{ runner.os }}-meteor-${{ hashFiles('**/package-lock.json', 'meteor') }}
           restore-keys: |
             ${{ runner.os }}-meteor-
+
+      # 👇 Run ONLY when the cache was NOT restored!
+      - name: Prepare Meteor (cache miss)
+        if: steps.meteor-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $env:PATH = "C:\Program Files\7-Zip;$env:PATH"
+          .\meteor.bat --get-ready
 
       - name: Install dependencies
         shell: pwsh

--- a/.github/workflows/meteor-selftest-windows.yml
+++ b/.github/workflows/meteor-selftest-windows.yml
@@ -40,6 +40,21 @@ jobs:
         with:
           node-version: 22.x
 
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            dev_bundle
+            .babel-cache
+            .meteor
+            ~\.npm
+            node_modules
+            tools\modern-tests\node_modules
+            packages\**\.npm
+          key: ${{ runner.os }}-meteor-${{ hashFiles('**/package-lock.json', 'meteor') }}
+          restore-keys: |
+            ${{ runner.os }}-meteor-
+
       - name: Install dependencies
         shell: pwsh
         run: |
@@ -51,12 +66,3 @@ jobs:
         run: |
           $env:PATH = "C:\Program Files\7-Zip;$env:PATH"
           .\scripts\windows\ci\test.ps1
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            .\dev_bundle
-            .\.babel-cache
-            .\.meteor
-          key: ${{ runner.os }}-meteor-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/meteor-selftest-windows.yml
+++ b/.github/workflows/meteor-selftest-windows.yml
@@ -40,13 +40,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            dev_bundle
-            .babel-cache
-            .meteor
-            ~\.npm
+            dev_bundle/
+            .babel-cache/
+            .meteor/
+            ~/.npm
             node_modules
-            tools\modern-tests\node_modules
-            packages\**\.npm
+            packages/**/.npm
           key: ${{ runner.os }}-meteor-${{ hashFiles('**/package-lock.json', 'meteor') }}
           restore-keys: |
             ${{ runner.os }}-meteor-

--- a/.github/workflows/meteor-selftest-windows.yml
+++ b/.github/workflows/meteor-selftest-windows.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           node-version: 22.x
 
+      - name: Prefer Windows tar over Git tar
+        shell: pwsh
+        run: |
+          "C:\Windows\System32" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/meteor-selftest-windows.yml
+++ b/.github/workflows/meteor-selftest-windows.yml
@@ -44,7 +44,7 @@ jobs:
             .babel-cache/
             .meteor/
             ~/.npm
-            node_modules
+            node_modules/
             packages/**/.npm
           key: ${{ runner.os }}-meteor-${{ hashFiles('**/package-lock.json', 'meteor') }}
           restore-keys: |

--- a/.github/workflows/meteor-selftest-windows.yml
+++ b/.github/workflows/meteor-selftest-windows.yml
@@ -1,4 +1,4 @@
-name: Meteor Selftest Windows
+name: Windows Selftest
 
 on:
   pull_request:

--- a/.github/workflows/meteor-selftest-windows.yml
+++ b/.github/workflows/meteor-selftest-windows.yml
@@ -40,11 +40,6 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: Prefer Windows tar over Git tar
-        shell: pwsh
-        run: |
-          "C:\Windows\System32" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/meteor-selftest-windows.yml
+++ b/.github/workflows/meteor-selftest-windows.yml
@@ -28,10 +28,6 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: cleanup
-        shell: powershell
-        run: Remove-Item -Recurse -Force ${{ github.workspace }}\*
-
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/windows-selftest.yml
+++ b/.github/workflows/windows-selftest.yml
@@ -61,19 +61,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-meteor-
 
-      # 👇 Run ONLY when the cache was NOT restored!
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          $env:PATH = "C:\Program Files\7-Zip;$env:PATH"
+          .\scripts\windows\ci\install.ps1
+
+      # Run ONLY when the cache was NOT restored
       - name: Prepare Meteor (cache miss)
         if: steps.meteor-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           $env:PATH = "C:\Program Files\7-Zip;$env:PATH"
           .\meteor.bat --get-ready
-
-      - name: Install dependencies
-        shell: pwsh
-        run: |
-          $env:PATH = "C:\Program Files\7-Zip;$env:PATH"
-          .\scripts\windows\ci\install.ps1
 
       - name: Run tests
         shell: pwsh

--- a/.github/workflows/windows-selftest.yml
+++ b/.github/workflows/windows-selftest.yml
@@ -14,7 +14,7 @@ on:
       - 'packages/dynamic-import/**'
       - 'packages/meteor/**'
       - 'packages/meteor-tool/**'
-      - '.github/workflows/windows-selftest.yml'
+      - 'windows-selftest.yml'
 
   push:
     branches:

--- a/.github/workflows/windows-selftest.yml
+++ b/.github/workflows/windows-selftest.yml
@@ -14,7 +14,7 @@ on:
       - 'packages/dynamic-import/**'
       - 'packages/meteor/**'
       - 'packages/meteor-tool/**'
-      - 'windows-selftest.yml'
+      - '.github/workflows/windows-selftest.yml'
 
   push:
     branches:

--- a/.github/workflows/windows-selftest.yml
+++ b/.github/workflows/windows-selftest.yml
@@ -57,7 +57,7 @@ jobs:
             ~/.npm
             node_modules/
             packages/**/.npm
-          key: ${{ runner.os }}-meteor-${{ hashFiles('**/package-lock.json', 'meteor') }}
+          key: ${{ runner.os }}-meteor-${{ hashFiles('**/package-lock.json', 'meteor', 'meteor.bat') }}
           restore-keys: |
             ${{ runner.os }}-meteor-
 

--- a/scripts/windows/ci/install.ps1
+++ b/scripts/windows/ci/install.ps1
@@ -4,6 +4,9 @@ If ($env:PLATFORM -Match '^x86|x64$') {
   $env:PLATFORM = "windows_${env:PLATFORM}"
 }
 
+# Check if we're running in a CI environment
+$isCI = $env:GITHUB_ACTIONS -eq "true"
+
 $dirCheckout = (Get-Item $PSScriptRoot).parent.parent.parent.FullName
 $meteorBat = Join-Path $dirCheckout 'meteor.bat'
 
@@ -15,9 +18,10 @@ Write-Host "Updating submodules recursively..." -ForegroundColor Magenta
 # Appveyor suggests -q flag for 'git submodule...' https://goo.gl/4TFAHm
 & git.exe -C "$dirCheckout" submodule -q update --init --recursive
 
-# If ($LASTEXITCODE -ne 0) {
-#   throw "Updating submodules failed."
-# }
+# Only throw locally
+If ($LASTEXITCODE -ne 0 -and -not $isCI) {
+  throw "Updating submodules failed."
+}
 
 # The `meteor npm install` subcommand should work
 & "$meteorBat" npm install
@@ -25,25 +29,28 @@ If ($LASTEXITCODE -ne 0) {
   throw "'meteor npm install' failed."
 }
 
+# Only `meteor --get-ready` get-ready locally to have better control on CI
 # The `meteor --get-ready` command is susceptible to EPERM errors, so
 # we attempt it three times.
-$attempt = 3
-$success = $false
-while ($attempt -gt 0 -and -not $success) {
+If (-not $isCI) {
+  $attempt = 3
+  $success = $false
+  while ($attempt -gt 0 -and -not $success) {
 
-  Write-Host "Running 'meteor --get-ready'..." -ForegroundColor Magenta
-  # By redirecting error to host, we avoid a shocking/false error color,
-  # since --get-ready and --version can print (anything) to STDERR and
-  # PowerShell will interpret that as something being terribly wrong.
-  # & "$meteorBat" --get-ready
+    Write-Host "Running 'meteor --get-ready'..." -ForegroundColor Magenta
+    # By redirecting error to host, we avoid a shocking/false error color,
+    # since --get-ready and --version can print (anything) to STDERR and
+    # PowerShell will interpret that as something being terribly wrong.
+    & "$meteorBat" --get-ready
 
-  If ($LASTEXITCODE -eq 0) {
-    $success = $true
-  } else {
-    $attempt--
+    If ($LASTEXITCODE -eq 0) {
+      $success = $true
+    } else {
+      $attempt--
+    }
   }
-}
 
-If ($LASTEXITCODE -ne 0) {
-  throw "Running .\meteor --get-ready failed three times."
+  If ($LASTEXITCODE -ne 0) {
+    throw "Running .\meteor --get-ready failed three times."
+  }
 }

--- a/scripts/windows/ci/install.ps1
+++ b/scripts/windows/ci/install.ps1
@@ -35,7 +35,7 @@ while ($attempt -gt 0 -and -not $success) {
   # By redirecting error to host, we avoid a shocking/false error color,
   # since --get-ready and --version can print (anything) to STDERR and
   # PowerShell will interpret that as something being terribly wrong.
-  & "$meteorBat" --get-ready
+  # & "$meteorBat" --get-ready
 
   If ($LASTEXITCODE -eq 0) {
     $success = $true

--- a/scripts/windows/ci/install.ps1
+++ b/scripts/windows/ci/install.ps1
@@ -15,9 +15,9 @@ Write-Host "Updating submodules recursively..." -ForegroundColor Magenta
 # Appveyor suggests -q flag for 'git submodule...' https://goo.gl/4TFAHm
 & git.exe -C "$dirCheckout" submodule -q update --init --recursive
 
-If ($LASTEXITCODE -ne 0) {
-  throw "Updating submodules failed."
-}
+# If ($LASTEXITCODE -ne 0) {
+#   throw "Updating submodules failed."
+# }
 
 # The `meteor npm install` subcommand should work
 & "$meteorBat" npm install


### PR DESCRIPTION
This PR applies properly the caching strategy to speed up the Windows CI check.

I have reviewed the Windows CI check to ensure:

- **Cache behaves correctly.** The issue was that the cache was added in the wrong step of the CI pipeline. Also, the custom Windows runner didn’t have the right tools to archive the cache properly, since the correct tar.exe wasn’t used, so storing the cache after execution failed.
- **Runs only on specific changes on PRs.** The Windows self-tests usually don’t fail, but they are still useful on detecting Windows inconsistencies in Meteor. With the new changes, they run much less often, and only when changes affect specific packages or tooling (we can refine this set of paths as we better understand the effects). We also want them to always run on release branches or PRs to ensure stable releases.

With these changes, this check now runs faster by using the proper cache, avoiding long queue times across runs. It also limits when it runs, so it only triggers when needed and doesn’t block most PRs.

---

<img width="740" height="281" alt="image" src="https://github.com/user-attachments/assets/c156cb71-5e31-4bc7-b72d-4ebe2d74b0a8" />

> Most of the time, the Windows CI check takes around 1 hour and 20–30 minutes because of the time spent setting up the Meteor dependencies. With cache configured and stored properly, this should no longer be an issue.

---

<img width="568" height="239" alt="image" src="https://github.com/user-attachments/assets/8888ec37-37c0-4b22-b697-c0f8d70e3ad4" />


> Once the cache is set up properly, the check no longer spends time setting up the Meteor dependencies, so it can focus on running the Windows CI tests and speed up. In the picture it took 47 min, but could be less in cases where tests are not retried due to flakiness.

