### PR TITLE
Handle deleted PostCSS dependency files gracefully

### DIFF
--- a/packages/standard-minifier-css/plugin/postcss.js
+++ b/packages/standard-minifier-css/plugin/postcss.js
@@ -114,7 +114,7 @@ export const watchAndHashDeps = Profile(
       if (dep.type === 'dependency') {
         fileCount += 1;
         const fileHash = hashAndWatchFile(dep.file);
-        hash.update(fileHash).update('\0');
+        hash.update(fileHash || 'deleted').update('\0');
       } else if (dep.type === 'dir-dependency') {
         if (dep.dir in globsByDir) {
           globsByDir[dep.dir].push(dep.glob || '**');

--- a/tools/isobuild/minifier-plugin.js
+++ b/tools/isobuild/minifier-plugin.js
@@ -91,7 +91,7 @@ export class CssFile extends InputFile {
     const filePath = convertToPosixPath(path);
 
     const hash = optimisticHashOrNull(filePath);
-    const contents = optimisticReadFile(filePath);
+    const contents = hash !== null ? optimisticReadFile(filePath) : null;
     this._watchSet.addFile(filePath, hash);
 
     return {


### PR DESCRIPTION
## Summary

- Fix ENOENT crash in CSS minifier when a PostCSS dependency file is deleted between builds
- Affects any project using `@tailwindcss/postcss` (or similar PostCSS plugins that register source files as dependencies) with `standard-minifier-css`

## Problem

Tailwind v4's auto-content-detection registers every scanned source file (.tsx, .ts, .json, etc.) as a PostCSS dependency message. On the next rebuild, `readAndWatchFileWithHash` calls `optimisticReadFile` for each dependency to check cache validity. If any file was deleted (branch switch, rebase, removing a component), `optimisticReadFile` throws ENOENT and the minifier crashes.

`optimisticHashOrNull` (called in the same method) already handles ENOENT gracefully by returning `null` — but `optimisticReadFile` does not.

## Fix

- **`tools/isobuild/minifier-plugin.js`**: Skip `optimisticReadFile` when `optimisticHashOrNull` returned `null` (the file doesn't exist, so the read would throw anyway)
- **`packages/standard-minifier-css/plugin/postcss.js`**: Handle `null` hash in `watchAndHashDeps` by using a sentinel value, so the cache key changes and the CSS pipeline correctly re-runs

## Test plan

- [x] Tested manually with a Meteor 3 app using `@tailwindcss/postcss` and `standard-minifier-css` — deleting a component file during dev no longer crashes the rebuild

Fixes #13633

🤖 Generated with [Claude Code](https://claude.com/claude-code)