### PR TITLE
Add node:test driver POC (node-test-in-console)

### DIFF
--- a/packages/node-test-in-console/package.js
+++ b/packages/node-test-in-console/package.js
@@ -1,0 +1,10 @@
+Package.describe({
+  name: 'node-test-in-console',
+  summary: 'Test driver using the Node.js native test runner (node:test)',
+  version: '1.0.0',
+});
+
+Package.onUse(function (api) {
+  api.use('ecmascript', 'server');
+  api.addFiles('server.js', 'server');
+});

--- a/packages/node-test-in-console/server.js
+++ b/packages/node-test-in-console/server.js
@@ -8,62 +8,206 @@
 // (HTTP server, Mongo), node:test never fires `beforeExit` so it never
 // writes its final summary or sets process.exitCode.
 //
-// Strategy: detect node:test output (TAP or spec), track failures,
-// debounce — when stdout goes quiet for 2s after test output, exit
-// with the right code.
-
-const nodeTestMarkers = [
-  'TAP version',      // TAP reporter
-  /^[▶✔✕✗⚠●○─]/m,  // spec reporter symbols
-  /^ok \d/m,           // TAP ok line
-  /^not ok \d/m,       // TAP failure line
-];
-
-const failureMarkers = [
-  /^not ok /m,   // TAP failure
-  /^[✖✕✗]/m,    // spec reporter failure symbols
-  /^\s+[✖✕✗]/m, // indented spec failures
-];
+// Strategy: intercept TAP output, parse it into compact colored lines,
+// debounce — when stdout goes quiet for 2s after test output, print
+// summary and exit with the right code.
+//
+// Set NODE_TEST_VERBOSE=1 for raw TAP output.
 
 const originalWrite = process.stdout.write.bind(process.stdout);
-let sawNodeTest = false;
-let debounceTimer = null;
-let failures = 0;
+const verbose = process.env.NODE_TEST_VERBOSE === '1';
 
