### PR TITLE
refactor(accounts-base): replace hasOwnProperty.call with Object.hasOwn

### DIFF
--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -260,7 +260,7 @@ export class AccountsCommon {
     // We need to validate the oauthSecretKey option at the time
     // Accounts.config is called. We also deliberately don't store the
     // oauthSecretKey in Accounts._options.
-    if (Object.prototype.hasOwnProperty.call(options, 'oauthSecretKey')) {
+    if (Object.hasOwn(options, 'oauthSecretKey')) {
       if (Meteor.isClient) {
         throw new Error(
           'The oauthSecretKey option may only be specified on the server'

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -7,7 +7,6 @@ import {
 } from './accounts_common.js';
 import { URL } from 'meteor/url';
 
-const hasOwn = Object.prototype.hasOwnProperty;
 
 /**
  * @summary Constructor for the `Accounts` namespace on the server.
@@ -801,7 +800,7 @@ export class AccountsServer extends AccountsCommon {
 
         if (Package["oauth-encryption"]) {
           const { OAuthEncryption } = Package["oauth-encryption"]
-          if (hasOwn.call(options, 'secret') && OAuthEncryption.keyIsLoaded())
+          if (Object.hasOwn(options, 'secret') && OAuthEncryption.keyIsLoaded())
             options.secret = OAuthEncryption.seal(options.secret);
         }
 
@@ -1008,7 +1007,7 @@ export class AccountsServer extends AccountsCommon {
   // the observe that we started when we associated the connection with
   // this token.
   _removeTokenFromConnection(connectionId) {
-    if (hasOwn.call(this._userObservesForConnections, connectionId)) {
+    if (Object.hasOwn(this._userObservesForConnections, connectionId)) {
       const observe = this._userObservesForConnections[connectionId];
       if (typeof observe === 'number') {
         // We're in the process of setting up an observe for this connection. We
@@ -1220,7 +1219,7 @@ export class AccountsServer extends AccountsCommon {
 
     // If the user set loginExpirationInDays to null, then we need to clear the
     // timer that periodically expires tokens.
-    if (hasOwn.call(this._options, 'loginExpirationInDays') &&
+    if (Object.hasOwn(this._options, 'loginExpirationInDays') &&
       this._options.loginExpirationInDays === null &&
       this.expireTokenInterval) {
       Meteor.clearInterval(this.expireTokenInterval);
@@ -1377,7 +1376,7 @@ export class AccountsServer extends AccountsCommon {
         "Can't use updateOrCreateUserFromExternalService with internal service "
         + serviceName);
     }
-    if (!hasOwn.call(serviceData, 'id')) {
+    if (!Object.hasOwn(serviceData, 'id')) {
       throw new Error(
         `Service data for service ${serviceName} must include id`);
     }
@@ -1527,7 +1526,7 @@ export class AccountsServer extends AccountsCommon {
   ) {
     // Some tests need the ability to add users with the same case insensitive
     // value, hence the _skipCaseInsensitiveChecksForTest check
-    const skipCheck = Object.prototype.hasOwnProperty.call(
+    const skipCheck = Object.hasOwn(
       this._skipCaseInsensitiveChecksForTest,
       fieldValue
     );


### PR DESCRIPTION
Part of my code modernization review.

- Replace `Object.prototype.hasOwnProperty.call()` and the `hasOwn` alias with the modern `Object.hasOwn()` static method (ES2022) across `accounts_server.js` and `accounts_common.js`
- Remove the now-unused `const hasOwn = Object.prototype.hasOwnProperty` alias

`Object.hasOwn()` is a drop-in replacement with identical semantics — just cleaner and more readable. It was introduced in ES2022.