### PR TITLE
Fix type declarations and add tsc-based validation

### DIFF
--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -1,0 +1,17 @@
+name: Check type declarations
+on:
+  pull_request:
+    paths:
+      - 'packages/**/*.ts'
+      - 'packages/**/package-types.json'
+      - 'scripts/test-types.mjs'
+jobs:
+  check-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: npm ci
+      - run: npm run test:types

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,13 @@
         "@babel/eslint-parser": "^7.21.3",
         "@babel/eslint-plugin": "^7.19.1",
         "@babel/preset-react": "^7.18.6",
+        "@types/express": "^5.0.6",
         "@types/lodash.isempty": "^4.4.9",
         "@types/node": "^18.16.18",
+        "@types/nodemailer": "^7.0.11",
         "@types/sockjs": "^0.3.36",
         "@types/sockjs-client": "^1.5.4",
+        "@types/underscore": "^1.13.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "@typescript-eslint/parser": "^5.56.0",
         "eslint": "^8.36.0",
@@ -28,6 +31,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "mongodb": "^6.16.0",
         "prettier": "^2.8.8",
         "typescript": "^5.4.5"
       }
@@ -746,6 +750,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
+      "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -803,6 +817,59 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -839,11 +906,56 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/semver": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.36",
@@ -859,6 +971,30 @@
       "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.4.tgz",
       "integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
       "dev": true
+    },
+    "node_modules/@types/underscore": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.13.0.tgz",
+      "integrity": "sha512-L6LBgy1f0EFQZ+7uSA57+n2g/s4Qs5r06Vwrwn0/nuK1de+adz00NWaztRQ30aEqw5qOaWbPI8u2cGQ52lj6VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -1629,6 +1765,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/call-bind": {
@@ -3670,6 +3816,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3712,6 +3865,64 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
+      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/ms": {
@@ -4319,6 +4530,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
@@ -4469,6 +4690,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -4661,6 +4895,30 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
     "@babel/eslint-parser": "^7.21.3",
     "@babel/eslint-plugin": "^7.19.1",
     "@babel/preset-react": "^7.18.6",
+    "@types/express": "^5.0.6",
     "@types/lodash.isempty": "^4.4.9",
     "@types/node": "^18.16.18",
+    "@types/nodemailer": "^7.0.11",
     "@types/sockjs": "^0.3.36",
     "@types/sockjs-client": "^1.5.4",
+    "@types/underscore": "^1.13.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
     "eslint": "^8.36.0",
@@ -31,6 +34,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "mongodb": "^6.16.0",
     "prettier": "^2.8.8",
     "typescript": "^5.4.5"
   },
@@ -39,7 +43,8 @@
     "test:unit": "cd tools/unit-tests && npm test",
     "test:idle-bot": "node --test .github/scripts/__tests__/inactive-issues.test.js",
     "install:e2e": "cd tools/modern-tests && npm install && npx playwright install --with-deps chromium chromium-headless-shell",
-    "test:e2e": "cd tools/modern-tests && npm test -- "
+    "test:e2e": "cd tools/modern-tests && npm test -- ",
+    "test:types": "node scripts/test-types.mjs"
   },
   "jshintConfig": {
     "esversion": 11

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -666,7 +666,7 @@ export namespace Mongo {
   }
 }
 
