### PR TITLE
[Rspack] Enable automatic CSS delegation to Rspack

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -86,10 +86,25 @@ jobs:
         run: ./meteor --get-ready
 
       - name: Run tests for ${{ matrix.category }}
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          retry_on: error
-          timeout_minutes: 15
-          retry_wait_seconds: 90
-          command: npm run test:e2e -- -t="${{ matrix.category }}"
+        id: test-run
+        continue-on-error: true
+        timeout-minutes: 15
+        run: npm run test:e2e -- -t="${{ matrix.category }}"
+
+      - name: Retry failed tests for ${{ matrix.category }} (attempt 2)
+        id: test-retry-1
+        if: steps.test-run.outcome == 'failure'
+        continue-on-error: true
+        timeout-minutes: 15
+        run: |
+          echo "::warning::First attempt failed, retrying..."
+          sleep 90
+          npm run test:e2e -- -t="${{ matrix.category }}"
+
+      - name: Retry failed tests for ${{ matrix.category }} (attempt 3)
+        if: steps.test-retry-1.outcome == 'failure'
+        timeout-minutes: 15
+        run: |
+          echo "::warning::Second attempt failed, retrying..."
+          sleep 90
+          npm run test:e2e -- -t="${{ matrix.category }}"

--- a/dev/modern-tools/rspack/E2E_COVERAGE.md
+++ b/dev/modern-tools/rspack/E2E_COVERAGE.md
@@ -54,7 +54,7 @@ Full-featured React Router app with custom packages, Less, and advanced rspack c
 | Compiler output cached in dev (babel.config.js) | Run |
 | 404 page routing (renders "Page Not Found") | Run, Prod |
 | Less stylesheet support (`white-space: break-spaces`) | Run, Prod |
-| Meteor modules config styles (`align-content: center`) | Run, Prod |
+| `meteor.modules` config styles (`align-content: center`) | Run, Prod |
 | Custom HTML meta tags (`theme-color`) | Run, Prod |
 | Default + custom package loading | Run |
 | `resolve.extensions` loading (`.jsx`) | Run |
@@ -132,12 +132,15 @@ CoffeeScript language support.
 
 ### vue
 
-Vue.js framework with Tailwind CSS.
+Vue.js framework with Tailwind CSS, CSS auto-delegation, and `meteor.modules` config.
 
 | What is covered | Phase |
 |----------------|-------|
 | Vue single-file components | All |
 | Tailwind CSS styles (`.p-8` padding) | Run, Prod |
+| CSS auto-delegation (`client/main.css` processed by Rspack, not Meteor) | All |
+| `meteor.modules` config preserves `client/meteor.css` for Meteor processing | All |
+| Rspack CSS + Meteor CSS coexistence in same entry folder | All |
 | HMR works in dev, disabled in prod | Run, Prod |
 
 ### solid
@@ -262,7 +265,7 @@ Where each feature is tested across apps and skeletons.
 | Static asset bundling | react-router, monorepo | |
 | Less styles | react-router | |
 | SCSS styles | typescript | |
-| Tailwind CSS | vue | tailwind |
+| Tailwind CSS | vue (PostCSS) | tailwind |
 | Image asset loading | react | |
 | 404 routing | react-router | |
 | Meta tags | react-router | |
@@ -278,6 +281,8 @@ Where each feature is tested across apps and skeletons.
 | Custom NODE_ENV compilation | babel | |
 | Portable build (no isDev/isProd defines) | typescript | |
 | `Meteor.extendSwcConfig` (path aliases) | typescript | |
+| CSS auto-delegation (entry folder filtering) | vue | |
+| `meteor.modules` config (preserve files for Meteor) | react-router, vue | |
 | `meteor reset` cleanup | all apps | all skeletons |
 | Skeleton creation | | all 14 skeletons |
 | Body style assertions | | react, tailwind (custom); most others (default) |

--- a/npm-packages/meteor-rspack/README.md
+++ b/npm-packages/meteor-rspack/README.md
@@ -14,6 +14,7 @@ When Meteor runs with the Rspack bundler enabled, this package is what generates
 - **Asset externals and HTML generation** through custom Rspack plugins
 - **A `defineConfig` helper** that accepts a factory function receiving Meteor environment flags and build utilities
 - **Customizable config** via `rspack.config.js` in your project root, with safe merging that warns if you try to override reserved settings
