### PR TITLE
[.meteorignore]: Watchers still trigger on ignored paths

### DIFF
--- a/tools/fs/optimistic.ts
+++ b/tools/fs/optimistic.ts
@@ -10,6 +10,7 @@ import {
   pathDirname,
   pathIsAbsolute,
   pathJoin,
+  pathRelative,
   statOrNull,
   lstat,
   readFile,
@@ -338,6 +339,10 @@ makeOptimistic("readJsonOrNull", (
   }
 });
 
+// Registry of .meteorignore patterns keyed by directory path.
+// This is populated as .meteorignore files are read during the build process.
+const meteorIgnoreRegistry = new Map<string, ReturnType<typeof ignore>>();
+
 export const optimisticReadMeteorIgnore = wrap((dir: string) => {
   const meteorIgnorePath = pathJoin(dir, ".meteorignore");
   const meteorIgnoreStat = optimisticStatOrNull(meteorIgnorePath);
@@ -356,8 +361,56 @@ export const optimisticReadMeteorIgnore = wrap((dir: string) => {
     ignoreConfig = ignoreConfig.add(customMeteorIgnore);
   }
 
+  // Update the registry with this directory's ignore config
+  if (ignoreConfig) {
+    meteorIgnoreRegistry.set(dir, ignoreConfig);
+  } else {
+    meteorIgnoreRegistry.delete(dir);
+  }
+
   return ignoreConfig;
 });
+
+/**
+ * Check if a path should be ignored based on .meteorignore patterns.
+ * This function checks all registered .meteorignore files to see if the given
+ * absolute path matches any ignore patterns.
+ * 
+ * @param absPath - Absolute path to check
+ * @returns true if the path should be ignored, false otherwise
+ */
+export function shouldIgnorePathFromMeteorIgnore(absPath: string): boolean {
+  if (!pathIsAbsolute(absPath)) {
+    return false;
+  }
+
+  // Don't ignore .meteorignore files themselves - changes to them should trigger rebuilds
+  if (pathBasename(absPath) === ".meteorignore") {
+    return false;
+  }
+
+  // Check each directory's ignore patterns
+  for (const [dir, ignoreConfig] of meteorIgnoreRegistry.entries()) {
+    // Calculate relative path from the directory containing the .meteorignore file
+    const relPath = pathRelative(dir, absPath);
+    
+    // Only check if the file is within this directory
+    // pathRelative returns a path starting with '..' if absPath is outside dir
+    // Skip empty strings and "." (the directory itself)
+    if (!relPath || relPath === "." || relPath.startsWith("..")) {
+      continue;
+    }
+    
+    // The ignore library expects forward slashes and handles directories with trailing slashes
+    const normalizedRelPath = relPath.split(pathSep).join("/");
+    
+    if (ignoreConfig.ignores(normalizedRelPath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 type LookupPkgJsonType = OptimisticWrapperFunction<
   [string, string],

--- a/tools/fs/safe-watcher-legacy.ts
+++ b/tools/fs/safe-watcher-legacy.ts
@@ -12,6 +12,7 @@ import {
     join as nativeJoin
 } from 'path';
 import nsfw from 'vscode-nsfw';
+import { shouldIgnorePathFromMeteorIgnore } from "./optimistic";
 
 const pathwatcher = require('pathwatcher');
 
@@ -407,6 +408,14 @@ function maybeSuggestRaisingWatchLimit(error: Error & { errno: number }) {
 export const watch = Profile(
     "safeWatcher.watchLegacy",
     (absPath: string, callback: EntryCallback) => {
+        // Check if the path should be ignored based on .meteorignore patterns
+        if (shouldIgnorePathFromMeteorIgnore(absPath)) {
+            // Return a no-op watcher for ignored files
+            return {
+                close() {}
+            } as SafeWatcher;
+        }
+
         const entry = acquireWatcher(absPath, callback);
         return {
             close() {

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -5,6 +5,7 @@ import { watch as watchLegacy, addWatchRoot as addWatchRootLegacy, closeAllWatch
 import { Profile } from "../tool-env/profile";
 import { statOrNull, lstat, toPosixPath, convertToOSPath, pathRelative, watchFile, unwatchFile, pathResolve, pathDirname } from "./files";
 import { getMeteorConfig } from "../tool-env/meteor-config";
+import { shouldIgnorePathFromMeteorIgnore } from "./optimistic";
 
 // Register process exit handlers to ensure subscriptions are properly cleaned up
 const registerExitHandlers = () => {
@@ -175,6 +176,10 @@ function shouldIgnorePath(absPath: string): boolean {
       }
       return true;
     } else {
+      // Check if the path matches any .meteorignore patterns
+      if (shouldIgnorePathFromMeteorIgnore(absPath)) {
+        return true;
+      }
       // Otherwise, don't ignore non-npm node_modules
       return false;
     }


### PR DESCRIPTION
Meteor supports a `.meteorignore` file, which correctly excludes the listed paths from the build process.  
However, both the modern and legacy file watchers still monitor these ignored paths.

Unless there's a deliberate reason for this behavior, this PR proposes updating the watchers so that paths listed in `.meteorignore` are also excluded from triggering rebuilds.

### Why this matters

When working on mobile apps with Capacitor, we often need a `capacitor/` directory at the project root that contains compiled native sources - which of course is listed in `.meteorignore`.  
Each time we synchronize `./meteor/local/build/programs/web.cordova` with Capacitor, any changes inside the ignored folder still trigger Meteor’s watchers, leading to unnecessary rebuilds, workflow slowdown, and even infinite loops when trying to automate this synchronization with external watchers on meteor's build.

@nachocodoner — have you run into this when working with Capacitor? I’m surprised I didn’t encounter it earlier, but it has become quite disruptive now.