-function isNodeTestOutput(str) {
-  return nodeTestMarkers.some(m =>
-    typeof m === 'string' ? str.includes(m) : m.test(str)
-  );
+// --- ANSI colors ---
+const c = {
+  green:  s => `\x1b[32m${s}\x1b[0m`,
+  red:    s => `\x1b[31m${s}\x1b[0m`,
+  yellow: s => `\x1b[33m${s}\x1b[0m`,
+  gray:   s => `\x1b[90m${s}\x1b[0m`,
+  bold:   s => `\x1b[1m${s}\x1b[0m`,
+  cyan:   s => `\x1b[36m${s}\x1b[0m`,
+};
+
+// --- TAP parser state ---
+let sawTAP = false;
+let debounceTimer = null;
+let inYamlBlock = false;
+let pendingError = null;
+
+// Top-level suite tracking
+let currentSuite = null;
+const suites = [];
+
+// Global counters
+let totalPassed = 0;
+let totalFailed = 0;
+let totalSkipped = 0;
+let totalTodo = 0;
+
+function newSuite(name) {
+  return { name, passed: 0, failed: 0, skipped: 0, todo: 0, errors: [], duration: null };
 }
 
-function countFailures(str) {
-  return failureMarkers.reduce((count, m) => {
-    const matches = str.match(new RegExp(m.source, 'gm'));
-    return count + (matches ? matches.length : 0);
-  }, 0);
+function flushSuite() {
+  if (!currentSuite) return;
+  suites.push(currentSuite);
+
+  const s = currentSuite;
+  const total = s.passed + s.failed + s.skipped + s.todo;
+  const parts = [];
+
+  if (s.passed)  parts.push(c.green(`${s.passed} passed`));
+  if (s.failed)  parts.push(c.red(`${s.failed} failed`));
+  if (s.skipped) parts.push(c.yellow(`${s.skipped} skipped`));
+  if (s.todo)    parts.push(c.gray(`${s.todo} todo`));
+
+  const dur = s.duration !== null ? c.gray(` (${s.duration}ms)`) : '';
+  let icon, name;
+  if (s.failed > 0) {
+    icon = c.red('✗');
+    name = c.red(s.name);
+  } else if (total === 0) {
+    // Suite with no counted tests (e.g. describe.skip with no individual results)
+    icon = c.yellow('⊘');
+    name = c.yellow(s.name);
+    if (!parts.length) parts.push(c.yellow('skipped'));
+  } else if (s.passed === 0 && s.skipped > 0) {
+    icon = c.yellow('⊘');
+    name = c.yellow(s.name);
+  } else {
+    icon = c.green('✓');
+    name = s.name;
+  }
+
+  originalWrite(`  ${icon} ${name}  ${parts.join(', ')}${dur}\n`);
+
+  // Print errors inline
+  for (const err of s.errors) {
+    originalWrite(`    ${c.red('→')} ${c.red(err)}\n`);
+  }
+
+  totalPassed  += s.passed;
+  totalFailed  += s.failed;
+  totalSkipped += s.skipped;
+  totalTodo    += s.todo;
+  currentSuite = null;
+}
+
+function parseTAPLine(line) {
+  // YAML metadata block (--- / ... delimiters)
+  if (/^\s+---\s*$/.test(line)) {
+    inYamlBlock = true;
+    return;
+  }
+  if (/^\s+\.\.\.\s*$/.test(line)) {
+    inYamlBlock = false;
+    // Capture error from yaml block
+    if (pendingError && currentSuite) {
+      currentSuite.errors.push(pendingError);
+      pendingError = null;
+    }
+    return;
+  }
+  if (inYamlBlock) {
+    // Capture duration for top-level suites
+    const durMatch = line.match(/^\s+duration_ms:\s+([\d.]+)/);
+    if (durMatch && currentSuite) {
+      currentSuite.duration = Math.round(parseFloat(durMatch[1]));
+    }
+    // Capture error message
+    const errMatch = line.match(/^\s+error:\s+'?(.*?)'?\s*$/);
+    if (errMatch) {
+      pendingError = errMatch[1];
+    }
+    return;
+  }
+
+  // TAP version header
+  if (line.startsWith('TAP version')) return;
+
+  // Plan line (1..N)
+  if (/^\s*1\.\.\d+/.test(line)) return;
+
+  // Top-level suite start: "# Subtest: Name" (no leading spaces)
+  const topSubtest = line.match(/^# Subtest: (.+)/);
+  if (topSubtest) {
+    flushSuite();
+    currentSuite = newSuite(topSubtest[1]);
+    return;
+  }
+
+  // Nested subtest (indented = individual test within a suite)
+  const nestedSubtest = line.match(/^\s+# Subtest: /);
+  if (nestedSubtest) return; // just a header, result comes on ok/not ok
+
+  // Test result lines — count only leaf tests (indented)
+  const okMatch = line.match(/^(\s+)ok \d+ - (.+)/);
+  if (okMatch) {
+    if (!currentSuite) return;
+    const name = okMatch[2];
+    if (name.includes('# SKIP'))      currentSuite.skipped++;
+    else if (name.includes('# TODO')) currentSuite.todo++;
+    else                              currentSuite.passed++;
+    return;
+  }
+
+  const notOkMatch = line.match(/^(\s+)not ok \d+ - (.+)/);
+  if (notOkMatch) {
+    if (!currentSuite) return;
+    currentSuite.failed++;
+    return;
+  }
+
+  // Top-level ok/not ok (suite summary) — triggers duration capture
+  if (/^ok \d+ - /.test(line) || /^not ok \d+ - /.test(line)) {
+    // duration is in the yaml block that follows
+    return;
+  }
 }
 
 process.stdout.write = function (chunk, encoding, cb) {
-  const result = originalWrite(chunk, encoding, cb);
   const str = typeof chunk === 'string' ? chunk : chunk.toString();
 
-  if (!sawNodeTest && isNodeTestOutput(str)) {
-    sawNodeTest = true;
+  if (!sawTAP && str.includes('TAP version')) {
+    sawTAP = true;
+    originalWrite(`\n${c.bold('node:test')} ${c.gray('results')}\n\n`);
   }
 
-  if (sawNodeTest) {
-    failures += countFailures(str);
+  if (sawTAP) {
+    // In verbose mode, also print raw TAP
+    if (verbose) originalWrite(chunk, encoding);
+
+    // Parse line by line
+    for (const line of str.split('\n')) {
+      parseTAPLine(line);
+    }
 
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
-      console.log(`\n[node-test-in-console] tests complete. ${failures ? 'FAILURES: ' + failures : 'ALL PASSED'}`);
-      process.exit(failures > 0 ? 1 : 0);
+      flushSuite(); // flush last suite
+
+      // Summary
+      const total = totalPassed + totalFailed + totalSkipped + totalTodo;
+      originalWrite('\n' + c.bold('  Summary: '));
+
+      const parts = [];
+      if (totalPassed)  parts.push(c.green(`${totalPassed} passed`));
+      if (totalFailed)  parts.push(c.red(`${totalFailed} failed`));
+      if (totalSkipped) parts.push(c.yellow(`${totalSkipped} skipped`));
+      if (totalTodo)    parts.push(c.gray(`${totalTodo} todo`));
+      originalWrite(parts.join(c.gray(', ')) + c.gray(` (${total} tests)`) + '\n\n');
+
+      process.exit(totalFailed > 0 ? 1 : 0);
     }, 2000);
+
+    // Don't forward TAP to stdout (we print our own format)
+    if (typeof cb === 'function') cb();
+    return true;
   }
 
-  return result;
+  // Non-TAP output: pass through normally
+  return originalWrite(chunk, encoding, cb);
 };
 
 Meteor.startup(() => {
-  console.log('[node-test-in-console] waiting for node:test to complete...');
+  originalWrite(c.gray('[node-test-in-console] waiting for node:test...\n'));
 });

--- a/packages/node-test-in-console/server.js
+++ b/packages/node-test-in-console/server.js
@@ -1,0 +1,69 @@
+// Minimal driver for node:test.
+//
+// Package test files should `import { describe, it } from 'node:test'`
+// and `import assert from 'node:assert/strict'`.
+//
+// node:test queues tests at import time and runs them after the
+// microtask queue drains.  Because Meteor keeps the event loop alive
+// (HTTP server, Mongo), node:test never fires `beforeExit` so it never
+// writes its final summary or sets process.exitCode.
+//
+// Strategy: detect node:test output (TAP or spec), track failures,
+// debounce — when stdout goes quiet for 2s after test output, exit
+// with the right code.
+
+const nodeTestMarkers = [
+  'TAP version',      // TAP reporter
+  /^[▶✔✕✗⚠●○─]/m,  // spec reporter symbols
+  /^ok \d/m,           // TAP ok line
+  /^not ok \d/m,       // TAP failure line
+];
+
+const failureMarkers = [
+  /^not ok /m,   // TAP failure
+  /^[✖✕✗]/m,    // spec reporter failure symbols
+  /^\s+[✖✕✗]/m, // indented spec failures
+];
+
+const originalWrite = process.stdout.write.bind(process.stdout);
+let sawNodeTest = false;
+let debounceTimer = null;
+let failures = 0;
+
+function isNodeTestOutput(str) {
+  return nodeTestMarkers.some(m =>
+    typeof m === 'string' ? str.includes(m) : m.test(str)
+  );
+}
+
+function countFailures(str) {
+  return failureMarkers.reduce((count, m) => {
+    const matches = str.match(new RegExp(m.source, 'gm'));
+    return count + (matches ? matches.length : 0);
+  }, 0);
+}
+
+process.stdout.write = function (chunk, encoding, cb) {
+  const result = originalWrite(chunk, encoding, cb);
+  const str = typeof chunk === 'string' ? chunk : chunk.toString();
+
+  if (!sawNodeTest && isNodeTestOutput(str)) {
+    sawNodeTest = true;
+  }
+
+  if (sawNodeTest) {
+    failures += countFailures(str);
+
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      console.log(`\n[node-test-in-console] tests complete. ${failures ? 'FAILURES: ' + failures : 'ALL PASSED'}`);
+      process.exit(failures > 0 ? 1 : 0);
+    }, 2000);
+  }
+
+  return result;
+};
+
+Meteor.startup(() => {
+  console.log('[node-test-in-console] waiting for node:test to complete...');
+});

--- a/packages/node-test-poc/README.md
+++ b/packages/node-test-poc/README.md
@@ -1,0 +1,112 @@
+# node-test-poc — Node.js Native Test Runner POC
+
+Demonstrates that Node.js 22+ `node:test` covers all major testing features
+without external dependencies. Each file targets a specific capability.
+
+## Quick Start
+
+```bash
+# Run all POC tests
+meteor test-packages ./packages/node-test-poc \
+  --driver-package node-test-in-console \
+  --once
+```
+
+## Feature Demos
+
+### 1. Basic (tests.js)
+Standard `describe`/`it` with `assert` — the baseline.
+
+### 2. Mocking (tests-mock.js)
+```bash
+# No special flags needed — mocking is built-in
+# Demonstrates: mock.fn(), mock.method(), mock.timers (setTimeout, setInterval, Date)
+```
+**Jest equivalent:** `jest.fn()`, `jest.spyOn()`, `jest.useFakeTimers()`
+
+### 3. Code Coverage (tests-coverage.js)
+```bash
+SERVER_NODE_OPTIONS='--experimental-test-coverage' \
+  meteor test-packages ./packages/node-test-poc \
+  --driver-package node-test-in-console --once
+```
+Outputs line/branch/function coverage table. Intentionally leaves some branches
+uncovered to show the report.
+
+**Jest equivalent:** `jest --coverage`
+
+### 4. Snapshot Testing (tests-snapshot.js)
+```bash
+# First run — generate snapshots:
+SERVER_NODE_OPTIONS='--experimental-test-snapshots --test-update-snapshots' \
+  meteor test-packages ...
+
+# Subsequent runs — verify against snapshots:
+SERVER_NODE_OPTIONS='--experimental-test-snapshots' \
+  meteor test-packages ...
+```
+Snapshots stored in `.snapshot` file next to tests.
+
+**Jest equivalent:** `expect(x).toMatchSnapshot()`
+
+### 5. Advanced Filtering (tests-filtering.js)
+```bash
+# Run only "validation" tests:
+SERVER_NODE_OPTIONS='--test-name-pattern="validation"' meteor test-packages ...
+
+# Run only tests marked with it.only:
+SERVER_NODE_OPTIONS='--test-only' meteor test-packages ...
+
+# Exclude slow tests:
+SERVER_NODE_OPTIONS='--test-name-pattern="^(?!.*slow)"' meteor test-packages ...
+```
+Also demonstrates `it.skip()`, `it.todo()`, `it.only()`.
+
+**Jest equivalent:** `jest --testNamePattern`, `it.only()`, `it.skip()`, `it.todo()`
+
+### 6. Performance — Parallel & Sharding (tests-perf.js)
+```bash
+# Parallel tests within suites (concurrency option — no flags needed)
+
+# Sharding across CI jobs:
+# Job 1: SERVER_NODE_OPTIONS='--test-shard=1/3' meteor test-packages ...
+# Job 2: SERVER_NODE_OPTIONS='--test-shard=2/3' meteor test-packages ...
+# Job 3: SERVER_NODE_OPTIONS='--test-shard=3/3' meteor test-packages ...
+```
+Demonstrates `{ concurrency: N }`, `{ timeout: ms }`, nested concurrency control.
+
+**Jest equivalent:** `jest --maxWorkers`, `jest --shard`
+
+### 7. Multiple & Custom Reporters (tests-reporters.js)
+```bash
+# TAP format:
+SERVER_NODE_OPTIONS='--test-reporter=tap' meteor test-packages ...
+
+# Dot reporter:
+SERVER_NODE_OPTIONS='--test-reporter=dot' meteor test-packages ...
+
+# JUnit XML (CI integration):
+SERVER_NODE_OPTIONS='--test-reporter=junit' meteor test-packages ...
+
+# Multiple reporters simultaneously:
+SERVER_NODE_OPTIONS='--test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=./results.xml' \
+  meteor test-packages ...
+```
+Includes a custom reporter example in comments.
+
+**Jest equivalent:** `jest --reporters`
+
+## Feature Comparison
+
+| Feature | node:test (Node 22+) | Jest |
+|---------|---------------------|------|
+| `describe`/`it`/`assert` | Built-in | Built-in |
+| Mocking | `mock.fn()`, `mock.method()`, `mock.timers` | `jest.fn()`, `jest.spyOn()`, `jest.useFakeTimers()` |
+| Code coverage | `--experimental-test-coverage` (V8) | `--coverage` (V8 via babel) |
+| Snapshots | `t.assert.snapshot()` | `toMatchSnapshot()` |
+| Filtering | `--test-name-pattern`, `skip`/`only`/`todo` | `--testNamePattern`, `skip`/`only`/`todo` |
+| Parallel | `{ concurrency: N }` per suite | `--maxWorkers` (process-level) |
+| Sharding | `--test-shard=N/M` | `--shard=N/M` |
+| Reporters | spec, TAP, dot, JUnit, lcov, custom | jest-junit, custom |
+| External deps | **Zero** | jest + babel + transformers |
+| isobuild compatible | **Yes** (native `node:` imports) | **No** (own module resolution) |

--- a/packages/node-test-poc/main.js
+++ b/packages/node-test-poc/main.js
@@ -1,0 +1,1 @@
+// Placeholder — this package exists only to test node:test integration.

--- a/packages/node-test-poc/package.js
+++ b/packages/node-test-poc/package.js
@@ -1,0 +1,17 @@
+Package.describe({
+  name: 'node-test-poc',
+  summary: 'POC: test a Meteor package with node:test',
+  version: '0.0.1',
+  testOnly: true,
+});
+
+Package.onUse(function (api) {
+  api.use('ecmascript', 'server');
+  api.mainModule('main.js', 'server');
+});
+
+Package.onTest(function (api) {
+  api.use(['ecmascript', 'random'], 'server');
+  // NO tinytest — using node:test instead
+  api.addFiles('tests.js', 'server');
+});

--- a/packages/node-test-poc/package.js
+++ b/packages/node-test-poc/package.js
@@ -13,5 +13,13 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   api.use(['ecmascript', 'random'], 'server');
   // NO tinytest — using node:test instead
-  api.addFiles('tests.js', 'server');
+  api.addFiles([
+    'tests.js',            // Basic: assert + describe/it
+    'tests-mock.js',       // Mocking: mock.fn(), mock.method(), mock.timers
+    'tests-coverage.js',   // Coverage: branching code (run with --experimental-test-coverage)
+    'tests-snapshot.js',   // Snapshots: t.assert.snapshot() (run with --experimental-test-snapshots)
+    'tests-filtering.js',  // Filtering: skip, todo, only, name patterns
+    'tests-perf.js',       // Perf: concurrency, timeouts, sharding
+    'tests-reporters.js',  // Reporters: spec, TAP, dot, JUnit, custom
+  ], 'server');
 });

