### PR TITLE
chore: replace rimraf.sync with fs.rmSync in files.ts

### DIFF
--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -347,7 +347,7 @@ export function rm_recursive_async(path: string) {
 // Like rm -r.
 export const rm_recursive = Profile("files.rm_recursive", async (path: string) => {
   try {
-    fs.rmSync(convertToOSPath(path), { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    fs.rmSync(convertToOSPath(path), { recursive: true, force: true, maxRetries: 5, retryDelay: 500 });
   } catch (e: any) {
     if ((e.code === "ENOTEMPTY" ||
          e.code === "EPERM")) {
@@ -1615,7 +1615,7 @@ export const rename = isWindowsLikeFilesystem() ? function (from: string, to: st
         // Despite previous failures, the top-level destination directory
         // may have been successfully created, so we must remove it to
         // avoid moving the source file *into* the destination directory.
-        fs.rmSync(osTo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+        fs.rmSync(osTo, { recursive: true, force: true, maxRetries: 5, retryDelay: 500 });
         wrappedRename(from, to);
         resolve();
       } catch (err: any) {

--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -347,7 +347,7 @@ export function rm_recursive_async(path: string) {
 // Like rm -r.
 export const rm_recursive = Profile("files.rm_recursive", async (path: string) => {
   try {
-    rimraf.sync(convertToOSPath(path));
+    fs.rmSync(convertToOSPath(path), { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   } catch (e: any) {
     if ((e.code === "ENOTEMPTY" ||
          e.code === "EPERM")) {
@@ -1615,7 +1615,7 @@ export const rename = isWindowsLikeFilesystem() ? function (from: string, to: st
         // Despite previous failures, the top-level destination directory
         // may have been successfully created, so we must remove it to
         // avoid moving the source file *into* the destination directory.
-        rimraf.sync(osTo);
+        fs.rmSync(osTo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
         wrappedRename(from, to);
         resolve();
       } catch (err: any) {


### PR DESCRIPTION
### Summary

Replaced deprecated `rimraf.sync` usages with native `fs.rmSync` in `tools/fs/files.ts`.

### Changes

- Updated `rm_recursive` to use `fs.rmSync`
- Updated rename fallback cleanup logic to use `fs.rmSync`
- Preserved existing behavior with `recursive`, `force`, and retry options

### Notes

- Async `rimraf` usage is intentionally left unchanged and will be handled separately.