### PR TITLE
Await _clearAllLoginTokens database update

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -697,7 +697,7 @@ export class AccountsServer extends AccountsCommon {
     methods.logoutAllClients = async function() {
       const logoutUserId = this.userId;
       accounts._setLoginToken(logoutUserId, this.connection, null);
-      accounts._clearAllLoginTokens(logoutUserId);
+      await accounts._clearAllLoginTokens(logoutUserId);
       await accounts._successfulLogout(this.connection, logoutUserId);
       await this.setUserId(null);
     };
@@ -962,8 +962,8 @@ export class AccountsServer extends AccountsCommon {
    * @private
    * @returns {Promise<void>}
    */
-  _clearAllLoginTokens(userId) {
-    this.users.updateAsync(userId, {
+  async _clearAllLoginTokens(userId) {
+    await this.users.updateAsync(userId, {
       $set: {
         'services.resume.loginTokens': [],
       },


### PR DESCRIPTION
Previously, _clearAllLoginTokens called updateAsync without awaiting it, so callers (notably logoutAllClients) could proceed before login tokens were actually cleared from the database.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