+- **Automatic CSS delegation** — when rspack is configured with CSS, Less, or SCSS loaders, Meteor automatically detects the handled extensions after the first compilation and stops processing those files itself. No `.meteorignore` entries needed.
 
 ## Installation
 

--- a/npm-packages/meteor-rspack/README.md
+++ b/npm-packages/meteor-rspack/README.md
@@ -14,7 +14,7 @@ When Meteor runs with the Rspack bundler enabled, this package is what generates
 - **Asset externals and HTML generation** through custom Rspack plugins
 - **A `defineConfig` helper** that accepts a factory function receiving Meteor environment flags and build utilities
 - **Customizable config** via `rspack.config.js` in your project root, with safe merging that warns if you try to override reserved settings
-- **Automatic CSS delegation** — when rspack is configured with CSS, Less, or SCSS loaders, Meteor automatically detects the handled extensions after the first compilation and stops processing those files itself. No `.meteorignore` entries needed.
+- **Automatic CSS delegation** when rspack is configured with CSS, Less, or SCSS loaders, Meteor automatically detects the handled extensions after the first compilation and stops processing those files itself in the entry folder context. No `.meteorignore` entries needed.
 
 ## Installation
 

--- a/npm-packages/meteor-rspack/plugins/MeteorRspackOutputPlugin.js
+++ b/npm-packages/meteor-rspack/plugins/MeteorRspackOutputPlugin.js
@@ -6,6 +6,40 @@
 
 const { outputMeteorRspack } = require('../lib/meteorRspackHelpers');
 
