### PR TITLE
Replace hasOwnProperty.call() with Object.hasOwn()

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -35,7 +35,6 @@ const createExpressApp = () => {
 export const WebApp = {};
 export const WebAppInternals = {};
 
-const hasOwn = Object.prototype.hasOwnProperty;
 
 
 WebAppInternals.NpmModules = {
@@ -174,7 +173,7 @@ WebApp.categorizeRequest = function(req) {
 
   if (archKey.startsWith('__')) {
     const archCleaned = 'web.' + archKey.slice(2);
-    if (hasOwn.call(WebApp.clientPrograms, archCleaned)) {
+    if (Object.hasOwn(WebApp.clientPrograms, archCleaned)) {
       pathParts.splice(1, 1); // Remove the archKey part.
       return Object.assign(categorized, {
         arch: archCleaned,
@@ -197,7 +196,7 @@ WebApp.categorizeRequest = function(req) {
     // clients are better off receiving web.browser (which might actually
     // work) than receiving an HTTP 404 response. If none of the archs in
     // preferredArchOrder are defined, only then should we send a 404.
-    if (hasOwn.call(WebApp.clientPrograms, arch)) {
+    if (Object.hasOwn(WebApp.clientPrograms, arch)) {
       return Object.assign(categorized, { arch });
     }
   }
@@ -631,7 +630,7 @@ WebAppInternals.staticFilesMiddleware = async function(
 
   const { arch, path } = WebApp.categorizeRequest(req);
 
-  if (!hasOwn.call(WebApp.clientPrograms, arch)) {
+  if (!Object.hasOwn(WebApp.clientPrograms, arch)) {
     // We could come here in case we run with some architectures excluded
     next();
     return;
@@ -745,7 +744,7 @@ WebAppInternals.staticFilesMiddleware = async function(
 };
 
 function getStaticFileInfo(staticFilesByArch, originalPath, path, arch) {
-  if (!hasOwn.call(WebApp.clientPrograms, arch)) {
+  if (!Object.hasOwn(WebApp.clientPrograms, arch)) {
     return null;
   }
 
@@ -774,12 +773,12 @@ function getStaticFileInfo(staticFilesByArch, originalPath, path, arch) {
 
     // If staticFiles contains originalPath with the arch inferred above,
     // use that information.
-    if (hasOwn.call(staticFiles, originalPath)) {
+    if (Object.hasOwn(staticFiles, originalPath)) {
       return finalize(originalPath);
     }
 
     // If categorizeRequest returned an alternate path, try that instead.
-    if (path !== originalPath && hasOwn.call(staticFiles, path)) {
+    if (path !== originalPath && Object.hasOwn(staticFiles, path)) {
       return finalize(path);
     }
   });
@@ -1271,7 +1270,7 @@ async function runWebAppServer() {
       const { arch } = request;
       assert.strictEqual(typeof arch, 'string', { arch });
 
-      if (!hasOwn.call(WebApp.clientPrograms, arch)) {
+      if (!Object.hasOwn(WebApp.clientPrograms, arch)) {
         // We could come here in case we run with some architectures excluded
         headers['Cache-Control'] = 'no-cache';
         res.writeHead(404, headers);

--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -10,7 +10,6 @@ var Profile = require('./profile').Profile;
 // This code is duplicated in tools/main.js.
 var MIN_NODE_VERSION = 'v18.16.0';
 
-var hasOwn = Object.prototype.hasOwnProperty;
 
 if (require('semver').lt(process.version, MIN_NODE_VERSION)) {
   process.stderr.write(
@@ -131,7 +130,7 @@ serverJson.load.forEach(function (fileInfo) {
 });
 
 function retrieveSourceMap(pathForSourceMap) {
-  if (hasOwn.call(parsedSourceMaps, pathForSourceMap)) {
+  if (Object.hasOwn(parsedSourceMaps, pathForSourceMap)) {
     return { map: parsedSourceMaps[pathForSourceMap] };
   }
   return null;
@@ -342,7 +341,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
       // using this string elsewhere.
       assetPath = files.unicodeNormalizePath(assetPath);
 
-      if (! fileInfo.assets || ! hasOwn.call(fileInfo.assets, assetPath)) {
+      if (! fileInfo.assets || ! Object.hasOwn(fileInfo.assets, assetPath)) {
         _callback(new Error("Unknown asset: " + assetPath));
       } else {
         const filePath = path.join(serverDir, fileInfo.assets[assetPath]);
@@ -372,7 +371,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
         assetPath = files.unicodeNormalizePath(assetPath);
         assetPath = files.convertToStandardPath(assetPath);
 
-        if (! fileInfo.assets || ! hasOwn.call(fileInfo.assets, assetPath)) {
+        if (! fileInfo.assets || ! Object.hasOwn(fileInfo.assets, assetPath)) {
           throw new Error("Unknown asset: " + assetPath);
         }
 
@@ -387,7 +386,7 @@ const loadServerBundles = Profile("Load server bundles", async function () {
     const wrapParts = ["(function(Npm,Assets"];
 
     const specialArgs =
-        hasOwn.call(specialArgPaths, fileInfo.path) &&
+        Object.hasOwn(specialArgPaths, fileInfo.path) &&
         specialArgPaths[fileInfo.path](fileInfo);
 
     const specialKeys = Object.keys(specialArgs || {});


### PR DESCRIPTION
Both `webapp_server.js` and `boot.js` define a manual `hasOwn` helper aliasing `Object.prototype.hasOwnProperty` and then call it as `hasOwn.call(obj, key)` throughout.

`Object.hasOwn(obj, key)` is the standard replacement for this pattern, available since Node 16.9. Meteor requires Node 18.16+, so this is safe to use unconditionally.

This PR replaces all `hasOwn.call()` usages with `Object.hasOwn()` and removes the helper definitions.

**Changes:**
- `packages/webapp/webapp_server.js` — 7 call sites updated, helper removed
- `tools/static-assets/server/boot.js` — 4 call sites updated, helper removed

**Validation:**
- `meteor create --blaze` app boots and serves HTTP 200
- No behavioral change — `Object.hasOwn()` is a direct equivalent of `Object.prototype.hasOwnProperty.call()`

Forum thread for the broader series context: https://forums.meteor.com/t/small-server-runtime-modernization-pr-if-you-want/64522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modernized internal code patterns for improved maintainability and compatibility with current JavaScript standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->