### PR TITLE
Docs: guide LLMs to use test-in-console for package tests

### DIFF
--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -22,8 +22,11 @@ Test patterns, commands, and utilities for the Meteor codebase.
 ./meteor test-packages mongo                 # Test specific package
 TINYTEST_FILTER="collection" ./meteor test-packages  # Filter specific tests
 
-# Package tests in console (headless via Puppeteer)
+# Package tests in console (headless via Puppeteer — prints results to terminal)
+# Use this for automation or when you need terminal output without a browser.
 PUPPETEER_DOWNLOAD_PATH=~/.npm/chromium ./packages/test-in-console/run.sh
+./packages/test-in-console/run.sh            # Test all core packages
+./packages/test-in-console/run.sh "mongo"    # Test specific package
 
 # Modern E2E tests (Jest + Playwright)
 npm run install:modern                       # Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,16 @@ Full-stack JavaScript platform for modern web and mobile applications.
 ./meteor run                                 # Run from source
 ./meteor create my-app                       # Create app
 ./meteor self-test                           # CLI tests
-./meteor test-packages ./packages/<name>     # Package tests
+./meteor test-packages ./packages/<name>     # Package tests (browser UI at localhost:3000)
+./packages/test-in-console/run.sh "<name>"   # Package tests (terminal output via Puppeteer)
 npm run test:unit                            # Unit tests (Jest)
 npm run test:e2e                             # E2E tests (Jest + Playwright)
 ```
+
+> **Note:** `./meteor test-packages` starts a web server and waits for a browser —
+> it produces no terminal output. For automated/headless runs, use
+> `./packages/test-in-console/run.sh "<package>"` instead, which runs the same tests
+> via Puppeteer and prints pass/fail results to stdout.
 
 ## Structure
 


### PR DESCRIPTION

`./meteor test-packages` starts a web server and waits for a browser connection, producing no terminal output. LLM agents that follow the current docs will run this command and hang indefinitely. `./packages/test-in-console/run.sh` runs the same tests headlessly via Puppeteer and prints results to stdout, making it suitable for automated iteration.