### PR TITLE
fix(typescript): constrain extension types to Document

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -122,14 +122,14 @@ export namespace Mongo {
      * Add a constructor extension function that runs when collections are created.
      * @param extension Extension function called with (name, options) and 'this' bound to collection instance
      */
-    addExtension<T = any, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
+    addExtension<T extends NpmModuleMongodb.Document, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
 
     /**
      * Add a prototype method to all collection instances.
      * @param name The name of the method to add
      * @param method The method function, bound to the collection instance
      */
-    addPrototypeMethod<T = any, U = T>(name: string, method: (this: Collection<T, U>, ...args: any[]) => any): void;
+    addPrototypeMethod<T extends NpmModuleMongodb.Document, U = T>(name: string, method: (this: Collection<T, U>, ...args: any[]) => any): void;
 
     /**
      * Add a static method to the Mongo.Collection constructor.
@@ -573,14 +573,14 @@ export namespace Mongo {
      * Add a constructor extension function that runs when collections are created.
      * @param extension Extension function called with (name, options) and 'this' bound to collection instance
      */
-    addExtension<T = any, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
+    addExtension<T extends NpmModuleMongodb.Document, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
     
     /**
      * Add a prototype method to all collection instances.
      * @param name The name of the method to add
      * @param method The method function, bound to the collection instance
      */
-    addPrototypeMethod<T = any, U = T>(name: string, method: (this: Collection<T, U>, ...args: any[]) => any): void;
+    addPrototypeMethod<T extends NpmModuleMongodb.Document, U = T>(name: string, method: (this: Collection<T, U>, ...args: any[]) => any): void;
 
     /**
      * Add a static method to the Mongo.Collection constructor.


### PR DESCRIPTION
These functions were introduced to mongo.d.ts without constraint (i.e. T=any) in 8ca07cc0d3d3051a6da9b4b432096ec1a039e3ee, which was included in Meteor 3.4 but not 3.3.  As we attempted to update our downstream project from Meteor 3.3 to Meteor 3.4, we found that through consuming these types through `zodern-types` we hit new type errors like:

```
.meteor/local/types/node_modules/package-types/mongo/package/os/packages/mongo/mongo.d.ts:125:63 - error TS2344: Type 'T' does not satisfy the constraint 'Document'.

125     addExtension<T = any, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
                                                                  ~

  .meteor/local/types/node_modules/package-types/mongo/package/os/packages/mongo/mongo.d.ts:125:18
    125     addExtension<T = any, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
                         ~~~~~~~
    This type parameter might need an `extends NpmModuleMongodb.BSON.Document` constraint.
```

even though we don't use these methods.

The types should require that the type parameter to Collection extends the mongo Document type, so this patch adds the additional suggested constraints, which then satisfies the typechecker.