### PR TITLE
refactor(accounts-base): use spread operator instead of .apply() in loginFunctions

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -109,7 +109,7 @@ export class AccountsClient extends AccountsCommon {
     if (!this._loginFuncs[funcName]) {
       throw new Error(`${funcName} was not defined`);
     }
-    return this._loginFuncs[funcName].apply(this, funcArgs);
+    return this._loginFuncs[funcName].call(this, ...funcArgs);
   }
 
   /**
@@ -123,7 +123,7 @@ export class AccountsClient extends AccountsCommon {
     if (!this._loginFuncs[funcName]) {
       throw new Error(`${funcName} was not defined`);
     }
-    return this._loginFuncs[funcName].apply(this, funcArgs);
+    return this._loginFuncs[funcName].call(this, ...funcArgs);
   }
 
   /**


### PR DESCRIPTION
Replace `.apply(this, funcArgs)` with `.call(this, ...funcArgs)` in `callLoginFunction` and `applyLoginFunction`