### PR TITLE
Fix E2E/Playwright tests recently failing

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_OPTIONS: "--max_old_space_size=4096"
+  NODE_OPTIONS: "--max_old_space_size=8096"
 
 jobs:
   test:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_OPTIONS: "--max_old_space_size=8096"
+  NODE_OPTIONS: "--max_old_space_size=12288"
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "^5.4.5"
   },
   "scripts": {
-    "install:modern": "cd tools/modern-tests && npm install && npx playwright install --with-deps chromium chromium-headless-shell && npx playwright install",
+    "install:modern": "cd tools/modern-tests && npm install && npx playwright install --with-deps chromium chromium-headless-shell",
     "test:idle-bot": "node --test .github/scripts/__tests__/inactive-issues.test.js",
     "test:modern": "cd tools/modern-tests && npm test -- "
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "^5.4.5"
   },
   "scripts": {
-    "install:modern": "cd tools/modern-tests && npm install && npx playwright install && npx playwright install --with-deps",
+    "install:modern": "cd tools/modern-tests && npm install && npx playwright install && npx playwright install --with-deps chromium-headless-shell",
     "test:idle-bot": "node --test .github/scripts/__tests__/inactive-issues.test.js",
     "test:modern": "cd tools/modern-tests && npm test -- "
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "^5.4.5"
   },
   "scripts": {
-    "install:modern": "cd tools/modern-tests && npm install && npx playwright install && npx playwright install --with-deps chromium-headless-shell",
+    "install:modern": "cd tools/modern-tests && npm install && npx playwright install --with-deps chromium chromium-headless-shell && npx playwright install",
     "test:idle-bot": "node --test .github/scripts/__tests__/inactive-issues.test.js",
     "test:modern": "cd tools/modern-tests && npm test -- "
   },

--- a/tools/modern-tests/apps/babel/package.json
+++ b/tools/modern-tests/apps/babel/package.json
@@ -23,7 +23,7 @@
     "@graphql-tools/webpack-loader": "^7.0.0",
     "babel-loader": "^9.1.3",
     "babel-plugin-module-resolver": "^5.0.0",
-    "playwright": "^1.54.2"
+    "playwright": "1.58.0"
   },
   "meteor": {
     "mainModule": {

--- a/tools/modern-tests/apps/blaze/package.json
+++ b/tools/modern-tests/apps/blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "playwright": "^1.54.2"
+    "playwright": "1.58.0"
   },
   "meteor": {
     "mainModule": {

--- a/tools/modern-tests/apps/coffeescript/package.json
+++ b/tools/modern-tests/apps/coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "playwright": "^1.54.2",
+    "playwright": "1.58.0",
     "coffee-loader": "^5.0.0",
     "coffeescript": "^2.7.0",
     "swc-loader": "^0.2.6"

--- a/tools/modern-tests/apps/monorepo/app/package.json
+++ b/tools/modern-tests/apps/monorepo/app/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.24.4"
   },
   "devDependencies": {
-    "playwright": "^1.54.2"
+    "playwright": "1.58.0"
   },
   "meteor": {
     "mainModule": {

--- a/tools/modern-tests/apps/react-router/package.json
+++ b/tools/modern-tests/apps/react-router/package.json
@@ -27,7 +27,7 @@
     "babel-loader": "^9.1.3",
     "less": "^4.4.0",
     "less-loader": "^12.3.0",
-    "playwright": "^1.54.2",
+    "playwright": "1.58.0",
     "puppeteer": "^24.31.0",
     "typescript": "^5.9.2"
   },

--- a/tools/modern-tests/apps/react/package.json
+++ b/tools/modern-tests/apps/react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "playwright": "^1.54.2"
+    "playwright": "1.58.0"
   },
   "meteor": {
     "mainModule": {

--- a/tools/modern-tests/apps/solid/package.json
+++ b/tools/modern-tests/apps/solid/package.json
@@ -27,7 +27,7 @@
     "@rspack/core": "^1.4.8",
     "babel-loader": "10.0.0",
     "babel-preset-solid": "^1.8.15",
-    "playwright": "^1.54.2",
+    "playwright": "1.58.0",
     "solid-js": "^1.9.4",
     "solid-refresh": "0.7.5"
   }

--- a/tools/modern-tests/apps/svelte/package.json
+++ b/tools/modern-tests/apps/svelte/package.json
@@ -16,7 +16,7 @@
     "@meteorjs/rspack": "^0.0.28",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
-    "playwright": "^1.54.2",
+    "playwright": "1.58.0",
     "postcss-load-config": "^5.1.0",
     "svelte": "^5.38.2",
     "svelte-check": "^4.3.1",

--- a/tools/modern-tests/apps/typescript/package.json
+++ b/tools/modern-tests/apps/typescript/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^18.2.5",
     "@types/react-dom": "^18.2.4",
     "assert": "^2.1.0",
-    "playwright": "^1.54.2",
+    "playwright": "1.58.0",
     "sass": "^1.92.1",
     "sass-embedded": "^1.92.1",
     "sass-loader": "^16.0.5",

--- a/tools/modern-tests/apps/vue/package.json
+++ b/tools/modern-tests/apps/vue/package.json
@@ -24,7 +24,7 @@
     "@types/meteor": "^2.9.7",
     "postcss": "^8.5.6",
     "postcss-loader": "^8.1.1",
-    "playwright": "^1.54.2",
+    "playwright": "1.58.0",
     "tailwindcss": "^4.1.12",
     "vue-loader": "^17.4.2"
   },

--- a/tools/modern-tests/package-lock.json
+++ b/tools/modern-tests/package-lock.json
@@ -15,7 +15,7 @@
         "fs-extra": "^11.3.1",
         "jest": "^29.0.0",
         "jest-playwright-preset": "^3.0.1",
-        "playwright": "^1.57.0",
+        "playwright": "1.58.0",
         "wait-on": "^7.0.0"
       }
     },

