### PR TITLE
Add test-headless driver for headless package testing

### DIFF
--- a/packages/test-headless/client.js
+++ b/packages/test-headless/client.js
@@ -1,0 +1,20 @@
+runTests = function () {
+  // Only run CLIENT-side tests here.
+  // Server tests are run directly by the server via Tinytest._runTests().
+  // Using _runTests (not _runTestsEverywhere) avoids running server tests twice.
+  Tinytest._runTests(
+    function (results) {
+      Meteor.call('test-headless/report', {
+        groupPath: results.groupPath,
+        test: results.test,
+        events: results.events,
+        server: false
+      });
+    },
+    function () {
+      // All client tests done — tell the server
+      Meteor.call('test-headless/done');
+    },
+    ["tinytest"]
+  );
+};

--- a/packages/test-headless/package.js
+++ b/packages/test-headless/package.js
@@ -6,6 +6,11 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(['tinytest', 'ejson'], 'server');
-  api.addFiles(['server.js'], 'server');
+  api.use(['tinytest', 'ejson'], ['client', 'server']);
+  api.use('random', 'client');
+
+  api.addFiles('server.js', 'server');
+  api.addFiles('client.js', 'client');
+
+  api.export('runTests', 'client');
 });

--- a/packages/test-headless/package.js
+++ b/packages/test-headless/package.js
@@ -1,0 +1,11 @@
+Package.describe({
+  name: 'test-headless',
+  summary: 'Run package tests headlessly and print results to the terminal.',
+  version: '1.0.0',
+  testOnly: true,
+});
+
+Package.onUse(function (api) {
+  api.use(['tinytest', 'ejson'], 'server');
+  api.addFiles(['server.js'], 'server');
+});

--- a/packages/test-headless/run.sh
+++ b/packages/test-headless/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Run headless package tests with results printed to the terminal.
+#
+# Usage:
+#   ./packages/test-headless/run.sh                 # Test all packages
+#   ./packages/test-headless/run.sh "check"          # Test specific package
+#   ./packages/test-headless/run.sh "mongo"           # Test specific package
+#
+# Unlike test-in-console, results flow via DDP (not console scraping),
+# so there's no Puppeteer API fragility.
+
+cd "$(dirname "$0")/../.."
+export METEOR_HOME="$(pwd)"
+
+# Install Puppeteer if needed (reuses dev_bundle install)
+./meteor npm install -g puppeteer@23.6.0 2>/dev/null
+
+export PATH="$METEOR_HOME:$PATH"
+
+PORT=4097
+
+# Start Meteor test-packages in background — output goes directly to terminal
+./meteor test-packages \
+  --driver-package test-headless \
+  --once \
+  -p $PORT \
+  ${TEST_PACKAGES_EXCLUDE:+--exclude "$TEST_PACKAGES_EXCLUDE"} \
+  $1 2>&1 &
+METEOR_PID=$!
+trap "kill $METEOR_PID 2>/dev/null; exit 1" SIGINT SIGTERM
+
+# Wait for the HTTP server to be ready by polling the port
+echo "Waiting for Meteor to start on port $PORT..."
+while ! curl -s -o /dev/null http://127.0.0.1:$PORT/ 2>/dev/null; do
+  # Check if Meteor died
+  if ! kill -0 $METEOR_PID 2>/dev/null; then
+    echo "Meteor process exited before server was ready"
+    wait $METEOR_PID 2>/dev/null
+    exit $?
+  fi
+  sleep 1
+done
+
+# Open a headless browser so client tests run.
+# We don't scrape console — results flow via DDP to the server.
+node -e "
+  const puppeteer = require('$METEOR_HOME/dev_bundle/lib/node_modules/puppeteer');
+  (async () => {
+    const browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-web-security'],
+    });
+    const page = await browser.newPage();
+    await page.goto('http://127.0.0.1:$PORT/');
+    // Just keep the page open — the server will exit when tests are done
+    // which will kill this process too
+  })().catch(e => { console.error('Puppeteer error:', e); process.exit(1); });
+" &
+PUPPETEER_PID=$!
+
+# Wait for the Meteor process to exit (it calls process.exit when tests complete)
+wait $METEOR_PID 2>/dev/null
+STATUS=$?
+
+kill $PUPPETEER_PID 2>/dev/null
+exit $STATUS

