### PR TITLE
chore: replace rimraf with native fs.rmSync in dev-bundle-links.js

### DIFF
--- a/tools/cli/dev-bundle-links.js
+++ b/tools/cli/dev-bundle-links.js
@@ -17,7 +17,7 @@ exports.makeLink = function (target, linkPath) {
     fs.renameSync(tempPath, linkPath);
   } catch (e) {
     // If renaming fails, try unlinking first.
-    require("rimraf").sync(linkPath);
+    fs.rmSync(linkPath, { recursive: true, force: true });
     fs.renameSync(tempPath, linkPath);
   }
 };


### PR DESCRIPTION
### Summary
Replaced deprecated `rimraf.sync` usage in `tools/cli/dev-bundle-links.js` with native Node.js `fs.rmSync`.

---

### What this PR does
- Replaces:
  ```js
  require("rimraf").sync(linkPath);

with:

```
fs.rmSync(linkPath, { recursive: true, force: true });
```
This occurs in the fallback logic when fs.renameSync fails.