--- a/packages/node-test-poc/tests-coverage.js
+++ b/packages/node-test-poc/tests-coverage.js
@@ -1,0 +1,94 @@
+// POC: node:test native code coverage
+// Run with: SERVER_NODE_OPTIONS='--experimental-test-coverage'
+// Equivalent to Jest's --coverage (uses V8 coverage under the hood, same as c8/istanbul)
+// Docs: https://nodejs.org/api/test.html#collecting-code-coverage
+//
+// Output includes:
+// - Line, branch, and function coverage percentages
+// - Uncovered line numbers
+// - Summary table (like Istanbul/nyc)
+//
+// CI integration: combine with --test-reporter=lcov for machine-readable output
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// --- Module under test (inline for POC) ---
+
+function classifyTemperature(celsius) {
+  if (celsius < 0) return 'freezing';
+  if (celsius < 15) return 'cold';
+  if (celsius < 25) return 'comfortable';
+  if (celsius < 35) return 'warm';
+  return 'hot';
+}
+
+function formatUser(user) {
+  const name = user.name || 'Anonymous';
+  const role = user.admin ? 'Admin' : 'User';
+  const badge = user.verified ? ' ✓' : '';
+  return `${role}: ${name}${badge}`;
+}
+
+function parsePort(value) {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed)) throw new Error(`Invalid port: ${value}`);
+    return parsed;
+  }
+  throw new TypeError(`Expected string or number, got ${typeof value}`);
+}
+
+// --- Tests: intentionally cover most but not all branches ---
+// Coverage report will show which branches are missed
+
+describe('Coverage — classifyTemperature', () => {
+  it('should return freezing for negative', () => {
+    assert.strictEqual(classifyTemperature(-10), 'freezing');
+  });
+
+  it('should return cold for 0-14', () => {
+    assert.strictEqual(classifyTemperature(10), 'cold');
+  });
+
+  it('should return comfortable for 15-24', () => {
+    assert.strictEqual(classifyTemperature(22), 'comfortable');
+  });
+
+  // Intentionally skip 'warm' and 'hot' — coverage will flag these
+});
+
+describe('Coverage — formatUser', () => {
+  it('should format basic user', () => {
+    assert.strictEqual(formatUser({ name: 'Ada' }), 'User: Ada');
+  });
+
+  it('should format admin', () => {
+    assert.strictEqual(formatUser({ name: 'Bob', admin: true }), 'Admin: Bob');
+  });
+
+  it('should handle missing name', () => {
+    assert.strictEqual(formatUser({}), 'User: Anonymous');
+  });
+
+  it('should show verified badge', () => {
+    assert.strictEqual(formatUser({ name: 'Eve', verified: true }), 'User: Eve ✓');
+  });
+});
+
+describe('Coverage — parsePort', () => {
+  it('should pass through numbers', () => {
+    assert.strictEqual(parsePort(3000), 3000);
+  });
+
+  it('should parse string ports', () => {
+    assert.strictEqual(parsePort('8080'), 8080);
+  });
+
+  it('should throw on invalid string', () => {
+    assert.throws(() => parsePort('abc'), { message: 'Invalid port: abc' });
+  });
+
+  // Intentionally skip TypeError branch — coverage will show it
+});

