### PR TITLE
Replace url.parse() with WHATWG URL in stream_server.js

### DIFF
--- a/packages/ddp-server/stream_server.js
+++ b/packages/ddp-server/stream_server.js
@@ -179,10 +179,10 @@ Object.assign(StreamServer.prototype, {
 
       // request and upgrade have different arguments passed but
       // we only care about the first one which is always request
-      var newListener = function(request, ...rest) {
+      const newListener = function (request, ...rest) {
         // Rewrite /websocket and /websocket/ urls to /sockjs/websocket while
         // preserving query string.
-        var parsedUrl = new URL(request.url, 'http://dummy');
+        const parsedUrl = new URL(request.url, 'http://dummy');
         if (parsedUrl.pathname === pathPrefix + '/websocket' ||
             parsedUrl.pathname === pathPrefix + '/websocket/') {
           parsedUrl.pathname = self.prefix + '/websocket';

--- a/packages/ddp-server/stream_server.js
+++ b/packages/ddp-server/stream_server.js
@@ -179,23 +179,17 @@ Object.assign(StreamServer.prototype, {
 
       // request and upgrade have different arguments passed but
       // we only care about the first one which is always request
-      var newListener = function(request /*, moreArguments */) {
-        // Store arguments for use within the closure below
-        var args = arguments;
-
-        // TODO replace with url package
-        var url = Npm.require('url');
-
+      var newListener = function(request, ...rest) {
         // Rewrite /websocket and /websocket/ urls to /sockjs/websocket while
         // preserving query string.
-        var parsedUrl = url.parse(request.url);
+        var parsedUrl = new URL(request.url, 'http://dummy');
         if (parsedUrl.pathname === pathPrefix + '/websocket' ||
             parsedUrl.pathname === pathPrefix + '/websocket/') {
           parsedUrl.pathname = self.prefix + '/websocket';
-          request.url = url.format(parsedUrl);
+          request.url = parsedUrl.pathname + parsedUrl.search;
         }
         oldHttpServerListeners.forEach(function(oldListener) {
-          oldListener.apply(httpServer, args);
+          oldListener.call(httpServer, request, ...rest);
         });
       };
       httpServer.addListener(event, newListener);


### PR DESCRIPTION
The WebSocket path rewriting in `stream_server.js` uses the legacy `url.parse()` / `url.format()` APIs via a dynamic `Npm.require('url')` call. There was an existing `// TODO replace with url package` comment on that line.

This PR replaces them with the WHATWG `URL` constructor, which is a global available since Node 10. It also modernizes the `arguments` capture into rest parameters (`...rest`).

**Changes:**
- `new URL(request.url, 'http://dummy')` instead of `url.parse(request.url)`
- `parsedUrl.pathname + parsedUrl.search` instead of `url.format(parsedUrl)`
- `function(request, ...rest)` instead of `function(request) { var args = arguments; }`
- Removes the `Npm.require('url')` call inside the hot path

**Validation:**
- `meteor create --blaze` app boots and serves HTTP 200
- No behavioral change — pathname and search string are preserved identically

Forum thread for the broader series context: https://forums.meteor.com/t/small-server-runtime-modernization-pr-if-you-want/64522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized WebSocket endpoint handling in the DDP server: updated URL rewriting and request handling flow and streamlined how existing request listeners are delegated, improving reliability and simplifying internal request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->