### PR TITLE
Exclude transient `.cache` directory from `node_modules` during bundling

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,7 @@ on:
       - 'packages/babel-compiler/**'
       - 'packages/meteor-tool/**'
       - 'npm-packages/meteor-rspack/**'
+      - 'tools/isobuild/**'
       - 'tools/static-assets/skel-**'
       - '.github/workflows/e2e-tests.yml'
 

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -538,21 +538,28 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     // assert.strictEqual(files.pathBasename(options.from), "node_modules");
     assert.strictEqual(files.pathBasename(options.to), "node_modules");
 
-    if (options.symlink) {
+    // Exclude node_modules/.cache: transient bundler scratch space that
+    // races with readdir (ENOENT) and doesn't belong in the bundle.
+    const optionsWithCacheIgnored = {
+      ...options,
+      ignore: [/^\.cache\/$/, ...(options.ignore || [])],
+    };
+
+    if (optionsWithCacheIgnored.symlink) {
       // If we're going to use symlinks to speed up this copy, then we
       // need to make sure we've reserved all directories that are not
       // package directories, such as the node_modules directory itself,
       // as well as node_modules/meteor and the parent directories of any
       // scoped npm packages.
       this._ensureAllNonPackageDirectories(
-        realpath(options.from),
-        options.to
+        realpath(optionsWithCacheIgnored.from),
+        optionsWithCacheIgnored.to
       );
     }
 
     // Call this._copyDirectory rather than this.copyDirectory so that the
     // subBuilder hacks from Builder#enter won't apply a second time.
-    return this._copyDirectory(options);
+    return this._copyDirectory(optionsWithCacheIgnored);
   }
 
   _ensureAllNonPackageDirectories(absFromDir, relToDir) {
@@ -575,6 +582,8 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     this._ensureDirectory(relToDir);
 
     optimisticReaddir(absFromDir).forEach(item => {
+      // Skip node_modules/.cache (see copyNodeModulesDirectory).
+      if (item === ".cache") return;
       this._ensureAllNonPackageDirectories(
         files.pathJoin(absFromDir, item),
         files.pathJoin(relToDir, item)

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -538,28 +538,25 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     // assert.strictEqual(files.pathBasename(options.from), "node_modules");
     assert.strictEqual(files.pathBasename(options.to), "node_modules");
 
-    // Exclude node_modules/.cache: transient bundler scratch space that
-    // races with readdir (ENOENT) and doesn't belong in the bundle.
-    const optionsWithCacheIgnored = {
-      ...options,
-      ignore: [/^\.cache\/$/, ...(options.ignore || [])],
-    };
-
-    if (optionsWithCacheIgnored.symlink) {
+    if (options.symlink) {
       // If we're going to use symlinks to speed up this copy, then we
       // need to make sure we've reserved all directories that are not
       // package directories, such as the node_modules directory itself,
       // as well as node_modules/meteor and the parent directories of any
       // scoped npm packages.
       this._ensureAllNonPackageDirectories(
-        realpath(optionsWithCacheIgnored.from),
-        optionsWithCacheIgnored.to
+        realpath(options.from),
+        options.to
       );
     }
 
+    // Exclude node_modules/.cache: transient bundler scratch space that
+    // races with readdir (ENOENT) and doesn't belong in the bundle.
     // Call this._copyDirectory rather than this.copyDirectory so that the
     // subBuilder hacks from Builder#enter won't apply a second time.
-    return this._copyDirectory(optionsWithCacheIgnored);
+    return this._copyDirectory(Object.assign({}, options, {
+      ignore: [/^\.cache\/$/].concat(options.ignore || []),
+    }));
   }
 
   _ensureAllNonPackageDirectories(absFromDir, relToDir) {

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -581,7 +581,17 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
 
     this._ensureDirectory(relToDir);
 
-    optimisticReaddir(absFromDir).forEach(item => {
+    let entries;
+    try {
+      entries = optimisticReaddir(absFromDir);
+    } catch (e) {
+      // The directory may have vanished between stat and readdir (e.g.
+      // a bundler tool rewriting files underneath us). Skip it.
+      if (e.code === "ENOENT") return;
+      throw e;
+    }
+
+    entries.forEach(item => {
       // Skip node_modules/.cache (see copyNodeModulesDirectory).
       if (item === ".cache") return;
       this._ensureAllNonPackageDirectories(
@@ -667,7 +677,17 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
 
       this._ensureDirectory(relTo);
 
-      for (const item of optimisticReaddir(absFrom)) {
+      let items;
+      try {
+        items = optimisticReaddir(absFrom);
+      } catch (e) {
+        // The directory may have disappeared mid-walk (e.g. a bundler
+        // tool rewriting files underneath us). Skip it.
+        if (e.code === "ENOENT") return;
+        throw e;
+      }
+
+      for (const item of items) {
         let thisAbsFrom = files.pathResolve(absFrom, item);
         const thisRelTo = files.pathJoin(relTo, item);
 


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/pull/14331

This PR teaches the builder to ignore `node_modules/.cache/` when walking an app's local `node_modules` into the Meteor bundle.

Tools like rspack, webpack, babel-loader, swc-loader, eslint, jest, and others write scratch files into `node_modules/.cache/`. It's transient by design, owned by the tool that wrote it, rotated often, and never read at runtime.

A problem with letting the builder walk into it showed up in [E2E tests and related flakiness](https://github.com/meteor/meteor/pull/14331):

- **ENOENT races.** While we're enumerating `.cache/`, rspack or another tool may delete and rewrite files underneath us. `readdir` returns a name, then `stat` fails. This leads to intermittent build failures with no useful signal.

`meteor build` already avoids this by accident. Its `prodPackagePredicate` filter only allows real npm package names, and `.cache` isn't one. But `meteor run` has no such filter, so the race happens there.

The fix provided is to teach `copyNodeModulesDirectory` and its `_ensureAllNonPackageDirectories` walker to skip any entry literally named `.cache` at the top level of a `node_modules/`. This is narrowly scoped. We're not ignoring `.cache` anywhere else.

After the patch, `find .meteor/local/build -name .cache` returns nothing under `npm/node_modules/`, and the ENOENT flakes go away.

This is a change in the Meteor tool. It should be safe, but not sure yet if it will land in 3.4.1 or 3.5.