### PR TITLE
[Rspack] Add E2E tests for cache tracking of imported plugins

### DIFF
--- a/dev/modern-tools/rspack/E2E_COVERAGE.md
+++ b/dev/modern-tools/rspack/E2E_COVERAGE.md
@@ -40,6 +40,9 @@ Core React integration with custom Meteor local directory.
 | React + JSX environment detection | Run, Prod, Test, Build |
 | Image assets load (generated + public + background) | Run, Prod |
 | `Meteor.disablePlugins` suppresses rspack plugins | Run, Prod, Test, Build |
+| Unplugin transform hook fires on first run (fresh cache) | Init |
+| Unplugin factory created on cached run — #14031 regression | Run |
+| Unplugin transform + buildDependencies tracking in production | Prod |
 | Custom rspack config (`rspack.config.cjs`) | All |
 | HMR works in dev, disabled in prod | Run, Prod |
 
@@ -227,6 +230,12 @@ Several apps import specific npm packages to verify that Meteor + Rspack handles
 | `node:buffer` | `imports/api/links.js` | Node.js built-in via `node:` protocol in shared client/server code — must be ignored on client without errors |
 | `@react-email/components` | `imports/emails/TestEmail.jsx` | JSX-heavy ESM package with many subpath exports |
 
+### react (`apps/react/plugins/demo-unplugin.js`)
+
+| Package | Reason |
+|---------|--------|
+| `unplugin` | Unplugin transform hook integration — validates rspack cache tracks plugin dependency files (#14031) |
+
 ### babel (`apps/babel/server/apollo.js`)
 
 | Package | Reason |
@@ -269,6 +278,7 @@ Where each feature is tested across apps and skeletons.
 | Babel compiler plugin | react-router | |
 | TypeScript type checking | typescript | |
 | Meteor.disablePlugins | react | |
+| Unplugin transform with cache (#14031) | react | |
 | Custom package dirs | react-router | |
 | CoffeeScript compilation | coffeescript | coffeescript |
 | Server-only (no client) | server-only | |

--- a/tools/e2e-tests/apps/react/package.json
+++ b/tools/e2e-tests/apps/react/package.json
@@ -11,6 +11,7 @@
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
     "meteor-node-stubs": "^1.2.12",
+    "unplugin": "^2.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/e2e-tests/apps/react/plugins/demo-unplugin.js
+++ b/tools/e2e-tests/apps/react/plugins/demo-unplugin.js
@@ -1,0 +1,30 @@
+const { createUnplugin } = require('unplugin');
+
+const demoUnplugin = createUnplugin(() => {
+  console.log('[demo-unplugin][factory-created]');
+  return {
+    name: 'demo-unplugin',
+    transformInclude(id) {
+      // Only process app source files, skip node_modules and .meteor
+      if (id.includes('node_modules') || id.includes('.meteor')) {
+        return false;
+      }
+      const ok =
+        id.endsWith('.tsx') ||
+        id.endsWith('.ts') ||
+        id.endsWith('.jsx') ||
+        id.endsWith('.js');
+
+      if (ok) {
+        console.log('[demo-unplugin][transformInclude]', id, '=> true');
+      }
+      return ok;
+    },
+    transform(code, id) {
+      console.log('[demo-unplugin][transform-enter]', id);
+      return { code, map: null };
+    },
+  };
+});
+
+module.exports = { demoRspackPlugin: demoUnplugin.rspack };

--- a/tools/e2e-tests/apps/react/rspack.config.cjs
+++ b/tools/e2e-tests/apps/react/rspack.config.cjs
@@ -1,6 +1,7 @@
 const { defineConfig } = require('@meteorjs/rspack');
 const path = require('path');
 const CustomConsoleLogPlugin = require("./plugins/CustomConsoleLogPlugin");
+const { demoRspackPlugin } = require("./plugins/demo-unplugin");
 
 /**
  * Rspack configuration for Meteor projects.
@@ -39,6 +40,6 @@ module.exports = defineConfig(Meteor => {
         },
       ],
     },
-    plugins: [new CustomConsoleLogPlugin()],
+    plugins: [new CustomConsoleLogPlugin(), demoRspackPlugin()],
   };
 });

--- a/tools/e2e-tests/react.test.js
+++ b/tools/e2e-tests/react.test.js
@@ -78,6 +78,13 @@ describe('React App Bundling /', () => {
       buildDir: "_build-local-custom",
       env: { METEOR_LOCAL_DIR: ".meteor/local-custom" },
       customAssertions: {
+        afterInit: async ({ result }) => {
+          // Verify unplugin transform hook is called on first run (fresh cache)
+          await waitForMeteorOutput(
+            result.outputLines,
+            /.*\[demo-unplugin\]\[transform-enter\].*/
+          );
+        },
         afterRun: async ({ result, tempDir }) => {
           const appDir = tempDir; // testMeteorRspackBundler uses tempDir as appDir if not monorepo
 
@@ -95,10 +102,19 @@ describe('React App Bundling /', () => {
           await assertImagesExistAndLoad();
 
           // Check custom plugin is disabled with Meteor.disablePlugins
+          // Use specific log prefix to avoid matching the filename in buildDependencies
           await waitForMeteorOutput(
             result.outputLines,
-            /.*CustomConsoleLogPlugin.*/,
+            /.*\[CustomConsoleLogPlugin\].*/,
             { negate: true }
+          );
+
+          // Verify unplugin factory is still created on second run (with cache)
+          // This confirms the plugin is loaded and active even when rspack uses
+          // cached transform results (#14031 regression test)
+          await waitForMeteorOutput(
+            result.outputLines,
+            /.*\[demo-unplugin\]\[factory-created\].*/
           );
         },
         afterRunRebuildClient: async ({ allConsoleLogs }) => {
@@ -115,10 +131,23 @@ describe('React App Bundling /', () => {
           await assertImagesExistAndLoad();
 
           // Check custom plugin is disabled with Meteor.disablePlugins
+          // Use specific log prefix to avoid matching the filename in buildDependencies
           await waitForMeteorOutput(
             result.outputLines,
-            /.*CustomConsoleLogPlugin.*/,
+            /.*\[CustomConsoleLogPlugin\].*/,
             { negate: true }
+          );
+
+          // Verify demo-unplugin.js is tracked in rspack buildDependencies (#14031)
+          await waitForMeteorOutput(
+            result.outputLines,
+            /.*plugins\/demo-unplugin\.js.*/
+          );
+
+          // Verify unplugin transform hook fires in production (separate cache version)
+          await waitForMeteorOutput(
+            result.outputLines,
+            /.*\[demo-unplugin\]\[transform-enter\].*/
           );
         },
         afterRunProductionRebuildClient: async ({ allConsoleLogs }) => {
@@ -133,9 +162,10 @@ describe('React App Bundling /', () => {
           await waitForReactEnvs(result.outputLines);
 
           // Check custom plugin is disabled with Meteor.disablePlugins
+          // Use specific log prefix to avoid matching the filename in buildDependencies
           await waitForMeteorOutput(
             result.outputLines,
-            /.*CustomConsoleLogPlugin.*/,
+            /.*\[CustomConsoleLogPlugin\].*/,
             { negate: true }
           );
         },
@@ -143,9 +173,10 @@ describe('React App Bundling /', () => {
           await waitForReactEnvs(result.outputLines);
 
           // Check custom plugin is disabled with Meteor.disablePlugins
+          // Use specific log prefix to avoid matching the filename in buildDependencies
           await waitForMeteorOutput(
             result.outputLines,
-            /.*CustomConsoleLogPlugin.*/,
+            /.*\[CustomConsoleLogPlugin\].*/,
             { negate: true }
           );
         },
@@ -153,9 +184,10 @@ describe('React App Bundling /', () => {
           await waitForReactEnvs(result.outputLines, { isJsxEnabled: true });
 
           // Check custom plugin is disabled with Meteor.disablePlugins
+          // Use specific log prefix to avoid matching the filename in buildDependencies
           await waitForMeteorOutput(
             result.outputLines,
-            /.*CustomConsoleLogPlugin.*/,
+            /.*\[CustomConsoleLogPlugin\].*/,
             { negate: true }
           );
         },


### PR DESCRIPTION
Continues: https://github.com/meteor/meteor/pull/14111

This PR adds missing tests to validate a contribution for the fix https://github.com/meteor/meteor/issues/14031.