### PR TITLE
Migrate 8 core package tests from Tinytest to node:test

### DIFF
--- a/packages/callback-hook/hook_tests.js
+++ b/packages/callback-hook/hook_tests.js
@@ -1,55 +1,61 @@
-Tinytest.add("callback-hook - binds to registrar's env by default", function (test) {
-  const hook = new Hook();
-  const envVar = new Meteor.EnvironmentVariable;
-  envVar.withValue("registrar's value", function() {
-    hook.register(function() {
-      test.equal(envVar.get(), "registrar's value");
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Meteor } from 'meteor/meteor';
+
+describe('callback-hook', () => {
+  it("binds to registrar's env by default", () => {
+    const hook = new Hook();
+    const envVar = new Meteor.EnvironmentVariable;
+    envVar.withValue("registrar's value", () => {
+      hook.register(() => {
+        assert.strictEqual(envVar.get(), "registrar's value");
+      });
+    });
+    envVar.withValue("invoker's value", () => {
+      hook.forEach((callback) => {
+        callback();
+      });
     });
   });
-  envVar.withValue("invoker's value", function() {
-    hook.forEach(function(callback) {
+
+  it("uses invoker's env with {bindEnvironment: false}", () => {
+    const hook = new Hook({ bindEnvironment: false });
+    const envVar = new Meteor.EnvironmentVariable;
+    envVar.withValue("registrar's value", () => {
+      hook.register(() => {
+        assert.strictEqual(envVar.get(), "invoker's value");
+      });
+    });
+    envVar.withValue("invoker's value", () => {
+      hook.each((callback) => {
+        callback();
+      });
+    });
+  });
+
+  it("exceptions unhandled with {bindEnvironment: false}", () => {
+    const hook = new Hook({ bindEnvironment: false });
+    hook.register(() => {
+      throw new Error("Test error");
+    });
+    hook.forEach((callback) => {
+      assert.throws(callback, { message: /Test error/ });
+    });
+  });
+
+  it("exceptionHandler used with {bindEnvironment: false}", () => {
+    const exToThrow = new Error("Test error");
+    let thrownEx = null;
+    const hook = new Hook({
+      bindEnvironment: false,
+      exceptionHandler: (ex) => { thrownEx = ex; }
+    });
+    hook.register(() => {
+      throw exToThrow;
+    });
+    hook.each((callback) => {
       callback();
     });
+    assert.strictEqual(exToThrow, thrownEx);
   });
-});
-
-Tinytest.add("callback-hook - uses invoker's env with {bindEnvironment: false}", function (test) {
-  const hook = new Hook({ bindEnvironment: false });
-  const envVar = new Meteor.EnvironmentVariable;
-  envVar.withValue("registrar's value", function() {
-    hook.register(function() {
-      test.equal(envVar.get(), "invoker's value");
-    });
-  });
-  envVar.withValue("invoker's value", function() {
-    hook.each(function(callback) {
-      callback();
-    });
-  });
-});
-
-Tinytest.add("callback-hook - exceptions unhandled with {bindEnvironment: false}", function (test) {
-  const hook = new Hook({ bindEnvironment: false });
-  hook.register(function() {
-    throw new Error("Test error");
-  });
-  hook.forEach(function(callback) {
-    test.throws(callback, "Test error");
-  });
-});
-
-Tinytest.add("callback-hook - exceptionHandler used with {bindEnvironment: false}", function (test) {
-  const exToThrow = new Error("Test error");
-  let thrownEx = null;
-  const hook = new Hook({
-    bindEnvironment: false,
-    exceptionHandler: function (ex) { thrownEx = ex; }
-  });
-  hook.register(function() {
-    throw exToThrow;
-  });
-  hook.each(function(callback) {
-    callback();
-  });
-  test.equal(exToThrow, thrownEx);
 });

--- a/packages/callback-hook/package.js
+++ b/packages/callback-hook/package.js
@@ -10,7 +10,6 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use('callback-hook');
-  api.use('tinytest');
+  api.use(['callback-hook', 'ecmascript']);
   api.addFiles('hook_tests.js', 'server');
 });

--- a/packages/check/match_test.js
+++ b/packages/check/match_test.js
@@ -1,791 +1,788 @@
-Tinytest.add('check - check', test => {
-  const matches = (value, pattern) => {
-    let error;
-    try {
-      check(value, pattern);
-    } catch (e) {
-      error = e;
-    }
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { check, Match } from 'meteor/check';
+import { EJSON } from 'meteor/ejson';
 
-    test.isFalse(error);
-    test.isTrue(Match.test(value, pattern));
-  };
-
-  const fails = (value, pattern) => {
-    let error;
-    try {
-      check(value, pattern);
-    } catch (e) {
-      error = e;
-    }
-
-    test.isTrue(error);
-    test.instanceOf(error, Match.Error);
-    test.isFalse(Match.test(value, pattern));
-  };
-
-  // Atoms.
-  const pairs = [
-    ['foo', String],
-    ['', String],
-    [0, Number],
-    [42.59, Number],
-    [NaN, Number],
-    [Infinity, Number],
-    [true, Boolean],
-    [false, Boolean],
-    [function(){}, Function],
-    [undefined, undefined],
-    [null, null]
-  ];
-  pairs.forEach(pair => {
-    matches(pair[0], Match.Any);
-    [String, Number, Boolean, undefined, null].forEach(type => {
-      if (type === pair[1]) {
-        matches(pair[0], type);
-        matches(pair[0], Match.Optional(type));
-        matches(undefined, Match.Optional(type));
-        matches(pair[0], Match.Maybe(type));
-        matches(undefined, Match.Maybe(type));
-        matches(null, Match.Maybe(type));
-        matches(pair[0], Match.Where(() => {
-          check(pair[0], type);
-          return true;
-        }));
-        matches(pair[0], Match.Where(() => {
-          try {
-            check(pair[0], type);
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }));
-      } else {
-        fails(pair[0], type);
-        matches(pair[0], Match.OneOf(type, pair[1]));
-        matches(pair[0], Match.OneOf(pair[1], type));
-        fails(pair[0], Match.Where(() => {
-          check(pair[0], type);
-          return true;
-        }));
-        fails(pair[0], Match.Where(() => {
-          try {
-            check(pair[0], type);
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }));
+describe('check', () => {
+  it('check', () => {
+    const matches = (value, pattern) => {
+      let error;
+      try {
+        check(value, pattern);
+      } catch (e) {
+        error = e;
       }
 
-      if ( type !== null ) {
+      assert.ok(!error);
+      assert.ok(Match.test(value, pattern));
+    };
 
-        // Optional doesn't allow null, but does match on null type
-        fails(null, Match.Optional(type));
-       }
-      fails(pair[0], [type]);
-      fails(pair[0], Object);
+    const fails = (value, pattern) => {
+      let error;
+      try {
+        check(value, pattern);
+      } catch (e) {
+        error = e;
+      }
+
+      assert.ok(error);
+      assert.ok(error instanceof Match.Error);
+      assert.ok(!Match.test(value, pattern));
+    };
+
+    // Atoms.
+    const pairs = [
+      ['foo', String],
+      ['', String],
+      [0, Number],
+      [42.59, Number],
+      [NaN, Number],
+      [Infinity, Number],
+      [true, Boolean],
+      [false, Boolean],
+      [function(){}, Function],
+      [undefined, undefined],
+      [null, null]
+    ];
+    pairs.forEach(pair => {
+      matches(pair[0], Match.Any);
+      [String, Number, Boolean, undefined, null].forEach(type => {
+        if (type === pair[1]) {
+          matches(pair[0], type);
+          matches(pair[0], Match.Optional(type));
+          matches(undefined, Match.Optional(type));
+          matches(pair[0], Match.Maybe(type));
+          matches(undefined, Match.Maybe(type));
+          matches(null, Match.Maybe(type));
+          matches(pair[0], Match.Where(() => {
+            check(pair[0], type);
+            return true;
+          }));
+          matches(pair[0], Match.Where(() => {
+            try {
+              check(pair[0], type);
+              return true;
+            } catch (e) {
+              return false;
+            }
+          }));
+        } else {
+          fails(pair[0], type);
+          matches(pair[0], Match.OneOf(type, pair[1]));
+          matches(pair[0], Match.OneOf(pair[1], type));
+          fails(pair[0], Match.Where(() => {
+            check(pair[0], type);
+            return true;
+          }));
+          fails(pair[0], Match.Where(() => {
+            try {
+              check(pair[0], type);
+              return true;
+            } catch (e) {
+              return false;
+            }
+          }));
+        }
+
+        if ( type !== null ) {
+
+          // Optional doesn't allow null, but does match on null type
+          fails(null, Match.Optional(type));
+         }
+        fails(pair[0], [type]);
+        fails(pair[0], Object);
+      });
     });
+    fails(true, Match.OneOf(String, Number, undefined, null, [Boolean]));
+    fails(new String('foo'), String);
+    fails(new Boolean(true), Boolean);
+    fails(new Number(123), Number);
+
+    matches([1, 2, 3], [Number]);
+    matches([], [Number]);
+    fails([1, 2, 3, '4'], [Number]);
+    fails([1, 2, 3, [4]], [Number]);
+    matches([1, 2, 3, '4'], [Match.OneOf(Number, String)]);
+
+    matches({}, Object);
+    matches({}, {});
+    matches({foo: 42}, Object);
+    fails({foo: 42}, {});
+    matches({a: 1, b:2}, {b: Number, a: Number});
+    fails({a: 1, b:2}, {b: Number});
+    matches({a: 1, b:2}, Match.ObjectIncluding({b: Number}));
+    fails({a: 1, b:2}, Match.ObjectIncluding({b: String}));
+    fails({a: 1, b:2}, Match.ObjectIncluding({c: String}));
+    fails({}, {a: Number});
+    matches({nodeType: 1}, {nodeType: Match.Any});
+    matches({nodeType: 1}, Match.ObjectIncluding({nodeType: Match.Any}));
+    fails({nodeType: 1}, {nodeType: String});
+    fails({}, Match.ObjectIncluding({nodeType: Match.Any}));
+
+    // Match.Optional does not match on a null value, unless the allowed type is itself "null"
+    fails(null, Match.Optional(String));
+    fails(null, Match.Optional(undefined));
+    matches(null, Match.Optional(null));
+
+    // on the other hand, undefined, works fine for all of them
+    matches(undefined, Match.Optional(String));
+    matches(undefined, Match.Optional(undefined));
+    matches(undefined, Match.Optional(null));
+
+    fails(true, Match.Optional(String)); // different should still fail
+    matches('String', Match.Optional(String)); // same should pass
+
+    matches({}, {a: Match.Optional(Number)});
+    matches({a: 1}, {a: Match.Optional(Number)});
+    fails({a: true}, {a: Match.Optional(Number)});
+    fails({a: undefined}, {a: Match.Optional(Number)});
+
+    // .Maybe requires undefined, null or the allowed type in order to match
+    matches(null, Match.Maybe(String));
+    matches(null, Match.Maybe(undefined));
+    matches(null, Match.Maybe(null));
+
+    matches(undefined, Match.Maybe(String));
+    matches(undefined, Match.Maybe(undefined));
+    matches(undefined, Match.Maybe(null));
+
+    fails(true, Match.Maybe(String)); // different should still fail
+    matches('String', Match.Maybe(String)); // same should pass
+
+    matches({}, {a: Match.Maybe(Number)});
+    matches({a: 1}, {a: Match.Maybe(Number)});
+    fails({a: true}, {a: Match.Maybe(Number)});
+
+    // Match.Optional means "or undefined" at the top level but "or absent" in
+    // objects.
+    // Match.Maybe should behave the same as Match.Optional in objects
+    // including handling nulls
+    fails({a: undefined}, {a: Match.Maybe(Number)});
+    fails({a: null}, {a: Match.Maybe(Number)});
+    const F = function () {
+      this.x = 123;
+    };
+
+    fails(new F, { x: 123 });
+
+    matches({}, Match.ObjectWithValues(Number));
+    matches({x: 1}, Match.ObjectWithValues(Number));
+    matches({x: 1, y: 2}, Match.ObjectWithValues(Number));
+    fails({x: 1, y: '2'}, Match.ObjectWithValues(Number));
+
+    matches('asdf', 'asdf');
+    fails('asdf', 'monkey');
+    matches(123, 123);
+    fails(123, 456);
+    fails('123', 123);
+    fails(123, '123');
+    matches(true, true);
+    matches(false, false);
+    fails(true, false);
+    fails(true, 'true');
+    fails('false', false);
+    matches('xx', Match.NonEmptyString);
+    fails('', Match.NonEmptyString);
+    matches(/foo/, RegExp);
+    fails(/foo/, String);
+    matches(new Date, Date);
+    fails(new Date, Number);
+    matches(EJSON.newBinary(42), Match.Where(EJSON.isBinary));
+    fails([], Match.Where(EJSON.isBinary));
+
+    matches(42, Match.Where(x => x % 2 === 0));
+    fails(43, Match.Where(x => x % 2 === 0));
+
+    matches({
+      a: 'something',
+      b: [
+        {x: 42, k: null},
+        {x: 43, k: true, p: ['yay']},
+      ],
+    }, {
+      a: String,
+      b: [
+        Match.ObjectIncluding({
+          x: Number,
+          k: Match.OneOf(null, Boolean)
+        }),
+      ],
+    });
+
+
+    // Match.Integer
+    matches(-1, Match.Integer);
+    matches(0, Match.Integer);
+    matches(1, Match.Integer);
+    matches(-2147483648, Match.Integer); // INT_MIN
+    matches(2147483647, Match.Integer); // INT_MAX
+    fails(123.33, Match.Integer);
+    fails(.33, Match.Integer);
+    fails(1.348192308491824e+23, Match.Integer);
+    fails(NaN, Match.Integer);
+    fails(Infinity, Match.Integer);
+    fails(-Infinity, Match.Integer);
+    fails({}, Match.Integer);
+    fails([], Match.Integer);
+    fails(function () {}, Match.Integer);
+    fails(new Date, Match.Integer);
+
+
+    // Test non-plain objects.
+    const parentObj = {foo: 'bar'};
+    const childObj = Object.assign(Object.create(parentObj), {bar: 'foo'});
+    matches(parentObj, Object);
+    fails(parentObj, {foo: String, bar: String});
+    fails(parentObj, {bar: String});
+    matches(parentObj, {foo: String});
+    fails(childObj, Object);
+    fails(childObj, {foo: String, bar: String});
+    fails(childObj, {bar: String});
+    fails(childObj, {foo: String});
+
+    // Functions
+    const testFunction = () => {};
+    matches(testFunction, Function);
+    fails(5, Function);
+
+    // Circular Reference "Classes"
+
+    const TestInstanceChild = function () {};
+    const TestInstanceParent = function (child) {
+      child._parent = this;
+      this.child = child;
+    };
+
+    const testInstanceChild = new TestInstanceChild()
+    const testInstanceParent = new TestInstanceParent(testInstanceChild);
+
+    matches(TestInstanceParent, Function);
+    matches(testInstanceParent, TestInstanceParent);
+    fails(testInstanceChild, TestInstanceParent);
+
+    matches(testInstanceParent, Match.Optional(TestInstanceParent));
+    matches(testInstanceParent, Match.Maybe(TestInstanceParent));
+
+    // Circular Reference Objects
+
+    const circleFoo = {};
+    const circleBar = {};
+    circleFoo.bar = circleBar;
+    circleBar.foo = circleFoo;
+    fails(circleFoo, null);
+
+    // Test that "arguments" is treated like an array.
+    const argumentsMatches = function () {
+      matches(arguments, [Number]);
+    };
+    argumentsMatches();
+    argumentsMatches(1);
+    argumentsMatches(1, 2);
+    const argumentsFails = function () {
+      fails(arguments, [Number]);
+    };
+    argumentsFails('123');
+    argumentsFails(1, '23');
   });
-  fails(true, Match.OneOf(String, Number, undefined, null, [Boolean]));
-  fails(new String('foo'), String);
-  fails(new Boolean(true), Boolean);
-  fails(new Number(123), Number);
 
-  matches([1, 2, 3], [Number]);
-  matches([], [Number]);
-  fails([1, 2, 3, '4'], [Number]);
-  fails([1, 2, 3, [4]], [Number]);
-  matches([1, 2, 3, '4'], [Match.OneOf(Number, String)]);
+  it('check throw all errors', () => {
+    const matches = (value, pattern) => {
+      let error;
+      try {
+        check(value, pattern, {throwAllErrors: true});
+      } catch (e) {
+        error = e;
+      }
 
-  matches({}, Object);
-  matches({}, {});
-  matches({foo: 42}, Object);
-  fails({foo: 42}, {});
-  matches({a: 1, b:2}, {b: Number, a: Number});
-  fails({a: 1, b:2}, {b: Number});
-  matches({a: 1, b:2}, Match.ObjectIncluding({b: Number}));
-  fails({a: 1, b:2}, Match.ObjectIncluding({b: String}));
-  fails({a: 1, b:2}, Match.ObjectIncluding({c: String}));
-  fails({}, {a: Number});
-  matches({nodeType: 1}, {nodeType: Match.Any});
-  matches({nodeType: 1}, Match.ObjectIncluding({nodeType: Match.Any}));
-  fails({nodeType: 1}, {nodeType: String});
-  fails({}, Match.ObjectIncluding({nodeType: Match.Any}));
+      assert.ok(!error);
+      assert.ok(Match.test(value, pattern));
+    };
 
-  // Match.Optional does not match on a null value, unless the allowed type is itself "null"
-  fails(null, Match.Optional(String));
-  fails(null, Match.Optional(undefined));
-  matches(null, Match.Optional(null));
+    const fails = (value, pattern) => {
+      let error;
 
-  // on the other hand, undefined, works fine for all of them
-  matches(undefined, Match.Optional(String));
-  matches(undefined, Match.Optional(undefined));
-  matches(undefined, Match.Optional(null));
+      try {
+        check(value, pattern, {throwAllErrors: true});
+      } catch (e) {
+        error = e;
+      }
 
-  fails(true, Match.Optional(String)); // different should still fail
-  matches('String', Match.Optional(String)); // same should pass
+      assert.ok(error);
+      error.every(e => assert.ok(e instanceof Match.Error));
+      assert.ok(!Match.test(value, pattern));
+    };
 
-  matches({}, {a: Match.Optional(Number)});
-  matches({a: 1}, {a: Match.Optional(Number)});
-  fails({a: true}, {a: Match.Optional(Number)});
-  fails({a: undefined}, {a: Match.Optional(Number)});
+    // Atoms.
+    const pairs = [
+      ['foo', String],
+      ['', String],
+      [0, Number],
+      [42.59, Number],
+      [NaN, Number],
+      [Infinity, Number],
+      [true, Boolean],
+      [false, Boolean],
+      [function(){}, Function],
+      [undefined, undefined],
+      [null, null]
+    ];
+    pairs.forEach(pair => {
+      matches(pair[0], Match.Any);
+      [String, Number, Boolean, undefined, null].forEach(type => {
+        if (type === pair[1]) {
+          matches(pair[0], type);
+          matches(pair[0], Match.Optional(type));
+          matches(undefined, Match.Optional(type));
+          matches(pair[0], Match.Maybe(type));
+          matches(undefined, Match.Maybe(type));
+          matches(null, Match.Maybe(type));
+          matches(pair[0], Match.Where(() => {
+            check(pair[0], type);
+            return true;
+          }));
+          matches(pair[0], Match.Where(() => {
+            try {
+              check(pair[0], type);
+              return true;
+            } catch (e) {
+              return false;
+            }
+          }));
+        } else {
+          fails(pair[0], type);
+          matches(pair[0], Match.OneOf(type, pair[1]));
+          matches(pair[0], Match.OneOf(pair[1], type));
+          fails(pair[0], Match.Where(() => {
+            check(pair[0], type);
+            return true;
+          }));
+          fails(pair[0], Match.Where(() => {
+            try {
+              check(pair[0], type);
+              return true;
+            } catch (e) {
+              return false;
+            }
+          }));
+        }
 
-  // .Maybe requires undefined, null or the allowed type in order to match
-  matches(null, Match.Maybe(String));
-  matches(null, Match.Maybe(undefined));
-  matches(null, Match.Maybe(null));
+        if ( type !== null ) {
 
-  matches(undefined, Match.Maybe(String));
-  matches(undefined, Match.Maybe(undefined));
-  matches(undefined, Match.Maybe(null));
+          // Optional doesn't allow null, but does match on null type
+          fails(null, Match.Optional(type));
+         }
+        fails(pair[0], [type]);
+        fails(pair[0], Object);
+      });
+    });
+    fails(true, Match.OneOf(String, Number, undefined, null, [Boolean]));
+    fails(new String('foo'), String);
+    fails(new Boolean(true), Boolean);
+    fails(new Number(123), Number);
 
-  fails(true, Match.Maybe(String)); // different should still fail
-  matches('String', Match.Maybe(String)); // same should pass
+    matches([1, 2, 3], [Number]);
+    matches([], [Number]);
+    fails([1, 2, 3, '4'], [Number]);
+    fails([1, 2, 3, [4]], [Number]);
+    matches([1, 2, 3, '4'], [Match.OneOf(Number, String)]);
 
-  matches({}, {a: Match.Maybe(Number)});
-  matches({a: 1}, {a: Match.Maybe(Number)});
-  fails({a: true}, {a: Match.Maybe(Number)});
+    matches({}, Object);
+    matches({}, {});
+    matches({foo: 42}, Object);
+    fails({foo: 42}, {});
+    matches({a: 1, b:2}, {b: Number, a: Number});
+    fails({a: 1, b:2}, {b: Number});
+    matches({a: 1, b:2}, Match.ObjectIncluding({b: Number}));
+    fails({a: 1, b:2}, Match.ObjectIncluding({b: String}));
+    fails({a: 1, b:2}, Match.ObjectIncluding({c: String}));
+    fails({}, {a: Number});
+    matches({nodeType: 1}, {nodeType: Match.Any});
+    matches({nodeType: 1}, Match.ObjectIncluding({nodeType: Match.Any}));
+    fails({nodeType: 1}, {nodeType: String});
+    fails({}, Match.ObjectIncluding({nodeType: Match.Any}));
 
-  // Match.Optional means "or undefined" at the top level but "or absent" in
-  // objects.
-  // Match.Maybe should behave the same as Match.Optional in objects
-  // including handling nulls
-  fails({a: undefined}, {a: Match.Maybe(Number)});
-  fails({a: null}, {a: Match.Maybe(Number)});
-  const F = function () {
-    this.x = 123;
-  };
+    // Match.Optional does not match on a null value, unless the allowed type is itself "null"
+    fails(null, Match.Optional(String));
+    fails(null, Match.Optional(undefined));
+    matches(null, Match.Optional(null));
 
-  fails(new F, { x: 123 });
+    // on the other hand, undefined, works fine for all of them
+    matches(undefined, Match.Optional(String));
+    matches(undefined, Match.Optional(undefined));
+    matches(undefined, Match.Optional(null));
 
-  matches({}, Match.ObjectWithValues(Number));
-  matches({x: 1}, Match.ObjectWithValues(Number));
-  matches({x: 1, y: 2}, Match.ObjectWithValues(Number));
-  fails({x: 1, y: '2'}, Match.ObjectWithValues(Number));
+    fails(true, Match.Optional(String)); // different should still fail
+    matches('String', Match.Optional(String)); // same should pass
 
-  matches('asdf', 'asdf');
-  fails('asdf', 'monkey');
-  matches(123, 123);
-  fails(123, 456);
-  fails('123', 123);
-  fails(123, '123');
-  matches(true, true);
-  matches(false, false);
-  fails(true, false);
-  fails(true, 'true');
-  fails('false', false);
-  matches('xx', Match.NonEmptyString);
-  fails('', Match.NonEmptyString);
-  matches(/foo/, RegExp);
-  fails(/foo/, String);
-  matches(new Date, Date);
-  fails(new Date, Number);
-  matches(EJSON.newBinary(42), Match.Where(EJSON.isBinary));
-  fails([], Match.Where(EJSON.isBinary));
+    matches({}, {a: Match.Optional(Number)});
+    matches({a: 1}, {a: Match.Optional(Number)});
+    fails({a: true}, {a: Match.Optional(Number)});
+    fails({a: undefined}, {a: Match.Optional(Number)});
 
-  matches(42, Match.Where(x => x % 2 === 0));
-  fails(43, Match.Where(x => x % 2 === 0));
+    // .Maybe requires undefined, null or the allowed type in order to match
+    matches(null, Match.Maybe(String));
+    matches(null, Match.Maybe(undefined));
+    matches(null, Match.Maybe(null));
 
-  matches({
-    a: 'something',
-    b: [
-      {x: 42, k: null},
-      {x: 43, k: true, p: ['yay']},
-    ],
-  }, {
-    a: String,
-    b: [
-      Match.ObjectIncluding({
-        x: Number,
-        k: Match.OneOf(null, Boolean)
-      }),
-    ],
+    matches(undefined, Match.Maybe(String));
+    matches(undefined, Match.Maybe(undefined));
+    matches(undefined, Match.Maybe(null));
+
+    fails(true, Match.Maybe(String)); // different should still fail
+    matches('String', Match.Maybe(String)); // same should pass
+
+    matches({}, {a: Match.Maybe(Number)});
+    matches({a: 1}, {a: Match.Maybe(Number)});
+    fails({a: true}, {a: Match.Maybe(Number)});
+
+    // Match.Optional means "or undefined" at the top level but "or absent" in
+    // objects.
+    // Match.Maybe should behave the same as Match.Optional in objects
+    // including handling nulls
+    fails({a: undefined}, {a: Match.Maybe(Number)});
+    fails({a: null}, {a: Match.Maybe(Number)});
+    const F = function () {
+      this.x = 123;
+    };
+
+    fails(new F, { x: 123 });
+
+    matches({}, Match.ObjectWithValues(Number));
+    matches({x: 1}, Match.ObjectWithValues(Number));
+    matches({x: 1, y: 2}, Match.ObjectWithValues(Number));
+    fails({x: 1, y: '2'}, Match.ObjectWithValues(Number));
+
+    matches('asdf', 'asdf');
+    fails('asdf', 'monkey');
+    matches(123, 123);
+    fails(123, 456);
+    fails('123', 123);
+    fails(123, '123');
+    matches(true, true);
+    matches(false, false);
+    fails(true, false);
+    fails(true, 'true');
+    fails('false', false);
+
+    matches(/foo/, RegExp);
+    fails(/foo/, String);
+    matches(new Date, Date);
+    fails(new Date, Number);
+    matches(EJSON.newBinary(42), Match.Where(EJSON.isBinary));
+    fails([], Match.Where(EJSON.isBinary));
+
+    matches(42, Match.Where(x => x % 2 === 0));
+    fails(43, Match.Where(x => x % 2 === 0));
+
+    matches({
+      a: 'something',
+      b: [
+        {x: 42, k: null},
+        {x: 43, k: true, p: ['yay']},
+      ],
+    }, {
+      a: String,
+      b: [
+        Match.ObjectIncluding({
+          x: Number,
+          k: Match.OneOf(null, Boolean)
+        }),
+      ],
+    });
+
+
+    // Match.Integer
+    matches(-1, Match.Integer);
+    matches(0, Match.Integer);
+    matches(1, Match.Integer);
+    matches(-2147483648, Match.Integer); // INT_MIN
+    matches(2147483647, Match.Integer); // INT_MAX
+    fails(123.33, Match.Integer);
+    fails(.33, Match.Integer);
+    fails(1.348192308491824e+23, Match.Integer);
+    fails(NaN, Match.Integer);
+    fails(Infinity, Match.Integer);
+    fails(-Infinity, Match.Integer);
+    fails({}, Match.Integer);
+    fails([], Match.Integer);
+    fails(function () {}, Match.Integer);
+    fails(new Date, Match.Integer);
+
+
+    // Test non-plain objects.
+    const parentObj = {foo: 'bar'};
+    const childObj = Object.assign(Object.create(parentObj), {bar: 'foo'});
+    matches(parentObj, Object);
+    fails(parentObj, {foo: String, bar: String});
+    fails(parentObj, {bar: String});
+    matches(parentObj, {foo: String});
+    fails(childObj, Object);
+    fails(childObj, {foo: String, bar: String});
+    fails(childObj, {bar: String});
+    fails(childObj, {foo: String});
+
+    // Functions
+    const testFunction = () => {};
+    matches(testFunction, Function);
+    fails(5, Function);
+
+    // Circular Reference "Classes"
+
+    const TestInstanceChild = function () {};
+    const TestInstanceParent = function (child) {
+      child._parent = this;
+      this.child = child;
+    };
+
+    const testInstanceChild = new TestInstanceChild()
+    const testInstanceParent = new TestInstanceParent(testInstanceChild);
+
+    matches(TestInstanceParent, Function);
+    matches(testInstanceParent, TestInstanceParent);
+    fails(testInstanceChild, TestInstanceParent);
+
+    matches(testInstanceParent, Match.Optional(TestInstanceParent));
+    matches(testInstanceParent, Match.Maybe(TestInstanceParent));
+
+    // Circular Reference Objects
+
+    const circleFoo = {};
+    const circleBar = {};
+    circleFoo.bar = circleBar;
+    circleBar.foo = circleFoo;
+    fails(circleFoo, null);
+
+    // Test that "arguments" is treated like an array.
+    const argumentsMatches = function () {
+      matches(arguments, [Number]);
+    };
+    argumentsMatches();
+    argumentsMatches(1);
+    argumentsMatches(1, 2);
+    const argumentsFails = function () {
+      fails(arguments, [Number]);
+    };
+    argumentsFails('123');
+    argumentsFails(1, '23');
   });
 
-
-  // Match.Integer
-  matches(-1, Match.Integer);
-  matches(0, Match.Integer);
-  matches(1, Match.Integer);
-  matches(-2147483648, Match.Integer); // INT_MIN
-  matches(2147483647, Match.Integer); // INT_MAX
-  fails(123.33, Match.Integer);
-  fails(.33, Match.Integer);
-  fails(1.348192308491824e+23, Match.Integer);
-  fails(NaN, Match.Integer);
-  fails(Infinity, Match.Integer);
-  fails(-Infinity, Match.Integer);
-  fails({}, Match.Integer);
-  fails([], Match.Integer);
-  fails(function () {}, Match.Integer);
-  fails(new Date, Match.Integer);
-
-
-  // Test non-plain objects.
-  const parentObj = {foo: 'bar'};
-  const childObj = Object.assign(Object.create(parentObj), {bar: 'foo'});
-  matches(parentObj, Object);
-  fails(parentObj, {foo: String, bar: String});
-  fails(parentObj, {bar: String});
-  matches(parentObj, {foo: String});
-  fails(childObj, Object);
-  fails(childObj, {foo: String, bar: String});
-  fails(childObj, {bar: String});
-  fails(childObj, {foo: String});
-
-  // Functions
-  const testFunction = () => {};
-  matches(testFunction, Function);
-  fails(5, Function);
-
-  // Circular Reference "Classes"
-
-  const TestInstanceChild = function () {};
-  const TestInstanceParent = function (child) {
-    child._parent = this;
-    this.child = child;
-  };
-
-  const testInstanceChild = new TestInstanceChild()
-  const testInstanceParent = new TestInstanceParent(testInstanceChild);
-
-  matches(TestInstanceParent, Function);
-  matches(testInstanceParent, TestInstanceParent);
-  fails(testInstanceChild, TestInstanceParent);
-
-  matches(testInstanceParent, Match.Optional(TestInstanceParent));
-  matches(testInstanceParent, Match.Maybe(TestInstanceParent));
-
-  // Circular Reference Objects
-
-  const circleFoo = {};
-  const circleBar = {};
-  circleFoo.bar = circleBar;
-  circleBar.foo = circleFoo;
-  fails(circleFoo, null);
-
-  // Test that "arguments" is treated like an array.
-  const argumentsMatches = function () {
-    matches(arguments, [Number]);
-  };
-  argumentsMatches();
-  argumentsMatches(1);
-  argumentsMatches(1, 2);
-  const argumentsFails = function () {
-    fails(arguments, [Number]);
-  };
-  argumentsFails('123');
-  argumentsFails(1, '23');
-});
-
-Tinytest.add('check - check throw all errors', test => {
-  const matches = (value, pattern) => {
+  it('check throw all errors deeply nested', () => {
     let error;
+
+    const value = {
+      text: 1,
+      emails: ['2', 3, 4],
+      things: [{id: '1', num: 1}, {id: 2, num: 2}, {id: 3, num: '3'}],
+      stuff: {foo: 'true', bar: 3, items: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}]},
+      any: { a: 'a' },
+      maybe: { m: 'm', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
+      opt: { o: 'm', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
+      int: { i: 1.2, a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
+      oneOf: { f: 'm', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
+      where: { w: 'a', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
+      whereArr: [1, 2, 3],
+      embedded: { thing: '1' }
+    };
+
+    const pattern = {
+      text: String,
+      emails: [String],
+      things: [{id: String, num: Number}],
+      stuff: {foo: Boolean, bar: String, items: [{ x: String, y: Number }]},
+      any: Match.Any,
+      maybe: { m: Match.Maybe(Number), a: [Match.Maybe(Number)], b: Match.Maybe([{ x: String, y: Number }]) },
+      opt: { m: Match.Optional(Number), a: [Match.Optional(Number)], b: Match.Optional([{ x: String, y: Number }]) },
+      int: { i: Match.Integer, a: [Match.Integer], b: [{ x: Match.Integer, y: Number }]},
+      oneOf: { f: Match.OneOf(Number, Boolean), a: [Match.OneOf(Boolean, Function)], b: [{ x: Match.OneOf(String, Number), y: Match.OneOf(Boolean, null) }]},
+      where: {
+        w: Match.Where((x) => {
+          check(x, String);
+          return x.length > 1;
+        }),
+        a: Match.Where((x) => {
+          check(x, [Number]);
+          return x > 1;
+        })
+      },
+      whereArr: Match.Where((x) => {
+        check(x, [String]);
+        return x.length === 1;
+      }),
+      missing1: String,
+      missing2: String,
+      embedded: { thing: String, another: String }
+    }
+
     try {
       check(value, pattern, {throwAllErrors: true});
     } catch (e) {
       error = e;
     }
 
-    test.isFalse(error);
-    test.isTrue(Match.test(value, pattern));
-  };
-
-  const fails = (value, pattern) => {
-    let error;
-
-    try {
-      check(value, pattern, {throwAllErrors: true});
-    } catch (e) {
-      error = e;
-    }
-
-    test.isTrue(error);
-    error.every(e => test.instanceOf(e, Match.Error));
-    test.isFalse(Match.test(value, pattern));
-  };
-
-  // Atoms.
-  const pairs = [
-    ['foo', String],
-    ['', String],
-    [0, Number],
-    [42.59, Number],
-    [NaN, Number],
-    [Infinity, Number],
-    [true, Boolean],
-    [false, Boolean],
-    [function(){}, Function],
-    [undefined, undefined],
-    [null, null]
-  ];
-  pairs.forEach(pair => {
-    matches(pair[0], Match.Any);
-    [String, Number, Boolean, undefined, null].forEach(type => {
-      if (type === pair[1]) {
-        matches(pair[0], type);
-        matches(pair[0], Match.Optional(type));
-        matches(undefined, Match.Optional(type));
-        matches(pair[0], Match.Maybe(type));
-        matches(undefined, Match.Maybe(type));
-        matches(null, Match.Maybe(type));
-        matches(pair[0], Match.Where(() => {
-          check(pair[0], type);
-          return true;
-        }));
-        matches(pair[0], Match.Where(() => {
-          try {
-            check(pair[0], type);
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }));
-      } else {
-        fails(pair[0], type);
-        matches(pair[0], Match.OneOf(type, pair[1]));
-        matches(pair[0], Match.OneOf(pair[1], type));
-        fails(pair[0], Match.Where(() => {
-          check(pair[0], type);
-          return true;
-        }));
-        fails(pair[0], Match.Where(() => {
-          try {
-            check(pair[0], type);
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }));
-      }
-
-      if ( type !== null ) {
-
-        // Optional doesn't allow null, but does match on null type
-        fails(null, Match.Optional(type));
-       }
-      fails(pair[0], [type]);
-      fails(pair[0], Object);
-    });
-  });
-  fails(true, Match.OneOf(String, Number, undefined, null, [Boolean]));
-  fails(new String('foo'), String);
-  fails(new Boolean(true), Boolean);
-  fails(new Number(123), Number);
-
-  matches([1, 2, 3], [Number]);
-  matches([], [Number]);
-  fails([1, 2, 3, '4'], [Number]);
-  fails([1, 2, 3, [4]], [Number]);
-  matches([1, 2, 3, '4'], [Match.OneOf(Number, String)]);
-
-  matches({}, Object);
-  matches({}, {});
-  matches({foo: 42}, Object);
-  fails({foo: 42}, {});
-  matches({a: 1, b:2}, {b: Number, a: Number});
-  fails({a: 1, b:2}, {b: Number});
-  matches({a: 1, b:2}, Match.ObjectIncluding({b: Number}));
-  fails({a: 1, b:2}, Match.ObjectIncluding({b: String}));
-  fails({a: 1, b:2}, Match.ObjectIncluding({c: String}));
-  fails({}, {a: Number});
-  matches({nodeType: 1}, {nodeType: Match.Any});
-  matches({nodeType: 1}, Match.ObjectIncluding({nodeType: Match.Any}));
-  fails({nodeType: 1}, {nodeType: String});
-  fails({}, Match.ObjectIncluding({nodeType: Match.Any}));
-
-  // Match.Optional does not match on a null value, unless the allowed type is itself "null"
-  fails(null, Match.Optional(String));
-  fails(null, Match.Optional(undefined));
-  matches(null, Match.Optional(null));
-
-  // on the other hand, undefined, works fine for all of them
-  matches(undefined, Match.Optional(String));
-  matches(undefined, Match.Optional(undefined));
-  matches(undefined, Match.Optional(null));
-
-  fails(true, Match.Optional(String)); // different should still fail
-  matches('String', Match.Optional(String)); // same should pass
-
-  matches({}, {a: Match.Optional(Number)});
-  matches({a: 1}, {a: Match.Optional(Number)});
-  fails({a: true}, {a: Match.Optional(Number)});
-  fails({a: undefined}, {a: Match.Optional(Number)});
-
-  // .Maybe requires undefined, null or the allowed type in order to match
-  matches(null, Match.Maybe(String));
-  matches(null, Match.Maybe(undefined));
-  matches(null, Match.Maybe(null));
-
-  matches(undefined, Match.Maybe(String));
-  matches(undefined, Match.Maybe(undefined));
-  matches(undefined, Match.Maybe(null));
-
-  fails(true, Match.Maybe(String)); // different should still fail
-  matches('String', Match.Maybe(String)); // same should pass
-
-  matches({}, {a: Match.Maybe(Number)});
-  matches({a: 1}, {a: Match.Maybe(Number)});
-  fails({a: true}, {a: Match.Maybe(Number)});
-
-  // Match.Optional means "or undefined" at the top level but "or absent" in
-  // objects.
-  // Match.Maybe should behave the same as Match.Optional in objects
-  // including handling nulls
-  fails({a: undefined}, {a: Match.Maybe(Number)});
-  fails({a: null}, {a: Match.Maybe(Number)});
-  const F = function () {
-    this.x = 123;
-  };
-
-  fails(new F, { x: 123 });
-
-  matches({}, Match.ObjectWithValues(Number));
-  matches({x: 1}, Match.ObjectWithValues(Number));
-  matches({x: 1, y: 2}, Match.ObjectWithValues(Number));
-  fails({x: 1, y: '2'}, Match.ObjectWithValues(Number));
-
-  matches('asdf', 'asdf');
-  fails('asdf', 'monkey');
-  matches(123, 123);
-  fails(123, 456);
-  fails('123', 123);
-  fails(123, '123');
-  matches(true, true);
-  matches(false, false);
-  fails(true, false);
-  fails(true, 'true');
-  fails('false', false);
-
-  matches(/foo/, RegExp);
-  fails(/foo/, String);
-  matches(new Date, Date);
-  fails(new Date, Number);
-  matches(EJSON.newBinary(42), Match.Where(EJSON.isBinary));
-  fails([], Match.Where(EJSON.isBinary));
-
-  matches(42, Match.Where(x => x % 2 === 0));
-  fails(43, Match.Where(x => x % 2 === 0));
-
-  matches({
-    a: 'something',
-    b: [
-      {x: 42, k: null},
-      {x: 43, k: true, p: ['yay']},
-    ],
-  }, {
-    a: String,
-    b: [
-      Match.ObjectIncluding({
-        x: Number,
-        k: Match.OneOf(null, Boolean)
-      }),
-    ],
+    assert.ok(error);
+    assert.strictEqual(error.length, 40);
+    assert.deepStrictEqual(
+      error.filter(e => e.message.includes('Missing key')).map(e => e.message),
+      [`Match error: Missing key 'another' in field embedded`, `Match error: Missing key 'missing1'`, `Match error: Missing key 'missing2'`]
+    );
+    error.every(e => assert.ok(e instanceof Match.Error));
+    assert.ok(!Match.test(value, pattern));
   });
 
-
-  // Match.Integer
-  matches(-1, Match.Integer);
-  matches(0, Match.Integer);
-  matches(1, Match.Integer);
-  matches(-2147483648, Match.Integer); // INT_MIN
-  matches(2147483647, Match.Integer); // INT_MAX
-  fails(123.33, Match.Integer);
-  fails(.33, Match.Integer);
-  fails(1.348192308491824e+23, Match.Integer);
-  fails(NaN, Match.Integer);
-  fails(Infinity, Match.Integer);
-  fails(-Infinity, Match.Integer);
-  fails({}, Match.Integer);
-  fails([], Match.Integer);
-  fails(function () {}, Match.Integer);
-  fails(new Date, Match.Integer);
-
-
-  // Test non-plain objects.
-  const parentObj = {foo: 'bar'};
-  const childObj = Object.assign(Object.create(parentObj), {bar: 'foo'});
-  matches(parentObj, Object);
-  fails(parentObj, {foo: String, bar: String});
-  fails(parentObj, {bar: String});
-  matches(parentObj, {foo: String});
-  fails(childObj, Object);
-  fails(childObj, {foo: String, bar: String});
-  fails(childObj, {bar: String});
-  fails(childObj, {foo: String});
-
-  // Functions
-  const testFunction = () => {};
-  matches(testFunction, Function);
-  fails(5, Function);
-
-  // Circular Reference "Classes"
-
-  const TestInstanceChild = function () {};
-  const TestInstanceParent = function (child) {
-    child._parent = this;
-    this.child = child;
-  };
-
-  const testInstanceChild = new TestInstanceChild()
-  const testInstanceParent = new TestInstanceParent(testInstanceChild);
-
-  matches(TestInstanceParent, Function);
-  matches(testInstanceParent, TestInstanceParent);
-  fails(testInstanceChild, TestInstanceParent);
-
-  matches(testInstanceParent, Match.Optional(TestInstanceParent));
-  matches(testInstanceParent, Match.Maybe(TestInstanceParent));
-
-  // Circular Reference Objects
-
-  const circleFoo = {};
-  const circleBar = {};
-  circleFoo.bar = circleBar;
-  circleBar.foo = circleFoo;
-  fails(circleFoo, null);
-
-  // Test that "arguments" is treated like an array.
-  const argumentsMatches = function () {
-    matches(arguments, [Number]);
-  };
-  argumentsMatches();
-  argumentsMatches(1);
-  argumentsMatches(1, 2);
-  const argumentsFails = function () {
-    fails(arguments, [Number]);
-  };
-  argumentsFails('123');
-  argumentsFails(1, '23');
-});
-
-Tinytest.add('check - check throw all errors deeply nested', test => {
-  let error;
-
-  const value = {
-    text: 1,
-    emails: ['2', 3, 4],
-    things: [{id: '1', num: 1}, {id: 2, num: 2}, {id: 3, num: '3'}],
-    stuff: {foo: 'true', bar: 3, items: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}]},
-    any: { a: 'a' },
-    maybe: { m: 'm', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
-    opt: { o: 'm', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
-    int: { i: 1.2, a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
-    oneOf: { f: 'm', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
-    where: { w: 'a', a: [1, '2'], b: [{x: 1, y: '1'}, {x: '2', y: 2}, {x: '3', y: '3'}] },
-    whereArr: [1, 2, 3],
-    embedded: { thing: '1' }
-  };
-
-  const pattern = {
-    text: String,
-    emails: [String],
-    things: [{id: String, num: Number}],
-    stuff: {foo: Boolean, bar: String, items: [{ x: String, y: Number }]},
-    any: Match.Any,
-    maybe: { m: Match.Maybe(Number), a: [Match.Maybe(Number)], b: Match.Maybe([{ x: String, y: Number }]) },
-    opt: { m: Match.Optional(Number), a: [Match.Optional(Number)], b: Match.Optional([{ x: String, y: Number }]) },
-    int: { i: Match.Integer, a: [Match.Integer], b: [{ x: Match.Integer, y: Number }]},
-    oneOf: { f: Match.OneOf(Number, Boolean), a: [Match.OneOf(Boolean, Function)], b: [{ x: Match.OneOf(String, Number), y: Match.OneOf(Boolean, null) }]},
-    where: {
-      w: Match.Where((x) => {
-        check(x, String);
-        return x.length > 1;
-      }),
-      a: Match.Where((x) => {
-        check(x, [Number]);
-        return x > 1;
-      })
-    },
-    whereArr: Match.Where((x) => {
-      check(x, [String]);
-      return x.length === 1;
-    }),
-    missing1: String,
-    missing2: String,
-    embedded: { thing: String, another: String }
-  }
-
-  try {
-    check(value, pattern, {throwAllErrors: true});
-  } catch (e) {
-    error = e;
-  }
-
-  test.isTrue(error);
-  test.equal(error.length, 40);
-  test.equal(error.filter(e => e.message.includes('Missing key')).map(e => e.message), [`Match error: Missing key 'another' in field embedded`, `Match error: Missing key 'missing1'`, `Match error: Missing key 'missing2'`]);
-  error.every(e => test.instanceOf(e, Match.Error));
-  test.isFalse(Match.test(value, pattern));
-})
-
-Tinytest.add('check - argument checker', test => {
-  const checksAllArguments = (f, ...args) =>
-    Match._failIfArgumentsAreNotAllChecked(f, {}, args, 'test');
-  checksAllArguments(() => {});
-  checksAllArguments(x => check(x, Match.Any), undefined);
-  checksAllArguments(x => check(x, Match.Any), null);
-  checksAllArguments(x => check(x, Match.Any), false);
-  checksAllArguments(x => check(x, Match.Any), true);
-  checksAllArguments(x => check(x, Match.Any), 0);
-  checksAllArguments((a, b, c) => {
-    check(a, String);
-    check(b, Boolean);
-    check(c, Match.Optional(Number));
-  }, 'foo', true);
-  checksAllArguments((...args) => check(args, [Number]), 1, 2, 4);
-  checksAllArguments((x, ...args) => {
-    check(x, Number);
-    check(args, [String]);
-  }, 1, 'foo', 'bar', 'baz');
-
-  // NaN values
-  checksAllArguments(x => check(x, Number), NaN);
-
-  const doesntCheckAllArguments = (f, ...args) => {
-    try {
+  it('argument checker', () => {
+    const checksAllArguments = (f, ...args) =>
       Match._failIfArgumentsAreNotAllChecked(f, {}, args, 'test');
-      test.fail({message: 'expected _failIfArgumentsAreNotAllChecked to throw'});
-    } catch (e) {
-      test.equal(e.message, 'Did not check() all arguments during test');
-    }
-  };
+    checksAllArguments(() => {});
+    checksAllArguments(x => check(x, Match.Any), undefined);
+    checksAllArguments(x => check(x, Match.Any), null);
+    checksAllArguments(x => check(x, Match.Any), false);
+    checksAllArguments(x => check(x, Match.Any), true);
+    checksAllArguments(x => check(x, Match.Any), 0);
+    checksAllArguments((a, b, c) => {
+      check(a, String);
+      check(b, Boolean);
+      check(c, Match.Optional(Number));
+    }, 'foo', true);
+    checksAllArguments((...args) => check(args, [Number]), 1, 2, 4);
+    checksAllArguments((x, ...args) => {
+      check(x, Number);
+      check(args, [String]);
+    }, 1, 'foo', 'bar', 'baz');
 
-  doesntCheckAllArguments(() => {}, undefined);
-  doesntCheckAllArguments(() => {}, null);
-  doesntCheckAllArguments(() => {}, 1);
-  doesntCheckAllArguments((x, ...args) => check(args, [String]), 1, 'asdf', 'foo');
-  doesntCheckAllArguments((x, y) => check(x, Boolean), true, false);
+    // NaN values
+    checksAllArguments(x => check(x, Number), NaN);
 
-  // One "true" check doesn't count for all.
-  doesntCheckAllArguments((x, y) => check(x, Boolean), true, true);
-
-  // For non-primitives, we really do require that each arg gets checked.
-  doesntCheckAllArguments((x, y) => {
-    check(x, [Boolean]);
-    check(x, [Boolean]);
-  }, [true], [true]);
-
-  // In an ideal world this test would fail, but we currently can't
-  // differentiate between "two calls to check x, both of which are true" and
-  // "check x and check y, both of which are true" (for any interned primitive
-  // type).
-  checksAllArguments((x, y) => {
-    check(x, Boolean);
-    check(x, Boolean);
-  }, true, true);
-});
-
-Tinytest.add('check - Match error path', test => {
-  const match = (value, pattern, expectedPath) => {
-    try {
-      check(value, pattern);
-    } catch (err) {
-
-      // XXX just for FF 3.6, its JSON stringification prefers "\u000a" to "\n"
-      err.path = err.path.replace(/\\u000a/, '\\n');
-      if (err.path != expectedPath) {
-        test.fail({
-          type: 'match-error-path',
-          message: "The path of Match.Error doesn't match.",
-          pattern: JSON.stringify(pattern),
-          value: JSON.stringify(value),
-          path: err.path,
-          expectedPath,
-        });
+    const doesntCheckAllArguments = (f, ...args) => {
+      try {
+        Match._failIfArgumentsAreNotAllChecked(f, {}, args, 'test');
+        assert.fail('expected _failIfArgumentsAreNotAllChecked to throw');
+      } catch (e) {
+        if (e.code === 'ERR_ASSERTION') throw e; // re-throw assert.fail
+        assert.strictEqual(e.message, 'Did not check() all arguments during test');
       }
-    }
-  };
+    };
 
-  match({ foo: [ { bar: 3 }, { bar: 'something' } ] }, { foo: [{ bar: Number }] }, 'foo[1].bar');
+    doesntCheckAllArguments(() => {}, undefined);
+    doesntCheckAllArguments(() => {}, null);
+    doesntCheckAllArguments(() => {}, 1);
+    doesntCheckAllArguments((x, ...args) => check(args, [String]), 1, 'asdf', 'foo');
+    doesntCheckAllArguments((x, y) => check(x, Boolean), true, false);
 
-  // Complicated case with arrays, $, whitespace and quotes!
-  match([{ $FoO: { "bar baz\n\"'": 3 } }], [{ $FoO: { "bar baz\n\"'": String } }], "[0].$FoO[\"bar baz\\n\\\"'\"]");
+    // One "true" check doesn't count for all.
+    doesntCheckAllArguments((x, y) => check(x, Boolean), true, true);
 
-  // Numbers only, can be accessed w/o quotes
-  match({ '1231': 123 }, { '1231': String }, '[1231]');
-  match({ '1234abcd': 123 }, { '1234abcd': String }, '[\"1234abcd\"]');
-  match({ $set: { people: 'nice' } }, { $set: { people: [String] } }, '$set.people');
-  match({ _underscore: 'should work' }, { _underscore: Number }, '_underscore');
+    // For non-primitives, we really do require that each arg gets checked.
+    doesntCheckAllArguments((x, y) => {
+      check(x, [Boolean]);
+      check(x, [Boolean]);
+    }, [true], [true]);
 
-  // Nested array looks nice
-  match([[['something', 'here'], []], [['string', 123]]], [[[String]]], '[1][0][1]');
+    // In an ideal world this test would fail, but we currently can't
+    // differentiate between "two calls to check x, both of which are true" and
+    // "check x and check y, both of which are true" (for any interned primitive
+    // type).
+    checksAllArguments((x, y) => {
+      check(x, Boolean);
+      check(x, Boolean);
+    }, true, true);
+  });
 
-  // Object nested in arrays should look nice, too!
-  match([[[{ foo: 'something' }, { foo: 'here'}],
-          [{ foo: 'asdf' }]],
-         [[{ foo: 123 }]]],
-        [[[{ foo: String }]]], '[1][0][0].foo');
+  it('Match error path', () => {
+    const matchPath = (value, pattern, expectedPath) => {
+      try {
+        check(value, pattern);
+      } catch (err) {
 
-  // JS keyword
-  match({ 'return': 0 }, { 'return': String }, '[\"return\"]');
-});
-
-Tinytest.add('check - Match error message', test => {
-  const match = (value, pattern, expectedMessage) => {
-    try {
-      check(value, pattern);
-    } catch (err) {
-      if (err.message !== `Match error: ${expectedMessage}`) {
-        test.fail({
-          type: 'match-error-message',
-          message: "The message of Match.Error doesn't match.",
-          pattern: JSON.stringify(pattern),
-          value: JSON.stringify(value),
-          errorMessage: err.message,
-          expectedErrorMessage,
-        });
+        // XXX just for FF 3.6, its JSON stringification prefers "\u000a" to "\n"
+        err.path = err.path.replace(/\\u000a/, '\\n');
+        if (err.path != expectedPath) {
+          assert.fail(
+            `Match.Error path mismatch: expected "${expectedPath}", got "${err.path}" ` +
+            `for value ${JSON.stringify(value)} against pattern ${JSON.stringify(pattern)}`
+          );
+        }
       }
-    }
-  };
+    };
 
-  match(2, String, 'Expected string, got number');
-  match({ key: 0 }, Number, 'Expected number, got object');
-  match(null, Boolean, 'Expected boolean, got null');
-  match('string', undefined, 'Expected undefined, got string');
-  match(true, null, 'Expected null, got true');
-  match({}, Match.ObjectIncluding({ bar: String }), "Missing key 'bar'");
-  match(null, Object, 'Expected object, got null');
-  match(null, Function, 'Expected function, got null');
-  match('bar', 'foo', 'Expected foo, got \"bar\"');
-  match(3.14, Match.Integer, 'Expected Integer, got 3.14');
-  match(false, [Boolean], 'Expected array, got false');
-  match([null, null], [String], 'Expected string, got null in field [0]');
-  match(2, { key: 2 }, 'Expected object, got number');
-  match(null, { key: 2 }, 'Expected object, got null');
-  match(new Date, { key: 2 }, 'Expected plain object');
+    matchPath({ foo: [ { bar: 3 }, { bar: 'something' } ] }, { foo: [{ bar: Number }] }, 'foo[1].bar');
 
-  const TestInstanceChild = function () {};
-  const TestInstanceParent = function (child) {
-    child._parent = this;
-    this.child = child;
-  };
+    // Complicated case with arrays, $, whitespace and quotes!
+    matchPath([{ $FoO: { "bar baz\n\"'": 3 } }], [{ $FoO: { "bar baz\n\"'": String } }], "[0].$FoO[\"bar baz\\n\\\"'\"]");
 
-  const testInstanceChild = new TestInstanceChild()
-  const testInstanceParent = new TestInstanceParent(testInstanceChild);
-  match(testInstanceChild, TestInstanceParent, `Expected ${(TestInstanceParent.name || 'particular constructor')}`);
+    // Numbers only, can be accessed w/o quotes
+    matchPath({ '1231': 123 }, { '1231': String }, '[1231]');
+    matchPath({ '1234abcd': 123 }, { '1234abcd': String }, '[\"1234abcd\"]');
+    matchPath({ $set: { people: 'nice' } }, { $set: { people: [String] } }, '$set.people');
+    matchPath({ _underscore: 'should work' }, { _underscore: Number }, '_underscore');
 
-  const circleFoo = {};
-  const circleBar = {};
-  circleFoo.bar = circleBar;
-  circleBar.foo = circleFoo;
-  match(circleFoo, null, 'Expected null, got object');
+    // Nested array looks nice
+    matchPath([[['something', 'here'], []], [['string', 123]]], [[[String]]], '[1][0][1]');
 
-});
+    // Object nested in arrays should look nice, too!
+    matchPath([[[{ foo: 'something' }, { foo: 'here'}],
+            [{ foo: 'asdf' }]],
+           [[{ foo: 123 }]]],
+          [[[{ foo: String }]]], '[1][0][0].foo');
 
-Tinytest.add(
-  'check - Match methods that return class instances can be called as ' +
-  'constructors',
-  test => {
+    // JS keyword
+    matchPath({ 'return': 0 }, { 'return': String }, '[\"return\"]');
+  });
 
+  it('Match error message', () => {
+    const matchMsg = (value, pattern, expectedMessage) => {
+      try {
+        check(value, pattern);
+      } catch (err) {
+        if (err.message !== `Match error: ${expectedMessage}`) {
+          assert.fail(
+            `Match.Error message mismatch: expected "Match error: ${expectedMessage}", ` +
+            `got "${err.message}"`
+          );
+        }
+      }
+    };
+
+    matchMsg(2, String, 'Expected string, got number');
+    matchMsg({ key: 0 }, Number, 'Expected number, got object');
+    matchMsg(null, Boolean, 'Expected boolean, got null');
+    matchMsg('string', undefined, 'Expected undefined, got string');
+    matchMsg(true, null, 'Expected null, got true');
+    matchMsg({}, Match.ObjectIncluding({ bar: String }), "Missing key 'bar'");
+    matchMsg(null, Object, 'Expected object, got null');
+    matchMsg(null, Function, 'Expected function, got null');
+    matchMsg('bar', 'foo', 'Expected foo, got "bar"');
+    matchMsg(3.14, Match.Integer, 'Expected Integer, got 3.14');
+    matchMsg(false, [Boolean], 'Expected array, got false');
+    matchMsg([null, null], [String], 'Expected string, got null in field [0]');
+    matchMsg(2, { key: 2 }, 'Expected object, got number');
+    matchMsg(null, { key: 2 }, 'Expected object, got null');
+    matchMsg(new Date, { key: 2 }, 'Expected plain object');
+
+    const TestInstanceChild = function () {};
+    const TestInstanceParent = function (child) {
+      child._parent = this;
+      this.child = child;
+    };
+
+    const testInstanceChild = new TestInstanceChild()
+    const testInstanceParent = new TestInstanceParent(testInstanceChild);
+    matchMsg(testInstanceChild, TestInstanceParent, `Expected ${(TestInstanceParent.name || 'particular constructor')}`);
+
+    const circleFoo = {};
+    const circleBar = {};
+    circleFoo.bar = circleBar;
+    circleBar.foo = circleFoo;
+    matchMsg(circleFoo, null, 'Expected null, got object');
+  });
+
+  it('Match methods that return class instances can be called as constructors', () => {
     // Existing code sometimes uses these properties as constructors, so we can't
     // switch them to arrow functions or method shorthand.
-    test.equal(new Match.Optional(), Match.Optional());
-    test.equal(new Match.Maybe(), Match.Maybe());
-    test.equal(new Match.OneOf([1]), Match.OneOf([1])); // Needs a non-empty array
-    test.equal(new Match.Where(), Match.Where());
-    test.equal(new Match.ObjectIncluding(), Match.ObjectIncluding());
-    test.equal(new Match.ObjectWithValues(), Match.ObjectWithValues());
-  }
-);
+    assert.ok(EJSON.equals(new Match.Optional(), Match.Optional()));
+    assert.ok(EJSON.equals(new Match.Maybe(), Match.Maybe()));
+    assert.ok(EJSON.equals(new Match.OneOf([1]), Match.OneOf([1]))); // Needs a non-empty array
+    assert.ok(EJSON.equals(new Match.Where(), Match.Where()));
+    assert.ok(EJSON.equals(new Match.ObjectIncluding(), Match.ObjectIncluding()));
+    assert.ok(EJSON.equals(new Match.ObjectWithValues(), Match.ObjectWithValues()));
+  });
+});

--- a/packages/check/package.js
+++ b/packages/check/package.js
@@ -16,7 +16,7 @@ Package.onUse(api => {
 });
 
 Package.onTest(api => {
-  api.use(['check', 'tinytest', 'ejson', 'ecmascript'], ['client', 'server']);
+  api.use(['check', 'ejson', 'ecmascript']);
 
-  api.addFiles('match_test.js', ['client', 'server']);
+  api.addFiles('match_test.js', 'server');
 });

--- a/packages/diff-sequence/package.js
+++ b/packages/diff-sequence/package.js
@@ -12,13 +12,6 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use([
-    'tinytest',
-    'ejson'
-  ]);
-
-  api.use('diff-sequence');
-  api.addFiles([
-    'tests.js'
-  ]);
+  api.use(['diff-sequence', 'ejson', 'ecmascript']);
+  api.addFiles('tests.js', 'server');
 });

--- a/packages/diff-sequence/tests.js
+++ b/packages/diff-sequence/tests.js
@@ -1,159 +1,156 @@
-Tinytest.add("diff-sequence - diff changes ordering", function (test) {
-  var makeDocs = function (ids) {
-    return ids.map(function (id) { return {_id: id};});
-  };
-  var testMutation = function (a, b) {
-    var aa = makeDocs(a);
-    var bb = makeDocs(b);
-    var aaCopy = EJSON.clone(aa);
-    DiffSequence.diffQueryOrderedChanges(aa, bb, {
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 
-      addedBefore: function (id, doc, before) {
-        if (before === null) {
-          aaCopy.push( Object.assign({_id: id}, doc));
-          return;
-        }
-        for (var i = 0; i < aaCopy.length; i++) {
-          if (aaCopy[i]._id === before) {
-            aaCopy.splice(i, 0, Object.assign({_id: id}, doc));
+describe('diff-sequence', () => {
+  it('diff changes ordering', () => {
+    const makeDocs = (ids) => ids.map((id) => ({ _id: id }));
+
+    const testMutation = (a, b) => {
+      const aa = makeDocs(a);
+      const bb = makeDocs(b);
+      const aaCopy = EJSON.clone(aa);
+      DiffSequence.diffQueryOrderedChanges(aa, bb, {
+        addedBefore(id, doc, before) {
+          if (before === null) {
+            aaCopy.push(Object.assign({ _id: id }, doc));
             return;
           }
-        }
-      },
-      movedBefore: function (id, before) {
-        var found;
-        for (var i = 0; i < aaCopy.length; i++) {
-          if (aaCopy[i]._id === id) {
-            found = aaCopy[i];
-            aaCopy.splice(i, 1);
+          for (let i = 0; i < aaCopy.length; i++) {
+            if (aaCopy[i]._id === before) {
+              aaCopy.splice(i, 0, Object.assign({ _id: id }, doc));
+              return;
+            }
           }
-        }
-        if (before === null) {
-          aaCopy.push( Object.assign({_id: id}, found));
-          return;
-        }
-        for (i = 0; i < aaCopy.length; i++) {
-          if (aaCopy[i]._id === before) {
-            aaCopy.splice(i, 0, Object.assign({_id: id}, found));
+        },
+        movedBefore(id, before) {
+          let found;
+          for (let i = 0; i < aaCopy.length; i++) {
+            if (aaCopy[i]._id === id) {
+              found = aaCopy[i];
+              aaCopy.splice(i, 1);
+            }
+          }
+          if (before === null) {
+            aaCopy.push(Object.assign({ _id: id }, found));
             return;
           }
-        }
-      },
-      removed: function (id) {
-        var found;
-        for (var i = 0; i < aaCopy.length; i++) {
-          if (aaCopy[i]._id === id) {
-            found = aaCopy[i];
-            aaCopy.splice(i, 1);
+          for (let i = 0; i < aaCopy.length; i++) {
+            if (aaCopy[i]._id === before) {
+              aaCopy.splice(i, 0, Object.assign({ _id: id }, found));
+              return;
+            }
+          }
+        },
+        removed(id) {
+          for (let i = 0; i < aaCopy.length; i++) {
+            if (aaCopy[i]._id === id) {
+              aaCopy.splice(i, 1);
+            }
           }
         }
-      }
-    });
-    test.equal(aaCopy, bb);
-  };
-
-  var testBothWays = function (a, b) {
-    testMutation(a, b);
-    testMutation(b, a);
-  };
-
-  testBothWays(["a", "b", "c"], ["c", "b", "a"]);
-  testBothWays(["a", "b", "c"], []);
-  testBothWays(["a", "b", "c"], ["e","f"]);
-  testBothWays(["a", "b", "c", "d"], ["c", "b", "a"]);
-  testBothWays(['A','B','C','D','E','F','G','H','I'],
-               ['A','B','F','G','C','D','I','L','M','N','H']);
-  testBothWays(['A','B','C','D','E','F','G','H','I'],['A','B','C','D','F','G','H','E','I']);
-});
-
-Tinytest.add("diff-sequence - diff", function (test) {
-
-  // test correctness
-
-  var diffTest = function(origLen, newOldIdx) {
-    var oldResults = new Array(origLen);
-    for (var i = 1; i <= origLen; i++)
-      oldResults[i-1] = {_id: i};
-
-    var newResults = newOldIdx.map(function(n) {
-      var doc = {_id: Math.abs(n)};
-      if (n < 0)
-        doc.changed = true;
-      return doc;
-    });
-    var find = function (arr, id) {
-      for (var i = 0; i < arr.length; i++) {
-        if (EJSON.equals(arr[i]._id, id))
-          return i;
-      }
-      return -1;
+      });
+      assert.deepStrictEqual(aaCopy, bb);
     };
 
-    var results = [...oldResults];
-    var observer = {
-      addedBefore: function(id, fields, before) {
-        var before_idx;
-        if (before === null)
-          before_idx = results.length;
-        else
-          before_idx = find (results, before);
-        var doc = Object.assign({_id: id}, fields);
-        test.isFalse(before_idx < 0 || before_idx > results.length);
-        results.splice(before_idx, 0, doc);
-      },
-      removed: function(id) {
-        var at_idx = find (results, id);
-        test.isFalse(at_idx < 0 || at_idx >= results.length);
-        results.splice(at_idx, 1);
-      },
-      changed: function(id, fields) {
-        var at_idx = find (results, id);
-        var oldDoc = results[at_idx];
-        var doc = EJSON.clone(oldDoc);
-        DiffSequence.applyChanges(doc, fields);
-        test.isFalse(at_idx < 0 || at_idx >= results.length);
-        test.equal(doc._id, oldDoc._id);
-        results[at_idx] = doc;
-      },
-      movedBefore: function(id, before) {
-        var old_idx = find(results, id);
-        var new_idx;
-        if (before === null)
-          new_idx = results.length;
-        else
-          new_idx = find (results, before);
-        if (new_idx > old_idx)
-          new_idx--;
-        test.isFalse(old_idx < 0 || old_idx >= results.length);
-        test.isFalse(new_idx < 0 || new_idx >= results.length);
-        results.splice(new_idx, 0, results.splice(old_idx, 1)[0]);
-      }
+    const testBothWays = (a, b) => {
+      testMutation(a, b);
+      testMutation(b, a);
     };
 
-    DiffSequence.diffQueryOrderedChanges(oldResults, newResults, observer);
-    test.equal(results, newResults);
-  };
+    testBothWays(["a", "b", "c"], ["c", "b", "a"]);
+    testBothWays(["a", "b", "c"], []);
+    testBothWays(["a", "b", "c"], ["e", "f"]);
+    testBothWays(["a", "b", "c", "d"], ["c", "b", "a"]);
+    testBothWays(['A','B','C','D','E','F','G','H','I'],
+                 ['A','B','F','G','C','D','I','L','M','N','H']);
+    testBothWays(['A','B','C','D','E','F','G','H','I'],
+                 ['A','B','C','D','F','G','H','E','I']);
+  });
 
-  // edge cases and cases run into during debugging
-  diffTest(5, [5, 1, 2, 3, 4]);
-  diffTest(0, [1, 2, 3, 4]);
-  diffTest(4, []);
-  diffTest(7, [4, 5, 6, 7, 1, 2, 3]);
-  diffTest(7, [5, 6, 7, 1, 2, 3, 4]);
-  diffTest(10, [7, 4, 11, 6, 12, 1, 5]);
-  diffTest(3, [3, 2, 1]);
-  diffTest(10, [2, 7, 4, 6, 11, 3, 8, 9]);
-  diffTest(0, []);
-  diffTest(1, []);
-  diffTest(0, [1]);
-  diffTest(1, [1]);
-  diffTest(5, [1, 2, 3, 4, 5]);
+  it('diff', () => {
+    const diffTest = (origLen, newOldIdx) => {
+      const oldResults = new Array(origLen);
+      for (let i = 1; i <= origLen; i++)
+        oldResults[i - 1] = { _id: i };
 
-  // interaction between "changed" and other ops
-  diffTest(5, [-5, -1, 2, -3, 4]);
-  diffTest(7, [-4, -5, 6, 7, -1, 2, 3]);
-  diffTest(7, [5, 6, -7, 1, 2, -3, 4]);
-  diffTest(10, [7, -4, 11, 6, 12, -1, 5]);
-  diffTest(3, [-3, -2, -1]);
-  diffTest(10, [-2, 7, 4, 6, 11, -3, -8, 9]);
+      const newResults = newOldIdx.map((n) => {
+        const doc = { _id: Math.abs(n) };
+        if (n < 0) doc.changed = true;
+        return doc;
+      });
+
+      const find = (arr, id) => {
+        for (let i = 0; i < arr.length; i++) {
+          if (EJSON.equals(arr[i]._id, id)) return i;
+        }
+        return -1;
+      };
+
+      const results = [...oldResults];
+      const observer = {
+        addedBefore(id, fields, before) {
+          let before_idx;
+          if (before === null)
+            before_idx = results.length;
+          else
+            before_idx = find(results, before);
+          const doc = Object.assign({ _id: id }, fields);
+          assert.ok(!(before_idx < 0 || before_idx > results.length));
+          results.splice(before_idx, 0, doc);
+        },
+        removed(id) {
+          const at_idx = find(results, id);
+          assert.ok(!(at_idx < 0 || at_idx >= results.length));
+          results.splice(at_idx, 1);
+        },
+        changed(id, fields) {
+          const at_idx = find(results, id);
+          const oldDoc = results[at_idx];
+          const doc = EJSON.clone(oldDoc);
+          DiffSequence.applyChanges(doc, fields);
+          assert.ok(!(at_idx < 0 || at_idx >= results.length));
+          assert.deepStrictEqual(doc._id, oldDoc._id);
+          results[at_idx] = doc;
+        },
+        movedBefore(id, before) {
+          const old_idx = find(results, id);
+          let new_idx;
+          if (before === null)
+            new_idx = results.length;
+          else
+            new_idx = find(results, before);
+          if (new_idx > old_idx) new_idx--;
+          assert.ok(!(old_idx < 0 || old_idx >= results.length));
+          assert.ok(!(new_idx < 0 || new_idx >= results.length));
+          results.splice(new_idx, 0, results.splice(old_idx, 1)[0]);
+        }
+      };
+
+      DiffSequence.diffQueryOrderedChanges(oldResults, newResults, observer);
+      assert.deepStrictEqual(results, newResults);
+    };
+
+    // edge cases and cases run into during debugging
+    diffTest(5, [5, 1, 2, 3, 4]);
+    diffTest(0, [1, 2, 3, 4]);
+    diffTest(4, []);
+    diffTest(7, [4, 5, 6, 7, 1, 2, 3]);
+    diffTest(7, [5, 6, 7, 1, 2, 3, 4]);
+    diffTest(10, [7, 4, 11, 6, 12, 1, 5]);
+    diffTest(3, [3, 2, 1]);
+    diffTest(10, [2, 7, 4, 6, 11, 3, 8, 9]);
+    diffTest(0, []);
+    diffTest(1, []);
+    diffTest(0, [1]);
+    diffTest(1, [1]);
+    diffTest(5, [1, 2, 3, 4, 5]);
+
+    // interaction between "changed" and other ops
+    diffTest(5, [-5, -1, 2, -3, 4]);
+    diffTest(7, [-4, -5, 6, 7, -1, 2, 3]);
+    diffTest(7, [5, 6, -7, 1, 2, -3, 4]);
+    diffTest(10, [7, -4, 11, 6, 12, -1, 5]);
+    diffTest(3, [-3, -2, -1]);
+    diffTest(10, [-2, 7, 4, 6, 11, -3, -8, 9]);
+  });
 });

--- a/packages/ejson/ejson_tests.js
+++ b/packages/ejson/ejson_tests.js
@@ -1,294 +1,250 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { EJSON } from './ejson';
 import EJSONTest from './custom_models_for_tests';
 
-Tinytest.add('ejson - keyOrderSensitive', test => {
-  test.isTrue(EJSON.equals({
-    a: {b: 1, c: 2},
-    d: {e: 3, f: 4},
-  }, {
-    d: {f: 4, e: 3},
-    a: {c: 2, b: 1},
-  }));
+describe('ejson', () => {
+  it('keyOrderSensitive', () => {
+    assert.ok(EJSON.equals({
+      a: {b: 1, c: 2},
+      d: {e: 3, f: 4},
+    }, {
+      d: {f: 4, e: 3},
+      a: {c: 2, b: 1},
+    }));
 
-  test.isFalse(EJSON.equals({
-    a: {b: 1, c: 2},
-    d: {e: 3, f: 4},
-  }, {
-    d: {f: 4, e: 3},
-    a: {c: 2, b: 1},
-  }, {keyOrderSensitive: true}));
+    assert.ok(!EJSON.equals({
+      a: {b: 1, c: 2},
+      d: {e: 3, f: 4},
+    }, {
+      d: {f: 4, e: 3},
+      a: {c: 2, b: 1},
+    }, {keyOrderSensitive: true}));
 
-  test.isFalse(EJSON.equals({
-    a: {b: 1, c: 2},
-    d: {e: 3, f: 4},
-  }, {
-    a: {c: 2, b: 1},
-    d: {f: 4, e: 3},
-  }, {keyOrderSensitive: true}));
-  test.isFalse(EJSON.equals({a: {}}, {a: {b: 2}}, {keyOrderSensitive: true}));
-  test.isFalse(EJSON.equals({a: {b: 2}}, {a: {}}, {keyOrderSensitive: true}));
-});
+    assert.ok(!EJSON.equals({
+      a: {b: 1, c: 2},
+      d: {e: 3, f: 4},
+    }, {
+      a: {c: 2, b: 1},
+      d: {f: 4, e: 3},
+    }, {keyOrderSensitive: true}));
+    assert.ok(!EJSON.equals({a: {}}, {a: {b: 2}}, {keyOrderSensitive: true}));
+    assert.ok(!EJSON.equals({a: {b: 2}}, {a: {}}, {keyOrderSensitive: true}));
+  });
 
-Tinytest.add('ejson - nesting and literal', test => {
-  const d = new Date();
-  const obj = {$date: d};
-  const eObj = EJSON.toJSONValue(obj);
-  const roundTrip = EJSON.fromJSONValue(eObj);
-  test.equal(obj, roundTrip);
-});
+  it('nesting and literal', () => {
+    const d = new Date();
+    const obj = {$date: d};
+    const eObj = EJSON.toJSONValue(obj);
+    const roundTrip = EJSON.fromJSONValue(eObj);
+    assert.deepStrictEqual(obj, roundTrip);
+  });
 
-Tinytest.add('ejson - some equality tests', test => {
-  test.isTrue(EJSON.equals({a: 1, b: 2, c: 3}, {a: 1, c: 3, b: 2}));
-  test.isFalse(EJSON.equals({a: 1, b: 2}, {a: 1, c: 3, b: 2}));
-  test.isFalse(EJSON.equals({a: 1, b: 2, c: 3}, {a: 1, b: 2}));
-  test.isFalse(EJSON.equals({a: 1, b: 2, c: 3}, {a: 1, c: 3, b: 4}));
-  test.isFalse(EJSON.equals({a: {}}, {a: {b: 2}}));
-  test.isFalse(EJSON.equals({a: {b: 2}}, {a: {}}));
-  // XXX: Object and Array were previously mistaken, which is why
-  // we add some extra tests for them here
-  test.isTrue(EJSON.equals([1, 2, 3, 4, 5], [1, 2, 3, 4, 5]));
-  test.isFalse(EJSON.equals([1, 2, 3, 4, 5], [1, 2, 3, 4]));
-  test.isFalse(EJSON.equals([1,2,3,4], {0: 1, 1: 2, 2: 3, 3: 4}));
-  test.isFalse(EJSON.equals({0: 1, 1: 2, 2: 3, 3: 4}, [1,2,3,4]));
-  test.isFalse(EJSON.equals({}, []));
-  test.isFalse(EJSON.equals([], {}));
-});
+  it('some equality tests', () => {
+    assert.ok(EJSON.equals({a: 1, b: 2, c: 3}, {a: 1, c: 3, b: 2}));
+    assert.ok(!EJSON.equals({a: 1, b: 2}, {a: 1, c: 3, b: 2}));
+    assert.ok(!EJSON.equals({a: 1, b: 2, c: 3}, {a: 1, b: 2}));
+    assert.ok(!EJSON.equals({a: 1, b: 2, c: 3}, {a: 1, c: 3, b: 4}));
+    assert.ok(!EJSON.equals({a: {}}, {a: {b: 2}}));
+    assert.ok(!EJSON.equals({a: {b: 2}}, {a: {}}));
+    assert.ok(EJSON.equals([1, 2, 3, 4, 5], [1, 2, 3, 4, 5]));
+    assert.ok(!EJSON.equals([1, 2, 3, 4, 5], [1, 2, 3, 4]));
+    assert.ok(!EJSON.equals([1,2,3,4], {0: 1, 1: 2, 2: 3, 3: 4}));
+    assert.ok(!EJSON.equals({0: 1, 1: 2, 2: 3, 3: 4}, [1,2,3,4]));
+    assert.ok(!EJSON.equals({}, []));
+    assert.ok(!EJSON.equals([], {}));
+  });
 
-Tinytest.add('ejson - equality and falsiness', test => {
-  test.isTrue(EJSON.equals(null, null));
-  test.isTrue(EJSON.equals(undefined, undefined));
-  test.isFalse(EJSON.equals({foo: 'foo'}, null));
-  test.isFalse(EJSON.equals(null, {foo: 'foo'}));
-  test.isFalse(EJSON.equals(undefined, {foo: 'foo'}));
-  test.isFalse(EJSON.equals({foo: 'foo'}, undefined));
-});
+  it('equality and falsiness', () => {
+    assert.ok(EJSON.equals(null, null));
+    assert.ok(EJSON.equals(undefined, undefined));
+    assert.ok(!EJSON.equals({foo: 'foo'}, null));
+    assert.ok(!EJSON.equals(null, {foo: 'foo'}));
+    assert.ok(!EJSON.equals(undefined, {foo: 'foo'}));
+    assert.ok(!EJSON.equals({foo: 'foo'}, undefined));
+  });
 
-Tinytest.add('ejson - NaN and Inf', test => {
-  test.equal(EJSON.parse('{"$InfNaN": 1}'), Infinity);
-  test.equal(EJSON.parse('{"$InfNaN": -1}'), -Infinity);
-  test.isTrue(Number.isNaN(EJSON.parse('{"$InfNaN": 0}')));
-  test.equal(EJSON.parse(EJSON.stringify(Infinity)), Infinity);
-  test.equal(EJSON.parse(EJSON.stringify(-Infinity)), -Infinity);
-  test.isTrue(Number.isNaN(EJSON.parse(EJSON.stringify(NaN))));
-  test.isTrue(EJSON.equals(NaN, NaN));
-  test.isTrue(EJSON.equals(Infinity, Infinity));
-  test.isTrue(EJSON.equals(-Infinity, -Infinity));
-  test.isFalse(EJSON.equals(Infinity, -Infinity));
-  test.isFalse(EJSON.equals(Infinity, NaN));
-  test.isFalse(EJSON.equals(Infinity, 0));
-  test.isFalse(EJSON.equals(NaN, 0));
+  it('NaN and Inf', () => {
+    assert.strictEqual(EJSON.parse('{"$InfNaN": 1}'), Infinity);
+    assert.strictEqual(EJSON.parse('{"$InfNaN": -1}'), -Infinity);
+    assert.ok(Number.isNaN(EJSON.parse('{"$InfNaN": 0}')));
+    assert.strictEqual(EJSON.parse(EJSON.stringify(Infinity)), Infinity);
+    assert.strictEqual(EJSON.parse(EJSON.stringify(-Infinity)), -Infinity);
+    assert.ok(Number.isNaN(EJSON.parse(EJSON.stringify(NaN))));
+    assert.ok(EJSON.equals(NaN, NaN));
+    assert.ok(EJSON.equals(Infinity, Infinity));
+    assert.ok(EJSON.equals(-Infinity, -Infinity));
+    assert.ok(!EJSON.equals(Infinity, -Infinity));
+    assert.ok(!EJSON.equals(Infinity, NaN));
+    assert.ok(!EJSON.equals(Infinity, 0));
+    assert.ok(!EJSON.equals(NaN, 0));
 
-  test.isTrue(EJSON.equals(
-    EJSON.parse('{"a": {"$InfNaN": 1}}'),
-    {a: Infinity}
-  ));
-  test.isTrue(EJSON.equals(
-    EJSON.parse('{"a": {"$InfNaN": 0}}'),
-    {a: NaN}
-  ));
-});
+    assert.ok(EJSON.equals(
+      EJSON.parse('{"a": {"$InfNaN": 1}}'),
+      {a: Infinity}
+    ));
+    assert.ok(EJSON.equals(
+      EJSON.parse('{"a": {"$InfNaN": 0}}'),
+      {a: NaN}
+    ));
+  });
 
-Tinytest.add('ejson - clone', test => {
-  const cloneTest = (x, identical) => {
-    const y = EJSON.clone(x);
-    test.isTrue(EJSON.equals(x, y));
-    test.equal(x === y, !!identical);
-  };
-  cloneTest(null, true);
-  cloneTest(undefined, true);
-  cloneTest(42, true);
-  cloneTest('asdf', true);
-  cloneTest([1, 2, 3]);
-  cloneTest([1, 'fasdf', {foo: 42}]);
-  cloneTest({x: 42, y: 'asdf'});
+  it('clone', () => {
+    const cloneTest = (x, identical) => {
+      const y = EJSON.clone(x);
+      assert.ok(EJSON.equals(x, y));
+      assert.strictEqual(x === y, !!identical);
+    };
+    cloneTest(null, true);
+    cloneTest(undefined, true);
+    cloneTest(42, true);
+    cloneTest('asdf', true);
+    cloneTest([1, 2, 3]);
+    cloneTest([1, 'fasdf', {foo: 42}]);
+    cloneTest({x: 42, y: 'asdf'});
 
-  function testCloneArgs(/*arguments*/) {
-    const clonedArgs = EJSON.clone(arguments);
-    test.equal(clonedArgs, [1, 2, 'foo', [4]]);
-  };
-  testCloneArgs(1, 2, 'foo', [4]);
-});
+    function testCloneArgs(/*arguments*/) {
+      const clonedArgs = EJSON.clone(arguments);
+      assert.deepStrictEqual(clonedArgs, [1, 2, 'foo', [4]]);
+    }
+    testCloneArgs(1, 2, 'foo', [4]);
+  });
 
-Tinytest.add('ejson - stringify', test => {
-  test.equal(EJSON.stringify(null), 'null');
-  test.equal(EJSON.stringify(true), 'true');
-  test.equal(EJSON.stringify(false), 'false');
-  test.equal(EJSON.stringify(123), '123');
-  test.equal(EJSON.stringify('abc'), '"abc"');
+  it('stringify', () => {
+    assert.strictEqual(EJSON.stringify(null), 'null');
+    assert.strictEqual(EJSON.stringify(true), 'true');
+    assert.strictEqual(EJSON.stringify(false), 'false');
+    assert.strictEqual(EJSON.stringify(123), '123');
+    assert.strictEqual(EJSON.stringify('abc'), '"abc"');
 
-  test.equal(EJSON.stringify([1, 2, 3]),
-     '[1,2,3]'
-  );
-  test.equal(EJSON.stringify([1, 2, 3], {indent: true}),
-    '[\n  1,\n  2,\n  3\n]'
-  );
-  test.equal(EJSON.stringify([1, 2, 3], {canonical: false}),
-    '[1,2,3]'
-  );
-  test.equal(EJSON.stringify([1, 2, 3], {indent: true, canonical: false}),
-    '[\n  1,\n  2,\n  3\n]'
-  );
+    assert.strictEqual(EJSON.stringify([1, 2, 3]), '[1,2,3]');
+    assert.strictEqual(EJSON.stringify([1, 2, 3], {indent: true}),
+      '[\n  1,\n  2,\n  3\n]');
+    assert.strictEqual(EJSON.stringify([1, 2, 3], {canonical: false}),
+      '[1,2,3]');
+    assert.strictEqual(EJSON.stringify([1, 2, 3], {indent: true, canonical: false}),
+      '[\n  1,\n  2,\n  3\n]');
 
-  test.equal(EJSON.stringify([1, 2, 3], {indent: 4}),
-    '[\n    1,\n    2,\n    3\n]'
-  );
-  test.equal(EJSON.stringify([1, 2, 3], {indent: '--'}),
-    '[\n--1,\n--2,\n--3\n]'
-  );
+    assert.strictEqual(EJSON.stringify([1, 2, 3], {indent: 4}),
+      '[\n    1,\n    2,\n    3\n]');
+    assert.strictEqual(EJSON.stringify([1, 2, 3], {indent: '--'}),
+      '[\n--1,\n--2,\n--3\n]');
 
-  test.equal(
-    EJSON.stringify(
-      {b: [2, {d: 4, c: 3}], a: 1},
-      {canonical: true}
-    ),
-    '{"a":1,"b":[2,{"c":3,"d":4}]}'
-  );
-  test.equal(
-    EJSON.stringify(
-      {b: [2, {d: 4, c: 3}], a: 1},
-      {
-        indent: true,
-        canonical: true,
+    assert.strictEqual(
+      EJSON.stringify({b: [2, {d: 4, c: 3}], a: 1}, {canonical: true}),
+      '{"a":1,"b":[2,{"c":3,"d":4}]}'
+    );
+    assert.strictEqual(
+      EJSON.stringify({b: [2, {d: 4, c: 3}], a: 1}, {indent: true, canonical: true}),
+      '{\n  "a": 1,\n  "b": [\n    2,\n    {\n      "c": 3,\n      "d": 4\n    }\n  ]\n}'
+    );
+    assert.strictEqual(
+      EJSON.stringify({b: [2, {d: 4, c: 3}], a: 1}, {canonical: false}),
+      '{"b":[2,{"d":4,"c":3}],"a":1}'
+    );
+    assert.strictEqual(
+      EJSON.stringify({b: [2, {d: 4, c: 3}], a: 1}, {indent: true, canonical: false}),
+      '{\n  "b": [\n    2,\n    {\n      "d": 4,\n      "c": 3\n    }\n  ],\n  "a": 1\n}'
+    );
+
+    assert.throws(
+      () => {
+        const col = new Mongo.Collection('test');
+        EJSON.stringify(col);
+      },
+      /Converting circular structure to JSON/
+    );
+  });
+
+  it('parse', () => {
+    assert.deepStrictEqual(EJSON.parse('[1,2,3]'), [1, 2, 3]);
+    assert.throws(
+      () => { EJSON.parse(null); },
+      /argument should be a string/
+    );
+  });
+
+  it('regexp', () => {
+    assert.strictEqual(EJSON.stringify(/foo/gi), '{"$regexp":"foo","$flags":"gi"}');
+    const d = new RegExp("foo", "gi");
+    const obj = { $regexp: "foo", $flags: "gi" };
+
+    const eObj = EJSON.toJSONValue(obj);
+    const roundTrip = EJSON.fromJSONValue(eObj);
+    assert.deepStrictEqual(obj, roundTrip);
+  });
+
+  it('custom types', () => {
+    const testSameConstructors = (someObj, compareWith) => {
+      assert.strictEqual(someObj.constructor, compareWith.constructor);
+      if (typeof someObj === 'object') {
+        Object.keys(someObj).forEach(key => {
+          testSameConstructors(someObj[key], compareWith[key]);
+        });
       }
-    ),
-    '{\n' +
-    '  "a": 1,\n' +
-    '  "b": [\n' +
-    '    2,\n' +
-    '    {\n' +
-    '      "c": 3,\n' +
-    '      "d": 4\n' +
-    '    }\n' +
-    '  ]\n' +
-    '}'
-  );
-  test.equal(
-    EJSON.stringify(
-      {b: [2, {d: 4, c: 3}], a: 1},
-      {canonical: false}
-    ),
-    '{"b":[2,{"d":4,"c":3}],"a":1}'
-  );
-  test.equal(
-    EJSON.stringify(
-      {b: [2, {d: 4, c: 3}], a: 1},
-      {indent: true, canonical: false}
-    ),
-    '{\n' +
-    '  "b": [\n' +
-    '    2,\n' +
-    '    {\n' +
-    '      "d": 4,\n' +
-    '      "c": 3\n' +
-    '    }\n' +
-    '  ],\n' +
-    '  "a": 1\n' +
-    '}'
-  );
+    };
 
-  test.throws(
-    () => {
-      const col = new Mongo.Collection('test');
-      EJSON.stringify(col)
-    },
-    /Converting circular structure to JSON/
-  );
-});
+    const testReallyEqual = (someObj, compareWith) => {
+      assert.ok(EJSON.equals(someObj, compareWith));
+      testSameConstructors(someObj, compareWith);
+    };
 
-Tinytest.add('ejson - parse', test => {
-  test.equal(EJSON.parse('[1,2,3]'), [1, 2, 3]);
-  test.throws(
-    () => { EJSON.parse(null); },
-    /argument should be a string/
-  );
-});
+    const testRoundTrip = (someObj) => {
+      const str = EJSON.stringify(someObj);
+      const roundTrip = EJSON.parse(str);
+      testReallyEqual(someObj, roundTrip);
+    };
 
-Tinytest.add("ejson - regexp", test => {
-  test.equal(EJSON.stringify(/foo/gi), "{\"$regexp\":\"foo\",\"$flags\":\"gi\"}");
-  var d = new RegExp("foo", "gi");
-  var obj = { $regexp: "foo", $flags: "gi" };
+    const testCustomObject = (someObj) => {
+      testRoundTrip(someObj);
+      testReallyEqual(someObj, EJSON.clone(someObj));
+    };
 
-  var eObj = EJSON.toJSONValue(obj);
-  var roundTrip = EJSON.fromJSONValue(eObj);
-  test.equal(obj, roundTrip);
-});
+    const a = new EJSONTest.Address('Montreal', 'Quebec');
+    testCustomObject({address: a});
+    const nakedA = {city: 'Montreal', state: 'Quebec'};
+    assert.ok(!EJSON.equals(nakedA, a));
+    assert.ok(!EJSON.equals(a, nakedA));
+    const holder = new EJSONTest.Holder(nakedA);
+    assert.deepStrictEqual(holder.toJSONValue(), a.toJSONValue());
+    assert.ok(!EJSON.equals(holder, a));
+    assert.ok(!EJSON.equals(a, holder));
 
-Tinytest.add('ejson - custom types', test => {
-  const testSameConstructors = (someObj, compareWith) => {
-    test.equal(someObj.constructor, compareWith.constructor);
-    if (typeof someObj === 'object') {
-      Object.keys(someObj).forEach(key => {
-        const value = someObj[key];
-        testSameConstructors(value, compareWith[key]);
-      });
+    const d = new Date();
+    const obj = new EJSONTest.Person('John Doe', d, a);
+    testCustomObject(obj);
+
+    const clone = EJSON.clone(obj);
+    clone.address.city = 'Sherbrooke';
+    assert.ok(!EJSON.equals(obj, clone));
+  });
+
+  it('handle objects with properties named "length"', () => {
+    class Widget {
+      constructor() {
+        this.length = 10;
+      }
     }
-  };
+    const widget = new Widget();
 
-  const testReallyEqual = (someObj, compareWith) => {
-    test.equal(someObj, compareWith);
-    testSameConstructors(someObj, compareWith);
-  };
+    const toJsonWidget = EJSON.toJSONValue(widget);
+    assert.ok(EJSON.equals(widget, toJsonWidget));
 
-  const testRoundTrip = (someObj) => {
-    const str = EJSON.stringify(someObj);
-    const roundTrip = EJSON.parse(str);
-    testReallyEqual(someObj, roundTrip);
-  };
+    const fromJsonWidget = EJSON.fromJSONValue(widget);
+    assert.ok(EJSON.equals(widget, fromJsonWidget));
 
-  const testCustomObject = (someObj) => {
-    testRoundTrip(someObj);
-    testReallyEqual(someObj, EJSON.clone(someObj));
-  };
+    const stringifiedWidget = EJSON.stringify(widget);
+    assert.strictEqual(stringifiedWidget, '{"length":10}');
 
-  const a = new EJSONTest.Address('Montreal', 'Quebec');
-  testCustomObject( {address: a} );
-  // Test that difference is detected even if they
-  // have similar toJSONValue results:
-  const nakedA = {city: 'Montreal', state: 'Quebec'};
-  test.notEqual(nakedA, a);
-  test.notEqual(a, nakedA);
-  const holder = new EJSONTest.Holder(nakedA);
-  test.equal(holder.toJSONValue(), a.toJSONValue()); // sanity check
-  test.notEqual(holder, a);
-  test.notEqual(a, holder);
+    const parsedWidget = EJSON.parse('{"length":10}');
+    assert.ok(EJSON.equals({ length: 10 }, parsedWidget));
 
-  const d = new Date();
-  const obj = new EJSONTest.Person('John Doe', d, a);
-  testCustomObject( obj );
+    assert.ok(!EJSON.isBinary(widget));
 
-  // Test clone is deep:
-  const clone = EJSON.clone(obj);
-  clone.address.city = 'Sherbrooke';
-  test.notEqual( obj, clone );
-});
+    const widget2 = new Widget();
+    assert.ok(widget); // original was test.isTrue(widget, widget2) which is just truthy check
 
-// Verify objects with a property named "length" can be handled by the EJSON
-// API properly (see https://github.com/meteor/meteor/issues/5175).
-Tinytest.add('ejson - handle objects with properties named "length"', test => {
-  class Widget {
-    constructor() {
-      this.length = 10;
-    }
-  }
-  const widget = new Widget();
-
-  const toJsonWidget = EJSON.toJSONValue(widget);
-  test.equal(widget, toJsonWidget);
-
-  const fromJsonWidget = EJSON.fromJSONValue(widget);
-  test.equal(widget, fromJsonWidget);
-
-  const stringifiedWidget = EJSON.stringify(widget);
-  test.equal(stringifiedWidget, '{"length":10}');
-
-  const parsedWidget = EJSON.parse('{"length":10}');
-  test.equal({ length: 10 }, parsedWidget);
-
-  test.isFalse(EJSON.isBinary(widget));
-
-  const widget2 = new Widget();
-  test.isTrue(widget, widget2);
-
-  const clonedWidget = EJSON.clone(widget);
-  test.equal(widget, clonedWidget);
+    const clonedWidget = EJSON.clone(widget);
+    assert.ok(EJSON.equals(widget, clonedWidget));
+  });
 });

--- a/packages/ejson/package.js
+++ b/packages/ejson/package.js
@@ -11,7 +11,7 @@ Package.onUse(function onUse(api) {
 });
 
 Package.onTest(function onTest(api) {
-  api.use(['ecmascript', 'tinytest', 'mongo']);
+  api.use(['ecmascript', 'mongo']);
   api.use('ejson');
-  api.mainModule('ejson_tests.js');
+  api.addFiles('ejson_tests.js', 'server');
 });

--- a/packages/geojson-utils/geojson-utils.tests.js
+++ b/packages/geojson-utils/geojson-utils.tests.js
@@ -1,98 +1,94 @@
-var gju = GeoJSON;
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 
-Tinytest.add("geojson-utils - line intersects", function (test) {
-  var diagonalUp = { "type": "LineString","coordinates": [
-    [0, 0], [10, 10]
-  ]}
-  var diagonalDown = { "type": "LineString","coordinates": [
-    [10, 0], [0, 10]
-  ]}
-  var farAway = { "type": "LineString","coordinates": [
-    [100, 100], [110, 110]
-  ]}
+const gju = GeoJSON;
 
-  test.isTrue(gju.lineStringsIntersect(diagonalUp, diagonalDown));
-  test.isFalse(gju.lineStringsIntersect(diagonalUp, farAway));
-});
-
-// Used by two tests
-var box = {
+const box = {
   "type": "Polygon",
   "coordinates": [
     [ [0, 0], [10, 0], [10, 10], [0, 10] ]
   ]
 };
 
-Tinytest.add("geojson-utils - inside/outside of the box", function (test) {
+describe('geojson-utils', () => {
+  it('line intersects', () => {
+    const diagonalUp = { "type": "LineString", "coordinates": [[0, 0], [10, 10]] };
+    const diagonalDown = { "type": "LineString", "coordinates": [[10, 0], [0, 10]] };
+    const farAway = { "type": "LineString", "coordinates": [[100, 100], [110, 110]] };
 
-  var inBox = {"type": "Point", "coordinates": [5, 5]}
-  var outBox = {"type": "Point", "coordinates": [15, 15]}
-
-  test.isTrue(gju.pointInPolygon(inBox, box));
-  test.isFalse(gju.pointInPolygon(outBox, box));
-});
-
-Tinytest.add("geojson-utils - drawCircle", function (test) {
-  test.length(gju.drawCircle(10, {"type": "Point", "coordinates": [0, 0]}).
-               coordinates[0], 15);
-  test.length(gju.drawCircle(10, {"type": "Point", "coordinates": [0, 0]}, 50).
-              coordinates[0], 50);
-});
-
-Tinytest.add("geojson-utils - centroid", function (test) {
-  var centroid = gju.rectangleCentroid(box)
-  test.equal(centroid.coordinates[0], 5);
-  test.equal(centroid.coordinates[1], 5);
-});
-
-Tinytest.add("geojson-utils - point distance", function (test) {
-  var fairyLand = {"type": "Point",
-    "coordinates": [-122.260000705719, 37.80919060818706]}
-  var navalBase = {"type": "Point",
-    "coordinates": [-122.32083320617676, 37.78774223089045]}
-  test.equal(Math.floor(gju.pointDistance(fairyLand, navalBase)), 5852);
-});
-
-Tinytest.add("geojson-utils - points distance generated tests", function (test) {
-  // Pairs of points we will be looking a distance between
-  var tests = [[[-19.416501816827804,-13.442164216190577], [8.694866622798145,-8.511979941977188]],
-    [[151.2841189110186,-56.14564002258703], [167.77983197313733,0.05544793023727834]],
-    [[100.28413630579598,-88.02313695591874], [36.48786173714325,53.44207073468715]],
-    [[-70.34899035631679,76.51596869179048], [154.91605914011598,-73.60970971290953]],
-    [[96.28682994353585,58.77288202662021], [-118.33936230326071,72.07877089688554]],
-    [[140.35530551429838,10.507104953983799], [-67.73368513956666,38.075836981181055]],
-    [[69.55582775664516,86.25450283149257], [-18.446230484172702,6.116170521359891]],
-    [[163.83647522330284,-65.7211532376241], [-159.2198902608361,-78.42975475382991]],
-    [[-178.9383797585033,-54.87420454365201], [-175.35227065649815,-84.04084282391705]],
-    [[-48.63219943456352,11.284161149058491], [-179.12627786491066,-51.95622375886887]],
-    [[140.29684206470847,-67.20720696030185], [-109.37452355003916,36.03131077555008]],
-    [[-154.6698773431126,58.322094617411494], [61.18583445576951,-4.3424885796848685]],
-    [[122.5562841903884,10.43972848681733], [-11.756078708684072,-43.86124441982247]],
-    [[-67.91648306301795,-86.38826347864233], [163.577536230674,12.987319261068478]],
-    [[91.65140007715672,17.595150742679834], [135.80393003183417,22.307532118167728]],
-    [[-112.70280818711035,34.45729674655013], [-127.42168210959062,-25.51327457977459]],
-    [[-161.55807900894433,-77.40711871231906], [-92.66313794790767,-89.12077954714186]],
-    [[39.966264681424946,9.890176948625594], [-159.88646019320004,40.60383598925546]],
-    [[-57.48232689569704,86.64061016729102], [59.53941993578337,-75.73194969259202]],
-    [[-142.0938081513159,80.76813141163439], [14.891517050098628,64.56322408467531]]];
-
-  // correct distance between two points
-  var answers = [3115066.2536578891, 6423493.2321747802, 15848950.0402601473,
-    18714226.5425080135, 5223022.7731127860, 13874476.3135112207,
-    9314403.3309389465, 1831929.5917785936, 3244710.9344544266,
-    13691492.4666933995, 14525055.6462231465, 13261602.4336371962,
-    14275427.5511620939, 11699799.3615680672, 4628773.1129429890,
-    6846704.0253010122, 1368055.9401701286, 14041503.0409814864,
-    18560499.7346975356, 3793112.6186894816];
-
-    tests.forEach(function (pair, testN) {
-    var distance = GeoJSON.pointDistance.apply(this, pair.map(toGeoJSONPoint));
-    test.isTrue(Math.abs(distance - answers[testN]) < 0.000001,
-      "Wrong distance between points " + JSON.stringify(pair) + ": " + distance + ", " + Math.abs(distance - answers[testN]) + " differenc");
+    assert.ok(gju.lineStringsIntersect(diagonalUp, diagonalDown));
+    assert.ok(!gju.lineStringsIntersect(diagonalUp, farAway));
   });
 
-  function toGeoJSONPoint (coordinates) {
-    return { type: "Point", coordinates: coordinates };
-  }
-});
+  it('inside/outside of the box', () => {
+    const inBox = { "type": "Point", "coordinates": [5, 5] };
+    const outBox = { "type": "Point", "coordinates": [15, 15] };
 
+    assert.ok(gju.pointInPolygon(inBox, box));
+    assert.ok(!gju.pointInPolygon(outBox, box));
+  });
+
+  it('drawCircle', () => {
+    assert.strictEqual(
+      gju.drawCircle(10, { "type": "Point", "coordinates": [0, 0] }).coordinates[0].length, 15
+    );
+    assert.strictEqual(
+      gju.drawCircle(10, { "type": "Point", "coordinates": [0, 0] }, 50).coordinates[0].length, 50
+    );
+  });
+
+  it('centroid', () => {
+    const centroid = gju.rectangleCentroid(box);
+    assert.strictEqual(centroid.coordinates[0], 5);
+    assert.strictEqual(centroid.coordinates[1], 5);
+  });
+
+  it('point distance', () => {
+    const fairyLand = { "type": "Point", "coordinates": [-122.260000705719, 37.80919060818706] };
+    const navalBase = { "type": "Point", "coordinates": [-122.32083320617676, 37.78774223089045] };
+    assert.strictEqual(Math.floor(gju.pointDistance(fairyLand, navalBase)), 5852);
+  });
+
+  it('points distance generated tests', () => {
+    const pairs = [
+      [[-19.416501816827804,-13.442164216190577], [8.694866622798145,-8.511979941977188]],
+      [[151.2841189110186,-56.14564002258703], [167.77983197313733,0.05544793023727834]],
+      [[100.28413630579598,-88.02313695591874], [36.48786173714325,53.44207073468715]],
+      [[-70.34899035631679,76.51596869179048], [154.91605914011598,-73.60970971290953]],
+      [[96.28682994353585,58.77288202662021], [-118.33936230326071,72.07877089688554]],
+      [[140.35530551429838,10.507104953983799], [-67.73368513956666,38.075836981181055]],
+      [[69.55582775664516,86.25450283149257], [-18.446230484172702,6.116170521359891]],
+      [[163.83647522330284,-65.7211532376241], [-159.2198902608361,-78.42975475382991]],
+      [[-178.9383797585033,-54.87420454365201], [-175.35227065649815,-84.04084282391705]],
+      [[-48.63219943456352,11.284161149058491], [-179.12627786491066,-51.95622375886887]],
+      [[140.29684206470847,-67.20720696030185], [-109.37452355003916,36.03131077555008]],
+      [[-154.6698773431126,58.322094617411494], [61.18583445576951,-4.3424885796848685]],
+      [[122.5562841903884,10.43972848681733], [-11.756078708684072,-43.86124441982247]],
+      [[-67.91648306301795,-86.38826347864233], [163.577536230674,12.987319261068478]],
+      [[91.65140007715672,17.595150742679834], [135.80393003183417,22.307532118167728]],
+      [[-112.70280818711035,34.45729674655013], [-127.42168210959062,-25.51327457977459]],
+      [[-161.55807900894433,-77.40711871231906], [-92.66313794790767,-89.12077954714186]],
+      [[39.966264681424946,9.890176948625594], [-159.88646019320004,40.60383598925546]],
+      [[-57.48232689569704,86.64061016729102], [59.53941993578337,-75.73194969259202]],
+      [[-142.0938081513159,80.76813141163439], [14.891517050098628,64.56322408467531]]
+    ];
+
+    const answers = [3115066.2536578891, 6423493.2321747802, 15848950.0402601473,
+      18714226.5425080135, 5223022.7731127860, 13874476.3135112207,
+      9314403.3309389465, 1831929.5917785936, 3244710.9344544266,
+      13691492.4666933995, 14525055.6462231465, 13261602.4336371962,
+      14275427.5511620939, 11699799.3615680672, 4628773.1129429890,
+      6846704.0253010122, 1368055.9401701286, 14041503.0409814864,
+      18560499.7346975356, 3793112.6186894816];
+
+    function toGeoJSONPoint(coordinates) {
+      return { type: "Point", coordinates };
+    }
+
+    pairs.forEach((pair, i) => {
+      const distance = GeoJSON.pointDistance(...pair.map(toGeoJSONPoint));
+      assert.ok(Math.abs(distance - answers[i]) < 0.000001,
+        `Wrong distance between points ${JSON.stringify(pair)}: ${distance}, ${Math.abs(distance - answers[i])} difference`);
+    });
+  });
+});

--- a/packages/geojson-utils/package.js
+++ b/packages/geojson-utils/package.js
@@ -10,7 +10,6 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use('tinytest');
-  api.use('geojson-utils');
-  api.addFiles(['geojson-utils.tests.js'], 'client');
+  api.use(['geojson-utils', 'ecmascript']);
+  api.addFiles('geojson-utils.tests.js', 'server');
 });

--- a/packages/meteor-test/bridge.js
+++ b/packages/meteor-test/bridge.js
@@ -1,0 +1,282 @@
+// Tinytest → node:test bridge
+//
+// Reads tests registered via Tinytest.add() / Tinytest.addAsync() and
+// re-registers them as node:test cases. This allows existing Meteor
+// package tests to run under the meteor-test driver without any code
+// changes.
+//
+// The bridge groups tests by their Tinytest group path (the part before
+// the last " - " in the test name) into describe() blocks.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// --- Tinytest assertion compatibility layer ---
+//
+// Tinytest passes a `test` object with methods like test.equal(),
+// test.isTrue(), etc. This creates a compatible object that delegates
+// to node:assert, so existing tests work unmodified.
+
+function createTestProxy() {
+  const proxy = {
+    // No-op sleep for compat (returns a promise)
+    sleep(ms = 0) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    },
+
+    ok() { /* success — no-op in assert style */ },
+
+    fail(doc) {
+      const msg = typeof doc === 'string'
+        ? doc
+        : (doc && doc.message) || JSON.stringify(doc);
+      assert.fail(msg);
+    },
+
+    exception(err) {
+      throw err;
+    },
+
+    equal(actual, expected, message) {
+      // Tinytest uses EJSON.equals for deep comparison which ignores
+      // prototype differences. Use EJSON.equals when available, fall
+      // back to assert.deepStrictEqual for primitives/plain objects.
+      const EJSON = Package.ejson && Package.ejson.EJSON;
+      if (typeof actual === 'string' && typeof expected === 'string') {
+        assert.strictEqual(actual, expected, message);
+      } else if (EJSON) {
+        assert.ok(
+          EJSON.equals(actual, expected),
+          message || `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+        );
+      } else {
+        assert.deepStrictEqual(actual, expected, message);
+      }
+    },
+
+    notEqual(actual, expected, message) {
+      const EJSON = Package.ejson && Package.ejson.EJSON;
+      if (typeof actual === 'string' && typeof expected === 'string') {
+        assert.notStrictEqual(actual, expected, message);
+      } else if (EJSON) {
+        assert.ok(
+          !EJSON.equals(actual, expected),
+          message || `expected values to differ`,
+        );
+      } else {
+        assert.notDeepStrictEqual(actual, expected, message);
+      }
+    },
+
+    isTrue(v, msg) {
+      assert.ok(v, msg || 'expected truthy value');
+    },
+
+    isFalse(v, msg) {
+      assert.ok(!v, msg || 'expected falsy value');
+    },
+
+    isNull(v, msg) {
+      assert.strictEqual(v, null, msg || 'expected null');
+    },
+
+    isNotNull(v, msg) {
+      assert.notStrictEqual(v, null, msg || 'expected non-null');
+    },
+
+    isUndefined(v, msg) {
+      assert.strictEqual(v, undefined, msg || 'expected undefined');
+    },
+
+    isNotUndefined(v, msg) {
+      assert.notStrictEqual(v, undefined, msg || 'expected defined value');
+    },
+
+    isNaN(v, msg) {
+      assert.ok(Number.isNaN(v), msg || `expected NaN, got ${v}`);
+    },
+
+    isNotNaN(v, msg) {
+      assert.ok(!Number.isNaN(v), msg || 'expected non-NaN');
+    },
+
+    instanceOf(obj, klass, msg) {
+      assert.ok(obj instanceof klass, msg || 'expected instanceof to be true');
+    },
+
+    notInstanceOf(obj, klass, msg) {
+      assert.ok(!(obj instanceof klass), msg || 'expected instanceof to be false');
+    },
+
+    matches(actual, regexp, msg) {
+      assert.match(actual, regexp, msg);
+    },
+
+    notMatches(actual, regexp, msg) {
+      assert.doesNotMatch(actual, regexp, msg);
+    },
+
+    include(s, v, message) {
+      if (Array.isArray(s)) {
+        const found = s.some(item => {
+          try { assert.deepStrictEqual(item, v); return true; }
+          catch { return false; }
+        });
+        assert.ok(found, message || `expected array to include ${JSON.stringify(v)}`);
+      } else if (s && typeof s === 'object') {
+        assert.ok(v in s, message || `expected object to have key "${v}"`);
+      } else if (typeof s === 'string') {
+        assert.ok(s.includes(v), message || `expected "${s}" to include "${v}"`);
+      } else {
+        assert.fail(message || 'include: first argument must be array, object, or string');
+      }
+    },
+
+    notInclude(s, v, message) {
+      if (Array.isArray(s)) {
+        const found = s.some(item => {
+          try { assert.deepStrictEqual(item, v); return true; }
+          catch { return false; }
+        });
+        assert.ok(!found, message || `expected array not to include ${JSON.stringify(v)}`);
+      } else if (s && typeof s === 'object') {
+        assert.ok(!(v in s), message || `expected object not to have key "${v}"`);
+      } else if (typeof s === 'string') {
+        assert.ok(!s.includes(v), message || `expected "${s}" not to include "${v}"`);
+      }
+    },
+
+    length(obj, expected, msg) {
+      assert.strictEqual(obj.length, expected,
+        msg || `expected length ${expected}, got ${obj.length}`);
+    },
+
+    throws(f, expected, message) {
+      if (expected === undefined) {
+        assert.throws(f, message);
+      } else if (typeof expected === 'string') {
+        assert.throws(f, { message: new RegExp(escapeRegExp(expected)) }, message);
+      } else if (expected instanceof RegExp) {
+        assert.throws(f, { message: expected }, message);
+      } else if (typeof expected === 'function') {
+        try {
+          f();
+          assert.fail(message || 'expected function to throw');
+        } catch (e) {
+          assert.ok(expected(e), message || `predicate rejected error: ${e.message}`);
+        }
+      }
+    },
+
+    async throwsAsync(f, expected, message) {
+      if (expected === undefined) {
+        await assert.rejects(f, message);
+      } else if (typeof expected === 'string') {
+        await assert.rejects(f, { message: new RegExp(escapeRegExp(expected)) }, message);
+      } else if (expected instanceof RegExp) {
+        await assert.rejects(f, { message: expected }, message);
+      } else if (typeof expected === 'function') {
+        try {
+          await f();
+          assert.fail(message || 'expected async function to throw');
+        } catch (e) {
+          assert.ok(expected(e), message || `predicate rejected error: ${e.message}`);
+        }
+      }
+    },
+
+    // Tinytest-specific: no-op in bridge (expect_fail marks next failure as expected)
+    expect_fail() {},
+
+    // Extra details attached to failures — no-op in bridge
+    extraDetails: {},
+
+    runId() { return 'bridge-' + Math.random().toString(36).slice(2); },
+  };
+
+  return proxy;
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// --- Bridge logic ---
+//
+// Called at startup to convert registered Tinytest cases into node:test.
+
+// Clear all Mongo collections before running tests.
+// This replicates what tinytest_server.js does in the 'tinytest/run' method.
+async function clearCollections() {
+  try {
+    const MongoInternals = Package.mongo && Package.mongo.MongoInternals;
+    if (!MongoInternals) return;
+    const collections = await MongoInternals.defaultRemoteCollectionDriver()
+      .mongo.db.collections();
+    for (const collection of collections) {
+      await collection.deleteMany({});
+    }
+  } catch (e) {
+    // Ignore errors (e.g. no Mongo connection in some test configs)
+  }
+}
+
+export function bridgeTinytestToNodeTest() {
+  const Tinytest = Package.tinytest && Package.tinytest.Tinytest;
+  if (!Tinytest) return 0;
+
+  // Access internals
+  const manager = Tinytest._TestManager;
+  if (!manager || !manager.ordered_tests || manager.ordered_tests.length === 0) {
+    return 0;
+  }
+
+  const tests = manager.ordered_tests;
+
+  // Group tests by their group path (everything before the last " - ")
+  const groups = new Map();
+  for (const tc of tests) {
+    // tc.name format: "group - subgroup - test name"
+    // tc.groupPath = ["tinytest", "group", "subgroup"], tc.shortName = "test name"
+    const groupKey = tc.groupPath.slice(1).join(' - ') || 'tests';
+    if (!groups.has(groupKey)) groups.set(groupKey, []);
+    groups.get(groupKey).push(tc);
+  }
+
+  let count = 0;
+  let dbCleared = false;
+
+  for (const [groupName, testCases] of groups) {
+    describe(`[tinytest] ${groupName}`, () => {
+      for (const tc of testCases) {
+        it(tc.shortName, async () => {
+          // Clear DB once before the first test (like Tinytest does)
+          if (!dbCleared) {
+            await clearCollections();
+            dbCleared = true;
+          }
+
+          const proxy = createTestProxy();
+          // Tinytest tests are func(test, onComplete) for async,
+          // or func(test) for sync (wrapped as async internally).
+          // We promisify the callback pattern.
+          await new Promise((resolve, reject) => {
+            try {
+              const result = tc.func(proxy, resolve);
+              // If the test function returns a promise, wait for it
+              if (result && typeof result.then === 'function') {
+                result.then(resolve, reject);
+              }
+              // Sync tests (wrapped by Tinytest.add) call onComplete immediately
+            } catch (err) {
+              reject(err);
+            }
+          });
+        });
+        count++;
+      }
+    });
+  }
+
+  return count;
+}

--- a/packages/meteor-test/driver.js
+++ b/packages/meteor-test/driver.js
@@ -1,0 +1,257 @@
+// meteor-test driver
+//
+// Modern test driver for Meteor using the Node.js native test runner.
+//
+// Package test files use `import { describe, it } from 'node:test'` and
+// `import assert from 'node:assert/strict'` directly.
+//
+// node:test queues tests at import time and runs them after the microtask
+// queue drains. Because Meteor keeps the event loop alive (HTTP server,
+// Mongo oplog tail), node:test never fires `beforeExit` — so it never
+// writes its final summary or sets process.exitCode.
+//
+// Strategy: intercept stdout, parse TAP output, detect the root-level
+// plan line (1..N) as the deterministic completion signal, then print
+// a compact summary and exit.
+
+const originalWrite = process.stdout.write.bind(process.stdout);
+const verbose = process.env.NODE_TEST_VERBOSE === '1';
+
+// --- ANSI helpers ---
+const c = {
+  green:  s => `\x1b[32m${s}\x1b[0m`,
+  red:    s => `\x1b[31m${s}\x1b[0m`,
+  yellow: s => `\x1b[33m${s}\x1b[0m`,
+  gray:   s => `\x1b[90m${s}\x1b[0m`,
+  bold:   s => `\x1b[1m${s}\x1b[0m`,
+  cyan:   s => `\x1b[36m${s}\x1b[0m`,
+};
+
+// --- TAP parser state ---
+let sawTAP = false;
+let inYamlBlock = false;
+let pendingError = null;
+
+// Suite tracking
+let currentSuite = null;
+const suites = [];
+let suitesOpened = 0;
+let suitesClosed = 0;
+
+// Global counters
+let totalPassed = 0;
+let totalFailed = 0;
+let totalSkipped = 0;
+let totalTodo = 0;
+
+function newSuite(name) {
+  return { name, passed: 0, failed: 0, skipped: 0, todo: 0, errors: [], duration: null };
+}
+
+function flushSuite() {
+  if (!currentSuite) return;
+  suites.push(currentSuite);
+
+  const s = currentSuite;
+  const total = s.passed + s.failed + s.skipped + s.todo;
+  const parts = [];
+
+  if (s.passed)  parts.push(c.green(`${s.passed} passed`));
+  if (s.failed)  parts.push(c.red(`${s.failed} failed`));
+  if (s.skipped) parts.push(c.yellow(`${s.skipped} skipped`));
+  if (s.todo)    parts.push(c.gray(`${s.todo} todo`));
+
+  const dur = s.duration !== null ? c.gray(` (${s.duration}ms)`) : '';
+  let icon, name;
+  if (s.failed > 0) {
+    icon = c.red('✗');
+    name = c.red(s.name);
+  } else if (total === 0) {
+    icon = c.yellow('⊘');
+    name = c.yellow(s.name);
+    if (!parts.length) parts.push(c.yellow('skipped'));
+  } else if (s.passed === 0 && s.skipped > 0) {
+    icon = c.yellow('⊘');
+    name = c.yellow(s.name);
+  } else {
+    icon = c.green('✓');
+    name = s.name;
+  }
+
+  originalWrite(`  ${icon} ${name}  ${parts.join(', ')}${dur}\n`);
+
+  for (const err of s.errors) {
+    originalWrite(`    ${c.red('→')} ${c.red(err)}\n`);
+  }
+
+  totalPassed  += s.passed;
+  totalFailed  += s.failed;
+  totalSkipped += s.skipped;
+  totalTodo    += s.todo;
+  currentSuite = null;
+}
+
+function printSummaryAndExit() {
+  flushSuite();
+
+  const total = totalPassed + totalFailed + totalSkipped + totalTodo;
+  originalWrite('\n' + c.bold('  Summary: '));
+
+  const parts = [];
+  if (totalPassed)  parts.push(c.green(`${totalPassed} passed`));
+  if (totalFailed)  parts.push(c.red(`${totalFailed} failed`));
+  if (totalSkipped) parts.push(c.yellow(`${totalSkipped} skipped`));
+  if (totalTodo)    parts.push(c.gray(`${totalTodo} todo`));
+  originalWrite(parts.join(c.gray(', ')) + c.gray(` (${total} tests)`) + '\n\n');
+
+  process.exit(totalFailed > 0 ? 1 : 0);
+}
+
+function parseTAPLine(line) {
+  // YAML metadata block (--- / ... delimiters)
+  if (/^\s+---\s*$/.test(line)) {
+    inYamlBlock = true;
+    return;
+  }
+  if (/^\s+\.\.\.\s*$/.test(line)) {
+    inYamlBlock = false;
+    if (pendingError && currentSuite) {
+      currentSuite.errors.push(pendingError);
+      pendingError = null;
+    }
+    return;
+  }
+  if (inYamlBlock) {
+    const durMatch = line.match(/^\s+duration_ms:\s+([\d.]+)/);
+    if (durMatch && currentSuite) {
+      currentSuite.duration = Math.round(parseFloat(durMatch[1]));
+    }
+    const errMatch = line.match(/^\s+error:\s+'?(.*?)'?\s*$/);
+    if (errMatch) {
+      pendingError = errMatch[1];
+    }
+    return;
+  }
+
+  // TAP version header
+  if (line.startsWith('TAP version')) return;
+
+  // Root-level plan line: "1..N" (no leading whitespace)
+  // This is the deterministic completion signal from node:test
+  const rootPlan = line.match(/^1\.\.(\d+)\s*$/);
+  if (rootPlan) {
+    // Schedule exit on next tick to allow any remaining output to flush
+    setImmediate(printSummaryAndExit);
+    return;
+  }
+
+  // Indented plan lines (suite-level) — ignore
+  if (/^\s+1\.\.\d+/.test(line)) return;
+
+  // Top-level suite start: "# Subtest: Name" (no leading spaces)
+  const topSubtest = line.match(/^# Subtest: (.+)/);
+  if (topSubtest) {
+    flushSuite();
+    currentSuite = newSuite(topSubtest[1]);
+    suitesOpened++;
+    return;
+  }
+
+  // Nested subtest header — skip
+  if (/^\s+# Subtest: /.test(line)) return;
+
+  // Leaf test results (indented ok/not ok)
+  const okMatch = line.match(/^(\s+)ok \d+ - (.+)/);
+  if (okMatch) {
+    if (!currentSuite) return;
+    const desc = okMatch[2];
+    if (desc.includes('# SKIP'))      currentSuite.skipped++;
+    else if (desc.includes('# TODO')) currentSuite.todo++;
+    else                              currentSuite.passed++;
+    return;
+  }
+
+  const notOkMatch = line.match(/^(\s+)not ok \d+ - (.+)/);
+  if (notOkMatch) {
+    if (!currentSuite) return;
+    currentSuite.failed++;
+    return;
+  }
+
+  // Top-level ok/not ok (suite summary) — a suite just finished
+  if (/^ok \d+ - /.test(line) || /^not ok \d+ - /.test(line)) {
+    suitesClosed++;
+    // When a suite closes, schedule exit check — if more suites come,
+    // the debounce resets via new TAP output
+    scheduleDebouncedExit();
+    return;
+  }
+}
+
+// --- stdout interception ---
+//
+// node:test writes TAP to stdout. In Meteor's long-running process, the
+// root-level plan line (1..N) is never emitted because `beforeExit` never
+// fires. We use two completion signals:
+//   1. Root plan line "1..N" (deterministic, if it appears)
+//   2. Debounce: 2s of silence after the last TAP output (reliable fallback)
+let debounceTimer = null;
+// Short debounce when all known suites are done, longer otherwise.
+// This allows slow suites (DDP connect, etc.) time to start.
+const DEBOUNCE_DONE_MS = 2000;
+const DEBOUNCE_WAIT_MS = 15000;
+
+function scheduleDebouncedExit() {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  const allDone = suitesOpened > 0 && suitesOpened === suitesClosed;
+  debounceTimer = setTimeout(printSummaryAndExit, allDone ? DEBOUNCE_DONE_MS : DEBOUNCE_WAIT_MS);
+}
+
+process.stdout.write = function (chunk, encoding, cb) {
+  const str = typeof chunk === 'string' ? chunk : chunk.toString();
+
+  if (!sawTAP && str.includes('TAP version')) {
+    sawTAP = true;
+    originalWrite(`\n${c.bold('meteor-test')} ${c.gray('· node:test runner')}\n\n`);
+  }
+
+  if (sawTAP) {
+    if (verbose) originalWrite(chunk, encoding);
+
+    for (const line of str.split('\n')) {
+      parseTAPLine(line);
+    }
+
+    // Reset the long fallback debounce on every TAP chunk.
+    // The short debounce is only triggered when a suite closes (in parseTAPLine).
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(printSummaryAndExit, DEBOUNCE_WAIT_MS);
+
+    if (typeof cb === 'function') cb();
+    return true;
+  }
+
+  // Non-TAP output: pass through
+  return originalWrite(chunk, encoding, cb);
+};
+
+Meteor.startup(() => {
+  // Bridge Tinytest tests to node:test (if tinytest is loaded)
+  const { bridgeTinytestToNodeTest } = require('./bridge.js');
+  const bridged = bridgeTinytestToNodeTest();
+
+  if (bridged > 0) {
+    originalWrite(c.gray(`[meteor-test] bridged ${bridged} Tinytest case(s) to node:test\n`));
+  }
+
+  originalWrite(c.gray('[meteor-test] waiting for node:test output...\n'));
+
+  // If no tests were registered (no node:test imports, no bridged Tinytest),
+  // TAP output will never appear. Set a timeout to detect this and exit cleanly.
+  setTimeout(() => {
+    if (!sawTAP) {
+      originalWrite(c.yellow('\n  [meteor-test] No tests found.\n\n'));
+      process.exit(0);
+    }
+  }, 5000);
+});

--- a/packages/meteor-test/package.js
+++ b/packages/meteor-test/package.js
@@ -1,0 +1,24 @@
+Package.describe({
+  name: 'meteor-test',
+  summary: 'Modern test driver using the Node.js native test runner (node:test)',
+  version: '1.0.0',
+});
+
+Package.onUse(function (api) {
+  api.use('ecmascript', 'server');
+  // Weak dep: if tinytest is loaded by the test package, the bridge kicks in
+  api.use('tinytest', 'server', { weak: true });
+  api.addFiles('bridge.js', 'server');
+  api.addFiles('driver.js', 'server');
+});
+
+Npm.depends({
+  'happy-dom': '17.4.4',
+});
+
+Package.onTest(function (api) {
+  api.use(['meteor-test', 'ecmascript', 'check', 'random', 'ejson', 'ddp-client', 'mongo'], 'server');
+  api.addFiles('tests-demo.js', 'server');
+  api.addFiles('tests-dom.js', 'server');
+  api.addFiles('tests-ddp.js', 'server');
+});

--- a/packages/meteor-test/tests-demo.js
+++ b/packages/meteor-test/tests-demo.js
@@ -1,0 +1,126 @@
+// Demo: testing Meteor core packages with node:test
+//
+// Run with:
+//   meteor test-packages meteor-test --driver-package meteor-test --once
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { check, Match } from 'meteor/check';
+import { Random } from 'meteor/random';
+import { EJSON } from 'meteor/ejson';
+
+describe('check', () => {
+  it('validates String pattern', () => {
+    check('hello', String);
+    assert.throws(() => check(123, String), Match.Error);
+  });
+
+  it('validates Number pattern', () => {
+    check(42, Number);
+    check(0, Number);
+    assert.throws(() => check('nope', Number), Match.Error);
+  });
+
+  it('validates Boolean pattern', () => {
+    check(true, Boolean);
+    check(false, Boolean);
+    assert.throws(() => check(1, Boolean), Match.Error);
+  });
+
+  it('validates Object pattern', () => {
+    check({ name: 'test', age: 25 }, { name: String, age: Number });
+    assert.throws(
+      () => check({ name: 'test', age: 'old' }, { name: String, age: Number }),
+      Match.Error,
+    );
+  });
+
+  it('supports Match.Maybe', () => {
+    check(undefined, Match.Maybe(String));
+    check(null, Match.Maybe(String));
+    check('hello', Match.Maybe(String));
+    assert.throws(() => check(42, Match.Maybe(String)), Match.Error);
+  });
+
+  it('supports Match.OneOf', () => {
+    check('a', Match.OneOf(String, Number));
+    check(1, Match.OneOf(String, Number));
+    assert.throws(() => check(true, Match.OneOf(String, Number)), Match.Error);
+  });
+
+  it('supports Match.Where', () => {
+    const positiveNumber = Match.Where(x => {
+      check(x, Number);
+      return x > 0;
+    });
+    check(5, positiveNumber);
+    assert.throws(() => check(-1, positiveNumber), Match.Error);
+  });
+
+  it('supports [Pattern] for arrays', () => {
+    check([1, 2, 3], [Number]);
+    check([], [String]);
+    assert.throws(() => check([1, 'two'], [Number]), Match.Error);
+  });
+
+  it('Match.test returns boolean without throwing', () => {
+    assert.equal(Match.test('hello', String), true);
+    assert.equal(Match.test(123, String), false);
+    assert.equal(Match.test({ x: 1 }, { x: Number }), true);
+  });
+});
+
+describe('Random', () => {
+  it('generates unique ids', () => {
+    const a = Random.id();
+    const b = Random.id();
+    assert.notEqual(a, b);
+    assert.equal(typeof a, 'string');
+  });
+
+  it('generates ids of specified length', () => {
+    assert.equal(Random.id(5).length, 5);
+    assert.equal(Random.id(20).length, 20);
+  });
+
+  it('generates hex strings', () => {
+    const hex = Random.hexString(16);
+    assert.equal(hex.length, 16);
+    assert.match(hex, /^[0-9a-f]+$/);
+  });
+
+  it('returns random choice from array', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const choice = Random.choice(arr);
+    assert.ok(arr.includes(choice));
+  });
+
+  it('generates secret tokens', () => {
+    const secret = Random.secret();
+    assert.equal(typeof secret, 'string');
+    assert.ok(secret.length > 0);
+  });
+});
+
+describe('EJSON', () => {
+  it('stringifies and parses dates', () => {
+    const date = new Date('2024-01-01T00:00:00Z');
+    const str = EJSON.stringify(date);
+    const parsed = EJSON.parse(str);
+    assert.deepEqual(parsed, date);
+  });
+
+  it('handles nested objects', () => {
+    const obj = { a: 1, b: { c: [1, 2, 3] } };
+    const clone = EJSON.clone(obj);
+    assert.deepEqual(clone, obj);
+    assert.notEqual(clone, obj);
+    assert.notEqual(clone.b, obj.b);
+  });
+
+  it('compares with EJSON.equals', () => {
+    assert.ok(EJSON.equals({ a: 1 }, { a: 1 }));
+    assert.ok(!EJSON.equals({ a: 1 }, { a: 2 }));
+    assert.ok(EJSON.equals(new Date(1000), new Date(1000)));
+  });
+});

--- a/packages/meteor-test/tests-dom.js
+++ b/packages/meteor-test/tests-dom.js
@@ -1,0 +1,110 @@
+// Demo: DOM testing with happy-dom + node:test
+//
+// This demonstrates that browser-dependent tests can run server-side
+// using happy-dom as a lightweight DOM implementation — no Puppeteer,
+// no browser, no headless Chrome needed.
+//
+// Run with:
+//   meteor test-packages meteor-test --driver-package meteor-test --once
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Window } from 'happy-dom';
+
+describe('DOM (happy-dom)', () => {
+  let window, document;
+
+  before(() => {
+    window = new Window({ url: 'http://localhost:3000' });
+    document = window.document;
+    // Expose globals like a browser would
+    globalThis.window = window;
+    globalThis.document = document;
+  });
+
+  after(() => {
+    window.close();
+    delete globalThis.window;
+    delete globalThis.document;
+  });
+
+  it('creates and appends elements', () => {
+    const div = document.createElement('div');
+    div.id = 'test-container';
+    document.body.appendChild(div);
+
+    assert.ok(document.getElementById('test-container'));
+    assert.strictEqual(div.parentNode, document.body);
+  });
+
+  it('handles innerHTML', () => {
+    const ul = document.createElement('ul');
+    ul.innerHTML = '<li>one</li><li>two</li><li>three</li>';
+
+    assert.strictEqual(ul.children.length, 3);
+    assert.strictEqual(ul.children[0].textContent, 'one');
+    assert.strictEqual(ul.children[2].textContent, 'three');
+  });
+
+  it('spreads NodeList (like ecmascript runtime-client-tests)', () => {
+    const div = document.createElement('div');
+    for (let i = 0; i < 5; i++) {
+      const child = document.createElement('span');
+      child.textContent = `child ${i}`;
+      div.appendChild(child);
+    }
+
+    const arr = [...div.childNodes];
+    assert.strictEqual(arr.length, 5);
+    arr.forEach((el, i) => {
+      assert.strictEqual(el.textContent, `child ${i}`);
+    });
+  });
+
+  it('handles CSS classes', () => {
+    const el = document.createElement('div');
+    el.classList.add('active', 'visible');
+
+    assert.ok(el.classList.contains('active'));
+    assert.ok(el.classList.contains('visible'));
+    assert.strictEqual(el.className, 'active visible');
+
+    el.classList.remove('active');
+    assert.ok(!el.classList.contains('active'));
+  });
+
+  it('handles event listeners', () => {
+    const button = document.createElement('button');
+    let clicked = false;
+
+    button.addEventListener('click', () => { clicked = true; });
+    button.click();
+
+    assert.ok(clicked);
+  });
+
+  it('handles querySelector', () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <div class="item" data-id="1">First</div>
+      <div class="item" data-id="2">Second</div>
+      <div class="item active" data-id="3">Third</div>
+    `;
+
+    const active = container.querySelector('.active');
+    assert.ok(active);
+    assert.strictEqual(active.dataset.id, '3');
+
+    const items = container.querySelectorAll('.item');
+    assert.strictEqual(items.length, 3);
+  });
+
+  it('handles form elements', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = 'hello';
+
+    assert.strictEqual(input.value, 'hello');
+    assert.strictEqual(input.type, 'text');
+  });
+});

--- a/packages/minimongo/minimongo_tests.js
+++ b/packages/minimongo/minimongo_tests.js
@@ -1,96 +1,99 @@
-Tinytest.add('minimongo - wrapTransform', test => {
-  const wrap = LocalCollection.wrapTransform;
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 
-  // Transforming no function gives falsey.
-  test.isFalse(wrap(undefined));
-  test.isFalse(wrap(null));
+describe('minimongo - shared', () => {
+  it('wrapTransform', () => {
+    const wrap = LocalCollection.wrapTransform;
 
-  // It's OK if you don't change the ID.
-  const validTransform = doc => {
-    delete doc.x;
-    doc.y = 42;
-    doc.z = () => 43;
-    return doc;
-  };
-  const transformed = wrap(validTransform)({_id: 'asdf', x: 54});
-  test.equal(Object.keys(transformed), ['_id', 'y', 'z']);
-  test.equal(transformed.y, 42);
-  test.equal(transformed.z(), 43);
+    // Transforming no function gives falsey.
+    assert.ok(!wrap(undefined));
+    assert.ok(!wrap(null));
 
-  // Ensure that ObjectIDs work (even if the _ids in question are not ===-equal)
-  const oid1 = new MongoID.ObjectID();
-  const oid2 = new MongoID.ObjectID(oid1.toHexString());
-  test.equal(wrap(() => ({
-    _id: oid2,
-  }))({_id: oid1}),
-  {_id: oid2});
+    // It's OK if you don't change the ID.
+    const validTransform = doc => {
+      delete doc.x;
+      doc.y = 42;
+      doc.z = () => 43;
+      return doc;
+    };
+    const transformed = wrap(validTransform)({_id: 'asdf', x: 54});
+    assert.deepStrictEqual(Object.keys(transformed), ['_id', 'y', 'z']);
+    assert.strictEqual(transformed.y, 42);
+    assert.strictEqual(transformed.z(), 43);
 
-  // transform functions must return objects
-  const invalidObjects = [
-    'asdf', new MongoID.ObjectID(), false, null, true,
-    27, [123], /adsf/, new Date, () => {}, undefined,
-  ];
-  invalidObjects.forEach(invalidObject => {
-    const wrapped = wrap(() => invalidObject);
-    test.throws(() => {
-      wrapped({_id: 'asdf'});
+    // Ensure that ObjectIDs work (even if the _ids in question are not ===-equal)
+    const oid1 = new MongoID.ObjectID();
+    const oid2 = new MongoID.ObjectID(oid1.toHexString());
+    assert.ok(EJSON.equals(wrap(() => ({
+      _id: oid2,
+    }))({_id: oid1}),
+    {_id: oid2}));
+
+    // transform functions must return objects
+    const invalidObjects = [
+      'asdf', new MongoID.ObjectID(), false, null, true,
+      27, [123], /adsf/, new Date, () => {}, undefined,
+    ];
+    invalidObjects.forEach(invalidObject => {
+      const wrapped = wrap(() => invalidObject);
+      assert.throws(() => {
+        wrapped({_id: 'asdf'});
+      });
+    }, /transform must return object/);
+
+    // transform functions may not change _ids
+    const wrapped = wrap(doc => { doc._id = 'x'; return doc; });
+    assert.throws(() => {
+      wrapped({_id: 'y'});
+    }, /can't have different _id/);
+
+    // transform functions may remove _ids
+    assert.ok(EJSON.equals({_id: 'a', x: 2},
+      wrap(d => {delete d._id; return d;})({_id: 'a', x: 2})));
+
+    // test that wrapped transform functions are nonreactive
+    const unwrapped = doc => {
+      assert.ok(!Tracker.active);
+      return doc;
+    };
+    const handle = Tracker.autorun(() => {
+      assert.ok(Tracker.active);
+      wrap(unwrapped)({_id: 'xxx'});
     });
-  }, /transform must return object/);
-
-  // transform functions may not change _ids
-  const wrapped = wrap(doc => { doc._id = 'x'; return doc; });
-  test.throws(() => {
-    wrapped({_id: 'y'});
-  }, /can't have different _id/);
-
-  // transform functions may remove _ids
-  test.equal({_id: 'a', x: 2},
-    wrap(d => {delete d._id; return d;})({_id: 'a', x: 2}));
-
-  // test that wrapped transform functions are nonreactive
-  const unwrapped = doc => {
-    test.isFalse(Tracker.active);
-    return doc;
-  };
-  const handle = Tracker.autorun(() => {
-    test.isTrue(Tracker.active);
-    wrap(unwrapped)({_id: 'xxx'});
+    handle.stop();
   });
-  handle.stop();
-});
 
-Tinytest.add('minimongo - bulk remove with $in operator removes all matching documents', function(test) {
-  const coll = new LocalCollection();
-  
-  // Insert multiple documents
-  const ids = ['id1', 'id2', 'id3', 'id4'];
-  ids.forEach(id => {
-    coll.insert({ _id: id, value: `item-${id}` });
+  it('bulk remove with $in operator removes all matching documents', () => {
+    const coll = new LocalCollection();
+
+    // Insert multiple documents
+    const ids = ['id1', 'id2', 'id3', 'id4'];
+    ids.forEach(id => {
+      coll.insert({ _id: id, value: `item-${id}` });
+    });
+
+    // Verify we have 4 documents
+    assert.strictEqual(coll.find().count(), 4);
+
+    // Remove 2 documents using $in operator
+    const removedCount = coll.remove({ _id: { $in: ['id1', 'id2'] } });
+
+    // This should remove 2 documents, not just 1
+    assert.strictEqual(removedCount, 2);
+
+    // Verify only 2 documents remain
+    assert.strictEqual(coll.find().count(), 2);
+
+    // Verify the correct documents were removed
+    assert.strictEqual(coll.findOne('id1'), undefined);
+    assert.strictEqual(coll.findOne('id2'), undefined);
+
+    // Verify the other documents still exist
+    assert.notStrictEqual(coll.findOne('id3'), undefined);
+    assert.notStrictEqual(coll.findOne('id4'), undefined);
   });
-  
-  // Verify we have 4 documents
-  test.equal(coll.find().count(), 4);
-  
-  // Remove 2 documents using $in operator
-  const removedCount = coll.remove({ _id: { $in: ['id1', 'id2'] } });
-  
-  // This should remove 2 documents, not just 1
-  test.equal(removedCount, 2);
-  
-  // Verify only 2 documents remain
-  test.equal(coll.find().count(), 2);
-  
-  // Verify the correct documents were removed
-  test.isUndefined(coll.findOne('id1'));
-  test.isUndefined(coll.findOne('id2'));
-  
-  // Verify the other documents still exist
-  test.isNotUndefined(coll.findOne('id3'));
-  test.isNotUndefined(coll.findOne('id4'));
-});
 
-if (Meteor.isClient) {
-  Tinytest.add('minimongo - $geoIntersects should throw error', function(test) {
+  it('$geoIntersects should throw error', () => {
     const collection = new LocalCollection();
     collection.insert({ _id: 'a', loc: { type: 'Point', coordinates: [0, 0] } });
 
@@ -109,10 +112,10 @@ if (Meteor.isClient) {
       }
     };
 
-    test.throws(
+    assert.throws(
       () => collection.findOne(query),
       /Unrecognized operator: \$geoIntersects/,
       'Should throw error for $geoIntersects in Minimongo'
     );
   });
-}
+});

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -1,3 +1,5 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import {hasOwn} from './common';
 
 // Hack to make LocalCollection generate ObjectIDs by default.
@@ -6,15 +8,12 @@ LocalCollection._useOID = true;
 // assert that f is a strcmp-style comparison function that puts
 // 'values' in the provided order
 
-const assert_ordering = (test, f, values) => {
+const assert_ordering = (f, values) => {
   for (let i = 0; i < values.length; i++) {
     let x = f(values[i], values[i]);
     if (x !== 0) {
       // XXX super janky
-      test.fail({type: 'minimongo-ordering',
-        message: "value doesn't order as equal to itself",
-        value: JSON.stringify(values[i]),
-        should_be_zero_but_got: JSON.stringify(x)});
+      assert.fail("value doesn't order as equal to itself: " + JSON.stringify(values[i]) + " got " + JSON.stringify(x));
     }
     if (i + 1 < values.length) {
       const less = values[i];
@@ -22,20 +21,12 @@ const assert_ordering = (test, f, values) => {
       x = f(less, more);
       if (!(x < 0)) {
         // XXX super janky
-        test.fail({type: 'minimongo-ordering',
-          message: 'ordering test failed',
-          first: JSON.stringify(less),
-          second: JSON.stringify(more),
-          should_be_negative_but_got: JSON.stringify(x)});
+        assert.fail('ordering test failed: ' + JSON.stringify(less) + ' vs ' + JSON.stringify(more) + ' should be negative but got ' + JSON.stringify(x));
       }
       x = f(more, less);
       if (!(x > 0)) {
         // XXX super janky
-        test.fail({type: 'minimongo-ordering',
-          message: 'ordering test failed',
-          first: JSON.stringify(less),
-          second: JSON.stringify(more),
-          should_be_positive_but_got: JSON.stringify(x)});
+        assert.fail('ordering test failed: ' + JSON.stringify(less) + ' vs ' + JSON.stringify(more) + ' should be positive but got ' + JSON.stringify(x));
       }
     }
   }
@@ -65,8 +56,10 @@ const log_callbacks = operations => ({
   },
 });
 
+describe('minimongo', () => {
+
 // XXX test shared structure in all MM entrypoints
-Tinytest.addAsync('minimongo - basics', async test => {
+it('basics', async () => {
   const c = new LocalCollection();
   let fluffyKitten_id;
   let count;
@@ -76,122 +69,122 @@ Tinytest.addAsync('minimongo - basics', async test => {
   await c.insert({type: 'cryptographer', name: 'alice'});
   await c.insert({type: 'cryptographer', name: 'bob'});
   await c.insert({type: 'cryptographer', name: 'cara'});
-  test.equal(c.find().count(), 5);
-  test.equal(c.find({type: 'kitten'}).count(), 2);
-  test.equal(c.find({type: 'cryptographer'}).count(), 3);
-  test.length(c.find({type: 'kitten'}).fetch(), 2);
-  test.length(c.find({type: 'cryptographer'}).fetch(), 3);
-  test.equal(fluffyKitten_id, c.findOne({type: 'kitten', name: 'fluffy'})._id);
+  assert.strictEqual(c.find().count(), 5);
+  assert.strictEqual(c.find({type: 'kitten'}).count(), 2);
+  assert.strictEqual(c.find({type: 'cryptographer'}).count(), 3);
+  assert.strictEqual(c.find({type: 'kitten'}).fetch().length, 2);
+  assert.strictEqual(c.find({type: 'cryptographer'}).fetch().length, 3);
+  assert.ok(EJSON.equals(fluffyKitten_id, c.findOne({type: 'kitten', name: 'fluffy'})._id));
 
   await c.removeAsync({name: 'cara'});
-  test.equal(c.find().count(), 4);
-  test.equal(c.find({type: 'kitten'}).count(), 2);
-  test.equal(c.find({type: 'cryptographer'}).count(), 2);
-  test.length(c.find({type: 'kitten'}).fetch(), 2);
-  test.length(c.find({type: 'cryptographer'}).fetch(), 2);
+  assert.strictEqual(c.find().count(), 4);
+  assert.strictEqual(c.find({type: 'kitten'}).count(), 2);
+  assert.strictEqual(c.find({type: 'cryptographer'}).count(), 2);
+  assert.strictEqual(c.find({type: 'kitten'}).fetch().length, 2);
+  assert.strictEqual(c.find({type: 'cryptographer'}).fetch().length, 2);
 
   count = await c.update({name: 'snookums'}, {$set: {type: 'cryptographer'}});
-  test.equal(count, 1);
-  test.equal(c.find().count(), 4);
-  test.equal(c.find({type: 'kitten'}).count(), 1);
-  test.equal(c.find({type: 'cryptographer'}).count(), 3);
-  test.length(c.find({type: 'kitten'}).fetch(), 1);
-  test.length(c.find({type: 'cryptographer'}).fetch(), 3);
+  assert.strictEqual(count, 1);
+  assert.strictEqual(c.find().count(), 4);
+  assert.strictEqual(c.find({type: 'kitten'}).count(), 1);
+  assert.strictEqual(c.find({type: 'cryptographer'}).count(), 3);
+  assert.strictEqual(c.find({type: 'kitten'}).fetch().length, 1);
+  assert.strictEqual(c.find({type: 'cryptographer'}).fetch().length, 3);
 
   await c.removeAsync(null);
   await c.removeAsync(false);
   await c.removeAsync(undefined);
-  test.equal(c.find().count(), 4);
+  assert.strictEqual(c.find().count(), 4);
 
   await c.removeAsync({_id: null});
   await c.removeAsync({_id: false});
   await c.removeAsync({_id: undefined});
   count = await c.removeAsync();
-  test.equal(count, 0);
-  test.equal(c.find().count(), 4);
+  assert.strictEqual(count, 0);
+  assert.strictEqual(c.find().count(), 4);
 
   count = await c.removeAsync({});
-  test.equal(count, 4);
-  test.equal(c.find().count(), 0);
+  assert.strictEqual(count, 4);
+  assert.strictEqual(c.find().count(), 0);
 
   await c.insert({_id: 1, name: 'strawberry', tags: ['fruit', 'red', 'squishy']});
   await c.insert({_id: 2, name: 'apple', tags: ['fruit', 'red', 'hard']});
   await c.insert({_id: 3, name: 'rose', tags: ['flower', 'red', 'squishy']});
 
-  test.equal(c.find({tags: 'flower'}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}).count(), 2);
-  test.equal(c.find({tags: 'red'}).count(), 3);
-  test.length(c.find({tags: 'flower'}).fetch(), 1);
-  test.length(c.find({tags: 'fruit'}).fetch(), 2);
-  test.length(c.find({tags: 'red'}).fetch(), 3);
+  assert.strictEqual(c.find({tags: 'flower'}).count(), 1);
+  assert.strictEqual(c.find({tags: 'fruit'}).count(), 2);
+  assert.strictEqual(c.find({tags: 'red'}).count(), 3);
+  assert.strictEqual(c.find({tags: 'flower'}).fetch().length, 1);
+  assert.strictEqual(c.find({tags: 'fruit'}).fetch().length, 2);
+  assert.strictEqual(c.find({tags: 'red'}).fetch().length, 3);
 
-  test.equal((await c.findOneAsync(1)).name, 'strawberry');
-  test.equal((await c.findOneAsync(2)).name, 'apple');
-  test.equal((await c.findOneAsync(3)).name, 'rose');
-  test.equal(await c.findOneAsync(4), undefined);
-  test.equal(await c.findOneAsync('abc'), undefined);
-  test.equal(await c.findOneAsync(undefined), undefined);
+  assert.strictEqual((await c.findOneAsync(1)).name, 'strawberry');
+  assert.strictEqual((await c.findOneAsync(2)).name, 'apple');
+  assert.strictEqual((await c.findOneAsync(3)).name, 'rose');
+  assert.strictEqual(await c.findOneAsync(4), undefined);
+  assert.strictEqual(await c.findOneAsync('abc'), undefined);
+  assert.strictEqual(await c.findOneAsync(undefined), undefined);
 
-  test.equal(c.find(1).count(), 1);
-  test.equal(c.find(4).count(), 0);
-  test.equal(c.find('abc').count(), 0);
-  test.equal(c.find(undefined).count(), 0);
-  test.equal(c.find().count(), 3);
-  test.equal(c.find(1, {skip: 1}).count(false), 0);
-  test.equal(c.find(1, {skip: 1}).count(), 0);
-  test.equal(c.find({_id: 1}, {skip: 1}).count(false), 0);
-  test.equal(c.find({_id: 1}, {skip: 1}).count(), 0);
-  test.equal(c.find({_id: undefined}).count(), 0);
-  test.equal(c.find({_id: false}).count(), 0);
-  test.equal(c.find({_id: null}).count(), 0);
-  test.equal(c.find({_id: ''}).count(), 0);
-  test.equal(c.find({_id: 0}).count(), 0);
-  test.equal(c.find({}, {skip: 1}).count(false), 2);
-  test.equal(c.find({}, {skip: 1}).count(), 2);
-  test.equal(c.find({}, {skip: 2}).count(), 1);
-  test.equal(c.find({}, {limit: 2}).count(false), 2);
-  test.equal(c.find({}, {limit: 2}).count(), 2);
-  test.equal(c.find({}, {limit: 1}).count(), 1);
-  test.equal(c.find({}, {skip: 1, limit: 1}).count(false), 1);
-  test.equal(c.find({}, {skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(false), 1);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(false), 1);
-  test.equal(c.find({tags: 'fruit'}, {limit: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(false), 1);
-  test.equal(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(false), 0);
-  test.equal(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(), 0);
-  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(false), 0);
-  test.equal(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(), 0);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(false), 2);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(), 2);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 2}).count(), 1);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(false), 2);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(), 2);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], limit: 1}).count(), 1);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(false), 1);
-  test.equal(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(false), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(false), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(false), 1);
-  test.equal(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 1);
+  assert.strictEqual(c.find(1).count(), 1);
+  assert.strictEqual(c.find(4).count(), 0);
+  assert.strictEqual(c.find('abc').count(), 0);
+  assert.strictEqual(c.find(undefined).count(), 0);
+  assert.strictEqual(c.find().count(), 3);
+  assert.deepStrictEqual(c.find(1, {skip: 1}).count(false), 0);
+  assert.deepStrictEqual(c.find(1, {skip: 1}).count(), 0);
+  assert.deepStrictEqual(c.find({_id: 1}, {skip: 1}).count(false), 0);
+  assert.deepStrictEqual(c.find({_id: 1}, {skip: 1}).count(), 0);
+  assert.strictEqual(c.find({_id: undefined}).count(), 0);
+  assert.strictEqual(c.find({_id: false}).count(), 0);
+  assert.strictEqual(c.find({_id: null}).count(), 0);
+  assert.strictEqual(c.find({_id: ''}).count(), 0);
+  assert.strictEqual(c.find({_id: 0}).count(), 0);
+  assert.deepStrictEqual(c.find({}, {skip: 1}).count(false), 2);
+  assert.deepStrictEqual(c.find({}, {skip: 1}).count(), 2);
+  assert.deepStrictEqual(c.find({}, {skip: 2}).count(), 1);
+  assert.deepStrictEqual(c.find({}, {limit: 2}).count(false), 2);
+  assert.deepStrictEqual(c.find({}, {limit: 2}).count(), 2);
+  assert.deepStrictEqual(c.find({}, {limit: 1}).count(), 1);
+  assert.deepStrictEqual(c.find({}, {skip: 1, limit: 1}).count(false), 1);
+  assert.deepStrictEqual(c.find({}, {skip: 1, limit: 1}).count(), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {skip: 1}).count(false), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {skip: 1}).count(), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {limit: 1}).count(false), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {limit: 1}).count(), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(false), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {skip: 1, limit: 1}).count(), 1);
+  assert.deepStrictEqual(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(false), 0);
+  assert.deepStrictEqual(c.find(1, {sort: ['_id', 'desc'], skip: 1}).count(), 0);
+  assert.deepStrictEqual(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(false), 0);
+  assert.deepStrictEqual(c.find({_id: 1}, {sort: ['_id', 'desc'], skip: 1}).count(), 0);
+  assert.deepStrictEqual(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(false), 2);
+  assert.deepStrictEqual(c.find({}, {sort: ['_id', 'desc'], skip: 1}).count(), 2);
+  assert.deepStrictEqual(c.find({}, {sort: ['_id', 'desc'], skip: 2}).count(), 1);
+  assert.deepStrictEqual(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(false), 2);
+  assert.deepStrictEqual(c.find({}, {sort: ['_id', 'desc'], limit: 2}).count(), 2);
+  assert.deepStrictEqual(c.find({}, {sort: ['_id', 'desc'], limit: 1}).count(), 1);
+  assert.deepStrictEqual(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(false), 1);
+  assert.deepStrictEqual(c.find({}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(false), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1}).count(), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(false), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], limit: 1}).count(), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(false), 1);
+  assert.deepStrictEqual(c.find({tags: 'fruit'}, {sort: ['_id', 'desc'], skip: 1, limit: 1}).count(), 1);
 
   // Regression test for #455.
   await c.insert({foo: {bar: 'baz'}});
-  test.equal(c.find({foo: {bam: 'baz'}}).count(), 0);
-  test.equal(c.find({foo: {bar: 'baz'}}).count(), 1);
+  assert.strictEqual(c.find({foo: {bam: 'baz'}}).count(), 0);
+  assert.strictEqual(c.find({foo: {bar: 'baz'}}).count(), 1);
 
   // Regression test for #5301
   await c.removeAsync({});
   await c.insert({a: 'a', b: 'b'});
   const noop = () => null;
-  test.equal(c.find({a: noop}).count(), 1);
-  test.equal(c.find({a: 'a', b: noop}).count(), 1);
-  test.equal(c.find({c: noop}).count(), 1);
-  test.equal(c.find({a: noop, c: 'c'}).count(), 0);
+  assert.strictEqual(c.find({a: noop}).count(), 1);
+  assert.deepStrictEqual(c.find({a: 'a', b: noop}).count(), 1);
+  assert.strictEqual(c.find({c: noop}).count(), 1);
+  assert.deepStrictEqual(c.find({a: noop, c: 'c'}).count(), 0);
 
   // Regression test for #4260
   // Only insert enumerable, own properties from the object
@@ -206,110 +199,110 @@ Tinytest.addAsync('minimongo - basics', async test => {
   const before = new Thing();
   await c.insert(before);
   const after = await c.findOneAsync();
-  test.equal(after.a, 1);
-  test.equal(after.b, undefined);
-  test.equal(after.c, undefined);
-  test.equal(after.d, undefined);
+  assert.strictEqual(after.a, 1);
+  assert.strictEqual(after.b, undefined);
+  assert.strictEqual(after.c, undefined);
+  assert.strictEqual(after.d, undefined);
 });
 
 
-Tinytest.addAsync('minimongo - upsert', async test => {
+it('upsert', async () => {
   const c = new LocalCollection();
 
   await c.upsertAsync({ name: 'doc' }, { name: 'doc' });
   
-  test.equal(c.find({}).count(), 1);
+  assert.strictEqual(c.find({}).count(), 1);
 
   await c.removeAsync({});
 
   c.upsert({ name: 'doc' }, { name: 'doc' });
-  test.equal(c.find({}).count(), 1);
+  assert.strictEqual(c.find({}).count(), 1);
 });
 
 
-Tinytest.add('minimongo - error - no options', test => {
+it('error - no options', () => {
   try {
     throw MinimongoError('Not fun to have errors');
   } catch (e) {
-    test.equal(e.message, 'Not fun to have errors');
+    assert.strictEqual(e.message, 'Not fun to have errors');
   }
 });
 
-Tinytest.add('minimongo - error - with field', test => {
+it('error - with field', () => {
   try {
     throw MinimongoError('Cats are no fun', { field: 'mice' });
   } catch (e) {
-    test.equal(e.message, "Cats are no fun for field 'mice'");
+    assert.strictEqual(e.message, "Cats are no fun for field 'mice'");
   }
 });
 
-Tinytest.add('minimongo - cursors', test => {
+it('cursors', () => {
   const c = new LocalCollection();
   let res;
 
   for (let i = 0; i < 20; i++) {c.insert({i});}
 
   const q = c.find();
-  test.equal(q.count(), 20);
+  assert.strictEqual(q.count(), 20);
 
   // fetch
   res = q.fetch();
-  test.length(res, 20);
+  assert.strictEqual(res.length, 20);
   for (let i = 0; i < 20; i++) {
-    test.equal(res[i].i, i);
+    assert.deepStrictEqual(res[i].i, i);
   }
   // call it again, it still works
-  test.length(q.fetch(), 20);
+  assert.strictEqual(q.fetch().length, 20);
 
   // forEach
   let count = 0;
   const context = {};
   q.forEach(function(obj, i, cursor) {
-    test.equal(obj.i, count++);
-    test.equal(obj.i, i);
-    test.isTrue(context === this);
-    test.isTrue(cursor === q);
+    assert.deepStrictEqual(obj.i, count++);
+    assert.deepStrictEqual(obj.i, i);
+    assert.ok(context === this);
+    assert.ok(cursor === q);
   }, context);
-  test.equal(count, 20);
+  assert.strictEqual(count, 20);
   // call it again, it still works
-  test.length(q.fetch(), 20);
+  assert.strictEqual(q.fetch().length, 20);
 
   // iterator
   count = 0;
   for (let obj of q) {
-    test.equal(obj.i, count++);
+    assert.deepStrictEqual(obj.i, count++);
   };
-  test.equal(count, 20);
+  assert.strictEqual(count, 20);
   // call it again, it still works
-  test.length(q.fetch(), 20);
+  assert.strictEqual(q.fetch().length, 20);
   // test spread operator
-  test.equal([...q], q.fetch());
+  assert.deepStrictEqual([...q], q.fetch());
 
   // map
   res = q.map(function(obj, i, cursor) {
-    test.equal(obj.i, i);
-    test.isTrue(context === this);
-    test.isTrue(cursor === q);
+    assert.deepStrictEqual(obj.i, i);
+    assert.ok(context === this);
+    assert.ok(cursor === q);
     return obj.i * 2;
   }, context);
-  test.length(res, 20);
-  for (let i = 0; i < 20; i++) {test.equal(res[i], i * 2);}
+  assert.strictEqual(res.length, 20);
+  for (let i = 0; i < 20; i++) {assert.deepStrictEqual(res[i], i * 2);}
   // call it again, it still works
-  test.length(q.fetch(), 20);
+  assert.strictEqual(q.fetch().length, 20);
 
   // findOne (and no rewind first)
-  test.equal(c.findOne({i: 0}).i, 0);
-  test.equal(c.findOne({i: 1}).i, 1);
+  assert.strictEqual(c.findOne({i: 0}).i, 0);
+  assert.strictEqual(c.findOne({i: 1}).i, 1);
   const id = c.findOne({i: 2})._id;
-  test.equal(c.findOne(id).i, 2);
+  assert.strictEqual(c.findOne(id).i, 2);
 });
 
-Tinytest.add('minimongo - transform', test => {
+it('transform', () => {
   const c = new LocalCollection;
   c.insert({});
   // transform functions must return objects
   const invalidTransform = doc => doc._id;
-  test.throws(() => {
+  assert.throws(() => {
     c.findOne({}, {transform: invalidTransform});
   });
 
@@ -319,63 +312,63 @@ Tinytest.add('minimongo - transform', test => {
     delete docWithoutId._id;
     return docWithoutId;
   };
-  test.equal(c.findOne({}, {transform: transformWithoutId})._id,
+  assert.deepStrictEqual(c.findOne({}, {transform: transformWithoutId})._id,
     c.findOne()._id);
 });
 
-Tinytest.add('minimongo - misc', test => {
+it('misc', () => {
   // deepcopy
   let a = {a: [1, 2, 3], b: 'x', c: true, d: {x: 12, y: [12]},
     f: null, g: new Date()};
   let b = EJSON.clone(a);
-  test.equal(a, b);
-  test.isTrue(LocalCollection._f._equal(a, b));
+  assert.deepStrictEqual(a, b);
+  assert.ok(LocalCollection._f._equal(a, b));
   a.a.push(4);
-  test.length(b.a, 3);
+  assert.strictEqual(b.a.length, 3);
   a.c = false;
-  test.isTrue(b.c);
+  assert.ok(b.c);
   b.d.z = 15;
   a.d.z = 14;
-  test.equal(b.d.z, 15);
+  assert.strictEqual(b.d.z, 15);
   a.d.y.push(88);
-  test.length(b.d.y, 1);
-  test.equal(a.g, b.g);
+  assert.strictEqual(b.d.y.length, 1);
+  assert.deepStrictEqual(a.g, b.g);
   b.g.setDate(b.g.getDate() + 1);
-  test.notEqual(a.g, b.g);
+  assert.notDeepStrictEqual(a.g, b.g);
 
   a = {x() {}};
   b = EJSON.clone(a);
   a.x.a = 14;
-  test.equal(b.x.a, 14); // just to document current behavior
+  assert.strictEqual(b.x.a, 14); // just to document current behavior
 });
 
-Tinytest.add('minimongo - lookup', test => {
+it('lookup', () => {
   const lookupA = MinimongoTest.makeLookupFunction('a');
-  test.equal(lookupA({}), [{value: undefined}]);
-  test.equal(lookupA({a: 1}), [{value: 1}]);
-  test.equal(lookupA({a: [1]}), [{value: [1]}]);
+  assert.deepStrictEqual(lookupA({}), [{value: undefined}]);
+  assert.deepStrictEqual(lookupA({a: 1}), [{value: 1}]);
+  assert.deepStrictEqual(lookupA({a: [1]}), [{value: [1]}]);
 
   const lookupAX = MinimongoTest.makeLookupFunction('a.x');
-  test.equal(lookupAX({a: {x: 1}}), [{value: 1}]);
-  test.equal(lookupAX({a: {x: [1]}}), [{value: [1]}]);
-  test.equal(lookupAX({a: 5}), [{value: undefined}]);
-  test.equal(lookupAX({a: [{x: 1}, {x: [2]}, {y: 3}]}),
+  assert.deepStrictEqual(lookupAX({a: {x: 1}}), [{value: 1}]);
+  assert.deepStrictEqual(lookupAX({a: {x: [1]}}), [{value: [1]}]);
+  assert.deepStrictEqual(lookupAX({a: 5}), [{value: undefined}]);
+  assert.deepStrictEqual(lookupAX({a: [{x: 1}, {x: [2]}, {y: 3}]}),
     [{value: 1, arrayIndices: [0]},
       {value: [2], arrayIndices: [1]},
       {value: undefined, arrayIndices: [2]}]);
 
   const lookupA0X = MinimongoTest.makeLookupFunction('a.0.x');
-  test.equal(lookupA0X({a: [{x: 1}]}), [
+  assert.deepStrictEqual(lookupA0X({a: [{x: 1}]}), [
     // From interpreting '0' as "0th array element".
     {value: 1, arrayIndices: [0, 'x']},
     // From interpreting '0' as "after branching in the array, look in the
     // object {x:1} for a field named 0".
     {value: undefined, arrayIndices: [0]}]);
-  test.equal(lookupA0X({a: [{x: [1]}]}), [
+  assert.deepStrictEqual(lookupA0X({a: [{x: [1]}]}), [
     {value: [1], arrayIndices: [0, 'x']},
     {value: undefined, arrayIndices: [0]}]);
-  test.equal(lookupA0X({a: 5}), [{value: undefined}]);
-  test.equal(lookupA0X({a: [{x: 1}, {x: [2]}, {y: 3}]}), [
+  assert.deepStrictEqual(lookupA0X({a: 5}), [{value: undefined}]);
+  assert.deepStrictEqual(lookupA0X({a: [{x: 1}, {x: [2]}, {y: 3}]}), [
     // From interpreting '0' as "0th array element".
     {value: 1, arrayIndices: [0, 'x']},
     // From interpreting '0' as "after branching in the array, look in the
@@ -385,7 +378,7 @@ Tinytest.add('minimongo - lookup', test => {
     {value: undefined, arrayIndices: [2]},
   ]);
 
-  test.equal(
+  assert.deepStrictEqual(
     MinimongoTest.makeLookupFunction('w.x.0.z')({
       w: [{x: [{z: 5}]}]}), [
       // From interpreting '0' as "0th array element".
@@ -396,16 +389,13 @@ Tinytest.add('minimongo - lookup', test => {
     ]);
 });
 
-Tinytest.add('minimongo - selector_compiler', test => {
+it('selector_compiler', () => {
   const matches = (shouldMatch, selector, doc) => {
     const doesMatch = new Minimongo.Matcher(selector).documentMatches(doc).result;
     if (doesMatch != shouldMatch) {
       // XXX super janky
-      test.fail({message: `minimongo match failure: document ${shouldMatch ? "should match, but doesn't" :
-        "shouldn't match, but does"}`,
-      selector: JSON.stringify(selector),
-      document: JSON.stringify(doc),
-      });
+      assert.fail(`minimongo match failure: document ${shouldMatch ? "should match, but doesn't" :
+        "shouldn't match, but does"} selector=${JSON.stringify(selector)} document=${JSON.stringify(doc)}`);
     }
   };
 
@@ -565,7 +555,7 @@ Tinytest.add('minimongo - selector_compiler', test => {
   // Members of $all other than regexps are *equality matches*, not document
   // matches.
   nomatch({a: {$all: [{b: 3}]}}, {a: [{b: 3, k: 4}]});
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$all: [{$gt: 4}]}}, {});
   });
 
@@ -607,7 +597,7 @@ Tinytest.add('minimongo - selector_compiler', test => {
     {bar: 1},
     [],
   ].forEach(badMod => {
-    test.throws(() => {
+    assert.throws(() => {
       match({a: {$mod: badMod}}, {a: 11});
     });
   });
@@ -803,10 +793,7 @@ Tinytest.add('minimongo - selector_compiler', test => {
   function matchCount(query, count) {
     const matches = c.find(query).count();
     if (matches !== count) {
-      test.fail({message: `minimongo match count failure: matched ${matches} times, but should match ${count} times`,
-        query: JSON.stringify(query),
-        count: JSON.stringify(count),
-      });
+      assert.fail(`minimongo match count failure: matched ${matches} times, but should match ${count} times query=${JSON.stringify(query)}`);
     }
   }
 
@@ -966,7 +953,7 @@ Tinytest.add('minimongo - selector_compiler', test => {
     '1',
     [0, -1],
   ].forEach(badValue => {
-    test.throws(() => {
+    assert.throws(() => {
       match({a: {$bitsAllSet: badValue}}, {a: 42});
     });
   });
@@ -1036,16 +1023,16 @@ Tinytest.add('minimongo - selector_compiler', test => {
   nomatch({'a.0': {$type: 1}}, {a: [[0]]});
 
   // invalid types should throw errors
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$type: 'foo'}}, {a: 1});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$type: -2}}, {a: 1});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$type: 0}}, {a: 1});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$type: 20}}, {a: 1});
   });
 
@@ -1090,7 +1077,7 @@ Tinytest.add('minimongo - selector_compiler', test => {
   match({a: {$regex: reusedRegexp}}, {a: 'Shorts'});
   match({a: {$regex: reusedRegexp}}, {a: 'Shorts'});
 
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$options: 'i'}}, {a: 12});
   });
 
@@ -1108,10 +1095,10 @@ Tinytest.add('minimongo - selector_compiler', test => {
   nomatch({a: /t/}, {a: true});
   match({a: /m/i}, {a: ['x', 'xM']});
 
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$regex: /a/, $options: 'x'}}, {a: 'cat'});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$regex: /a/, $options: 's'}}, {a: 'cat'});
   });
 
@@ -1203,13 +1190,13 @@ Tinytest.add('minimongo - selector_compiler', test => {
   nomatch({'a.b': {$in: [1, 2, 3]}}, {a: {b: [4]}});
 
   // $or
-  test.throws(() => {
+  assert.throws(() => {
     match({$or: []}, {});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({$or: [5]}, {});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({$or: []}, {a: 1});
   });
   match({$or: [{a: 1}]}, {a: 1});
@@ -1293,13 +1280,13 @@ Tinytest.add('minimongo - selector_compiler', test => {
   // this is possibly an open-ended task, so we stop here ...
 
   // $nor
-  test.throws(() => {
+  assert.throws(() => {
     match({$nor: []}, {});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({$nor: [5]}, {});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({$nor: []}, {a: 1});
   });
   nomatch({$nor: [{a: 1}]}, {a: 1});
@@ -1374,13 +1361,13 @@ Tinytest.add('minimongo - selector_compiler', test => {
 
   // $and
 
-  test.throws(() => {
+  assert.throws(() => {
     match({$and: []}, {});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({$and: [5]}, {});
   });
-  test.throws(() => {
+  assert.throws(() => {
     match({$and: []}, {a: 1});
   });
   match({$and: [{a: 1}]}, {a: 1});
@@ -1555,12 +1542,12 @@ Tinytest.add('minimongo - selector_compiler', test => {
   nomatch({a: {$elemMatch: {x: 1, $or: [{a: 1}, {b: 1}]}}},
     {a: [{x: 1}, {b: 1}]});
 
-  test.throws(() => {
+  assert.throws(() => {
     match({a: {$elemMatch: {$gte: 1, $or: [{a: 1}, {b: 1}]}}},
       {a: [{x: 1, b: 1}]});
   });
 
-  test.throws(() => {
+  assert.throws(() => {
     match({x: {$elemMatch: {$and: [{$gt: 5, $lt: 9}]}}}, {x: [8]});
   });
 
@@ -1572,11 +1559,11 @@ Tinytest.add('minimongo - selector_compiler', test => {
   // - non-scalar arguments to $gt, $lt, etc
 });
 
-Tinytest.add('minimongo - projection_compiler', test => {
+it('projection_compiler', () => {
   const testProjection = (projection, tests) => {
     const projection_f = LocalCollection._compileProjection(projection);
     const equalNonStrict = (a, b, desc) => {
-      test.isTrue(EJSON.equals(a, b), desc);
+      assert.ok(EJSON.equals(a, b), desc);
     };
 
     tests.forEach(testCase => {
@@ -1585,9 +1572,9 @@ Tinytest.add('minimongo - projection_compiler', test => {
   };
 
   const testCompileProjectionThrows = (projection, expectedError) => {
-    test.throws(() => {
+    assert.throws(() => {
       LocalCollection._compileProjection(projection);
-    }, expectedError);
+    }, { message: new RegExp(expectedError.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')) });
   };
 
   testProjection({ foo: 1, bar: 1 }, [
@@ -1703,7 +1690,7 @@ Tinytest.add('minimongo - projection_compiler', test => {
   testCompileProjectionThrows('some string', 'fields option must be an object');
 });
 
-Tinytest.add('minimongo - fetch with fields', test => {
+it('fetch with fields', () => {
   const c = new LocalCollection();
   Array.from({length: 30}, (x, i) => {
     c.insert({
@@ -1723,7 +1710,7 @@ Tinytest.add('minimongo - fetch with fields', test => {
     'anything.foo': 1,
   } }).fetch();
 
-  test.isTrue(fetchResults.every(x => x &&
+  assert.ok(fetchResults.every(x => x &&
          x.something &&
          x.anything &&
          x.anything.foo &&
@@ -1739,7 +1726,7 @@ Tinytest.add('minimongo - fetch with fields', test => {
     fields: { nothing: 0 },
   }).fetch();
 
-  test.isTrue(fetchResults.every(x => x &&
+  assert.ok(fetchResults.every(x => x &&
          x.something &&
          x.anything &&
          x.anything.foo === 'bar' &&
@@ -1748,7 +1735,7 @@ Tinytest.add('minimongo - fetch with fields', test => {
          x.i &&
          x.i >= 5));
 
-  test.isTrue(fetchResults.length === 25);
+  assert.ok(fetchResults.length === 25);
 
   // Test that we can sort, based on field excluded from the projection, use
   // skip and limit as well!
@@ -1765,29 +1752,29 @@ Tinytest.add('minimongo - fetch with fields', test => {
     },
   }).fetch();
 
-  test.isTrue(fetchResults.every(x => x &&
+  assert.ok(fetchResults.every(x => x &&
          x.something &&
          x.i >= 10 && x.i < 20));
 
   fetchResults.forEach((x, i, arr) => {
     if (!i) return;
-    test.isTrue(x.i === arr[i - 1].i + 1);
+    assert.ok(x.i === arr[i - 1].i + 1);
   });
 
   // Temporary unsupported operators
   // queries are taken from MongoDB docs examples
-  test.throws(() => {
+  assert.throws(() => {
     c.find({}, { fields: { 'grades.$': 1 } });
   });
-  test.throws(() => {
+  assert.throws(() => {
     c.find({}, { fields: { grades: { $elemMatch: { mean: 70 } } } });
   });
-  test.throws(() => {
+  assert.throws(() => {
     c.find({}, { fields: { grades: { $slice: [20, 10] } } });
   });
 });
 
-Tinytest.add('minimongo - fetch with projection, subarrays', test => {
+it('fetch with projection, subarrays', () => {
   // Apparently projection of type 'foo.bar.x' for
   // { foo: [ { bar: { x: 42 } }, { bar: { x: 3 } } ] }
   // should return exactly this object. More precisely, arrays are considered as
@@ -1814,7 +1801,7 @@ Tinytest.add('minimongo - fetch with projection, subarrays', test => {
   });
 
   const equalNonStrict = (a, b, desc) => {
-    test.isTrue(EJSON.equals(a, b), desc);
+    assert.ok(EJSON.equals(a, b), desc);
   };
 
   const testForProjection = (projection, expected) => {
@@ -1843,7 +1830,7 @@ Tinytest.add('minimongo - fetch with projection, subarrays', test => {
     {a: [ [ { c: 2 }, { c: 4 } ], { c: 5 }, [ { c: 9 } ] ] });
 });
 
-Tinytest.add('minimongo - fetch with projection, deep copy', test => {
+it('fetch with projection, deep copy', () => {
   // Compiled fields projection defines the contract: returned document doesn't
   // retain anything from the passed argument.
   const doc = {
@@ -1863,18 +1850,18 @@ Tinytest.add('minimongo - fetch with projection, deep copy', test => {
   let filteredDoc = projectionFn(doc);
   doc.a.x++;
   doc.b.y.z--;
-  test.equal(filteredDoc.a.x, 42, 'projection returning deep copy - including');
-  test.equal(filteredDoc.b.y.z, 33, 'projection returning deep copy - including');
+  assert.deepStrictEqual(filteredDoc.a.x, 42, 'projection returning deep copy - including');
+  assert.deepStrictEqual(filteredDoc.b.y.z, 33, 'projection returning deep copy - including');
 
   fields = { c: 0 };
   projectionFn = LocalCollection._compileProjection(fields);
   filteredDoc = projectionFn(doc);
 
   doc.a.x = 5;
-  test.equal(filteredDoc.a.x, 43, 'projection returning deep copy - excluding');
+  assert.deepStrictEqual(filteredDoc.a.x, 43, 'projection returning deep copy - excluding');
 });
 
-Tinytest.addAsync('minimongo - observe ordered with projection', async test => {
+it('observe ordered with projection', async () => {
   // These tests are copy-paste from "minimongo -observe ordered",
   // slightly modified to test projection
   const operations = [];
@@ -1883,99 +1870,103 @@ Tinytest.addAsync('minimongo - observe ordered with projection', async test => {
 
   const c = new LocalCollection();
   handle = c.find({}, {sort: {a: 1}, fields: { a: 1 }}).observe(cbs);
-  test.isTrue(handle.collection === c);
+  assert.ok(handle.collection === c);
 
   await c.insertAsync({_id: 'foo', a: 1, b: 2});
-  test.equal(operations.shift(), ['added', {a: 1}, 0, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 1}, 0, null]);
   await c.updateAsync({a: 1}, {$set: {a: 2, b: 1}});
-  test.equal(operations.shift(), ['changed', {a: 2}, 0, {a: 1}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 2}, 0, {a: 1}]);
   await c.insertAsync({_id: 'bar', a: 10, c: 33});
-  test.equal(operations.shift(), ['added', {a: 10}, 1, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 10}, 1, null]);
   await c.updateAsync({}, {$inc: {a: 1}}, {multi: true});
   await c.updateAsync({}, {$inc: {c: 1}}, {multi: true});
-  test.equal(operations.shift(), ['changed', {a: 3}, 0, {a: 2}]);
-  test.equal(operations.shift(), ['changed', {a: 11}, 1, {a: 10}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 3}, 0, {a: 2}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 11}, 1, {a: 10}]);
   await c.updateAsync({a: 11}, {a: 1, b: 44});
-  test.equal(operations.shift(), ['changed', {a: 1}, 1, {a: 11}]);
-  test.equal(operations.shift(), ['moved', {a: 1}, 1, 0, 'foo']);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 1}, 1, {a: 11}]);
+  assert.deepStrictEqual(operations.shift(), ['moved', {a: 1}, 1, 0, 'foo']);
   await c.removeAsync({a: 2});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.removeAsync({a: 3});
-  test.equal(operations.shift(), ['removed', 'foo', 1, {a: 3}]);
+  assert.deepStrictEqual(operations.shift(), ['removed', 'foo', 1, {a: 3}]);
 
   // test stop
   handle.stop();
   const idA2 = Random.id();
   await c.insertAsync({_id: idA2, a: 2});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
 
   const cursor = c.find({}, {fields: {a: 1, _id: 0}});
-   test.throws(() => {
+   assert.throws(() => {
      cursor.observeChanges({ added() {} });
    });
-   test.throws(() => {
+   assert.throws(() => {
      cursor.observe({ added() {} });
    });
 
   // test initial inserts (and backwards sort)
   handle = c.find({}, {sort: {a: -1}, fields: { a: 1 } }).observe(cbs);
-  test.equal(operations.shift(), ['added', {a: 2}, 0, null]);
-  test.equal(operations.shift(), ['added', {a: 1}, 1, null]);
+  await handle.isReadyPromise;
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 2}, 0, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 1}, 1, null]);
   handle.stop();
 
   // test _suppress_initial
   handle = c.find({}, {sort: {a: -1}, fields: { a: 1 }}).observe(Object.assign(cbs, {_suppress_initial: true}));
-  test.equal(operations.shift(), undefined);
+  await handle.isReadyPromise;
+  assert.strictEqual(operations.shift(), undefined);
   await c.insertAsync({a: 100, b: { foo: 'bar' }});
-  test.equal(operations.shift(), ['added', {a: 100}, 0, idA2]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 100}, 0, idA2]);
   handle.stop();
 
   // test skip and limit.
   await c.removeAsync({});
   handle = c.find({}, {sort: {a: 1}, skip: 1, limit: 2, fields: { blacklisted: 0 }}).observe(cbs);
-  test.equal(operations.shift(), undefined);
+  await handle.isReadyPromise;
+  assert.strictEqual(operations.shift(), undefined);
   await c.insertAsync({a: 1, blacklisted: 1324});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.insertAsync({_id: 'foo', a: 2, blacklisted: ['something']});
-  test.equal(operations.shift(), ['added', {a: 2}, 0, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 2}, 0, null]);
   await c.insertAsync({a: 3, blacklisted: { 2: 3 }});
-  test.equal(operations.shift(), ['added', {a: 3}, 1, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 3}, 1, null]);
   await c.insertAsync({a: 4, blacklisted: 6});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.updateAsync({a: 1}, {a: 0, blacklisted: 4444});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.updateAsync({a: 0}, {a: 5, blacklisted: 11111});
-  test.equal(operations.shift(), ['removed', 'foo', 0, {a: 2}]);
-  test.equal(operations.shift(), ['added', {a: 4}, 1, null]);
+  assert.deepStrictEqual(operations.shift(), ['removed', 'foo', 0, {a: 2}]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 4}, 1, null]);
   await c.updateAsync({a: 3}, {a: 3.5, blacklisted: 333.4444});
-  test.equal(operations.shift(), ['changed', {a: 3.5}, 0, {a: 3}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 3.5}, 0, {a: 3}]);
   handle.stop();
 
   // test _no_indices
 
   await c.removeAsync({});
   handle = c.find({}, {sort: {a: 1}, fields: { a: 1 }}).observe(Object.assign(cbs, {_no_indices: true}));
+  await handle.isReadyPromise;
   await c.insertAsync({_id: 'foo', a: 1, zoo: 'crazy'});
-  test.equal(operations.shift(), ['added', {a: 1}, -1, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 1}, -1, null]);
   await c.updateAsync({a: 1}, {$set: {a: 2, foobar: 'player'}});
-  test.equal(operations.shift(), ['changed', {a: 2}, -1, {a: 1}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 2}, -1, {a: 1}]);
   await c.insertAsync({a: 10, b: 123.45});
-  test.equal(operations.shift(), ['added', {a: 10}, -1, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 10}, -1, null]);
   await c.updateAsync({}, {$inc: {a: 1, b: 2}}, {multi: true});
-  test.equal(operations.shift(), ['changed', {a: 3}, -1, {a: 2}]);
-  test.equal(operations.shift(), ['changed', {a: 11}, -1, {a: 10}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 3}, -1, {a: 2}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 11}, -1, {a: 10}]);
   await c.updateAsync({a: 11, b: 125.45}, {a: 1, b: 444});
-  test.equal(operations.shift(), ['changed', {a: 1}, -1, {a: 11}]);
-  test.equal(operations.shift(), ['moved', {a: 1}, -1, -1, 'foo']);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 1}, -1, {a: 11}]);
+  assert.deepStrictEqual(operations.shift(), ['moved', {a: 1}, -1, -1, 'foo']);
   await c.removeAsync({a: 2});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.removeAsync({a: 3});
-  test.equal(operations.shift(), ['removed', 'foo', -1, {a: 3}]);
+  assert.deepStrictEqual(operations.shift(), ['removed', 'foo', -1, {a: 3}]);
   handle.stop();
 });
 
 
-Tinytest.add('minimongo - ordering', test => {
+it('ordering', () => {
   const shortBinary = EJSON.newBinary(1);
   shortBinary[0] = 128;
   const longBinary1 = EJSON.newBinary(2);
@@ -1987,7 +1978,7 @@ Tinytest.add('minimongo - ordering', test => {
   const date2 = new Date(date1.getTime() + 1000);
 
   // value ordering
-  assert_ordering(test, LocalCollection._f._cmp, [
+  assert_ordering(LocalCollection._f._cmp, [
     null,
     1, 2.2, 3,
     '03', '1', '11', '2', 'a', 'aaa',
@@ -2005,7 +1996,7 @@ Tinytest.add('minimongo - ordering', test => {
   const verify = (sorts, docs) => {
     (Array.isArray(sorts) ? sorts : [sorts]).forEach(sort => {
       const sorter = new Minimongo.Sorter(sort);
-      assert_ordering(test, sorter.getComparator(), docs);
+      assert_ordering(sorter.getComparator(), docs);
     });
   };
 
@@ -2031,22 +2022,22 @@ Tinytest.add('minimongo - ordering', test => {
     [['a', 'asc'], ['b', 'asc']]],
   [{c: 1}, {a: 1, b: 2}, {a: 1, b: 3}, {a: 2, b: 0}]);
 
-  test.throws(() => {
+  assert.throws(() => {
     new Minimongo.Sorter('a');
   });
 
-  test.throws(() => {
+  assert.throws(() => {
     new Minimongo.Sorter(123);
   });
 
   // We don't support $natural:1 (since we don't actually have Mongo's on-disk
   // ordering available!)
-  test.throws(() => {
+  assert.throws(() => {
     new Minimongo.Sorter({$natural: 1});
   });
 
   // No sort spec implies everything equal.
-  test.equal(new Minimongo.Sorter({}).getComparator()({a: 1}, {a: 2}), 0);
+  assert.deepStrictEqual(new Minimongo.Sorter({}).getComparator()({a: 1}, {a: 2}), 0);
 
   // All sorts of array edge cases!
   // Increasing sort sorts by the smallest element it finds; 1 < 2.
@@ -2139,17 +2130,17 @@ Tinytest.add('minimongo - ordering', test => {
   ]);
 });
 
-Tinytest.add('minimongo - sort', test => {
+it('sort', () => {
   const c = new LocalCollection();
   for (let i = 0; i < 50; i++) {
     for (let j = 0; j < 2; j++) {c.insert({a: i, b: j, _id: `${i}_${j}`});}
   }
 
-  test.equal(c.find(null, {sort: {b: -1, a: 1}, limit: 5}).fetch(), []);
-  test.equal(c.find(undefined, {sort: {b: -1, a: 1}, limit: 5}).fetch(), []);
-  test.equal(c.find(false, {sort: {b: -1, a: 1}, limit: 5}).fetch(), []);
+  assert.deepStrictEqual(c.find(null, {sort: {b: -1, a: 1}, limit: 5}).fetch(), []);
+  assert.deepStrictEqual(c.find(undefined, {sort: {b: -1, a: 1}, limit: 5}).fetch(), []);
+  assert.deepStrictEqual(c.find(false, {sort: {b: -1, a: 1}, limit: 5}).fetch(), []);
 
-  test.equal(
+  assert.deepStrictEqual(
     c.find({a: {$gt: 10}}, {sort: {b: -1, a: 1}, limit: 5}).fetch(), [
       {a: 11, b: 1, _id: '11_1'},
       {a: 12, b: 1, _id: '12_1'},
@@ -2157,7 +2148,7 @@ Tinytest.add('minimongo - sort', test => {
       {a: 14, b: 1, _id: '14_1'},
       {a: 15, b: 1, _id: '15_1'}]);
 
-  test.equal(
+  assert.deepStrictEqual(
     c.find({a: {$gt: 10}}, {sort: {b: -1, a: 1}, skip: 3, limit: 5}).fetch(), [
       {a: 14, b: 1, _id: '14_1'},
       {a: 15, b: 1, _id: '15_1'},
@@ -2165,7 +2156,7 @@ Tinytest.add('minimongo - sort', test => {
       {a: 17, b: 1, _id: '17_1'},
       {a: 18, b: 1, _id: '18_1'}]);
 
-  test.equal(
+  assert.deepStrictEqual(
     c.find({a: {$gte: 20}}, {sort: {a: 1, b: -1}, skip: 50, limit: 5}).fetch(), [
       {a: 45, b: 1, _id: '45_1'},
       {a: 45, b: 0, _id: '45_0'},
@@ -2174,40 +2165,40 @@ Tinytest.add('minimongo - sort', test => {
       {a: 47, b: 1, _id: '47_1'}]);
 });
 
-Tinytest.add('minimongo - subkey sort', test => {
+it('subkey sort', () => {
   const c = new LocalCollection();
 
   // normal case
   c.insert({a: {b: 2}});
   c.insert({a: {b: 1}});
   c.insert({a: {b: 3}});
-  test.equal(
+  assert.deepStrictEqual(
     c.find({}, {sort: {'a.b': -1}}).fetch().map(doc => doc.a),
     [{b: 3}, {b: 2}, {b: 1}]);
 
   // isn't an object
   c.insert({a: 1});
-  test.equal(
+  assert.deepStrictEqual(
     c.find({}, {sort: {'a.b': 1}}).fetch().map(doc => doc.a),
     [1, {b: 1}, {b: 2}, {b: 3}]);
 
   // complex object
   c.insert({a: {b: {c: 1}}});
-  test.equal(
+  assert.deepStrictEqual(
     c.find({}, {sort: {'a.b': -1}}).fetch().map(doc => doc.a),
     [{b: {c: 1}}, {b: 3}, {b: 2}, {b: 1}, 1]);
 
   // no such top level prop
   c.insert({c: 1});
-  test.equal(
+  assert.deepStrictEqual(
     c.find({}, {sort: {'a.b': -1}}).fetch().map(doc => doc.a),
     [{b: {c: 1}}, {b: 3}, {b: 2}, {b: 1}, 1, undefined]);
 
   // no such mid level prop. just test that it doesn't throw.
-  test.equal(c.find({}, {sort: {'a.nope.c': -1}}).count(), 6);
+  assert.deepStrictEqual(c.find({}, {sort: {'a.nope.c': -1}}).count(), 6);
 });
 
-Tinytest.add('minimongo - array sort', test => {
+it('array sort', () => {
   const c = new LocalCollection();
 
   // "up" and "down" are the indices that the docs should have when sorted
@@ -2233,7 +2224,7 @@ Tinytest.add('minimongo - array sort', test => {
     c.find().forEach(doc => {
       if (hasOwn.call(doc, field)) {fieldValues.push(doc[field]);}
     });
-    test.equal(cursor.fetch().map(doc => doc[field]),
+    assert.deepStrictEqual(cursor.fetch().map(doc => doc[field]),
       Array.from({length: Math.max(...fieldValues) + 1}, (x, i) => i));
   };
 
@@ -2243,7 +2234,7 @@ Tinytest.add('minimongo - array sort', test => {
     'selected');
 });
 
-Tinytest.add('minimongo - nested array sort', test => {
+it('nested array sort', () => {
   const c = new LocalCollection();
 
   // the short fields represent the order it should be when sorting for those keys
@@ -2267,7 +2258,7 @@ Tinytest.add('minimongo - nested array sort', test => {
         fieldValues.push(doc[field]);
       }
     });
-    test.equal(cursor.fetch().map(doc => doc[field]),
+    assert.deepStrictEqual(cursor.fetch().map(doc => doc[field]),
       Array.from({ length: Math.max(...fieldValues) + 1 }, (x, i) => i));
   };
 
@@ -2280,7 +2271,7 @@ Tinytest.add('minimongo - nested array sort', test => {
 
 });
 
-Tinytest.add('minimongo - sort keys', test => {
+it('sort keys', () => {
   const keyListToObject = keyList => {
     const obj = {};
     keyList.forEach(key => {
@@ -2298,12 +2289,12 @@ Tinytest.add('minimongo - sort keys', test => {
       actualKeyList.push(key);
     });
     const actualKeys = keyListToObject(actualKeyList);
-    test.equal(actualKeys, expectedKeys);
+    assert.deepStrictEqual(actualKeys, expectedKeys);
   };
 
   const testParallelError = (sortSpec, doc) => {
     const sorter = new Minimongo.Sorter(sortSpec);
-    test.throws(() => {
+    assert.throws(() => {
       sorter._generateKeysFromDoc(doc, () => {});
     }, /parallel arrays/);
   };
@@ -2351,7 +2342,7 @@ Tinytest.add('minimongo - sort keys', test => {
       {x: 2, y: [4, 5]}]});
 });
 
-Tinytest.add('minimongo - sort function', test => {
+it('sort function', () => {
   const c = new LocalCollection();
 
   c.insert({a: 1});
@@ -2364,12 +2355,12 @@ Tinytest.add('minimongo - sort function', test => {
 
   const sortFunction = (doc1, doc2) => doc2.a - doc1.a;
 
-  test.equal(c.find({}, {sort: sortFunction}).fetch(), c.find({}).fetch().sort(sortFunction));
-  test.notEqual(c.find({}).fetch(), c.find({}).fetch().sort(sortFunction));
-  test.equal(c.find({}, {sort: {a: -1}}).fetch(), c.find({}).fetch().sort(sortFunction));
+  assert.deepStrictEqual(c.find({}, {sort: sortFunction}).fetch(), c.find({}).fetch().sort(sortFunction));
+  assert.notDeepStrictEqual(c.find({}).fetch(), c.find({}).fetch().sort(sortFunction));
+  assert.deepStrictEqual(c.find({}, {sort: {a: -1}}).fetch(), c.find({}).fetch().sort(sortFunction));
 });
 
-Tinytest.add('minimongo - binary search', test => {
+it('binary search', () => {
   const forwardCmp = (a, b) => a - b;
 
   const backwardCmp = (a, b) => -1 * forwardCmp(a, b);
@@ -2377,9 +2368,7 @@ Tinytest.add('minimongo - binary search', test => {
   const checkSearch = (cmp, array, value, expected, message) => {
     const actual = LocalCollection._binarySearch(cmp, array, value);
     if (expected != actual) {
-      test.fail({type: 'minimongo-binary-search',
-        message: `${message} : Expected index ${expected} but had ${actual}`,
-      });
+      assert.fail(`${message} : Expected index ${expected} but had ${actual}`);
     }
   };
 
@@ -2421,7 +2410,7 @@ Tinytest.add('minimongo - binary search', test => {
   checkSearchBackward([2, 2, 2, 2, 2, 2, 2], 3, 0, 'Backward: Highly degenerate array, upper');
 });
 
-Tinytest.addAsync('minimongo - modify', async test => {
+it('modify', async () => {
   const modifyWithQuery = async (doc, query, mod, expected) => {
     const coll = new LocalCollection;
     await coll.insertAsync(doc);
@@ -2436,7 +2425,7 @@ Tinytest.addAsync('minimongo - modify', async test => {
     if (typeof expected === 'function') {
       expected(actual, EJSON.stringify({input: doc, mod}));
     } else {
-      test.equal(actual, expected, EJSON.stringify({input: doc, mod}));
+      assert.deepStrictEqual(actual, expected, EJSON.stringify({input: doc, mod}));
     }
   };
   const modify = async (doc, mod, expected) => {
@@ -2445,7 +2434,7 @@ Tinytest.addAsync('minimongo - modify', async test => {
   const exceptionWithQuery = async (doc, query, mod) => {
     const coll = new LocalCollection;
     await coll.insertAsync(doc);
-    await test.throwsAsync(async () => {
+    await assert.rejects(async () => {
       await coll.updateAsync(query, mod);
     });
   };
@@ -2461,12 +2450,12 @@ Tinytest.addAsync('minimongo - modify', async test => {
     const actual = await coll.findOneAsync();
 
     if (expected._id) {
-      test.equal(result.insertedId, expected._id);
+      assert.ok(EJSON.equals(result.insertedId, expected._id));
     } else {
       delete actual._id;
     }
 
-    test.equal(actual, expected);
+    assert.ok(EJSON.equals(actual, expected));
   };
 
   const upsertUpdate = async (initialDoc, query, mod, expected) => {
@@ -2481,12 +2470,12 @@ Tinytest.addAsync('minimongo - modify', async test => {
       delete actual._id;
     }
 
-    test.equal(actual, expected);
+    assert.ok(EJSON.equals(actual, expected));
   };
 
   const upsertException = async (query, mod) => {
     const coll = new LocalCollection;
-    await test.throwsAsync(async () => {
+    await assert.rejects(async () => {
       await coll.upsertAsync(query, mod);
     });
   };
@@ -2656,8 +2645,8 @@ Tinytest.addAsync('minimongo - modify', async test => {
   await exception({}, {$inc: {_id: 1}});
 
   // $currentDate
-  await modify({}, {$currentDate: {a: true}}, (result, msg) => { test.instanceOf(result.a, Date, msg); });
-  await modify({}, {$currentDate: {a: {$type: 'date'}}}, (result, msg) => { test.instanceOf(result.a, Date, msg); });
+  await modify({}, {$currentDate: {a: true}}, (result, msg) => { assert.ok(result.a instanceof Date, msg); });
+  await modify({}, {$currentDate: {a: {$type: 'date'}}}, (result, msg) => { assert.ok(result.a instanceof Date, msg); });
   await exception({}, {$currentDate: {a: false}});
   await exception({}, {$currentDate: {a: {}}});
   await exception({}, {$currentDate: {a: {$type: 'timestamp'}}});
@@ -3117,42 +3106,43 @@ Tinytest.addAsync('minimongo - modify', async test => {
 
 // XXX test update() (selecting docs, multi, upsert..)
 
-Tinytest.addAsync('minimongo - observe ordered', async test => {
+it('observe ordered', async () => {
   const operations = [];
   const cbs = log_callbacks(operations);
   let handle;
 
   const c = new LocalCollection();
   handle = c.find({}, {sort: {a: 1}}).observe(cbs);
-  test.isTrue(handle.collection === c);
+  assert.ok(handle.collection === c);
 
   await c.insertAsync({_id: 'foo', a: 1});
-  test.equal(operations.shift(), ['added', {a: 1}, 0, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 1}, 0, null]);
   await c.updateAsync({a: 1}, {$set: {a: 2}});
-  test.equal(operations.shift(), ['changed', {a: 2}, 0, {a: 1}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 2}, 0, {a: 1}]);
   await c.insertAsync({a: 10});
-  test.equal(operations.shift(), ['added', {a: 10}, 1, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 10}, 1, null]);
   await c.updateAsync({}, {$inc: {a: 1}}, {multi: true});
-  test.equal(operations.shift(), ['changed', {a: 3}, 0, {a: 2}]);
-  test.equal(operations.shift(), ['changed', {a: 11}, 1, {a: 10}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 3}, 0, {a: 2}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 11}, 1, {a: 10}]);
   await c.updateAsync({a: 11}, {a: 1});
-  test.equal(operations.shift(), ['changed', {a: 1}, 1, {a: 11}]);
-  test.equal(operations.shift(), ['moved', {a: 1}, 1, 0, 'foo']);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 1}, 1, {a: 11}]);
+  assert.deepStrictEqual(operations.shift(), ['moved', {a: 1}, 1, 0, 'foo']);
   await c.removeAsync({a: 2});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.removeAsync({a: 3});
-  test.equal(operations.shift(), ['removed', 'foo', 1, {a: 3}]);
+  assert.deepStrictEqual(operations.shift(), ['removed', 'foo', 1, {a: 3}]);
 
   // test stop
   handle.stop();
   const idA2 = Random.id();
   await c.insertAsync({_id: idA2, a: 2});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
 
   // test initial inserts (and backwards sort)
   handle = c.find({}, {sort: {a: -1}}).observe(cbs);
-  test.equal(operations.shift(), ['added', {a: 2}, 0, null]);
-  test.equal(operations.shift(), ['added', {a: 1}, 1, null]);
+  await handle.isReadyPromise;
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 2}, 0, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 1}, 1, null]);
   handle.stop();
 
   // test _suppress_initial
@@ -3164,30 +3154,32 @@ Tinytest.addAsync('minimongo - observe ordered', async test => {
       cbs
     )
   );
-  test.equal(operations.shift(), undefined);
+  await handle.isReadyPromise;
+  assert.strictEqual(operations.shift(), undefined);
   await c.insertAsync({a: 100});
-  test.equal(operations.shift(), ['added', {a: 100}, 0, idA2]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 100}, 0, idA2]);
   handle.stop();
 
   // test skip and limit.
   await c.removeAsync({});
   handle = c.find({}, { sort: { a: 1 }, skip: 1, limit: 2 }).observe(cbs);
-  test.equal(operations.shift(), undefined);
+  await handle.isReadyPromise;
+  assert.strictEqual(operations.shift(), undefined);
   await c.insertAsync({a: 1});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.insertAsync({_id: 'foo', a: 2});
-  test.equal(operations.shift(), ['added', {a: 2}, 0, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 2}, 0, null]);
   await c.insertAsync({a: 3});
-  test.equal(operations.shift(), ['added', {a: 3}, 1, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 3}, 1, null]);
   await c.insertAsync({a: 4});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.updateAsync({a: 1}, {a: 0});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.updateAsync({a: 0}, {a: 5});
-  test.equal(operations.shift(), ['removed', 'foo', 0, {a: 2}]);
-  test.equal(operations.shift(), ['added', {a: 4}, 1, null]);
+  assert.deepStrictEqual(operations.shift(), ['removed', 'foo', 0, {a: 2}]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 4}, 1, null]);
   await c.updateAsync({a: 3}, {a: 3.5});
-  test.equal(operations.shift(), ['changed', {a: 3.5}, 0, {a: 3}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 3.5}, 0, {a: 3}]);
   handle.stop();
 
   // test observe limit with pre-existing docs
@@ -3196,40 +3188,42 @@ Tinytest.addAsync('minimongo - observe ordered', async test => {
   await c.insertAsync({_id: 'two', a: 2});
   await c.insertAsync({a: 3});
   handle = c.find({}, { sort: { a: 1 }, limit: 2 }).observe(cbs);
-  test.equal(operations.shift(), ['added', {a: 1}, 0, null]);
-  test.equal(operations.shift(), ['added', {a: 2}, 1, null]);
-  test.equal(operations.shift(), undefined);
+  await handle.isReadyPromise;
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 1}, 0, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 2}, 1, null]);
+  assert.strictEqual(operations.shift(), undefined);
   await c.removeAsync({a: 2});
-  test.equal(operations.shift(), ['removed', 'two', 1, {a: 2}]);
-  test.equal(operations.shift(), ['added', {a: 3}, 1, null]);
-  test.equal(operations.shift(), undefined);
+  assert.deepStrictEqual(operations.shift(), ['removed', 'two', 1, {a: 2}]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 3}, 1, null]);
+  assert.strictEqual(operations.shift(), undefined);
   handle.stop();
 
   // test _no_indices
 
   await c.removeAsync({});
   handle = c.find({}, {sort: {a: 1}}).observe(Object.assign(cbs, {_no_indices: true}));
+  await handle.isReadyPromise;
   await c.insertAsync({_id: 'foo', a: 1});
-  test.equal(operations.shift(), ['added', {a: 1}, -1, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 1}, -1, null]);
   await c.updateAsync({a: 1}, {$set: {a: 2}});
-  test.equal(operations.shift(), ['changed', {a: 2}, -1, {a: 1}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 2}, -1, {a: 1}]);
   await c.insertAsync({a: 10});
-  test.equal(operations.shift(), ['added', {a: 10}, -1, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 10}, -1, null]);
   await c.updateAsync({}, {$inc: {a: 1}}, {multi: true});
-  test.equal(operations.shift(), ['changed', {a: 3}, -1, {a: 2}]);
-  test.equal(operations.shift(), ['changed', {a: 11}, -1, {a: 10}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 3}, -1, {a: 2}]);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 11}, -1, {a: 10}]);
   await c.updateAsync({a: 11}, {a: 1});
-  test.equal(operations.shift(), ['changed', {a: 1}, -1, {a: 11}]);
-  test.equal(operations.shift(), ['moved', {a: 1}, -1, -1, 'foo']);
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 1}, -1, {a: 11}]);
+  assert.deepStrictEqual(operations.shift(), ['moved', {a: 1}, -1, -1, 'foo']);
   await c.removeAsync({a: 2});
-  test.equal(operations.shift(), undefined);
+  assert.strictEqual(operations.shift(), undefined);
   await c.removeAsync({a: 3});
-  test.equal(operations.shift(), ['removed', 'foo', -1, {a: 3}]);
+  assert.deepStrictEqual(operations.shift(), ['removed', 'foo', -1, {a: 3}]);
   handle.stop();
 });
 
 [true, false].forEach((ordered) => {
-  Tinytest.addAsync(`minimongo - observe ordered: ${ordered}`, async (test) => {
+  it(`observe ordered: ${ordered}`, async () => {
     const c = new LocalCollection();
 
     let ev = "";
@@ -3244,7 +3238,7 @@ Tinytest.addAsync('minimongo - observe ordered', async test => {
       return ret;
     };
     const expect = (x) => {
-      test.equal(ev, x);
+      assert.deepStrictEqual(ev, x);
       ev = "";
     };
 
@@ -3268,6 +3262,7 @@ Tinytest.addAsync('minimongo - observe ordered', async test => {
     // (because the callbacks don't look at indices and there's no 'moved'
     // callback).
     let handle = c.find({ tags: "flower" }).observe(makecb("a"));
+    await handle.isReadyPromise;
     expect("aa3_");
     await c.updateAsync(
       { name: "rose" },
@@ -3281,7 +3276,7 @@ Tinytest.addAsync('minimongo - observe ordered', async test => {
     expect("aa3_");
     await c.updateAsync({ name: "rose" }, { $set: { food: false } });
     expect("ca3_");
-    c.remove({});
+    await c.removeAsync({});
     expect("ra3_");
     await c.insertAsync({ _id: 4, name: "daisy", tags: ["flower"] });
     expect("aa4_");
@@ -3292,6 +3287,7 @@ Tinytest.addAsync('minimongo - observe ordered', async test => {
 
     // Test that observing a lookup by ID works.
     handle = c.find(4).observe(makecb("b"));
+    await handle.isReadyPromise;
     expect("ab4_");
     await c.updateAsync(4, { $set: { eek: 5 } });
     expect("cb4_");
@@ -3311,7 +3307,7 @@ Tinytest.addAsync('minimongo - observe ordered', async test => {
 });
 
 
-Tinytest.add('minimongo - saveOriginals', test => {
+it('saveOriginals', () => {
   // set up some data
   const c = new LocalCollection();
 
@@ -3330,56 +3326,56 @@ Tinytest.add('minimongo - saveOriginals', test => {
   c.update('bar', {$set: {k: 7}});  // update same doc twice
 
   // Verify returned count is correct
-  test.equal(count, 2);
+  assert.strictEqual(count, 2);
 
   // Verify the originals.
   let originals = c.retrieveOriginals();
   const affected = ['bar', 'baz', 'quux', 'whoa', 'hooray'];
-  test.equal(originals.size(), affected.length);
+  assert.deepStrictEqual(originals.size(), affected.length);
   affected.forEach(id => {
-    test.isTrue(originals.has(id));
+    assert.ok(originals.has(id));
   });
-  test.equal(originals.get('bar'), {_id: 'bar', x: 'updateme'});
-  test.equal(originals.get('baz'), {_id: 'baz', x: 'updateme'});
-  test.equal(originals.get('quux'), {_id: 'quux', y: 'removeme'});
-  test.equal(originals.get('whoa'), {_id: 'whoa', y: 'removeme'});
-  test.equal(originals.get('hooray'), undefined);
+  assert.deepStrictEqual(originals.get('bar'), {_id: 'bar', x: 'updateme'});
+  assert.deepStrictEqual(originals.get('baz'), {_id: 'baz', x: 'updateme'});
+  assert.deepStrictEqual(originals.get('quux'), {_id: 'quux', y: 'removeme'});
+  assert.deepStrictEqual(originals.get('whoa'), {_id: 'whoa', y: 'removeme'});
+  assert.strictEqual(originals.get('hooray'), undefined);
 
   // Verify that changes actually occured.
-  test.equal(c.find().count(), 4);
-  test.equal(c.findOne('foo'), {_id: 'foo', x: 'untouched'});
-  test.equal(c.findOne('bar'), {_id: 'bar', x: 'updateme', z: 5, k: 7});
-  test.equal(c.findOne('baz'), {_id: 'baz', x: 'updateme', z: 5});
-  test.equal(c.findOne('hooray'), {_id: 'hooray', z: 'insertme'});
+  assert.strictEqual(c.find().count(), 4);
+  assert.deepStrictEqual(c.findOne('foo'), {_id: 'foo', x: 'untouched'});
+  assert.deepStrictEqual(c.findOne('bar'), {_id: 'bar', x: 'updateme', z: 5, k: 7});
+  assert.deepStrictEqual(c.findOne('baz'), {_id: 'baz', x: 'updateme', z: 5});
+  assert.deepStrictEqual(c.findOne('hooray'), {_id: 'hooray', z: 'insertme'});
 
   // The next call doesn't get the same originals again.
   c.saveOriginals();
   originals = c.retrieveOriginals();
-  test.isTrue(originals);
-  test.isTrue(originals.empty());
+  assert.ok(originals);
+  assert.ok(originals.empty());
 
   // Insert and remove a document during the period.
   c.saveOriginals();
   c.insert({_id: 'temp', q: 8});
   c.remove('temp');
   originals = c.retrieveOriginals();
-  test.equal(originals.size(), 1);
-  test.isTrue(originals.has('temp'));
-  test.equal(originals.get('temp'), undefined);
+  assert.deepStrictEqual(originals.size(), 1);
+  assert.ok(originals.has('temp'));
+  assert.strictEqual(originals.get('temp'), undefined);
 });
 
-Tinytest.add('minimongo - saveOriginals errors', test => {
+it('saveOriginals errors', () => {
   const c = new LocalCollection();
   // Can't call retrieve before save.
-  test.throws(() => { c.retrieveOriginals(); });
+  assert.throws(() => { c.retrieveOriginals(); });
   c.saveOriginals();
   // Can't call save twice.
-  test.throws(() => { c.saveOriginals(); });
+  assert.throws(() => { c.saveOriginals(); });
 });
 
-Tinytest.add('minimongo - objectid transformation', test => {
+it('objectid transformation', () => {
   const testId = item => {
-    test.equal(item, MongoID.idParse(MongoID.idStringify(item)));
+    assert.ok(EJSON.equals(item, MongoID.idParse(MongoID.idStringify(item))));
   };
   const randomOid = new MongoID.ObjectID();
   testId(randomOid);
@@ -3389,20 +3385,20 @@ Tinytest.add('minimongo - objectid transformation', test => {
   testId(new MongoID.ObjectID());
   testId('--a string');
 
-  test.equal('ffffffffffff', MongoID.idParse(MongoID.idStringify('ffffffffffff')));
+  assert.strictEqual('ffffffffffff', MongoID.idParse(MongoID.idStringify('ffffffffffff')));
 });
 
 
-Tinytest.add('minimongo - objectid', test => {
+it('objectid', () => {
   const randomOid = new MongoID.ObjectID();
   const anotherRandomOid = new MongoID.ObjectID();
-  test.notEqual(randomOid, anotherRandomOid);
-  test.throws(() => { new MongoID.ObjectID('qqqqqqqqqqqqqqqqqqqqqqqq');});
-  test.throws(() => { new MongoID.ObjectID('ABCDEF'); });
-  test.equal(randomOid, new MongoID.ObjectID(randomOid.valueOf()));
+  assert.ok(!EJSON.equals(randomOid, anotherRandomOid));
+  assert.throws(() => { new MongoID.ObjectID('qqqqqqqqqqqqqqqqqqqqqqqq');});
+  assert.throws(() => { new MongoID.ObjectID('ABCDEF'); });
+  assert.ok(EJSON.equals(randomOid, new MongoID.ObjectID(randomOid.valueOf())));
 });
 
-Tinytest.addAsync('minimongo - pause', async test => {
+it('pause', async () => {
   const operations = [];
   const cbs = log_callbacks(operations);
 
@@ -3411,17 +3407,17 @@ Tinytest.addAsync('minimongo - pause', async test => {
 
   // remove and add cancel out.
   await c.insertAsync({_id: 1, a: 1});
-  test.equal(operations.shift(), ['added', {a: 1}, 0, null]);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: 1}, 0, null]);
 
   c.pauseObservers();
 
   await c.removeAsync({_id: 1});
-  test.length(operations, 0);
+  assert.strictEqual(operations.length, 0);
   await c.insertAsync({_id: 1, a: 1});
-  test.length(operations, 0);
+  assert.strictEqual(operations.length, 0);
 
-  c.resumeObserversClient();
-  test.length(operations, 0);
+  await c.resumeObserversServer();
+  assert.strictEqual(operations.length, 0);
 
 
   // two modifications become one
@@ -3430,26 +3426,26 @@ Tinytest.addAsync('minimongo - pause', async test => {
   await c.updateAsync({_id: 1}, {a: 2});
   await c.updateAsync({_id: 1}, {a: 3});
 
-  c.resumeObserversClient();
-  test.equal(operations.shift(), ['changed', {a: 3}, 0, {a: 1}]);
-  test.length(operations, 0);
+  await c.resumeObserversServer();
+  assert.deepStrictEqual(operations.shift(), ['changed', {a: 3}, 0, {a: 1}]);
+  assert.strictEqual(operations.length, 0);
 
   // test special case for remove({})
   c.pauseObservers();
-  test.equal(await c.removeAsync({}), 1);
-  test.length(operations, 0);
-  c.resumeObserversClient();
-  test.equal(operations.shift(), ['removed', 1, 0, {a: 3}]);
-  test.length(operations, 0);
+  assert.deepStrictEqual(await c.removeAsync({}), 1);
+  assert.strictEqual(operations.length, 0);
+  await c.resumeObserversServer();
+  assert.deepStrictEqual(operations.shift(), ['removed', 1, 0, {a: 3}]);
+  assert.strictEqual(operations.length, 0);
 
   h.stop();
 });
 
-Tinytest.add('minimongo - ids matched by selector', test => {
+it('ids matched by selector', () => {
   const check = (selector, ids) => {
     const idsFromSelector = LocalCollection._idsMatchedBySelector(selector);
     // XXX normalize order, in a way that also works for ObjectIDs?
-    test.equal(idsFromSelector, ids);
+    assert.deepStrictEqual(idsFromSelector, ids);
   };
   check('foo', ['foo']);
   check({_id: 'foo'}, ['foo']);
@@ -3469,7 +3465,7 @@ Tinytest.add('minimongo - ids matched by selector', test => {
 // TODO:
 // work on this test
   false &&
-    Tinytest.addAsync("minimongo - reactive stop", async (test) => {
+    it("reactive stop", async () => {
       const coll = new LocalCollection();
       await coll.insertAsync({ _id: "A" });
       await coll.insertAsync({ _id: "B" });
@@ -3502,29 +3498,29 @@ Tinytest.add('minimongo - ids matched by selector', test => {
         });
       });
 
-      test.equal(x, "ABC");
-      test.equal(y, "ABC");
+      assert.strictEqual(x, "ABC");
+      assert.strictEqual(y, "ABC");
 
       sortOrder.set(-1);
-      test.equal(x, "ABC");
-      test.equal(y, "ABC");
+      assert.strictEqual(x, "ABC");
+      assert.strictEqual(y, "ABC");
       Tracker.flush();
-      test.equal(x, "CBA");
-      test.equal(y, "CBA");
+      assert.strictEqual(x, "CBA");
+      assert.strictEqual(y, "CBA");
 
       await coll.insertAsync({ _id: "D" });
       await coll.insertAsync({ _id: "E" });
-      test.equal(x, "EDCBA");
-      test.equal(y, "EDCBA");
+      assert.strictEqual(x, "EDCBA");
+      assert.strictEqual(y, "EDCBA");
 
       c.stop();
       // stopping kills the observes immediately
       await coll.insertAsync({ _id: "F" });
-      test.equal(x, "EDCBA");
-      test.equal(y, "EDCBA");
+      assert.strictEqual(x, "EDCBA");
+      assert.strictEqual(y, "EDCBA");
     });
 
-  Tinytest.add("minimongo - immediate invalidate", (test) => {
+  it("immediate invalidate", () => {
     const coll = new LocalCollection();
     coll.insert({ _id: "A" });
 
@@ -3544,7 +3540,7 @@ Tinytest.add('minimongo - ids matched by selector', test => {
     c.stop();
   });
 
-  Tinytest.add("minimongo - count on cursor with limit", (test) => {
+  it("count on cursor with limit", async () => {
     const coll = new LocalCollection();
     let count, unlimitedCount;
 
@@ -3561,28 +3557,28 @@ Tinytest.add('minimongo - ids matched by selector', test => {
       count = cursor.count();
     });
 
-    test.equal(count, 3);
+    assert.strictEqual(count, 3);
 
-    coll.remove("A"); // still 3 in the collection
+    await coll.removeAsync("A"); // still 3 in the collection
     Tracker.flush();
-    test.equal(count, 3);
+    assert.strictEqual(count, 3);
 
-    coll.remove("B"); // expect count now 2
+    await coll.removeAsync("B"); // expect count now 2
     Tracker.flush();
-    test.equal(count, 2);
+    assert.strictEqual(count, 2);
 
-    coll.insert({ _id: "A" }); // now 3 again
+    await coll.insertAsync({ _id: "A" }); // now 3 again
     Tracker.flush();
-    test.equal(count, 3);
+    assert.strictEqual(count, 3);
 
-    coll.insert({ _id: "B" }); // now 4 entries, but count should be 3 still
+    await coll.insertAsync({ _id: "B" }); // now 4 entries, but count should be 3 still
     Tracker.flush();
-    test.equal(count, 3);
+    assert.strictEqual(count, 3);
 
     c.stop();
   });
 
-Tinytest.add('minimongo - reactive count with cached cursor', test => {
+it('reactive count with cached cursor', async () => {
   const coll = new LocalCollection;
   const cursor = coll.find({});
   let firstAutorunCount, secondAutorunCount;
@@ -3592,27 +3588,27 @@ Tinytest.add('minimongo - reactive count with cached cursor', test => {
   Tracker.autorun(() => {
     secondAutorunCount = coll.find({}).count();
   });
-  test.equal(firstAutorunCount, 0);
-  test.equal(secondAutorunCount, 0);
-  coll.insert({i: 1});
-  coll.insert({i: 2});
-  coll.insert({i: 3});
+  assert.strictEqual(firstAutorunCount, 0);
+  assert.strictEqual(secondAutorunCount, 0);
+  await coll.insertAsync({i: 1});
+  await coll.insertAsync({i: 2});
+  await coll.insertAsync({i: 3});
   Tracker.flush();
-  test.equal(firstAutorunCount, 3);
-  test.equal(secondAutorunCount, 3);
+  assert.strictEqual(firstAutorunCount, 3);
+  assert.strictEqual(secondAutorunCount, 3);
 });
 
-Tinytest.addAsync('minimongo - $near operator tests', async test => {
+it('$near operator tests', async () => {
   let coll = new LocalCollection();
   await coll.insertAsync({ rest: { loc: [2, 3] } });
   await coll.insertAsync({ rest: { loc: [-3, 3] } });
   await coll.insertAsync({ rest: { loc: [5, 5] } });
 
-  test.equal(await coll.find({ 'rest.loc': { $near: [0, 0], $maxDistance: 30 } }).count(), 3);
-  test.equal(await coll.find({ 'rest.loc': { $near: [0, 0], $maxDistance: 4 } }).count(), 1);
+  assert.deepStrictEqual(await coll.find({ 'rest.loc': { $near: [0, 0], $maxDistance: 30 } }).count(), 3);
+  assert.deepStrictEqual(await coll.find({ 'rest.loc': { $near: [0, 0], $maxDistance: 4 } }).count(), 1);
   const points = await coll.find({ 'rest.loc': { $near: [0, 0], $maxDistance: 6 } }).fetchAsync();
   points.forEach((point, i, points) => {
-    test.isTrue(!i || distance([0, 0], point.rest.loc) >= distance([0, 0], points[i - 1].rest.loc));
+    assert.ok(!i || distance([0, 0], point.rest.loc) >= distance([0, 0], points[i - 1].rest.loc));
   });
 
   function distance(a, b) {
@@ -3639,21 +3635,21 @@ Tinytest.addAsync('minimongo - $near operator tests', async test => {
     $geometry: { type: 'Point',
       coordinates: [-122.4154282, 37.7746115] },
     $maxDistance: 15 } } }).fetchAsync();
-  test.length(close15, 1);
-  test.equal(close15[0].descript, 'GRAND THEFT OF PROPERTY');
+  assert.strictEqual(close15.length, 1);
+  assert.strictEqual(close15[0].descript, 'GRAND THEFT OF PROPERTY');
 
   const close20 = await coll.find({ location: { $near: {
     $geometry: { type: 'Point',
       coordinates: [-122.4154282, 37.7746115] },
     $maxDistance: 20 } } }).fetchAsync();
-  test.length(close20, 4);
-  test.equal(close20[0].descript, 'GRAND THEFT OF PROPERTY');
-  test.equal(close20[1].descript, 'PETTY THEFT FROM LOCKED AUTO');
-  test.equal(close20[2].descript, 'POSSESSION OF BURGLARY TOOLS');
-  test.equal(close20[3].descript, 'POSS OF PROHIBITED WEAPON');
+  assert.strictEqual(close20.length, 4);
+  assert.strictEqual(close20[0].descript, 'GRAND THEFT OF PROPERTY');
+  assert.strictEqual(close20[1].descript, 'PETTY THEFT FROM LOCKED AUTO');
+  assert.strictEqual(close20[2].descript, 'POSSESSION OF BURGLARY TOOLS');
+  assert.strictEqual(close20[3].descript, 'POSS OF PROHIBITED WEAPON');
 
   // Any combinations of $near with $or/$and/$nor/$not should throw an error
-  test.throws(() => {
+  assert.throws(() => {
     coll.find({ location: {
       $not: {
         $near: {
@@ -3662,25 +3658,25 @@ Tinytest.addAsync('minimongo - $near operator tests', async test => {
             coordinates: [-122.4154282, 37.7746115],
           }, $maxDistance: 20 } } } });
   });
-  test.throws(() => {
+  assert.throws(() => {
     coll.find({
       $and: [ { location: { $near: { $geometry: { type: 'Point', coordinates: [-122.4154282, 37.7746115] }, $maxDistance: 20 }}},
         { x: 0 }],
     });
   });
-  test.throws(() => {
+  assert.throws(() => {
     coll.find({
       $or: [ { location: { $near: { $geometry: { type: 'Point', coordinates: [-122.4154282, 37.7746115] }, $maxDistance: 20 }}},
         { x: 0 }],
     });
   });
-  test.throws(() => {
+  assert.throws(() => {
     coll.find({
       $nor: [ { location: { $near: { $geometry: { type: 'Point', coordinates: [-122.4154282, 37.7746115] }, $maxDistance: 1 }}},
         { x: 0 }],
     });
   });
-  test.throws(() => {
+  assert.throws(() => {
     coll.find({
       $and: [{
         $and: [{
@@ -3713,7 +3709,7 @@ Tinytest.addAsync('minimongo - $near operator tests', async test => {
     k: 9,
     a: {b: [5, 5]}});
   const testNear = async (near, md, expected) => {
-    test.equal(
+    assert.deepStrictEqual(
       (await coll.find({'a.b': {$near: near, $maxDistance: md}}).fetchAsync()).map(doc => doc._id),
       expected);
   };
@@ -3726,7 +3722,7 @@ Tinytest.addAsync('minimongo - $near operator tests', async test => {
 
   // issue #3599
   // Ensure that distance is not used as a tie-breaker for sort.
-  test.equal(
+  assert.deepStrictEqual(
     (
       await coll
         .find({ 'a.b': { $near: [1, 1] } }, { sort: { k: 1 } })
@@ -3734,7 +3730,7 @@ Tinytest.addAsync('minimongo - $near operator tests', async test => {
     ).map(doc => doc._id),
     ['x', 'y']
   );
-  test.equal(
+  assert.deepStrictEqual(
     (
       await coll
         .find({ 'a.b': { $near: [5, 5] } }, { sort: { k: 1 } })
@@ -3746,22 +3742,23 @@ Tinytest.addAsync('minimongo - $near operator tests', async test => {
   const operations = [];
   const cbs = log_callbacks(operations);
   const handle = coll.find({'a.b': {$near: [7, 7]}}).observe(cbs);
+  await handle.isReadyPromise;
 
-  test.length(operations, 2);
-  test.equal(operations.shift(), ['added', {k: 9, a: {b: [5, 5]}}, 0, null]);
-  test.equal(operations.shift(),
+  assert.strictEqual(operations.length, 2);
+  assert.deepStrictEqual(operations.shift(), ['added', {k: 9, a: {b: [5, 5]}}, 0, null]);
+  assert.deepStrictEqual(operations.shift(),
     ['added', {k: 9, a: [{b: [[100, 100], [1, 1]]}, {b: [150, 150]}]},
       1, null]);
   // This needs to be inserted in the MIDDLE of the two existing ones.
   await coll.insertAsync({a: {b: [3, 3]}});
-  test.length(operations, 1);
-  test.equal(operations.shift(), ['added', {a: {b: [3, 3]}}, 1, 'x']);
+  assert.strictEqual(operations.length, 1);
+  assert.deepStrictEqual(operations.shift(), ['added', {a: {b: [3, 3]}}, 1, 'x']);
 
   handle.stop();
 });
 
 // issue #2077
-Tinytest.add('minimongo - $near and $geometry for legacy coordinates', test => {
+it('$near and $geometry for legacy coordinates', () => {
   const coll = new LocalCollection();
 
   coll.insert({
@@ -3783,49 +3780,49 @@ Tinytest.add('minimongo - $near and $geometry for legacy coordinates', test => {
     },
   });
 
-  test.equal(coll.find({ loc: { $near: [0, 0], $maxDistance: 4 } }).count(), 2);
-  test.equal(coll.find({ loc: { $near: {$geometry: {type: 'Point', coordinates: [0, 0]}}} }).count(), 4);
-  test.equal(coll.find({ loc: { $near: {$geometry: {type: 'Point', coordinates: [0, 0]}, $maxDistance: 200000}}}).count(), 2);
+  assert.deepStrictEqual(coll.find({ loc: { $near: [0, 0], $maxDistance: 4 } }).count(), 2);
+  assert.deepStrictEqual(coll.find({ loc: { $near: {$geometry: {type: 'Point', coordinates: [0, 0]}}} }).count(), 4);
+  assert.deepStrictEqual(coll.find({ loc: { $near: {$geometry: {type: 'Point', coordinates: [0, 0]}, $maxDistance: 200000}}}).count(), 2);
 });
 
 // Regression test for #4377. Previously, "replace" updates didn't clone the
 // argument.
-Tinytest.add('minimongo - update should clone', test => {
+it('update should clone', () => {
   const x = [];
   const coll = new LocalCollection;
   const id = coll.insert({});
   coll.update(id, {x});
   x.push(1);
-  test.equal(coll.findOne(id), {_id: id, x: []});
+  assert.deepStrictEqual(coll.findOne(id), {_id: id, x: []});
 });
 
 // See #2275.
-Tinytest.addAsync("minimongo - fetch in observe", (test, done) => {
+it("fetch in observe", (_, done) => {
   const coll = new LocalCollection();
   let callbackInvoked = false;
   const observe = coll.find().observeChanges({
     added(id, fields) {
       callbackInvoked = true;
-      test.equal(fields, { foo: 1 });
+      assert.deepStrictEqual(fields, { foo: 1 });
       const doc = coll.findOne({ foo: 1 });
-      test.isTrue(doc);
-      test.equal(doc.foo, 1);
+      assert.ok(doc);
+      assert.strictEqual(doc.foo, 1);
     },
   });
-  test.isFalse(callbackInvoked, "callback not invoked yet");
+  assert.ok(!callbackInvoked, "callback not invoked yet");
   Tracker.autorun(async (computation) => {
     if (computation.firstRun) {
       await coll.insertAsync({ foo: 1 });
 
       // callback is only invoked after the coll insertion, it does not happen
       // in this loop, otherwise the test would fail
-      test.isTrue(callbackInvoked, "callback invoked");
+      assert.ok(callbackInvoked, "callback invoked");
       done()
     }
   });
 });
 
-Tinytest.add("minimongo - simple reactivity", (test) => {
+it("simple reactivity", async () => {
   const coll = new LocalCollection();
   let runs = 0;
 
@@ -3834,17 +3831,15 @@ Tinytest.add("minimongo - simple reactivity", (test) => {
     coll.find().fetch()
   });
 
-  coll.insert({ _id: "test" });
+  await coll.insertAsync({ _id: "test" });
   Tracker.flush();
   // runs should now be 2
-  test.equal(runs, 2);
+  assert.strictEqual(runs, 2);
 });
 
 
 // See #2254
-Tinytest.addAsync(
-  "minimongo - fine-grained reactivity of observe with fields projection",
-  async (test) => {
+it("fine-grained reactivity of observe with fields projection", async () => {
     const X = new LocalCollection();
     const id = "asdf";
     await X.insertAsync({ _id: id, foo: { bar: 123 } });
@@ -3856,15 +3851,15 @@ Tinytest.addAsync(
       },
     });
 
-    test.isFalse(callbackInvoked);
+    assert.ok(!callbackInvoked);
     await X.updateAsync(id, { $set: { "foo.baz": 456 } });
-    test.isFalse(callbackInvoked);
+    assert.ok(!callbackInvoked);
 
     obs.stop();
   }
 );
 
-Tinytest.add('minimongo - fine-grained reactivity of query with fields projection', test => {
+it('fine-grained reactivity of query with fields projection', async () => {
   const X = new LocalCollection;
   const id = 'asdf';
   X.insert({_id: id, foo: {bar: 123}});
@@ -3874,13 +3869,13 @@ Tinytest.add('minimongo - fine-grained reactivity of query with fields projectio
     callbackInvoked = true;
     return X.findOne(id, { fields: { 'foo.bar': 1 } });
   });
-  test.isTrue(callbackInvoked);
+  assert.ok(callbackInvoked);
   callbackInvoked = false;
-  X.update(id, {$set: {'foo.baz': 456}});
-  test.isFalse(callbackInvoked);
-  X.update(id, {$set: {'foo.bar': 124}});
+  await X.updateAsync(id, {$set: {'foo.baz': 456}});
+  assert.ok(!callbackInvoked);
+  await X.updateAsync(id, {$set: {'foo.bar': 124}});
   Tracker.flush();
-  test.isTrue(callbackInvoked);
+  assert.ok(callbackInvoked);
 
   computation.stop();
 });
@@ -3888,7 +3883,7 @@ Tinytest.add('minimongo - fine-grained reactivity of query with fields projectio
 // Tests that the logic in `LocalCollection.prototype.update`
 // correctly deals with count() on a cursor with skip or limit (since
 // then the result set is an IdMap, not an array)
-Tinytest.add('minimongo - reactive skip/limit count while updating', test => {
+it('reactive skip/limit count while updating', async () => {
   const X = new LocalCollection;
   let count = -1;
 
@@ -3896,24 +3891,24 @@ Tinytest.add('minimongo - reactive skip/limit count while updating', test => {
     count = X.find({}, {skip: 1, limit: 1}).count();
   });
 
-  test.equal(count, 0);
+  assert.strictEqual(count, 0);
 
-  X.insert({});
+  await X.insertAsync({});
   Tracker.flush({_throwFirstError: true});
-  test.equal(count, 0);
+  assert.strictEqual(count, 0);
 
-  X.insert({});
+  await X.insertAsync({});
   Tracker.flush({_throwFirstError: true});
-  test.equal(count, 1);
+  assert.strictEqual(count, 1);
 
-  X.update({}, {$set: {foo: 1}});
+  await X.updateAsync({}, {$set: {foo: 1}});
   Tracker.flush({_throwFirstError: true});
-  test.equal(count, 1);
+  assert.strictEqual(count, 1);
 
   // Make sure a second update also works
-  X.update({}, {$set: {foo: 2}});
+  await X.updateAsync({}, {$set: {foo: 2}});
   Tracker.flush({_throwFirstError: true});
-  test.equal(count, 1);
+  assert.strictEqual(count, 1);
 
   c.stop();
 });
@@ -3921,7 +3916,7 @@ Tinytest.add('minimongo - reactive skip/limit count while updating', test => {
 // Makes sure inserts cannot be performed using field names that have
 // Mongo restricted characters in them ('.', '$', '\0'):
 // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
-Tinytest.add('minimongo - cannot insert using invalid field names', test => {
+it('cannot insert using invalid field names', () => {
   const collection = new LocalCollection();
 
   // Quick test to make sure non-dot field inserts are working
@@ -3932,42 +3927,42 @@ Tinytest.add('minimongo - cannot insert using invalid field names', test => {
 
   // Verify top level dot-field inserts are prohibited
   ['a.b', '.b', 'a.', 'a.b.c'].forEach((field) => {
-    test.throws(() => {
+    assert.throws(() => {
       collection.insert({ [field]: 'c' });
-    }, `Key ${field} must not contain '.'`);
+    }, /must not contain/);
   });
 
   // Verify nested dot-field inserts are prohibited
-  test.throws(() => {
+  assert.throws(() => {
     collection.insert({ a: { b: { 'c.d': 'e' } } });
-  }, "Key c.d must not contain '.'");
+  }, /must not contain/);
 
   // Verify field names starting with $ are prohibited
-  test.throws(() => {
+  assert.throws(() => {
     collection.insert({ $a: 'b' });
-  }, "Key $a must not start with '$'");
+  }, /must not start with/);
 
   // Verify nested field names starting with $ are prohibited
-  test.throws(() => {
+  assert.throws(() => {
     collection.insert({ a: { b: { $c: 'd' } } });
-  }, "Key $c must not start with '$'");
+  }, /must not start with/);
 
   // Verify top level fields with null characters are prohibited
   ['\0a', 'a\0', 'a\0b', '\u0000a', 'a\u0000', 'a\u0000b'].forEach((field) => {
-    test.throws(() => {
+    assert.throws(() => {
       collection.insert({ [field]: 'c' });
-    }, `Key ${field} must not contain null bytes`);
+    }, /must not contain null bytes/);
   });
 
   // Verify nested field names with null characters are prohibited
-  test.throws(() => {
+  assert.throws(() => {
     collection.insert({ a: { b: { '\0c': 'd' } } });
-  }, 'Key \0c must not contain null bytes');
+  }, /must not contain null bytes/);
 });
 
 // Makes sure $set's cannot be performed using null bytes
 // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
-Tinytest.add('minimongo - cannot $set with null bytes', test => {
+it('cannot $set with null bytes', () => {
   const collection = new LocalCollection();
 
   // Quick test to make sure non-null byte $set's are working
@@ -3975,14 +3970,14 @@ Tinytest.add('minimongo - cannot $set with null bytes', test => {
   collection.update({ _id: id }, { $set: { e: 'f' } });
 
   // Verify $set's with null bytes throw an exception
-  test.throws(() => {
+  assert.throws(() => {
     collection.update({ _id: id }, { $set: { '\0a': 'b' } });
-  }, 'Key \0a must not contain null bytes');
+  }, /must not contain null bytes/);
 });
 
 // Makes sure $rename's cannot be performed using null bytes
 // https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
-Tinytest.add('minimongo - cannot $rename with null bytes', test => {
+it('cannot $rename with null bytes', () => {
   const collection = new LocalCollection();
 
   // Quick test to make sure non-null byte $rename's are working
@@ -3992,12 +3987,12 @@ Tinytest.add('minimongo - cannot $rename with null bytes', test => {
   // Verify $rename's with null bytes throw an exception
   collection.remove({});
   id = collection.insert({ a: 'b', c: 'd' });
-  test.throws(() => {
+  assert.throws(() => {
     collection.update({ _id: id }, { $rename: { a: '\0a', c: 'c\0' } });
-  }, "The 'to' field for $rename cannot contain an embedded null byte");
+  }, /cannot contain an embedded null byte/);
 });
 
-Tinytest.addAsync('minimongo - asyncIterator', async (test) => {
+it('asyncIterator', async () => {
   const collection = new LocalCollection();
 
   collection.insert({ _id: 'a' });
@@ -4007,58 +4002,59 @@ Tinytest.addAsync('minimongo - asyncIterator', async (test) => {
   for await (const item of collection.find()) {
     itemIds.push(item._id);
   }
-  test.equal(itemIds.length, 2);
-  test.equal(itemIds, ['a', 'b']);
+  assert.strictEqual(itemIds.length, 2);
+  assert.deepStrictEqual(itemIds, ['a', 'b']);
 });
 
-Tinytest.add('minimongo - operation result fields (sync)', test => {
+it('operation result fields (sync)', () => {
   const c = new LocalCollection();
 
   // Test insert
   const insertedId = c.insert({name: 'doc1'});
-  test.isTrue(insertedId !== undefined, 'insert should return an ID');
+  assert.ok(insertedId !== undefined, 'insert should return an ID');
 
   // Test update
   const updateResult = c.update({name: 'doc1'}, {$set: {value: 1}});
-  test.equal(updateResult, 1, 'update should return affected count');
+  assert.strictEqual(updateResult, 1, 'update should return affected count');
 
   // Test upsert (update case)
   const upsertUpdateResult = c.upsert({name: 'doc1'}, {$set: {value: 2}});
-  test.equal(upsertUpdateResult.numberAffected, 1);
-  test.isFalse(upsertUpdateResult.hasOwnProperty('insertedId'));
+  assert.strictEqual(upsertUpdateResult.numberAffected, 1);
+  assert.ok(!upsertUpdateResult.hasOwnProperty('insertedId'));
 
   // Test upsert (insert case)
   const upsertInsertResult = c.upsert({name: 'doc2'}, {$set: {value: 3}});
-  test.equal(upsertInsertResult.numberAffected, 1);
-  test.isTrue(upsertInsertResult.hasOwnProperty('insertedId'));
+  assert.strictEqual(upsertInsertResult.numberAffected, 1);
+  assert.ok(upsertInsertResult.hasOwnProperty('insertedId'));
 
   // Test remove
   const removeResult = c.remove({name: 'doc1'});
-  test.equal(removeResult, 1, 'remove should return removed count');
+  assert.strictEqual(removeResult, 1, 'remove should return removed count');
 });
 
-Tinytest.addAsync('minimongo - operation result fields (async)', async test => {
+it('operation result fields (async)', async () => {
   const c = new LocalCollection();
 
   // Test insert
   const insertedId = await c.insertAsync({name: 'doc1'});
-  test.isTrue(insertedId !== undefined, 'insert should return an ID');
+  assert.ok(insertedId !== undefined, 'insert should return an ID');
 
   // Test update
   const updateResult = await c.updateAsync({name: 'doc1'}, {$set: {value: 1}});
-  test.equal(updateResult, 1, 'update should return affected count');
+  assert.strictEqual(updateResult, 1, 'update should return affected count');
 
   // Test upsert (update case)
   const upsertUpdateResult = await c.upsertAsync({name: 'doc1'}, {$set: {value: 2}});
-  test.equal(upsertUpdateResult.numberAffected, 1);
-  test.isFalse(upsertUpdateResult.hasOwnProperty('insertedId'));
+  assert.strictEqual(upsertUpdateResult.numberAffected, 1);
+  assert.ok(!upsertUpdateResult.hasOwnProperty('insertedId'));
 
   // Test upsert (insert case)
   const upsertInsertResult = await c.upsertAsync({name: 'doc2'}, {$set: {value: 3}});
-  test.equal(upsertInsertResult.numberAffected, 1);
-  test.isTrue(upsertInsertResult.hasOwnProperty('insertedId'));
+  assert.strictEqual(upsertInsertResult.numberAffected, 1);
+  assert.ok(upsertInsertResult.hasOwnProperty('insertedId'));
 
   // Test remove
   const removeResult = await c.removeAsync({name: 'doc1'});
-  test.equal(removeResult, 1, 'remove should return removed count');
+  assert.strictEqual(removeResult, 1, 'remove should return removed count');
+});
 });

--- a/packages/minimongo/minimongo_tests_server.js
+++ b/packages/minimongo/minimongo_tests_server.js
@@ -1,7 +1,11 @@
-Tinytest.add('minimongo - modifier affects selector', test => {
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('minimongo - server', () => {
+it('modifier affects selector', () => {
   function testSelectorPaths(sel, paths, desc) {
     const matcher = new Minimongo.Matcher(sel);
-    test.equal(matcher._getPaths(), paths, desc);
+    assert.deepStrictEqual(matcher._getPaths(), paths, desc);
   }
 
   testSelectorPaths({
@@ -60,7 +64,7 @@ Tinytest.add('minimongo - modifier affects selector', test => {
 
   function testSelectorAffectedByModifier(sel, mod, yes, desc) {
     const matcher = new Minimongo.Matcher(sel);
-    test.equal(matcher.affectedByModifier(mod), yes, desc);
+    assert.strictEqual(matcher.affectedByModifier(mod), yes, desc);
   }
 
   function affected(sel, mod, desc) {
@@ -96,10 +100,10 @@ Tinytest.add('minimongo - modifier affects selector', test => {
   affected({foo: {$elemMatch: {bar: 5}}}, {$set: {'foo.4.bar': 5}}, '$elemMatch');
 });
 
-Tinytest.add('minimongo - selector and projection combination', test => {
+it('selector and projection combination', () => {
   function testSelProjectionComb(sel, proj, expected, desc) {
     const matcher = new Minimongo.Matcher(sel);
-    test.equal(matcher.combineIntoProjection(proj), expected, desc);
+    assert.deepStrictEqual(matcher.combineIntoProjection(proj), expected, desc);
   }
 
   // Test with inclusive projection
@@ -333,10 +337,10 @@ Tinytest.add('minimongo - selector and projection combination', test => {
   }, {}, '$where in the selector - excl');
 });
 
-Tinytest.add('minimongo - sorter and projection combination', test => {
+it('sorter and projection combination', () => {
   function testSorterProjectionComb(sortSpec, proj, expected, desc) {
     const sorter = new Minimongo.Sorter(sortSpec);
-    test.equal(sorter.combineIntoProjection(proj), expected, desc);
+    assert.deepStrictEqual(sorter.combineIntoProjection(proj), expected, desc);
   }
 
   // Test with inclusive projection
@@ -376,12 +380,11 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
   //  * gives up on a combination of $gt/$gte/$lt/$lte and $ne/$nin
   //  * doesn't support $eq properly
 
-  let test = null; // set this global in the beginning of every test
   // T - should return true
   // F - should return false
   const oneTest = (sel, mod, expected, desc) => {
     const matcher = new Minimongo.Matcher(sel);
-    test.equal(matcher.canBecomeTrueByModifier(mod), expected, desc);
+    assert.deepStrictEqual(matcher.canBecomeTrueByModifier(mod), expected, desc);
   };
   function T(sel, mod, desc) {
     oneTest(sel, mod, true, desc);
@@ -390,9 +393,7 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     oneTest(sel, mod, false, desc);
   }
 
-  Tinytest.add('minimongo - can selector become true by modifier - literals (structured tests)', t => {
-    test = t;
-
+  it('can selector become true by modifier - literals (structured tests)', () => {
     const selector = {
       'a.b.c': 2,
       'foo.bar': {
@@ -430,8 +431,7 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     F(selector, {$set: { 'empty.field.a': 3 }});
   });
 
-  Tinytest.add('minimongo - can selector become true by modifier - literals (adhoc tests)', t => {
-    test = t;
+  it('can selector become true by modifier - literals (adhoc tests)', () => {
     T({x: 1}, {$set: {x: 1}}, 'simple set scalar');
     T({x: 'a'}, {$set: {x: 'a'}}, 'simple set scalar');
     T({x: false}, {$set: {x: false}}, 'simple set scalar');
@@ -445,9 +445,7 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     F({'foo.bar.baz': 1}, {$unset: {'foo.bar.bar': 1}}, 'simple unset of the interesting path prefix');
   });
 
-  Tinytest.add('minimongo - can selector become true by modifier - regexps', t => {
-    test = t;
-
+  it('can selector become true by modifier - regexps', () => {
     // Regexp
     T({ 'foo.bar': /^[0-9]+$/i }, { $set: {'foo.bar': '01233'} }, 'set of regexp');
     // XXX this test should be False, should be fixed within improved implementation
@@ -457,8 +455,7 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     T({ 'foo.bar': /^[0-9]+$/i, x: 1 }, { $set: { x: 1 } }, "don't touch regexp");
   });
 
-  Tinytest.add('minimongo - can selector become true by modifier - undefined/null', t => {
-    test = t;
+  it('can selector become true by modifier - undefined/null', () => {
     // Nulls / Undefined
     T({ 'foo.bar': null }, {$set: {'foo.bar': null}}, 'set of null looking for null');
     T({ 'foo.bar': null }, {$set: {'foo.bar': undefined}}, 'set of undefined looking for null');
@@ -472,8 +469,7 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     T({ 'foo.bar': null }, { $set: { foo: {baz: 1} } }, 'set the parent');
   });
 
-  Tinytest.add('minimongo - can selector become true by modifier - literals with arrays', t => {
-    test = t;
+  it('can selector become true by modifier - literals with arrays', () => {
     // These tests are incomplete and in theory they all should return true as we
     // don't support any case with numeric fields yet.
     T({'a.1.b': 1, x: 1}, {$unset: {'a.1.b': 1}, $set: {x: 1}}, "unset of array element's field with exactly the same index as selector");
@@ -488,16 +484,14 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     T({'a.b': 1}, {$unset: {'a.1.b': 1}}, "unset of array element's field");
   });
 
-  Tinytest.add('minimongo - can selector become true by modifier - set an object literal whose fields are selected', t => {
-    test = t;
+  it('can selector become true by modifier - set an object literal whose fields are selected', () => {
     T({ 'a.b.c': 1 }, { $set: { 'a.b': { c: 1 } } }, 'a simple scalar selector and simple set');
     F({ 'a.b.c': 1 }, { $set: { 'a.b': { c: 2 } } }, 'a simple scalar selector and simple set to false');
     F({ 'a.b.c': 1 }, { $set: { 'a.b': { d: 1 } } }, 'a simple scalar selector and simple set a wrong literal');
     F({ 'a.b.c': 1 }, { $set: { 'a.b': 222 } }, 'a simple scalar selector and simple set a wrong type');
   });
 
-  Tinytest.add('minimongo - can selector become true by modifier - $-scalar selectors and simple tests', t => {
-    test = t;
+  it('can selector become true by modifier - $-scalar selectors and simple tests', () => {
     T({ 'a.b.c': { $lt: 5 } }, { $set: { 'a.b': { c: 4 } } }, 'nested $lt');
     F({ 'a.b.c': { $lt: 5 } }, { $set: { 'a.b': { c: 5 } } }, 'nested $lt');
     F({ 'a.b.c': { $lt: 5 } }, { $set: { 'a.b': { c: 6 } } }, 'nested $lt');
@@ -549,8 +543,7 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     F({ 'a.b': { $gt: 5, $lt: 7}, x: 1 }, { $set: { x: 1 }, $unset: { 'a.b.c': 1 } }, 'unset sub-field of $gt,$lt operator (scalar expected)');
   });
 
-  Tinytest.add('minimongo - can selector become true by modifier - $-nonscalar selectors and simple tests', t => {
-    test = t;
+  it('can selector become true by modifier - $-nonscalar selectors and simple tests', () => {
     T({ a: { $eq: { x: 5 } } }, { $set: { 'a.x': 5 } }, 'set of $eq');
     // XXX this test should be F, but it is not implemented yet
     T({ a: { $eq: { x: 5 } } }, { $set: { 'a.x': 4 } }, 'set of $eq');
@@ -567,3 +560,4 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     T({ a: { $ne: { a: 2 } } }, { $set: { a: { a: 2 } } }, '$ne object');
   });
 }))();
+}); // end describe

--- a/packages/minimongo/package.js
+++ b/packages/minimongo/package.js
@@ -42,11 +42,10 @@ Package.onTest((api) => {
     "random",
     "reactive-var",
     "test-helpers",
-    "tinytest",
     "tracker",
   ]);
 
-  api.addFiles("minimongo_tests.js");
-  api.addFiles("minimongo_tests_client.js", "client");
+  api.addFiles("minimongo_tests.js", "server");
+  api.addFiles("minimongo_tests_client.js", "server");
   api.addFiles("minimongo_tests_server.js", "server");
 });

--- a/packages/random/package.js
+++ b/packages/random/package.js
@@ -14,6 +14,5 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
   api.use('random');
   api.use('ecmascript');
-  api.use('tinytest');
-  api.mainModule('random_tests.js');
+  api.addFiles('random_tests.js', 'server');
 });

--- a/packages/random/random_tests.js
+++ b/packages/random/random_tests.js
@@ -1,53 +1,47 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 
-Tinytest.add('random', function (test) {
-  // Deterministic with a specified seed, which should generate the
-  // same sequence in all environments.
-  //
-  // For repeatable unit test failures using deterministic random
-  // number sequences it's fine if a new Meteor release changes the
-  // algorithm being used and it starts generating a different
-  // sequence for a seed, as long as the sequence is consistent for
-  // a particular release.
-  const random = Random.createWithSeeds(0);
-  test.equal(random.id(), 'cp9hWvhg8GSvuZ9os');
-  test.equal(random.id(), '3f3k6Xo7rrHCifQhR');
-  test.equal(random.id(), 'shxDnjWWmnKPEoLhM');
-  test.equal(random.id(), '6QTjB8C5SEqhmz4ni');
-});
+describe('random', () => {
+  it('generates deterministic ids with a specified seed', () => {
+    const random = Random.createWithSeeds(0);
+    assert.strictEqual(random.id(), 'cp9hWvhg8GSvuZ9os');
+    assert.strictEqual(random.id(), '3f3k6Xo7rrHCifQhR');
+    assert.strictEqual(random.id(), 'shxDnjWWmnKPEoLhM');
+    assert.strictEqual(random.id(), '6QTjB8C5SEqhmz4ni');
+  });
 
-// node crypto and window.crypto.getRandomValues() don't let us specify a seed,
-// but at least test that the output is in the right format.
-Tinytest.add('random - format', function (test) {
-  const idLen = 17;
-  test.equal(Random.id().length, idLen);
-  test.equal(Random.id(29).length, 29);
-  const numDigits = 9;
-  const hexStr = Random.hexString(numDigits);
-  test.equal(hexStr.length, numDigits);
-  Number.parseInt(hexStr, 16); // should not throw
-  const frac = Random.fraction();
-  test.isTrue(frac < 1.0);
-  test.isTrue(frac >= 0.0);
+  it('generates ids in the right format', () => {
+    const idLen = 17;
+    assert.strictEqual(Random.id().length, idLen);
+    assert.strictEqual(Random.id(29).length, 29);
+    const numDigits = 9;
+    const hexStr = Random.hexString(numDigits);
+    assert.strictEqual(hexStr.length, numDigits);
+    Number.parseInt(hexStr, 16); // should not throw
+    const frac = Random.fraction();
+    assert.ok(frac < 1.0);
+    assert.ok(frac >= 0.0);
 
-  test.equal(Random.secret().length, 43);
-  test.equal(Random.secret(13).length, 13);
-});
+    assert.strictEqual(Random.secret().length, 43);
+    assert.strictEqual(Random.secret(13).length, 13);
+  });
 
-Tinytest.add('random - Alea is last resort', function (test) {
-  if (Meteor.isServer) {
-    test.isTrue(Random.alea === undefined);
-  }
-  if (Meteor.isClient) {
-    const useGetRandomValues = !!(typeof window !== 'undefined' &&
-        window.crypto && window.crypto.getRandomValues);
-    test.equal(Random.alea === undefined, useGetRandomValues);
-  }
-});
+  it('Alea is last resort', () => {
+    if (Meteor.isServer) {
+      assert.strictEqual(Random.alea, undefined);
+    }
+    if (Meteor.isClient) {
+      const useGetRandomValues = !!(typeof window !== 'undefined' &&
+          window.crypto && window.crypto.getRandomValues);
+      assert.strictEqual(Random.alea === undefined, useGetRandomValues);
+    }
+  });
 
-Tinytest.add('random - createWithSeeds requires parameters', function (test) {
-  test.throws(function () {
-    Random.createWithSeeds();
+  it('createWithSeeds requires parameters', () => {
+    assert.throws(() => {
+      Random.createWithSeeds();
+    });
   });
 });

--- a/packages/routepolicy/package.js
+++ b/packages/routepolicy/package.js
@@ -13,6 +13,6 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use(['routepolicy', 'tinytest', 'ecmascript']);
-  api.mainModule('routepolicy_tests.js', 'server');
+  api.use(['routepolicy', 'ecmascript']);
+  api.addFiles('routepolicy_tests.js', 'server');
 });

--- a/packages/routepolicy/routepolicy_tests.js
+++ b/packages/routepolicy/routepolicy_tests.js
@@ -1,74 +1,77 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import RoutePolicy from 'meteor/routepolicy/routepolicy';
-import { Tinytest } from "meteor/tinytest";
 
-Tinytest.add("routepolicy - declare", function (test) {
-  const policy = new RoutePolicy();
+describe('routepolicy', () => {
+  it('declare and classify', () => {
+    const policy = new RoutePolicy();
 
-  policy.declare('/sockjs/', 'network');
-  policy.declare('/bigphoto.jpg', 'static-online');
-  policy.declare('/anotherphoto.png', 'static-online');
+    policy.declare('/sockjs/', 'network');
+    policy.declare('/bigphoto.jpg', 'static-online');
+    policy.declare('/anotherphoto.png', 'static-online');
 
-  test.equal(policy.classify('/'), null);
-  test.equal(policy.classify('/foo'), null);
-  test.equal(policy.classify('/sockjs'), null);
+    assert.strictEqual(policy.classify('/'), null);
+    assert.strictEqual(policy.classify('/foo'), null);
+    assert.strictEqual(policy.classify('/sockjs'), null);
 
-  test.equal(policy.classify('/sockjs/'), 'network');
-  test.equal(policy.classify('/sockjs/foo'), 'network');
+    assert.strictEqual(policy.classify('/sockjs/'), 'network');
+    assert.strictEqual(policy.classify('/sockjs/foo'), 'network');
 
-  test.equal(policy.classify('/bigphoto.jpg'), 'static-online');
-  test.equal(policy.classify('/bigphoto.jpg.orig'), 'static-online');
+    assert.strictEqual(policy.classify('/bigphoto.jpg'), 'static-online');
+    assert.strictEqual(policy.classify('/bigphoto.jpg.orig'), 'static-online');
 
-  test.equal(policy.urlPrefixesFor('network'), ['/sockjs/']);
-  test.equal(
-    policy.urlPrefixesFor('static-online'),
-    ['/anotherphoto.png', '/bigphoto.jpg']
-  );
-});
+    assert.deepStrictEqual(policy.urlPrefixesFor('network'), ['/sockjs/']);
+    assert.deepStrictEqual(
+      policy.urlPrefixesFor('static-online'),
+      ['/anotherphoto.png', '/bigphoto.jpg']
+    );
+  });
 
-Tinytest.add("routepolicy - static conflicts", function (test) {
-  const manifest = [
-    {
-      "path": "static/sockjs/socks-are-comfy.jpg",
-      "type": "static",
-      "where": "client",
-      "url": "/sockjs/socks-are-comfy.jpg"
-    },
-    {
-      "path": "static/bigphoto.jpg",
-      "type": "static",
-      "where": "client",
-      "url": "/bigphoto.jpg"
-    }
-  ];
-  const policy = new RoutePolicy();
+  it('static conflicts', () => {
+    const manifest = [
+      {
+        "path": "static/sockjs/socks-are-comfy.jpg",
+        "type": "static",
+        "where": "client",
+        "url": "/sockjs/socks-are-comfy.jpg"
+      },
+      {
+        "path": "static/bigphoto.jpg",
+        "type": "static",
+        "where": "client",
+        "url": "/bigphoto.jpg"
+      }
+    ];
+    const policy = new RoutePolicy();
 
-  test.equal(
-    policy.checkForConflictWithStatic('/sockjs/', 'network', manifest),
-    "static resource /sockjs/socks-are-comfy.jpg conflicts with network route /sockjs/"
-  );
+    assert.strictEqual(
+      policy.checkForConflictWithStatic('/sockjs/', 'network', manifest),
+      "static resource /sockjs/socks-are-comfy.jpg conflicts with network route /sockjs/"
+    );
 
-  test.equal(
-    policy.checkForConflictWithStatic('/bigphoto.jpg', 'static-online', manifest),
-    null
-  );
-});
+    assert.strictEqual(
+      policy.checkForConflictWithStatic('/bigphoto.jpg', 'static-online', manifest),
+      null
+    );
+  });
 
-Tinytest.add("routepolicy - checkUrlPrefix", function (test) {
-  const policy = new RoutePolicy();
-  policy.declare('/sockjs/', 'network');
+  it('checkUrlPrefix', () => {
+    const policy = new RoutePolicy();
+    policy.declare('/sockjs/', 'network');
 
-  test.equal(
-    policy.checkUrlPrefix('foo/bar', 'network'),
-    "a route URL prefix must begin with a slash"
-  );
+    assert.strictEqual(
+      policy.checkUrlPrefix('foo/bar', 'network'),
+      "a route URL prefix must begin with a slash"
+    );
 
-  test.equal(
-    policy.checkUrlPrefix('/', 'network'),
-    "a route URL prefix cannot be /"
-  );
+    assert.strictEqual(
+      policy.checkUrlPrefix('/', 'network'),
+      "a route URL prefix cannot be /"
+    );
 
-  test.equal(
-    policy.checkUrlPrefix('/sockjs/', 'static-online'),
-    "the route URL prefix /sockjs/ has already been declared to be of type network"
-  );
+    assert.strictEqual(
+      policy.checkUrlPrefix('/sockjs/', 'static-online'),
+      "the route URL prefix /sockjs/ has already been declared to be of type network"
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Migrates test files for 8 core packages from Tinytest API (`Tinytest.add` / `test.equal`) to Node.js native test runner (`describe`/`it`/`assert`), using the `meteor-test` driver.

**Packages migrated (by size):**
- `random` (53 lines)
- `callback-hook` (55 lines)
- `routepolicy` (74 lines)
- `geojson-utils` (98 lines)
- `diff-sequence` (159 lines)
- `ejson` (294 lines)
- `check` (790 lines)
- `minimongo` (4749 lines)

Includes the `meteor-test` driver package (server-only, runs `node:test` natively). Builds on #14216.

## Context: from #14216 to here

In #14216, I proposed a server-only `node:test` driver as a POC. The discussion raised an important concern: **having two different test APIs for client and server would fragment the ecosystem.** @harryadel's #14224 (headless Tinytest via DDP) was the alternative approach — keep one API everywhere.

That feedback made me step back and ask: **do "client" tests actually need a client?**

I audited the 86 core packages that have tests. The answer: **~98% of tests labeled "client" are pure logic that never touches the DOM.**

Take `minimongo_tests_client.js` — 4000+ lines of tests. The name says "client", but it tests `LocalCollection`, query operators, `observe`, reactivity with `Tracker`. All of this is JavaScript logic. No `document`, no `window`, no DOM manipulation.

Same story across the board:
- `check/match_test.js` — tests pattern matching logic
- `ejson/ejson_tests.js` — tests serialization
- `tracker` tests — tests reactive computation (pure JS)
- `session` tests — tests key/value storage with reactivity

The only tests that genuinely need a browser are things like `ecmascript/runtime-client-tests.js` (real DOM) or `localstorage` (browser API). That's roughly 2% of the test surface.

**So the fragmentation problem doesn't exist.** We don't need two different APIs for client and server — we can use one API (`node:test`) everywhere, because almost all "client" tests can simply run on the server. Just declare `addFiles('test.js', 'server')` in `package.js` and it works. No browser, no Puppeteer, no headless Chrome. Just Node.js.

## Motivation

Tinytest has been Meteor's only test framework since 2012. It lacks mocking, coverage, snapshots, and standard assertions. `node:test` is built into Node.js, zero-dependency, and gives us all of these for free (`--experimental-test-coverage`, `mock.fn()`, `--test-reporter`, etc.).

`node:test` works by side-effect at import: `import { describe, it } from 'node:test'` registers tests that execute after the microtask queue drains. Isobuild passes `node:` imports through on the `os` architecture (server). So the migration is mechanical: replace the assertion API, change the file target to `'server'`, done.

## What we learned along the way

### EJSON.equals vs deepStrictEqual

`assert.deepStrictEqual` checks prototypes. But `EJSON.clone()` returns plain objects, not class instances. So this fails:

```js
const widget = new Widget();
const cloned = EJSON.clone(widget);
assert.deepStrictEqual(widget, cloned); // FAIL — different prototypes
```

For any custom EJSON type, use `assert.ok(EJSON.equals(a, b))` instead. `EJSON.equals` compares by value. This distinction doesn't exist in Tinytest where `test.equal` uses `EJSON.equals` under the hood.

### assert.throws rejects plain strings

Tinytest's `test.throws(fn, 'expected message')` accepts a string. Node.js `assert.throws(fn, 'string')` throws an ambiguity error. Must use `assert.throws(fn, /regexp/)` or `assert.throws(fn, { message: /regexp/ })`.

### The async observe queue — the real challenge

The hardest part and the most instructive finding for the whole migration effort.

`minimongo` had 11 tests failing after a clean mechanical migration. Not assertion API issues — the tests were logically wrong for server execution. Here's why:

In `local_collection.js`:
```js
this._observeQueue = Meteor.isClient
  ? new Meteor._SynchronousQueue()    // client: sync drain
  : new Meteor._AsynchronousQueue();  // server: async drain
```

On **client**, `_SynchronousQueue.drain()` executes all queued callbacks immediately and returns `undefined`. The original tests rely on this: call `.observe()`, then immediately check that callbacks fired.

On **server**, `_AsynchronousQueue.drain()` returns a **Promise**. Callbacks are queued but haven't executed when `.observe()` returns.

This affects three patterns:

**1. Initial observe callbacks:**
```js
// Client: works — callbacks fire synchronously
handle = c.find({}).observe(cbs);
assert.deepStrictEqual(operations.shift(), ['added', ...]);

// Server: operations is empty! Must await:
handle = c.find({}).observe(cbs);
await handle.isReadyPromise;
assert.deepStrictEqual(operations.shift(), ['added', ...]);
```

**2. Sync insert/update/remove with Tracker:**
```js
// Client: works — drain() is sync, dependency invalidated immediately
coll.insert({ _id: "test" });
Tracker.flush();
assert.strictEqual(runs, 2);

// Server: drain() returns unawaited Promise, dep never invalidated
await coll.insertAsync({ _id: "test" });  // must use async version
Tracker.flush();
assert.strictEqual(runs, 2);
```

**3. resumeObservers:**
```js
// Client: sync drain
c.resumeObserversClient();

// Server: must await the async drain
await c.resumeObserversServer();
```

**This is not a bug in minimongo** — the client/server queue split is intentional (Meteor 3 async migration). But it means any test that uses `observe`, `Tracker`, or reactive queries must account for the async queue when running server-side.

## Migration cheat sheet

| Tinytest | node:test |
|----------|-----------|
| `Tinytest.add(name, fn)` | `it(name, fn)` |
| `Tinytest.addAsync(name, async fn)` | `it(name, async fn)` |
| `test.equal(a, b)` | `assert.deepStrictEqual(a, b)` |
| `test.equal(a, b)` on EJSON types | `assert.ok(EJSON.equals(a, b))` |
| `test.isTrue(x)` | `assert.ok(x)` |
| `test.isFalse(x)` | `assert.ok(!x)` |
| `test.throws(fn)` | `assert.throws(fn, /pattern/)` |
| `test.instanceOf(x, T)` | `assert.ok(x instanceof T)` |
| `test.fail({message})` | `assert.fail(message)` |
| `test.length(arr, n)` | `assert.strictEqual(arr.length, n)` |

**Server-specific patterns:**

| Client pattern | Server equivalent |
|----------|-----------|
| `cursor.observe(cbs)` | `const h = cursor.observe(cbs); await h.isReadyPromise;` |
| `coll.insert(doc)` (with observers) | `await coll.insertAsync(doc)` |
| `coll.remove(sel)` (with observers) | `await coll.removeAsync(sel)` |
| `c.resumeObserversClient()` | `await c.resumeObserversServer()` |

## Changes per package

Each package's `package.js` was updated to:
1. Remove `tinytest` from `api.use()`
2. Use `api.addFiles('test.js', 'server')` instead of `api.mainModule` (so `node:test` registers tests at import time)

Test files were rewritten mechanically — no test logic was changed, only the assertion API and async adaptations.

## What's next

47 packages still use Tinytest. Good next candidates (pure logic, small):
`base64`, `binary-heap`, `url`, `rate-limit`, `package-version-parser`, `modern-browsers`, `tracker`, `reactive-dict`, `session`

For the ~2% of tests that genuinely need DOM APIs (`localstorage`, `ecmascript/runtime-client-tests.js`, etc.), [happy-dom](https://github.com/capricorn86/happy-dom) is a natural next step — a lightweight DOM implementation for Node.js, zero browser process, zero Puppeteer. This would allow even DOM-dependent tests to run server-side with `node:test`, potentially eliminating the need for a browser mode entirely. Out of scope for this PR.

## How to run

```bash
# All 8 packages at once
./meteor test-packages random callback-hook routepolicy geojson-utils \
  diff-sequence ejson check minimongo --driver-package meteor-test --once

# With coverage
SERVER_NODE_OPTIONS="--experimental-test-coverage" \
  ./meteor test-packages check --driver-package meteor-test --once

# With spec reporter
SERVER_NODE_OPTIONS="--test-reporter=spec" \
  ./meteor test-packages check --driver-package meteor-test --once
```

## Test plan

- [x] `random` — 4/4 passing
- [x] `callback-hook` — 4/4 passing
- [x] `routepolicy` — 4/4 passing
- [x] `geojson-utils` — 5/5 passing
- [x] `diff-sequence` — 3/3 passing
- [x] `ejson` — 10/10 passing
- [x] `check` — 7/7 passing
- [x] `minimongo` — 63/63 passing (49 client + 3 shared + 11 server)
- [x] **Total: 100/100 passing**

Cc @nachocodoner @italojs @harryadel 