+/**
+ * Extracts file extensions that rspack is configured to handle
+ * from the resolved module.rules test patterns.
+ * Only returns extensions relevant for Meteor delegation (CSS-family).
+ * @param {import('@rspack/core').Compiler} compiler
+ * @returns {string[]} Array of extensions like ['.css', '.less', '.scss']
+ */
+function extractDelegatedExtensions(compiler) {
+  const delegatableExtensions = ['.css', '.less', '.scss', '.sass', '.styl'];
+  const found = new Set();
+
+  function inspectRules(rules) {
+    for (const rule of rules) {
+      if (!rule) continue;
+      if (rule.test) {
+        const testStr = rule.test instanceof RegExp
+          ? rule.test.source
+          : String(rule.test);
+        for (const ext of delegatableExtensions) {
+          const escaped = ext.replace('.', '\\.');
+          if (testStr.includes(escaped)) {
+            found.add(ext);
+          }
+        }
+      }
+      if (rule.oneOf) inspectRules(rule.oneOf);
+      if (rule.rules) inspectRules(rule.rules);
+    }
+  }
+
+  inspectRules(compiler.options.module?.rules || []);
+  return Array.from(found);
+}
+
 class MeteorRspackOutputPlugin {
   constructor(options = {}) {
     this.pluginName = 'MeteorRspackOutputPlugin';
@@ -26,6 +60,7 @@ class MeteorRspackOutputPlugin {
         ...(this.getData(stats, {
           compilationCount: this.compilationCount,
           isRebuild: this.compilationCount > 1,
+          compiler,
         }) || {}),
       };
       outputMeteorRspack(data);
@@ -33,4 +68,4 @@ class MeteorRspackOutputPlugin {
   }
 }
 
-module.exports = { MeteorRspackOutputPlugin };
+module.exports = { MeteorRspackOutputPlugin, extractDelegatedExtensions };

--- a/npm-packages/meteor-rspack/plugins/MeteorRspackOutputPlugin.js
+++ b/npm-packages/meteor-rspack/plugins/MeteorRspackOutputPlugin.js
@@ -40,11 +40,11 @@ function extractConfiguredExtensions(compiler) {
 }
 
 /**
- * Extracts file extensions that rspack both has rules for AND actually compiled.
- * An extension is only delegated if it appears in the config rules and at least
- * one file with that extension was part of the compilation dependency graph.
- * This prevents Meteor from ignoring files that Rspack is configured for but
- * never actually processes.
+ * Extracts file extensions that rspack both has rules for AND actually compiled
+ * from files within entry folder paths (e.g. client/, server/).
+ * An extension is only delegated if Rspack compiled a file with that extension
+ * from an entry folder. Files in non-entry folders (e.g. imports/) don't count,
+ * since delegation only ignores entry folder files for Meteor.
  * @param {import('@rspack/core').Stats} stats
  * @param {import('@rspack/core').Compiler} compiler
  * @returns {string[]} Array of extensions like ['.css', '.less', '.scss']
@@ -53,12 +53,39 @@ function extractDelegatedExtensions(stats, compiler) {
   const configured = extractConfiguredExtensions(compiler);
   if (configured.size === 0) return [];
 
-  const found = new Set();
   const path = require('path');
+  const fs = require('fs');
+  const appRoot = compiler.options.context || process.cwd();
+
+  // Read entry folders from package.json meteor.mainModule
+  const entryFolders = new Set();
+  try {
+    const pkgPath = path.join(appRoot, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const mainModule = pkg?.meteor?.mainModule || {};
+    for (const entry of Object.values(mainModule)) {
+      if (typeof entry === 'string') {
+        const folder = entry.split('/')[0];
+        if (folder) entryFolders.add(folder);
+      }
+    }
+  } catch (e) {
+    // If we can't read package.json, fall back to config-only
+    return Array.from(configured);
+  }
+
+  if (entryFolders.size === 0) return Array.from(configured);
+
+  const found = new Set();
 
   for (const module of stats.compilation.modules) {
     const resource = module.resource || module.userRequest;
     if (!resource) continue;
+
+    const relativePath = path.relative(appRoot, resource);
+    const topFolder = relativePath.split(path.sep)[0];
+    if (!entryFolders.has(topFolder)) continue;
+
     const ext = path.extname(resource);
     if (configured.has(ext)) {
       found.add(ext);

--- a/npm-packages/meteor-rspack/plugins/MeteorRspackOutputPlugin.js
+++ b/npm-packages/meteor-rspack/plugins/MeteorRspackOutputPlugin.js
@@ -9,11 +9,10 @@ const { outputMeteorRspack } = require('../lib/meteorRspackHelpers');
 /**
  * Extracts file extensions that rspack is configured to handle
  * from the resolved module.rules test patterns.
- * Only returns extensions relevant for Meteor delegation (CSS-family).
  * @param {import('@rspack/core').Compiler} compiler
- * @returns {string[]} Array of extensions like ['.css', '.less', '.scss']
+ * @returns {Set<string>} Set of extensions like .css, .less, .scss
  */
-function extractDelegatedExtensions(compiler) {
+function extractConfiguredExtensions(compiler) {
   const delegatableExtensions = ['.css', '.less', '.scss', '.sass', '.styl'];
   const found = new Set();
 
@@ -37,6 +36,36 @@ function extractDelegatedExtensions(compiler) {
   }
 
   inspectRules(compiler.options.module?.rules || []);
+  return found;
+}
+
+/**
+ * Extracts file extensions that rspack both has rules for AND actually compiled.
+ * An extension is only delegated if it appears in the config rules and at least
+ * one file with that extension was part of the compilation dependency graph.
+ * This prevents Meteor from ignoring files that Rspack is configured for but
+ * never actually processes.
+ * @param {import('@rspack/core').Stats} stats
+ * @param {import('@rspack/core').Compiler} compiler
+ * @returns {string[]} Array of extensions like ['.css', '.less', '.scss']
+ */
+function extractDelegatedExtensions(stats, compiler) {
+  const configured = extractConfiguredExtensions(compiler);
+  if (configured.size === 0) return [];
+
+  const found = new Set();
+  const path = require('path');
+
+  for (const module of stats.compilation.modules) {
+    const resource = module.resource || module.userRequest;
+    if (!resource) continue;
+    const ext = path.extname(resource);
+    if (configured.has(ext)) {
+      found.add(ext);
+      if (found.size === configured.size) break;
+    }
+  }
+
   return Array.from(found);
 }
 

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -854,7 +854,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       compilationCount,
       isRebuild,
       ...(!isRebuild && compiler && {
-        delegatedExtensions: extractDelegatedExtensions(compiler),
+        delegatedExtensions: extractDelegatedExtensions(stats, compiler),
       }),
     }),
   });

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -10,7 +10,7 @@ const { getMeteorAppSwcConfig } = require('./lib/swc.js');
 const HtmlRspackPlugin = require('./plugins/HtmlRspackPlugin.js');
 const { RequireExternalsPlugin } = require('./plugins/RequireExtenalsPlugin.js');
 const { AssetExternalsPlugin } = require('./plugins/AssetExternalsPlugin.js');
