### PR TITLE
Lazy-load cluster in webapp when UNIX_SOCKET_PATH is used

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -17,7 +17,6 @@ import {
   removeExistingSocketFile,
   registerSocketFileCleanup,
 } from './socket_file.js';
-import cluster from 'cluster';
 import { execSync } from 'child_process';
 
 var SHORT_SOCKET_TIMEOUT = 5 * 1000;
@@ -1424,10 +1423,15 @@ async function runWebAppServer() {
     let unixSocketPath = process.env.UNIX_SOCKET_PATH;
 
     if (unixSocketPath) {
-      if (cluster.isWorker) {
-        const workerName = cluster.worker.process.env.name || cluster.worker.id;
-        unixSocketPath += '.' + workerName + '.sock';
-      }
+      // Lazy-load cluster only when needed (UNIX_SOCKET_PATH with workers).
+      // Avoids loading the module in the common case where it is unused.
+      try {
+        const cluster = require('cluster');
+        if (cluster.isWorker) {
+          const workerName = cluster.worker.process.env.name || cluster.worker.id;
+          unixSocketPath += '.' + workerName + '.sock';
+        }
+      } catch (e) {}
       // Start the HTTP server using a socket file.
       removeExistingSocketFile(unixSocketPath);
       startHttpServer({ path: unixSocketPath });

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -1425,13 +1425,16 @@ async function runWebAppServer() {
     if (unixSocketPath) {
       // Lazy-load cluster only when needed (UNIX_SOCKET_PATH with workers).
       // Avoids loading the module in the common case where it is unused.
+      let cluster;
       try {
-        const cluster = require('cluster');
-        if (cluster.isWorker) {
-          const workerName = cluster.worker.process.env.name || cluster.worker.id;
-          unixSocketPath += '.' + workerName + '.sock';
-        }
-      } catch (e) {}
+        cluster = require('cluster');
+      } catch (e) {
+        // cluster module unavailable in this runtime; continue without worker suffix.
+      }
+      if (cluster?.isWorker && cluster.worker) {
+        const workerName = cluster.worker.process.env.name || cluster.worker.id;
+        unixSocketPath += '.' + workerName + '.sock';
+      }
       // Start the HTTP server using a socket file.
       removeExistingSocketFile(unixSocketPath);
       startHttpServer({ path: unixSocketPath });


### PR DESCRIPTION
`webapp_server.js` imports `cluster` at module initialization time, but it is only used in a narrow branch related to `UNIX_SOCKET_PATH` worker naming.

This PR moves that import to a lazy `require()` inside the conditional block where it is actually needed.

Benefits:

- avoids loading `cluster` in the common case where it is unused
- keeps the code more aligned with actual usage
- preserves behavior in normal Node deployments

This is just a small cleanup in the current Node runtime/server path.

I validated this locally by checking that:

- baseline and modified bundles still boot and return HTTP 200
- `UNIX_SOCKET_PATH` still creates the socket correctly
- HTTP requests through the Unix socket still return 200
- `meteor run` still works as expected

Forum thread for the broader series context: https://forums.meteor.com/t/what-if-meteor-was-created-in-2025/63566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved server startup: module loading for worker detection is now deferred and the UNIX socket path will include a worker-specific suffix when applicable, improving robustness with worker processes and falling back gracefully when worker detection isn't available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->