### PR TITLE
[CI/CD] splitting Library job

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,8 @@ jobs:
           - Babel
           - Blaze
           - Coffeescript
-          - Library
+          - Full Skeleton
+          - Tailwind Skeleton
           - Monorepo
           - React
           - R.Router

--- a/tools/modern-tests/skeleton.test.js
+++ b/tools/modern-tests/skeleton.test.js
@@ -93,7 +93,7 @@ describe('Meteor Skeletons /', () => {
   );
 
   describe(
-    'Full Library Skeleton /',
+    'Full Skeleton /',
     testMeteorSkeleton({
       skeletonName: 'full',
       port: 3204,
@@ -150,7 +150,7 @@ describe('Meteor Skeletons /', () => {
   );
 
   describe(
-    'Tailwind Library Skeleton /',
+    'Tailwind Skeleton /',
     testMeteorSkeleton({
       skeletonName: 'tailwind',
       port: 3208,


### PR DESCRIPTION
## Problem

The `Library` CI job was consistently failing with exit code 137 (SIGKILL) during
the Tailwind skeleton cleanup phase. The exact trigger is uncertain, but the two
most likely causes are:

1. **Timeout**: The `Library` category matched both "Full Library Skeleton" and
   "Tailwind Library Skeleton", running ~10 sequential Meteor app starts (create,
   run, run --production, test --once, build × 2 skeletons) within a single job.
   With a 15-minute total timeout shared across 3 retry attempts, there was likely
   insufficient time for both skeletons to complete.

2. **OOM**: `NODE_OPTIONS=--max_old_space_size=12288` is inherited by all child
   processes spawned by Meteor (CLI, app server, Rspack). Under sustained load from
   running two heavy skeletons back-to-back, accumulated memory pressure across
   multiple simultaneous Node processes may have triggered SIGKILL.

## Changes

- **`skeleton.test.js`**: Renamed `Full Library Skeleton /` → `Full Skeleton /` and
  `Tailwind Library Skeleton /` → `Tailwind Skeleton /` to match the new CI categories.

- **`e2e-tests.yml`**: Replaced the single `Library` matrix entry with two separate
  entries (`Full Skeleton` and `Tailwind Skeleton`), so each skeleton runs in its
  own isolated CI job with a fresh process and its own 15-minute timeout.

- **`helpers.js`**: Override `NODE_OPTIONS` for child Meteor processes to
  `--max_old_space_size=3072`, preventing the Jest runner's heap limit from being
  inherited by every Node subprocess spawned during tests.

## Why this fixes it

Each job now runs a single skeleton (5 sub-tests instead of 10), halving both the
execution time and peak memory footprint per job. The child process heap cap ensures
Meteor subprocesses don't compete with the Jest runner for heap space regardless of
what `NODE_OPTIONS` is set to at the workflow level.