### PR TITLE
chore(webapp): add missing type definitions to WebAppInternals module

### DIFF
--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -104,7 +104,7 @@ export declare module WebAppInternals {
   var staticFiles: StaticFiles;
   function inlineScriptsAllowed(): boolean;
   function setInlineScriptsAllowed(inlineScriptsAllowed: boolean): void;
-
+  function enableSubresourceIntegrity(use_credentials?: boolean): void;
   function setBundledJsCssUrlRewriteHook(hookFn: (url: string) => string): void;
   function setBundledJsCssPrefix(bundledJsCssPrefix: string): void;
   function addStaticJs(): void;


### PR DESCRIPTION
Adds the missing type definition for the `enableSubresourceIntegrity` method within the WebAppInternals module