--- a/packages/node-test-poc/tests-filtering.js
+++ b/packages/node-test-poc/tests-filtering.js
@@ -1,0 +1,85 @@
+// POC: node:test advanced filtering capabilities
+// Equivalent to Jest's --testNamePattern, it.only, it.skip, it.todo
+// Docs: https://nodejs.org/api/test.html#filtering-tests-by-name
+//
+// Run examples:
+//   All tests:          (no special flags)
+//   By name pattern:    SERVER_NODE_OPTIONS='--test-name-pattern="validation"'
+//   Only tests:         SERVER_NODE_OPTIONS='--test-only'
+//   Skip slow tests:    SERVER_NODE_OPTIONS='--test-name-pattern="^(?!.*slow)"'
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// --- Feature: describe/it.skip — mark tests to skip ---
+
+describe('Filtering — skip', () => {
+  it('should run this test', () => {
+    assert.ok(true);
+  });
+
+  it.skip('should be skipped (not implemented yet)', () => {
+    // This test is skipped — shown as "skipped" in the report
+    assert.fail('this should never run');
+  });
+
+  it('should also run', () => {
+    assert.strictEqual(1 + 1, 2);
+  });
+});
+
+// --- Feature: describe/it.todo — placeholder tests ---
+
+describe('Filtering — todo', () => {
+  it('should pass', () => {
+    assert.ok(true);
+  });
+
+  it.todo('implement rate limiting validation');
+  it.todo('add edge case for empty input');
+  // todo tests show up in the report as "TODO" — great for planning
+});
+
+// --- Feature: it.only — focus on specific tests ---
+// Requires: SERVER_NODE_OPTIONS='--test-only'
+
+describe('Filtering — only (requires --test-only flag)', () => {
+  it('this runs normally without --test-only', () => {
+    assert.ok(true);
+  });
+
+  it.only('with --test-only flag, ONLY this test runs in this suite', () => {
+    assert.ok(true);
+  });
+
+  it('this is also skipped when --test-only is set', () => {
+    assert.ok(true);
+  });
+});
+
+// --- Feature: --test-name-pattern filtering ---
+// Tests with descriptive names for pattern matching
+
+describe('Filtering — name patterns', () => {
+  it('validation: should reject empty string', () => {
+    assert.throws(() => { if (!'' ) throw new Error('empty'); });
+  });
+
+  it('validation: should reject null', () => {
+    assert.throws(() => { if (null === null) throw new Error('null'); });
+  });
+
+  it('formatting: should trim whitespace', () => {
+    assert.strictEqual('  hello  '.trim(), 'hello');
+  });
+
+  it('formatting: should lowercase', () => {
+    assert.strictEqual('HELLO'.toLowerCase(), 'hello');
+  });
+
+  it('slow: heavy computation simulation', async () => {
+    // With --test-name-pattern="^(?!.*slow)" this test is excluded
+    await new Promise(r => setTimeout(r, 10));
+    assert.ok(true);
+  });
+});

