### PR TITLE
Fix puppeteer test runner console output

### DIFF
--- a/packages/test-in-console/puppeteer_runner.js
+++ b/packages/test-in-console/puppeteer_runner.js
@@ -16,7 +16,7 @@ async function runNextUrl(browser) {
     if (text.includes('Permissions policy violation')) {
       return;
     }
-    if (msg._text !== undefined) console.log(msg._text);
+    if (text) console.log(text);
     else {
       testNumber++;
       const currentClientTest =


### PR DESCRIPTION
When puppeteer was bumped from 20.4.0 to 23.6.0 in [d8c8c3db77](https://github.com/meteor/meteor/commit/d8c8c3db77c2b951d19611196499d1a08c118ef8), the `ConsoleMessage` class switched from an underscore-prefixed `_text` property to an ES2022 private `#text` field, accessible only via the public `msg.text()` method.

One hour later in [bd5d58a3a8](https://github.com/meteor/meteor/commit/bd5d58a3a890bc0900ebb6724f638b8670e671e1), `msg.text()` was added for filtering `Permissions policy violation` messages, but the broken `msg._text` on the very next line was left untouched.

As a result, `msg._text !== undefined` is always `false`, and the runner falls through to the else branch — printing only `"Test number: N"` with no actual test names or pass/fail results. The tests still pass in CI because `poll()` checks `TEST_STATUS.DONE` independently, but the CI logs show no useful output.
