### PR TITLE
chore(deps): Update meteor-node-stubs to 6.14.2 in meteor-node-stubs …

### DIFF
--- a/npm-packages/meteor-node-stubs/package-lock.json
+++ b/npm-packages/meteor-node-stubs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meteor-node-stubs",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meteor-node-stubs",
-      "version": "1.2.23",
+      "version": "1.2.24",
       "bundleDependencies": [
         "@meteorjs/crypto-browserify",
         "assert",
@@ -1473,9 +1473,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
To address security vulnerability

See https://github.com/advisories/GHSA-w7fw-mjwx-w883

This fixes #14137

after merge, there is a need to publish a new version