### PR TITLE
fix(accounts-password): fix operator precedence bug in passwordValidator

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -290,7 +290,7 @@ Accounts._checkPasswordAsync = checkPasswordAsync;
 
 
 const passwordValidator = Match.OneOf(
-  Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256), {
+  Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)), {
     digest: Match.Where(str => Match.test(str, String) && str.length === 64),
     algorithm: Match.OneOf('sha-256')
   }
@@ -472,7 +472,7 @@ Meteor.methods(
 Accounts.setPasswordAsync =
   async (userId, newPlaintextPassword, options) => {
     check(userId, String);
-    check(newPlaintextPassword, Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256));
+    check(newPlaintextPassword, Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)));
     check(options, Match.Maybe({ logout: Boolean }));
     options = { logout: true, ...options };
 


### PR DESCRIPTION
Fixes #14072

## Problem
Due to JavaScript operator precedence, `<=` binds tighter than `||`, causing the password length validation to always pass:

```js
str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256
// Parses as: (str.length <= undefined) || 256 → false || 256 → 256 (truthy)
```

This means **any password length passes validation**, regardless of the configured `passwordMaxLength` or the default 256 limit.

## Fix
Added parentheses so the `||` fallback applies to the max length value, not the entire comparison:

```js
str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)
```

Fixed in both occurrences:
1. The `passwordValidator` (line 293)
2. The `newPlaintextPassword` check in the password change flow (line 475)

## Security Impact
- **DoS potential**: Extremely long passwords consume resources during hashing
- **Policy bypass**: Any configured `passwordMaxLength` setting was completely ignored