### PR TITLE
Enhance `meteor create --example/--from` command

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -1183,7 +1183,12 @@ main.registerCommand({
       if (example.isInternal) {
         await cloneSubdirectory(EXAMPLES_REPO, EXAMPLES_BRANCH, example.internalPath, appPath);
       } else {
-        await cloneRepo(example.repositoryUrl, appPath);
+        const parsed = parseGitUrl(example.repositoryUrl);
+        if (parsed.dir) {
+          await cloneSubdirectory(parsed.repoUrl, parsed.branch, parsed.dir, appPath);
+        } else {
+          await cloneRepo(parsed.repoUrl, appPath, { branch: parsed.branch });
+        }
       }
 
       await setupMessages();

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -127,7 +127,7 @@ import { ensureDevBundleDependencies } from '../cordova/index.js';
 import { CordovaRunner } from '../cordova/runner.js';
 import { iOSRunTarget, AndroidRunTarget } from '../cordova/run-targets.js';
 
-import { getExamples, findExample, cloneRepo, cloneSubdirectory, validateMeteorApp, EXAMPLES_REPO, EXAMPLES_BRANCH } from './examples.js';
+import { getExamples, findExample, cloneRepo, cloneSubdirectory, parseGitUrl, validateMeteorApp, EXAMPLES_REPO, EXAMPLES_BRANCH } from './examples.js';
 
 // The architecture used by Meteor Software's hosted servers; it's the
 // architecture used by 'meteor deploy'.
@@ -1200,10 +1200,14 @@ main.registerCommand({
   }
 
   if (options.from) {
-    const branch = options['from-branch'] || null;
+    // Smart-parse the URL to extract repo, branch, and dir when possible.
+    // Explicit --from-branch / --from-dir always take precedence.
+    const parsed = parseGitUrl(options.from);
+    const branch = options['from-branch'] || parsed.branch || null;
+    const subdir = options['from-dir'] || parsed.dir || null;
     try {
-      if (options['from-dir']) {
-        let repoUrl = options.from;
+      if (subdir) {
+        let repoUrl = parsed.repoUrl;
         try {
           const examples = await getExamples();
           const example = findExample(examples, options.from);
@@ -1214,10 +1218,10 @@ main.registerCommand({
           // If examples fetch fails, treat --from as a URL
         }
 
-        await cloneSubdirectory(repoUrl, branch, options['from-dir'], appPath);
+        await cloneSubdirectory(repoUrl, branch, subdir, appPath);
         validateMeteorApp(appPath);
       } else {
-        await cloneRepo(options.from, appPath, { branch });
+        await cloneRepo(parsed.repoUrl, appPath, { branch });
         validateMeteorApp(appPath);
       }
 

--- a/tools/cli/examples.js
+++ b/tools/cli/examples.js
@@ -106,58 +106,58 @@ function findExample(examples, slug) {
   return examples.find(e => e.slug === slug) || null;
 }
 
-async function cloneRepo(url, destPath, { branch = null } = {}) {
+function execGit(args, options = {}) {
   const env = Object.assign({}, process.env, { GIT_TERMINAL_PROMPT: '0' });
-
   return new Promise((resolve, reject) => {
-    execFile('git', ['--version'], (error) => {
+    execFile('git', args, { env, ...options }, (error, stdout) => {
       if (error) {
-        reject(new Error('git is not installed'));
+        reject(error);
         return;
       }
-
-      const args = ['clone', '--progress'];
-      if (branch) {
-        args.push('--branch', branch);
-      }
-      args.push(url, files.convertToOSPath(destPath));
-
-      execFile('git', args, { env }, async (cloneError) => {
-        if (cloneError) {
-          reject(new Error(`Failed to clone ${url}: ${cloneError.message}`));
-          return;
-        }
-
-        try {
-          await files.rm_recursive_async(files.pathJoin(destPath, '.git'));
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
-      });
+      resolve(stdout);
     });
   });
+}
+
+async function cloneRepo(url, destPath, { branch = null } = {}) {
+  try {
+    await execGit(['--version']);
+  } catch (e) {
+    throw new Error('git is not installed');
+  }
+
+  const dest = files.convertToOSPath(destPath);
+
+  if (branch) {
+    // Try --branch first (works for branches and tags)
+    try {
+      await execGit(['clone', '--progress', '--branch', branch, url, dest]);
+    } catch (branchError) {
+      // --branch fails for commit hashes; clone then checkout
+      await execGit(['clone', '--progress', url, dest]);
+      await execGit(['checkout', branch], { cwd: dest });
+    }
+  } else {
+    await execGit(['clone', '--progress', url, dest]);
+  }
+
+  await files.rm_recursive_async(files.pathJoin(destPath, '.git'));
 }
 
 async function cloneSubdirectory(repoUrl, branch, subdir, destPath) {
   const tempDir = files.mkdtemp('meteor-example-');
   try {
-    const env = Object.assign({}, process.env, { GIT_TERMINAL_PROMPT: '0' });
-    const args = ['clone', '--progress'];
     if (branch) {
-      args.push('--branch', branch);
+      try {
+        await execGit(['clone', '--progress', '--branch', branch, repoUrl, tempDir]);
+      } catch (branchError) {
+        // --branch fails for commit hashes; clone then checkout
+        await execGit(['clone', '--progress', repoUrl, tempDir]);
+        await execGit(['checkout', branch], { cwd: tempDir });
+      }
+    } else {
+      await execGit(['clone', '--progress', repoUrl, tempDir]);
     }
-    args.push(repoUrl, tempDir);
-
-    await new Promise((resolve, reject) => {
-      execFile('git', args, { env }, (error) => {
-        if (error) {
-          reject(new Error(`Failed to clone ${repoUrl}: ${error.message}`));
-          return;
-        }
-        resolve();
-      });
-    });
 
     const path = require('path');
     const resolvedTemp = path.resolve(tempDir) + path.sep;
@@ -186,6 +186,75 @@ async function cloneSubdirectory(repoUrl, branch, subdir, destPath) {
   }
 }
 
+/**
+ * Parse a GitHub, GitLab, or Bitbucket tree/src URL into its components.
+ * Returns { repoUrl, branch, dir } where branch and dir may be null.
+ *
+ * Explicit --from-branch / --from-dir flags should override the parsed values.
+ *
+ * Supported URL patterns:
+ *   GitHub:    https://github.com/owner/repo/tree/branch[/path]
+ *   GitLab:    https://gitlab.com/owner/repo/-/tree/branch[/path]
+ *   Bitbucket: https://bitbucket.org/owner/repo/src/branch[/path]
+ */
+function parseGitUrl(url) {
+  const result = { repoUrl: url, branch: null, dir: null };
+  if (!url || typeof url !== 'string') return result;
+
+  // GitHub: https://github.com/owner/repo/tree/branch[/path]
+  const ghMatch = url.match(
+    /^(https?:\/\/github\.com\/[^/]+\/[^/]+)\/tree\/(.+)$/
+  );
+  if (ghMatch) {
+    result.repoUrl = ghMatch[1];
+    const rest = ghMatch[2];
+    const slashIdx = rest.indexOf('/');
+    if (slashIdx === -1) {
+      result.branch = decodeURIComponent(rest);
+    } else {
+      result.branch = decodeURIComponent(rest.slice(0, slashIdx));
+      result.dir = rest.slice(slashIdx + 1).replace(/\/+$/, '') || null;
+    }
+    return result;
+  }
+
+  // GitLab: https://gitlab.com/owner/repo/-/tree/branch[/path]
+  const glMatch = url.match(
+    /^(https?:\/\/gitlab\.com\/[^/]+\/[^/]+)\/-\/tree\/(.+)$/
+  );
+  if (glMatch) {
+    result.repoUrl = glMatch[1];
+    const rest = glMatch[2];
+    const slashIdx = rest.indexOf('/');
+    if (slashIdx === -1) {
+      result.branch = decodeURIComponent(rest);
+    } else {
+      result.branch = decodeURIComponent(rest.slice(0, slashIdx));
+      result.dir = rest.slice(slashIdx + 1).replace(/\/+$/, '') || null;
+    }
+    return result;
+  }
+
+  // Bitbucket: https://bitbucket.org/owner/repo/src/branch[/path]
+  const bbMatch = url.match(
+    /^(https?:\/\/bitbucket\.org\/[^/]+\/[^/]+)\/src\/(.+)$/
+  );
+  if (bbMatch) {
+    result.repoUrl = bbMatch[1];
+    const rest = bbMatch[2];
+    const slashIdx = rest.indexOf('/');
+    if (slashIdx === -1) {
+      result.branch = decodeURIComponent(rest);
+    } else {
+      result.branch = decodeURIComponent(rest.slice(0, slashIdx));
+      result.dir = rest.slice(slashIdx + 1).replace(/\/+$/, '') || null;
+    }
+    return result;
+  }
+
+  return result;
+}
+
 function validateMeteorApp(dirPath) {
   const meteorDir = files.pathJoin(dirPath, '.meteor');
   if (!files.exists(meteorDir)) {
@@ -201,6 +270,7 @@ module.exports = {
   findExample,
   cloneRepo,
   cloneSubdirectory,
+  parseGitUrl,
   validateMeteorApp,
   EXAMPLES_REPO,
   EXAMPLES_BRANCH,

--- a/tools/cli/examples.test.js
+++ b/tools/cli/examples.test.js
@@ -1,0 +1,141 @@
+// Mock heavy dependencies that examples.js requires at module load
+jest.mock('../fs/files', () => ({}));
+jest.mock('../utils/http-helpers.js', () => ({}));
+jest.mock('../console/console.js', () => ({ Console: { warn: jest.fn() } }));
+
+const { parseGitUrl } = require('./examples.js');
+
+describe('parseGitUrl', () => {
+  describe('GitHub URLs', () => {
+    it('parses branch-only URL', () => {
+      const result = parseGitUrl('https://github.com/meteor/meteor3-vue3/tree/3.4-rspack');
+      expect(result).toEqual({
+        repoUrl: 'https://github.com/meteor/meteor3-vue3',
+        branch: '3.4-rspack',
+        dir: null,
+      });
+    });
+
+    it('parses branch and directory', () => {
+      const result = parseGitUrl('https://github.com/meteor/examples/tree/main/parties');
+      expect(result).toEqual({
+        repoUrl: 'https://github.com/meteor/examples',
+        branch: 'main',
+        dir: 'parties',
+      });
+    });
+
+    it('parses branch and nested directory', () => {
+      const result = parseGitUrl('https://github.com/owner/repo/tree/develop/src/app/demo');
+      expect(result).toEqual({
+        repoUrl: 'https://github.com/owner/repo',
+        branch: 'develop',
+        dir: 'src/app/demo',
+      });
+    });
+
+    it('strips trailing slashes from dir', () => {
+      const result = parseGitUrl('https://github.com/owner/repo/tree/main/dir/');
+      expect(result).toEqual({
+        repoUrl: 'https://github.com/owner/repo',
+        branch: 'main',
+        dir: 'dir',
+      });
+    });
+
+    it('decodes percent-encoded branch names', () => {
+      const result = parseGitUrl('https://github.com/owner/repo/tree/feature%2Ftest');
+      expect(result).toEqual({
+        repoUrl: 'https://github.com/owner/repo',
+        branch: 'feature/test',
+        dir: null,
+      });
+    });
+
+    it('works with http (not https)', () => {
+      const result = parseGitUrl('http://github.com/owner/repo/tree/main');
+      expect(result).toEqual({
+        repoUrl: 'http://github.com/owner/repo',
+        branch: 'main',
+        dir: null,
+      });
+    });
+  });
+
+  describe('GitLab URLs', () => {
+    it('parses branch-only URL', () => {
+      const result = parseGitUrl('https://gitlab.com/owner/repo/-/tree/main');
+      expect(result).toEqual({
+        repoUrl: 'https://gitlab.com/owner/repo',
+        branch: 'main',
+        dir: null,
+      });
+    });
+
+    it('parses branch and directory', () => {
+      const result = parseGitUrl('https://gitlab.com/ns/project/-/tree/develop/src');
+      expect(result).toEqual({
+        repoUrl: 'https://gitlab.com/ns/project',
+        branch: 'develop',
+        dir: 'src',
+      });
+    });
+  });
+
+  describe('Bitbucket URLs', () => {
+    it('parses branch-only URL', () => {
+      const result = parseGitUrl('https://bitbucket.org/owner/repo/src/main');
+      expect(result).toEqual({
+        repoUrl: 'https://bitbucket.org/owner/repo',
+        branch: 'main',
+        dir: null,
+      });
+    });
+
+    it('parses branch and directory', () => {
+      const result = parseGitUrl('https://bitbucket.org/owner/repo/src/develop/lib/core');
+      expect(result).toEqual({
+        repoUrl: 'https://bitbucket.org/owner/repo',
+        branch: 'develop',
+        dir: 'lib/core',
+      });
+    });
+  });
+
+  describe('plain git URLs (no tree/src segment)', () => {
+    it('returns URL unchanged with null branch and dir', () => {
+      const result = parseGitUrl('https://github.com/meteor/meteor3-vue3');
+      expect(result).toEqual({
+        repoUrl: 'https://github.com/meteor/meteor3-vue3',
+        branch: null,
+        dir: null,
+      });
+    });
+
+    it('handles SSH-style URLs unchanged', () => {
+      const result = parseGitUrl('git@github.com:owner/repo.git');
+      expect(result).toEqual({
+        repoUrl: 'git@github.com:owner/repo.git',
+        branch: null,
+        dir: null,
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns defaults for null input', () => {
+      const result = parseGitUrl(null);
+      expect(result).toEqual({ repoUrl: null, branch: null, dir: null });
+    });
+
+    it('returns defaults for empty string', () => {
+      const result = parseGitUrl('');
+      expect(result).toEqual({ repoUrl: '', branch: null, dir: null });
+    });
+
+    it('returns defaults for non-string input', () => {
+      const result = parseGitUrl(42);
+      expect(result).toEqual({ repoUrl: 42, branch: null, dir: null });
+    });
+  });
+});

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -199,9 +199,11 @@ Skeleton options:
 Example options:
   --example      Create from a community example (use --list to browse).
   --list         Show detailed list of available examples.
-  --from         Clone a Meteor project from a Git URL.
-  --from-branch  Branch to clone from (use with --from).
-  --from-dir     Extract only a subdirectory (use with --from).
+  --from         Clone a Meteor project from a Git URL. Accepts GitHub, GitLab,
+                 and Bitbucket tree/src URLs. branch and subdirectory are
+                 auto-detected from the URL when possible.
+  --from-branch  Branch to clone from (overrides branch parsed from URL).
+  --from-dir     Extract only a subdirectory (overrides dir parsed from URL).
 
 Other options:
   --package      Create a new meteor package instead of an app.

--- a/tools/e2e-tests/example.test.js
+++ b/tools/e2e-tests/example.test.js
@@ -80,6 +80,56 @@ describe('Examples /', () => {
     }
   });
 
+  it('meteor create --from parses a GitHub tree URL (branch auto-detected)', async () => {
+    const { appName, tempDir } = tempApp('fromurl');
+    try {
+      await runMeteorCommand(
+        'create', [
+          '--from', 'https://github.com/meteor/meteor3-react/tree/3.4-rspack',
+          appName
+        ], os.tmpdir(),
+        { checkExitCode: true }
+      );
+      expect(fs.existsSync(path.join(tempDir, '.meteor'))).toBe(true);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it('meteor create --from parses a GitHub tree URL with subdirectory', async () => {
+    const { appName, tempDir } = tempApp('fromurldir');
+    try {
+      await runMeteorCommand(
+        'create', [
+          '--from', 'https://github.com/meteor/examples/tree/migrate-examples/parties',
+          appName
+        ], os.tmpdir(),
+        { checkExitCode: true }
+      );
+      expect(fs.existsSync(path.join(tempDir, '.meteor'))).toBe(true);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it('meteor create --from with explicit --from-branch overrides parsed branch', async () => {
+    const { appName, tempDir } = tempApp('fromoverride');
+    try {
+      // The URL points to tree/3.4-rspack, but --from-branch overrides it
+      await runMeteorCommand(
+        'create', [
+          '--from', 'https://github.com/meteor/meteor3-react/tree/3.4-rspack',
+          '--from-branch', '3.4-rspack',
+          appName
+        ], os.tmpdir(),
+        { checkExitCode: true }
+      );
+      expect(fs.existsSync(path.join(tempDir, '.meteor'))).toBe(true);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   it('meteor create --from fails for a non-Meteor repository', async () => {
     const { appName, tempDir } = tempApp('nonmeteor');
     try {

--- a/tools/tests/create.js
+++ b/tools/tests/create.js
@@ -46,7 +46,7 @@ selftest.define("create main", async function () {
 
   run = s.run("create", "--list");
   await run.match('Meteor Examples');
-  await run.match('react');
+  await run.match('simple-tasks');
   await run.expectExit(0);
 });
 

--- a/tools/tests/create.js
+++ b/tools/tests/create.js
@@ -50,8 +50,7 @@ selftest.define("create main", async function () {
   await run.expectExit(0);
 });
 
-// TODO: Enable once rspack is published for the first time
-// Also, the new modern test suite covers more than this test.
+// The new modern test suite covers more than this test.
 // This test may not work, as rspack relies on project npm dependencies
 // being installed, and this suite apparently does not install them.
 /* AVAILABLE_SKELETONS.forEach(template => {


### PR DESCRIPTION
This PR solves an issue on parsing properly certain urls using in the[ meteor/examples](https://github.com/meteor/examples/pull/42) repository for tutorials. Starting now, `meteor create --from` understands GitHub, GitLab, and Bitbucket tree URLs natively. Just paste the URL from your browser:

```bash
# Before
meteor create my-app --from https://github.com/meteor/meteor3-react --from-branch 3.4-rspack

# After
meteor create my-app --from https://github.com/meteor/meteor3-react/tree/3.4-rspack
```

Subdirectories are also auto-detected from the URL. The parser recognizes the patterns used by all three major platforms (`/tree/` for GitHub and GitLab, `/src/` for Bitbucket). Plain Git URLs continue to work as before, and explicit `--from-branch` and `--from-dir` flags always take precedence over parsed values.

We also improved ref resolution during cloning. Previously only branches and tags were supported via `git clone --branch`. Now, if that fails, the clone falls back to `git checkout`, so commit hashes work too.

This change ships with unit tests covering all supported platforms and edge cases, and E2E tests that clone real repositories including [meteor3-react](https://github.com/meteor/meteor3-react) on the `3.4-rspack` branch.