### PR TITLE
Remove unused ejson dependency from packages

### DIFF
--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -15,7 +15,7 @@ Npm.depends({
 });
 
 Package.onUse((api) => {
-  api.use(["accounts-base", "sha", "ejson", "ddp"], ["client", "server"]);
+  api.use(["accounts-base", "sha", "ddp"], ["client", "server"]);
 
   // Export Accounts (etc) to packages using this one.
   api.imply("accounts-base", ["client", "server"]);

--- a/packages/accounts-passwordless/package.js
+++ b/packages/accounts-passwordless/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.onUse(api => {
-  api.use(['accounts-base', 'sha', 'ejson', 'ddp'], ['client', 'server']);
+  api.use(['accounts-base', 'sha', 'ddp'], ['client', 'server']);
 
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);

--- a/packages/session/package.js
+++ b/packages/session/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(['ecmascript', 'reactive-dict', 'ejson'], 'client');
+  api.use(['ecmascript', 'reactive-dict'], 'client');
 
   // Session can work with or without reload, but if reload is present
   // it should load first so we can detect it at startup and populate


### PR DESCRIPTION
I pulled these changes out of https://github.com/meteor/meteor/pull/13980 

- Remove direct `ejson` dependency from `accounts-password`, `accounts-passwordless`, and `session` packages
- These packages don't use EJSON directly — they get it transitively through their other dependencies