### PR TITLE
refactor(react-fast-refresh): Modernize react-fast-refresh and bump to 0.18.0

### DIFF
--- a/packages/react-fast-refresh/client-runtime.js
+++ b/packages/react-fast-refresh/client-runtime.js
@@ -1,141 +1,86 @@
-var runtime = require('react-refresh/runtime');
+const runtime = require('react-refresh/runtime');
 
-var timeout = null;
+let timeout;
 function scheduleRefresh() {
-  if (!timeout) {
-    timeout = setTimeout(function () {
-      timeout = null;
-      runtime.performReactRefresh();
-    }, 0);
-  }
+  timeout ??= setTimeout(() => {
+    timeout = null;
+    runtime.performReactRefresh();
+  }, 0);
 }
 
 // The react refresh babel plugin only registers functions. For react
 // to update other types of exports (such as classes), we have to
 // register them
 function registerExportsForReactRefresh(moduleId, moduleExports) {
-  runtime.register(moduleExports, moduleId + ' %exports%');
+  runtime.register(moduleExports, `${moduleId} %exports%`);
+  if (moduleExports == null || typeof moduleExports !== 'object') return;
 
-  if (moduleExports == null || typeof moduleExports !== 'object') {
-    // Exit if we can't iterate over exports.
-    return;
-  }
-
-  for (var key in moduleExports) {
-    var desc = Object.getOwnPropertyDescriptor(moduleExports, key);
-    if (desc && desc.get) {
-      // Don't invoke getters as they may have side effects.
-      continue;
+  for (const key of Object.keys(moduleExports)) {
+    if (!Object.getOwnPropertyDescriptor(moduleExports, key)?.get) {
+      runtime.register(moduleExports[key], `${moduleId} %exports% ${key}`);
     }
-
-    var exportValue = moduleExports[key];
-    var typeID = moduleId + ' %exports% ' + key;
-    runtime.register(exportValue, typeID);
   }
 }
 
 // Modules that only export components become React Refresh boundaries.
+// DOM elements are excluded to avoid triggering deprecated getter warnings.
 function isReactRefreshBoundary(moduleExports) {
-  if (runtime.isLikelyComponentType(moduleExports)) {
-    return true;
-  }
-  if (moduleExports == null || typeof moduleExports !== 'object') {
-    // Exit if we can't iterate over exports.
+  if (runtime.isLikelyComponentType(moduleExports)) return true;
+  if (moduleExports == null || typeof moduleExports !== 'object' || moduleExports instanceof Element) {
     return false;
   }
 
-  // Is a DOM element. If we iterate its properties, we might cause the
-  // browser to show warnings when accessing depreciated getters on its
-  // prototype
-  if (moduleExports instanceof Element) {
-    return false;
-  }
+  const keys = Object.keys(moduleExports);
+  if (keys.length === 0) return false;
 
-  var hasExports = false;
-  var onlyExportComponents = true;
-
-  for (var key in moduleExports) {
-    hasExports = true;
-
-    var desc = Object.getOwnPropertyDescriptor(moduleExports, key);
-    if (desc && desc.get) {
-      // Don't invoke getters as they may have side effects.
-      return false;
-    }
-
+  return keys.every(key => {
+    // Don't invoke getters as they may have side effects
+    if (Object.getOwnPropertyDescriptor(moduleExports, key)?.get) return false;
     try {
-      if (!runtime.isLikelyComponentType(moduleExports[key])) {
-        onlyExportComponents = false;
-      }
+      return runtime.isLikelyComponentType(moduleExports[key]);
     } catch (e) {
-      if (e.name === 'SecurityError') {
-        // Not a component. Could be a cross-origin object or something else
-        // we don't have access to
-        return false;
-      }
-
+      if (e.name === 'SecurityError') return false;
       throw e;
     }
-  }
-
-  return hasExports && onlyExportComponents;
+  });
 }
 
 runtime.injectIntoGlobalHook(window);
 
-window.$RefreshReg$ = function () { };
-window.$RefreshSig$ = function () {
-  return function (type) { return type; };
-};
+window.$RefreshReg$ = () => {};
+window.$RefreshSig$ = () => (type) => type;
 
-var moduleInitialState = new WeakMap();
+const moduleInitialState = new WeakMap();
 
 module.hot.onRequire({
-  after: function (module) {
-    // TODO: handle modules with errors
-
-    var beforeStates = moduleInitialState.get(module);
-    var beforeState = beforeStates && beforeStates.pop();
-    if (!beforeState) {
-      return;
-    }
+  after(module) {
+    const beforeState = moduleInitialState.get(module)?.pop();
+    if (!beforeState) return;
 
     window.$RefreshReg$ = beforeState.prevRefreshReg;
     window.$RefreshSig$ = beforeState.prevRefreshSig;
     if (isReactRefreshBoundary(module.exports)) {
       registerExportsForReactRefresh(module.id, module.exports);
       module.hot.accept();
-
       scheduleRefresh();
     }
   }
 });
 
-module.exports = function setupModule (module) {
-  if (module.loaded) {
-    // The module was already executed
-    return;
+module.exports = function setupModule(module) {
+  if (module.loaded) return;
+
+  if (!moduleInitialState.has(module)) {
+    moduleInitialState.set(module, []);
   }
 
-  var beforeStates = moduleInitialState.get(module);
-
-  if (beforeStates === undefined) {
-    beforeStates = [];
-    moduleInitialState.set(module, beforeStates);
-  }
-
-  var prevRefreshReg = window.$RefreshReg$;
-  var prevRefreshSig = window.$RefreshSig$;
-
-  window.RefreshRuntime = runtime;
-  window.$RefreshReg$ = function (type, _id) {
-    var fullId = module.id + ' ' + _id;
-    RefreshRuntime.register(type, fullId);
-  };
-  window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
-
-  beforeStates.push({
-    prevRefreshReg: prevRefreshReg,
-    prevRefreshSig: prevRefreshSig
+  moduleInitialState.get(module).push({
+    prevRefreshReg: window.$RefreshReg$,
+    prevRefreshSig: window.$RefreshSig$
   });
+
+  window.$RefreshReg$ = (type, _id) => {
+    runtime.register(type, `${module.id} ${_id}`);
+  };
+  window.$RefreshSig$ = runtime.createSignatureFunctionForTransform;
 };

--- a/packages/react-fast-refresh/client.js
+++ b/packages/react-fast-refresh/client.js
@@ -1,27 +1,23 @@
-var enabled = __meteor_runtime_config__ &&
-  __meteor_runtime_config__.reactFastRefreshEnabled;
-var hmrEnabled = !!module.hot;
-var setupModule;
+const enabled = __meteor_runtime_config__?.reactFastRefreshEnabled;
+const hmrEnabled = !!module.hot;
+let setupModule;
 
 function init(module) {
   if (!hmrEnabled) {
     return;
   }
 
-  setupModule = setupModule || require('./client-runtime.js');
+  setupModule ??= require('./client-runtime.js');
   setupModule(module);
 }
 
-if (
-  hmrEnabled &&
-  enabled
-) {
-  var inBefore = false;
+if (hmrEnabled && enabled) {
+  let inBefore = false;
   module.hot.onRequire({
-    before: function (module) {
+    before(module) {
       if (inBefore) {
         // This is a module required while loading the react refresh runtime
-        // Do not initialize it to avoid an infinite loop 
+        // Do not initialize it to avoid an infinite loop
         return;
       }
 
@@ -31,7 +27,7 @@ if (
     }
   });
 
-  window.___INIT_METEOR_FAST_REFRESH = function () {};
+  window.___INIT_METEOR_FAST_REFRESH = () => {};
 } else {
   window.___INIT_METEOR_FAST_REFRESH = init;
 }

--- a/packages/react-fast-refresh/package.js
+++ b/packages/react-fast-refresh/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'react-refresh': '0.14.0',
+  'react-refresh': '0.18.0',
   semver: '7.5.4',
 });
 

--- a/packages/react-fast-refresh/server.js
+++ b/packages/react-fast-refresh/server.js
@@ -6,8 +6,7 @@ if (enabled) {
     const semverGte = require('semver/functions/gte');
     const pkg = require('react/package.json');
 
-    enabled = pkg && pkg.version &&
-      semverGte(pkg.version, '16.9.0');
+    enabled = pkg?.version && semverGte(pkg.version, '16.9.0');
   } catch (e) {
     // If the app doesn't directly depend on react, leave react-refresh
     // enabled in case a package or indirect dependency uses react.
@@ -26,20 +25,13 @@ const babelPlugin = enabled ?
 // Babel plugin that adds a call to global.___INIT_METEOR_FAST_REFRESH()
 // at the start of every file compiled with react-refresh to ensure the runtime
 // is enabled if it is used.
-function enableReactRefreshBabelPlugin(babel) {
-  const { types: t } = babel;
-
+function enableReactRefreshBabelPlugin({ types: t }) {
   return {
     name: "meteor-enable-react-fast-refresh",
     post(state) {
-      // This is the path for the Program node
-      let path = state.path;
-      let method = t.identifier("___INIT_METEOR_FAST_REFRESH");
-      let call = t.callExpression(
-        method,
-        [t.identifier("module")]
-      );
-      path.unshiftContainer("body", t.expressionStatement(call));
+      state.path.unshiftContainer("body", t.expressionStatement(
+        t.callExpression(t.identifier("___INIT_METEOR_FAST_REFRESH"), [t.identifier("module")])
+      ));
     },
   };
 }


### PR DESCRIPTION
Cleaned up the react-fast-refresh internals and bumped the `react-refresh` dependency from 0.14.0 to 0.18.0.

#### What changed

**Dependency bump**
- `react-refresh` 0.14.0 → 0.18.0 (aligns with React 19.2). All APIs used by this package are unchanged. The only removal across this range (`findAffectedHostInstances`) was never used here.

**Bug fixes**
- Fixed typo: "depreciated" → "deprecated" in a comment about DOM element getters
- Removed unnecessary `window.RefreshRuntime` global — the module-scoped `runtime` variable is used directly now
- Switched `for...in` to `Object.keys()` so we no longer walk the prototype chain when iterating module exports

**Modernization (ES2022+)**
- `var` → `const`/`let` throughout client files
- Optional chaining (`?.`) instead of manual null checks
- Nullish coalescing assignment (`??=`) for lazy initialization
- Template literals instead of string concatenation
- Arrow functions and shorthand methods for callbacks
- `isReactRefreshBoundary` rewritten with `Object.keys().every()` instead of mutable flag tracking
- `setupModule` simplified — saves/pushes previous state before overwriting globals, removing intermediate variables
- `enableReactRefreshBabelPlugin` in server.js — inlined temp variables, destructured param