--- a/packages/test-headless/server.js
+++ b/packages/test-headless/server.js
@@ -3,94 +3,148 @@ var failed = 0;
 var expected = 0;
 var resultSet = {};
 var whereFailed = [];
+var serverDone = false;
+var clientDone = false;
+var clientConnected = false;
 
 var getName = function (result) {
-  return "S: " + result.groupPath.join(" - ") + " - " + result.test;
+  return (result.server ? "S" : "C") + ": " +
+    result.groupPath.join(" - ") + " - " + result.test;
 };
 
-Meteor.startup(function () {
-  Tinytest._runTests(function (results) {
-    var name = getName(results);
-    if (!Object.hasOwn(resultSet, name)) {
-      var testPath = EJSON.clone(results.groupPath);
-      testPath.push(results.test);
-      resultSet[name] = {
-        name: name,
-        status: "PENDING",
-        events: [],
-        testPath: testPath
-      };
-    }
-    results.events.forEach(function (event) {
-      resultSet[name].events.push(event);
-      switch (event.type) {
-      case "ok":
+var processResult = function (results) {
+  var name = getName(results);
+  if (!Object.hasOwn(resultSet, name)) {
+    var testPath = EJSON.clone(results.groupPath);
+    testPath.push(results.test);
+    resultSet[name] = {
+      name: name,
+      status: "PENDING",
+      events: [],
+      server: !!results.server,
+      testPath: testPath
+    };
+  }
+  results.events.forEach(function (event) {
+    resultSet[name].events.push(event);
+    switch (event.type) {
+    case "ok":
+      break;
+    case "expected_fail":
+      if (resultSet[name].status !== "FAIL")
+        resultSet[name].status = "EXPECTED";
+      break;
+    case "exception":
+      console.log(name, ":", "!!!!!!!!! FAIL !!!!!!!!!!!");
+      if (event.details && event.details.stack)
+        console.log(event.details.stack);
+      else
+        console.log("Test failed with exception");
+      failed++;
+      whereFailed.push({ name: name, info: JSON.stringify(event) });
+      break;
+    case "finish":
+      switch (resultSet[name].status) {
+      case "OK":
         break;
-      case "expected_fail":
-        if (resultSet[name].status !== "FAIL")
-          resultSet[name].status = "EXPECTED";
+      case "PENDING":
+        resultSet[name].status = "OK";
+        console.log(name, ":", "OK");
+        passed++;
         break;
-      case "exception":
-        console.log(name, ":", "!!!!!!!!! FAIL !!!!!!!!!!!");
-        if (event.details && event.details.stack)
-          console.log(event.details.stack);
-        else
-          console.log("Test failed with exception");
+      case "EXPECTED":
+        console.log(name, ":", "EXPECTED FAILURE");
+        expected++;
+        break;
+      case "FAIL":
         failed++;
-        whereFailed.push({ name: name, info: JSON.stringify(event) });
-        break;
-      case "finish":
-        switch (resultSet[name].status) {
-        case "OK":
-          break;
-        case "PENDING":
-          resultSet[name].status = "OK";
-          console.log(name, ":", "OK");
-          passed++;
-          break;
-        case "EXPECTED":
-          console.log(name, ":", "EXPECTED FAILURE");
-          expected++;
-          break;
-        case "FAIL":
-          failed++;
-          console.log(name, ":", "!!!!!!!!! FAIL !!!!!!!!!!!");
-          console.log(JSON.stringify(resultSet[name].info));
-          whereFailed.push({ name: name, info: JSON.stringify(resultSet[name].info) });
-          break;
-        default:
-          console.log(name, ": unknown state for the test to be in");
-        }
+        console.log(name, ":", "!!!!!!!!! FAIL !!!!!!!!!!!");
+        console.log(JSON.stringify(resultSet[name].info));
+        whereFailed.push({ name: name, info: JSON.stringify(resultSet[name].info) });
         break;
       default:
-        resultSet[name].status = "FAIL";
-        resultSet[name].info = results;
-        break;
+        console.log(name, ": unknown state for the test to be in");
       }
-    });
-  }, function () {
-    if (failed > 0) {
-      console.log("~~~~~~~ THERE ARE FAILURES ~~~~~~~");
+      break;
+    default:
+      resultSet[name].status = "FAIL";
+      resultSet[name].info = results;
+      break;
     }
-    console.log("passed/expected/failed/total",
-                passed, "/", expected, "/", failed, "/", Object.keys(resultSet).length);
+  });
+};
 
-    if (whereFailed.length > 0) {
-      console.log("");
-      whereFailed.forEach(function (f) {
-        console.log(f.name, "failed:", f.info);
-      });
-    }
+var printSummary = function () {
+  if (failed > 0) {
+    console.log("~~~~~~~ THERE ARE FAILURES ~~~~~~~");
+  }
+  console.log("passed/expected/failed/total",
+              passed, "/", expected, "/", failed, "/", Object.keys(resultSet).length);
 
-    if (failed > 0) {
-      console.log("TESTS FAILED");
-    } else {
-      console.log("ALL TESTS PASSED");
-    }
-
+  if (whereFailed.length > 0) {
     console.log("");
-    console.log("NOTE: Only server-side tests were run. Client-only tests require a browser.");
+    whereFailed.forEach(function (f) {
+      console.log(f.name, "failed:", f.info);
+    });
+  }
 
-    process.exit(failed ? 1 : 0);
+  if (!clientConnected) {
+    console.log("");
+    console.log("NOTE: Only server-side tests were run.");
+    console.log("Client tests require a browser (use run.sh or set TEST_HEADLESS_BROWSER=1).");
+  }
+
+  if (failed > 0) {
+    console.log("TESTS FAILED");
+  } else {
+    console.log("ALL TESTS PASSED");
+  }
+
+  process.exit(failed ? 1 : 0);
+};
+
+var maybePrintSummary = function () {
+  if (serverDone && (clientDone || !clientConnected)) {
+    printSummary();
+  }
+};
+
+// Methods for the client to report results back via DDP
+Meteor.methods({
+  'test-headless/report'(result) {
+    clientConnected = true;
+    processResult(result);
+  },
+  'test-headless/done'() {
+    clientDone = true;
+    maybePrintSummary();
+  }
+});
+
+// Run server-side tests directly
+Meteor.startup(function () {
+  console.log("test-headless listening");
+  console.log("Running server-side tests...");
+
+  Tinytest._runTests(function (results) {
+    // Tag as server results
+    results.server = true;
+    processResult(results);
+  }, function () {
+    console.log("Server tests complete.");
+    serverDone = true;
+
+    // If no client connected, wait a short time then print summary.
+    // If a client is connected, wait for it to finish.
+    if (!clientConnected) {
+      // Give the client a chance to connect (e.g., if run.sh is launching puppeteer)
+      Meteor.setTimeout(function () {
+        if (!clientConnected) {
+          maybePrintSummary();
+        }
+      }, 10000);
+    } else {
+      maybePrintSummary();
+    }
   });
 });

--- a/packages/test-headless/server.js
+++ b/packages/test-headless/server.js
@@ -1,0 +1,96 @@
+var passed = 0;
+var failed = 0;
+var expected = 0;
+var resultSet = {};
+var whereFailed = [];
+
+var getName = function (result) {
+  return "S: " + result.groupPath.join(" - ") + " - " + result.test;
+};
+
+Meteor.startup(function () {
+  Tinytest._runTests(function (results) {
+    var name = getName(results);
+    if (!Object.hasOwn(resultSet, name)) {
+      var testPath = EJSON.clone(results.groupPath);
+      testPath.push(results.test);
+      resultSet[name] = {
+        name: name,
+        status: "PENDING",
+        events: [],
+        testPath: testPath
+      };
+    }
+    results.events.forEach(function (event) {
+      resultSet[name].events.push(event);
+      switch (event.type) {
+      case "ok":
+        break;
+      case "expected_fail":
+        if (resultSet[name].status !== "FAIL")
+          resultSet[name].status = "EXPECTED";
+        break;
+      case "exception":
+        console.log(name, ":", "!!!!!!!!! FAIL !!!!!!!!!!!");
+        if (event.details && event.details.stack)
+          console.log(event.details.stack);
+        else
+          console.log("Test failed with exception");
+        failed++;
+        whereFailed.push({ name: name, info: JSON.stringify(event) });
+        break;
+      case "finish":
+        switch (resultSet[name].status) {
+        case "OK":
+          break;
+        case "PENDING":
+          resultSet[name].status = "OK";
+          console.log(name, ":", "OK");
+          passed++;
+          break;
+        case "EXPECTED":
+          console.log(name, ":", "EXPECTED FAILURE");
+          expected++;
+          break;
+        case "FAIL":
+          failed++;
+          console.log(name, ":", "!!!!!!!!! FAIL !!!!!!!!!!!");
+          console.log(JSON.stringify(resultSet[name].info));
+          whereFailed.push({ name: name, info: JSON.stringify(resultSet[name].info) });
+          break;
+        default:
+          console.log(name, ": unknown state for the test to be in");
+        }
+        break;
+      default:
+        resultSet[name].status = "FAIL";
+        resultSet[name].info = results;
+        break;
+      }
+    });
+  }, function () {
+    if (failed > 0) {
+      console.log("~~~~~~~ THERE ARE FAILURES ~~~~~~~");
+    }
+    console.log("passed/expected/failed/total",
+                passed, "/", expected, "/", failed, "/", Object.keys(resultSet).length);
+
+    if (whereFailed.length > 0) {
+      console.log("");
+      whereFailed.forEach(function (f) {
+        console.log(f.name, "failed:", f.info);
+      });
+    }
+
+    if (failed > 0) {
+      console.log("TESTS FAILED");
+    } else {
+      console.log("ALL TESTS PASSED");
+    }
+
+    console.log("");
+    console.log("NOTE: Only server-side tests were run. Client-only tests require a browser.");
+
+    process.exit(failed ? 1 : 0);
+  });
+});


### PR DESCRIPTION
## Motivation

I found myself recently when working with Meteor packages that I need a quick command to test out packages in the terminal quickly and using the aid of LLMs this need became greater as I had to instruct the LLM to run or test a package.
By default `meteor test-packages` command runs in the browser so LLMs tries to fire up puppeteer or hang indefinitely.

This PR is an attempt to fix this problem. I could've easily expanded `test-in-console` but I chose to create an entirely new package to free myself from the burdens of backwards maintainability and the fear of breaking something.

I tried to take all of the leanings in packages like `test-in-server-once`, `test-in-console` and `mtest` and put them together in one package:

- **No console scraping** — Unlike test-in-console which relies on Puppeteer's page.on('console') to forward console.log from browser to terminal (which broke when Puppeteer changed msg._text to a private field), results flow via DDP methods. Puppeteer is just a dumb browser launcher.

- **Server runs tests directly** — Server calls Tinytest._runTests() itself rather than waiting for the client to orchestrate via _runTestsEverywhere. This means even without a browser, you get server test results.

- **Graceful degradation** — If no browser connects within 10 seconds after server tests finish, it prints results with a note saying "Only server-side tests were run." This lets you use it without run.sh for quick server-only iteration.

- **Composable** — TINYTEST_FILTER env var works automatically (handled by tinytest internally) for filtering specific tests by regex.

## Usage

```bash
# Run all tests for a package
./meteor test-packages --driver-package test-headless --once ./packages/check

# Filter to specific tests
TINYTEST_FILTER="argument" ./meteor test-packages --driver-package test-headless --once ./packages/check
```