### PR TITLE
Security: gate Bootstrap href selectors (CVE-2016-10735) in deprecated package

### DIFF
--- a/packages/deprecated/bootstrap/js/bootstrap.js
+++ b/packages/deprecated/bootstrap/js/bootstrap.js
@@ -97,7 +97,7 @@
 
     if (!selector) {
       selector = $this.attr('href')
-      selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
+      selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
     }
 
     $parent = $(selector)
@@ -452,7 +452,7 @@
 
   $(document).on('click.carousel.data-api', '[data-slide], [data-slide-to]', function (e) {
     var $this = $(this), href
-      , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
+      , $target = $($this.attr('data-target') || (href = $this.attr('href')) && /#[A-Za-z]/.test(href) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
       , options = $.extend({}, $target.data(), $this.data())
       , slideIndex
 
@@ -625,7 +625,7 @@
     var $this = $(this), href
       , target = $this.attr('data-target')
         || e.preventDefault()
-        || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
+        || (href = $this.attr('href')) && /#[A-Za-z]/.test(href) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
       , option = $(target).data('collapse') ? 'toggle' : $this.data()
     $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
     $(target).collapse(option)
@@ -748,7 +748,7 @@
 
     if (!selector) {
       selector = $this.attr('href')
-      selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
+      selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
     }
 
     $parent = selector && $(selector)
@@ -1030,7 +1030,7 @@
   $(document).on('click.modal.data-api', '[data-toggle="modal"]', function (e) {
     var $this = $(this)
       , href = $this.attr('href')
-      , $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
+      , $target = $($this.attr('data-target') || (href && /#[A-Za-z]/.test(href) && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
       , option = $target.data('modal') ? 'toggle' : $.extend({ remote:!/#/.test(href) && href }, $target.data(), $this.data())
 
     e.preventDefault()
@@ -1545,7 +1545,7 @@
     this.options = $.extend({}, $.fn.scrollspy.defaults, options)
     this.$scrollElement = $element.on('scroll.scroll-spy.data-api', process)
     this.selector = (this.options.target
-      || ((href = $(element).attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
+      || ((href = $(element).attr('href')) && /#[A-Za-z]/.test(href) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
       || '') + ' .nav li > a'
     this.$body = $('body')
     this.refresh()
@@ -1717,7 +1717,7 @@
 
       if (!selector) {
         selector = $this.attr('href')
-        selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
+        selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
       }
 
       if ( $this.parent('li').hasClass('active') ) return


### PR DESCRIPTION
## Summary

Harden `href`-derived selectors in the deprecated bundled Bootstrap 2.x copy under `packages/deprecated/bootstrap/`, aligned with [twbs/bootstrap#d9be1da](https://github.com/twbs/bootstrap/commit/d9be1da55bf0f94a81e8a2c9acf5574fb801306e) (CVE-2016-10735 class: unsafe fragment handling before `replace`).

## Scope

Single file: `packages/deprecated/bootstrap/js/bootstrap.js`. Seven call sites now require `/#[A-Za-z]/.test(...)` before stripping to a selector (alert dismiss, carousel data-API, collapse data-API, dropdown `getParent`, modal data-API, scrollspy, tab `show`). One site previously used `/#/.test`; it now uses the stricter upstream guard.

## Reproduction (before)

On `devel` at parent of this commit, the same file had seven lines using `replace(/.*(?=#[^\s]…)/, …)` without the `#[A-Za-z]` gate (or with a weaker `/#/` test). Python audit (see below) counted **7 unguarded** vs **0 guarded** lines matching that pattern.

## Verification (after)

Static audit (Python): **0 unguarded**, **7 guarded** lines for that `replace` pattern.

Commands run locally:

```bash
cd scripts/admin/check-legacy-syntax && npm ci && node check-syntax.js
```

Exit code **0** (legacy syntax check for listed core packages; unchanged semantics in edited file).

```bash
npm run test:idle-bot
```

**7 passed, 0 failed**.

## Notes

- Deprecated package has no dedicated automated tests in-tree; change is minimal and matches upstream remediation pattern.
- `package-lock.json` was not modified for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved selector resolution logic in Bootstrap components (alerts, carousels, collapse, dropdowns, modals, scrollspy, tabs) for more precise href attribute handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->