### PR TITLE
Fix DDP connection latency regression from dynamic SockJS import

### DIFF
--- a/packages/socket-stream-client/browser.js
+++ b/packages/socket-stream-client/browser.js
@@ -5,9 +5,11 @@ import {
 
 import { StreamClientCommon } from "./common.js";
 
-// SockJS is loaded dynamically (via import()) only when DISABLE_SOCKJS is not
-// set. This avoids bundling the 57 KB SockJS library when it's not needed.
-// When DISABLE_SOCKJS=1, only native WebSocket is used.
+// SockJS is imported statically to avoid the startup latency introduced by
+// dynamic import() in _launchConnection(). When DISABLE_SOCKJS=1, SockJS
+// remains bundled in the client, but the connection uses the native
+// WebSocket path directly with no import-time delay.
+import SockJS from "./sockjs-1.6.1-min-.js";
 
 export class ClientStream extends StreamClientCommon {
   // @param url {String} URL to Meteor app
@@ -153,15 +155,12 @@ export class ClientStream extends StreamClientCommon {
     return protocolsWhitelist;
   }
 
-  async _launchConnection() {
+  _launchConnection() {
     this._cleanup(); // cleanup the old socket, if there was one.
 
-    const disableSockJS = __meteor_runtime_config__.DISABLE_SOCKJS;
-
-    if (disableSockJS) {
+    if (__meteor_runtime_config__.DISABLE_SOCKJS) {
       this.socket = new WebSocket(toWebsocketUrl(this.rawUrl));
     } else {
-      const { default: SockJS } = await import("./sockjs-1.6.1-min-.js");
       const options = {
         transports: this._sockjsProtocolsWhitelist(),
         ...this.options._sockjsOptions


### PR DESCRIPTION
## Summary

- Reverts the dynamic `import()` of SockJS introduced in #14206 back to a static import, eliminating the ~110 ms latency added to every DDP connection for apps using the default SockJS transport
- `_launchConnection()` is synchronous again — no `async`/`await`
- All `DISABLE_SOCKJS=1` functionality is preserved: runtime check routes to native WebSocket when enabled

## Context

[Community feedback on the 3.5-beta thread](https://forums.meteor.com/t/meteor-3-5-beta-change-streams-performance-improvements/64461/49?u=dupontbertrand) flagged that the dynamic import adds significant latency. This is the same pitfall that caused PRs #9353 and #9985 to be reverted in 2020 (#10741) — Meteor's module system resolves `import()` asynchronously, and the constructor calls `_launchConnection()` synchronously during module evaluation.

### Benchmark results

| Variant | SockJS load | launch→open | vs baseline |
|---------|------------|-------------|-------------|
| **Static (3.4 baseline)** | ~0 ms | ~103 ms | — |
| **Dynamic (3.5-beta — #14206)** | ~110 ms | ~136 ms | **+32%** |
| **This fix (static + runtime check)** | ~0 ms | ~103 ms | **0%** |

### Trade-off

SockJS (57 KB) remains in the client bundle even when `DISABLE_SOCKJS=1`. This is acceptable since apps opting into `DISABLE_SOCKJS=1` already save far more from eliminating the `/sockjs/info` round-trip (100–300 ms in production).

## Test plan

- [x] Benchmark with SockJS enabled: `pageLoad→ddpConnected` back to ~12 ms (was ~23 ms with dynamic import)
- [x] Verify `DISABLE_SOCKJS=1`: native WebSocket connection, no `/sockjs/` in network tab, `pageLoad→ddpConnected` ~0.3 ms

Related to issue : https://github.com/meteor/meteor/issues/14228