### PR TITLE
fix(accounts-passwordless): add argument validation to requestLoginTokenForUser

### DIFF
--- a/packages/accounts-passwordless/passwordless_server.js
+++ b/packages/accounts-passwordless/passwordless_server.js
@@ -114,7 +114,20 @@ function generateSequence() {
 }
 
 Meteor.methods({
-  requestLoginTokenForUser: ({ selector, userData, options = {} }) => {
+  requestLoginTokenForUser: (args) => {
+    check(args, Match.ObjectIncluding({
+      selector: Accounts._userQueryValidator,
+      userData: Match.Optional(Match.ObjectIncluding({
+        username: Match.Optional(NonEmptyString),
+        email: Match.Optional(NonEmptyString),
+      })),
+      options: Match.Optional(Match.ObjectIncluding({
+        userCreationDisabled: Match.Optional(Boolean),
+        extra: Match.Optional(Object),
+      })),
+    }));
+
+    const { selector, userData, options } = args;
     let user = Accounts._findUserByQuery(selector, {
       fields: { emails: 1 },
     });


### PR DESCRIPTION
## Problem

When the `audit-argument-checks` package is enabled in a Meteor application, the `requestLoginTokenForUser` method in the `accounts-passwordless` package throws an error:

```
Exception while invoking method 'requestLoginTokenForUser' Error: Did not check() all arguments during call to 'requestLoginTokenForUser'
```

This happens because the method doesn't validate its arguments using `check()`, which is required when `audit-argument-checks` is active. 

## Solution

Added `check()` calls to validate all arguments in the `requestLoginTokenForUser`.

The validation is placed at the beginning of the method, following the same pattern used in the `registerLoginHandler` at line 34 of the same file.

## Related Issues

Fixes [#12053](https://github.com/meteor/meteor/issues/12053)

PS: I fixed it in version 2.16 because that's the version my project is running on.