### PR TITLE
Bumps @meteorjs/rspack 1.0.1 and add scripts to handle beta and officials

### DIFF
--- a/npm-packages/meteor-rspack/README.md
+++ b/npm-packages/meteor-rspack/README.md
@@ -1,0 +1,141 @@
+# @meteorjs/rspack
+
+The default [Rspack](https://rspack.dev) configuration for Meteor applications. This package provides everything you need to bundle your Meteor app with Rspack out of the box: client and server builds, SWC transpilation, React/Blaze/Angular support, hot module replacement, asset management, and all the Meteor-specific wiring so you don't have to.
+
+When Meteor runs with the Rspack bundler enabled, this package is what generates the underlying Rspack configuration. It detects your project setup (TypeScript, React, Blaze, Angular), sets up the right loaders and plugins, defines `Meteor.isClient`/`Meteor.isServer` and friends, configures caching, and exposes a set of helpers you can use in your own `rspack.config.js` to customize the build without breaking Meteor integration.
+
+## What it provides
+
+- **Dual client/server builds** with the correct targets, externals, and output paths
+- **SWC-based transpilation** for JS/TS/JSX/TSX with automatic framework detection
+- **React Fast Refresh** in development when React is enabled
+- **Blaze template handling** via ignore-loader when Blaze is enabled
+- **Persistent filesystem caching** for fast rebuilds
+- **Asset externals and HTML generation** through custom Rspack plugins
+- **A `defineConfig` helper** that accepts a factory function receiving Meteor environment flags and build utilities
+- **Customizable config** via `rspack.config.js` in your project root, with safe merging that warns if you try to override reserved settings
+
+## Installation
+
+[Rspack integration](https://docs.meteor.com/about/modern-build-stack/rspack-bundler-integration.html) is automatically managed by the rspack Atmosphere package.
+
+```bash
+meteor add rspack
+```
+
+By doing this, your Meteor app will automatically serve `@meteorjs/rspack` and the required `@rspack/cli`, `@rspack/core`, among others.
+
+## Usage
+
+In your project's `rspack.config.js`, use the `defineConfig` helper to customize the build. The factory function receives a `env` object with Meteor environment flags and helper utilities:
+
+```js
+const { defineConfig } = require('@meteorjs/rspack');
+
+module.exports = defineConfig((env, argv) => {
+  // env.isClient, env.isServer, env.isDevelopment, env.isProduction
+  // env.isReactEnabled, env.isBlazeEnabled, etc.
+
+  return {
+    // Your custom Rspack configuration here.
+    // It gets safely merged with the Meteor defaults.
+  };
+});
+```
+
+More information is available in the official docs: [Rspack Bundler Integration](https://docs.meteor.com/about/modern-build-stack/rspack-bundler-integration.html#custom-rspack-config-js).
+
+## Development
+
+### Install dependencies
+
+```bash
+npm install
+```
+
+### Version bumping
+
+Use `npm run bump` to update the version in `package.json` before publishing.
+
+```bash
+npm run bump -- <major|minor|patch> [--beta]
+```
+
+**Standard bumps** increment the version and remove any prerelease suffix:
+
+```bash
+npm run bump -- patch   # 1.0.1 -> 1.0.2
+npm run bump -- minor   # 1.0.1 -> 1.1.0
+npm run bump -- major   # 1.0.1 -> 2.0.0
+```
+
+**Beta bumps** append or increment a `-beta.N` prerelease suffix:
+
+```bash
+npm run bump -- patch --beta   # 1.0.1 -> 1.0.2-beta.0
+npm run bump -- patch --beta   # 1.0.2-beta.0 -> 1.0.2-beta.1
+npm run bump -- patch --beta   # 1.0.2-beta.1 -> 1.0.2-beta.2
+```
+
+If you change the bump level while on a beta, the base version updates and the beta counter resets:
+
+```bash
+npm run bump -- minor --beta   # 1.0.2-beta.2 -> 1.1.0-beta.0
+npm run bump -- major --beta   # 1.1.0-beta.0 -> 2.0.0-beta.0
+```
+
+### Publishing a beta release
+
+After bumping to a beta version, publish to the `beta` dist-tag:
+
+```bash
+npm run bump -- patch --beta
+npm run publish:beta
+```
+
+Users can then install the beta with:
+
+```bash
+npm install @meteorjs/rspack@beta
+```
+
+You can pass extra flags to `npm publish` through the script:
+
+```bash
+npm run publish:beta -- --dry-run
+```
+
+### Publishing an official release
+
+After bumping to a stable version, publish with the default `latest` tag:
+
+```bash
+npm run bump -- patch
+npm publish
+```
+
+### Typical workflows
+
+**Beta iteration**: ship multiple beta builds for the same upcoming patch:
+
+```bash
+npm run bump -- patch --beta    # 1.0.1 -> 1.0.2-beta.0
+npm run publish:beta
+# ... fix issues ...
+npm run bump -- patch --beta    # 1.0.2-beta.0 -> 1.0.2-beta.1
+npm run publish:beta
+```
+
+**Promote beta to stable**: once the beta is ready, bump to the stable version and publish:
+
+```bash
+npm run bump -- patch           # 1.0.2-beta.1 -> 1.0.3
+npm publish
+```
+
+**Direct stable release**: skip the beta phase entirely:
+
+```bash
+npm run bump -- minor           # 1.0.1 -> 1.1.0
+npm publish
+```

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -14,6 +14,9 @@
         "node-polyfill-webpack-plugin": "^4.1.0",
         "webpack-merge": "^6.0.1"
       },
+      "devDependencies": {
+        "semver": "^7.7.4"
+      },
       "peerDependencies": {
         "@rspack/cli": ">=1.3.0",
         "@rspack/core": ">=1.3.0"
@@ -4202,6 +4205,19 @@
       "dependencies": {
         "@types/node-forge": "^1.3.0",
         "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -12,8 +12,15 @@
     "node-polyfill-webpack-plugin": "^4.1.0",
     "webpack-merge": "^6.0.1"
   },
+  "scripts": {
+    "bump": "node ./scripts/bump-version.js",
+    "publish:beta": "bash ./scripts/publish-beta.sh"
+  },
   "peerDependencies": {
     "@rspack/cli": ">=1.3.0",
     "@rspack/core": ">=1.3.0"
+  },
+  "devDependencies": {
+    "semver": "^7.7.4"
   }
 }

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/scripts/bump-version.js
+++ b/npm-packages/meteor-rspack/scripts/bump-version.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver');
+
+const VALID_LEVELS = ['major', 'minor', 'patch'];
+
+function usage() {
+  console.log(`Usage: node ${path.basename(__filename)} <major|minor|patch> [--beta]`);
+  console.log('');
+  console.log('Examples:');
+  console.log('  patch          # 1.0.1 -> 1.0.2');
+  console.log('  minor          # 1.0.1 -> 1.1.0');
+  console.log('  major          # 1.0.1 -> 2.0.0');
+  console.log('  patch --beta   # 1.0.1 -> 1.0.2-beta.0');
+  console.log('  patch --beta   # 1.0.2-beta.0 -> 1.0.2-beta.1 (already beta, bumps beta number)');
+  console.log('  minor --beta   # 1.0.2-beta.1 -> 1.1.0-beta.0 (different bump level resets)');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const level = args[0];
+const beta = args.includes('--beta');
+
+if (!level || !VALID_LEVELS.includes(level)) {
+  if (level) console.error(`Error: first argument must be major, minor, or patch`);
+  usage();
+}
+
+const pkgPath = path.resolve(__dirname, '..', 'package.json');
+const raw = fs.readFileSync(pkgPath, 'utf8');
+const pkg = JSON.parse(raw);
+const current = pkg.version;
+const parsed = semver.parse(current);
+
+if (!parsed) {
+  console.error(`Error: invalid current version "${current}"`);
+  process.exit(1);
+}
+
+let newVersion;
+
+if (beta) {
+  const isBeta = parsed.prerelease.length > 0 && parsed.prerelease[0] === 'beta';
+
+  if (isBeta) {
+    // Already a beta. The base version already has a prior bump applied.
+    // Check if the same bump level is being requested by inspecting which
+    // components are zeroed out (major resets minor+patch, minor resets patch).
+    // If the same level, just increment the beta number.
+    const { major, minor, patch } = parsed;
+    const betaNum = typeof parsed.prerelease[1] === 'number' ? parsed.prerelease[1] : 0;
+    let sameLevel = false;
+
+    if (level === 'patch') {
+      sameLevel = true;
+    } else if (level === 'minor') {
+      sameLevel = patch === 0 && minor > 0;
+    } else if (level === 'major') {
+      sameLevel = minor === 0 && patch === 0;
+    }
+
+    if (sameLevel) {
+      newVersion = `${major}.${minor}.${patch}-beta.${betaNum + 1}`;
+    } else {
+      const bumped = semver.inc(`${major}.${minor}.${patch}`, level);
+      newVersion = `${bumped}-beta.0`;
+    }
+  } else {
+    // Not a beta yet: bump the base and start at beta.0
+    const bumped = semver.inc(current, level);
+    newVersion = `${bumped}-beta.0`;
+  }
+} else {
+  if (parsed.prerelease.length > 0) {
+    // Currently a prerelease: bump base version from the clean base
+    const cleanBase = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+    newVersion = semver.inc(cleanBase, level);
+  } else {
+    newVersion = semver.inc(current, level);
+  }
+}
+
+pkg.version = newVersion;
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+console.log(`Bumped version: ${current} -> ${newVersion}`);

--- a/npm-packages/meteor-rspack/scripts/publish-beta.sh
+++ b/npm-packages/meteor-rspack/scripts/publish-beta.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm publish --tag beta "$@"

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -5,7 +5,7 @@
 
 export const DEFAULT_RSPACK_VERSION = '1.7.1';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '1.0.0';
+export const DEFAULT_METEOR_RSPACK_VERSION = '1.0.1';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/tools/modern-tests/apps/vue/package.json
+++ b/tools/modern-tests/apps/vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^20.0.0",
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@nx/angular-rspack": "^21.1.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@graphql-tools/webpack-loader": "^7.0.0",
     "@rsdoctor/rspack-plugin": "^1.2.3",
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",
     "@rspack/plugin-react-refresh": "^1.4.3",

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.23.3",
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -12,7 +12,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -14,7 +14,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.0.0",
+    "@meteorjs/rspack": "^1.0.1",
     "@rsdoctor/rspack-plugin": "^1.2.3",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",


### PR DESCRIPTION
This PR bumps and publish to @meteorjs/rspack 1.0.1 to fix an issue introduced while developing the next @meteorjs/rspack beta for Meteor 3.4.1. When those versions were published, they became the latest, making `npm i @meteorjs/rspack` install them if no version is specified.

Apart from that, and to keep a consistent process, I added docs and scripts to handle beta and official version bumps and publishing more quickly.