### PR TITLE
perf(ddp): zero-clone stringifyDDP

### DIFF
--- a/packages/ddp-common/utils.js
+++ b/packages/ddp-common/utils.js
@@ -81,13 +81,9 @@ DDPCommon.stringifyDDP = function (msg) {
     throw new Error("Message id is not a string");
   }
 
-  const hasFields = hasOwn.call(msg, 'fields');
-  const hasParams = hasOwn.call(msg, 'params');
-  const hasResult = hasOwn.call(msg, 'result');
-
   // Fast path: messages without fields/params/result need no EJSON conversion
   // (e.g. 'removed', 'ready', 'nosub', 'ping', 'pong')
-  if (!hasFields && !hasParams && !hasResult) {
+  if (msg.fields === undefined && msg.params === undefined && msg.result === undefined) {
     return JSON.stringify(msg);
   }
 
@@ -96,41 +92,37 @@ DDPCommon.stringifyDDP = function (msg) {
   // objects for subtrees that actually contain EJSON types (Date, Binary, etc.).
   const wire = {};
 
-  for (const key of Object.keys(msg)) {
+  for (const key in msg) {
     if (key === 'fields' || key === 'params' || key === 'result') {
       continue;
     }
     wire[key] = msg[key];
   }
 
-  if (hasFields) {
-    const cleared = [];
+  if (msg.fields !== undefined) {
+    let cleared = null;
     const wireFields = {};
     let hasAnyField = false;
 
-    for (const key of Object.keys(msg.fields)) {
+    for (const key in msg.fields) {
       const value = msg.fields[key];
-      if (typeof value === 'undefined') {
-        cleared.push(key);
+      if (value === undefined) {
+        (cleared ??= []).push(key);
       } else {
         wireFields[key] = EJSON.toJSONValue(value);
         hasAnyField = true;
       }
     }
 
-    if (hasAnyField) {
-      wire.fields = wireFields;
-    }
-    if (cleared.length > 0) {
-      wire.cleared = cleared;
-    }
+    if (hasAnyField) wire.fields = wireFields;
+    if (cleared !== null) wire.cleared = cleared;
   }
 
-  if (hasParams) {
+  if (msg.params !== undefined) {
     wire.params = EJSON.toJSONValue(msg.params);
   }
 
-  if (hasResult) {
+  if (msg.result !== undefined) {
     wire.result = EJSON.toJSONValue(msg.result);
   }
 

--- a/packages/ddp-common/utils.js
+++ b/packages/ddp-common/utils.js
@@ -77,41 +77,62 @@ DDPCommon.parseDDP = function (stringMessage) {
 };
 
 DDPCommon.stringifyDDP = function (msg) {
-  const copy = EJSON.clone(msg);
-
-  // swizzle 'changed' messages from 'fields undefined' rep to 'fields
-  // and cleared' rep
-  if (hasOwn.call(msg, 'fields')) {
-    const cleared = [];
-
-    Object.keys(msg.fields).forEach(key => {
-      const value = msg.fields[key];
-
-      if (typeof value === "undefined") {
-        cleared.push(key);
-        delete copy.fields[key];
-      }
-    });
-
-    if (! isEmpty(cleared)) {
-      copy.cleared = cleared;
-    }
-
-    if (isEmpty(copy.fields)) {
-      delete copy.fields;
-    }
-  }
-
-  // adjust types to basic
-  ['fields', 'params', 'result'].forEach(field => {
-    if (hasOwn.call(copy, field)) {
-      copy[field] = EJSON._adjustTypesToJSONValue(copy[field]);
-    }
-  });
-
   if (msg.id && typeof msg.id !== 'string') {
     throw new Error("Message id is not a string");
   }
 
-  return JSON.stringify(copy);
+  const hasFields = hasOwn.call(msg, 'fields');
+  const hasParams = hasOwn.call(msg, 'params');
+  const hasResult = hasOwn.call(msg, 'result');
+
+  // Fast path: messages without fields/params/result need no EJSON conversion
+  // (e.g. 'removed', 'ready', 'nosub', 'ping', 'pong')
+  if (!hasFields && !hasParams && !hasResult) {
+    return JSON.stringify(msg);
+  }
+
+  // Build wire-format object without cloning the entire message.
+  // Uses EJSON.toJSONValue (copy-on-write) per field — only allocates new
+  // objects for subtrees that actually contain EJSON types (Date, Binary, etc.).
+  const wire = {};
+
+  for (const key of Object.keys(msg)) {
+    if (key === 'fields' || key === 'params' || key === 'result') {
+      continue;
+    }
+    wire[key] = msg[key];
+  }
+
+  if (hasFields) {
+    const cleared = [];
+    const wireFields = {};
+    let hasAnyField = false;
+
+    for (const key of Object.keys(msg.fields)) {
+      const value = msg.fields[key];
+      if (typeof value === 'undefined') {
+        cleared.push(key);
+      } else {
+        wireFields[key] = EJSON.toJSONValue(value);
+        hasAnyField = true;
+      }
+    }
+
+    if (hasAnyField) {
+      wire.fields = wireFields;
+    }
+    if (cleared.length > 0) {
+      wire.cleared = cleared;
+    }
+  }
+
+  if (hasParams) {
+    wire.params = EJSON.toJSONValue(msg.params);
+  }
+
+  if (hasResult) {
+    wire.result = EJSON.toJSONValue(msg.result);
+  }
+
+  return JSON.stringify(wire);
 };

--- a/packages/ddp-common/utils.js
+++ b/packages/ddp-common/utils.js
@@ -91,40 +91,38 @@ DDPCommon.stringifyDDP = function (msg) {
   // Uses EJSON.toJSONValue (copy-on-write) per field — only allocates new
   // objects for subtrees that actually contain EJSON types (Date, Binary, etc.).
   const wire = {};
+  let cleared = null;
+  const wireFields = {};
+  let hasAnyField = false;
 
   for (const key in msg) {
-    if (key === 'fields' || key === 'params' || key === 'result') {
-      continue;
+    if (!hasOwn.call(msg, key)) continue;
+    switch (key) {
+      case 'fields':
+        for (const fieldKey in msg.fields) {
+          if (!hasOwn.call(msg.fields, fieldKey)) continue;
+          const value = msg.fields[fieldKey];
+          if (value === undefined) {
+            (cleared ??= []).push(fieldKey);
+          } else {
+            wireFields[fieldKey] = EJSON.toJSONValue(value);
+            hasAnyField = true;
+          }
+        }
+        break;
+      case 'params':
+        wire.params = EJSON.toJSONValue(msg.params);
+        break;
+      case 'result':
+        wire.result = EJSON.toJSONValue(msg.result);
+        break;
+      default:
+        wire[key] = msg[key];
     }
-    wire[key] = msg[key];
   }
 
-  if (msg.fields !== undefined) {
-    let cleared = null;
-    const wireFields = {};
-    let hasAnyField = false;
-
-    for (const key in msg.fields) {
-      const value = msg.fields[key];
-      if (value === undefined) {
-        (cleared ??= []).push(key);
-      } else {
-        wireFields[key] = EJSON.toJSONValue(value);
-        hasAnyField = true;
-      }
-    }
-
-    if (hasAnyField) wire.fields = wireFields;
-    if (cleared !== null) wire.cleared = cleared;
-  }
-
-  if (msg.params !== undefined) {
-    wire.params = EJSON.toJSONValue(msg.params);
-  }
-
-  if (msg.result !== undefined) {
-    wire.result = EJSON.toJSONValue(msg.result);
-  }
+  if (hasAnyField) wire.fields = wireFields;
+  if (cleared !== null) wire.cleared = cleared;
 
   return JSON.stringify(wire);
 };

--- a/packages/ddp-common/utils.js
+++ b/packages/ddp-common/utils.js
@@ -92,8 +92,7 @@ DDPCommon.stringifyDDP = function (msg) {
   // objects for subtrees that actually contain EJSON types (Date, Binary, etc.).
   const wire = {};
   let cleared = null;
-  const wireFields = {};
-  let hasAnyField = false;
+  let wireFields = null;
 
   for (const key in msg) {
     if (!hasOwn.call(msg, key)) continue;
@@ -105,8 +104,7 @@ DDPCommon.stringifyDDP = function (msg) {
           if (value === undefined) {
             (cleared ??= []).push(fieldKey);
           } else {
-            wireFields[fieldKey] = EJSON.toJSONValue(value);
-            hasAnyField = true;
+            (wireFields ??= {})[fieldKey] = EJSON.toJSONValue(value);
           }
         }
         break;
@@ -121,7 +119,7 @@ DDPCommon.stringifyDDP = function (msg) {
     }
   }
 
-  if (hasAnyField) wire.fields = wireFields;
+  if (wireFields !== null) wire.fields = wireFields;
   if (cleared !== null) wire.cleared = cleared;
 
   return JSON.stringify(wire);

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -362,12 +362,13 @@ Object.assign(Session.prototype, {
       return;
     }
     if (self.socket) {
+      const stringMsg = DDPCommon.stringifyDDP(msg);
       if (Meteor._printSentDDP)
-        Meteor._debug("Sent DDP", DDPCommon.stringifyDDP(msg));
+        Meteor._debug("Sent DDP", stringMsg);
       if (!isIgnoredMsg) {
         self.sentCount++;
       }
-      self.socket.send(DDPCommon.stringifyDDP(msg));
+      self.socket.send(stringMsg);
     }
   },
 

--- a/packages/ejson/ejson.js
+++ b/packages/ejson/ejson.js
@@ -292,27 +292,17 @@ EJSON._adjustTypesToJSONValue = adjustTypesToJSONValue;
 // Only allocates new objects/arrays along paths that actually change,
 // returning the original reference when nothing needs conversion.
 const toJSONValueDeep = value => {
-  if (value === null || value === undefined) {
+  // Short-circuit for primitives that toJSONValueHelper can never match.
+  if (value === null || value === undefined
+      || typeof value === 'boolean'
+      || typeof value === 'string'
+      || (typeof value === 'number' && !isInfOrNaN(value))) {
     return value;
   }
 
-  // Atom-level conversion (Date, Binary, custom types, etc.)
-  const replaced = toJSONValueHelper(value);
-  if (replaced !== undefined) {
-    return replaced;
-  }
-
-  // Primitives that aren't Inf/NaN pass through unchanged.
-  if (typeof value !== 'object') {
-    // Inf/NaN are the only non-object values that need conversion,
-    // and toJSONValueHelper already handled them.
-    return value;
-  }
-
-  const isArray = Array.isArray(value);
-  let result = null; // stays null until first change detected
-
-  if (isArray) {
+  // Arrays can't be EJSON atoms, so process them directly.
+  if (Array.isArray(value)) {
+    let result = null;
     for (let i = 0; i < value.length; i++) {
       const child = value[i];
       const converted = toJSONValueDeep(child);
@@ -323,24 +313,33 @@ const toJSONValueDeep = value => {
         result.push(child);
       }
     }
-  } else {
-    const keys = keysOf(value);
-    for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
-      const child = value[key];
-      const converted = toJSONValueDeep(child);
-      if (converted !== child) {
-        if (result === null) {
-          result = {};
-          // backfill preceding keys
-          for (let j = 0; j < i; j++) {
-            result[keys[j]] = value[keys[j]];
-          }
+    return result ?? value;
+  }
+
+  // Atom-level conversion (Date, Binary, NaN/Inf, custom types, etc.)
+  const replaced = toJSONValueHelper(value);
+  if (replaced !== undefined) {
+    return replaced;
+  }
+
+  // Plain object: copy-on-write
+  const keys = keysOf(value);
+  let result = null;
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const child = value[key];
+    const converted = toJSONValueDeep(child);
+    if (converted !== child) {
+      if (result === null) {
+        result = {};
+        // backfill preceding keys
+        for (let j = 0; j < i; j++) {
+          result[keys[j]] = value[keys[j]];
         }
-        result[key] = converted;
-      } else if (result !== null) {
-        result[key] = child;
       }
+      result[key] = converted;
+    } else if (result !== null) {
+      result[key] = child;
     }
   }
 
@@ -418,16 +417,9 @@ const fromJSONValueDeep = value => {
     return value;
   }
 
-  // Check if this value itself is a JSON-encoded EJSON type (e.g. {$date: ...})
-  const replaced = fromJSONValueHelper(value);
-  if (replaced !== value) {
-    return replaced;
-  }
-
-  const isArray = Array.isArray(value);
-  let result = null;
-
-  if (isArray) {
+  // Arrays can't be EJSON-encoded types, so process them directly.
+  if (Array.isArray(value)) {
+    let result = null;
     for (let i = 0; i < value.length; i++) {
       const child = value[i];
       const converted = fromJSONValueDeep(child);
@@ -438,23 +430,31 @@ const fromJSONValueDeep = value => {
         result.push(child);
       }
     }
-  } else {
-    const keys = keysOf(value);
-    for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
-      const child = value[key];
-      const converted = fromJSONValueDeep(child);
-      if (converted !== child) {
-        if (result === null) {
-          result = {};
-          for (let j = 0; j < i; j++) {
-            result[keys[j]] = value[keys[j]];
-          }
+    return result ?? value;
+  }
+
+  // Check if this value itself is a JSON-encoded EJSON type (e.g. {$date: ...})
+  const replaced = fromJSONValueHelper(value);
+  if (replaced !== value) {
+    return replaced;
+  }
+
+  const keys = keysOf(value);
+  let result = null;
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const child = value[key];
+    const converted = fromJSONValueDeep(child);
+    if (converted !== child) {
+      if (result === null) {
+        result = {};
+        for (let j = 0; j < i; j++) {
+          result[keys[j]] = value[keys[j]];
         }
-        result[key] = converted;
-      } else if (result !== null) {
-        result[key] = child;
       }
+      result[key] = converted;
+    } else if (result !== null) {
+      result[key] = child;
     }
   }
 

--- a/packages/ejson/ejson_tests.js
+++ b/packages/ejson/ejson_tests.js
@@ -224,9 +224,7 @@ Tinytest.add('ejson - toJSONValue converts nested Dates', test => {
   const d = new Date('2024-01-01');
   const obj = {name: 'test', createdAt: d, meta: {updatedAt: d}};
   const result = EJSON.toJSONValue(obj);
-  test.equal(result.name, 'test');
-  test.equal(result.createdAt, {$date: d.getTime()});
-  test.equal(result.meta, {updatedAt: {$date: d.getTime()}});
+  test.equal(result, {name: 'test', createdAt: {$date: d.getTime()}, meta: {updatedAt: {$date: d.getTime()}}});
 });
 
 Tinytest.add('ejson - toJSONValue handles arrays', test => {
@@ -239,10 +237,7 @@ Tinytest.add('ejson - toJSONValue handles arrays', test => {
   const d = new Date();
   const arrWithDate = ['a', d, 'b'];
   const result2 = EJSON.toJSONValue(arrWithDate);
-  test.equal(result2[0], 'a');
-  test.equal(result2[1], {$date: d.getTime()});
-  test.equal(result2[2], 'b');
-  test.length(result2, 3);
+  test.equal(result2, ['a', {$date: d.getTime()}, 'b']);
 
   // Empty array
   test.equal(EJSON.toJSONValue([]), []);
@@ -251,17 +246,11 @@ Tinytest.add('ejson - toJSONValue handles arrays', test => {
 Tinytest.add('ejson - toJSONValue handles NaN/Infinity inside objects and arrays', test => {
   const obj = {a: 1, b: NaN, c: Infinity, d: -Infinity, e: 'normal'};
   const result = EJSON.toJSONValue(obj);
-  test.equal(result.a, 1);
-  test.equal(result.b, {$InfNaN: 0});
-  test.equal(result.c, {$InfNaN: 1});
-  test.equal(result.d, {$InfNaN: -1});
-  test.equal(result.e, 'normal');
+  test.equal(result, {a: 1, b: {$InfNaN: 0}, c: {$InfNaN: 1}, d: {$InfNaN: -1}, e: 'normal'});
 
   const arr = [NaN, 42, Infinity];
   const result2 = EJSON.toJSONValue(arr);
-  test.equal(result2[0], {$InfNaN: 0});
-  test.equal(result2[1], 42);
-  test.equal(result2[2], {$InfNaN: 1});
+  test.equal(result2, [{$InfNaN: 0}, 42, {$InfNaN: 1}]);
 });
 
 Tinytest.add('ejson - toJSONValue escapes $-prefixed keys that look like EJSON types', test => {


### PR DESCRIPTION
- Eliminate `EJSON.clone(msg)` in `DDPCommon.stringifyDDP` — every DDP message sent to every client was deep-cloned before serialization, purely to avoid mutating the caller's object. Replaced with a wire-format builder that reads the original message and uses `EJSON.toJSONValue` (copy-on-write from #14209) per field value.
- Add fast path for payload-free messages (`removed`, `ready`, `ping`, `pong`, `nosub`) — `JSON.stringify(msg)` directly, no field iteration.
- Fix double serialization in `Session.send()` — when `Meteor._printSentDDP` is enabled, `stringifyDDP` was called twice on the same message. Now serializes once and reuses the string.

**Depends on #14209** (EJSON copy-on-write `toJSONValue`/`fromJSONValue`).

## How it works

The old `stringifyDDP` did three things on every outgoing DDP message:

1. `EJSON.clone(msg)` — full deep clone of the entire message (strings, nested objects, Dates, everything)
2. `EJSON._adjustTypesToJSONValue(copy.fields)` — mutate the clone to convert EJSON types (Date to `{$date}`, etc.)
3. `JSON.stringify(copy)` — serialize to wire format

For 500 connected clients receiving the same document change, that's 500 deep clones producing the same string.

The new implementation:

1. **Fast path**: messages without `fields`/`params`/`result` (ping, pong, removed, ready) go straight to `JSON.stringify(msg)` — zero overhead.
2. **Normal path**: builds a wire-format object by iterating the original message's keys (no clone). Each field value is converted via `EJSON.toJSONValue()` which, after #14209, uses copy-on-write — returning the original reference for primitives and only allocating for subtrees containing EJSON types.
3. `cleared` field handling (moving `undefined` values to a `cleared` array) is done inline during the field iteration, not as a separate pass over a clone.

## Benchmark

500 clients x 1,000 iterations per message type:

| Message type | Before | After | Speedup |
|---|---|---|---|
| `changed` with cleared fields | 729 ms | 225 ms | **3.2x** |
| `changed` (all cleared) | 660 ms | 163 ms | **4.1x** |
| `added` (with Date) | 440 ms | 329 ms | **1.3x** |
| `added` (nested objects, no EJSON types) | 856 ms | 624 ms | **1.4x** |
| `method params` with Date | 442 ms | 313 ms | **1.4x** |
| `added` (20 fields, 1 Date) | 1164 ms | 968 ms | **1.2x** |
| `ping` / `ready` (common) | 66-118 ms | 48-84 ms | **1.3-1.4x** |

<details>
<summary>Test Script</summary>

```js
// Compares old stringifyDDP (EJSON.clone + mutate) vs new (zero-clone + COW).

'use strict';

// --- Minimal EJSON subset ---

const builtinConverters = [
  {
    matchObject(obj) { return obj instanceof Date; },
    toJSONValue(obj) { return { $date: obj.getTime() }; },
  },
  {
    matchObject(obj) { return obj instanceof RegExp; },
    toJSONValue(r) { return { $regexp: r.source, $flags: r.flags }; },
  },
  {
    matchObject(obj) { return Number.isNaN(obj) || obj === Infinity || obj === -Infinity; },
    toJSONValue(obj) {
      if (Number.isNaN(obj)) return { $InfNaN: 0 };
      return { $InfNaN: obj === Infinity ? 1 : -1 };
    },
  },
];

function toJSONValueHelper(item) {
  for (const c of builtinConverters) {
    if (c.matchObject(item)) return c.toJSONValue(item);
  }
  return undefined;
}

function clone(v) {
  if (v === null || typeof v !== 'object') return v;
  if (v instanceof Date) return new Date(v.getTime());
  if (v instanceof RegExp) return new RegExp(v.source, v.flags);
  if (Array.isArray(v)) return v.map(clone);
  const r = {};
  for (const k of Object.keys(v)) r[k] = clone(v[k]);
  return r;
}

// --- OLD: clone + mutate (current Meteor devel) ---

function adjustTypesInPlace(obj) {
  if (obj === null) return null;
  const mc = toJSONValueHelper(obj);
  if (mc !== undefined) return mc;
  if (typeof obj !== 'object') return obj;
  for (const key of Object.keys(obj)) {
    const value = obj[key];
    if (typeof value !== 'object' && value !== undefined &&
        !(Number.isNaN(value) || value === Infinity || value === -Infinity)) continue;
    const changed = toJSONValueHelper(value);
    if (changed) { obj[key] = changed; continue; }
    adjustTypesInPlace(value);
  }
  return obj;
}

function stringifyDDP_OLD(msg) {
  const copy = clone(msg);
  const hasOwn = Object.prototype.hasOwnProperty;

  if (hasOwn.call(msg, 'fields')) {
    const cleared = [];
    for (const key of Object.keys(msg.fields)) {
      if (typeof msg.fields[key] === 'undefined') {
        cleared.push(key);
        delete copy.fields[key];
      }
    }
    if (cleared.length > 0) copy.cleared = cleared;
    if (Object.keys(copy.fields).length === 0) delete copy.fields;
  }

  for (const field of ['fields', 'params', 'result']) {
    if (hasOwn.call(copy, field)) {
      copy[field] = adjustTypesInPlace(copy[field]);
    }
  }

  if (msg.id && typeof msg.id !== 'string') throw new Error("Message id is not a string");
  return JSON.stringify(copy);
}

// --- NEW: zero-clone + COW (this PR, depends on #14209 toJSONValue COW) ---

function toJSONValueCOW(value) {
  if (value === null || value === undefined) return value;
  const replaced = toJSONValueHelper(value);
  if (replaced !== undefined) return replaced;
  if (typeof value !== 'object') return value;

  const isArray = Array.isArray(value);
  let result = null;

  if (isArray) {
    for (let i = 0; i < value.length; i++) {
      const child = value[i];
      const converted = toJSONValueCOW(child);
      if (converted !== child) {
        result ??= value.slice(0, i);
        result.push(converted);
      } else if (result !== null) {
        result.push(child);
      }
    }
  } else {
    const keys = Object.keys(value);
    for (let i = 0; i < keys.length; i++) {
      const key = keys[i];
      const child = value[key];
      const converted = toJSONValueCOW(child);
      if (converted !== child) {
        if (result === null) {
          result = {};
          for (let j = 0; j < i; j++) result[keys[j]] = value[keys[j]];
        }
        result[key] = converted;
      } else if (result !== null) {
        result[key] = child;
      }
    }
  }
  return result ?? value;
}

function stringifyDDP_NEW(msg) {
  if (msg.id && typeof msg.id !== 'string') throw new Error("Message id is not a string");
  const hasOwn = Object.prototype.hasOwnProperty;

  const hasFields = hasOwn.call(msg, 'fields');
  const hasParams = hasOwn.call(msg, 'params');
  const hasResult = hasOwn.call(msg, 'result');

  if (!hasFields && !hasParams && !hasResult) return JSON.stringify(msg);

  const wire = {};
  for (const key of Object.keys(msg)) {
    if (key === 'fields' || key === 'params' || key === 'result') continue;
    wire[key] = msg[key];
  }

  if (hasFields) {
    const cleared = [];
    const wireFields = {};
    let hasAnyField = false;
    for (const key of Object.keys(msg.fields)) {
      const value = msg.fields[key];
      if (typeof value === 'undefined') {
        cleared.push(key);
      } else {
        wireFields[key] = toJSONValueCOW(value);
        hasAnyField = true;
      }
    }
    if (hasAnyField) wire.fields = wireFields;
    if (cleared.length > 0) wire.cleared = cleared;
  }

  if (hasParams) wire.params = toJSONValueCOW(msg.params);
  if (hasResult) wire.result = toJSONValueCOW(msg.result);

  return JSON.stringify(wire);
}

// --- Test messages ---

const messages = {
  'removed (no fields)':
    { msg: 'removed', collection: 'posts', id: 'abc123' },
  'added (primitives only)':
    { msg: 'added', collection: 'posts', id: 'abc123',
      fields: { title: 'Hello World', count: 42, active: true, tags: 'news' } },
  'added (with Date)':
    { msg: 'added', collection: 'posts', id: 'abc123',
      fields: { title: 'Hello', count: 42, createdAt: new Date(1700000000000) } },
  'changed (1 primitive field)':
    { msg: 'changed', collection: 'posts', id: 'abc123',
      fields: { count: 43 } },
  'changed (with cleared)':
    { msg: 'changed', collection: 'posts', id: 'abc123',
      fields: { title: 'Updated', oldField: undefined } },
  'changed (all cleared)':
    { msg: 'changed', collection: 'posts', id: 'abc123',
      fields: { removed1: undefined, removed2: undefined } },
  'added (20 fields, 1 Date)':
    { msg: 'added', collection: 'users', id: 'user1',
      fields: Object.fromEntries([
        ...Array.from({ length: 19 }, (_, i) => [`field${i}`, `value${i}`]),
        ['createdAt', new Date(1700000000000)]
      ]) },
  'added (nested objects, no EJSON types)':
    { msg: 'added', collection: 'orders', id: 'order1',
      fields: {
        customer: { name: 'Alice', email: 'alice@example.com' },
        items: [{ sku: 'A1', qty: 2, price: 9.99 }, { sku: 'B2', qty: 1, price: 24.99 }],
        total: 44.97, status: 'pending'
      } },
  'method result':
    { msg: 'result', id: '5', result: { success: true, insertedId: 'xyz789' } },
  'method params with Date':
    { msg: 'method', method: 'updatePost', id: '7',
      params: [{ title: 'New Title', updatedAt: new Date(1700000000000) }] },
  'ping':
    { msg: 'ping' },
  'ready':
    { msg: 'ready', subs: ['sub1', 'sub2'] },
};

// --- Correctness ---

console.log('=== Correctness ===\n');
let allCorrect = true;
for (const [name, msg] of Object.entries(messages)) {
  const a = stringifyDDP_OLD(msg);
  const b = stringifyDDP_NEW(msg);
  if (a !== b) {
    console.log(`MISMATCH: ${name}\n  OLD: ${a}\n  NEW: ${b}`);
    allCorrect = false;
  }
}
console.log(allCorrect ? 'All messages produce identical output.\n' : '\nFAILED!\n');
if (!allCorrect) process.exit(1);

// --- Benchmark ---

const CLIENTS = 500;
const ITERS = 1000;

console.log(`=== Benchmark (${CLIENTS} clients x ${ITERS} iterations) ===\n`);

for (const [name, msg] of Object.entries(messages)) {
  for (let i = 0; i < 200; i++) { stringifyDDP_OLD(msg); stringifyDDP_NEW(msg); }

  const t0 = performance.now();
  for (let c = 0; c < CLIENTS; c++) for (let i = 0; i < ITERS; i++) stringifyDDP_OLD(msg);
  const oldMs = performance.now() - t0;

  const t1 = performance.now();
  for (let c = 0; c < CLIENTS; c++) for (let i = 0; i < ITERS; i++) stringifyDDP_NEW(msg);
  const newMs = performance.now() - t1;

  const speedup = (oldMs / newMs).toFixed(2);
  const pct = ((1 - newMs / oldMs) * 100).toFixed(1);
  console.log(
    `${name.padEnd(45)} OLD: ${oldMs.toFixed(0).padStart(6)}ms` +
    `  NEW: ${newMs.toFixed(0).padStart(6)}ms  ${speedup}x (${pct}% faster)`
  );
}
```

</details>
