### PR TITLE
fix(accounts-base): await findOneAsync in _reportLoginFailure

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -591,7 +591,7 @@ export class AccountsServer extends AccountsCommon {
     };
 
     if (result.userId) {
-      attempt.user = this.users.findOneAsync(result.userId, {fields: this._options.defaultFieldSelector});
+      attempt.user = await this.users.findOneAsync(result.userId, {fields: this._options.defaultFieldSelector});
     }
 
     await this._validateLogin(methodInvocation.connection, attempt);

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -1078,6 +1078,10 @@ if (Meteor.isClient) (() => {
         test.equal(attempt.type, "password");
         test.isFalse(attempt.allowed);
         test.equal(attempt.error.reason, "Incorrect password");
+        // Verify attempt.user is a resolved document, not a Promise (#14151)
+        test.isTrue(attempt.user && typeof attempt.user === 'object');
+        test.isFalse(attempt.user instanceof Promise);
+        test.isTrue(attempt.user._id);
       }));
     },
     function (test, expect) {


### PR DESCRIPTION
## Summary

- Add missing `await` on `this.users.findOneAsync()` in `_reportLoginFailure`, which caused `attempt.user` to be a Promise instead of the resolved user document in `onLoginFailure` callbacks
- Add test assertions verifying `attempt.user` is a resolved document with an `_id`, not a Promise

Fixes #14151

## Test plan

- [x] Existing `passwords - server onLoginFailure hook` test now also verifies `attempt.user` is a proper document (not a Promise)