### PR TITLE
fix(accounts-password): fix operator precedence bug in passwordValidator

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -290,7 +290,7 @@ Accounts._checkPasswordAsync = checkPasswordAsync;
 
 
 const passwordValidator = Match.OneOf(
-  Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256), {
+  Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength ?? 256)), {
     digest: Match.Where(str => Match.test(str, String) && str.length === 64),
     algorithm: Match.OneOf('sha-256')
   }
@@ -472,7 +472,7 @@ Meteor.methods(
 Accounts.setPasswordAsync =
   async (userId, newPlaintextPassword, options) => {
     check(userId, String);
-    check(newPlaintextPassword, Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256));
+    check(newPlaintextPassword, Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength ?? 256)));
     check(options, Match.Maybe({ logout: Boolean }));
     options = { logout: true, ...options };
 


### PR DESCRIPTION
Fixes #14072

## Problem

The `passwordValidator` in `password_server.js` has an operator precedence bug that causes password max length validation to always pass.

```js
// Before (broken):
str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256
// Parses as: (str.length <= undefined) || 256 → false || 256 → 256 (truthy!)
```

## Fix

Use nullish coalescing (`??`) with parentheses:

```js
// After (correct):
str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength ?? 256)
// Parses as: str.length <= 256 → correct boolean comparison
```

## Changes

- Fixed both occurrences in `packages/accounts-password/password_server.js` (line 292 in `passwordValidator` and line 475 in `setPasswordAsync`)