### PR TITLE
[Rspack] Improve test on full app mode to consume less resources

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  TOOL_NODE_FLAGS: "--max_old_space_size=12288"
   NODE_OPTIONS: "--max_old_space_size=12288"
 
 jobs:

--- a/npm-packages/meteor-rspack/lib/test.js
+++ b/npm-packages/meteor-rspack/lib/test.js
@@ -13,13 +13,14 @@ const { createIgnoreRegex, createIgnoreGlobConfig } = require("./ignore.js");
  * @returns {string} The path to the generated file
  */
 const generateEagerTestFile = ({
-                                 isAppTest,
-                                 projectDir,
-                                 buildContext,
-                                 ignoreEntries: inIgnoreEntries = [],
-                                 prefix: inPrefix = '',
-                                 extraEntry,
-                               }) => {
+  isAppTest,
+  projectDir,
+  buildContext,
+  ignoreEntries: inIgnoreEntries = [],
+  prefix: inPrefix = '',
+  extraEntry,
+  globalImportPath,
+}) => {
   const distDir = path.resolve(projectDir, ".meteor/local/test");
   if (!fs.existsSync(distDir)) {
     fs.mkdirSync(distDir, { recursive: true });
@@ -49,7 +50,9 @@ const generateEagerTestFile = ({
     ? "/\\.app-(?:test|spec)s?\\.[^.]+$/"
     : "/\\.(?:test|spec)s?\\.[^.]+$/";
 
-  const content = `{
+  const content = `${
+    globalImportPath ? `import '${globalImportPath}';\n\n` : ''
+  }{
   const ctx = import.meta.webpackContext('/', {
     recursive: true,
     regExp: ${regExp},
@@ -60,14 +63,14 @@ const generateEagerTestFile = ({
   ${
     extraEntry
       ? `const extra = import.meta.webpackContext('${path.dirname(
-        extraEntry
-      )}', {
+          extraEntry
+        )}', {
     recursive: false,
     regExp: ${new RegExp(`${path.basename(extraEntry)}$`).toString()},
     mode: 'eager',
   });
   extra.keys().forEach(extra);`
-      : ''
+      : ""
   }
 }`;
 

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "1.0.0",
+      "version": "1.1.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "1.1.0-beta.1",
+      "version": "1.1.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.1",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -429,7 +429,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
   const lazyCompilationConfig = { lazyCompilation: false };
 
   const clientEntry =
-    isTest && isTestEager && isTestFullApp
+    isClient && isTest && isTestEager && isTestFullApp
       ? generateEagerTestFile({
           isAppTest: true,
           projectDir,
@@ -437,8 +437,9 @@ module.exports = async function (inMeteor = {}, argv = {}) {
           ignoreEntries: [...meteorIgnoreEntries, "**/server/**"],
           prefix: "client",
           extraEntry: path.resolve(process.cwd(), Meteor.mainClientEntry),
+          globalImportPath: path.resolve(projectDir, buildContext, entryPath),
         })
-      : isTest && isTestEager
+      : isClient && isTest && isTestEager
       ? generateEagerTestFile({
           isAppTest: false,
           isClient: true,
@@ -446,10 +447,16 @@ module.exports = async function (inMeteor = {}, argv = {}) {
           buildContext,
           ignoreEntries: [...meteorIgnoreEntries, "**/server/**"],
           prefix: "client",
+          globalImportPath: path.resolve(projectDir, buildContext, entryPath),
         })
-      : isTest && testEntry
+      : isClient && isTest && testEntry
       ? path.resolve(process.cwd(), testEntry)
       : path.resolve(process.cwd(), buildContext, entryPath);
+  console.log(
+    "--> (rspack.config.js-Line: 431)\n clientEntry: ",
+    clientEntry,
+    entryPath
+  );
   const clientNameConfig = `[${(isTest && 'test-') || ''}client-rspack]`;
   // Base client config
   let clientConfig = {
@@ -548,26 +555,33 @@ module.exports = async function (inMeteor = {}, argv = {}) {
   };
 
   const serverEntry =
-    isTest && isTestEager && isTestFullApp
+    isServer && isTest && isTestEager && isTestFullApp
       ? generateEagerTestFile({
           isAppTest: true,
           projectDir,
           buildContext,
           ignoreEntries: [...meteorIgnoreEntries, "**/client/**"],
           prefix: "server",
+          globalImportPath: path.resolve(projectDir, buildContext, entryPath),
         })
-      : isTest && isTestEager
+      : isServer && isTest && isTestEager
       ? generateEagerTestFile({
           isAppTest: false,
           projectDir,
           buildContext,
           ignoreEntries: [...meteorIgnoreEntries, "**/client/**"],
           prefix: "server",
+          globalImportPath: path.resolve(projectDir, buildContext, entryPath),
         })
-      : isTest && testEntry
+      : isServer && isTest && testEntry
       ? path.resolve(process.cwd(), testEntry)
       : path.resolve(projectDir, buildContext, entryPath);
   const serverNameConfig = `[${(isTest && 'test-') || ''}server-rspack]`;
+  console.log(
+    "--> (rspack.config.js-Line: 576)\n serverEntry: ",
+    serverEntry,
+    entryPath
+  );
   // Base server config
   let serverConfig = {
     name: serverNameConfig,

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -452,11 +452,6 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       : isClient && isTest && testEntry
       ? path.resolve(process.cwd(), testEntry)
       : path.resolve(process.cwd(), buildContext, entryPath);
-  console.log(
-    "--> (rspack.config.js-Line: 431)\n clientEntry: ",
-    clientEntry,
-    entryPath
-  );
   const clientNameConfig = `[${(isTest && 'test-') || ''}client-rspack]`;
   // Base client config
   let clientConfig = {
@@ -577,11 +572,6 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       ? path.resolve(process.cwd(), testEntry)
       : path.resolve(projectDir, buildContext, entryPath);
   const serverNameConfig = `[${(isTest && 'test-') || ''}server-rspack]`;
-  console.log(
-    "--> (rspack.config.js-Line: 576)\n serverEntry: ",
-    serverEntry,
-    entryPath
-  );
   // Base server config
   let serverConfig = {
     name: serverNameConfig,

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -230,8 +230,6 @@ module.exports = async function (inMeteor = {}, argv = {}) {
   const projectConfigPath = Meteor.projectConfigPath || path.resolve(projectDir, 'rspack.config.js');
   const configPath = Meteor.configPath;
   const testEntry = Meteor.testEntry;
-  const testClientEntry = Meteor.testClientEntry;
-  const testServerEntry = Meteor.testServerEntry;
 
   const isTypescriptEnabled = Meteor.isTypescriptEnabled || false;
   const isJsxEnabled =
@@ -451,8 +449,6 @@ module.exports = async function (inMeteor = {}, argv = {}) {
         })
       : isTest && testEntry
       ? path.resolve(process.cwd(), testEntry)
-      : isTest && testClientEntry
-      ? path.resolve(process.cwd(), testClientEntry)
       : path.resolve(process.cwd(), buildContext, entryPath);
   const clientNameConfig = `[${(isTest && 'test-') || ''}client-rspack]`;
   // Base client config
@@ -570,8 +566,6 @@ module.exports = async function (inMeteor = {}, argv = {}) {
         })
       : isTest && testEntry
       ? path.resolve(process.cwd(), testEntry)
-      : isTest && testServerEntry
-      ? path.resolve(process.cwd(), testServerEntry)
       : path.resolve(projectDir, buildContext, entryPath);
   const serverNameConfig = `[${(isTest && 'test-') || ''}server-rspack]`;
   // Base server config

--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -21,6 +21,7 @@ const {
   isMeteorAppBuild,
   isMeteorBlazeProject,
   isMeteorAppNative,
+  isMeteorAppTestFullApp,
 } = require('meteor/tools-core/lib/meteor');
 
 const {
@@ -129,11 +130,14 @@ export function ensureModuleFilesExist() {
   const testClientFiles = {
     entryFile: initialEntrypoints.testClient || '',
     outputFile: getBuildFilePath({ isTest: true, isTestModule, isClient: true, role: FILE_ROLE.output, onlyFilename: true }),
+    mainEntryFile: mainClientFiles.entryFile,
   };
   const testServerFiles = {
     entryFile: initialEntrypoints.testServer || '',
     outputFile: getBuildFilePath({ isTest: true, isTestModule, isServer: true, role: FILE_ROLE.output, onlyFilename: true }),
+    mainEntryFile: mainServerFiles.entryFile,
   };
+  const isTestFullApp = isMeteorAppTestFullApp();
 
   const moduleFiles = {
     /* Main module files for client and server */
@@ -150,18 +154,18 @@ export function ensureModuleFilesExist() {
     [getBuildFilePath({ isMain: true, isServer: true, ...env, role: FILE_ROLE.output })]:
       getBuildFileContent({ isMain: true, isServer: true, ...env, role: FILE_ROLE.output, ...mainServerFiles }),
     /* Test module files when test module, test module files for client and server are present or eager discovery */
-    [getBuildFilePath({ isTest: true, isTestModule, isClient: true, ...commandRole })]:
-      getBuildFileContent({ isTest: true, isTestModule, isClient: true, ...commandRole, ...testClientFiles }),
-    [getBuildFilePath({ isTest: true, isTestModule, isClient: true, role: FILE_ROLE.entry })]:
-      getBuildFileContent({ isTest: true, isTestModule, isClient: true, role: FILE_ROLE.entry, ...testClientFiles }),
-    [getBuildFilePath({ isTest: true, isTestModule, isClient: true, role: FILE_ROLE.output })]:
-      getBuildFileContent({ isTest: true, isTestModule, isClient: true, role: FILE_ROLE.output, ...testClientFiles }),
-    [getBuildFilePath({ isTest: true, isTestModule, isServer: true, ...commandRole })]:
-      getBuildFileContent({ isTest: true, isTestModule, isServer: true, ...commandRole, ...testServerFiles }),
-    [getBuildFilePath({ isTest: true, isTestModule, isServer: true, role: FILE_ROLE.entry })]:
-      getBuildFileContent({ isTest: true, isTestModule, isServer: true, role: FILE_ROLE.entry, ...testServerFiles }),
-    [getBuildFilePath({ isTest: true, isTestModule, isServer: true, role: FILE_ROLE.output })]:
-      getBuildFileContent({ isTest: true, isTestModule, isServer: true, role: FILE_ROLE.output, ...testServerFiles }),
+    [getBuildFilePath({ isTest: true, isTestFullApp, isTestModule, isClient: true, ...commandRole })]:
+      getBuildFileContent({ isTest: true, isTestFullApp, isTestModule, isClient: true, ...commandRole, ...testClientFiles }),
+    [getBuildFilePath({ isTest: true, isTestFullApp, isTestModule, isClient: true, role: FILE_ROLE.entry })]:
+      getBuildFileContent({ isTest: true, isTestFullApp, isTestModule, isClient: true, role: FILE_ROLE.entry, ...testClientFiles }),
+    [getBuildFilePath({ isTest: true, isTestFullApp, isTestModule, isClient: true, role: FILE_ROLE.output })]:
+      getBuildFileContent({ isTest: true, isTestFullApp, isTestModule, isClient: true, role: FILE_ROLE.output, ...testClientFiles }),
+    [getBuildFilePath({ isTest: true, isTestFullApp, isTestModule, isServer: true, ...commandRole })]:
+      getBuildFileContent({ isTest: true, isTestFullApp, isTestModule, isServer: true, ...commandRole, ...testServerFiles }),
+    [getBuildFilePath({ isTest: true, isTestFullApp, isTestModule, isServer: true, role: FILE_ROLE.entry })]:
+      getBuildFileContent({ isTest: true, isTestFullApp, isTestModule, isServer: true, role: FILE_ROLE.entry, ...testServerFiles }),
+    [getBuildFilePath({ isTest: true, isTestFullApp, isTestModule, isServer: true, role: FILE_ROLE.output })]:
+      getBuildFileContent({ isTest: true, isTestFullApp, isTestModule, isServer: true, role: FILE_ROLE.output, ...testServerFiles }),
   };
 
   Object.entries(moduleFiles).forEach(([filename, defaultContent]) => {
@@ -418,9 +422,29 @@ if (module.hot) {
  * @returns {string} The import content
  */
 function getImportContent(config, side, role) {
-  if (config?.entryFile && role === FILE_ROLE.entry) {
-    return `/* Link to 🔌 Meteor ${capitalizeFirstLetter(side)} Entry */
+  if (role === FILE_ROLE.entry) {
+    if (config?.isTest) {
+      return `${
+        config?.isTestFullApp && config?.mainEntryFile
+          ? `/* Link to 🔌 Meteor ${capitalizeFirstLetter(
+              side
+            )} Main Entry (--full-app mode) */
+import '../../${config.mainEntryFile}';`
+          : ""
+      }
+${
+  config?.entryFile
+    ? `
+/* Link to 🔌 Meteor ${capitalizeFirstLetter(side)} Test Entry */
+import '../../${config.entryFile}';`
+    : ""
+}`;
+    }
+
+    if (config?.entryFile) {
+      return `/* Link to 🔌 Meteor ${capitalizeFirstLetter(side)} Entry */
 import '../../${config?.entryFile}';`;
+    }
   }
 
   if (config?.outputFile &&

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -17,6 +17,7 @@ const {
   isMeteorAppBuild,
   isMeteorAppDebug,
   isMeteorAppTest,
+  isMeteorAppTestFullApp,
   isMeteorAppConfigModernVerbose,
   isMeteorBlazeProject,
   isMeteorLessProject,
@@ -338,12 +339,10 @@ export function configureMeteorForRspack() {
     isServer: true,
   });
 
-  const appEntrypoints = {
+  let appEntrypoints = {
     mainClient: `${RSPACK_BUILD_CONTEXT}/${mainClientModule}`,
     mainServer: `${RSPACK_BUILD_CONTEXT}/${mainServerModule}`,
     ...((isTestModule && {
-      mainClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
-      mainServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
       testClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
       testServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
     }) || {
@@ -351,6 +350,13 @@ export function configureMeteorForRspack() {
       testServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
     }),
   };
+  if (isMeteorAppTestFullApp()) {
+    appEntrypoints = {
+      ...appEntrypoints,
+      mainClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
+      mainServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
+    };
+  }
   // Set entry points in environment variables if they exist
   setMeteorAppEntrypoints(appEntrypoints);
 

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -342,9 +342,13 @@ export function configureMeteorForRspack() {
     mainClient: `${RSPACK_BUILD_CONTEXT}/${mainClientModule}`,
     mainServer: `${RSPACK_BUILD_CONTEXT}/${mainServerModule}`,
     ...((isTestModule && {
+      mainClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
+      mainServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
       testClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
       testServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
     }) || {
+      mainClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
+      mainServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
       testClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
       testServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
     }),

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -347,8 +347,6 @@ export function configureMeteorForRspack() {
       testClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
       testServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
     }) || {
-      mainClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
-      mainServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
       testClient: `${RSPACK_BUILD_CONTEXT}/${testClientModule}`,
       testServer: `${RSPACK_BUILD_CONTEXT}/${testServerModule}`,
     }),

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -5,7 +5,7 @@
 
 export const DEFAULT_RSPACK_VERSION = '1.7.1';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '1.0.0';
+export const DEFAULT_METEOR_RSPACK_VERSION = '1.1.0-beta.1';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -5,7 +5,7 @@
 
 export const DEFAULT_RSPACK_VERSION = '1.7.1';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '1.1.0-beta.1';
+export const DEFAULT_METEOR_RSPACK_VERSION = '1.1.0-beta.2';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/packages/rspack/rspack_plugin.js
+++ b/packages/rspack/rspack_plugin.js
@@ -67,7 +67,6 @@ const {
   getMeteorAppEntrypoints,
   isMeteorAppTest,
   isMeteorAppTestWatch,
-  isMeteorAppTestFullApp,
   isMeteorAppDevelopment,
   isMeteorAppProduction,
   isMeteorAppDebug,

--- a/packages/rspack/rspack_plugin.js
+++ b/packages/rspack/rspack_plugin.js
@@ -264,27 +264,6 @@ if (isMeteorAppRun() || isMeteorAppBuild() || isMeteorAppTest()) {
         onCompileServer,
       } = setupCompilationTracking();
 
-      // When run test for full app, run Rspack app server as well
-      // isTestLike ensures the app runtime environment inherit test envs
-      if (isMeteorAppTestFullApp()) {
-        await runRspackBuild({
-          isTest: false,
-          isTestLike: true,
-          isServer: true,
-          isClient: false,
-        });
-
-        if (isMeteorAppTestWatch()) {
-          runRspackBuild({
-            isServer: true,
-            isClient: false,
-            isTest: false,
-            isTestLike: true,
-            watch: true,
-          });
-        }
-      }
-
       // When testModule is specified for client or server, run Rspack considering those files
       if (initialEntrypoints?.testClient || initialEntrypoints?.testServer) {
         runRspackBuild({

--- a/tools/modern-tests/apps/vue/package.json
+++ b/tools/modern-tests/apps/vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^20.0.0",
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@nx/angular-rspack": "^21.1.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@graphql-tools/webpack-loader": "^7.0.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",
     "@rspack/plugin-react-refresh": "^1.4.3",

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.23.3",
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -12,7 +12,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -14,7 +14,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.0-beta.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",


### PR DESCRIPTION
<!-- https://meteorsoftware.atlassian.net/browse/OSS-873 -->

Context: https://github.com/meteor/meteor/issues/14055

This PR ensures we no longer keep an extra Rspack process running when using `meteor test` in `--full-app` mode.

The changes must support all test configurations: entrypoints in package.json, eager mode, watch mode, with and without `--full-app`. All these cases are covered E2E in the new test suite. I will re-verify they pass properly and add any new tests if needed after these changes.