### PR TITLE
fix: Generated .d.ts files use 'module' keyword instead of 'namespace' — breaks TypeScript 6

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -666,7 +666,7 @@ export namespace Mongo {
   }
 }
 
-export declare module MongoInternals {
+export declare namespace MongoInternals {
   interface MongoConnection {
     db: NpmModuleMongodb.Db;
     client: NpmModuleMongodb.MongoClient;

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -22,7 +22,7 @@ type ExpressModule = {
   urlencoded: typeof express.urlencoded;
 };
 
-export declare module WebApp {
+export declare namespace WebApp {
   var defaultArch: string;
   var clientPrograms: {
     [key: string]: {
@@ -69,7 +69,7 @@ export declare module WebApp {
   function addHtmlAttributeHook(hook: Function): void;
 }
 
-export declare module WebAppInternals {
+export declare namespace WebAppInternals {
   var NpmModules: {
     [key: string]: {
       version: string;


### PR DESCRIPTION
## Summary

Closes #14253

Addresses: **Generated .d.ts files use 'module' keyword instead of 'namespace' — breaks TypeScript 6**

### Changes
```
 packages/mongo/mongo.d.ts   | 2 +-
 packages/webapp/webapp.d.ts | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)
```

---
*Contribution by [@karthikeyansundaram2](https://github.com/karthikeyansundaram2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript type declarations to use modern syntax conventions for improved compatibility with current TypeScript standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->