### PR TITLE
Fix loggingIn flag stuck on true for non-default DDP connections

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -292,8 +292,7 @@ export class AccountsClient extends AccountsCommon {
     // getting the results of subscription rerun, we WILL NOT re-send this
     // method (because we never re-send methods whose results we've received)
     // but we WILL call loggedInAndDataReadyCallback at "reconnect quiesce"
-    // time. This will lead to makeClientLoggedIn(result.id) even though we
-    // haven't actually sent a login method!
+    // time. This will lead to makeClientLoggedIn(result.id) even though we haven't actually sent a login method!
     //
     // But by making sure that we send this "resume" login in that case (and
     // calling makeClientLoggedOut if it fails), we'll end up with an accurate
@@ -406,17 +405,26 @@ export class AccountsClient extends AccountsCommon {
       this.makeClientLoggedIn(result.id, result.token, result.tokenExpires);
 
       // use Tracker to make we sure have a user before calling the callbacks
-      Tracker.autorun(async (computation) => {
-        const user = await Tracker.withComputation(computation, () =>
-          Meteor.userAsync(),
-        );
+      // However, if we're using a custom connection (not Meteor.connection),
+      // the user won't be in the local Meteor.users collection
+      if (this.connection === Meteor.connection) {
+        Tracker.autorun(async (computation) => {
+          const user = await Tracker.withComputation(computation, () =>
+            Meteor.userAsync(),
+          );
 
-        if (user) {
-          loginCallbacks({ loginDetails: result });
-          this._setLoggingIn(false);
-          computation.stop();
-        }
-      });
+          if (user) {
+            loginCallbacks({ loginDetails: result });
+            this._setLoggingIn(false);
+            computation.stop();
+          }
+        });
+      } else {
+        // For custom DDP connections, call the callbacks immediately
+        // since we won't have a local user document
+        loginCallbacks({ loginDetails: result });
+        this._setLoggingIn(false);
+      }
 
     };
 

--- a/packages/accounts-base/accounts_client_tests.js
+++ b/packages/accounts-base/accounts_client_tests.js
@@ -398,3 +398,94 @@ Tinytest.addAsync('accounts - should only start subscription when connected', as
 
   cleanup()
 });
+
+Tinytest.addAsync(
+  'accounts - Meteor.loggingIn() is false after login with custom DDP connection',
+  async (test, done) => {
+    // Create a custom DDP connection
+    const customConnection = DDP.connect(Meteor.absoluteUrl());
+    
+    // Create a custom Accounts instance with the custom connection
+    const customAccounts = new AccountsClient({
+      connection: customConnection,
+    });
+
+    // First, create a user on the default connection
+    createUserAndLogout(test, done, async () => {
+      // Now login using the custom connection
+      customAccounts.callLoginMethod({
+        methodName: 'login',
+        methodArguments: [{ user: { username }, password }],
+        userCallback: (error) => {
+          test.isFalse(error);
+          
+          // Wait a bit for the login to complete
+          Meteor.setTimeout(() => {
+            // Verify that loggingIn is false after login completes
+            test.isFalse(customAccounts.loggingIn());
+            
+            // Verify that we got a userId
+            test.isTrue(!!customAccounts.userId());
+            
+            // Cleanup
+            customAccounts.logout(() => {
+              customConnection.disconnect();
+              removeTestUser(done);
+            });
+          }, 100);
+        }
+      });
+      
+      // Immediately after calling login, loggingIn should be true
+      test.isTrue(customAccounts.loggingIn());
+    });
+  }
+);
+
+Tinytest.addAsync(
+  'accounts - loginWithPassword works with custom DDP connection',
+  async (test, done) => {
+    // Create a custom DDP connection
+    const customConnection = DDP.connect(Meteor.absoluteUrl());
+    
+    // Create a custom Accounts instance with the custom connection
+    const customAccounts = new AccountsClient({
+      connection: customConnection,
+    });
+
+    // First, create a user on the default connection
+    createUserAndLogout(test, done, () => {
+      // Register the loginWithPassword method on the custom accounts instance
+      customAccounts.registerClientLoginFunction('password', function(username, password, callback) {
+        this.callLoginMethod({
+          methodName: 'login',
+          methodArguments: [{ user: { username }, password }],
+          userCallback: callback
+        });
+      });
+
+      // Now login using the custom connection
+      customAccounts.callLoginFunction('password', username, password, (error) => {
+        test.isFalse(error);
+        
+        // Wait a bit for the login to complete
+        Meteor.setTimeout(() => {
+          // Verify that loggingIn is false after login completes
+          test.isFalse(customAccounts.loggingIn());
+          
+          // Verify that we got a userId
+          test.isTrue(!!customAccounts.userId());
+          
+          // Cleanup
+          customAccounts.logout(() => {
+            customConnection.disconnect();
+            removeTestUser(done);
+          });
+        }, 100);
+      });
+      
+      // Immediately after calling login, loggingIn should be true
+      test.isTrue(customAccounts.loggingIn());
+    });
+  }
+);


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
Fixes loggingIn() reactive state when using DDP.connect() and loginWithPassword

### Problem
When connecting to a different host via `DDP.connect()` and subsequently logging in with a username and password, the `loggingIn()` flag gets stuck on `true`. This happens because the flag is only set to `false` after `Meteor.userAsync()` returns a user, but `Meteor.userAsync()` only works with the default `Meteor.connection`, not custom DDP connections.

This regression was introduced in version 3.0.4 when the `_setLoggingIn(false)` call was moved inside a `Tracker.autorun` that waits for `Meteor.userAsync()`.

### Solution
Check if the login is happening on the default `Meteor.connection` or a custom DDP connection:
- For the default connection: wait for `Meteor.userAsync()` to return a user before completing the login flow (existing behavior)
- For custom connections: immediately complete the login flow and set `loggingIn` to `false`, since `Meteor.userAsync()` won't work for them

### Testing
- Existing tests pass
- Fixes issue with `loggingIn()` stuck on `true` for custom DDP connections
- Maintains backward compatibility with default connection behavior

Fixes #13492 