### PR TITLE
CI: skiping login on deploy test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - PUPPETEER_DOWNLOAD_PATH=~/.npm/chromium
     - TEST_PACKAGES_EXCLUDE=stylus
     - METEOR_MODERN=true
+    - TRAVIS_CI=true
 addons:
   apt:
     sources:

--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -8,13 +8,6 @@
 cd $(dirname $0)/../..
 export METEOR_HOME=`pwd`
 
-# We are keeping travis just as a fallback, if we detect we have TRAVIS_CI env var,
-# We want to stop early and return true
-if [ "$TRAVIS_CI" = "true" ]; then
-  echo "Running in Travis CI, skipping test-in-console tests."
-  exit 0
-fi
-
 # Install puppeteer into dev_bundle only when it is not already available globally
 # (e.g. on oss-vm, where puppeteer@23.6.0 is pre-installed via system npm and
 # NODE_PATH is set to $(npm root -g) by the CI workflow).

--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -8,6 +8,13 @@
 cd $(dirname $0)/../..
 export METEOR_HOME=`pwd`
 
+# We are keeping travis just as a fallback, if we detect we have TRAVIS_CI env var,
+# We want to stop early and return true
+if [ "$TRAVIS_CI" = "true" ]; then
+  echo "Running in Travis CI, skipping test-in-console tests."
+  exit 0
+fi
+
 # Install puppeteer into dev_bundle only when it is not already available globally
 # (e.g. on oss-vm, where puppeteer@23.6.0 is pre-installed via system npm and
 # NODE_PATH is set to $(npm root -g) by the CI workflow).

--- a/tools/tests/login.js
+++ b/tools/tests/login.js
@@ -152,6 +152,6 @@ selftest.define("login on deploy", ['net'], async function () {
   run.waitSecs(commandTimeoutSecs);
   await run.match("Talking to Galaxy servers");
   run.waitSecs(commandTimeoutSecs * 10);
-  // "test" user can't actually deploy, so it will still fail.
-  await run.expectExit(1);
+  await run.match("View deployment progress at:");
+
 });

--- a/tools/tests/login.js
+++ b/tools/tests/login.js
@@ -152,6 +152,7 @@ selftest.define("login on deploy", ['net'], async function () {
   run.waitSecs(commandTimeoutSecs);
   await run.match("Talking to Galaxy servers");
 
+  // Galaxy had some changes in the CLI, we plan to uncomment this test after we update the CLI in the tool.
   // run.waitSecs(commandTimeoutSecs * 10);
   // await run.match("View deployment progress at:");
   // await run.expectExit();

--- a/tools/tests/login.js
+++ b/tools/tests/login.js
@@ -153,5 +153,5 @@ selftest.define("login on deploy", ['net'], async function () {
   await run.match("Talking to Galaxy servers");
   run.waitSecs(commandTimeoutSecs * 10);
   await run.match("View deployment progress at:");
-
+  await run.expectExit();
 });

--- a/tools/tests/login.js
+++ b/tools/tests/login.js
@@ -151,7 +151,4 @@ selftest.define("login on deploy", ['net'], async function () {
   run.write("testtest\n");
   run.waitSecs(commandTimeoutSecs);
   await run.match("Talking to Galaxy servers");
-  run.waitSecs(commandTimeoutSecs * 10);
-  await run.match("View deployment progress at:");
-  await run.expectExit();
 });

--- a/tools/tests/login.js
+++ b/tools/tests/login.js
@@ -151,4 +151,8 @@ selftest.define("login on deploy", ['net'], async function () {
   run.write("testtest\n");
   run.waitSecs(commandTimeoutSecs);
   await run.match("Talking to Galaxy servers");
+
+  // run.waitSecs(commandTimeoutSecs * 10);
+  // await run.match("View deployment progress at:");
+  // await run.expectExit();
 });


### PR DESCRIPTION
With https://github.com/meteor/meteor/pull/14300, we are keeping Travis just in case we need to fallback to it – we can start ignoring it now

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI environment updated to signal CI runs should skip local browser-based test setup and teardown during automated builds.

* **Tests**
  * Self-test adjusted to accept streaming deploy output rather than asserting a specific failure exit, improving stability in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->