### PR TITLE
fix: replace declare module with declare namespace in .d.ts files (TS6 compat)

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -666,7 +666,7 @@ export namespace Mongo {
   }
 }
 
-export declare module MongoInternals {
+export declare namespace MongoInternals {
   interface MongoConnection {
     db: NpmModuleMongodb.Db;
     client: NpmModuleMongodb.MongoClient;

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -22,7 +22,7 @@ type ExpressModule = {
   urlencoded: typeof express.urlencoded;
 };
 
-export declare module WebApp {
+export declare namespace WebApp {
   var defaultArch: string;
   var clientPrograms: {
     [key: string]: {
@@ -69,7 +69,7 @@ export declare module WebApp {
   function addHtmlAttributeHook(hook: Function): void;
 }
 
-export declare module WebAppInternals {
+export declare namespace WebAppInternals {
   var NpmModules: {
     [key: string]: {
       version: string;


### PR DESCRIPTION
## Summary

Closes #14253

### Problem

TypeScript 6 enforces [TS1540](https://github.com/microsoft/TypeScript/issues/51839): namespace declarations must use the `namespace` keyword, not `module`. Meteor's type declaration files used `declare module` in 3 places, causing `tsc` to fail with:

```
error TS1540: A 'namespace' declaration should not be declared using the 'module' keyword.
Please use the 'namespace' keyword instead.
```

### Fix

Replace `export declare module` → `export declare namespace` in the affected files:

| File | Line | Change |
|------|------|--------|
| `packages/mongo/mongo.d.ts` | 669 | `MongoInternals` |
| `packages/webapp/webapp.d.ts` | 25 | `WebApp` |
| `packages/webapp/webapp.d.ts` | 72 | `WebAppInternals` |

`declare namespace` and `declare module` are functionally identical for this use case — this is a pure keyword rename with no behavioral change.

### Testing

After this change, projects using TypeScript 6 with `skipLibCheck: false` will no longer get TS1540 errors from these declarations.

---
*Contribution by [@karthikeyansundaram2](https://github.com/karthikeyansundaram2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript type declarations for MongoDB and WebApp modules for better type definition structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->