### PR TITLE
DOCS: Update README files for `autopublish` and `insecure` packages

### DIFF
--- a/packages/autopublish/README.md
+++ b/packages/autopublish/README.md
@@ -4,4 +4,4 @@
 
 Publish all server collections to the client. This package is useful for prototyping an app without worrying about which clients have access to certain data, but should be removed as soon as the app needs to restrict which data is seen by the client.
 
-The `autopublish` package is automatically added to every Meteor app by `meteor create`.
+As of Meteor 3.x, the `autopublish` package is **not** included in new projects by default. To add it for prototyping, run `meteor add autopublish`.

--- a/packages/insecure/README.md
+++ b/packages/insecure/README.md
@@ -4,4 +4,4 @@
 
 Allow almost all collection methods, such as `insert`, `update`, and `remove`, to be called from the client. This package is useful for prototyping an app without worrying about database permissions, but should be removed as soon as the app needs to restrict database access.
 
-The `insecure` package is automatically added to every Meteor app by `meteor create`.
+As of Meteor 3.x, the `insecure` package is **not** included in new projects by default. To add it for prototyping, run `meteor add insecure`.


### PR DESCRIPTION
Update README files for `autopublish` and `insecure` packages to reflect changes in Meteor 3.x, noting that these packages are no longer included by default in new projects and providing instructions to add them for prototyping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated autopublish package documentation to reflect Meteor 3.x behavior where it is no longer automatically included and must be explicitly added using `meteor add autopublish`
  * Updated insecure package documentation to reflect Meteor 3.x behavior where it is no longer automatically included by default and must be explicitly added using `meteor add insecure`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->