-export declare module MongoInternals {
+export declare namespace MongoInternals {
   interface MongoConnection {
     db: NpmModuleMongodb.Db;
     client: NpmModuleMongodb.MongoClient;

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -122,14 +122,14 @@ export namespace Mongo {
      * Add a constructor extension function that runs when collections are created.
      * @param extension Extension function called with (name, options) and 'this' bound to collection instance
      */
-    addExtension<T = any, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
+    addExtension<T extends NpmModuleMongodb.Document = NpmModuleMongodb.Document, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
 
     /**
      * Add a prototype method to all collection instances.
      * @param name The name of the method to add
      * @param method The method function, bound to the collection instance
      */
-    addPrototypeMethod<T = any, U = T>(name: string, method: (this: Collection<T, U>, ...args: any[]) => any): void;
+    addPrototypeMethod<T extends NpmModuleMongodb.Document = NpmModuleMongodb.Document, U = T>(name: string, method: (this: Collection<T, U>, ...args: any[]) => any): void;
 
     /**
      * Add a static method to the Mongo.Collection constructor.
@@ -573,14 +573,14 @@ export namespace Mongo {
      * Add a constructor extension function that runs when collections are created.
      * @param extension Extension function called with (name, options) and 'this' bound to collection instance
      */
-    addExtension<T = any, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
+    addExtension<T extends NpmModuleMongodb.Document = NpmModuleMongodb.Document, U = T>(extension: (this: Collection<T, U>, name: string | null, options?: CollectionOptions<T, U>) => void): void;
     
     /**
      * Add a prototype method to all collection instances.
      * @param name The name of the method to add
      * @param method The method function, bound to the collection instance
      */
-    addPrototypeMethod<T = any, U = T>(name: string, method: (this: Collection<T, U>, ...args: any[]) => any): void;
+    addPrototypeMethod<T extends NpmModuleMongodb.Document = NpmModuleMongodb.Document, U = T>(name: string, method: (this: Collection<T, U>, ...args: any[]) => any): void;
 
     /**
      * Add a static method to the Mongo.Collection constructor.

--- a/packages/roles/definitions.d.ts
+++ b/packages/roles/definitions.d.ts
@@ -5,6 +5,7 @@
 // Minimum TypeScript Version: 4.1
 
 import { Mongo } from "meteor/mongo";
+import { Meteor, Subscription } from "meteor/meteor";
 
 /**
  * Provides functions related to user authorization. Compatible with built-in Meteor accounts packages.

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -22,7 +22,7 @@ type ExpressModule = {
   urlencoded: typeof express.urlencoded;
 };
 
-export declare module WebApp {
+export declare namespace WebApp {
   var defaultArch: string;
   var clientPrograms: {
     [key: string]: {
@@ -69,7 +69,7 @@ export declare module WebApp {
   function addHtmlAttributeHook(hook: Function): void;
 }
 
-export declare module WebAppInternals {
+export declare namespace WebAppInternals {
   var NpmModules: {
     [key: string]: {
       version: string;

--- a/scripts/test-types.mjs
+++ b/scripts/test-types.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+// Type-checks all package .d.ts files by discovering them via
+// package-types.json (the same metadata zodern:types uses) with a
+// fallback to index.d.ts, then generating a tsconfig with the
+// appropriate meteor/* path mappings.
+
+import { execFileSync } from 'child_process';
+import { existsSync, lstatSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+function walk(dir, name, maxDepth, depth = 0) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    if (entry === name) {
+      results.push(full);
+    } else if ((maxDepth == null || depth < maxDepth) && lstatSync(full).isDirectory()) {
+      results.push(...walk(full, name, maxDepth, depth + 1));
+    }
+  }
+  return results;
+}
+
+const packagesDir = join(root, 'packages');
+
+// Collect all (meteorModule, dtsPath) entries from two sources:
+// 1. package-types.json files
+// 2. index.d.ts files in packages that lack package-types.json (e.g. npm-mongo)
+const entries = new Map();
+
+for (const ptFile of walk(packagesDir, 'package-types.json')) {
+  const config = JSON.parse(readFileSync(ptFile, 'utf-8'));
+  if (!config.typesEntry) continue;
+
+  const pkgDir = dirname(ptFile);
+  const dtsPath = join(pkgDir, config.typesEntry);
+  if (!existsSync(dtsPath)) continue;
+
+  // Derive the meteor module name from the directory path.
+  // packages/foo -> meteor/foo
+  // packages/deprecated/underscore -> meteor/underscore
+  const relFromPackages = relative(packagesDir, pkgDir);
+  const pkgName = relFromPackages.split('/').pop();
+  entries.set(`meteor/${pkgName}`, dtsPath);
+}
+
+for (const dtsPath of walk(packagesDir, 'index.d.ts', 2)) {
+  const pkgDir = dirname(dtsPath);
+  if (existsSync(join(pkgDir, 'package-types.json'))) continue;
+
+  const pkgName = relative(packagesDir, pkgDir);
+  const meteorModule = `meteor/${pkgName}`;
+  if (!entries.has(meteorModule)) {
+    entries.set(meteorModule, dtsPath);
+  }
+}
+
+const paths = {};
+const include = [];
+for (const [meteorModule, dtsPath] of entries) {
+  paths[meteorModule] = [dtsPath];
+  include.push(dtsPath);
+}
+
+const tsconfig = {
+  compilerOptions: {
+    noEmit: true,
+    strict: true,
+    moduleResolution: 'node',
+    module: 'commonjs',
+    target: 'es2020',
+    skipLibCheck: false,
+    baseUrl: root,
+    paths,
+  },
+  include,
+};
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'meteor-types-test-'));
+const tsconfigPath = join(tmpDir, 'tsconfig.json');
+writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2));
+
+console.log(`Checking ${include.length} declaration files...`);
+
+try {
+  execFileSync('npx', ['tsc', '--noEmit', '-p', tsconfigPath], {
+    cwd: root,
+    stdio: 'inherit',
+  });
+  console.log('All type declarations OK.');
+} catch {
+  process.exit(1);
+}


### PR DESCRIPTION
- Replace `declare module` with `declare namespace` in `mongo.d.ts` and `webapp.d.ts`. The non-quoted `declare module Identifier` form is an error in both [TypeScript 6.0](https://github.com/microsoft/TypeScript/pull/62876) and in tsgo / TypeScript 7.0, which breaks downstream projects using tsgo for type checking (e.g. [jolly-roger](https://github.com/deathandmayhem/jolly-roger/actions/runs/22493866362/job/65163026344)).
- Add `npm run test:types`, which discovers all package `.d.ts` files from `package-types.json` metadata (the same way zodern:types resolves them) and runs `tsc --noEmit` with `meteor/*` path mappings. A CI workflow runs this on PRs that touch `.d.ts` or `package-types.json` files. This is a more robust approach to the per-package validation attempted in #14108 -- it covers all typed packages automatically and doesn't require a Meteor checkout to run.
- Setting up the test caught two additional pre-existing bugs:
  - `mongo.d.ts`: `CollectionExtensions` generic parameters defaulted to `T = any`, which doesn't satisfy the `T extends Document` constraint on `Collection` (same fix as #14105, which landed on `release-3.4.1` but hasn't merged back to `devel` yet)
  - `roles/definitions.d.ts`: referenced `Meteor` and `Subscription` types without importing them