--- a/packages/node-test-poc/tests-mock.js
+++ b/packages/node-test-poc/tests-mock.js
@@ -1,0 +1,92 @@
+// POC: node:test built-in mocking capabilities
+// Equivalent to Jest's jest.fn(), jest.spyOn(), jest.useFakeTimers()
+// Docs: https://nodejs.org/api/test.html#mocking
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('Mocking — mock.fn() (like jest.fn())', () => {
+  it('should create a mock function and track calls', () => {
+    const fn = mock.fn((a, b) => a + b);
+
+    fn(1, 2);
+    fn(3, 4);
+
+    assert.strictEqual(fn.mock.callCount(), 2);
+    assert.deepStrictEqual(fn.mock.calls[0].arguments, [1, 2]);
+    assert.strictEqual(fn.mock.calls[0].result, 3);
+    assert.deepStrictEqual(fn.mock.calls[1].arguments, [3, 4]);
+    assert.strictEqual(fn.mock.calls[1].result, 7);
+  });
+
+  it('should allow changing mock implementation', () => {
+    const fn = mock.fn(() => 'original');
+    assert.strictEqual(fn(), 'original');
+
+    fn.mock.mockImplementation(() => 'replaced');
+    assert.strictEqual(fn(), 'replaced');
+
+    fn.mock.restore();
+    assert.strictEqual(fn(), 'original');
+  });
+});
+
+describe('Mocking — mock.method() (like jest.spyOn())', () => {
+  it('should spy on an object method', (t) => {
+    const obj = {
+      greet(name) { return `Hello, ${name}!`; },
+    };
+
+    t.mock.method(obj, 'greet');
+
+    obj.greet('Meteor');
+    obj.greet('Node');
+
+    assert.strictEqual(obj.greet.mock.callCount(), 2);
+    assert.deepStrictEqual(obj.greet.mock.calls[0].arguments, ['Meteor']);
+    assert.strictEqual(obj.greet.mock.calls[0].result, 'Hello, Meteor!');
+  });
+
+  it('should replace a method and restore it', (t) => {
+    const service = {
+      fetchData() { return 'real-data'; },
+    };
+
+    t.mock.method(service, 'fetchData', () => 'mocked-data');
+    assert.strictEqual(service.fetchData(), 'mocked-data');
+
+    service.fetchData.mock.restore();
+    assert.strictEqual(service.fetchData(), 'real-data');
+  });
+});
+
+describe('Mocking — mock.timers (like jest.useFakeTimers())', () => {
+  it('should control setTimeout', (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+
+    let called = false;
+    setTimeout(() => { called = true; }, 5000);
+
+    assert.strictEqual(called, false);
+    t.mock.timers.tick(5000);
+    assert.strictEqual(called, true);
+  });
+
+  it('should control setInterval', (t) => {
+    t.mock.timers.enable({ apis: ['setInterval'] });
+
+    let count = 0;
+    setInterval(() => { count++; }, 1000);
+
+    t.mock.timers.tick(3500);
+    assert.strictEqual(count, 3);
+  });
+
+  it('should control Date.now()', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T00:00:00Z') });
+
+    assert.strictEqual(new Date().toISOString(), '2025-01-01T00:00:00.000Z');
+    t.mock.timers.tick(60_000);
+    assert.strictEqual(new Date().toISOString(), '2025-01-01T00:01:00.000Z');
+  });
+});

