### PR TITLE
fix: handle Watchman RootResolveError for symlinked packages

### DIFF
--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -305,9 +305,13 @@ async function ensureWatchRoot(dirPath: string): Promise<void> {
             if (/Events were dropped/.test(err.message)) {
               return;
             }
+            if (/RootResolveError/.test(err.message) || /failed to resolve root/.test(err.message)) {
+              console.warn(`Parcel watcher root resolve error on ${osDirPath}, ignoring: ${err.message}`);
+              ignoredWatchRoots.add(dirPath);
+              watchRoots.delete(dirPath);
+              return;
+            }
             console.error(`Parcel watcher error on ${osDirPath}:`, err);
-            // Only disable native watching for critical errors (like ENOSPC).
-            // @ts-ignore
             if (err.code === "ENOSPC" || err.errno === require("constants").ENOSPC) {
               fallbackToPolling();
             }
@@ -333,9 +337,11 @@ async function ensureWatchRoot(dirPath: string): Promise<void> {
         (e.code === "ENOTDIR" ||
             /Not a directory/.test(e.message) ||
             e.code === "EBADF" ||
-            /Bad file descriptor/.test(e.message))
+            /Bad file descriptor/.test(e.message) ||
+            /RootResolveError/.test(e.message) ||
+            /failed to resolve root/.test(e.message))
     ) {
-      console.warn(`Skipping watcher for ${osDirPath}: not a directory`);
+      console.warn(`Skipping watcher for ${osDirPath}: ${e.message || 'not watchable'}`);
       ignoredWatchRoots.add(dirPath);
     } else {
       console.error(`Failed to start watcher for ${osDirPath}:`, e);


### PR DESCRIPTION
<!-- OSS-868 -->

# Fix Watchman RootResolveError for Symlinked Packages

## Problem
When running Meteor 3.3+ projects on Ubuntu with the modern watcher enabled, users encounter `watchman::RootResolveError: failed to resolve root` errors. This happens with package directories in `.meteor/packages` that use symlinked isopacket structures.

The error occurs because Watchman enforces strict case-sensitive path resolution, and the symlinked directories (like `.3.12.0.50wn0900xn++os+web.browser+web.browser.legacy+web.cordova`) cause path mismatches that Watchman can't resolve.

This causes Meteor to fail during startup or file watching, making development impossible without disabling the watcher entirely.

## Solution
Modified the watcher error handling in `tools/fs/safe-watcher.ts` to gracefully handle `RootResolveError` exceptions:

- Detect `RootResolveError` and `failed to resolve root` error patterns
- Add affected paths to `ignoredWatchRoots` instead of crashing
- Log warnings instead of errors for these cases
- Fall back to polling for affected directories

This allows Meteor to continue running normally while still watching files through the polling mechanism.

## Changes Made
- Updated error handling in `ParcelWatcher.subscribe()` callback
- Updated error handling in subscription catch block
- Improved warning messages to show actual error details

## Verification
- No breaking changes
- Existing watcher functionality preserved
- Error handling pattern matches existing code style

Fixes #13883