### PR TITLE
Add METEOR_SETTINGS to deployment documentation

### DIFF
--- a/guide/source/deployment.md
+++ b/guide/source/deployment.md
@@ -196,6 +196,7 @@ MONGO_URL=mongodb://localhost:27017/myapp ROOT_URL=http://my-app.com PORT=3000 n
 * `ROOT_URL` is the base URL for your Meteor project
 * `PORT` is the port at which the application is running
 * `MONGO_URL` is a [Mongo connection string URI](https://docs.mongodb.com/manual/reference/connection-string/) supplied by the MongoDB provider.
+* `METEOR_SETTINGS` is a JSON object containing your application settings (can also be set via --settings flag). **Warning:** Any settings under the `public` key will be sent to the client - never put secrets there.
 
 
 Unless you have a specific need to roll your own hosting environment, the other options here are definitely easier, and probably make for a better setup than doing everything from scratch. Operating a Meteor app in a way that it works correctly for everyone can be complex, and [Galaxy](#galaxy) handles a lot of the specifics like routing clients to the right containers and handling coordinated version updates for you.

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -3133,6 +3133,7 @@ Node.js ${process.version}. To run the application:
   $ export MONGO_URL='mongodb://user:password@host:port/databasename'
   $ export ROOT_URL='http://example.com'
   $ export MAIL_URL='smtp://user:password@mailhost:port/'
+  $ export METEOR_SETTINGS='{"public":{"key":"value"}}'
   $ node main.js
 
 Use the PORT environment variable to set the port where the


### PR DESCRIPTION
Fixes #13458

## Summary
Added `METEOR_SETTINGS` environment variable documentation to deployment guides. This common configuration option was missing from both the bundle README and the custom deployment documentation.

## Changes
- **Bundle README template** (`tools/isobuild/bundler.js`): Added `METEOR_SETTINGS` example alongside other env vars (MONGO_URL, ROOT_URL, MAIL_URL)
- **Custom deployment guide** (`guide/source/deployment.md`): Documented `METEOR_SETTINGS` with a security warning about the `public` key

## Why this matters
Users deploying Meteor apps for the first time often don't know about `METEOR_SETTINGS` as a runtime configuration option. This causes confusion when they need to configure their production apps. Adding it to the bundle README (the first thing deployers read) and the deployment guide closes this documentation gap.

## Security note
Included a warning that settings under the `public` key are sent to the client to prevent accidental secret leakage.