### PR TITLE
fix: `passwordValidator` ignores `passwordMaxLength` due to operator pre

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -290,7 +290,7 @@ Accounts._checkPasswordAsync = checkPasswordAsync;
 
 
 const passwordValidator = Match.OneOf(
-  Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256), {
+  Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)), {
     digest: Match.Where(str => Match.test(str, String) && str.length === 64),
     algorithm: Match.OneOf('sha-256')
   }


### PR DESCRIPTION
Fixes #14072

The `passwordValidator` in `packages/accounts-password/password_server.js` was ignoring the `passwordMaxLength` setting, always defaulting to 256. Due to operator precedence, `&&` binds tighter than `||`, causing the expression to evaluate as `(Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength) || 256`, which always returned a truthy value. Adds parentheses around the `||` fallback to ensure `passwordMaxLength` is resolved before the comparison.