### PR TITLE
fix: replace `declare module` with `declare namespace` in .d.ts files

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -666,7 +666,7 @@ export namespace Mongo {
   }
 }
 
-export declare module MongoInternals {
+export declare namespace MongoInternals {
   interface MongoConnection {
     db: NpmModuleMongodb.Db;
     client: NpmModuleMongodb.MongoClient;

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -22,7 +22,7 @@ type ExpressModule = {
   urlencoded: typeof express.urlencoded;
 };
 
-export declare module WebApp {
+export declare namespace WebApp {
   var defaultArch: string;
   var clientPrograms: {
     [key: string]: {
@@ -69,7 +69,7 @@ export declare module WebApp {
   function addHtmlAttributeHook(hook: Function): void;
 }
 
-export declare module WebAppInternals {
+export declare namespace WebAppInternals {
   var NpmModules: {
     [key: string]: {
       version: string;


### PR DESCRIPTION
## Summary

- Replaces `export declare module` with `export declare namespace` in `packages/mongo/mongo.d.ts` and `packages/webapp/webapp.d.ts`
- Fixes TypeScript 6 [TS1540](https://github.com/microsoft/TypeScript/issues/51839) errors for `MongoInternals`, `WebApp`, and `WebAppInternals` declarations
- No runtime or behavioral change — `declare module X {}` (without quotes) and `declare namespace X {}` are semantically identical; TS6 simply enforces the modern keyword

Fixes #14253

## Test plan

- [ ] Verify `tsc --noEmit` passes with TypeScript 6 (`npm install typescript@next`)
- [ ] Verify existing TypeScript compilation still works with TypeScript 5.x
- [ ] Run `./meteor test-packages ./packages/mongo` and `./meteor test-packages ./packages/webapp`