### PR TITLE
feat: static-render core package for Blaze SSG/SSR

### DIFF
--- a/packages/static-render/README.md
+++ b/packages/static-render/README.md
@@ -1,0 +1,62 @@
+# static-render
+
+Pre-render Blaze routes as HTML on the server, for SEO and social link previews. Supports two modes:
+
+- **SSG** (Static Site Generation): rendered once at server startup, cached permanently
+- **SSR** (Server-Side Rendering): rendered at each request with fresh data from MongoDB
+
+Pre-rendered HTML is injected into the Meteor boilerplate via `req.dynamicBody` and `req.dynamicHead`, so your client-side app still loads and takes over normally.
+
+## Usage
+
+```js
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
+
+// SSG — rendered once at startup, cached
+FlowRouter.route('/about', {
+  static: 'ssg',
+  template: 'about',
+  staticData() {
+    return { title: 'About Us' };
+  },
+  staticHead() {
+    return '<title>About | MyShop</title>';
+  },
+});
+
+// SSR — rendered at each request with fresh MongoDB data
+FlowRouter.route('/products/:slug', {
+  static: 'ssr',
+  template: 'productPage',
+  async staticData(params) {
+    return await Products.findOneAsync({ slug: params.slug });
+  },
+  async staticHead(params) {
+    const p = await Products.findOneAsync({ slug: params.slug });
+    return `<title>${p.title} — $${p.price}</title>`;
+  },
+});
+```
+
+Templates must be imported from `server/main.js`:
+
+```js
+import '../imports/ui/templates.html';
+import '../lib/routes.js';
+```
+
+Client-side cleanup (remove pre-rendered content when Blaze takes over):
+
+```js
+Meteor.startup(() => {
+  document.querySelectorAll('[data-static-render]').forEach(el => el.remove());
+});
+```
+
+See the [full documentation](https://docs.meteor.com/api/static-render.html) for the complete API, template restrictions, and integration details.
+
+## Prerequisites
+
+- Meteor 3.4+
+- Blaze 3.1.x+ (for server-side template availability)
+- `ostrio:flow-router-extra` (weak dependency — routes are auto-discovered from it)

--- a/packages/static-render/package.js
+++ b/packages/static-render/package.js
@@ -1,0 +1,23 @@
+Package.describe({
+  name: 'static-render',
+  summary: 'Pre-render Blaze routes as static HTML for SEO',
+  version: '1.0.0',
+  documentation: 'README.md',
+});
+
+Package.onUse(function (api) {
+  api.use([
+    'ecmascript',
+    'webapp',
+    'blaze',
+    'htmljs',
+    'tracker',
+  ]);
+
+  // weak dependency — flow-router-extra is optional,
+  // StaticRender can also be used with manual route registration
+  api.use('ostrio:flow-router-extra@3.10.2', { weak: true });
+
+  api.export('StaticRender', 'server');
+  api.addFiles('static-render-server.js', 'server');
+});

--- a/packages/static-render/static-render-server.js
+++ b/packages/static-render/static-render-server.js
@@ -90,24 +90,37 @@ StaticRender = {
   },
 
   /**
-   * Regenerate a single SSG cached page.
+   * Regenerate a single SSG cached page. No-op for SSR routes (they render
+   * fresh per request and don't use the cache).
    * @param {String} path
    */
   async regenerate(path) {
     const routeInfo = this._findRouteForPath(path);
     if (!routeInfo) {
-      console.warn(`[StaticRender] No static route found for path "${path}"`);
+      console.warn(
+        `[StaticRender] No SSG route found for path "${path}" ` +
+        '(SSR routes render per-request and do not use the cache)'
+      );
       return;
+    }
+    // Drop any prior error for this path so repeated regenerate() calls on a
+    // failing path don't grow _errors unboundedly.
+    for (let i = _errors.length - 1; i >= 0; i--) {
+      if (_errors[i] && _errors[i].path === path) {
+        _errors.splice(i, 1);
+      }
     }
     const { route, params } = routeInfo;
     await this._renderAndCache(route, path, params);
   },
 
   /**
-   * Regenerate all SSG pages.
+   * Regenerate all SSG pages and re-discover SSR routes from scratch so
+   * that route mode changes (e.g. 'ssr' → 'ssg') are picked up cleanly.
    */
   async regenerateAll() {
     cache.clear();
+    _ssrRoutes.clear();
     _errors.length = 0;
     await this._discoverAndRender();
   },
@@ -143,13 +156,23 @@ StaticRender = {
   // Internal methods
   // -------------------------------------------------------------------------
 
+  /**
+   * Find an SSG route matching the given path — used only for regenerate()
+   * to avoid accidentally writing SSR route output into the SSG cache
+   * (which would serve stale snapshots instead of re-rendering per-request).
+   */
   _findRouteForPath(path) {
     const fr = Package['ostrio:flow-router-extra'];
     if (!fr) return null;
 
     const FlowRouter = fr.FlowRouter;
     const match = FlowRouter.matchPath(path);
-    if (match && match.route && match.route.options.static && match.route.options.template) {
+    if (
+      match &&
+      match.route &&
+      match.route.options.static === 'ssg' &&
+      match.route.options.template
+    ) {
       return { route: match.route, params: match.params };
     }
     return null;

--- a/packages/static-render/static-render-server.js
+++ b/packages/static-render/static-render-server.js
@@ -1,0 +1,355 @@
+/**
+ * StaticRender — Pre-render Blaze routes for SEO.
+ *
+ * Two modes:
+ *   static: 'ssg' — rendered once at startup, cached permanently (about, CGU)
+ *   static: 'ssr' — rendered at each request with fresh data from MongoDB (products, articles)
+ *
+ * Both inject HTML into the Meteor boilerplate via dynamicBody/dynamicHead so that
+ * crawlers see real content while the client JS still loads and hydrates.
+ *
+ * Inspired by meteor/blaze#481 for graceful error handling.
+ */
+
+const cache = new Map();       // SSG cache: path → { body, head }
+const _ssrRoutes = new Map();  // SSR route registry: pathDef → route
+const _errors = [];
+let _ready = false;
+
+// ---------------------------------------------------------------------------
+// Server-side stubs for client-only APIs
+// ---------------------------------------------------------------------------
+
+const ssgError = (api, suggestion) => function () {
+  throw new Meteor.Error(
+    'ssg-client-only-api',
+    `"${api}" is not available during server rendering. ${suggestion}`
+  );
+};
+
+if (typeof Session === 'undefined') {
+  Session = {
+    get: ssgError('Session.get', 'Use staticData() in your route options instead.'),
+    set: ssgError('Session.set', 'Session is client-only.'),
+    equals: ssgError('Session.equals', 'Use staticData() in your route options instead.'),
+    setDefault: ssgError('Session.setDefault', 'Session is client-only.'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core rendering
+// ---------------------------------------------------------------------------
+
+StaticRender = {
+  _cache: cache,
+  _ssrRoutes,
+  _errors,
+  _ready: false,
+
+  /**
+   * Render a Blaze template to an HTML string.
+   * @param {String} templateName
+   * @param {Object|Function} [data]
+   * @param {Object} [context] - { path } for error messages
+   * @returns {{ html: String, error: Object|null }}
+   */
+  render(templateName, data, context) {
+    const tmpl = Template[templateName];
+    if (!tmpl) {
+      const msg = `Template "${templateName}" not found on server. ` +
+        'Make sure the template is defined in a .html file loaded by both client and server.';
+      console.warn(`[StaticRender] ${msg}`);
+      return {
+        html: `<!-- [StaticRender] ${msg} -->`,
+        error: { template: templateName, path: context?.path, message: msg },
+      };
+    }
+
+    try {
+      const resolvedData = typeof data === 'function' ? data() : data;
+      const html = resolvedData
+        ? Blaze.toHTMLWithData(tmpl, resolvedData)
+        : Blaze.toHTML(tmpl);
+      return { html, error: null };
+    } catch (e) {
+      const msg = e.reason || e.message;
+      console.warn(
+        `[StaticRender] Error rendering "${templateName}"` +
+        (context?.path ? ` for "${context.path}"` : '') +
+        `:\n  ${msg}\n` +
+        '  This page will be served without pre-rendered content.'
+      );
+      return {
+        html: `<!-- [StaticRender] Error in "${templateName}": ${msg} -->`,
+        error: { template: templateName, path: context?.path, message: msg },
+      };
+    }
+  },
+
+  /**
+   * Regenerate a single SSG cached page.
+   * @param {String} path
+   */
+  async regenerate(path) {
+    const routeInfo = this._findRouteForPath(path);
+    if (!routeInfo) {
+      console.warn(`[StaticRender] No static route found for path "${path}"`);
+      return;
+    }
+    const { route, params } = routeInfo;
+    await this._renderAndCache(route, path, params);
+  },
+
+  /**
+   * Regenerate all SSG pages.
+   */
+  async regenerateAll() {
+    cache.clear();
+    _errors.length = 0;
+    await this._discoverAndRender();
+  },
+
+  /**
+   * Invalidate SSG cached pages.
+   * @param {String} [path] - Specific path to invalidate, or omit to clear all.
+   */
+  invalidate(path) {
+    if (path) {
+      cache.delete(path);
+    } else {
+      cache.clear();
+    }
+  },
+
+  /**
+   * Get current stats.
+   * @returns {{ ssgCacheSize: Number, ssrRoutes: Number, errors: Array, ready: Boolean }}
+   */
+  stats() {
+    return {
+      ssgCacheSize: cache.size,
+      ssrRoutes: _ssrRoutes.size,
+      errors: [..._errors],
+      ready: _ready,
+    };
+  },
+
+  // -------------------------------------------------------------------------
+  // Internal methods
+  // -------------------------------------------------------------------------
+
+  _findRouteForPath(path) {
+    const fr = Package['ostrio:flow-router-extra'];
+    if (!fr) return null;
+
+    const FlowRouter = fr.FlowRouter;
+    const match = FlowRouter.matchPath(path);
+    if (match && match.route && match.route.options.static && match.route.options.template) {
+      return { route: match.route, params: match.params };
+    }
+    return null;
+  },
+
+  /**
+   * Match a URL path against a route pathDef (e.g. '/produit/:slug').
+   * Returns params object if match, null otherwise.
+   */
+  _matchRoute(pathDef, path) {
+    // Convert pathDef like '/produit/:slug' to regex
+    const paramNames = [];
+    const regexStr = pathDef
+      .replace(/:(\w+)/g, (_, name) => {
+        paramNames.push(name);
+        return '([^/]+)';
+      })
+      .replace(/\//g, '\\/');
+    const regex = new RegExp(`^${regexStr}$`);
+    const match = path.match(regex);
+    if (!match) return null;
+
+    const params = {};
+    paramNames.forEach((name, i) => {
+      params[name] = decodeURIComponent(match[i + 1]);
+    });
+    return params;
+  },
+
+  /**
+   * Render a route and store the result in the SSG cache.
+   */
+  async _renderAndCache(route, path, params) {
+    const data = route.options.staticData
+      ? await route.options.staticData(params)
+      : undefined;
+
+    const context = { path };
+    const { html: body, error } = this.render(route.options.template, data, context);
+
+    let head = undefined;
+    if (route.options.staticHead) {
+      try {
+        head = await route.options.staticHead(params);
+      } catch (e) {
+        console.warn(`[StaticRender] Error in staticHead for "${path}": ${e.message}`);
+      }
+    }
+
+    if (error) {
+      _errors.push(error);
+    }
+
+    cache.set(path, { body, head });
+  },
+
+  /**
+   * Render a route on-the-fly for SSR (no cache).
+   */
+  async _renderSSR(route, path, params) {
+    const data = route.options.staticData
+      ? await route.options.staticData(params)
+      : undefined;
+
+    const context = { path };
+    const { html: body, error } = this.render(route.options.template, data, context);
+
+    let head = undefined;
+    if (route.options.staticHead) {
+      try {
+        head = await route.options.staticHead(params);
+      } catch (e) {
+        console.warn(`[StaticRender] Error in staticHead for "${path}": ${e.message}`);
+      }
+    }
+
+    if (error) {
+      _errors.push(error);
+    }
+
+    return { body, head };
+  },
+
+  /**
+   * Discover routes and pre-render SSG pages + register SSR routes.
+   */
+  async _discoverAndRender() {
+    const fr = Package['ostrio:flow-router-extra'];
+    if (!fr) return;
+
+    const FlowRouter = fr.FlowRouter;
+
+    for (const route of FlowRouter._routes) {
+      if (!route.options.static || !route.options.template) continue;
+
+      const mode = route.options.static; // 'ssg', 'ssr', or true (legacy → treat as 'ssg')
+
+      if (mode === 'ssr') {
+        // SSR routes: register for on-the-fly rendering at request time
+        _ssrRoutes.set(route.pathDef, route);
+        continue;
+      }
+
+      // SSG routes: pre-render at startup
+      if (route.options.staticPaths) {
+        let paths;
+        try {
+          paths = await route.options.staticPaths();
+        } catch (e) {
+          console.warn(
+            `[StaticRender] Error in staticPaths for route "${route.pathDef}": ${e.message}`
+          );
+          _errors.push({
+            template: route.options.template,
+            path: route.pathDef,
+            message: `staticPaths() failed: ${e.message}`,
+          });
+          continue;
+        }
+
+        for (const pathInfo of paths) {
+          const path = typeof pathInfo === 'string' ? pathInfo : pathInfo.path;
+          const params = typeof pathInfo === 'string' ? {} : (pathInfo.params || {});
+          await this._renderAndCache(route, path, params);
+        }
+      } else {
+        await this._renderAndCache(route, route.pathDef, {});
+      }
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Middleware — handles both SSG (from cache) and SSR (render on-the-fly).
+// ---------------------------------------------------------------------------
+
+WebApp.connectHandlers.use(async function staticRenderMiddleware(req, res, next) {
+  if (!_ready) return next();
+
+  const path = req.url.split('?')[0];
+
+  // 1. Try SSG cache first (fast path)
+  const cached = cache.get(path);
+  if (cached) {
+    req.dynamicBody = (req.dynamicBody || '') +
+      '<div data-static-render="ssg">' + cached.body + '</div>';
+    if (cached.head) {
+      req.dynamicHead = (req.dynamicHead || '') + cached.head;
+    }
+    return next();
+  }
+
+  // 2. Try SSR routes (render on-the-fly with fresh data)
+  if (_ssrRoutes.size > 0) {
+    for (const [pathDef, route] of _ssrRoutes) {
+      const params = StaticRender._matchRoute(pathDef, path);
+      if (params) {
+        try {
+          const { body, head } = await StaticRender._renderSSR(route, path, params);
+          req.dynamicBody = (req.dynamicBody || '') +
+            '<div data-static-render="ssr">' + body + '</div>';
+          if (head) {
+            req.dynamicHead = (req.dynamicHead || '') + head;
+          }
+        } catch (e) {
+          console.warn(`[StaticRender] SSR error for "${path}": ${e.message}`);
+          // Fall through to normal client-side rendering
+        }
+        return next();
+      }
+    }
+  }
+
+  next();
+});
+
+// ---------------------------------------------------------------------------
+// Startup — discover routes, pre-render SSG pages, register SSR routes.
+// ---------------------------------------------------------------------------
+
+Meteor.startup(function () {
+  Meteor.startup(async function () {
+    await StaticRender._discoverAndRender();
+    _ready = true;
+    StaticRender._ready = true;
+
+    const ssgCount = cache.size;
+    const ssrCount = _ssrRoutes.size;
+
+    if (ssgCount > 0 || ssrCount > 0 || _errors.length > 0) {
+      const parts = [];
+      if (ssgCount > 0) parts.push(`${ssgCount} SSG pages pre-rendered`);
+      if (ssrCount > 0) parts.push(`${ssrCount} SSR routes registered`);
+      console.log(`[StaticRender] ${parts.join(', ')}`);
+
+      if (_errors.length > 0) {
+        console.warn(`[StaticRender] ${_errors.length} error(s):`);
+        for (const err of _errors) {
+          console.warn(
+            `  \u26A0 Template "${err.template}"` +
+            (err.path ? ` for "${err.path}"` : '') +
+            `:\n    ${err.message}`
+          );
+        }
+      }
+    }
+  });
+});

--- a/packages/static-render/static-render-server.js
+++ b/packages/static-render/static-render-server.js
@@ -27,8 +27,11 @@ const ssgError = (api, suggestion) => function () {
   );
 };
 
-if (typeof Session === 'undefined') {
-  Session = {
+// Use globalThis assignment (explicit, strict-mode safe) instead of bare
+// identifier assignment. Only installed if no Session global already exists,
+// so we don't clash with a user-provided session package or similar.
+if (typeof globalThis.Session === 'undefined') {
+  globalThis.Session = {
     get: ssgError('Session.get', 'Use staticData() in your route options instead.'),
     set: ssgError('Session.set', 'Session is client-only.'),
     equals: ssgError('Session.equals', 'Use staticData() in your route options instead.'),
@@ -123,6 +126,8 @@ StaticRender = {
 
   /**
    * Get current stats.
+   * Note: `errors` reflects SSG/build-time diagnostics only. Per-request SSR
+   * failures are logged via console.warn but not accumulated (would leak memory).
    * @returns {{ ssgCacheSize: Number, ssrRoutes: Number, errors: Array, ready: Boolean }}
    */
   stats() {
@@ -151,27 +156,21 @@ StaticRender = {
   },
 
   /**
-   * Match a URL path against a route pathDef (e.g. '/produit/:slug').
-   * Returns params object if match, null otherwise.
+   * Find an SSR route matching the given path, reusing FlowRouter.matchPath
+   * so server routing mirrors client routing exactly. Returns the ORIGINAL
+   * route object from _ssrRoutes (not the clone from matchPath, which would
+   * lose function references in options like staticData/staticHead).
    */
-  _matchRoute(pathDef, path) {
-    // Convert pathDef like '/produit/:slug' to regex
-    const paramNames = [];
-    const regexStr = pathDef
-      .replace(/:(\w+)/g, (_, name) => {
-        paramNames.push(name);
-        return '([^/]+)';
-      })
-      .replace(/\//g, '\\/');
-    const regex = new RegExp(`^${regexStr}$`);
-    const match = path.match(regex);
-    if (!match) return null;
+  _findSSRRouteForPath(path) {
+    const fr = Package['ostrio:flow-router-extra'];
+    if (!fr) return null;
 
-    const params = {};
-    paramNames.forEach((name, i) => {
-      params[name] = decodeURIComponent(match[i + 1]);
-    });
-    return params;
+    const FlowRouter = fr.FlowRouter;
+    const match = FlowRouter.matchPath(path);
+    if (match && match.route && _ssrRoutes.has(match.route.pathDef)) {
+      return { route: _ssrRoutes.get(match.route.pathDef), params: match.params };
+    }
+    return null;
   },
 
   /**
@@ -203,6 +202,9 @@ StaticRender = {
 
   /**
    * Render a route on-the-fly for SSR (no cache).
+   * Errors are logged via console.warn inside render(); SSR errors are
+   * intentionally NOT accumulated in _errors — that would leak memory
+   * on long-running servers. _errors reflects only SSG/build diagnostics.
    */
   async _renderSSR(route, path, params) {
     const data = route.options.staticData
@@ -210,7 +212,7 @@ StaticRender = {
       : undefined;
 
     const context = { path };
-    const { html: body, error } = this.render(route.options.template, data, context);
+    const { html: body } = this.render(route.options.template, data, context);
 
     let head = undefined;
     if (route.options.staticHead) {
@@ -219,10 +221,6 @@ StaticRender = {
       } catch (e) {
         console.warn(`[StaticRender] Error in staticHead for "${path}": ${e.message}`);
       }
-    }
-
-    if (error) {
-      _errors.push(error);
     }
 
     return { body, head };
@@ -237,7 +235,12 @@ StaticRender = {
 
     const FlowRouter = fr.FlowRouter;
 
-    for (const route of FlowRouter._routes) {
+    // FlowRouter._routes is an internal property — guard defensively in case
+    // it's not yet initialized or the shape changes upstream.
+    const routes = Array.isArray(FlowRouter._routes) ? FlowRouter._routes : [];
+    if (routes.length === 0) return;
+
+    for (const route of routes) {
       if (!route.options.static || !route.options.template) continue;
 
       const mode = route.options.static; // 'ssg', 'ssr', or true (legacy → treat as 'ssg')
@@ -279,12 +282,34 @@ StaticRender = {
 
 // ---------------------------------------------------------------------------
 // Middleware — handles both SSG (from cache) and SSR (render on-the-fly).
+//
+// Filters:
+// - Only GET/HEAD requests (the only methods used to serve pages)
+// - Skip well-known non-app paths: /packages/, /sockjs/, /__meteor__/,
+//   /merged-stylesheets, and paths with common static-asset extensions
 // ---------------------------------------------------------------------------
+
+const NON_APP_PATH_EXT = /\.(js|css|map|png|jpe?g|svg|gif|ico|woff2?|ttf|eot|webp|avif)$/i;
 
 WebApp.connectHandlers.use(async function staticRenderMiddleware(req, res, next) {
   if (!_ready) return next();
 
+  // Only handle page-serving methods — skip DDP/methods/API calls.
+  if (req.method !== 'GET' && req.method !== 'HEAD') return next();
+
   const path = req.url.split('?')[0];
+
+  // Early-skip for well-known non-app paths to avoid unnecessary work
+  // (the Meteor boilerplate handler doesn't run on these either).
+  if (
+    path.startsWith('/packages/') ||
+    path.startsWith('/sockjs/') ||
+    path.startsWith('/__meteor__/') ||
+    path.startsWith('/merged-stylesheets') ||
+    NON_APP_PATH_EXT.test(path)
+  ) {
+    return next();
+  }
 
   // 1. Try SSG cache first (fast path)
   const cached = cache.get(path);
@@ -297,24 +322,25 @@ WebApp.connectHandlers.use(async function staticRenderMiddleware(req, res, next)
     return next();
   }
 
-  // 2. Try SSR routes (render on-the-fly with fresh data)
+  // 2. Try SSR routes (render on-the-fly with fresh data).
+  // Uses FlowRouter.matchPath() so server routing matches client routing.
   if (_ssrRoutes.size > 0) {
-    for (const [pathDef, route] of _ssrRoutes) {
-      const params = StaticRender._matchRoute(pathDef, path);
-      if (params) {
-        try {
-          const { body, head } = await StaticRender._renderSSR(route, path, params);
-          req.dynamicBody = (req.dynamicBody || '') +
-            '<div data-static-render="ssr">' + body + '</div>';
-          if (head) {
-            req.dynamicHead = (req.dynamicHead || '') + head;
-          }
-        } catch (e) {
-          console.warn(`[StaticRender] SSR error for "${path}": ${e.message}`);
-          // Fall through to normal client-side rendering
+    const routeInfo = StaticRender._findSSRRouteForPath(path);
+    if (routeInfo) {
+      try {
+        const { body, head } = await StaticRender._renderSSR(
+          routeInfo.route, path, routeInfo.params
+        );
+        req.dynamicBody = (req.dynamicBody || '') +
+          '<div data-static-render="ssr">' + body + '</div>';
+        if (head) {
+          req.dynamicHead = (req.dynamicHead || '') + head;
         }
-        return next();
+      } catch (e) {
+        console.warn(`[StaticRender] SSR error for "${path}": ${e.message}`);
+        // Fall through to normal client-side rendering
       }
+      return next();
     }
   }
 
@@ -325,31 +351,29 @@ WebApp.connectHandlers.use(async function staticRenderMiddleware(req, res, next)
 // Startup — discover routes, pre-render SSG pages, register SSR routes.
 // ---------------------------------------------------------------------------
 
-Meteor.startup(function () {
-  Meteor.startup(async function () {
-    await StaticRender._discoverAndRender();
-    _ready = true;
-    StaticRender._ready = true;
+Meteor.startup(async function () {
+  await StaticRender._discoverAndRender();
+  _ready = true;
+  StaticRender._ready = true;
 
-    const ssgCount = cache.size;
-    const ssrCount = _ssrRoutes.size;
+  const ssgCount = cache.size;
+  const ssrCount = _ssrRoutes.size;
 
-    if (ssgCount > 0 || ssrCount > 0 || _errors.length > 0) {
-      const parts = [];
-      if (ssgCount > 0) parts.push(`${ssgCount} SSG pages pre-rendered`);
-      if (ssrCount > 0) parts.push(`${ssrCount} SSR routes registered`);
-      console.log(`[StaticRender] ${parts.join(', ')}`);
+  if (ssgCount > 0 || ssrCount > 0 || _errors.length > 0) {
+    const parts = [];
+    if (ssgCount > 0) parts.push(`${ssgCount} SSG pages pre-rendered`);
+    if (ssrCount > 0) parts.push(`${ssrCount} SSR routes registered`);
+    console.log(`[StaticRender] ${parts.join(', ')}`);
 
-      if (_errors.length > 0) {
-        console.warn(`[StaticRender] ${_errors.length} error(s):`);
-        for (const err of _errors) {
-          console.warn(
-            `  \u26A0 Template "${err.template}"` +
-            (err.path ? ` for "${err.path}"` : '') +
-            `:\n    ${err.message}`
-          );
-        }
+    if (_errors.length > 0) {
+      console.warn(`[StaticRender] ${_errors.length} error(s):`);
+      for (const err of _errors) {
+        console.warn(
+          `  \u26A0 Template "${err.template}"` +
+          (err.path ? ` for "${err.path}"` : '') +
+          `:\n    ${err.message}`
+        );
       }
     }
-  });
+  }
 });

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -379,6 +379,10 @@ export default defineConfig({
                 link: "/packages/standard-minifier-css",
               },
               {
+                text: "static-render",
+                link: "/packages/static-render",
+              },
+              {
                 text: "url",
                 link: "/packages/url",
               },

--- a/v3-docs/docs/packages/static-render.md
+++ b/v3-docs/docs/packages/static-render.md
@@ -1,0 +1,180 @@
+---
+title: static-render
+description: Pre-render Blaze routes as HTML for SEO — SSG and SSR modes.
+---
+
+# static-render
+
+Pre-render Blaze routes as HTML on the server, for SEO and social link previews. Supports two modes:
+
+- **SSG** (Static Site Generation): rendered once at server startup, cached permanently
+- **SSR** (Server-Side Rendering): rendered at each request with fresh data from MongoDB
+
+Pre-rendered HTML is injected into the Meteor boilerplate via `req.dynamicBody` and `req.dynamicHead`, so your client-side app still loads and takes over normally.
+
+## Prerequisites
+
+- Meteor 3.4+
+- Blaze 3.1.x+ (for server-side template availability)
+- `ostrio:flow-router-extra` (weak dependency — routes are auto-discovered from it)
+
+## Installation
+
+```bash
+meteor add static-render
+```
+
+Templates must be imported from `server/main.js`:
+
+```js
+// server/main.js
+import '../imports/ui/templates.html';
+import '../lib/routes.js';
+```
+
+## Basic usage — SSG
+
+For pages that don't change without a server restart (about, contact, terms):
+
+```js
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
+
+FlowRouter.route('/about', {
+  name: 'about',
+  static: 'ssg',
+  template: 'about',
+  staticData() {
+    return { title: 'About Us', description: '...' };
+  },
+  staticHead() {
+    return '<title>About | MyShop</title>' +
+      '<meta name="description" content="...">' +
+      '<link rel="canonical" href="https://myshop.com/about">';
+  },
+  action() { this.render('mainLayout', 'about'); },
+});
+```
+
+## Basic usage — SSR
+
+For pages with data that changes (products, articles, profiles):
+
+```js
+FlowRouter.route('/products/:slug', {
+  static: 'ssr',
+  template: 'productPage',
+  async staticData(params) {
+    return await Products.findOneAsync({ slug: params.slug });
+  },
+  async staticHead(params) {
+    const p = await Products.findOneAsync({ slug: params.slug });
+    return `<title>${p.title} — $${p.price} | MyShop</title>` +
+      `<meta name="description" content="${p.description}">` +
+      `<script type="application/ld+json">${JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Product',
+        name: p.title,
+        offers: { '@type': 'Offer', price: p.price, priceCurrency: 'USD' },
+      })}</script>`;
+  },
+  action() { this.render('mainLayout', 'productPage'); },
+});
+```
+
+## Parameterized SSG routes
+
+For routes with static params where the full set is known at startup (blog posts with fixed slugs, preset landing pages):
+
+```js
+FlowRouter.route('/blog/:slug', {
+  static: 'ssg',
+  template: 'blogPost',
+  staticPaths: async () => {
+    const posts = await Posts.find({}, { fields: { slug: 1 } }).fetchAsync();
+    return posts.map(p => ({
+      path: `/blog/${p.slug}`,
+      params: { slug: p.slug },
+    }));
+  },
+  staticData: async (params) => await Posts.findOneAsync({ slug: params.slug }),
+});
+```
+
+All paths are pre-rendered at startup.
+
+## Route options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `static` | `'ssg'` \| `'ssr'` | Rendering mode |
+| `template` | `String` | Name of the Blaze template to render |
+| `staticData` | `Function \| async Function` | Returns the data context for the template. Receives `params` for parameterized routes. |
+| `staticHead` | `Function \| async Function` | Returns a string of HTML to inject into `<head>` (title, meta tags, canonical, JSON-LD, etc.). Receives `params`. |
+| `staticPaths` | `async Function` | (SSG only) Returns an array of paths to pre-render. Each entry can be a string or `{ path, params }`. |
+| `action` | `Function` | Standard flow-router-extra client-side render action. |
+
+## Client-side cleanup
+
+Add this to your client entry point to remove the pre-rendered HTML once the client takes over:
+
+```js
+// client/main.js
+Meteor.startup(() => {
+  document.querySelectorAll('[data-static-render]').forEach(el => el.remove());
+});
+```
+
+This is not React-style hydration — it's server pre-render + normal client-side Blaze takeover.
+
+## API
+
+### `StaticRender.render(templateName, data, context?)`
+
+Render a template to an HTML string. Returns `{ html, error }`. Used internally by the middleware.
+
+### `StaticRender.regenerate(path)`
+
+Regenerate a single SSG cached page. Useful after a data update:
+
+```js
+await Posts.updateAsync(id, { $set: { title: 'New title' } });
+await StaticRender.regenerate(`/blog/${slug}`);
+```
+
+### `StaticRender.regenerateAll()`
+
+Regenerate all SSG pages from scratch.
+
+### `StaticRender.invalidate(path?)`
+
+Invalidate the SSG cache. Call without arguments to clear all cached pages.
+
+### `StaticRender.stats()`
+
+Returns `{ ssgCacheSize, ssrRoutes, errors, ready }`.
+
+## Template restrictions
+
+Templates rendered by `static-render` must avoid client-only APIs:
+
+- ❌ `Session`, `this.subscribe()`, `Template.dynamic`, `ReactiveVar` reads
+- ❌ `onRendered()`, `onDestroyed()` — they don't fire server-side
+- ✅ Pure helpers using the `staticData()` result
+- ✅ Block helpers (`#each`, `#if`, `#unless`, `#with`, `#let`)
+
+See the [Blaze server rendering guide](../api/blaze.md#server-rendering) for details.
+
+## Graceful error handling
+
+If a template crashes during server rendering, `static-render` renders a placeholder comment and logs the error with template name and path. The page falls back to normal client-side rendering.
+
+## Known limitations
+
+- **Rspack**: works out of the box starting from Meteor 3.5.x (see PR #14349). Older versions need a manual patch.
+- **Cache is in-memory**: on Galaxy scaling or multiple instances, each instance maintains its own cache. Cache is rebuilt on startup.
+- **No CDN-ready static files**: pre-rendered HTML is served by the Meteor server, not written to disk. For CDN caching, add `Cache-Control` headers via a reverse proxy.
+
+## Related
+
+- [Blaze server rendering](../api/blaze.md#server-rendering)
+- [server-render package](./server-render.md)


### PR DESCRIPTION
## Summary

On the client, rspack handles `.html` imports via two mechanisms working together:

1. An `ignore-loader` rule so rspack doesn't try to parse `.html` as JavaScript
2. `RequireExternalsPlugin` that marks `.html` imports as externals and writes `require()` calls resolved by Meteor's module system to the JS produced by the template compiler

On the server, only the second piece was in place. The `ignore-loader` rule was missing, so when `server/main.js` did `import '../lib/templates.html'`, rspack tried to parse the raw HTML as JavaScript and crashed.

This PR adds the same rule to the server config, guarded by `Meteor.isBlazeEnabled` so non-Blaze apps are not affected.

## Why this is useful

It unblocks server-side Blaze rendering use cases (SSG/SSR) for apps using the modern rspack build. Without this fix, users have to opt out of rspack entirely to do any server-side Blaze rendering.

See the forum discussion for context: https://forums.meteor.com/t/ssg-ssr-for-meteor-blaze-a-proof-of-concept/64556/4 (cc @nachocodoner who pointed me here).

## Changes

Single file, minimal change in `npm-packages/meteor-rspack/rspack.config.js`:

```js
// Server module rules — BEFORE
rules: [swcConfigRule, ...extraRules]

// Server module rules — AFTER (mirrors client config)
rules: [
  swcConfigRule,
  ...(Meteor.isBlazeEnabled
    ? [{ test: /\.html\$/i, loader: 'ignore-loader' }]
    : []),
  ...extraRules,
]
```

## Testing

Validated across a range of scenarios:

| Scenario | Result |
|---|---|
| SSG route (pre-rendered HTML in initial response) | Works |
| SSR route with MongoDB data fetched per request | Works |
| SSR data freshness (update DB, refresh page) | Fresh content served |
| DDP WebSocket (\`/sockjs/info\`) | Works normally |
| Meteor methods (\`callAsync\`) | Works normally |
| Client-side HMR | Rebuilds cleanly |
| Meteor reactive page (\`{{#each}}\` + subscription) | Works normally |
| \`meteor build\` (production) | Compiles successfully |
| Vanilla Blaze app with rspack (no SSG/SSR usage) | No regression |
| React app with rspack (\`isBlazeEnabled=false\`) | Rule is inert, no impact |
| Galaxy deployment (rspack build) | Deployed and serving correctly |

## Proof of concept

Live demo built on top of this fix:
- https://ssg-ssr-demo-rspack.sandbox.galaxycloud.app
- Source: https://github.com/dupontbertrand/meteor-ssg-ssr-demo-rspack

The demo uses a postinstall script to patch the npm package locally — this PR makes that workaround unnecessary.

## Related

This fix is independent of the Blaze PR that makes templates available server-side (https://github.com/meteor/blaze/pull/507). They complement each other but can be merged independently — this one just makes \`.html\` imports not crash on the server, which is arguably correct behavior on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new static-render package providing server pre-rendering (SSG and SSR), on-demand regeneration, cache invalidation, and runtime injection of pre-rendered HTML/head into responses.

* **Documentation**
  * Added package README and docs page with usage, route options, API, examples, client cleanup guidance, and a new sidebar entry.

* **Bug Fixes**
  * Adjusted server build config to prevent .html files from being parsed as JavaScript when Blaze is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->