### PR TITLE
Fix race condition in observeChanges tailable test

### DIFF
--- a/packages/mongo/tests/observe_changes_tests.js
+++ b/packages/mongo/tests/observe_changes_tests.js
@@ -519,8 +519,8 @@ if (Meteor.isServer) {
       const [resolver1, promise1] = getPromiseAndResolver();
       const [resolver2, promise2] = getPromiseAndResolver();
 
-      await self.insert({x: 2, y: 3});
       self.expects.push(resolver1, resolver2);
+      await self.insert({x: 2, y: 3});
       await self.insert({x: 3, y: 7});  // filtered out by the query
       await self.insert({x: 4});
       // Expect two added calls to happen.


### PR DESCRIPTION
- Resolvers were pushed to `self.expects` after the insert that triggers the `added` callback, causing `self.expects.pop()` to return `undefined` when the callback fires before   the push
- Moved `self.expects.push(resolver1, resolver2)` before the inserts, matching the pattern already used in the first test step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected test execution order to ensure proper validation of asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->