### PR TITLE
[Rspack] Serve sw.js files as part of development (HMR)

### DIFF
--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -28,6 +28,7 @@ const {
 const { loadUserAndOverrideConfig } = require('./lib/meteorRspackConfigHelpers.js');
 const { prepareMeteorRspackConfig } = require("./lib/meteorRspackConfigFactory");
 
+
 // Safe require that doesn't throw if the module isn't found
 function safeRequire(moduleName) {
   try {
@@ -643,7 +644,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
         port: devServerPort,
         devMiddleware: {
           writeToDisk: (filePath) =>
-            /\.(html)$/.test(filePath) && !filePath.includes(".hot-update."),
+            /\.(html)$/.test(filePath) || filePath.endsWith('sw.js'),
         },
         onListening(devServer) {
           if (!devServer) return;

--- a/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
+++ b/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
@@ -827,6 +827,8 @@ new GenerateSW({
 })
 ```
 
+During development, the HMR dev server writes `sw.js` to disk by default, so build-generated service workers are served by Meteor's web server without extra configuration. If your service worker uses a different filename, see the [Dev Server](#dev-server) section for how to extend `writeToDisk`.
+
 ### Dev Server
 
 You can customize the Rspack dev server much like you would when using meteor run. Any [devServer option listed in the official Rspack guide](https://rspack.rs/config/dev-server) can be applied in your app’s [`rspack.config.js`](./rspack-bundler-integration.md#custom-rspackconfigjs).
@@ -839,6 +841,23 @@ RSPACK_DEVSERVER_PORT=3232 meteor run
 ```
 
 The reason is that the Rspack dev server is handled by the Meteor so it can make both dev server works together, and the info of the port needs to be properly shared via the env.
+
+During development, the HMR dev server keeps most build assets in memory and only writes HTML files and `sw.js` to disk by default. This means if your build pipeline generates files that need to be served from the root path, like `service-worker.js`, `manifest.json`, or any other output that Meteor's web server should serve directly, you can extend `writeToDisk` in your `rspack.config.js`:
+
+```js
+const { defineConfig } = require('@meteorjs/rspack');
+
+module.exports = defineConfig(Meteor => ({
+  devServer: {
+    devMiddleware: {
+      writeToDisk: (filePath) =>
+        /\.(html)$/.test(filePath) || filePath.endsWith('service-worker.js'),
+    },
+  },
+}));
+```
+
+In production, all build outputs are written to disk normally, so this only affects local development.
 
 ### Disable Plugins
 


### PR DESCRIPTION
Context: https://github.com/meteor/examples/pull/42

This PR serves the standard `sw.js` name for service workers as part of Rspack. By default, Rspack ignores writing generated artifacts to `public` during HMR and development to keep performance faster and avoid overloading the git context. There are exceptions, such as when working with HTML files. This now adds an exception for common `sw.js` files as well. It also updates the docs to explain this and allows users to enable writing other generated files as part of the build pipeline.

I ran into the need to manually copy an auto-generated `sw.js` file into `public` while working on the new official Meteor `notes-offline` app, which showcases community offline packages and Rspack PWA support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Dev server now writes service worker and root HTML build outputs to disk during development, so build-generated service workers and root pages can be served without extra configuration.
* **Documentation**
  * Added guidance on development artifact handling and examples for configuring how service-worker and root outputs are emitted; clarified production behavior (all outputs written to disk).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->