--- a/packages/node-test-poc/tests-perf.js
+++ b/packages/node-test-poc/tests-perf.js
@@ -1,0 +1,113 @@
+// POC: node:test parallel execution and performance features
+// Equivalent to Jest's --maxWorkers, --shard
+// Docs: https://nodejs.org/api/test.html#test-runner-execution-model
+//
+// Key features:
+//   Concurrency:  describe('suite', { concurrency: 4 }, ...) or it('test', { concurrency: true })
+//   Sharding:     SERVER_NODE_OPTIONS='--test-shard=1/3'  (run shard 1 of 3)
+//   Timeout:      it('test', { timeout: 5000 }, ...)
+//
+// In a Meteor CI pipeline, sharding splits tests across parallel CI jobs:
+//   Job 1: SERVER_NODE_OPTIONS='--test-shard=1/3'
+//   Job 2: SERVER_NODE_OPTIONS='--test-shard=2/3'
+//   Job 3: SERVER_NODE_OPTIONS='--test-shard=3/3'
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// --- Feature: concurrency within a suite ---
+
+describe('Perf — concurrent tests', { concurrency: 4 }, () => {
+  // These 4 async tests run in parallel instead of sequentially.
+  // Total time ≈ 100ms instead of 400ms.
+
+  it('async task A (100ms)', async () => {
+    const start = Date.now();
+    await new Promise(r => setTimeout(r, 100));
+    assert.ok(Date.now() - start >= 95);
+  });
+
+  it('async task B (100ms)', async () => {
+    const start = Date.now();
+    await new Promise(r => setTimeout(r, 100));
+    assert.ok(Date.now() - start >= 95);
+  });
+
+  it('async task C (100ms)', async () => {
+    const start = Date.now();
+    await new Promise(r => setTimeout(r, 100));
+    assert.ok(Date.now() - start >= 95);
+  });
+
+  it('async task D (100ms)', async () => {
+    const start = Date.now();
+    await new Promise(r => setTimeout(r, 100));
+    assert.ok(Date.now() - start >= 95);
+  });
+});
+
+// --- Feature: timeout per test ---
+
+describe('Perf — test timeouts', () => {
+  it('should complete within timeout', { timeout: 1000 }, async () => {
+    await new Promise(r => setTimeout(r, 50));
+    assert.ok(true);
+  });
+
+  // Uncomment to see timeout failure:
+  // it('should fail due to timeout', { timeout: 50 }, async () => {
+  //   await new Promise(r => setTimeout(r, 200));
+  // });
+});
+
+// --- Feature: sharding demonstration ---
+// These tests have distinct names so sharding splits them predictably.
+// Run with --test-shard=1/3, --test-shard=2/3, --test-shard=3/3
+
+describe('Perf — shard-friendly suites (group A)', () => {
+  it('shard test A1', () => assert.ok(true));
+  it('shard test A2', () => assert.ok(true));
+  it('shard test A3', () => assert.ok(true));
+});
+
+describe('Perf — shard-friendly suites (group B)', () => {
+  it('shard test B1', () => assert.ok(true));
+  it('shard test B2', () => assert.ok(true));
+  it('shard test B3', () => assert.ok(true));
+});
+
+describe('Perf — shard-friendly suites (group C)', () => {
+  it('shard test C1', () => assert.ok(true));
+  it('shard test C2', () => assert.ok(true));
+  it('shard test C3', () => assert.ok(true));
+});
+
+// --- Feature: nested concurrency control ---
+
+describe('Perf — mixed sequential + concurrent', () => {
+  // Outer suite is sequential (default), inner suite is concurrent.
+  // This mimics real-world patterns: setup → parallel tests → teardown.
+
+  it('setup step (sequential)', () => {
+    assert.ok(true, 'setup done');
+  });
+
+  describe('parallel assertions', { concurrency: 3 }, () => {
+    it('check 1', async () => {
+      await new Promise(r => setTimeout(r, 50));
+      assert.ok(true);
+    });
+    it('check 2', async () => {
+      await new Promise(r => setTimeout(r, 50));
+      assert.ok(true);
+    });
+    it('check 3', async () => {
+      await new Promise(r => setTimeout(r, 50));
+      assert.ok(true);
+    });
+  });
+
+  it('teardown step (sequential)', () => {
+    assert.ok(true, 'teardown done');
+  });
+});

