### PR TITLE
Update Svelte skeleton to Svelte 5

### DIFF
--- a/tools/e2e-tests/apps/svelte/imports/ui/App.svelte
+++ b/tools/e2e-tests/apps/svelte/imports/ui/App.svelte
@@ -3,13 +3,11 @@
   import { Tracker } from "meteor/tracker";
   import { onMount, onDestroy } from "svelte";
   import { LinksCollection } from "../api/links";
-
-  let counter = 0;
-  const addToCounter = () => { counter += 1 };
+  import { getCounter, addToCounter } from './counter.svelte';
 
   let handle;
-  let subIsReady = false;
-  let links = [];
+  let subIsReady = $state(false);
+  let links = $state([]);
 
   let computation; // Tracker.autorun handle
 
@@ -37,8 +35,8 @@
 
 <div class="container">
   <h1>Welcome to Meteor!</h1>
-  <button on:click={addToCounter}>Click Me</button>
-  <p>You've pressed the button {counter} times.</p>
+  <button onclick={addToCounter}>Click Me</button>
+  <p>You've pressed the button {getCounter()} times.</p>
 
   <h2>Learn Meteor!</h2>
   {#if subIsReady}

--- a/tools/e2e-tests/apps/svelte/imports/ui/App.svelte
+++ b/tools/e2e-tests/apps/svelte/imports/ui/App.svelte
@@ -3,7 +3,7 @@
   import { Tracker } from "meteor/tracker";
   import { onMount, onDestroy } from "svelte";
   import { LinksCollection } from "../api/links";
-  import { getCounter, addToCounter } from './counter.svelte';
+  import { getCounter, addToCounter } from './counter.svelte.js';
 
   let handle;
   let subIsReady = $state(false);

--- a/tools/e2e-tests/apps/svelte/imports/ui/counter.svelte.js
+++ b/tools/e2e-tests/apps/svelte/imports/ui/counter.svelte.js
@@ -1,0 +1,5 @@
+let counter = $state(0);
+
+export const getCounter = () => counter;
+
+export const addToCounter = () => { counter += 1 };

--- a/tools/e2e-tests/apps/svelte/imports/ui/counter.svelte.js
+++ b/tools/e2e-tests/apps/svelte/imports/ui/counter.svelte.js
@@ -2,4 +2,6 @@ let counter = $state(0);
 
 export const getCounter = () => counter;
 
-export const addToCounter = () => { counter += 1 };
+export const addToCounter = () => {
+  counter += 1;
+};

--- a/tools/e2e-tests/apps/svelte/rspack.config.js
+++ b/tools/e2e-tests/apps/svelte/rspack.config.js
@@ -23,7 +23,7 @@ module.exports = defineConfig(Meteor => {
       module: {
         rules: [
           {
-            test: /\.svelte$/,
+            test: /\.(svelte|svelte\.js)$/,
             use: [{
               loader: 'svelte-loader',
               options: {

--- a/tools/static-assets/skel-svelte/imports/ui/App.svelte
+++ b/tools/static-assets/skel-svelte/imports/ui/App.svelte
@@ -3,13 +3,11 @@
   import { Tracker } from "meteor/tracker";
   import { onMount, onDestroy } from "svelte";
   import { LinksCollection } from "../api/links";
-
-  let counter = 0;
-  const addToCounter = () => { counter += 1 };
+  import { getCounter, addToCounter } from './counter.svelte';
 
   let handle;
-  let subIsReady = false;
-  let links = [];
+  let subIsReady = $state(false);
+  let links = $state([]);
 
   let computation; // Tracker.autorun handle
 
@@ -37,8 +35,8 @@
 
 <div class="container">
   <h1>Welcome to Meteor!</h1>
-  <button on:click={addToCounter}>Click Me</button>
-  <p>You've pressed the button {counter} times.</p>
+  <button onclick={addToCounter}>Click Me</button>
+  <p>You've pressed the button {getCounter()} times.</p>
 
   <h2>Learn Meteor!</h2>
   {#if subIsReady}

--- a/tools/static-assets/skel-svelte/imports/ui/App.svelte
+++ b/tools/static-assets/skel-svelte/imports/ui/App.svelte
@@ -3,7 +3,7 @@
   import { Tracker } from "meteor/tracker";
   import { onMount, onDestroy } from "svelte";
   import { LinksCollection } from "../api/links";
-  import { getCounter, addToCounter } from './counter.svelte';
+  import { getCounter, addToCounter } from './counter.svelte.js';
 
   let handle;
   let subIsReady = $state(false);

--- a/tools/static-assets/skel-svelte/imports/ui/counter.svelte.js
+++ b/tools/static-assets/skel-svelte/imports/ui/counter.svelte.js
@@ -1,0 +1,5 @@
+let counter = $state(0);
+
+export const getCounter = () => counter;
+
+export const addToCounter = () => { counter += 1 };

--- a/tools/static-assets/skel-svelte/imports/ui/counter.svelte.js
+++ b/tools/static-assets/skel-svelte/imports/ui/counter.svelte.js
@@ -2,4 +2,6 @@ let counter = $state(0);
 
 export const getCounter = () => counter;
 
-export const addToCounter = () => { counter += 1 };
+export const addToCounter = () => {
+  counter += 1;
+};

--- a/tools/static-assets/skel-svelte/rspack.config.js
+++ b/tools/static-assets/skel-svelte/rspack.config.js
@@ -22,7 +22,7 @@ module.exports = defineConfig((Meteor) => {
       module: {
         rules: [
           {
-            test: /\.svelte$/,
+            test: /\.(svelte|svelte\.js)$/,
             use: [
               {
                 loader: "svelte-loader",


### PR DESCRIPTION
This PR includes two related changes for the Svelte skeleton app and the test app:

1. **Small fix to support `.svelte.js` files in the Rspack config.**
`.svelte.js` files are supported in Svelte 5 and may contain runes. They should be processed by `svelte-loader`, just like ordinary `.svelte` files. Currently, there is a compile-time error if you try to use them with runes.

2. **Update from Svelte 4 to Svelte 5 syntax.**
Svelte 4 syntax is now considered legacy and [is not recommended by the Svelte Docs](https://svelte.dev/docs/svelte/best-practices#Avoid-legacy-features). I also moved the `counter` state into a separate `counter.svelte.js` file to demonstrate support for `.svelte.js` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved counter into a shared UI module so multiple components read and update the same value.
  * Converted local flags and lists to reactive state for consistent UI updates.
  * Updated component event wiring and counter display to use the shared state accessors.

* **Chores**
  * Expanded build config so the Svelte toolchain recognizes an additional module filename pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->