### PR TITLE
[Rspack] `TOOL_NODE_FLAGS` inherits on Rspack processes

### DIFF
--- a/packages/rspack/lib/processes.js
+++ b/packages/rspack/lib/processes.js
@@ -33,6 +33,7 @@ const {
   isMeteorAppConfigModernVerbose,
   isMeteorBundleVisualizerProject,
   getMeteorAppPort,
+  inheritMeteorToolNodeFlags,
 } = require('meteor/tools-core/lib/meteor');
 
 const {
@@ -327,7 +328,7 @@ export function startRspackClientServe(options = {}) {
     command,
     args, {
       cwd: appDir,
-      env: { ...process.env, ...envs },
+      env: inheritMeteorToolNodeFlags({ ...process.env, ...envs }),
       onStdout: (data) => {
         logInfo(`[Rspack Client] ${data}`);
         if (onCompile && data.trim().includes("compiled")) {
@@ -390,7 +391,7 @@ export function startRspackServerWatch(options = {}) {
     command,
     args, {
     cwd: appDir,
-    env: { ...process.env, ...envs },
+    env: inheritMeteorToolNodeFlags({ ...process.env, ...envs }),
     onStdout: (data) => {
       logInfo(`[Rspack Server] ${data}`);
       if (onCompile && data.trim().includes("compiled")) {
@@ -457,7 +458,7 @@ export async function runRspackBuild({ isClient, isServer, isTest, isTestModule,
       args,
       {
       cwd: appDir,
-      env: { ...process.env, ...envs },
+      env: inheritMeteorToolNodeFlags({ ...process.env, ...envs }),
       onStdout: (data) => {
         logInfo(`[Rspack ${label} ${endpoint}] ${data}`);
         if (onCompile && data.trim().includes("compiled")) {

--- a/packages/tools-core/lib/meteor.js
+++ b/packages/tools-core/lib/meteor.js
@@ -487,3 +487,36 @@ export function getMeteorEnvPackageDirs() {
     ...(packageDirsFromEnvVar('PACKAGE_DIRS', ':')),
   ];
 }
+
+/**
+ * Spreads Meteor's TOOL_NODE_FLAGS to NODE_OPTIONS for proper inheritance
+ * of Meteor-specific tool environment process variables.
+ * Only spreads if TOOL_NODE_FLAGS_INHERIT is truthy (enabled by default).
+ * @param {Object} env - The current environment variables
+ * @returns {Object} The updated environment variables with NODE_OPTIONS
+ */
+export function inheritMeteorToolNodeFlags(env = {}) {
+  const toolFlags = env.TOOL_NODE_FLAGS;
+  if (!toolFlags) {
+    return env;
+  }
+
+  // Check if spreading is enabled (default: true)
+  // Only disable if TOOL_NODE_FLAGS_INHERIT is explicitly set to a falsy value
+  // Treat "0" as falsy for this specific case
+  const shouldSpread = env.TOOL_NODE_FLAGS_INHERIT !== undefined 
+    ? (env.TOOL_NODE_FLAGS_INHERIT !== "0" && !!env.TOOL_NODE_FLAGS_INHERIT)
+    : true;
+
+  if (!shouldSpread) {
+    return env;
+  }
+
+  return {
+    ...env,
+    NODE_OPTIONS: [toolFlags, env.NODE_OPTIONS]
+      .filter(Boolean)
+      .map(s => s.trim())
+      .join(' '),
+  };
+}

--- a/packages/tools-core/package.js
+++ b/packages/tools-core/package.js
@@ -18,13 +18,5 @@ Package.onTest(function (api) {
   // This structure allows easy addition of tests for other lib/ categories
   api.addFiles([
     'tests/meteor_tests.js',
-    // Add more test files here as needed:
-    // 'tests/process_tests.js',
-    // 'tests/npm_tests.js',
-    // 'tests/git_tests.js',
-    // 'tests/global-state_tests.js',
-    // 'tests/ignore_tests.js',
-    // 'tests/log_tests.js',
-    // 'tests/string_tests.js',
   ], 'server');
 });

--- a/packages/tools-core/package.js
+++ b/packages/tools-core/package.js
@@ -9,3 +9,22 @@ Package.onUse(function (api) {
 
   api.mainModule('tools-core.js', 'server');
 });
+
+Package.onTest(function (api) {
+  api.use(['ecmascript', 'tinytest']);
+  api.use('tools-core');
+
+  // Add test files for each lib/ module
+  // This structure allows easy addition of tests for other lib/ categories
+  api.addFiles([
+    'tests/meteor_tests.js',
+    // Add more test files here as needed:
+    // 'tests/process_tests.js',
+    // 'tests/npm_tests.js',
+    // 'tests/git_tests.js',
+    // 'tests/global-state_tests.js',
+    // 'tests/ignore_tests.js',
+    // 'tests/log_tests.js',
+    // 'tests/string_tests.js',
+  ], 'server');
+});

--- a/packages/tools-core/tests/meteor_tests.js
+++ b/packages/tools-core/tests/meteor_tests.js
@@ -1,0 +1,213 @@
+import { inheritMeteorToolNodeFlags } from "../lib/meteor.js";
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - no TOOL_NODE_FLAGS",
+  function (test) {
+    const env = {
+      NODE_OPTIONS: "--inspect",
+      TOOL_NODE_FLAGS_INHERIT: "true",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result,
+      env,
+      "Should return input unchanged when no TOOL_NODE_FLAGS"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - default behavior (inherit enabled)",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "--max-old-space-size=4096",
+      NODE_OPTIONS: "--inspect",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result.TOOL_NODE_FLAGS,
+      "--max-old-space-size=4096",
+      "TOOL_NODE_FLAGS should be preserved"
+    );
+    test.equal(
+      result.NODE_OPTIONS,
+      "--max-old-space-size=4096 --inspect",
+      "NODE_OPTIONS should contain both flags"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - inherit explicitly enabled",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "--max-old-space-size=4096",
+      NODE_OPTIONS: "--inspect",
+      TOOL_NODE_FLAGS_INHERIT: "true",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result.NODE_OPTIONS,
+      "--max-old-space-size=4096 --inspect",
+      "NODE_OPTIONS should contain both flags when explicitly enabled"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - inherit explicitly enabled with truthy value",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "--max-old-space-size=4096",
+      NODE_OPTIONS: "--inspect",
+      TOOL_NODE_FLAGS_INHERIT: "1",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result.NODE_OPTIONS,
+      "--max-old-space-size=4096 --inspect",
+      "NODE_OPTIONS should contain both flags with truthy string"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - inherit disabled with empty string",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "--max-old-space-size=4096",
+      NODE_OPTIONS: "--inspect",
+      TOOL_NODE_FLAGS_INHERIT: "",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result.NODE_OPTIONS,
+      "--inspect",
+      "NODE_OPTIONS should remain unchanged when inherit disabled with empty string"
+    );
+    test.equal(
+      result.TOOL_NODE_FLAGS,
+      "--max-old-space-size=4096",
+      "TOOL_NODE_FLAGS should be preserved"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - inherit disabled with false",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "--max-old-space-size=4096",
+      NODE_OPTIONS: "--inspect",
+      TOOL_NODE_FLAGS_INHERIT: false,
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result.NODE_OPTIONS,
+      "--inspect",
+      "NODE_OPTIONS should remain unchanged when inherit disabled with false"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - inherit disabled with zero",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "--max-old-space-size=4096",
+      NODE_OPTIONS: "--inspect",
+      TOOL_NODE_FLAGS_INHERIT: "0",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+    console.log("--> (meteor_tests.js-Line: 128)\n result: ", result);
+
+    test.equal(
+      result.NODE_OPTIONS,
+      "--inspect",
+      'NODE_OPTIONS should remain unchanged when inherit disabled with "0"'
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - no existing NODE_OPTIONS",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "--max-old-space-size=4096",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result.NODE_OPTIONS,
+      "--max-old-space-size=4096",
+      "NODE_OPTIONS should be set to TOOL_NODE_FLAGS when no existing NODE_OPTIONS"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - whitespace handling",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "  --max-old-space-size=4096  ",
+      NODE_OPTIONS: "  --inspect  ",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result.NODE_OPTIONS,
+      "--max-old-space-size=4096 --inspect",
+      "Should handle whitespace correctly"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - multiple flags",
+  function (test) {
+    const env = {
+      TOOL_NODE_FLAGS: "--max-old-space-size=4096 --expose-gc",
+      NODE_OPTIONS: "--inspect --trace-warnings",
+    };
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result.NODE_OPTIONS,
+      "--max-old-space-size=4096 --expose-gc --inspect --trace-warnings",
+      "Should handle multiple flags correctly"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - empty environment",
+  function (test) {
+    const env = {};
+    const result = inheritMeteorToolNodeFlags(env);
+
+    test.equal(
+      result,
+      env,
+      "Should return input unchanged for empty environment"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - inheritMeteorToolNodeFlags - undefined environment",
+  function (test) {
+    const result = inheritMeteorToolNodeFlags();
+
+    test.equal(
+      Object.keys(result).length,
+      0,
+      "Should return empty object for undefined input"
+    );
+  }
+);

--- a/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
+++ b/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
@@ -804,19 +804,19 @@ You can compare performance before and after enabling `modern` by running [`mete
 
 Large apps are more likely to hit memory limits during Meteor-Rspack builds, but this can also happen on smaller projects depending on the number of dependencies, cache size, and available system memory. If you experience crashes or out-of-memory errors, it's likely that the Rspack child process is running out of heap memory.
 
-A common first reaction is to set [`TOOL_NODE_FLAGS`](../../cli/environment-variables.md#tool-node-flags)` (`TOOL_NODE_FLAGS="--max-old-space-size=8192"`), but this flag is mainly for the Meteor tool's own Node.js process at startup. Rspack runs as a spawned child process and may not inherit it.
+Starting from Meteor 3.4.1, you can use [`TOOL_NODE_FLAGS`](../../cli/environment-variables.md#tool-node-flags) to set memory limits that will be automatically inherited by Rspack and other tool processes:
 
-Instead, use the standard `NODE_OPTIONS` environment variable, which Node.js propagates to child processes:
+```bash
+TOOL_NODE_FLAGS="--max-old-space-size=16384" meteor run
+```
+
+For Meteor 3.4, you should use the standard `NODE_OPTIONS` environment variable, which Node.js propagates to child processes:
 
 ```bash
 NODE_OPTIONS="--max-old-space-size=16384" meteor run
 ```
 
 This raises the heap limit for the Rspack process and should reduce how often memory-related crashes occur. Adjust the value according to your machine's available memory.
-
-:::info
-For the Meteor 3.4.x series, as `NODE_OPTIONS` is confirmed to help, one option being considered is to automatically inherit memory settings from `TOOL_NODE_FLAGS` into the spawned Rspack process.
-:::
 
 Another approach is to disable Rspack's persistent cache, which is enabled by default and can be memory-intensive. See the [Cache](#cache) migration topic to disable it:
 
@@ -828,7 +828,7 @@ module.exports = defineConfig(Meteor => ({
 }));
 ```
 
-You can combine both solutions: raise the heap limit with `NODE_OPTIONS` and disable persistent cache to reduce overall memory pressure.
+You can combine both solutions: raise the heap limit with `TOOL_NODE_FLAGS` (3.4.1+) or `NODE_OPTIONS` (3.4) and disable persistent cache to reduce overall memory pressure.
 
 Rspack itself has reported plans to optimize persistent cache and overall RAM consumption in [Rspack 2.0](https://rspack.rs/misc/planning/roadmap), which should improve memory behavior in future Meteor-Rspack releases.
 

--- a/v3-docs/docs/cli/environment-variables.md
+++ b/v3-docs/docs/cli/environment-variables.md
@@ -146,8 +146,21 @@ Used to generate URLs to your application by, among others, the accounts package
 ## TOOL_NODE_FLAGS
 (_development, production_)
 
-Used to pass flags/variables to Node inside Meteor build. For example you can use this to pass a link to icu data: `TOOL_NODE_FLAGS="--icu-data-dir=node_modules/full-icu"`
+Used to pass Node.js flags that Meteor will inherit and spread to other tool processes like Rspack. For example, to increase memory limits for all tools: `TOOL_NODE_FLAGS="--max-old-space-size=4096"`
+
+By default, these flags are automatically spread to `NODE_OPTIONS` so that tools like Rspack inherit them. This behavior can be controlled using [`TOOL_NODE_FLAGS_INHERIT`](#tool-node-flags-spread).
+
 For full list of available flags see the [Node documentation](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html).
+
+## TOOL_NODE_FLAGS_INHERIT
+(_development, production_)
+
+Controls whether `TOOL_NODE_FLAGS` are prepended to `NODE_OPTIONS`. Enabled by default.
+
+```bash
+# Disable inheritance - Rspack won't inherit the heap limit
+TOOL_NODE_FLAGS_INHERIT=0 TOOL_NODE_FLAGS="--max-old-space-size=4096" meteor run
+```
 
 ## UNIX_SOCKET_GROUP
 (_production_)


### PR DESCRIPTION
<!-- https://meteorsoftware.atlassian.net/browse/OSS-873 -->

Context: https://github.com/meteor/meteor/issues/14065 and https://forums.meteor.com/t/3-4-rc-3-release-candidate-faster-builds-smaller-bundles-and-modern-setups-with-the-rspack-integration/64124/225

This PR ensures that `TOOL_NODE_FLAGS` are inherited, so the values set in `NODE_OPTIONS` also apply to Rspack processes. This is necessary to avoid issues in large projects, where memory can crash once the heap limit is exceeded. Now any `TOOL_NODE_FLAGS` affecting the Meteor tool will also affect the Rspack process.

This can be disabled with `TOOL_NODE_FLAGS_INHERIT` in case this inheritance causes edge issues discovered later.