### PR TITLE
[Rspack] Skip Rspack HMR proxy middleware setup on Cordova

### DIFF
--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -15,6 +15,7 @@ const {
   isMeteorAppDevelopment,
   isMeteorAppRun,
   isMeteorAppBuild,
+  isMeteorAppNative,
   isMeteorAppDebug,
   isMeteorAppTest,
   isMeteorAppTestFullApp,
@@ -370,7 +371,7 @@ export function configureMeteorForRspack() {
   ensureModuleFilesExist();
 
   // Write content to module files
-  if (isMeteorAppRun() && isMeteorAppDevelopment()) {
+  if (isMeteorAppRun() && isMeteorAppDevelopment() && !isMeteorAppNative()) {
     const customScriptUrl = `/__rspack__/${getBuildFilePath({
       ...env,
       isMain: true,

--- a/packages/rspack/rspack_plugin.js
+++ b/packages/rspack/rspack_plugin.js
@@ -177,6 +177,11 @@ if (isMeteorAppRun() || isMeteorAppBuild() || isMeteorAppTest()) {
     // Configure Meteor settings for Rspack
     configureMeteorForRspack();
 
+    // Set native mode flag so the server module can skip dev proxy setup
+    if (isMeteorAppNative()) {
+      process.env.RSPACK_NATIVE = 'true';
+    }
+
     // Calculate and set the devServerPort at boot
     if (!process.env.RSPACK_DEVSERVER_PORT) {
       process.env.RSPACK_DEVSERVER_PORT = calculateDevServerPort();

--- a/packages/rspack/rspack_server.js
+++ b/packages/rspack/rspack_server.js
@@ -28,7 +28,11 @@ const RSPACK_ASSETS_REGEX = new RegExp(
   `^\/${rspackAssetsContext}\/(.+)$`,
 );
 
-if (global?.Package?.['tools-core'] != null && Meteor.isDevelopment) {
+const shouldEnableDevHMRProxy =
+  global?.Package?.["tools-core"] != null &&
+  Meteor.isDevelopment &&
+  !process.env.RSPACK_NATIVE;
+if (shouldEnableDevHMRProxy) {
   const { shuffleString } = require('meteor/tools-core/lib/string');
   const { createProxyMiddleware } = require('http-proxy-middleware');
 


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/issues/14154

This PR properly skips setting up the proxy middleware used for Rspack HMR when running a Cordova app. This was causing incorrect errors in development mode and made this change necessary.