### PR TITLE
FEATURE: Remove `import React from 'react';` from skels

### DIFF
--- a/tools/static-assets/skel-react/.swcrc
+++ b/tools/static-assets/skel-react/.swcrc
@@ -1,0 +1,9 @@
+{
+  "jsc": {
+    "transform": {
+      "react": {
+        "runtime": "automatic"
+      }
+    }
+  }
+}

--- a/tools/static-assets/skel-react/client/main.jsx
+++ b/tools/static-assets/skel-react/client/main.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Meteor } from 'meteor/meteor';
 import { App } from '/imports/ui/App';

--- a/tools/static-assets/skel-react/imports/ui/App.jsx
+++ b/tools/static-assets/skel-react/imports/ui/App.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Hello } from './Hello.jsx';
 import { Info } from './Info.jsx';
 

--- a/tools/static-assets/skel-react/imports/ui/Hello.jsx
+++ b/tools/static-assets/skel-react/imports/ui/Hello.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 export const Hello = () => {
   const [counter, setCounter] = useState(0);

--- a/tools/static-assets/skel-react/imports/ui/Info.jsx
+++ b/tools/static-assets/skel-react/imports/ui/Info.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useFind, useSubscribe } from 'meteor/react-meteor-data';
 import { LinksCollection } from '../api/links';
 

--- a/tools/static-assets/skel-typescript/.swcrc
+++ b/tools/static-assets/skel-typescript/.swcrc
@@ -1,0 +1,9 @@
+{
+  "jsc": {
+    "transform": {
+      "react": {
+        "runtime": "automatic"
+      }
+    }
+  }
+}

--- a/tools/static-assets/skel-typescript/client/main.tsx
+++ b/tools/static-assets/skel-typescript/client/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Meteor } from 'meteor/meteor';
 import { App } from '/imports/ui/App';

--- a/tools/static-assets/skel-typescript/imports/ui/App.tsx
+++ b/tools/static-assets/skel-typescript/imports/ui/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Hello } from './Hello';
 import { Info } from './Info';
 

--- a/tools/static-assets/skel-typescript/imports/ui/Hello.tsx
+++ b/tools/static-assets/skel-typescript/imports/ui/Hello.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 export const Hello = () => {
   const [counter, setCounter] = useState(0);

--- a/tools/static-assets/skel-typescript/imports/ui/Info.tsx
+++ b/tools/static-assets/skel-typescript/imports/ui/Info.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useFind, useSubscribe } from "meteor/react-meteor-data";
 import { LinksCollection, Link } from "../api/links";
 


### PR DESCRIPTION
With our SWC changes, we can both remove this import line and add an example of swc configuration

Relates to this Forum topic: https://forums.meteor.com/t/how-to-not-import-react-with-3-3-0/63758
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
