### PR TITLE
fix(build): fix cordova platforms detection to avoid modern/legacy

### DIFF
--- a/tools/project-context.js
+++ b/tools/project-context.js
@@ -1470,8 +1470,7 @@ Object.assign(exports.PlatformList.prototype, {
 
   getCordovaPlatforms: function () {
     var self = this;
-    return _.difference(self._platforms,
-                        exports.PlatformList.DEFAULT_PLATFORMS);
+    return _.intersection(self._platforms, ['ios', 'android']);
   },
 
   usesCordova: function () {


### PR DESCRIPTION
https://docs.meteor.com/about/modern-build-stack/meteor-bundler-optimizations.html#web-arch
As documented, adding `modern` to `.meteor/platforms` is supposed to exclude legacy builds in production. 

However, adding `modern` is currently treated as a Cordova platform because `getCordovaPlatforms()` returns all non-default platforms (`browser`, `server` are default). This causes `meteor build` to enter the Cordova build branch and require Cordova files even when no mobile platforms are present. The expected behavior is that Cordova platforms are only `android` and `iOS`, so web-only platforms like `modern/legacy` should not trigger Cordova builds.