--- a/packages/node-test-poc/tests-reporters.js
+++ b/packages/node-test-poc/tests-reporters.js
@@ -1,0 +1,81 @@
+// POC: node:test multiple and custom reporters
+// Docs: https://nodejs.org/api/test.html#test-reporters
+//
+// Built-in reporters (via SERVER_NODE_OPTIONS):
+//   spec (default):  SERVER_NODE_OPTIONS='--test-reporter=spec'
+//   TAP:             SERVER_NODE_OPTIONS='--test-reporter=tap'
+//   dot:             SERVER_NODE_OPTIONS='--test-reporter=dot'
+//   JUnit XML:       SERVER_NODE_OPTIONS='--test-reporter=junit'
+//   lcov (coverage): SERVER_NODE_OPTIONS='--experimental-test-coverage --test-reporter=lcov'
+//
+// Multiple reporters simultaneously (output to different destinations):
+//   SERVER_NODE_OPTIONS='--test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=./test-results.xml'
+//
+// Custom reporter — any module exporting a transform stream:
+//   SERVER_NODE_OPTIONS='--test-reporter=./my-reporter.js'
+//
+// CI/CD examples:
+//   GitHub Actions:  --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results.xml
+//   GitLab CI:       same pattern, GitLab auto-parses JUnit XML artifacts
+//   Codecov:         --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage.info
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// A mix of passing, failing (commented), and skipped tests
+// to show how different reporters render each state.
+
+describe('Reporters — basic output', () => {
+  it('passing test', () => {
+    assert.strictEqual(2 + 2, 4);
+  });
+
+  it('another passing test', () => {
+    assert.ok(true);
+  });
+
+  it.skip('skipped test');
+
+  it.todo('planned test');
+});
+
+describe('Reporters — nested suites', () => {
+  describe('inner suite A', () => {
+    it('test A1', () => assert.ok(true));
+    it('test A2', () => assert.ok(true));
+  });
+
+  describe('inner suite B', () => {
+    it('test B1', () => assert.ok(true));
+    it.skip('test B2 (skipped)');
+  });
+});
+
+describe('Reporters — async tests', () => {
+  it('fast async', async () => {
+    await new Promise(r => setTimeout(r, 10));
+    assert.ok(true);
+  });
+
+  it('medium async', async () => {
+    await new Promise(r => setTimeout(r, 50));
+    assert.ok(true);
+  });
+});
+
+// --- Custom reporter example (for reference) ---
+//
+// A custom reporter is just a module that transforms the test event stream.
+// Save this as `my-reporter.js`:
+//
+//   export default async function* reporter(source) {
+//     let passed = 0, failed = 0, skipped = 0;
+//     for await (const event of source) {
+//       if (event.type === 'test:pass') { passed++; yield `✓ ${event.data.name}\n`; }
+//       if (event.type === 'test:fail') { failed++; yield `✗ ${event.data.name}\n`; }
+//       if (event.type === 'test:skip') { skipped++; }
+//     }
+//     yield `\nResults: ${passed} passed, ${failed} failed, ${skipped} skipped\n`;
+//   }
+//
+// Then: SERVER_NODE_OPTIONS='--test-reporter=./my-reporter.js'

--- a/packages/node-test-poc/tests-snapshot.js
+++ b/packages/node-test-poc/tests-snapshot.js
@@ -1,0 +1,70 @@
+// POC: node:test snapshot testing
+// Run with: SERVER_NODE_OPTIONS='--experimental-test-snapshots'
+// Update snapshots: SERVER_NODE_OPTIONS='--experimental-test-snapshots --test-update-snapshots'
+// Equivalent to Jest's toMatchSnapshot() / toMatchInlineSnapshot()
+// Docs: https://nodejs.org/api/test.html#snapshot-testing
+//
+// Snapshots are stored in a .snapshot file next to the test file.
+// NOTE: Stable in Node 23+, experimental in Node 22.
+
+import { describe, it } from 'node:test';
+
+// Skip snapshot tests unless --experimental-test-snapshots is enabled.
+// Without the flag, t.assert.snapshot() throws ERR_INVALID_STATE.
+const snapshotsEnabled = process.execArgv.some(a => a.includes('test-snapshots'));
+const maybeDescribe = snapshotsEnabled ? describe : describe.skip;
+
+// --- Module under test (inline for POC) ---
+
+function buildMeteorPackageExport(pkg) {
+  return {
+    name: pkg.name,
+    version: pkg.version,
+    exports: pkg.mainModule ? [pkg.mainModule] : [],
+    platforms: pkg.platforms || ['server', 'client'],
+    dependencies: Object.keys(pkg.uses || {}),
+  };
+}
+
+function generateHTML(title, items) {
+  return [
+    '<!DOCTYPE html>',
+    `<html><head><title>${title}</title></head>`,
+    '<body>',
+    '<ul>',
+    ...items.map(i => `  <li>${i}</li>`),
+    '</ul>',
+    '</body></html>',
+  ].join('\n');
+}
+
+// --- Snapshot tests ---
+
+maybeDescribe('Snapshots — structured data', () => {
+  it('should snapshot a package export object', (t) => {
+    const result = buildMeteorPackageExport({
+      name: 'my-package',
+      version: '1.2.3',
+      mainModule: 'index.js',
+      uses: { ecmascript: '1.0.0', mongo: '2.0.0' },
+    });
+
+    t.assert.snapshot(result);
+  });
+
+  it('should snapshot a minimal package', (t) => {
+    const result = buildMeteorPackageExport({
+      name: 'minimal',
+      version: '0.1.0',
+    });
+
+    t.assert.snapshot(result);
+  });
+});
+
+maybeDescribe('Snapshots — string output', () => {
+  it('should snapshot generated HTML', (t) => {
+    const html = generateHTML('Test Page', ['Item A', 'Item B', 'Item C']);
+    t.assert.snapshot(html);
+  });
+});

