### PR TITLE
Fix React Skeleton and E2E test

### DIFF
--- a/tools/modern-tests/skeleton.test.js
+++ b/tools/modern-tests/skeleton.test.js
@@ -115,6 +115,11 @@ describe('Meteor Skeletons /', () => {
         server: 'server/main.js',
         test: 'tests/main.js',
       },
+      bodyStyles: {
+        'font-family':
+          'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        padding: '10px',
+      },
     }),
   );
 

--- a/tools/modern-tests/test-helpers.js
+++ b/tools/modern-tests/test-helpers.js
@@ -714,6 +714,7 @@ export function testMeteorSkeleton(options) {
     },
     customAssertions = {},
     checkBodyStyles = true,
+    bodyStyles,
     checkBundleFilePaths = [],
     beforeAllBehavior,
     afterAllBehavior,
@@ -789,7 +790,7 @@ export function testMeteorSkeleton(options) {
 
       if (checkBodyStyles) {
         // Assert that the body has the expected CSS styles
-        await assertBodyStyles({
+        await assertBodyStyles(bodyStyles || {
           "padding": "10px",
           "font-family": "sans-serif"
         });
@@ -823,7 +824,7 @@ export function testMeteorSkeleton(options) {
 
       if (checkBodyStyles) {
         // Assert that the body has the expected CSS styles
-        await assertBodyStyles({
+        await assertBodyStyles(bodyStyles || {
           "padding": "10px",
           "font-family": "sans-serif"
         });

--- a/tools/static-assets/skel-react/client/main.html
+++ b/tools/static-assets/skel-react/client/main.html
@@ -1,6 +1,10 @@
 <head>
   <title>~name~</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
 </head>
 
 <body>

--- a/tools/static-assets/skel-react/imports/ui/styles.css
+++ b/tools/static-assets/skel-react/imports/ui/styles.css
@@ -1,5 +1,4 @@
 /* this file is imported in client/main.jsx */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 
 :root {
   /* Colors */


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/pull/14056

This PR fixes:

# 1 - Console issue loading URL from SCSS

<img width="1010" height="472" alt="image" src="https://github.com/user-attachments/assets/be549833-4340-4b30-86fc-20abe7e934e8" />

I could have externalized the URL from the SCSS file. However, to keep rspack.config.js simpler, I added the URL import to the HTML file instead. Other option is to import these locally adding corresponding NPM packages, but to keep it simpler I modified to HTML approach instead.

I’ll make a note as a future task to externalize URL-like values in the SCSS file, so this works automatically without extra config. This can be done in the 3.4.x series.

# 2 - E2E test needs to check other loaded styles

After modifying the skeleton, the E2E test that verifies skeleton integrity and loading needed an update. The PR check was failing consistently and required a tweak to expect the new styles on the body element.
 