### PR TITLE
Disable HMR WebSocket connection during test modes to prevent errors

### DIFF
--- a/packages/hot-module-replacement/client.js
+++ b/packages/hot-module-replacement/client.js
@@ -14,10 +14,16 @@ var lastUpdated = initialVersions.versionHmr;
 var hmrSecret = __meteor_runtime_config__._hmrSecret;
 
 // Cordova doesn't need the hmrSecret, though cordova is also unable to tell
-// if Meteor needs to be restarted to enable HMR;
-// HMR is disabled by the compile layer during test runs (buildMode 'test'),
-// so skip the WebSocket connect to avoid spurious errors and upgrade-path
-// races with SockJS.
+// if Meteor needs to be restarted to enable HMR.
+//
+// HMR is also skipped during `meteor test` and `meteor test --full-app`.
+// The build pipeline already turns HMR off in those runs, so nothing gets
+// HMR-wrapped and the client has nothing useful to receive. The runner
+// still hands us an hmrSecret, though, which would otherwise cause this
+// client to open a WebSocket that can never do any work (and race with
+// SockJS for the upgrade path, same shape as the Rspack fix in #14329).
+// See `tools/runners/run-all.js` for the tool-side notes on where the
+// test build mode is preserved and why HMR is wired up anyway.
 var enabled = (Meteor.isCordova || !!hmrSecret) &&
   !Meteor.isTest && !Meteor.isAppTest;
 

--- a/packages/hot-module-replacement/client.js
+++ b/packages/hot-module-replacement/client.js
@@ -15,7 +15,11 @@ var hmrSecret = __meteor_runtime_config__._hmrSecret;
 
 // Cordova doesn't need the hmrSecret, though cordova is also unable to tell
 // if Meteor needs to be restarted to enable HMR;
-var enabled = Meteor.isCordova || !!hmrSecret;
+// HMR is disabled by the compile layer during test runs (buildMode 'test'),
+// so skip the WebSocket connect to avoid spurious errors and upgrade-path
+// races with SockJS.
+var enabled = (Meteor.isCordova || !!hmrSecret) &&
+  !Meteor.isTest && !Meteor.isAppTest;
 
 if (!enabled) {
   console.log('Restart Meteor to enable HMR');

--- a/tools/runners/run-all.js
+++ b/tools/runners/run-all.js
@@ -118,6 +118,18 @@ class Runner {
       mongoUrl = 'no-mongo-server';
     }
 
+    // Note: the HMR server is started here whenever the app uses
+    // `hot-module-replacement`, regardless of build mode. That includes
+    // `meteor test` and `meteor test --full-app`, even though HMR is
+    // effectively a no-op in those runs. The compile layer
+    // (`tools/isobuild/compiler-plugin.js`, `hmrAvailable`) gates HMR on
+    // `buildMode === 'development'`, and test runs build with
+    // `buildMode: 'test'` (set in `tools/cli/commands.js` and preserved
+    // above in the NODE_ENV/buildMode block, which explicitly notes
+    // "We *never* override buildMode (it can be 'test')"). The client side
+    // of the `hot-module-replacement` package is responsible for bailing
+    // out of its WebSocket connection when `Meteor.isTest` or
+    // `Meteor.isAppTest` is set, so we don't need an extra guard here.
     const hasHotModuleReplacementPackage = packageMap &&
         packageMap.getInfo('hot-module-replacement') != null;
     self.hmrServer = null;


### PR DESCRIPTION
Continues: https://github.com/meteor/meteor/pull/14329

When I was testing test mode to verify https://github.com/meteor/meteor/pull/14329
, I still saw error logs being triggered, but instead of coming from Rspack mode, they were coming from Meteor's HMR package.

Running `meteor test` / `meteor test --full-app` against an app with `hot-module-replacement` spams the browser console with:

```
WebSocket connection to 'ws://localhost:3000/__meteor__hmr__/websocket' failed
```

HMR is already disabled at compile time in test runs (`compiler-plugin.js` gates `hmrAvailable` on `buildMode === 'development'`), so no change sets ever flow, the client's connection attempts are dead wiring that also race with SockJS for the upgrade path, the same class of bug fixed for Rspack in [#14329](https://github.com/meteor/meteor/pull/14329).

This PR solves the fix and guard the `enabled` flag in `packages/hot-module-replacement/client.js` with `!Meteor.isTest && !Meteor.isAppTest`. Dev mode and Cordova unaffected.