### PR TITLE
refactor(sha/accounts): Replace hand-rolled SHA-256 with native crypto APIs

### DIFF
--- a/packages/accounts-password/password_argon_tests.js
+++ b/packages/accounts-password/password_argon_tests.js
@@ -136,9 +136,9 @@ if (Meteor.isServer) {
         const hash = user?.services?.password?.argon2;
         return Accounts._getArgon2Params(hash);
     }
-    const hashPasswordWithSha = function (password) {
+    const hashPasswordWithSha = async function (password) {
         return {
-            digest: SHA256(password),
+            digest: await SHA256(password),
             algorithm: "sha-256"
         };
     }
@@ -149,7 +149,7 @@ if (Meteor.isServer) {
             // Verify that a argon2 hash generated for a new account uses the
             // default params.
             let username = Random.id();
-            this.password = hashPasswordWithSha("abc123");
+            this.password = await hashPasswordWithSha("abc123");
             this.userId1 = await Accounts.createUserAsync({ username, password: this.password });
             this.user1 = await Meteor.users.findOneAsync(this.userId1);
             let argon2Params = getUserHashArgon2Params(this.user1);

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -7,15 +7,16 @@ const reportError = (error, callback) => {
    }
 };
 
-const internalLoginWithPassword = ({ selector, password, code, callback }) => {
+const internalLoginWithPassword = async ({ selector, password, code, callback }) => {
   if (typeof selector === 'string')
     if (!selector.includes('@')) selector = { username: selector };
     else selector = { email: selector };
+  const hashedPassword = await Accounts._hashPassword(password);
   Accounts.callLoginMethod({
     methodArguments: [
       {
         user: selector,
-        password: Accounts._hashPassword(password),
+        password: hashedPassword,
         code,
       },
     ],
@@ -57,8 +58,8 @@ Meteor.loginWithPassword = (selector, password, callback) => {
   return internalLoginWithPassword({ selector, password, callback });
 };
 
-Accounts._hashPassword = password => ({
-  digest: SHA256(password),
+Accounts._hashPassword = async (password) => ({
+  digest: await SHA256(password),
   algorithm: "sha-256"
 });
 
@@ -102,7 +103,7 @@ Meteor.loginWithPasswordAnd2faCode = (selector, password, code, callback) => {
  * @param {Function} [callback] Client only, optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  * @importFromPackage accounts-base
  */
-Accounts.createUser = (options, callback) => {
+Accounts.createUser = async (options, callback) => {
   options = { ...options }; // we'll be modifying options
 
   if (typeof options.password !== 'string')
@@ -112,7 +113,7 @@ Accounts.createUser = (options, callback) => {
   }
 
   // Replace password with the hashed password.
-  options.password = Accounts._hashPassword(options.password);
+  options.password = await Accounts._hashPassword(options.password);
 
   Accounts.callLoginMethod({
     methodName: 'createUser',
@@ -160,7 +161,7 @@ Accounts.createUserAsync = (options) => {
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  * @importFromPackage accounts-base
  */
-Accounts.changePassword = (oldPassword, newPassword, callback) => {
+Accounts.changePassword = async (oldPassword, newPassword, callback) => {
   if (!Meteor.user()) {
     return reportError(new Error("Must be logged in to change password."), callback);
   }
@@ -173,10 +174,12 @@ Accounts.changePassword = (oldPassword, newPassword, callback) => {
     return reportError(new Meteor.Error(400, "Password may not be empty"), callback);
   }
 
+  const oldHash = oldPassword ? await Accounts._hashPassword(oldPassword) : null;
+  const newHash = await Accounts._hashPassword(newPassword);
+
   Accounts.connection.apply(
     'changePassword',
-    [oldPassword ? Accounts._hashPassword(oldPassword) : null,
-     Accounts._hashPassword(newPassword)],
+    [oldHash, newHash],
     (error, result) => {
     if (error || !result) {
         // A normal error, not an error telling us to upgrade to bcrypt
@@ -231,7 +234,7 @@ Accounts.forgotPassword = (options, callback) => {
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  * @importFromPackage accounts-base
  */
-Accounts.resetPassword = (token, newPassword, callback) => {
+Accounts.resetPassword = async (token, newPassword, callback) => {
   if (!(typeof token === "string" || token instanceof String)) {
     return reportError(new Meteor.Error(400, "Token must be a string"), callback);
   }
@@ -244,9 +247,10 @@ Accounts.resetPassword = (token, newPassword, callback) => {
     return reportError(new Meteor.Error(400, "Password may not be empty"), callback);
   }
 
+  const hashedPassword = await Accounts._hashPassword(newPassword);
   Accounts.callLoginMethod({
     methodName: 'resetPassword',
-    methodArguments: [token, Accounts._hashPassword(newPassword)],
+    methodArguments: [token, hashedPassword],
     userCallback: callback});
 };
 

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -52,9 +52,9 @@ Accounts._argon2Parallelism = () => Accounts._options.argon2Parallelism || 1;
  *
  * @throws {Error} - If the `algorithm` in the password object is not "sha-256".
  */
-const getPasswordString = password => {
+const getPasswordString = async (password) => {
   if (typeof password === "string") {
-    password = SHA256(password);
+    password = await SHA256(password);
   }
   else { // 'password' is an object
     if (password.algorithm !== "sha-256") {
@@ -72,7 +72,7 @@ const getPasswordString = password => {
  * @returns {Promise<string>} The encrypted password.
  */
 const hashPassword = async (password) => {
-  password = getPasswordString(password);
+  password = await getPasswordString(password);
   if (Accounts._argon2Enabled() === true) {
     return await argon2.hash(password, {
       type: Accounts._argon2Type(),

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -10,9 +10,9 @@ const makeTestConnAsync =
     })
 const simplePollAsync = (fn) =>
   new Promise((resolve, reject) => simplePoll(fn,resolve,reject))
-function hashPasswordWithSha(password) {
+async function hashPasswordWithSha(password) {
   return {
-    digest: SHA256(password),
+    digest: await SHA256(password),
     algorithm: "sha-256"
   };
 }
@@ -489,7 +489,7 @@ if (Meteor.isClient) (() => {
     function (test, expect) {
       this.secondConn = DDP.connect(Meteor.absoluteUrl());
       this.secondConn.call('login',
-        { user: { username: this.username }, password: hashPasswordWithSha(this.password) },
+        { user: { username: this.username }, password: await hashPasswordWithSha(this.password) },
         expect((err, result) => {
           test.isFalse(err);
           this.secondConn.setUserId(result.id);
@@ -1233,7 +1233,7 @@ if (Meteor.isServer) (() => {
       const username = Random.id();
       const id = await Accounts.createUser({
         username: username,
-        password: hashPasswordWithSha('password')
+        password: await hashPasswordWithSha('password')
       });
 
       const {
@@ -1248,7 +1248,7 @@ if (Meteor.isServer) (() => {
 
       const result = await clientConn.callAsync('login', {
         user: { username: username },
-        password: hashPasswordWithSha('password')
+        password: await hashPasswordWithSha('password')
       });
 
       test.isTrue(result);
@@ -1281,7 +1281,7 @@ if (Meteor.isServer) (() => {
       const userId = await Accounts.createUser({
         username: username,
         email: email,
-        password: hashPasswordWithSha("old-password")
+        password: await hashPasswordWithSha("old-password")
       });
       const user = await Meteor.users.findOneAsync(userId);
 
@@ -1300,7 +1300,7 @@ if (Meteor.isServer) (() => {
 
       await test.throwsAsync(
         async () =>
-          await Meteor.callAsync("resetPassword", resetPasswordToken, hashPasswordWithSha("new-password")),
+          await Meteor.callAsync("resetPassword", resetPasswordToken, await hashPasswordWithSha("new-password")),
         /Token has invalid email address/
       );
       Accounts._options.ambiguousErrorMessages = true;
@@ -1310,7 +1310,7 @@ if (Meteor.isServer) (() => {
             "login",
             {
               user: { username: username },
-              password: hashPasswordWithSha("new-password")
+              password: await hashPasswordWithSha("new-password")
             }
           ),
         /Something went wrong. Please check your credentials./);
@@ -1325,7 +1325,7 @@ if (Meteor.isServer) (() => {
       const userId = await Accounts.createUser({
         username: username,
         email: email,
-        password: hashPasswordWithSha("old-password")
+        password: await hashPasswordWithSha("old-password")
       });
 
       const user = await Meteor.users.findOneAsync(userId);
@@ -1342,11 +1342,11 @@ if (Meteor.isServer) (() => {
       test.isTrue(await clientConn.callAsync(
         "resetPassword",
         resetPasswordToken,
-        hashPasswordWithSha("new-password")
+        await hashPasswordWithSha("new-password")
       ));
       test.isTrue(await clientConn.callAsync("login", {
         user: { username },
-        password: hashPasswordWithSha("new-password")
+        password: await hashPasswordWithSha("new-password")
       }));
     });
 
@@ -1359,7 +1359,7 @@ if (Meteor.isServer) (() => {
       const userId = await Accounts.createUser({
         username: username,
         email: email,
-        password: hashPasswordWithSha("old-password")
+        password: await hashPasswordWithSha("old-password")
       });
 
       const user = await Meteor.users.findOneAsync(userId);
@@ -1377,7 +1377,7 @@ if (Meteor.isServer) (() => {
       await Meteor.users.updateAsync(userId, { $set: { "services.password.reset.when": new Date(Date.now() + -5 * 24 * 3600 * 1000) } });
 
       try {
-        await Meteor.callAsync("resetPassword", resetPasswordToken, hashPasswordWithSha("new-password"))
+        await Meteor.callAsync("resetPassword", resetPasswordToken, await hashPasswordWithSha("new-password"))
       } catch (e) {
         test.throws(() => {
           throw e;
@@ -1390,7 +1390,7 @@ if (Meteor.isServer) (() => {
           "login",
           {
             user: { username: username },
-            password: hashPasswordWithSha("new-password")
+            password: await hashPasswordWithSha("new-password")
           }
         ),
         /Something went wrong. Please check your credentials./);
@@ -1410,7 +1410,7 @@ if (Meteor.isServer) (() => {
         {
           username: username,
           email: email,
-          password: hashPasswordWithSha(password)
+          password: await hashPasswordWithSha(password)
         },
       );
 
@@ -1437,7 +1437,7 @@ if (Meteor.isServer) (() => {
         await Accounts.createUser(
           {
             email: email,
-            password: hashPasswordWithSha('password')
+            password: await hashPasswordWithSha('password')
           }
         );
       await Accounts.sendResetPasswordEmail(userId, email);
@@ -1457,7 +1457,7 @@ if (Meteor.isServer) (() => {
         await Accounts.createUser(
           {
             email: email,
-            password: hashPasswordWithSha('password')
+            password: await hashPasswordWithSha('password')
           }
         );
       await Accounts.sendResetPasswordEmail(userId, email);
@@ -1503,12 +1503,12 @@ if (Meteor.isServer) (() => {
         await clientConn.callAsync(
           "resetPassword",
           enrollPasswordToken,
-          hashPasswordWithSha("new-password"))
+          await hashPasswordWithSha("new-password"))
       );
       test.isTrue(
         await clientConn.callAsync("login", {
           user: { username },
-          password: hashPasswordWithSha("new-password")
+          password: await hashPasswordWithSha("new-password")
         })
       );
 
@@ -1540,7 +1540,7 @@ if (Meteor.isServer) (() => {
       await Meteor.users.updateAsync(userId, { $set: { "services.password.enroll.when": new Date(Date.now() + -35 * 24 * 3600 * 1000) } });
 
       await test.throwsAsync(
-        async () => await Meteor.callAsync("resetPassword", enrollPasswordToken, hashPasswordWithSha("new-password")),
+        async () => await Meteor.callAsync("resetPassword", enrollPasswordToken, await hashPasswordWithSha("new-password")),
         /Token expired/
       );
     });
@@ -1549,7 +1549,7 @@ if (Meteor.isServer) (() => {
     async test => {
       const email = `${ test.id }-intercept@example.com`;
       const userId =
-        await Accounts.createUser({ email: email, password: hashPasswordWithSha('password') });
+        await Accounts.createUser({ email: email, password: await hashPasswordWithSha('password') });
 
       await Accounts.sendEnrollmentEmail(userId, email);
       const user1 = await Meteor.users.findOneAsync(userId);
@@ -1566,7 +1566,7 @@ if (Meteor.isServer) (() => {
       const userId =
         await Accounts.createUser({
           email: email,
-          password: hashPasswordWithSha('password')
+          password: await hashPasswordWithSha('password')
         });
 
       await Accounts.sendEnrollmentEmail(userId, email);
@@ -1585,7 +1585,7 @@ if (Meteor.isServer) (() => {
     async test => {
       const email = `${ test.id }-intercept@example.com`;
       const userId =
-        await Accounts.createUser({ email: email, password: hashPasswordWithSha('password') });
+        await Accounts.createUser({ email: email, password: await hashPasswordWithSha('password') });
 
       await Accounts.sendResetPasswordEmail(userId, email);
       const user1 = await Meteor.users.findOneAsync(userId);
@@ -1857,7 +1857,7 @@ Tinytest.addAsync("accounts emails - replace email", async test => {
     async function (test) {
       // Verify that a bcrypt hash generated for a new account uses the
       let username = Random.id();
-      this.password = hashPasswordWithSha('abc123');
+      this.password = await hashPasswordWithSha('abc123');
       this.userId1 = await Accounts.createUser({ username, password: this.password });
       this.user1 =  await Meteor.users.findOneAsync(this.userId1);
       let rounds = getUserHashRounds(this.user1);

--- a/packages/accounts-passwordless/passwordless_server.js
+++ b/packages/accounts-passwordless/passwordless_server.js
@@ -50,7 +50,7 @@ Accounts.registerLoginHandler('passwordless', async options => {
     Accounts._handleError('User has no token set');
   }
 
-  const result = checkToken({
+  const result = await checkToken({
     user,
     selector,
     sequence,
@@ -171,15 +171,20 @@ Meteor.methods({
       Accounts._handleError(`Login tokens could not be generated`);
     }
 
+    const mainToken = await SHA256(user._id + userSequence);
+    const hashedTokens = await Promise.all(
+      tokens.map(async ({ email, sequence }) => ({
+        email,
+        token: await SHA256(email + sequence),
+      }))
+    );
+
     await Meteor.users.updateAsync(user._id, {
       $set: {
         'services.passwordless': {
           createdAt: new Date(),
-          token: SHA256(user._id + userSequence),
-          tokens: tokens.map(({ email, sequence }) => ({
-            email,
-            token: SHA256(email + sequence),
-          })),
+          token: mainToken,
+          tokens: hashedTokens,
           ...(isNewUser ? { isNewUser } : {}),
         },
       },

--- a/packages/accounts-passwordless/server_tests.js
+++ b/packages/accounts-passwordless/server_tests.js
@@ -4,12 +4,12 @@ import { SHA256 } from 'meteor/sha';
 
 const USER_TOKEN = '123ABC';
 
-const getData = ({ createdAt }) => {
+const getData = async ({ createdAt }) => {
   const userId = Random.id();
   const email = `${userId}@meteorapp.com`;
 
-  const idToken = SHA256(userId + USER_TOKEN);
-  const emailToken = SHA256(email + USER_TOKEN);
+  const idToken = await SHA256(userId + USER_TOKEN);
+  const emailToken = await SHA256(email + USER_TOKEN);
 
   const user = {
     _id: userId,
@@ -27,13 +27,13 @@ const getData = ({ createdAt }) => {
   };
 };
 
-Tinytest.add('passwordless - time expired', test => {
+Tinytest.addAsync('passwordless - time expired', async (test) => {
   const createdAt = new Date('July 17, 2022 13:00:00');
   const currentDate = new Date('July 17, 2022 14:01:00');
 
-  const { user } = getData({ createdAt });
+  const { user } = await getData({ createdAt });
 
-  const result = checkToken({
+  const result = await checkToken({
     user,
     sequence: USER_TOKEN,
     selector: { email: user.email },
@@ -44,14 +44,14 @@ Tinytest.add('passwordless - time expired', test => {
   test.equal(result.error.reason, 'Expired token');
 });
 
-Tinytest.add('passwordless - Email and token mismatch', test => {
+Tinytest.addAsync('passwordless - Email and token mismatch', async (test) => {
   const createdAt = new Date('July 17, 2022 13:00:00');
   const currentDate = new Date('July 17, 2022 13:05:00');
 
-  const { user } = getData({ createdAt });
+  const { user } = await getData({ createdAt });
 
   // Email mismatch
-  const resultEmail = checkToken({
+  const resultEmail = await checkToken({
     user,
     sequence: USER_TOKEN,
     selector: { email: 'invalid@email.com' },
@@ -61,7 +61,7 @@ Tinytest.add('passwordless - Email and token mismatch', test => {
   test.isTrue(!!resultEmail.error);
   test.equal(resultEmail.error.reason, 'Email or token mismatch');
   // Token mismatch
-  const resultToken = checkToken({
+  const resultToken = await checkToken({
     user,
     sequence: 'ABC321',
     selector: { email: user.email },
@@ -72,13 +72,13 @@ Tinytest.add('passwordless - Email and token mismatch', test => {
   test.equal(resultToken.error.reason, 'Email or token mismatch');
 });
 
-Tinytest.add('passwordless - Token mismatch', test => {
+Tinytest.addAsync('passwordless - Token mismatch', async (test) => {
   const createdAt = new Date('July 17, 2022 13:00:00');
   const currentDate = new Date('July 17, 2022 13:05:00');
 
-  const { user } = getData({ createdAt });
+  const { user } = await getData({ createdAt });
 
-  const result = checkToken({
+  const result = await checkToken({
     user,
     sequence: 'AAA111',
     selector: {},
@@ -89,13 +89,13 @@ Tinytest.add('passwordless - Token mismatch', test => {
   test.equal(result.error.reason, 'Token mismatch');
 });
 
-Tinytest.add('passwordless - Valid token with email', test => {
+Tinytest.addAsync('passwordless - Valid token with email', async (test) => {
   const createdAt = new Date('July 17, 2022 13:00:00');
   const currentDate = new Date('July 17, 2022 13:05:00');
 
-  const { user } = getData({ createdAt });
+  const { user } = await getData({ createdAt });
 
-  const result = checkToken({
+  const result = await checkToken({
     user,
     sequence: USER_TOKEN,
     selector: { email: user.email },
@@ -105,13 +105,13 @@ Tinytest.add('passwordless - Valid token with email', test => {
   test.isFalse(!!result.error);
 });
 
-Tinytest.add('passwordless - Valid token without email', test => {
+Tinytest.addAsync('passwordless - Valid token without email', async (test) => {
   const createdAt = new Date('July 17, 2022 13:00:00');
   const currentDate = new Date('July 17, 2022 13:05:00');
 
-  const { user } = getData({ createdAt });
+  const { user } = await getData({ createdAt });
 
-  const result = checkToken({
+  const result = await checkToken({
     user,
     sequence: USER_TOKEN,
     selector: {},

--- a/packages/accounts-passwordless/server_utils.js
+++ b/packages/accounts-passwordless/server_utils.js
@@ -16,7 +16,7 @@ export const tokenValidator = () => {
   );
 };
 
-export const checkToken = ({
+export const checkToken = async ({
   user,
   sequence,
   selector,
@@ -39,20 +39,20 @@ export const checkToken = ({
   }
 
   if (selector.email) {
-    const foundTokenEmail = user.services.passwordless.tokens.find(
-      ({ email: tokenEmail, token }) =>
-        SHA256(selector.email + sequence) === token &&
+    for (const { email: tokenEmail, token } of user.services.passwordless.tokens) {
+      if (
+        await SHA256(selector.email + sequence) === token &&
         selector.email === tokenEmail
-    );
-    if (foundTokenEmail) {
-      return { ...result, verifiedEmail: foundTokenEmail.email };
+      ) {
+        return { ...result, verifiedEmail: tokenEmail };
+      }
     }
 
     result.error = Accounts._handleError('Email or token mismatch', false);
     return result;
   }
 
-  if (sequence && SHA256(user._id + sequence) === userToken) {
+  if (sequence && await SHA256(user._id + sequence) === userToken) {
     return result;
   }
 

--- a/packages/deprecated/srp/package.js
+++ b/packages/deprecated/srp/package.js
@@ -15,7 +15,6 @@ Package.onUse(function (api) {
     'ecmascript',
     'random',
     'check',
-    'sha'
   ], ['client', 'server']);
   api.export('SRP');
   api.mainModule('srp.js');

--- a/packages/deprecated/srp/sha256-legacy.js
+++ b/packages/deprecated/srp/sha256-legacy.js
@@ -1,19 +1,15 @@
-/// METEOR WRAPPER
-//
-SHA256 = (function () {
-
-
 /**
-*
-*  Secure Hash Algorithm (SHA256)
-*  http://www.webtoolkit.info/javascript-sha256.html
-*  http://anmar.eu.org/projects/jssha2/
-*
-*  Original code by Angel Marin, Paul Johnston.
-*
-**/
+ * Secure Hash Algorithm (SHA256)
+ * http://www.webtoolkit.info/javascript-sha256.html
+ * http://anmar.eu.org/projects/jssha2/
+ *
+ * Original code by Angel Marin, Paul Johnston.
+ *
+ * Vendored from packages/sha/sha256.js for backward compatibility.
+ * This is the legacy pure-JS implementation kept for the deprecated SRP package.
+ */
 
-function SHA256(s){
+function _SHA256(s){
 
 	var chrsz   = 8;
 	var hexcase = 0;
@@ -44,14 +40,8 @@ function SHA256(s){
 		m[((l + 64 >> 9) << 4) + 15] = l;
 
 		for ( var i = 0; i<m.length; i+=16 ) {
-			a = HASH[0];
-			b = HASH[1];
-			c = HASH[2];
-			d = HASH[3];
-			e = HASH[4];
-			f = HASH[5];
-			g = HASH[6];
-			h = HASH[7];
+			a = HASH[0]; b = HASH[1]; c = HASH[2]; d = HASH[3];
+			e = HASH[4]; f = HASH[5]; g = HASH[6]; h = HASH[7];
 
 			for ( var j = 0; j<64; j++) {
 				if (j < 16) W[j] = m[j + i];
@@ -60,24 +50,14 @@ function SHA256(s){
 				T1 = safe_add(safe_add(safe_add(safe_add(h, Sigma1256(e)), Ch(e, f, g)), K[j]), W[j]);
 				T2 = safe_add(Sigma0256(a), Maj(a, b, c));
 
-				h = g;
-				g = f;
-				f = e;
-				e = safe_add(d, T1);
-				d = c;
-				c = b;
-				b = a;
-				a = safe_add(T1, T2);
+				h = g; g = f; f = e; e = safe_add(d, T1);
+				d = c; c = b; b = a; a = safe_add(T1, T2);
 			}
 
-			HASH[0] = safe_add(a, HASH[0]);
-			HASH[1] = safe_add(b, HASH[1]);
-			HASH[2] = safe_add(c, HASH[2]);
-			HASH[3] = safe_add(d, HASH[3]);
-			HASH[4] = safe_add(e, HASH[4]);
-			HASH[5] = safe_add(f, HASH[5]);
-			HASH[6] = safe_add(g, HASH[6]);
-			HASH[7] = safe_add(h, HASH[7]);
+			HASH[0] = safe_add(a, HASH[0]); HASH[1] = safe_add(b, HASH[1]);
+			HASH[2] = safe_add(c, HASH[2]); HASH[3] = safe_add(d, HASH[3]);
+			HASH[4] = safe_add(e, HASH[4]); HASH[5] = safe_add(f, HASH[5]);
+			HASH[6] = safe_add(g, HASH[6]); HASH[7] = safe_add(h, HASH[7]);
 		}
 		return HASH;
 	}
@@ -92,19 +72,9 @@ function SHA256(s){
 	}
 
 	function Utf8Encode(string) {
-		// METEOR change:
-		// The webtoolkit.info version of this code added this
-		// Utf8Encode function (which does seem necessary for dealing
-		// with arbitrary Unicode), but the following line seems
-		// problematic:
-		//
-		// string = string.replace(/\r\n/g,"\n");
 		var utftext = "";
-
 		for (var n = 0; n < string.length; n++) {
-
 			var c = string.charCodeAt(n);
-
 			if (c < 128) {
 				utftext += String.fromCharCode(c);
 			}
@@ -117,9 +87,7 @@ function SHA256(s){
 				utftext += String.fromCharCode(((c >> 6) & 63) | 128);
 				utftext += String.fromCharCode((c & 63) | 128);
 			}
-
 		}
-
 		return utftext;
 	}
 
@@ -135,9 +103,6 @@ function SHA256(s){
 
 	s = Utf8Encode(s);
 	return binb2hex(core_sha256(str2binb(s), s.length * chrsz));
-
 }
 
-/// METEOR WRAPPER
-return SHA256;
-})();
+export { _SHA256 as SHA256 };

--- a/packages/deprecated/srp/srp.js
+++ b/packages/deprecated/srp/srp.js
@@ -1,5 +1,6 @@
 import { Random } from 'meteor/random';
 import BigInteger from './biginteger';
+import { SHA256 } from './sha256-legacy';
 
 // This package contains just enough of the original SRP code to
 // support the backwards-compatibility upgrade path.

--- a/packages/sha/package.js
+++ b/packages/sha/package.js
@@ -5,6 +5,8 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use('ecmascript');
   api.export('SHA256');
-  api.addFiles('sha256.js');
+  api.mainModule('sha256-server.js', 'server');
+  api.mainModule('sha256-client.js', 'client');
 });

--- a/packages/sha/sha256-client.js
+++ b/packages/sha/sha256-client.js
@@ -1,0 +1,6 @@
+export const SHA256 = async (input) => {
+  const encoded = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray, (b) => b.toString(16).padStart(2, '0')).join('');
+};

--- a/packages/sha/sha256-server.js
+++ b/packages/sha/sha256-server.js
@@ -1,0 +1,4 @@
+import { createHash } from 'crypto';
+
+export const SHA256 = (input) =>
+  createHash('sha256').update(input, 'utf8').digest('hex');


### PR DESCRIPTION
The `sha` package has shipped a pure-JS SHA-256 implementation since 2012. Since Meteor 3.x requires Node 18.16+ and targets modern browsers, we can use native crypto instead.

### What changed

**Server:** Uses Node.js `crypto.createHash('sha256')` — synchronous, fast, maintained.

**Client:** Uses Web Crypto `crypto.subtle.digest('SHA-256', ...)` — async, returns a Promise.

All consumers now use `await SHA256(...)`. Awaiting a sync value is a no-op, so this works uniformly on both server and client.

The deprecated SRP package gets a copy of the old implementation since its synchronous protocol math can't be made async. No changes to SRP's behavior. I don't know if there were existing tests for SRP that would've failed if removed.

### Files changed

- `packages/sha/` — new `sha256-server.js` and `sha256-client.js`, deleted old `sha256.js`, updated `package.js` to use `api.mainModule` with client/server split
- `packages/accounts-password/` — `password_client.js`, `password_server.js`, and test files updated to `await` SHA256 calls
- `packages/accounts-passwordless/` — `server_utils.js`, `passwordless_server.js`, and test files updated to `await` SHA256 calls
- `packages/deprecated/srp/` — vendored legacy SHA256 locally, dropped `sha` dependency