### PR TITLE
fix: disable HMR proxy in test mode

### DIFF
--- a/packages/rspack/rspack_server.js
+++ b/packages/rspack/rspack_server.js
@@ -31,6 +31,7 @@ const RSPACK_ASSETS_REGEX = new RegExp(
 const shouldEnableDevHMRProxy =
   global?.Package?.["tools-core"] != null &&
   Meteor.isDevelopment &&
+  !Meteor.isTest && !Meteor.isAppTest &&
   !process.env.RSPACK_NATIVE;
 if (shouldEnableDevHMRProxy) {
   const { shuffleString } = require('meteor/tools-core/lib/string');


### PR DESCRIPTION
## Summary

- Disable the rspack HMR dev proxy when running in test mode (`meteor test` / `meteor test --full-app`)
- In test mode, `Meteor.isDevelopment` is `true` but no rspack dev server is running (test uses `runRspackBuild`, not `startRspackClientServe`). The proxy was registering WebSocket upgrade handlers pointing to a port where nothing listens, causing SockJS WebSocket corruption and DDP message failures.

## Context

Reported by @schlaegerz in the [3.4 RC3 forum thread](https://forums.meteor.com/t/3-4-rc-3-release-candidate-faster-builds-smaller-bundles-and-modern-setups-with-the-rspack-integration/64124/241):
- `Invalid frame header` errors on SockJS WebSocket connections during `meteor test --full-app`
- `TypeError: Cannot convert undefined or null to object` in `methods_replication.js` (DDP `changed` messages arriving with undefined `fields`)
- Setting `RSPACK_NATIVE=1` resolved it (disables the proxy entirely)

## Fix

Add `!Meteor.isTest && !Meteor.isAppTest` to the HMR proxy guard, consistent with the existing `RSPACK_NATIVE` guard that was introduced for native mode.

@nachocodoner 