### PR TITLE
Replace +new Date with Date.now() in boot.js

### DIFF
--- a/tools/static-assets/server/boot.js
+++ b/tools/static-assets/server/boot.js
@@ -57,7 +57,7 @@ async function maybeWaitForDebuggerToAttach() {
     const { pause } = require("./debug");
     const pauseThresholdMs = 50;
     const pollIntervalMs = 500;
-    const waitStartTimeMs = +new Date;
+    const waitStartTimeMs = Date.now();
     const waitLimitMinutes = 5;
     const waitLimitMs = waitLimitMinutes * 60 * 1000;
 
@@ -65,7 +65,7 @@ async function maybeWaitForDebuggerToAttach() {
     // keeps the process alive by preventing the event loop from running
     // empty while the main Fiber yields.
     setTimeout(async function poll() {
-      const pauseStartTimeMs = +new Date;
+      const pauseStartTimeMs = Date.now();
 
       if (pauseStartTimeMs - waitStartTimeMs > waitLimitMs) {
         console.error(
@@ -87,7 +87,7 @@ async function maybeWaitForDebuggerToAttach() {
         // what we want to know: "Is the debugger keyword enabled yet?"
         pause();
 
-        if (new Date - pauseStartTimeMs > pauseThresholdMs) {
+        if (Date.now() - pauseStartTimeMs > pauseThresholdMs) {
           // If the pause() function call took a meaningful amount of
           // time, we can conclude the debugger keyword must be active,
           // which means a debugging client must be connected, which means


### PR DESCRIPTION
The debugger-attach polling loop in `boot.js` uses `+new Date` and `new Date - x` to measure elapsed time. These are functionally equivalent to `Date.now()` but less explicit and create unnecessary intermediate Date objects.

This PR replaces all three occurrences with `Date.now()`.

**Changes:**
- `tools/static-assets/server/boot.js` — 3 replacements in `maybeWaitForDebuggerToAttach()`

**Validation:**
- `meteor create --blaze` app boots and serves HTTP 200
- No behavioral change

Forum thread for the broader series context: https://forums.meteor.com/t/small-server-runtime-modernization-pr-if-you-want/64522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal timestamp computation and timing checks for debugger-attach polling to use modern JavaScript standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->