### PR TITLE
Update deployment hostname for Meteor app

### DIFF
--- a/guide/source/deployment.md
+++ b/guide/source/deployment.md
@@ -135,7 +135,7 @@ Once you've done that, it's easy to [deploy to Galaxy](https://galaxy-guide.mete
 DEPLOY_HOSTNAME=galaxy.meteor.com meteor deploy your-app.com --settings production-settings.json
 ```
 
-To deploy to the EU region, set DEPLOY_HOSTNAME to eu-west-1.galaxy.meteor.com.
+To deploy to the EU region, set DEPLOY_HOSTNAME to eu-west-1.galaxy-deploy.meteor.com.
 
 In order for Galaxy to work with your custom domain (`your-app.com` in this case), you need to [set up your DNS to point at Galaxy](http://galaxy-guide.meteor.com/dns.html). Once you've done this, you should be able to reach your site from a browser.
 

--- a/v3-docs/docs/tutorials/deployment/deployment.md
+++ b/v3-docs/docs/tutorials/deployment/deployment.md
@@ -109,7 +109,7 @@ In order to deploy to Galaxy, you'll need to sign up for an account and separate
 Once you've done that, deployment is straightforward. You need to add some environment variables to your settings file to point it at your MongoDB, and you can deploy with:
 
 ```bash
-DEPLOY_HOSTNAME=us-east-1.galaxy.meteor.com meteor deploy your-app.com --settings production-settings.json
+DEPLOY_HOSTNAME=us-east-1.galaxy-deploy.meteor.com meteor deploy your-app.com --settings production-settings.json
 ```
 
 You can also log into the Galaxy UI to manage your applications, monitor the number of connections and resource usage, view logs, and change settings.
@@ -277,7 +277,7 @@ jobs:
         run: |
           echo "$METEOR_SESSION_FILE" > meteor-session.json
           METEOR_SESSION_FILE=meteor-session.json \
-          DEPLOY_HOSTNAME=us-east-1.galaxy.meteor.com \
+          DEPLOY_HOSTNAME=us-east-1.galaxy-deploy.meteor.com \
           meteor deploy your-app.com --settings settings.json
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Galaxy deployment hostname examples for US and EU regions to the current `*-galaxy-deploy.meteor.com` endpoints, in both direct deploy command examples and CI/GitHub Actions workflow snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->