--- a/packages/node-test-poc/tests.js
+++ b/packages/node-test-poc/tests.js
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Random } from 'meteor/random';
+
+describe('Random (node:test POC)', () => {
+  it('should generate a string id', () => {
+    const id = Random.id();
+    assert.strictEqual(typeof id, 'string');
+    assert.strictEqual(id.length, 17);
+  });
+
+  it('should generate unique ids', () => {
+    const a = Random.id();
+    const b = Random.id();
+    assert.notStrictEqual(a, b);
+  });
+
+  it('should respect custom length', () => {
+    const id = Random.id(5);
+    assert.strictEqual(id.length, 5);
+  });
+
+  it('should pick from an array', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const choice = Random.choice(arr);
+    assert.ok(arr.includes(choice));
+  });
+});


### PR DESCRIPTION
# Node.js Native Test Runner as a Meteor Test Driver — POC & Proposal

Hey everyone! Following up on this discussion and @italojs's great work with `italojsmeteor:node-test-runner`, I've been prototyping a test driver that uses the **real `node:test`** module natively on the server side.

## What we built (POC)

A minimal Meteor test driver package (`node-test-in-console`) that lets package tests use `import { describe, it } from 'node:test'` and `import assert from 'node:assert/strict'` directly — no custom test framework, no Tinytest dependency.

**Package test files look like standard Node.js tests:**

```javascript
import { describe, it } from 'node:test';
import assert from 'node:assert/strict';
import { Random } from 'meteor/random';

describe('Random', () => {
  it('should generate unique ids', () => {
    const a = Random.id();
    const b = Random.id();
    assert.notStrictEqual(a, b);
  });
});
```

**Run with:**

```bash
meteor test-packages my-package --driver-package node-test-in-console --once

# With spec reporter
SERVER_NODE_OPTIONS="--test-reporter=spec" meteor test-packages ...

# With built-in coverage (Node 22!)
SERVER_NODE_OPTIONS="--experimental-test-coverage" meteor test-packages ...
```

## How it works

- isobuild already passes through `node:` imports on server arch (`resolver.ts` returns `null` for native modules on `"os"` target) — so **zero build system changes** needed
- `node:test` queues tests at import time and runs them after microtask drain, outputting TAP to stdout
- The driver detects test output completion via a debounce timer and calls `process.exit()` (Meteor's event loop prevents `beforeExit` from ever firing, which is how `node:test` normally finalizes)
- `SERVER_NODE_OPTIONS` passes flags like `--test-reporter` and `--experimental-test-coverage` to the app process — this already works in Meteor today

## Key difference from `italojsmeteor:node-test-runner`

italojs's package reimplements the `describe/it/test` API from scratch on both server and client (~300 lines each). Our approach uses the **actual `node:test` module** on the server, which gives us for free:

- Built-in reporters: TAP, spec, dot, JUnit (`--test-reporter`)
- Native code coverage (`--experimental-test-coverage`)
- Subtests, `test.todo()`, `test.skip()`, `test.only()`, `beforeEach/afterEach` — all from Node core
- Forward compatibility with future `node:test` improvements

For client tests, `node:test` is not available in the browser, so a lightweight shim (similar to italojs's approach) + `meteortesting:browser-tests` for headless execution would be needed.

## Current limitations / open questions

1. **Server-only for now** — client-side testing needs a shim since `node:test` is a Node.js API. Options:
   - Keep Tinytest for client tests (pragmatic, zero effort)
   - Build a thin client shim exposing `describe/it/assert` globals + `meteortesting:browser-tests` for Puppeteer (italojs's approach, proven to work)
   - Something else?

2. **Exit detection is debounce-based** — the driver watches stdout and exits 2s after the last test output. This works but feels hacky. Alternatives:
   - Use `node:test`'s programmatic `run()` API to get a `TestsStream` with proper completion events — but tests are already registered via imports before the driver can call `run()`, so timing is tricky
   - Use a custom reporter via `--test-reporter` that signals completion through a side channel
   - Any ideas from the core team on a cleaner approach?

3. **Failure detection from output** — since `process.exitCode` is only set at `beforeExit` (which never fires), we currently detect failures by pattern-matching TAP/spec output symbols. A custom reporter would solve this more cleanly.

4. **`Package.onTest` ergonomics** — test files using `node:test` must be server-only (`api.addFiles('tests.js', 'server')`). If someone omits `'server'`, isobuild will try to resolve `node:test` for the web target and hit `meteor-node-stubs` which doesn't have a `test` stub.

5. **No `--once` flag auto-integration** — the `--once` flag for `meteor test-packages` is designed for Tinytest drivers. Our driver uses its own exit logic.

## Possible next steps

- **Client shim**: build a minimal `describe/it/assert` for the browser + `meteortesting:browser-tests` integration, so one driver handles both sides
- **Custom Node reporter**: write a small reporter module that the driver loads via `--test-reporter`, giving us structured completion/failure events instead of parsing stdout
- **`meteor test` support**: make it work with app tests too, not just `test-packages`
- **Migration tooling**: a codemod to convert `Tinytest.add()` / `test.equal()` calls to `describe/it` / `assert.strictEqual()`
- **Integration with CI**: JUnit output via `--test-reporter=junit` for GitHub Actions, CircleCI, etc.

## Questions for the core team

1. Is this the right direction? A new driver package alongside Tinytest (opt-in) vs trying to retrofit `node:test` into Tinytest itself?
2. Any concerns about `node:test` inline execution within isobuild-compiled bundles?
3. Would you accept this as a core package (like `test-in-console`) or prefer it as a community package on Atmosphere first?
4. Any better approach for detecting `node:test` completion in a long-running Meteor process?

Happy to collaborate with @italojs on this — our approaches are complementary and could converge.
