### PR TITLE
fix: rspack child processes can't find Node without global install

### DIFF
--- a/packages/rspack/lib/processes.js
+++ b/packages/rspack/lib/processes.js
@@ -38,6 +38,7 @@ const {
 const {
   checkNpmDependencyExists,
   getNpxCommand,
+  getNodeBinEnv,
   getMonorepoPath,
 } = require('meteor/tools-core/lib/npm');
 
@@ -327,7 +328,7 @@ export function startRspackClientServe(options = {}) {
     command,
     args, {
       cwd: appDir,
-      env: { ...process.env, ...envs },
+      env: { ...process.env, ...getNodeBinEnv(), ...envs },
       onStdout: (data) => {
         logInfo(`[Rspack Client] ${data}`);
         if (onCompile && data.trim().includes("compiled")) {
@@ -390,7 +391,7 @@ export function startRspackServerWatch(options = {}) {
     command,
     args, {
     cwd: appDir,
-    env: { ...process.env, ...envs },
+    env: { ...process.env, ...getNodeBinEnv(), ...envs },
     onStdout: (data) => {
       logInfo(`[Rspack Server] ${data}`);
       if (onCompile && data.trim().includes("compiled")) {
@@ -457,7 +458,7 @@ export async function runRspackBuild({ isClient, isServer, isTest, isTestModule,
       args,
       {
       cwd: appDir,
-      env: { ...process.env, ...envs },
+      env: { ...process.env, ...getNodeBinEnv(), ...envs },
       onStdout: (data) => {
         logInfo(`[Rspack ${label} ${endpoint}] ${data}`);
         if (onCompile && data.trim().includes("compiled")) {

--- a/packages/tools-core/lib/npm.js
+++ b/packages/tools-core/lib/npm.js
@@ -3,31 +3,64 @@ const path = require('path');
 const { spawnProcess } = require('./process');
 
 /**
+ * Returns the Meteor dev_bundle bin directory path if available, otherwise null.
+ *
+ * @returns {string|null} The path to the dev_bundle bin directory, or null if not available
+ */
+function resolveNodeBinDir() {
+  try {
+    if (typeof Plugin !== 'undefined' &&
+        typeof Plugin.getCurrentNodeBinDir === 'function' &&
+        Plugin.getCurrentNodeBinDir()) {
+      return Plugin.getCurrentNodeBinDir();
+    }
+
+    if (typeof getCurrentNodeBinDir === 'function') {
+      return getCurrentNodeBinDir();
+    }
+  } catch (e) {
+    // fall through
+  }
+  return null;
+}
+
+/**
+ * Returns environment variables that ensure child processes can find
+ * Meteor's bundled Node.js (and npm/npx) on their PATH.
+ *
+ * When the dev_bundle bin directory is available, it is prepended to PATH
+ * so that `#!/usr/bin/env node` shebangs in spawned scripts resolve to
+ * Meteor's Node rather than requiring a separate global install.
+ *
+ * Returns an empty object when the bin directory cannot be determined,
+ * leaving the caller's environment unchanged.
+ *
+ * @returns {Object} An object with a PATH key, or empty object
+ */
+export function getNodeBinEnv() {
+  const binDir = resolveNodeBinDir();
+  if (!binDir) {
+    return {};
+  }
+  const currentPath = process.env.PATH || process.env.Path || '';
+  return {
+    PATH: binDir + path.delimiter + currentPath,
+  };
+}
+
+/**
  * Gets the path to a Node.js binary using Plugin.getCurrentNodeBinDir() if available,
  * otherwise returns null.
- * 
+ *
  * @param {string} binaryName - The name of the binary (e.g., 'npm', 'npx', 'node')
  * @returns {string|null} The path to the specified binary, or null if not available
  */
 export function getNodeBinaryPath(binaryName) {
-  try {
-    // Try to access Plugin.getCurrentNodeBinDir()
-    if (typeof Plugin !== 'undefined' && 
-        typeof Plugin.getCurrentNodeBinDir === 'function' && 
-        Plugin.getCurrentNodeBinDir()) {
-      return path.join(Plugin.getCurrentNodeBinDir(), binaryName);
-    }
-
-    // If we're in a context where we can directly access the function
-    if (typeof getCurrentNodeBinDir === 'function') {
-      return path.join(getCurrentNodeBinDir(), binaryName);
-    }
-
-    return null;
-  } catch (e) {
-    // If any error occurs, return null
-    return null;
+  const binDir = resolveNodeBinDir();
+  if (binDir) {
+    return path.join(binDir, binaryName);
   }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- When no global Node.js is installed, `meteor create --blaze && meteor run` hangs forever at "Loading plugin rspack..." because spawned rspack processes use `#!/usr/bin/env node` which fails to resolve
- The fix prepends Meteor's `dev_bundle/bin` to `PATH` in the environment passed to rspack child processes, so they find the bundled `node`, `npm`, and `npx`
- Extracts shared `resolveNodeBinDir()` helper in `tools-core/lib/npm.js` and adds `getNodeBinEnv()` for any package that needs to spawn processes with access to Meteor's Node

## Details

The rspack plugin uses `getNpxCommand()` which correctly resolves the **npx binary** via an absolute path. However, when npx spawns rspack (which has a `#!/usr/bin/env node` shebang), the child process inherits the parent's `PATH` — which doesn't include `dev_bundle/bin`. Without a global `node`, this fails silently and the plugin waits for a compilation event that never comes.

The Meteor CLI itself already handles this in `dev-bundle-bin-helpers.js` for `meteor npm/npx` commands, but the rspack plugin's `spawnProcess` calls were missing the same PATH setup.

### Edge cases covered
- **Windows**: uses `path.delimiter` and checks both `PATH` and `Path`
- **Global Node already installed**: prepends rather than replaces — existing PATH entries remain as fallback
- **Plugin context unavailable**: `getNodeBinEnv()` returns `{}`, no behavior change
- **`meteor npx` fallback path**: CLI already handles PATH, this is a no-op

## How to test

1. Ensure no global `node` is installed (only Meteor's bundled Node available)
2. `meteor create --blaze test-app && cd test-app && meteor run`
3. **Before fix**: hangs at "Loading plugin rspack..."
4. **After fix**: rspack starts normally

Forum report: https://forums.meteor.com/t/64422

## Test plan

- [ ] Reproduce the hang on a system without global Node, confirm the fix resolves it
- [ ] Verify `meteor create --blaze && meteor run` works normally on a system with global Node (no regression)
- [ ] Verify `meteor build` works in both scenarios
- [ ] Test on macOS and Linux