### PR TITLE
perf(ejson): fast-path primitive comparisons in EJSON.equals

### DIFF
--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -447,18 +447,21 @@ EJSON.equals = (a, b, options) => {
     return true;
   }
 
-  // This differs from the IEEE spec for NaN equality, b/c we don't want
-  // anything ever with a NaN to be poisoned from becoming equal to anything.
-  if (Number.isNaN(a) && Number.isNaN(b)) {
-    return true;
-  }
-
-  // if either one is falsy, they'd have to be === to be equal
-  if (!a || !b) {
+  // If types differ, they can't be equal.
+  // This also handles mixed null/primitive cases since typeof null is 'object'.
+  if (typeof a !== typeof b) {
     return false;
   }
 
-  if (!(isObject(a) && isObject(b))) {
+  // Same-type primitives that aren't === can only be equal if both are NaN.
+  // This skips the NaN check entirely for strings, booleans, etc.
+  if (typeof a !== 'object') {
+    return Number.isNaN(a) && Number.isNaN(b);
+  }
+
+  // Both are typeof 'object' — but either could be null.
+  // (If both were null, a === b would have caught it above.)
+  if (a === null || b === null) {
     return false;
   }
 

--- a/packages/ejson/ejson_tests.js
+++ b/packages/ejson/ejson_tests.js
@@ -63,6 +63,109 @@ Tinytest.add('ejson - equality and falsiness', test => {
   test.isFalse(EJSON.equals({foo: 'foo'}, undefined));
 });
 
+Tinytest.add('ejson - equals type-mismatch early exit', test => {
+  // Cross-type primitives: typeof a !== typeof b → false
+  test.isFalse(EJSON.equals('hello', 42));
+  test.isFalse(EJSON.equals(42, 'hello'));
+  test.isFalse(EJSON.equals(1, true));
+  test.isFalse(EJSON.equals(true, 1));
+  test.isFalse(EJSON.equals('true', true));
+  test.isFalse(EJSON.equals(true, 'true'));
+  test.isFalse(EJSON.equals('1', 1));
+  test.isFalse(EJSON.equals(1, '1'));
+
+  // Falsy cross-type: both are falsy but different types
+  test.isFalse(EJSON.equals(0, false));
+  test.isFalse(EJSON.equals(false, 0));
+  test.isFalse(EJSON.equals('', 0));
+  test.isFalse(EJSON.equals(0, ''));
+  test.isFalse(EJSON.equals('', false));
+  test.isFalse(EJSON.equals(false, ''));
+
+  // null/undefined vs primitives (typeof null is 'object', differs from 'number'/'string')
+  test.isFalse(EJSON.equals(null, 0));
+  test.isFalse(EJSON.equals(0, null));
+  test.isFalse(EJSON.equals(null, ''));
+  test.isFalse(EJSON.equals('', null));
+  test.isFalse(EJSON.equals(null, false));
+  test.isFalse(EJSON.equals(false, null));
+  test.isFalse(EJSON.equals(undefined, 0));
+  test.isFalse(EJSON.equals(0, undefined));
+  test.isFalse(EJSON.equals(undefined, ''));
+  test.isFalse(EJSON.equals('', undefined));
+  test.isFalse(EJSON.equals(undefined, false));
+  test.isFalse(EJSON.equals(false, undefined));
+  test.isFalse(EJSON.equals(null, undefined));
+  test.isFalse(EJSON.equals(undefined, null));
+});
+
+Tinytest.add('ejson - equals same-type primitives', test => {
+  // Same-type, same-value → caught by a === b
+  test.isTrue(EJSON.equals(0, 0));
+  test.isTrue(EJSON.equals(1, 1));
+  test.isTrue(EJSON.equals(-1, -1));
+  test.isTrue(EJSON.equals('', ''));
+  test.isTrue(EJSON.equals('hello', 'hello'));
+  test.isTrue(EJSON.equals(true, true));
+  test.isTrue(EJSON.equals(false, false));
+
+  // Same-type, different-value → typeof a !== 'object', then NaN check returns false
+  test.isFalse(EJSON.equals(1, 2));
+  test.isFalse(EJSON.equals('a', 'b'));
+  test.isFalse(EJSON.equals(true, false));
+  test.isFalse(EJSON.equals(false, true));
+  test.isFalse(EJSON.equals(0, 1));
+  test.isTrue(EJSON.equals(0, -0)); // 0 === -0 in JS, caught by a === b
+});
+
+Tinytest.add('ejson - equals null vs object', test => {
+  // Both typeof 'object', but one is null
+  test.isFalse(EJSON.equals(null, {}));
+  test.isFalse(EJSON.equals({}, null));
+  test.isFalse(EJSON.equals(null, []));
+  test.isFalse(EJSON.equals([], null));
+  test.isFalse(EJSON.equals(null, new Date()));
+  test.isFalse(EJSON.equals(new Date(), null));
+});
+
+Tinytest.add('ejson - equals nested falsy and type-mismatch fields', test => {
+  // Objects with falsy fields of different types
+  test.isFalse(EJSON.equals({a: 0}, {a: false}));
+  test.isFalse(EJSON.equals({a: ''}, {a: 0}));
+  test.isFalse(EJSON.equals({a: ''}, {a: false}));
+  test.isFalse(EJSON.equals({a: null}, {a: undefined}));
+  test.isFalse(EJSON.equals({a: null}, {a: 0}));
+  test.isFalse(EJSON.equals({a: null}, {a: ''}));
+  test.isFalse(EJSON.equals({a: null}, {a: false}));
+
+  // Objects with same falsy values should be equal
+  test.isTrue(EJSON.equals({a: 0}, {a: 0}));
+  test.isTrue(EJSON.equals({a: ''}, {a: ''}));
+  test.isTrue(EJSON.equals({a: false}, {a: false}));
+  test.isTrue(EJSON.equals({a: null}, {a: null}));
+  test.isTrue(EJSON.equals({a: undefined}, {a: undefined}));
+
+  // Deeply nested type mismatches
+  test.isFalse(EJSON.equals(
+    {a: {b: {c: 0}}},
+    {a: {b: {c: false}}}
+  ));
+  test.isFalse(EJSON.equals(
+    {a: {b: {c: null}}},
+    {a: {b: {c: undefined}}}
+  ));
+  test.isTrue(EJSON.equals(
+    {a: {b: {c: 0}}},
+    {a: {b: {c: 0}}}
+  ));
+
+  // Arrays with type-mismatched elements
+  test.isFalse(EJSON.equals([0, 1, 2], [false, 1, 2]));
+  test.isFalse(EJSON.equals([0, '', 2], [0, false, 2]));
+  test.isFalse(EJSON.equals([null], [undefined]));
+  test.isTrue(EJSON.equals([0, '', null], [0, '', null]));
+});
+
 Tinytest.add('ejson - NaN and Inf', test => {
   test.equal(EJSON.parse('{"$InfNaN": 1}'), Infinity);
   test.equal(EJSON.parse('{"$InfNaN": -1}'), -Infinity);


### PR DESCRIPTION
Restructure the early checks in `EJSON.equals` to use `typeof` gating instead of `Number.isNaN` + falsy + `isObject` checks

## What Changes

`EJSON.equals` is the hottest function in Meteor's live query pipeline. `DiffSequence.makeChangedFields` calls it for every field of every changed document, and the vast majority of field values are strings and numbers.

Previously, comparing two different strings like `"hello"` vs `"world"` required 4 checks including a `Number.isNaN` call that could never be true for strings:
  1. `a === b` — false
  2. `Number.isNaN("hello")` — false (wasted function call)
  3. `!"hello" || !"world"` — false
  4. `isObject("hello")` — false, return

Now the same comparison takes 3 checks with zero function calls:
  1. `a === b` — false
  2. `typeof a !== typeof b` — false (both `'string'`)
  3. `typeof a !== 'object'` — true, return false immediately

Comparing mismatched types (string vs number) is even faster — bails out at step 2 instead of step 4.

The `Number.isNaN` check is now only reached for two same-type non-object values that aren't `===`, which in practice means only actual `NaN` comparisons.

<details>
<summary>Benchmark Script</summary>

```javascript
'use strict';

// ─────────────────────────────────────────────────────────────
// EJSON.equals benchmark
// Compares old (NaN + falsy + isObject checks) vs new (typeof gating)
// ─────────────────────────────────────────────────────────────

const isObject = v => typeof v === 'object';
const isFunction = fn => typeof fn === 'function';
const keysOf = obj => Object.keys(obj);
const hasOwn = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);

// ── OLD implementation ──────────────────────

function oldEquals(a, b, options) {
  let i;
  const keyOrderSensitive = !!(options && options.keyOrderSensitive);

  if (a === b) {
    return true;
  }

  // This differs from the IEEE spec for NaN equality, b/c we don't want
  // anything ever with a NaN to be poisoned from becoming equal to anything.
  if (Number.isNaN(a) && Number.isNaN(b)) {
    return true;
  }

  // if either one is falsy, they'd have to be === to be equal
  if (!a || !b) {
    return false;
  }

  if (!(isObject(a) && isObject(b))) {
    return false;
  }

  if (a instanceof Date && b instanceof Date) {
    return a.valueOf() === b.valueOf();
  }

  if (isFunction(a.equals)) {
    return a.equals(b, options);
  }

  if (isFunction(b.equals)) {
    return b.equals(a, options);
  }

  const aIsArray = Array.isArray(a);
  const bIsArray = Array.isArray(b);

  if (aIsArray !== bIsArray) {
    return false;
  }

  if (aIsArray && bIsArray) {
    if (a.length !== b.length) {
      return false;
    }
    for (i = 0; i < a.length; i++) {
      if (!oldEquals(a[i], b[i], options)) {
        return false;
      }
    }
    return true;
  }

  switch (false) { // simplified — no custom types in bench
    default:
  }

  let ret;
  const aKeys = keysOf(a);
  const bKeys = keysOf(b);
  if (keyOrderSensitive) {
    i = 0;
    ret = aKeys.every(key => {
      if (i >= bKeys.length) { return false; }
      if (key !== bKeys[i]) { return false; }
      if (!oldEquals(a[key], b[key], options)) { return false; }
      i++;
      return true;
    });
  } else {
    i = 0;
    ret = aKeys.every(key => {
      if (!hasOwn(b, key)) { return false; }
      if (!oldEquals(a[key], b[key], options)) { return false; }
      i++;
      return true;
    });
  }
  return ret && i === bKeys.length;
}

// ── NEW implementation (typeof gating) ──────────

function newEquals(a, b, options) {
  let i;
  const keyOrderSensitive = !!(options && options.keyOrderSensitive);

  if (a === b) {
    return true;
  }

  // If types differ, they can't be equal.
  if (typeof a !== typeof b) {
    return false;
  }

  // Same-type primitives that aren't === can only be equal if both are NaN.
  if (typeof a !== 'object') {
    return Number.isNaN(a) && Number.isNaN(b);
  }

  // Both are typeof 'object' — but either could be null.
  if (a === null || b === null) {
    return false;
  }

  if (a instanceof Date && b instanceof Date) {
    return a.valueOf() === b.valueOf();
  }

  if (isFunction(a.equals)) {
    return a.equals(b, options);
  }

  if (isFunction(b.equals)) {
    return b.equals(a, options);
  }

  const aIsArray = Array.isArray(a);
  const bIsArray = Array.isArray(b);

  if (aIsArray !== bIsArray) {
    return false;
  }

  if (aIsArray && bIsArray) {
    if (a.length !== b.length) {
      return false;
    }
    for (i = 0; i < a.length; i++) {
      if (!newEquals(a[i], b[i], options)) {
        return false;
      }
    }
    return true;
  }

  switch (false) {
    default:
  }

  let ret;
  const aKeys = keysOf(a);
  const bKeys = keysOf(b);
  if (keyOrderSensitive) {
    i = 0;
    ret = aKeys.every(key => {
      if (i >= bKeys.length) { return false; }
      if (key !== bKeys[i]) { return false; }
      if (!newEquals(a[key], b[key], options)) { return false; }
      i++;
      return true;
    });
  } else {
    i = 0;
    ret = aKeys.every(key => {
      if (!hasOwn(b, key)) { return false; }
      if (!newEquals(a[key], b[key], options)) { return false; }
      i++;
      return true;
    });
  }
  return ret && i === bKeys.length;
}

// ── Test data generators ────────────────────────────────────

// Simulates comparing two identical DDP documents (common hot path)
function makeDoc(nFields) {
  const doc = { _id: 'abc123' };
  for (let i = 0; i < nFields; i++) doc[`field${i}`] = `value${i}`;
  doc.count = 42;
  doc.active = true;
  doc.score = 3.14;
  return doc;
}

// Two docs that differ in one field (triggers early-out vs full scan)
function makeDocPairDiffLast(n) {
  const a = makeDoc(n);
  const b = { ...a };
  b[`field${n - 1}`] = 'CHANGED';
  return [a, b];
}

function makeDocPairDiffFirst(n) {
  const a = makeDoc(n);
  const b = { ...a };
  b.field0 = 'CHANGED';
  return [a, b];
}

// Nested document (realistic user profile)
function makeNestedDoc() {
  return {
    _id: 'user1',
    name: 'Alice',
    age: 30,
    profile: {
      bio: 'Developer',
      settings: { theme: 'dark', lang: 'en', notifications: true, fontSize: 14 },
      tags: ['admin', 'developer', 'tester'],
    },
    scores: [95, 87, 92, 88, 76],
    metadata: { createdAt: new Date('2024-01-01'), version: 3 },
  };
}

// ── Scenarios focused on the changed code path ──────────────
// The PR changes the FIRST few checks in EJSON.equals.
// These scenarios specifically exercise those early checks.

const scenarios = [];

// 1. String vs string (equal) — common in field-by-field comparison
scenarios.push({
  name: 'string === string (identical)',
  a: 'hello world',
  b: 'hello world',
  expected: true,
});

// 2. String vs string (different) — OLD: goes through NaN check, falsy check, isObject check
scenarios.push({
  name: 'string !== string (different)',
  a: 'hello',
  b: 'world',
  expected: false,
});

// 3. Number vs number (equal)
scenarios.push({
  name: 'number === number (same)',
  a: 42,
  b: 42,
  expected: true,
});

// 4. Number vs number (different) — OLD: NaN check on both, falsy, isObject
scenarios.push({
  name: 'number !== number (different)',
  a: 42,
  b: 99,
  expected: false,
});

// 5. String vs number — OLD: NaN(string) + NaN(number), falsy, isObject
//    NEW: typeof mismatch → immediate false
scenarios.push({
  name: 'string vs number (type mismatch)',
  a: 'hello',
  b: 42,
  expected: false,
});

// 6. Number vs null — OLD: NaN(number), !null → false
//    NEW: typeof number !== typeof null → immediate false
scenarios.push({
  name: 'number vs null (type mismatch)',
  a: 42,
  b: null,
  expected: false,
});

// 7. String vs null
scenarios.push({
  name: 'string vs null',
  a: 'hello',
  b: null,
  expected: false,
});

// 8. null vs null
scenarios.push({
  name: 'null vs null (identical)',
  a: null,
  b: null,
  expected: true,
});

// 9. NaN vs NaN — both old and new handle this, but via different paths
scenarios.push({
  name: 'NaN vs NaN',
  a: NaN,
  b: NaN,
  expected: true,
});

// 10. Boolean vs boolean (different)
scenarios.push({
  name: 'boolean !== boolean',
  a: true,
  b: false,
  expected: false,
});

// 11. 0 vs false — OLD: both falsy → a === b check (false), return false
//     NEW: typeof mismatch → immediate false
scenarios.push({
  name: '0 vs false (type mismatch, both falsy)',
  a: 0,
  b: false,
  expected: false,
});

// 12. "" vs 0 — OLD: both falsy, a === b fails
//     NEW: typeof mismatch → immediate false
scenarios.push({
  name: '"" vs 0 (type mismatch, both falsy)',
  a: '',
  b: 0,
  expected: false,
});

// 13. undefined vs null
scenarios.push({
  name: 'undefined vs null',
  a: undefined,
  b: null,
  expected: false,
});

// 14. 0 vs 0 — same via ===
scenarios.push({
  name: '0 vs 0 (falsy but equal)',
  a: 0,
  b: 0,
  expected: true,
});

// 15. "" vs "" — same via ===
scenarios.push({
  name: '"" vs "" (falsy but equal)',
  a: '',
  b: '',
  expected: true,
});

// Object-level comparisons — these exercise the full function
// but the early checks still matter for every recursive field comparison

// 16. Identical flat documents (20 string fields → 20 recursive string comparisons)
const doc20 = makeDoc(20);
scenarios.push({
  name: 'identical flat doc (20 fields)',
  a: doc20,
  b: { ...doc20 },
  expected: true,
});

// 17. Identical flat documents (50 fields)
const doc50 = makeDoc(50);
scenarios.push({
  name: 'identical flat doc (50 fields)',
  a: doc50,
  b: { ...doc50 },
  expected: true,
});

// 18. Docs differ at last field
const [diffLastA, diffLastB] = makeDocPairDiffLast(20);
scenarios.push({
  name: 'docs differ at last field (20 fields)',
  a: diffLastA,
  b: diffLastB,
  expected: false,
});

// 19. Docs differ at first field
const [diffFirstA, diffFirstB] = makeDocPairDiffFirst(20);
scenarios.push({
  name: 'docs differ at first field (20 fields)',
  a: diffFirstA,
  b: diffFirstB,
  expected: false,
});

// 20. Nested documents (identical)
scenarios.push({
  name: 'identical nested doc',
  a: makeNestedDoc(),
  b: makeNestedDoc(),
  expected: true,
});

// 21. Object vs null — OLD: !null → false.  NEW: typeof match (both 'object'), then null check
scenarios.push({
  name: 'object vs null',
  a: { x: 1 },
  b: null,
  expected: false,
});

// 22. Array comparison (identical)
scenarios.push({
  name: 'identical arrays (10 numbers)',
  a: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
  b: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
  expected: true,
});

// 23. Array comparison (different lengths)
scenarios.push({
  name: 'arrays different length',
  a: [1, 2, 3],
  b: [1, 2, 3, 4],
  expected: false,
});

// 24. Date comparison (equal)
const dateA = new Date('2024-06-15');
scenarios.push({
  name: 'Date === Date (equal)',
  a: dateA,
  b: new Date(dateA.getTime()),
  expected: true,
});

// 25. Simulates DiffSequence.makeChangedFields comparing two versions of a document
//     Each field comparison hits the early primitive checks
function makeLargeDoc() {
  const doc = { _id: 'doc_large' };
  for (let i = 0; i < 100; i++) doc[`f${i}`] = i % 3 === 0 ? `str${i}` : i;
  doc.active = true;
  doc.label = null;
  return doc;
}
const largeA = makeLargeDoc();
scenarios.push({
  name: 'identical large doc (100 mixed fields)',
  a: largeA,
  b: { ...largeA },
  expected: true,
});

// ── Correctness verification ────────────────────────────────

function verify() {
  let passed = 0;
  let failed = 0;
  for (const { name, a, b, expected } of scenarios) {
    const oldResult = oldEquals(a, b);
    const newResult = newEquals(a, b);

    if (oldResult !== expected) {
      console.error(`FAIL [old] ${name}: got ${oldResult}, expected ${expected}`);
      failed++;
      continue;
    }
    if (newResult !== expected) {
      console.error(`FAIL [new] ${name}: got ${newResult}, expected ${expected}`);
      failed++;
      continue;
    }
    if (oldResult !== newResult) {
      console.error(`MISMATCH ${name}: old=${oldResult} new=${newResult}`);
      failed++;
      continue;
    }
    passed++;
  }
  console.log(`Correctness: ${passed} passed, ${failed} failed\n`);
  if (failed > 0) process.exit(1);
}

// ── Benchmark harness ───────────────────────────────────────

function bench(fn, a, b, iterations) {
  // Warmup
  for (let i = 0; i < Math.min(5000, iterations / 10); i++) fn(a, b);

  if (global.gc) global.gc();

  const start = process.hrtime.bigint();
  for (let i = 0; i < iterations; i++) fn(a, b);
  const elapsed = Number(process.hrtime.bigint() - start);

  const nsPerOp = Math.round(elapsed / iterations);
  const opsPerSec = Math.round((iterations / elapsed) * 1e9);

  return { nsPerOp, opsPerSec };
}

function runBenchmarks() {
  const primitiveIters = 2_000_000;
  const objectIters = 500_000;

  console.log('Scenario                                    │  Old (ns/op) │  New (ns/op) │ Speedup');
  console.log('────────────────────────────────────────────┼──────────────┼──────────────┼────────');

  for (const { name, a, b } of scenarios) {
    const isPrimitive = typeof a !== 'object' || a === null;
    const iters = isPrimitive ? primitiveIters : objectIters;

    const oldResult = bench(oldEquals, a, b, iters);
    const newResult = bench(newEquals, a, b, iters);

    const speedup = (oldResult.nsPerOp / newResult.nsPerOp).toFixed(2);
    const marker = parseFloat(speedup) >= 1.1 ? ' ◀' : '';

    console.log(
      `${name.padEnd(44)}│ ${String(oldResult.nsPerOp).padStart(12)} │ ${String(newResult.nsPerOp).padStart(12)} │ ${speedup}x${marker}`
    );
  }
}

// ── DiffSequence simulation ─────────────────────────────────
// This simulates the real hot path: comparing fields of two document versions

function simulateMakeChangedFields(equalsFn, oldDoc, newDoc) {
  const changed = {};
  const keys = keysOf(newDoc);
  for (let i = 0; i < keys.length; i++) {
    const key = keys[i];
    if (!equalsFn(oldDoc[key], newDoc[key])) {
      changed[key] = newDoc[key];
    }
  }
  return changed;
}

function benchDiffSequence(label, oldDocFn, newDocFn, iters) {
  const oldDoc = oldDocFn();
  const newDoc = newDocFn();

  // Warmup
  for (let i = 0; i < 2000; i++) {
    simulateMakeChangedFields(oldEquals, oldDoc, newDoc);
    simulateMakeChangedFields(newEquals, oldDoc, newDoc);
  }

  if (global.gc) global.gc();
  let start = process.hrtime.bigint();
  for (let i = 0; i < iters; i++) simulateMakeChangedFields(oldEquals, oldDoc, newDoc);
  const oldElapsed = Number(process.hrtime.bigint() - start);

  if (global.gc) global.gc();
  start = process.hrtime.bigint();
  for (let i = 0; i < iters; i++) simulateMakeChangedFields(newEquals, oldDoc, newDoc);
  const newElapsed = Number(process.hrtime.bigint() - start);

  const oldNs = Math.round(oldElapsed / iters);
  const newNs = Math.round(newElapsed / iters);
  const speedup = (oldNs / newNs).toFixed(2);

  console.log(`  ${label}`);
  console.log(`    Old: ${oldNs} ns/op  →  New: ${newNs} ns/op  (${speedup}x)`);
}

function runDiffSimulations() {
  console.log('\n── DiffSequence.makeChangedFields simulations ──');
  console.log('  (field-by-field comparison of two document versions)\n');

  // Scenario A: large doc, 2 fields changed (strings & numbers)
  benchDiffSequence(
    '100 mixed fields, 2 changed',
    makeLargeDoc,
    () => { const d = makeLargeDoc(); d.f50 = 'CHANGED'; d.f75 = 999999; return d; },
    200_000,
  );

  // Scenario B: identical docs — every field must be compared, all match
  benchDiffSequence(
    '100 mixed fields, 0 changed (identical)',
    makeLargeDoc,
    makeLargeDoc,
    200_000,
  );

  // Scenario C: small doc with type-mismatched changes (string→number, number→null)
  benchDiffSequence(
    '20 fields, 3 type-mismatch changes',
    () => makeDoc(20),
    () => { const d = makeDoc(20); d.field5 = 123; d.field10 = null; d.active = 'yes'; return d; },
    500_000,
  );

  // Scenario D: doc where all values are null (falsy path)
  const nullDoc = () => {
    const d = {};
    for (let i = 0; i < 30; i++) d[`f${i}`] = null;
    return d;
  };
  benchDiffSequence(
    '30 null fields, 0 changed',
    nullDoc,
    nullDoc,
    500_000,
  );

  // Scenario E: mixed types — some fields null, some 0, some false, some ""
  const falsyDoc = () => {
    const d = {};
    for (let i = 0; i < 40; i++) {
      d[`f${i}`] = [null, 0, false, '', undefined][i % 5];
    }
    return d;
  };
  benchDiffSequence(
    '40 falsy fields (null/0/false/""/undefined), 0 changed',
    falsyDoc,
    falsyDoc,
    500_000,
  );

  // Scenario F: compare docs with different-typed values at every field
  benchDiffSequence(
    '20 fields, ALL type-mismatched',
    () => { const d = {}; for (let i = 0; i < 20; i++) d[`f${i}`] = `str${i}`; return d; },
    () => { const d = {}; for (let i = 0; i < 20; i++) d[`f${i}`] = i; return d; },
    500_000,
  );
}

// ── Main ────────────────────────────────────────────────────

console.log('EJSON.equals Benchmark — PR #14208');
console.log('Old: NaN check → falsy check → isObject check');
console.log('New: typeof gating → early exit for type mismatches & primitives');
console.log('====================================================================\n');

verify();
runBenchmarks();
runDiffSimulations();

console.log('\nDone.');
```

</details>

<details>
<summary>Results</summary>

```javascript
Old: NaN check → falsy check → isObject check
New: typeof gating → early exit for type mismatches & primitives
====================================================================

Correctness: 25 passed, 0 failed

Scenario                                    │  Old (ns/op) │  New (ns/op) │ Speedup
────────────────────────────────────────────┼──────────────┼──────────────┼────────
string === string (identical)               │            9 │           11 │ 0.82x
string !== string (different)               │           15 │           13 │ 1.15x ◀
number === number (same)                    │           10 │           10 │ 1.00x
number !== number (different)               │           13 │           11 │ 1.18x ◀
string vs number (type mismatch)            │           14 │           11 │ 1.27x ◀
number vs null (type mismatch)              │           12 │           12 │ 1.00x
string vs null                              │           12 │           12 │ 1.00x
null vs null (identical)                    │           10 │           10 │ 1.00x
NaN vs NaN                                  │           12 │           13 │ 0.92x
boolean !== boolean                         │           11 │           12 │ 0.92x
0 vs false (type mismatch, both falsy)      │           10 │           11 │ 0.91x
"" vs 0 (type mismatch, both falsy)         │           11 │           11 │ 1.00x
undefined vs null                           │           11 │           12 │ 0.92x
0 vs 0 (falsy but equal)                    │           10 │           10 │ 1.00x
"" vs "" (falsy but equal)                  │           10 │           10 │ 1.00x
identical flat doc (20 fields)              │         1083 │         1044 │ 1.04x
identical flat doc (50 fields)              │         2877 │         2914 │ 0.99x
docs differ at last field (20 fields)       │          975 │          962 │ 1.01x
docs differ at first field (20 fields)      │          497 │          487 │ 1.02x
identical nested doc                        │          558 │          532 │ 1.05x
object vs null                              │           11 │           11 │ 1.00x
identical arrays (10 numbers)               │           98 │           92 │ 1.07x
arrays different length                     │           27 │           23 │ 1.17x ◀
Date === Date (equal)                       │           21 │           15 │ 1.40x ◀
identical large doc (100 mixed fields)      │         5749 │         5718 │ 1.01x

── DiffSequence.makeChangedFields simulations ──
  (field-by-field comparison of two document versions)

  100 mixed fields, 2 changed
    Old: 3698 ns/op  →  New: 3529 ns/op  (1.05x)
  100 mixed fields, 0 changed (identical)
    Old: 3543 ns/op  →  New: 3480 ns/op  (1.02x)
  20 fields, 3 type-mismatch changes
    Old: 811 ns/op  →  New: 795 ns/op  (1.02x)
  30 null fields, 0 changed
    Old: 907 ns/op  →  New: 909 ns/op  (1.00x)
  40 falsy fields (null/0/false/""/undefined), 0 changed
    Old: 1192 ns/op  →  New: 1184 ns/op  (1.01x)
  20 fields, ALL type-mismatched
    Old: 1374 ns/op  →  New: 1332 ns/op  (1.03x)
```
</details>