-const { MeteorRspackOutputPlugin } = require('./plugins/MeteorRspackOutputPlugin.js');
+const { MeteorRspackOutputPlugin, extractDelegatedExtensions } = require('./plugins/MeteorRspackOutputPlugin.js');
 const { generateEagerTestFile } = require("./lib/test.js");
 const { getMeteorIgnoreEntries, createIgnoreGlobConfig } = require("./lib/ignore");
 const {
@@ -843,7 +843,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
 
   // Add MeteorRspackOutputPlugin as the last plugin to output compilation info
   const meteorRspackOutputPlugin = new MeteorRspackOutputPlugin({
-    getData: (stats, { isRebuild, compilationCount }) => ({
+    getData: (stats, { isRebuild, compilationCount, compiler }) => ({
       name: config.name,
       mode: config.mode,
       hasErrors: stats.hasErrors(),
@@ -852,6 +852,9 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       statsOverrided,
       compilationCount,
       isRebuild,
+      ...(!isRebuild && compiler && {
+        delegatedExtensions: extractDelegatedExtensions(compiler),
+      }),
     }),
   });
   config.plugins = [meteorRspackOutputPlugin, ...(config.plugins || [])];

--- a/packages/rspack/lib/compilation.js
+++ b/packages/rspack/lib/compilation.js
@@ -16,6 +16,8 @@ const {
   setGlobalState
 } = require('meteor/tools-core/lib/global-state');
 
+const { applyDelegatedExtensions } = require('./config');
+
 // Helper function to format milliseconds with comma separators
 function formatMilliseconds(ms) {
   return ms.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -124,10 +126,15 @@ export function setupCompilationTracking() {
   };
 
   // Define separate onCompile callbacks for client and server
-  const onCompileClient = (data) => {
+  const onCompileClient = (data, config) => {
     // Resolve the promise if it's the first compilation
     const clientState = getGlobalState(GLOBAL_STATE_KEYS.CLIENT_FIRST_COMPILE, clientFirstCompile);
     if (!clientState?.resolved) {
+      // Apply delegated extensions before resolving (so they're set before Meteor scans)
+      if (config?.delegatedExtensions?.length > 0) {
+        applyDelegatedExtensions(config.delegatedExtensions);
+      }
+
       clientState.resolved = true;
       clientState.resolve();
       setGlobalState(GLOBAL_STATE_KEYS.CLIENT_FIRST_COMPILE, clientState);

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -386,3 +386,42 @@ export function configureMeteorForRspack() {
     }
   }
 }
+
+/**
+ * Applies delegated extension ignore patterns for entry folder files.
+ * Called after rspack's first compilation reports which extensions it handles.
+ * Since Meteor awaits rspack compilation before scanning files, these patterns
+ * are in place before Meteor processes any application files.
+ *
+ * Uses gitignore semantics: a later positive pattern (client/*.css) overrides
+ * an earlier negation (!client/*.css) that was set in configureMeteorForRspack.
+ *
+ * @param {string[]} extensions - Array of extensions like ['.css', '.less']
+ */
+export function applyDelegatedExtensions(extensions) {
+  if (!extensions || extensions.length === 0) return;
+
+  const initialEntrypoints = getInitialEntrypoints();
+  const entrypointContexts = [
+    initialEntrypoints.mainClient,
+    initialEntrypoints.mainServer,
+  ]
+    .filter(Boolean)
+    .map(entrypoint => path.dirname(entrypoint));
+
+  const ignorePatterns = [];
+  for (const dir of entrypointContexts) {
+    for (const ext of extensions) {
+      // ext comes as '.css', glob needs '*.css'
+      ignorePatterns.push(`${dir}/*${ext}`);
+    }
+  }
+
+  if (ignorePatterns.length > 0) {
+    setMeteorAppIgnore(ignorePatterns.join(' '));
+
+    if (isMeteorAppDebug() || isMeteorAppConfigModernVerbose()) {
+      logInfo(`[i] Rspack delegated extensions: ${extensions.join(', ')} (ignored in entry folders)`);
+    }
+  }
+}

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -418,7 +418,17 @@ export function applyDelegatedExtensions(extensions) {
   }
 
   if (ignorePatterns.length > 0) {
-    setMeteorAppIgnore(ignorePatterns.join(' '));
+    // Re-append meteor.modules unignore patterns after the delegation ignores
+    // so they take precedence (gitignore semantics: last match wins)
+    const meteorAppConfig = getMeteorAppConfig();
+    const unignoredFilesAndFolders = buildUnignorePatterns(
+      meteorAppConfig?.modules || [],
+      { skipLevel: 1 },
+    );
+
+    setMeteorAppIgnore(
+      [...ignorePatterns, ...unignoredFilesAndFolders].join(' ')
+    );
 
     if (isMeteorAppDebug() || isMeteorAppConfigModernVerbose()) {
       logInfo(`[i] Rspack delegated extensions: ${extensions.join(', ')} (ignored in entry folders)\n    ${process.env.METEOR_IGNORE}`);

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -421,7 +421,7 @@ export function applyDelegatedExtensions(extensions) {
     setMeteorAppIgnore(ignorePatterns.join(' '));
 
     if (isMeteorAppDebug() || isMeteorAppConfigModernVerbose()) {
-      logInfo(`[i] Rspack delegated extensions: ${extensions.join(', ')} (ignored in entry folders)`);
+      logInfo(`[i] Rspack delegated extensions: ${extensions.join(', ')} (ignored in entry folders)\n    ${process.env.METEOR_IGNORE}`);
     }
   }
 }

--- a/tools/e2e-tests/apps/vue/.meteorignore
+++ b/tools/e2e-tests/apps/vue/.meteorignore
@@ -1,2 +1,0 @@
-# Ignore client/main.css file so that is processed by Rspack import
-client/main.css

--- a/tools/e2e-tests/apps/vue/package.json
+++ b/tools/e2e-tests/apps/vue/package.json
@@ -34,6 +34,7 @@
       "client": "client/main.js",
       "server": "server/main.js"
     },
+    "modules": ["client/meteor.css"],
     "testModule": "tests/main.js"
   }
 }

--- a/tools/e2e-tests/jest.config.js
+++ b/tools/e2e-tests/jest.config.js
@@ -30,4 +30,8 @@ module.exports = {
     }
   },
   maxWorkers: 1,
+  reporters: [
+    'default',
+    '<rootDir>/summary-reporter.js',
+  ],
 };

--- a/tools/e2e-tests/jest.setup.js
+++ b/tools/e2e-tests/jest.setup.js
@@ -1,12 +1,6 @@
 // jest.setup.js
 import chalk from 'chalk';
 
-const isCI = process.env.GITHUB_ACTIONS === "true";
-if (isCI) {
-  jest.retryTimes(2);
-  console.log('Set 2 retries on Jest level');
-}
-
 // Clear NODE_ENV so meteor commands don't inherit any value from the test runner environment
 process.env.NODE_ENV = '';
 

--- a/tools/e2e-tests/summary-reporter.js
+++ b/tools/e2e-tests/summary-reporter.js
@@ -1,0 +1,95 @@
+/**
+ * Custom Jest reporter that prints a structured summary of all test results,
+ * including detailed error logs for failures.
+ */
+class SummaryReporter {
+  constructor(globalConfig) {
+    this._globalConfig = globalConfig;
+  }
+
+  onRunComplete(_contexts, results) {
+    const passed = [];
+    const failed = [];
+    const skipped = [];
+
+    for (const suite of results.testResults) {
+      for (const test of suite.testResults) {
+        const entry = {
+          name: test.fullName || test.title,
+          suite: suite.testFilePath.replace(this._globalConfig.rootDir + '/', ''),
+          duration: test.duration,
+          status: test.status,
+        };
+
+        if (test.status === 'passed') {
+          passed.push(entry);
+        } else if (test.status === 'failed') {
+          entry.errors = test.failureMessages || [];
+          failed.push(entry);
+        } else {
+          skipped.push(entry);
+        }
+      }
+    }
+
+    this._printConsole(passed, failed, skipped);
+  }
+
+  _printConsole(passed, failed, skipped) {
+    const divider = '═'.repeat(70);
+    const thinDivider = '─'.repeat(70);
+
+    console.log('\n' + divider);
+    console.log('  E2E TEST SUMMARY');
+    console.log(divider);
+
+    if (passed.length > 0) {
+      console.log(`\n  PASSED (${passed.length}):`);
+      console.log(thinDivider);
+      for (const t of passed) {
+        const duration = t.duration ? ` (${(t.duration / 1000).toFixed(1)}s)` : '';
+        console.log(`    [PASS] ${t.name}${duration}`);
+      }
+    }
+
+    if (skipped.length > 0) {
+      console.log(`\n  SKIPPED (${skipped.length}):`);
+      console.log(thinDivider);
+      for (const t of skipped) {
+        console.log(`    [SKIP] ${t.name}`);
+      }
+    }
+
+    if (failed.length > 0) {
+      console.log(`\n  FAILED (${failed.length}):`);
+      console.log(thinDivider);
+      for (const t of failed) {
+        const duration = t.duration ? ` (${(t.duration / 1000).toFixed(1)}s)` : '';
+        console.log(`\n    [FAIL] ${t.name}${duration}`);
+        console.log(`           Suite: ${t.suite}`);
+        for (const err of t.errors) {
+          const indented = err
+            .split('\n')
+            .map(line => `           ${line}`)
+            .join('\n');
+          console.log(indented);
+        }
+      }
+    }
+
+    const totalTime = [...passed, ...failed, ...skipped]
+      .reduce((sum, t) => sum + (t.duration || 0), 0);
+
+    console.log('\n' + divider);
+    console.log(
+      `  TOTAL: ${passed.length + failed.length + skipped.length} | ` +
+      `PASSED: ${passed.length} | ` +
+      `FAILED: ${failed.length} | ` +
+      `SKIPPED: ${skipped.length} | ` +
+      `TIME: ${(totalTime / 1000).toFixed(1)}s`
+    );
+    console.log(divider + '\n');
+  }
+}
+
+module.exports = SummaryReporter;

--- a/tools/e2e-tests/summary-reporter.js
+++ b/tools/e2e-tests/summary-reporter.js
@@ -57,7 +57,7 @@ class SummaryReporter {
       }
     }
 
