### PR TITLE
DOC: fix ssl issue

### DIFF
--- a/v3-docs/docs/generators/meteor-versions/metadata.generated.js
+++ b/v3-docs/docs/generators/meteor-versions/metadata.generated.js
@@ -2,55 +2,55 @@ export default {
   "versions": [
     {
       "version": "v3.0",
-      "url": "https://release-3-0.docs.meteor.com/"
+      "url": "https://release-3-0.docs-online.meteor.com/"
     },
     {
       "version": "v3.0.2",
-      "url": "https://release-3-0-2.docs.meteor.com/"
+      "url": "https://release-3-0-2.docs-online.meteor.com/"
     },
     {
       "version": "v3.0.3",
-      "url": "https://release-3-0-3.docs.meteor.com/"
+      "url": "https://release-3-0-3.docs-online.meteor.com/"
     },
     {
       "version": "v3.0.4",
-      "url": "https://release-3-0-4.docs.meteor.com/"
+      "url": "https://release-3-0-4.docs-online.meteor.com/"
     },
     {
       "version": "v3.1.0",
-      "url": "https://release-3-1-0.docs.meteor.com/"
+      "url": "https://release-3-1-0.docs-online.meteor.com/"
     },
     {
       "version": "v3.1.1",
-      "url": "https://release-3-1-1.docs.meteor.com/"
+      "url": "https://release-3-1-1.docs-online.meteor.com/"
     },
     {
       "version": "v3.1.2",
-      "url": "https://release-3-1-2.docs.meteor.com/"
+      "url": "https://release-3-1-2.docs-online.meteor.com/"
     },
     {
       "version": "v3.2.0",
-      "url": "https://release-3-2-0.docs.meteor.com/"
+      "url": "https://release-3-2-0.docs-online.meteor.com/"
     },
     {
       "version": "v3.2.2",
-      "url": "https://release-3-2-2.docs.meteor.com/"
+      "url": "https://release-3-2-2.docs-online.meteor.com/"
     },
     {
       "version": "v3.3.0",
-      "url": "https://release-3-3-0.docs.meteor.com/"
+      "url": "https://release-3-3-0.docs-online.meteor.com/"
     },
     {
       "version": "v3.3.1",
-      "url": "https://release-3-3-1.docs.meteor.com/"
+      "url": "https://release-3-3-1.docs-online.meteor.com/"
     },
     {
       "version": "v3.3.2",
-      "url": "https://release-3-3-2.docs.meteor.com/"
+      "url": "https://release-3-3-2.docs-online.meteor.com/"
     },
     {
       "version": "v3.4.0",
-      "url": "https://release-3-4-0.docs.meteor.com/",
+      "url": "https://release-3-4-0.docs-online.meteor.com/",
       "isCurrent": true
     }
   ],

--- a/v3-docs/docs/generators/meteor-versions/script.js
+++ b/v3-docs/docs/generators/meteor-versions/script.js
@@ -2,7 +2,7 @@ const _fs = require("fs");
 const fs = _fs.promises;
 
 const getDocsUrl = (version = "") =>
-  `https://release-${version}.docs.meteor.com/`;
+  `https://release-${version}.docs-online.meteor.com/`;
 
 exports.generateMeteorVersions = async () => {
   console.log("Reading meteor versions...");


### PR DESCRIPTION
Our SSL certificates are pointed to online-docs rather than just docs

This should fix this issue:

<img width="2562" height="1518" alt="image" src="https://github.com/user-attachments/assets/92768e0d-1772-44db-a453-c42560373d9e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated documentation links to point to the new documentation hosting domain, ensuring users are directed to the correct resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->