### PR TITLE
fix(accounts-password): fix operator precedence bug in passwordValidator

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -290,7 +290,7 @@ Accounts._checkPasswordAsync = checkPasswordAsync;
 
 
 const passwordValidator = Match.OneOf(
-  Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256), {
+  Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)), {
     digest: Match.Where(str => Match.test(str, String) && str.length === 64),
     algorithm: Match.OneOf('sha-256')
   }
@@ -472,7 +472,7 @@ Meteor.methods(
 Accounts.setPasswordAsync =
   async (userId, newPlaintextPassword, options) => {
     check(userId, String);
-    check(newPlaintextPassword, Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256));
+    check(newPlaintextPassword, Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)));
     check(options, Match.Maybe({ logout: Boolean }));
     options = { logout: true, ...options };
 


### PR DESCRIPTION
## Summary

This PR fixes a critical operator precedence bug in the `passwordValidator` that causes password length validation to always pass, regardless of the configured `passwordMaxLength` or the default value of 256.

**Root Cause:**
Due to JavaScript operator precedence, `<=` binds tighter than `||`, so the original expression:
```javascript
str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256
```

Parses as:
```javascript
(str.length <= passwordMaxLength) || 256
```

When `passwordMaxLength` is undefined:
- `str.length <= undefined` evaluates to `false`
- `false || 256` evaluates to `256` (truthy)
- Validation passes for ANY length password

**The Fix:**
Add parentheses to ensure correct operator precedence:
```javascript
str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)
```

This fix is applied to:
1. The `passwordValidator` constant (line 293)
2. The `Accounts.setPasswordAsync` function check (line 475)

## Security Implications

- **DoS potential**: Before this fix, extremely long passwords could be sent to the server, consuming resources during SHA256 hashing
- **Policy bypass**: Any configured `passwordMaxLength` setting was completely ignored

## Test Plan

- [x] Verified fix logic with standalone JavaScript tests
- [x] Code review confirms the parentheses fix is correct
- [x] The fix matches the suggested solution in issue #14072
- [ ] Run Meteor test suite (requires Meteor build environment)

Closes #14072

---

> [!NOTE]
> This PR was authored with assistance from an AI coding agent (Claude claude-opus-4-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)