### PR TITLE
chore: upgrade uuidfrom 3.4.0 to 8.3.2 in dev bundle

### DIFF
--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -30,7 +30,7 @@ var packageJson = {
     "@types/semver": "7.5.8",
     semver: "7.6.3",
     request: "2.88.2",
-    "uuid": "8.3.2",
+    uuid: "8.3.2",
     "graceful-fs": "4.2.11",
     fstream: "https://github.com/meteor/fstream/tarball/cf4ea6c175355cec7bee38311e170d08c4078a5d",
     tar: "6.1.11",

--- a/scripts/dev-bundle-tool-package.js
+++ b/scripts/dev-bundle-tool-package.js
@@ -30,7 +30,7 @@ var packageJson = {
     "@types/semver": "7.5.8",
     semver: "7.6.3",
     request: "2.88.2",
-    uuid: "3.4.0",
+    "uuid": "8.3.2",
     "graceful-fs": "4.2.11",
     fstream: "https://github.com/meteor/fstream/tarball/cf4ea6c175355cec7bee38311e170d08c4078a5d",
     tar: "6.1.11",


### PR DESCRIPTION
## Description

Upgrades `uuid` dependency from 3.4.0 to 8.3.2 in the dev bundle to resolve npm deprecation warning about security issues with `Math.random()` usage.


## Changes

- Updated `scripts/dev-bundle-tool-package.js`: `uuid: "3.4.0"` → `uuid: "8.3.2"`
- Updated `dev_bundle/lib/package.json`: `"uuid": "3.4.0"` → `"uuid": "8.3.2"`
- Regenerated dev bundle with new dependency

## Testing

Verified the upgrade by:
- UUID v4 generation works correctly: `require('uuid').v4()` produces valid UUIDs
- Old v3 import syntax correctly fails (confirms v8 is installed)
- `./meteor --version` runs without errors
- Dev bundle builds successfully
- No new errors introduced

## Notes

- This addresses one of the deprecated packages listed in #13812
- `request@2.88.2` (transitive dependency) still uses `uuid@3.4.0` - that will be addressed separately when `request` is replaced/upgraded