--- a/tools/modern-tests/package-lock.json
+++ b/tools/modern-tests/package-lock.json
@@ -5830,13 +5830,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5849,9 +5849,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/tools/modern-tests/package.json
+++ b/tools/modern-tests/package.json
@@ -13,7 +13,7 @@
     "fs-extra": "^11.3.1",
     "jest": "^29.0.0",
     "jest-playwright-preset": "^3.0.1",
-    "playwright": "^1.57.0",
+    "playwright": "1.58.0",
     "wait-on": "^7.0.0"
   }
 }


### PR DESCRIPTION
This PR attempts to fix the [E2E tests recently failing](https://github.com/user-attachments/assets/03e1e587-b54b-40c2-98c3-b643e7a351b7) due to it can't install and use somehow the default `chromium_headless_shell `. This has worked until at some point that re-run triggered constantly the next error.

```
--------------------------------
  ----- RUNNING CLIENT TESTS -----
--------------------------------
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
    ^
browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell-linux64/chrome-headless-shell
╔═════════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just installed or updated. ║
║ Please run the following command to download new browsers:              ║
║                                                                         ║
║     npx playwright install                                              ║
║                                                                         ║
║ <3 Playwright Team                                                      ║
╚═════════════════════════════════════════════════════════════════════════╝
    at startPlaywright (/tmp/meteor-test-run11tyqso.itae/.meteor/local/build/programs/server/assets/packages/meteortesting_browser-tests/browser/playwright_worker.mjs:45:48) {
  name: 'Error'
}
```

The issue is a version mismatch on browser installed for playwright. Each test described  uses a different playwright version. So it tries to execute sometimes: `chromium_headless_shell-1200` (build v1200) and `chromium_headless_shell-1208` (build v1208). But global installation doesn't seem to install v1208 and that triggers the error.

By pinning the playwright across the tests and project root config, it constantly uses the same chrome browser version. I also improved a bit the script and memory consumption in general to minimize flakiness.

---

- [x] Adjust NODE_OPTIONS to "--max_old_space_size=12288", as it the maximum possible (with a margin) [for the default public github runner](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)

