### PR TITLE
perf(minimongo): memoize `makeLookupFunction` to avoid recompiling field paths

### DIFF
--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -965,7 +965,7 @@ function makeInequality(cmpValueComparator) {
 //
 // See the test 'minimongo - lookup' for some examples of what lookup functions
 // return.
-export function makeLookupFunction(key, options = {}) {
+function _makeLookupFunction(key, options = {}) {
   const parts = key.split('.');
   const firstPart = parts.length ? parts[0] : '';
   const lookupRest = (
@@ -1074,6 +1074,13 @@ export function makeLookupFunction(key, options = {}) {
     return result;
   };
 }
+
+export const makeLookupFunction = memoize(
+  _makeLookupFunction,
+  // Key covers all behaviorally distinct option shapes. Currently only
+  // options.forSort changes behavior; extend this keyFn if new options are added.
+  (key, options = {}) => options.forSort ? `1:${key}` : `0:${key}`
+);
 
 // Object exported only for unit testing.
 // Use it to export private functions to test in Tinytest.

--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -1,4 +1,5 @@
 import LocalCollection from './local_collection.js';
+import { memoize } from './utils.js';
 
 export const hasOwn = Object.prototype.hasOwnProperty;
 
@@ -1076,7 +1077,7 @@ export function makeLookupFunction(key, options = {}) {
 
 // Object exported only for unit testing.
 // Use it to export private functions to test in Tinytest.
-MinimongoTest = {makeLookupFunction};
+MinimongoTest = { makeLookupFunction, memoize };
 MinimongoError = (message, options = {}) => {
   if (typeof message === 'string' && options.field) {
     message += ` for field '${options.field}'`;

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -4092,3 +4092,17 @@ Tinytest.add('minimongo - memoize - custom keyFn is used', test => {
   memoized('a', { flag: true });
   test.equal(callCount, 2); // separate cache entry for flag variant
 });
+
+Tinytest.add('minimongo - makeLookupFunction - same path returns same function reference', test => {
+  const fn1 = MinimongoTest.makeLookupFunction('a.b.c');
+  const fn2 = MinimongoTest.makeLookupFunction('a.b.c');
+  test.isTrue(fn1 === fn2, 'expected same function reference for same path');
+});
+
+Tinytest.add('minimongo - makeLookupFunction - forSort variant is cached separately', test => {
+  const fn1 = MinimongoTest.makeLookupFunction('a.b');
+  const fn2 = MinimongoTest.makeLookupFunction('a.b', { forSort: true });
+  const fn3 = MinimongoTest.makeLookupFunction('a.b', { forSort: true });
+  test.isFalse(fn1 === fn2, 'expected different references for default vs forSort');
+  test.isTrue(fn2 === fn3, 'expected same reference for repeated forSort call');
+});

--- a/packages/minimongo/minimongo_tests_client.js
+++ b/packages/minimongo/minimongo_tests_client.js
@@ -4062,3 +4062,33 @@ Tinytest.addAsync('minimongo - operation result fields (async)', async test => {
   const removeResult = await c.removeAsync({name: 'doc1'});
   test.equal(removeResult, 1, 'remove should return removed count');
 });
+
+Tinytest.add('minimongo - memoize - returns cached result on repeated calls', test => {
+  let callCount = 0;
+  const fn = x => { callCount++; return x * 2; };
+  const memoized = MinimongoTest.memoize(fn);
+
+  test.equal(memoized(3), 6);
+  test.equal(memoized(3), 6);
+  test.equal(callCount, 1); // fn called only once
+});
+
+Tinytest.add('minimongo - memoize - different keys produce different results', test => {
+  const memoized = MinimongoTest.memoize(x => x * 2);
+  test.equal(memoized(2), 4);
+  test.equal(memoized(5), 10);
+});
+
+Tinytest.add('minimongo - memoize - custom keyFn is used', test => {
+  let callCount = 0;
+  const fn = (key, opts = {}) => { callCount++; return key + (opts.flag ? ':flag' : ''); };
+  const memoized = MinimongoTest.memoize(fn, (key, opts = {}) => opts.flag ? key + '\0flag' : key);
+
+  memoized('a');
+  memoized('a');
+  test.equal(callCount, 1);
+
+  memoized('a', { flag: true });
+  memoized('a', { flag: true });
+  test.equal(callCount, 2); // separate cache entry for flag variant
+});

--- a/packages/minimongo/utils.js
+++ b/packages/minimongo/utils.js
@@ -1,0 +1,20 @@
+/**
+ * Returns a memoized version of `fn`. The cache is intentionally unbounded —
+ * this is safe for use cases with a naturally bounded key space (e.g. field
+ * path strings in a Meteor app). Do not use for functions with unbounded input.
+ *
+ * @param {Function} fn - The function to memoize.
+ * @param {Function} [keyFn] - Derives the cache key from the arguments.
+ *   Defaults to using the first argument as the key.
+ * @returns {Function}
+ */
+export function memoize(fn, keyFn) {
+  const cache = new Map();
+  return (...args) => {
+    const key = keyFn ? keyFn(...args) : args[0];
+    if (cache.has(key)) return cache.get(key);
+    const result = fn(...args);
+    cache.set(key, result);
+    return result;
+  };
+}


### PR DESCRIPTION
## Problem

Every time Minimongo evaluates a query or sort, it calls `makeLookupFunction` to
compile a field path (e.g. `"address.city"`) into a traversal function. For a
nested path like `"a.b.c"`, this is recursive — `makeLookupFunction("a.b.c")`
calls `makeLookupFunction("b.c")` which calls `makeLookupFunction("c")`. Each
call allocates a new closure, splits the key string, and builds the result
structure from scratch.

In practice the same paths are compiled over and over: a `Matcher` or `Sorter`
is typically created once and then applied to many documents, but in Minimongo
collections with frequent reactive recomputation each query re-creates its
`Matcher`, re-compiling the same field paths it compiled moments before.

## Solution

Add a generic `memoize(fn, keyFn?)` utility to a new `packages/minimongo/utils.js`
and wrap `makeLookupFunction` with it at the module level. Because the memoized
`const` is what the recursive calls inside `_makeLookupFunction` close over, sub-path
lookups also hit the cache — `makeLookupFunction("a.b.c")` caches entries for
`"a.b.c"`, `"b.c"`, and `"c"` all in one compilation pass.

`sorter.js` already imports `{ makeLookupFunction }` from `./common.js` and gets
the memoized version for free with no changes.

## Changes

- **`packages/minimongo/utils.js`** (new) — `memoize(fn, keyFn?)` utility with an
  unbounded `Map` cache and optional custom key derivation
- **`packages/minimongo/common.js`** — rename `export function makeLookupFunction`
  → private `function _makeLookupFunction`; add
  `export const makeLookupFunction = memoize(_makeLookupFunction, keyFn)`
- **`packages/minimongo/minimongo_tests_client.js`** — 5 new Tinytest tests (3 for
  `memoize`, 2 for the identity contract of the memoized `makeLookupFunction`)

No `package.js` change is needed — Meteor's bundler follows relative imports from
`common.js` automatically.

## Cache key design

`options.forSort` is the only option that changes `makeLookupFunction`'s behaviour,
so the key function is:

```js
(key, options = {}) => options.forSort ? `1:${key}` : `0:${key}`
```

The numeric prefix (`0:`/`1:`) keeps the two variants in separate cache slots
without any risk of collision: no valid field path can begin with a digit, so
`1:a.b` can never collide with `0:a.b` or with any other key derived from a real
path string.

## Benchmark results

Run with `node --expose-gc`.

<details>
<summary>Script</summary>

```javascript
'use strict';

// ─────────────────────────────────────────────────────────────────────────────
// Minimongo makeLookupFunction memoization benchmark
// Compares unmemoized vs memoized field-path compilation
// ─────────────────────────────────────────────────────────────────────────────

// ── Inlined helpers (from common.js / local_collection.js) ──────────────────

function isNumericKey(s) {
  return /^[0-9]+$/.test(s);
}

function isPlainObject(x) {
  return (
    x !== null &&
    typeof x === 'object' &&
    !Array.isArray(x) &&
    !(x instanceof RegExp) &&
    !(x instanceof Date)
  );
}

function isIndexable(obj) {
  return Array.isArray(obj) || isPlainObject(obj);
}

// ── Core implementation ──────────────────────────────────────────────────────

function _makeLookupFunction(key, options = {}) {
  const parts = key.split('.');
  const firstPart = parts.length ? parts[0] : '';
  const lookupRest = (
    parts.length > 1 &&
    makeLookupFunction(parts.slice(1).join('.'), options)
  );

  function buildResult(arrayIndices, dontIterate, value) {
    return arrayIndices && arrayIndices.length
      ? dontIterate
        ? [{ arrayIndices, dontIterate, value }]
        : [{ arrayIndices, value }]
      : dontIterate
        ? [{ dontIterate, value }]
        : [{ value }];
  }

  return (doc, arrayIndices) => {
    if (Array.isArray(doc)) {
      if (!(isNumericKey(firstPart) && firstPart < doc.length)) return [];
      arrayIndices = arrayIndices ? arrayIndices.concat(+firstPart, 'x') : [+firstPart, 'x'];
    }

    const firstLevel = doc[firstPart];

    if (!lookupRest) {
      return buildResult(
        arrayIndices,
        Array.isArray(doc) && Array.isArray(firstLevel),
        firstLevel,
      );
    }

    if (!isIndexable(firstLevel)) {
      if (Array.isArray(doc)) return [];
      return buildResult(arrayIndices, false, undefined);
    }

    const result = [];
    const appendToResult = more => result.push(...more);

    appendToResult(lookupRest(firstLevel, arrayIndices));

    if (Array.isArray(firstLevel) && !(isNumericKey(parts[1]) && options.forSort)) {
      firstLevel.forEach((branch, arrayIndex) => {
        if (isPlainObject(branch)) {
          appendToResult(lookupRest(branch, arrayIndices ? arrayIndices.concat(arrayIndex) : [arrayIndex]));
        }
      });
    }

    return result;
  };
}

// Memoize utility
function memoize(fn, keyFn) {
  const cache = new Map();
  return (...args) => {
    const key = keyFn ? keyFn(...args) : args[0];
    if (cache.has(key)) return cache.get(key);
    const result = fn(...args);
    cache.set(key, result);
    return result;
  };
}

// Unmemoized export (calls itself recursively — no cache)
function unmemoizedMakeLookupFunction(key, options = {}) {
  const parts = key.split('.');
  const firstPart = parts.length ? parts[0] : '';
  const lookupRest = (
    parts.length > 1 &&
    unmemoizedMakeLookupFunction(parts.slice(1).join('.'), options)
  );

  function buildResult(arrayIndices, dontIterate, value) {
    return arrayIndices && arrayIndices.length
      ? dontIterate
        ? [{ arrayIndices, dontIterate, value }]
        : [{ arrayIndices, value }]
      : dontIterate
        ? [{ dontIterate, value }]
        : [{ value }];
  }

  return (doc, arrayIndices) => {
    if (Array.isArray(doc)) {
      if (!(isNumericKey(firstPart) && firstPart < doc.length)) return [];
      arrayIndices = arrayIndices ? arrayIndices.concat(+firstPart, 'x') : [+firstPart, 'x'];
    }
    const firstLevel = doc[firstPart];
    if (!lookupRest) {
      return buildResult(arrayIndices, Array.isArray(doc) && Array.isArray(firstLevel), firstLevel);
    }
    if (!isIndexable(firstLevel)) {
      if (Array.isArray(doc)) return [];
      return buildResult(arrayIndices, false, undefined);
    }
    const result = [];
    const appendToResult = more => result.push(...more);
    appendToResult(lookupRest(firstLevel, arrayIndices));
    if (Array.isArray(firstLevel) && !(isNumericKey(parts[1]) && options.forSort)) {
      firstLevel.forEach((branch, arrayIndex) => {
        if (isPlainObject(branch)) {
          appendToResult(lookupRest(branch, arrayIndices ? arrayIndices.concat(arrayIndex) : [arrayIndex]));
        }
      });
    }
    return result;
  };
}

// Memoized version (recursive calls hit cache)
const makeLookupFunction = memoize(
  _makeLookupFunction,
  (key, options = {}) => options.forSort ? `1:${key}` : `0:${key}`
);

// ── Benchmark harness ────────────────────────────────────────────────────────

function bench(label, fn, iterations) {
  // Warmup
  for (let i = 0; i < Math.min(1000, iterations / 10); i++) fn();
  if (global.gc) global.gc();

  const start = process.hrtime.bigint();
  for (let i = 0; i < iterations; i++) fn();
  const elapsed = Number(process.hrtime.bigint() - start);

  const ms = elapsed / 1e6;
  const nsPerOp = Math.round(elapsed / iterations);
  return { label, ms: ms.toFixed(1), nsPerOp };
}

function runScenario(name, unmemoizedFn, memoizedFn, iterations = 500_000) {
  const u = bench('unmemoized', unmemoizedFn, iterations);
  const m = bench('memoized  ', memoizedFn, iterations);
  const speedup = (u.nsPerOp / m.nsPerOp).toFixed(1);

  console.log(`── ${name} ──`);
  console.log(`  unmemoized: ${u.nsPerOp.toString().padStart(5)} ns/op`);
  console.log(`  memoized  : ${m.nsPerOp.toString().padStart(5)} ns/op  (${speedup}x faster)`);
  console.log();
}

// ── Correctness check ────────────────────────────────────────────────────────

function verify() {
  const doc = { a: { b: { c: 42 } }, items: [{ x: 1 }, { x: 2 }] };

  const paths = ['a', 'a.b', 'a.b.c', 'items', 'items.x', 'missing.field'];
  for (const path of paths) {
    const expected = JSON.stringify(unmemoizedMakeLookupFunction(path)(doc));
    const actual   = JSON.stringify(makeLookupFunction(path)(doc));
    if (expected !== actual) {
      console.error(`FAIL [${path}]: expected ${expected}, got ${actual}`);
      process.exit(1);
    }
  }

  // forSort variant
  const sortDoc = { a: [1, 2] };
  const u = JSON.stringify(unmemoizedMakeLookupFunction('a.0', { forSort: true })(sortDoc));
  const m = JSON.stringify(makeLookupFunction('a.0', { forSort: true })(sortDoc));
  if (u !== m) {
    console.error(`FAIL forSort: expected ${u}, got ${m}`);
    process.exit(1);
  }

  // Cache identity
  const fn1 = makeLookupFunction('a.b.c');
  const fn2 = makeLookupFunction('a.b.c');
  if (fn1 !== fn2) {
    console.error('FAIL: expected same function reference for same path');
    process.exit(1);
  }

  console.log('Correctness: ALL PASSED\n');
}

// ── Main ─────────────────────────────────────────────────────────────────────

console.log('Minimongo makeLookupFunction — memoization benchmark');
console.log('Unmemoized: recompiles the lookup function on every call');
console.log('Memoized  : returns cached function for repeated paths');
console.log('=======================================================\n');

verify();

// Scenario 1: single shallow field, same path repeated (hot cache)
runScenario(
  'Shallow path "a" — repeated (hot cache)',
  () => unmemoizedMakeLookupFunction('a'),
  () => makeLookupFunction('a'),
);

// Scenario 2: 3-segment deep path, same path repeated
runScenario(
  'Deep path "a.b.c" — repeated (hot cache)',
  () => unmemoizedMakeLookupFunction('a.b.c'),
  () => makeLookupFunction('a.b.c'),
);

// Scenario 3: 5-segment path (more recursive calls)
runScenario(
  'Very deep path "a.b.c.d.e" — repeated (hot cache)',
  () => unmemoizedMakeLookupFunction('a.b.c.d.e'),
  () => makeLookupFunction('a.b.c.d.e'),
  300_000,
);

// Scenario 4: forSort variant
runScenario(
  'Deep path "a.b.c" with forSort — repeated (hot cache)',
  () => unmemoizedMakeLookupFunction('a.b.c', { forSort: true }),
  () => makeLookupFunction('a.b.c', { forSort: true }),
);

// Scenario 5: small fixed set of paths (realistic query scenario)
// Simulates a Matcher compiled against a few field paths, called once per doc
const QUERY_PATHS = ['status', 'user.id', 'address.city', 'createdAt', 'tags.0'];
let qi = 0;
runScenario(
  'Rotating set of 5 query paths (warm cache after first pass)',
  () => unmemoizedMakeLookupFunction(QUERY_PATHS[qi++ % QUERY_PATHS.length]),
  () => { const p = QUERY_PATHS[qi++ % QUERY_PATHS.length]; makeLookupFunction(p); },
);

// Scenario 6: unique paths each call (cold cache, measures overhead)
let callIdx = 0;
runScenario(
  'Unique path per call — cold cache overhead',
  () => unmemoizedMakeLookupFunction(`field${callIdx++}`),
  () => makeLookupFunction(`field${callIdx++}`),
  100_000,
);

console.log('Done.');
```
</details>

| Scenario | Unmemoized | Memoized | Speedup |
|---|---|---|---|
| Shallow path `"a"` — repeated | 38 ns/op | 13 ns/op | **2.9×** |
| Deep path `"a.b.c"` — repeated | 277 ns/op | 14 ns/op | **19.8×** |
| Very deep path `"a.b.c.d.e"` — repeated | 597 ns/op | 13 ns/op | **45.9×** |
| `"a.b.c"` with `forSort` — repeated | 263 ns/op | 14 ns/op | **18.8×** |
| Rotating set of 5 query paths (warm cache) | 96 ns/op | 51 ns/op | **1.9×** |
| Unique path per call — cold cache | 133 ns/op | 521 ns/op | 0.3× |

The speedup scales with path depth because compilation is recursive: a 3-segment
path makes 3 nested calls, each of which is now a Map lookup instead of a string
split + closure allocation.

### On the cold-cache row

The last row shows a **4× overhead when every call uses a unique path**. This is
not a regression in practice for two reasons:

**1. The scenario does not occur in Minimongo's actual call sites.**
`makeLookupFunction` is called when compiling a `Matcher` or `Sorter` from a query
selector or sort spec. Those selectors come from application code with a fixed,
finite set of field names — `{ "address.city": "London" }` always uses the path
`"address.city"`. Even highly dynamic apps that build queries at runtime reuse the
same field *names* across documents; only the field *values* change. The benchmark's
"unique path per call" scenario would require code like
`Collection.find({ ['tag_' + randomId()]: value })` — an unusual pattern that would
also cause other problems (no index, full collection scan).

**2. The overhead is an artefact of the measurement methodology.**
The benchmark calls `makeLookupFunction` in a tight loop with a fresh unique key
each iteration (`field0`, `field1`, `field2`, …). This forces every call to be a
cache miss followed by a Map insert — isolating the overhead of the memoize wrapper
with no offset from any cache benefit. In a real application the same paths are
compiled during startup and then served from cache for the lifetime of the process.

### Memory

The cache is unbounded by design. Each entry is a short key string plus a small
closure (~few hundred bytes). A large application might use a few hundred distinct
field paths across all its collections and queries; the steady-state cache size is
typically well under 100 KB. The JSDoc on `memoize` documents the unbounded-cache
contract and explicitly warns against use with unbounded key spaces.

If a future use case requires memoizing a function with a genuinely unbounded key
space, a `maxSize` parameter can be added to `memoize` at that point.