### PR TITLE
Remove unnecessary NPM_CONFIG_NODEDIR env var to fix npm 11+ warning

### DIFF
--- a/tools/cli/dev-bundle-bin-helpers.js
+++ b/tools/cli/dev-bundle-bin-helpers.js
@@ -98,8 +98,6 @@ async function getEnv(options) {
     env.NPM_CONFIG_UNSAFE_PERM = env.METEOR_ALLOW_SUPERUSER;
   }
 
-  env.NPM_CONFIG_NODEDIR = devBundleDir;
-
   const PATH = env.PATH || env.Path;
 
   if (PATH) {


### PR DESCRIPTION
# Remove obsolete `NPM_CONFIG_NODEDIR` from dev bundle npm env

## Summary

Since npm 11.2.0, npm warns when it sees unknown environment configs ([npm/cli#8153](https://github.com/npm/cli/issues/8153)). `NPM_CONFIG_NODEDIR` now triggers that warning because `nodedir` is a node-gyp config, not an npm one. npm also warns that this will stop working in the next major version.

Meteor originally added `NPM_CONFIG_NODEDIR` in 2017 (`67b76abc78`) to help node-gyp find headers in `dev_bundle/include/node/`.

I tested native addon builds without this variable in Meteor’s current dev bundle layout, and they still succeed in the scenarios tested so far on Linux. In other words, removing it does not appear to break native package compilation in the current setup.

This PR simply removes that obsolete env var.

## Note

`NPM_CONFIG_UNSAFE_PERM` in the same file (L95–98) also produces an npm warning and should be cleaned up separately. `unsafe-perm` was [removed in npm v7](https://github.com/npm/feedback/discussions/121).

## References

- [nodejs/node-gyp#3163](https://github.com/nodejs/node-gyp/issues/3163) — Alternative environment variable due to warning on `npm_config_nodedir`
- [npm/cli#8153](https://github.com/npm/cli/issues/8153) — Unknown config warnings starting in npm 11.2.0
- [nodejs/node-gyp#3192](https://github.com/nodejs/node-gyp/issues/3192) — Node-gyp config instructions are going to stop working soon

## Test plan

- [x] Verified that `dev_bundle/include/node/` contains the required headers
- [x] Tested native package compilation (`bufferutil`) with and without `NPM_CONFIG_NODEDIR` — both succeeded on Linux
- [x] Confirmed that the `nodedir` warning disappears after the change
- [ ] Still needs Windows verification, since node-gyp has historically had a few edge cases around `nodedir` and `common.gypi`