### PR TITLE
Fix ObjectID fields sent as binary when using projection with ChangeStreams

### DIFF
--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -41,7 +41,7 @@ export class ChangeStreamObserveDriver {
     if (projection) {
       const baseProjectionFn = LocalCollection._compileProjection(projection);
       this._projectionFn = (doc) => {
-        const projected = baseProjectionFn(doc);
+        const projected = baseProjectionFn(replaceTypes(doc, replaceMongoAtomWithMeteor));
         if (projected && typeof projected === 'object') {
           const { _id, ...fields } = projected;
           return fields;
@@ -50,7 +50,7 @@ export class ChangeStreamObserveDriver {
       };
     } else {
       this._projectionFn = (doc) => {
-        const { _id, ...fields } = doc;
+        const { _id, ...fields } = replaceTypes(doc, replaceMongoAtomWithMeteor);
         return fields;
       };
     }

--- a/packages/mongo/tests/mongo_livedata_tests.js
+++ b/packages/mongo/tests/mongo_livedata_tests.js
@@ -4670,4 +4670,137 @@ Tinytest.addAsync('mongo-livedata - publish with $geoIntersects returns correct 
   if (Meteor.isClient) {
     onComplete();
   }
+
+
+
+  // ============================================================================
+  // BUG REGRESSION: ObjectID fields with projection
+  // When a cursor uses a projection and a document field contains a MongoDB
+  // ObjectID, the field was being received as a binary blob instead of a
+  // Mongo.ObjectID instance. Root cause: LocalCollection._compileProjection
+  // uses EJSON.clone() on each projected value. EJSON does not know about
+  // MongoDB.ObjectId (a BSON type), so it serialises it to { id: Uint8Array },
+  // which is then not recognised by replaceMongoAtomWithMeteor.
+  // These tests cover all three paths (initial add, insert event, update event)
+  // and run regardless of the active reactivity driver (oplog, changestream, etc).
+  // ============================================================================
+
+  Tinytest.addAsync(
+    'mongo-livedata - projection preserves ObjectID field type on initial add',
+    async function (test) {
+      if (Meteor.isClient) return;
+      const coll = new Mongo.Collection('projObjIdInitial' + Random.id());
+
+      const refId = new Mongo.ObjectID();
+      await coll.insertAsync({ name: 'test', refId });
+
+      const output = [];
+      const handle = await coll.find({}, { fields: { refId: 1 } }).observeChanges({
+        added: function (id, fields) {
+          output.push(fields);
+        },
+      });
+
+      // observeChanges sends initial adds synchronously before returning
+      test.equal(output.length, 1, 'Should receive the initial added callback');
+
+      const receivedRefId = output[0].refId;
+
+      test.isTrue(
+        receivedRefId instanceof Mongo.ObjectID,
+        `refId should be Mongo.ObjectID but got: ${JSON.stringify(receivedRefId)}`
+      );
+      test.equal(
+        receivedRefId.toHexString(),
+        refId.toHexString(),
+        'ObjectID hex value should be preserved'
+      );
+
+      handle.stop();
+    }
+  );
+
+  Tinytest.addAsync(
+    'mongo-livedata - projection preserves ObjectID field type on insert event',
+    async function (test) {
+      if (Meteor.isClient) return;
+      const coll = new Mongo.Collection('projObjIdInsert' + Random.id());
+
+      const output = [];
+      const handle = await coll.find({}, { fields: { refId: 1 } }).observeChanges({
+        added: function (id, fields) {
+          output.push(fields);
+        },
+      });
+
+      const refId = new Mongo.ObjectID();
+      // runInFence guarantees the observer is notified before we check results
+      await runInFence(async function () {
+        await coll.insertAsync({ name: 'test', refId });
+      });
+
+      test.equal(output.length, 1, 'Should receive the added callback');
+
+      const receivedRefId = output[0].refId;
+
+      test.isTrue(
+        receivedRefId instanceof Mongo.ObjectID,
+        `refId should be Mongo.ObjectID but got: ${JSON.stringify(receivedRefId)}`
+      );
+      test.equal(
+        receivedRefId.toHexString(),
+        refId.toHexString(),
+        'ObjectID hex value should be preserved'
+      );
+
+      handle.stop();
+    }
+  );
+
+
+  Tinytest.addAsync(
+    'mongo-livedata - projection preserves ObjectID field type on update event',
+    async function (test) {
+      if (Meteor.isClient) return;
+      const coll = new Mongo.Collection('projObjIdUpdate' + Random.id());
+
+      const firstRefId = new Mongo.ObjectID();
+      const docId = await coll.insertAsync({ name: 'test', refId: firstRefId });
+
+      const added = [];
+      const changed = [];
+      const handle = await coll.find({}, { fields: { refId: 1 } }).observeChanges({
+        added: function (id, fields) {
+          added.push(fields);
+        },
+        changed: function (id, fields) {
+          changed.push(fields);
+        },
+      });
+
+      // Initial add is synchronous
+      test.equal(added.length, 1, 'Should receive the initial added callback');
+
+      const newRefId = new Mongo.ObjectID();
+      await runInFence(async function () {
+        await coll.updateAsync(docId, { $set: { refId: newRefId } });
+      });
+
+      test.equal(changed.length, 1, 'Should receive the changed callback');
+
+      const receivedRefId = changed[0].refId;
+
+      test.isTrue(
+        receivedRefId instanceof Mongo.ObjectID,
+        `Updated refId should be Mongo.ObjectID but got: ${JSON.stringify(receivedRefId)}`
+      );
+      test.equal(
+        receivedRefId.toHexString(),
+        newRefId.toHexString(),
+        'Updated ObjectID hex value should be preserved'
+      );
+
+      handle.stop();
+    }
+  );
 });


### PR DESCRIPTION
issue reported [here](https://forums.meteor.com/t/meteor-3-5-beta-change-streams-performance-improvements/64461/40?u=italojs)

**bug:**
When using observeChanges with a field projection, ObjectID fields were being sent to the client as raw binary buffers instead of Mongo.ObjectID instances.

**Root cause:**
The ChangeStream driver receives fullDocument with native BSON types. Passing the raw document directly to LocalCollection._compileProjection (which uses EJSON.clone internally) caused ObjectId values to be coerced to Binary buffers.

**Fix:** 
Apply replaceTypes(doc, replaceMongoAtomWithMeteor) before projecting, converting native BSON types to Meteor equivalents before _compileProjection processes the document.

This only affected the ChangeStream driver — the oplog driver re-fetches through Meteor's cursor layer which already handles type conversion.

Tests: Added regression tests for ObjectID field type preservation on initial add, insert event, and update event.