### PR TITLE
Recover cleanup step to Windows self-test workflow

### DIFF
--- a/.github/workflows/windows-selftest.yml
+++ b/.github/workflows/windows-selftest.yml
@@ -64,6 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-meteor-
 
+      - name: Reset submodules (force refetch)
+        shell: pwsh
+        run: |
+          git submodule deinit -f --all
+          if (Test-Path ".git/modules") { Remove-Item -Recurse -Force ".git/modules" }
+
       - name: Install dependencies
         shell: pwsh
         run: |

--- a/.github/workflows/windows-selftest.yml
+++ b/.github/workflows/windows-selftest.yml
@@ -38,6 +38,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      - name: Cleanup
+        shell: powershell
+        run: Remove-Item -Recurse -Force ${{ github.workspace }}\*
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
I removed the cleanup step when I was working on: https://github.com/meteor/meteor/pull/14032

Just want to verify that is safe to keep it, since I disable it temporary as I was facing an issue. I will merge this in case we can keep it as before, and doesn't introduce much delay.

Also, I included a fix to reset the git submodules, in order to fix a flaky scenario when re-running cached checks.