### PR TITLE
fix(rspack): enable .html imports on server config for Blaze apps

### DIFF
--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -713,7 +713,22 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       runtimeChunk: false,
     },
     module: {
-      rules: [swcConfigRule, ...extraRules],
+      rules: [
+        swcConfigRule,
+        // Mirror the client rule: ignore .html so rspack doesn't try to
+        // parse them as JavaScript. Meteor's template compiler handles
+        // .html files separately, and RequireExternalsPlugin below wires
+        // the imports to Meteor's module system.
+        ...(Meteor.isBlazeEnabled
+          ? [
+              {
+                test: /\.html$/i,
+                loader: 'ignore-loader',
+              },
+            ]
+          : []),
+        ...extraRules,
+      ],
       parser: {
         javascript: {
           // Dynamic imports on the server are treated as bundled in the same chunk


### PR DESCRIPTION
## Summary

Splits out the rspack-only portion of [#14349](https://github.com/meteor/meteor/pull/14349) per @nachocodoner's request, so it can land independently (it's a fix, not a feature, and is useful on its own).

On the client, rspack handles `.html` imports via two mechanisms working together:

1. An `ignore-loader` rule so rspack doesn't try to parse `.html` as JavaScript
2. `RequireExternalsPlugin` marks `.html` imports as externals and writes `require()` calls resolved by Meteor's module system to the JS produced by the template compiler

On the server, only the second piece is in place. The `ignore-loader` rule is missing, so `import '../lib/foo.html'` from server code causes rspack to try parsing raw HTML as JavaScript and crash.

This PR adds the missing rule to the server config, guarded by `Meteor.isBlazeEnabled` so non-Blaze apps are unaffected.

## Change

Single file, one rule added in `npm-packages/meteor-rspack/rspack.config.js`:

```js
// Server module rules — BEFORE
rules: [swcConfigRule, ...extraRules]

// Server module rules — AFTER (mirrors client config)
rules: [
  swcConfigRule,
  ...(Meteor.isBlazeEnabled
    ? [{ test: /\.html\$/i, loader: 'ignore-loader' }]
    : []),
  ...extraRules,
]
```

## Why this is useful on its own

Even without any new features built on top, making `.html` imports not crash on the server is arguably correct behavior — right now any Blaze app that does `import './foo.html'` from server code (intentionally or by mistake) crashes with a confusing parse error. This PR fixes that.

## Testing

| Scenario | Result |
|---|---|
| Vanilla Blaze app with rspack (no custom server HTML imports) | No regression, builds and runs identically |
| Blaze app with rspack + server-side HTML import | No longer crashes |
| React / Vue / Svelte app with rspack (`isBlazeEnabled=false`) | Rule is inert, no impact |
| `meteor build` (production) | Compiles successfully |
| Galaxy deployment | Deployed and working |

## Context

See the forum discussion for broader context: https://forums.meteor.com/t/ssg-ssr-for-meteor-blaze-a-proof-of-concept/64556

The `static-render` package and CodeRabbit discussion from #14349 are separated out — they are a new feature and need more review time. This PR keeps things minimal and focused.

cc @nachocodoner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side module configuration to properly handle HTML files when Blaze templating is enabled, preventing them from being incorrectly parsed as JavaScript by rspack and ensuring consistent handling between server and client configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->