-    if (skipped.length > 0) {
+    if (skipped.length > 0 && process.env.E2E_SHOW_SKIPPED) {
       console.log(chalk.yellow(`\n  SKIPPED (${skipped.length}):`));
       console.log(thinDivider);
       for (const t of skipped) {

--- a/tools/e2e-tests/summary-reporter.js
+++ b/tools/e2e-tests/summary-reporter.js
@@ -1,3 +1,5 @@
+const chalk = require('chalk');
+
 /**
  * Custom Jest reporter that prints a structured summary of all test results,
  * including detailed error logs for failures.
@@ -36,41 +38,44 @@ class SummaryReporter {
   }
 
   _printConsole(passed, failed, skipped) {
-    const divider = '═'.repeat(70);
-    const thinDivider = '─'.repeat(70);
+    const hasFails = failed.length > 0;
+    const divider = chalk.dim('═'.repeat(70));
+    const thinDivider = chalk.dim('─'.repeat(70));
 
     console.log('\n' + divider);
-    console.log('  E2E TEST SUMMARY');
+    console.log(hasFails
+      ? chalk.bold.red('  E2E TEST SUMMARY')
+      : chalk.bold.green('  E2E TEST SUMMARY'));
     console.log(divider);
 
     if (passed.length > 0) {
-      console.log(`\n  PASSED (${passed.length}):`);
+      console.log(chalk.green(`\n  PASSED (${passed.length}):`));
       console.log(thinDivider);
       for (const t of passed) {
-        const duration = t.duration ? ` (${(t.duration / 1000).toFixed(1)}s)` : '';
-        console.log(`    [PASS] ${t.name}${duration}`);
+        const duration = t.duration ? chalk.dim(` (${(t.duration / 1000).toFixed(1)}s)`) : '';
+        console.log(`    ${chalk.green('✓')} ${t.name}${duration}`);
       }
     }
 
     if (skipped.length > 0) {
-      console.log(`\n  SKIPPED (${skipped.length}):`);
+      console.log(chalk.yellow(`\n  SKIPPED (${skipped.length}):`));
       console.log(thinDivider);
       for (const t of skipped) {
-        console.log(`    [SKIP] ${t.name}`);
+        console.log(`    ${chalk.yellow('○')} ${chalk.dim(t.name)}`);
       }
     }
 
     if (failed.length > 0) {
-      console.log(`\n  FAILED (${failed.length}):`);
+      console.log(chalk.red(`\n  FAILED (${failed.length}):`));
       console.log(thinDivider);
       for (const t of failed) {
-        const duration = t.duration ? ` (${(t.duration / 1000).toFixed(1)}s)` : '';
-        console.log(`\n    [FAIL] ${t.name}${duration}`);
-        console.log(`           Suite: ${t.suite}`);
+        const duration = t.duration ? chalk.dim(` (${(t.duration / 1000).toFixed(1)}s)`) : '';
+        console.log(`\n    ${chalk.red('✕')} ${chalk.bold(t.name)}${duration}`);
+        console.log(`      ${chalk.dim('Suite:')} ${chalk.dim(t.suite)}`);
         for (const err of t.errors) {
           const indented = err
             .split('\n')
-            .map(line => `           ${line}`)
+            .map(line => `      ${chalk.red(line)}`)
             .join('\n');
           console.log(indented);
         }
@@ -82,11 +87,11 @@ class SummaryReporter {
 
     console.log('\n' + divider);
     console.log(
-      `  TOTAL: ${passed.length + failed.length + skipped.length} | ` +
-      `PASSED: ${passed.length} | ` +
-      `FAILED: ${failed.length} | ` +
-      `SKIPPED: ${skipped.length} | ` +
-      `TIME: ${(totalTime / 1000).toFixed(1)}s`
+      `  ${chalk.bold('TOTAL:')} ${passed.length + failed.length + skipped.length} ${chalk.dim('|')} ` +
+      `${chalk.green('PASSED:')} ${chalk.green(passed.length)} ${chalk.dim('|')} ` +
+      `${chalk.red('FAILED:')} ${chalk.red(failed.length)} ${chalk.dim('|')} ` +
+      `${chalk.yellow('SKIPPED:')} ${chalk.yellow(skipped.length)} ${chalk.dim('|')} ` +
+      `${chalk.dim('TIME:')} ${chalk.dim((totalTime / 1000).toFixed(1) + 's')}`
     );
     console.log(divider + '\n');
   }

--- a/tools/static-assets/skel-tailwind/.meteorignore
+++ b/tools/static-assets/skel-tailwind/.meteorignore
@@ -1,2 +1,0 @@
-# Ignore Meteor CSS handling; let Rspack resolve Tailwind styles
-client/main.css

--- a/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
+++ b/v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md
@@ -229,7 +229,7 @@ Ensure your app defines these entry files with the correct paths where each modu
 
 Defining entry points improves performance even with the Meteor bundler, as Meteor stops scanning and eagerly loading unnecessary files. For Meteor-Rspack integration, this is required, since it does not support automatic code discovery for efficiency.
 
-In Meteor-Rspack integration, all app code is ignored by Meteor and handled by Rspack. By default, Meteor still processes eagerly CSS and HTML files in the entry folder (e.g. `client/*.[html|css]` in most apps).
+In Meteor-Rspack integration, all app code is ignored by Meteor and handled by Rspack. By default, Meteor still processes eagerly HTML files in the entry folder (e.g. `client/*.html` in most apps). CSS files in the entry folder are automatically delegated to Rspack when a CSS loader is configured, see [CSS](#css) for details. If no CSS loader is present, Meteor handles them as before.
 
 If you need Meteor to handle CSS or HTML files outside the main entry folder, add them to the `modules` field. This field accepts an array of strings, each pointing to a file or folder.
 
@@ -421,6 +421,8 @@ With the Meteor–Rspack integration, `zodern:melte` no longer works. Use the of
 ### CSS
 
 Meteor-Rspack comes with built-in CSS support. You can import any CSS file into your code, and it will be processed and included in your HTML skeleton automatically. In addition, any CSS file placed in the same folder as your Meteor entry point will be processed and added as global styles without the need for explicit imports.
+
+When Rspack is configured with a CSS rule, whether through `postcss-loader`, `type: "css"`, or any other CSS-handling loader, Meteor automatically detects the handled file extensions after Rspack's first compilation and stops processing those files itself. This means you do not need to manually add CSS files to `.meteorignore` or otherwise tell Meteor to skip them. The same automatic delegation applies to Less and SCSS when their respective loaders are configured. If no CSS rule is present in the rspack configuration, Meteor continues to handle stylesheets as it normally would.
 
 ### CSS Modules
 


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/issues/14119

This PR improves the Meteor-Rspack integration to ensure that style files within the entry folders gets delegated automatically to Rspack if a Rspack loader rule is specified by the user. This will make not neccesary to manually ignore it on the `.meteorignore` file.