### PR TITLE
Add missing docs for Meteor 3.4

### DIFF
--- a/v3-docs/docs/about/modern-build-stack.md
+++ b/v3-docs/docs/about/modern-build-stack.md
@@ -46,7 +46,7 @@ Starting with Meteor 3.4
 Add this Atmosphere package to your app:
 
 ``` bash
-meteor add rspack@1.0.0
+meteor add rspack
 ```
 
 On first run, the package installs the required Rspack setup at the project level. It compiles your app code with Rspack to get the full benefit of this integration.

--- a/v3-docs/docs/about/modern-build-stack.md
+++ b/v3-docs/docs/about/modern-build-stack.md
@@ -58,3 +58,11 @@ On first run, the package installs the required Rspack setup at the project leve
 ### [Modern Build Stack in Meteor 3: Empower Your Meteor Apps with Faster, Feature-Rich Bundling](https://www.youtube.com/watch?v=LqU1eDbnG4I)
 
 Presented by [@nachocodoner](https://github.com/nachocodoner) at [Meteor Impact](https://impact.meteorjs.community/), this video covers the motivation behind this new era of Meteor bundler optimizations and modernization with Rspack integration, what initially drove us there, what we have achieved, and how you can adopt it today. It was recorded while Meteor 3.4 was in beta, but the content is still accurate. The only difference is that you can now upgrade directly to the official Meteor 3.4 release.
+
+### [Unlocking Meteor 3.2: New Profiling Tool to Track Bundler Performance and Size](https://dev.to/meteor/unlocking-meteor-32-new-profiling-tool-to-track-bundler-performance-and-size-1jc8)
+
+Release article introducing the profiling tool that laid the groundwork for measuring and improving bundler performance.
+
+### [Faster Builds in Meteor 3.3: Modern Build Stack with SWC and Bundler Optimizations](https://dev.to/meteor/faster-builds-in-meteor-33-modern-build-stack-with-swc-and-bundler-optimizations-fm2)
+
+Release article covering the SWC transpiler adoption and the bundler optimizations shipped in Meteor 3.3.

--- a/v3-docs/docs/about/modern-build-stack.md
+++ b/v3-docs/docs/about/modern-build-stack.md
@@ -52,3 +52,9 @@ meteor add rspack
 On first run, the package installs the required Rspack setup at the project level. It compiles your app code with Rspack to get the full benefit of this integration.
 
 > See the [**"Rspack Bundler Integration"** section](./modern-build-stack/rspack-bundler-integration.md) for migration requirements and config customization.
+
+## Learn more
+
+### [Modern Build Stack in Meteor 3: Empower Your Meteor Apps with Faster, Feature-Rich Bundling](https://www.youtube.com/watch?v=LqU1eDbnG4I)
+
+Presented by [@nachocodoner](https://github.com/nachocodoner) at [Meteor Impact](https://impact.meteorjs.community/), this video covers the motivation behind this new era of Meteor bundler optimizations and modernization with Rspack integration, what initially drove us there, what we have achieved, and how you can adopt it today. It was recorded while Meteor 3.4 was in beta, but the content is still accurate. The only difference is that you can now upgrade directly to the official Meteor 3.4 release.

--- a/v3-docs/docs/about/modern-build-stack/meteor-bundler-optimizations.md
+++ b/v3-docs/docs/about/modern-build-stack/meteor-bundler-optimizations.md
@@ -11,6 +11,7 @@ The Meteor bundler is made up of key components that enhance your experience in 
 - [**Minifier**](#minifier): Meteor uses the **SWC** minifier as a faster alternative to Terser.
 - [**Web archs**](#web-arch): Meteor now skips legacy architectures in development mode.
 - [**Watcher**](#watcher): Meteor now uses [`@parcel/watcher`](https://github.com/parcel-bundler/watcher) for a faster, more stable watch experience via native recursive file watching across all OS.
+- [**.meteorignore**](#meteorignore): Exclude files and directories from the bundler to reduce build and watch overhead.
 
 ## Quick start
 
@@ -44,6 +45,7 @@ You can also learn more about each part of the optimized components:
 - [**Minifier**](#minifier)
 - [**Web archs**](#web-arch)
 - [**Watcher**](#watcher)
+- [**.meteorignore**](#meteorignore)
 
 ---
 
@@ -519,6 +521,55 @@ METEOR_WATCH_POLLING_INTERVAL_MS=1000 METEOR_WATCH_FORCE_POLLING=true meteor run
 ```
 
 > Polling uses more CPU and RAM, but it's the most reliable option in some environments.
+
+---
+
+## .meteorignore
+
+> The `.meteorignore` file tells Meteor's bundler to skip specific files and directories, reducing unnecessary work during builds.
+
+Meteor's bundler processes every file in your project tree by default. In projects with folders that are not part of the app, such as documentation, design assets, or standalone tooling, the bundler still traverses and watches those directories. This adds overhead to both initial builds and file-change recompilations.
+
+You can place a `.meteorignore` file in any directory of your app or package. It uses the same pattern syntax as `.gitignore` and applies rules to the directory tree below it. Meteor's file watching system is fully integrated with `.meteorignore`, so you can add, remove, or modify these files during development and the changes take effect immediately.
+
+### Example .meteorignore
+
+Place this file at the root of your project as `.meteorignore`:
+
+```gitignore
+# Documentation
+docs/
+
+# Design and static assets not used by the app
+design/
+mockups/
+screenshots/
+
+# CI/CD and infrastructure
+docker/
+
+# Testing tools outside Meteor
+cypress/
+playwright/
+
+# Scripts and tooling unrelated to the app
+scripts/
+tools/
+benchmarks/
+
+# Misc
+LICENSE
+CHANGELOG.md
+CONTRIBUTING.md
+*.md
+!README.md
+```
+
+This keeps the bundler focused on your actual app code and Meteor packages, skipping folders and files that have no role in the build. The result is faster rebuilds during development, especially in larger projects with significant non-app content.
+
+You can also place `.meteorignore` files in subdirectories for more granular control. For example, a `.meteorignore` inside `packages/my-package/` applies only to that package's tree.
+
+For a more dynamic approach, you can use the [`METEOR_IGNORE`](../../cli/environment-variables.md#meteor-ignore) environment variable to define ignore patterns per command without modifying project files. This is especially useful when you need different ignore rules for `meteor run` and `meteor test`.
 
 ---
 

--- a/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
+++ b/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
@@ -796,7 +796,13 @@ A typical Docker step would look like this:
 RUN (meteor update --npm 2>/dev/null || true) && meteor npm install && meteor build [...]
 ```
 
+> Adding the `meteor update --npm` command in the same Docker step as `meteor build` or `meteor deploy` is important. If you forget to commit and push the NPM bumps, the docker environment can apply them on the fly and avoid errors. When using multiple Docker steps, each step is isolated, so NPM bumps will not carry over between steps.
+
 The `(meteor update --npm 2>/dev/null || true)` part is added for compatibility. The `--npm` option was introduced in Meteor 3.4. Older Meteor versions don’t support it and would fail. Redirecting the error and allowing the command to continue ensures the same Docker step works across versions, without breaking deployments on older Meteor releases.
+
+:: info
+The error in this section means the NPM bumps were not committed during the app update, and the Docker environment can't do it safely. Run `meteor update --npm` locally, or run the app once after upgrading Meteor, then commit and push both the Meteor update and the updated NPM dependencies.
+::
 
 ## Benefits
 

--- a/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
+++ b/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
@@ -780,30 +780,6 @@ module.exports = defineConfig(Meteor => ({
 }));
 ```
 
-### Docker
-
-When running a Meteor app inside Docker using a Dockerfile that calls `meteor build`, `meteor deploy`, or `meteor run`, you may need an extra step before installing dependencies.
-
-In some setups, it’s recommended to run `meteor update --npm` before `meteor npm install`.
-
-This command checks that the NPM dependencies expected by the Meteor tool meet the minimum supported versions. Each Meteor release requires specific minimum versions of tools like Rspack and other NPM packages. Running this ensures your project aligns with the Meteor version in use, helping avoid build and deploy issues.
-
-If you encounter an error like `Rspack plugin error: Could not find rspack.config.js`, it’s often a sign that this step is missing.
-
-A typical Docker step would look like this:
-
-```dockerfile
-RUN (meteor update --npm 2>/dev/null || true) && meteor npm install && meteor build [...]
-```
-
-> Adding the `meteor update --npm` command in the same Docker step as `meteor build` or `meteor deploy` is important. If you forget to commit and push the NPM bumps, the docker environment can apply them on the fly and avoid errors. When using multiple Docker steps, each step is isolated, so NPM bumps will not carry over between steps.
-
-The `(meteor update --npm 2>/dev/null || true)` part is added for compatibility. The `--npm` option was introduced in Meteor 3.4. Older Meteor versions don’t support it and would fail. Redirecting the error and allowing the command to continue ensures the same Docker step works across versions, without breaking deployments on older Meteor releases.
-
-:: info
-The error in this section means the NPM bumps were not committed during the app update, and the Docker environment can't do it safely. Run `meteor update --npm` locally, or run the app once after upgrading Meteor, then commit and push both the Meteor update and the updated NPM dependencies.
-::
-
 ## Benefits
 
 Meteor–Rspack integration sends your app code to Rspack to use modern bundler features. Meteor then uses Rspack’s output to handle Meteor-specific tasks (like Atmosphere package compilation) and create the final bundle.
@@ -876,3 +852,21 @@ module.exports = defineConfig(Meteor => ({
 You can combine both solutions: raise the heap limit with `NODE_OPTIONS` and disable persistent cache to reduce overall memory pressure.
 
 Rspack itself has reported plans to optimize persistent cache and overall RAM consumption in [Rspack 2.0](https://rspack.rs/misc/planning/roadmap), which should improve memory behavior in future Meteor-Rspack releases.
+
+### Docker
+
+When building or deploying a Meteor-Rspack app inside Docker, you may encounter errors like `Rspack plugin error: Could not find rspack.config.js`. This typically means the NPM dependencies expected by Meteor are not aligned with the Meteor version in use.
+
+Each Meteor release requires specific minimum versions of NPM packages like Rspack. If these were not committed after upgrading Meteor locally, the Docker environment won't have them. To fix this, run `meteor update --npm` before `meteor npm install` in your Dockerfile:
+
+```dockerfile
+RUN (meteor update --npm 2>/dev/null || true) && meteor npm install && meteor build [...]
+```
+
+The `(meteor update --npm 2>/dev/null || true)` wrapper is for compatibility. The `--npm` option was introduced in Meteor 3.4. Older versions don't support it and would fail, so redirecting the error and allowing the command to continue ensures the same Docker step works across Meteor versions.
+
+> Keep `meteor update --npm` in the same Docker step as `meteor build` or `meteor deploy`. If you forget to commit and push the NPM bumps locally, this lets the Docker environment apply them on the fly. When using multiple Docker steps, each step is isolated, so NPM bumps won't carry over between steps.
+
+:::info
+To avoid this issue entirely, run `meteor update --npm` locally after upgrading Meteor, or run the app once so the bumps are applied, then commit and push both the Meteor update and the updated NPM dependencies.
+:::

--- a/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
+++ b/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
@@ -867,6 +867,6 @@ The `(meteor update --npm 2>/dev/null || true)` wrapper is for compatibility. Th
 
 > Keep `meteor update --npm` in the same Docker step as `meteor build` or `meteor deploy`. If you forget to commit and push the NPM bumps locally, this lets the Docker environment apply them on the fly. When using multiple Docker steps, each step is isolated, so NPM bumps won't carry over between steps.
 
-:::info
+::: info
 To avoid this issue entirely, run `meteor update --npm` locally after upgrading Meteor, or run the app once so the bumps are applied, then commit and push both the Meteor update and the updated NPM dependencies.
 :::

--- a/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
+++ b/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
@@ -841,6 +841,38 @@ This limitation only applies to Blaze. Any other modern project will work with H
 
 If you run into issues, try `meteor reset` or delete the `.meteor/local` and `_build` folders in the project root.
 
-For help or to report issues, post on [GitHub](https://github.com/meteor/meteor/issues) or the [Meteor forums](https://forums.meteor.com). We’re focused on making Meteor faster and your feedback helps.
+For help or to report issues, post on [GitHub](https://github.com/meteor/meteor/issues) or the [Meteor forums](https://forums.meteor.com). We're focused on making Meteor faster and your feedback helps.
 
 You can compare performance before and after enabling `modern` by running [`meteor profile`](../../cli/index.md#meteorprofile). Share your results to show progress to others.
+
+### Memory Crashes
+
+Large apps are more likely to hit memory limits during Meteor-Rspack builds, but this can also happen on smaller projects depending on the number of dependencies, cache size, and available system memory. If you experience crashes or out-of-memory errors, it's likely that the Rspack child process is running out of heap memory.
+
+A common first reaction is to set [`TOOL_NODE_FLAGS`](../../cli/environment-variables.md#tool-node-flags)` (`TOOL_NODE_FLAGS="--max-old-space-size=8192"`), but this flag is mainly for the Meteor tool's own Node.js process at startup. Rspack runs as a spawned child process and may not inherit it.
+
+Instead, use the standard `NODE_OPTIONS` environment variable, which Node.js propagates to child processes:
+
+```bash
+NODE_OPTIONS="--max-old-space-size=16384" meteor run
+```
+
+This raises the heap limit for the Rspack process and should reduce how often memory-related crashes occur. Adjust the value according to your machine's available memory.
+
+:::info
+For the Meteor 3.4.x series, as `NODE_OPTIONS` is confirmed to help, one option being considered is to automatically inherit memory settings from `TOOL_NODE_FLAGS` into the spawned Rspack process.
+:::
+
+Another approach is to disable Rspack's persistent cache, which is enabled by default and can be memory-intensive. See the [Cache](#cache) migration topic to disable it:
+
+```js
+const { defineConfig } = require('@meteorjs/rspack');
+
+module.exports = defineConfig(Meteor => ({
+  ...Meteor.setCache(false),
+}));
+```
+
+You can combine both solutions: raise the heap limit with `NODE_OPTIONS` and disable persistent cache to reduce overall memory pressure.
+
+Rspack itself has reported plans to optimize persistent cache and overall RAM consumption in [Rspack 2.0](https://rspack.rs/misc/planning/roadmap), which should improve memory behavior in future Meteor-Rspack releases.

--- a/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
+++ b/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
@@ -18,7 +18,7 @@ Starting with Meteor 3.4
 Add this Atmosphere package to your app:
 
 ``` bash
-meteor add rspack@1.0.0
+meteor add rspack
 ```
 
 On first run, the package installs the required Rspack setup at the project level. It compiles your app code with Rspack to get the full benefit of this integration.

--- a/v3-docs/docs/cli/environment-variables.md
+++ b/v3-docs/docs/cli/environment-variables.md
@@ -59,6 +59,42 @@ When running `meteor build` or `meteor deploy` you can set `METEOR_DISABLE_OPTIM
 
 Since optimistic in-memory caching is one of the more memory-intensive parts of the build system, setting the environment variable `METEOR_DISABLE_OPTIMISTIC_CACHING=1` can help improve memory usage during meteor build, which seems to improve the total build times. This configuration is perfectly safe because the whole point of optimistic caching is to keep track of previous results for future rebuilds, but in the case of meteor `build` or `deploy` there's only ever one initial build, so the extra bookkeeping is unnecessary.
 
+## METEOR_IGNORE
+(_development_)
+
+An alternative way to exclude files and directories from the Meteor bundler, working similarly to a [`.meteorignore`](../about/modern-build-stack/meteor-bundler-optimizations.md#meteorignore) file but configured through an environment variable. This is useful when you want to ignore certain paths without modifying your project files.
+
+The value should be a space-delimited list of patterns (following the same syntax as `.meteorignore`), for example: `METEOR_IGNORE="tests/* private/drafts"`.
+
+When both `METEOR_IGNORE` and a `.meteorignore` file are present, their patterns are combined, so you can use the environment variable to complement your existing `.meteorignore` rules.
+
+An interesting use case is to define different `METEOR_IGNORE` patterns per command. Since the variable is set per process, you can tailor what the bundler sees depending on whether you are running the app or running tests:
+
+```bash
+# When developing, ignore test folders to speed up rebuilds
+METEOR_IGNORE="tests" meteor run
+
+# When testing, ignore folders only needed for the running app
+# e.g. public/ assets that are not consumed by tests
+METEOR_IGNORE="public" meteor test --driver-package meteor/meteortesting:mocha
+```
+
+You can also exclude heavy `node_modules` sub-dependencies that are only relevant to one workflow. For example, ignore test-only packages when running the app, or ignore app-only packages when running tests:
+
+```bash
+# Ignore test-only dependencies when running the app
+METEOR_IGNORE="node_modules/puppeteer node_modules/playwright-core" meteor run
+
+# Ignore heavy app-only dependencies when running tests
+METEOR_IGNORE="node_modules/pdfkit node_modules/sharp" meteor test --driver-package meteor/meteortesting:mocha
+```
+
+This way each command only processes the files it actually needs, reducing build times on both workflows without requiring changes to your project's `.meteorignore` file.
+
+:: info
+`METEOR_IGNORE` is automatically set when using the [Rspack bundler integration](../about/modern-build-stack/rspack-bundler-integration.md). Since Rspack handles the client and server app bundling, Meteor's bundler should only worry about what it strictly needs for the Meteor-Rspack integration. By using `METEOR_IGNORE` to exclude folders and dependencies that Rspack already manages or that are irrelevant to Meteor's side of the build, you ensure the most speed is gained from the Rspack delegation.
+::
+
 ## METEOR_PROFILE
 (_development_)
 
@@ -127,4 +163,3 @@ Configure Meteor's HTTP server to listen on a UNIX socket file path (e.g. `UNIX_
 (_production_)
 
 This overrides the default UNIX file permissions on the UNIX socket file configured in `UNIX_SOCKET_PATH`. For example, `UNIX_SOCKET_PERMISSIONS=660` would set read/write permissions for both the user and group.
-

--- a/v3-docs/docs/cli/environment-variables.md
+++ b/v3-docs/docs/cli/environment-variables.md
@@ -91,9 +91,9 @@ METEOR_IGNORE="node_modules/pdfkit node_modules/sharp" meteor test --driver-pack
 
 This way each command only processes the files it actually needs, reducing build times on both workflows without requiring changes to your project's `.meteorignore` file.
 
-:: info
+::: info
 `METEOR_IGNORE` is automatically set when using the [Rspack bundler integration](../about/modern-build-stack/rspack-bundler-integration.md). Since Rspack handles the client and server app bundling, Meteor's bundler should only worry about what it strictly needs for the Meteor-Rspack integration. By using `METEOR_IGNORE` to exclude folders and dependencies that Rspack already manages or that are irrelevant to Meteor's side of the build, you ensure the most speed is gained from the Rspack delegation.
-::
+:::
 
 ## METEOR_PROFILE
 (_development_)


### PR DESCRIPTION
This PR revisits the 3.4 docs to cover missing parts.

- `.meteorignore` / `METEOR_IGNORE`
-  Rspack troubleshooting: memory crashes and Docker issues

We also include other missing information that can be interesting to have in the docs.

