### PR TITLE
Add sourceURL pragma to vm-evaluated server packages

### DIFF
--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -395,10 +395,6 @@ const loadServerBundles = Profile("Load server bundles", async function () {
       wrapParts.push("," + key);
     });
 
-    // \n is necessary in case final line is a //-comment
-    wrapParts.push("){", code, "\n})");
-    const wrapped = wrapParts.join("");
-
     // It is safer to use the absolute path when source map is present as
     // different tooling, such as node-inspector, can get confused on relative
     // urls.
@@ -410,6 +406,12 @@ const loadServerBundles = Profile("Load server bundles", async function () {
 
     const scriptPath =
         parsedSourceMaps[absoluteFilePath] ? absoluteFilePath : fileInfoOSPath;
+
+    // \n is necessary in case final line is a //-comment
+    // The sourceURL pragma improves source attribution in V8 profilers
+    // and debugging contexts for dynamically evaluated code.
+    wrapParts.push("){", code, "\n//# sourceURL=" + scriptPath + "\n})");
+    const wrapped = wrapParts.join("");
 
     const func = require('vm').runInThisContext(wrapped, {
       filename: scriptPath,


### PR DESCRIPTION
While reading through the server runtime boot path, I noticed that server package code is wrapped and evaluated via `vm.runInThisContext`, with `filename` already passed through for source attribution.

This PR adds a `//# sourceURL=` pragma to the wrapped code before evaluation.

The change is intentionally very small and fully additive:

- no loading model change
- no behavioral change
- `vm.runInThisContext(..., { filename })` remains unchanged

The goal is simply to improve source attribution in V8/devtools/profiling contexts for dynamically evaluated code.

I also validated this locally by building baseline and modified bundles, triggering an error from real server-side app code loaded through `boot.js`, and comparing the resulting stack traces/log output.

Forum thread for the broader series context: https://forums.meteor.com/t/what-if-meteor-was-created-in-2025/63566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved source map handling for server bundle evaluation, including more reliable resolution of absolute source paths.
  * Enhanced debugging information for dynamically evaluated server code during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->