### PR TITLE
[SelfRunner] Increase TIMEOUT_SCALE_FACTOR and resources for self-tests flakiness optimization

### DIFF
--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   # Multiplies the waitSecs for self-tests.
-  TIMEOUT_SCALE_FACTOR: 14
+  TIMEOUT_SCALE_FACTOR: 8
   # Retry failed tests additional times.
   METEOR_SELF_TEST_RETRIES: 2
   METEOR_HEADLESS: true
@@ -153,6 +153,7 @@ jobs:
     needs: setup
     timeout-minutes: 35
     env:
+      TIMEOUT_SCALE_FACTOR: 14
       TEST_GROUP: "^[a-b]|^c[a-n]|^co[a-l]|^comm"
     steps:
       - name: Checkout repository
@@ -486,6 +487,7 @@ jobs:
     needs: setup
     timeout-minutes: 25
     env:
+      TIMEOUT_SCALE_FACTOR: 14
       TEST_GROUP: "^m[a-n]|^mo[a-d]"
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
+      options: --user root
     needs: setup
     timeout-minutes: 45
     steps:
@@ -149,7 +149,7 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      options: --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
     needs: setup
     timeout-minutes: 35
     env:
@@ -482,7 +482,7 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      options: --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
     needs: setup
     timeout-minutes: 25
     env:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   # Multiplies the waitSecs for self-tests.
-  TIMEOUT_SCALE_FACTOR: 8
+  TIMEOUT_SCALE_FACTOR: 14
   # Retry failed tests additional times.
   METEOR_SELF_TEST_RETRIES: 2
   METEOR_HEADLESS: true

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      options: --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
     needs: setup
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
Fixes: https://github.com/meteor/meteor/actions/runs/24666479720/job/72126868125?pr=14331

This PR attempts to fix a flakiness on a specific group job running. It's a match-timeout. Maybe this suffers from the same problems I got on [my E2E branch migration](https://github.com/meteor/meteor/pull/14331). I needed to increase the timeouts drastically for CI so that, on slower machines, it can still get the green signal at some point. We now have just two machines spinning up jobs from many branches in parallel. It seems everything is slower, and CI timeouts are an important thing to consider to reduce flakiness, or even add retries, but I would first try higher timeouts. Also, increasing the resources for those specific tests that are flaky is also an approach to make them run stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure resource allocation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->