### PR TITLE
Fix TypeScript ESM import resolution

### DIFF
--- a/npm-packages/meteor-node-stubs/package-lock.json
+++ b/npm-packages/meteor-node-stubs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meteor-node-stubs",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meteor-node-stubs",
-      "version": "1.2.23",
+      "version": "1.2.24",
       "bundleDependencies": [
         "@meteorjs/crypto-browserify",
         "assert",
@@ -1473,9 +1473,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/npm-packages/meteor-node-stubs/package-lock.json
+++ b/npm-packages/meteor-node-stubs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meteor-node-stubs",
-  "version": "1.2.24",
+  "version": "1.2.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meteor-node-stubs",
-      "version": "1.2.24",
+      "version": "1.2.26",
       "bundleDependencies": [
         "@meteorjs/crypto-browserify",
         "assert",

--- a/npm-packages/meteor-node-stubs/package.json
+++ b/npm-packages/meteor-node-stubs/package.json
@@ -2,7 +2,7 @@
   "name": "meteor-node-stubs",
   "author": "Ben Newman <ben@meteor.com>",
   "description": "Stub implementations of Node built-in modules, a la Browserify",
-  "version": "1.2.24",
+  "version": "1.2.26",
   "main": "index.js",
   "license": "MIT",
   "homepage": "https://github.com/meteor/meteor/blob/devel/npm-packages/meteor-node-stubs/README.md",

--- a/packages/typescript/test-esm-import.ts
+++ b/packages/typescript/test-esm-import.ts
@@ -1,0 +1,7 @@
+import { testValue, testFunction } from './test-module.js';
+import { Tinytest } from "meteor/tinytest";
+
+Tinytest.add("TypeScript - ESM import with .js extension", test => {
+  test.equal(testValue, "Hello from TypeScript module");
+  test.equal(testFunction(), "TypeScript ESM import works");
+});

--- a/packages/typescript/test-module.ts
+++ b/packages/typescript/test-module.ts
@@ -1,0 +1,5 @@
+export const testValue = "Hello from TypeScript module";
+
+export function testFunction(): string {
+  return "TypeScript ESM import works";
+}

--- a/packages/typescript/tests.ts
+++ b/packages/typescript/tests.ts
@@ -1,4 +1,5 @@
 import { Tinytest } from "meteor/tinytest";
+import './test-esm-import.js';
 
 Tinytest.add("TypeScript - basics", test => {
   test.equal(2 + 2, 4);

--- a/tools/isobuild/resolver.ts
+++ b/tools/isobuild/resolver.ts
@@ -263,6 +263,27 @@ export default class Resolver {
             return result = { path: pathWithExt, stat };
           }
         });
+
+        // TypeScript ESM compatibility: allow importing .ts/.tsx/.mts files with .js/.jsx/.mjs extensions
+        // https://github.com/meteor/meteor/issues/12011
+        if (!result && /\.(m?jsx?)$/i.test(path)) {
+          const pathWithoutJsExt = path.replace(/\.(m?jsx?)$/i, '');
+          const jsExt = path.match(/\.(m?jsx?)$/i)![0].toLowerCase();
+          const tsExtMap: Record<string, string> = {
+            '.js': '.ts',
+            '.jsx': '.tsx',
+            '.mjs': '.mts',
+          };
+          const tsExt = tsExtMap[jsExt];
+          
+          if (tsExt && this.extensions.includes(tsExt)) {
+            const pathWithTsExt = pathWithoutJsExt + tsExt;
+            const stat = this.statOrNull(pathWithTsExt);
+            if (stat && !stat.isDirectory()) {
+              result = { path: pathWithTsExt, stat };
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Problem
TypeScript's official ESM pattern allows importing `.ts` files using `.js` extensions in import statements. This is used by major packages like Google's Lit and is supported by Webpack, Rollup, and Babel.

Meteor's module resolver only appended extensions, never replaced them. When importing `./module.js` where only `./module.ts` exists, it would fail.

## Solution
Updates the module resolver to strip `.js`/`.jsx`/`.mjs` extensions and try corresponding TypeScript extensions (`.ts`/`.tsx`/`.mts`). Only activates when TypeScript extensions are registered (backward compatible).

## Changes
- `tools/isobuild/resolver.ts` - Add extension replacement logic
- `packages/typescript/tests.ts` - Add test case
- `packages/typescript/test-esm-import.ts` - Test file
- `packages/typescript/test-module.ts` - Test module

## Testing
```bash
./meteor test-packages typescript