### PR TITLE
perf(ejson): early bail-out on key count mismatch in EJSON.equals

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -518,6 +518,9 @@ EJSON.equals = (a, b, options) => {
   let ret;
   const aKeys = keysOf(a);
   const bKeys = keysOf(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
   if (keyOrderSensitive) {
     i = 0;
     ret = aKeys.every(key => {


### PR DESCRIPTION
`EJSON.equals` is the hottest function in Meteor's live query pipeline. It's called by `diff-sequence` for every field of every document on every query rerun, and by `minimongo` throughout `local_collection.js`.

When comparing two objects with different numbers of keys (e.g. a field was added or removed), the code would iterate through all keys of object `a`, check each one against `b`, and only discover the mismatch at the very end via `i === bKeys.length`. Both `Object.keys()` arrays were already allocated; the length comparison is free.

This is especially common in `DiffSequence.makeChangedFields`, where old and new documents frequently differ by one or two fields.