### PR TITLE
Support test retry handling for E2E and selftest to improve CI responsiveness

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,6 +23,8 @@ env:
   # Force "localhost" to resolve to 127.0.0.1; runner prefers ::1, which
   # breaks local proxies to IPv4-only dev servers (ECONNREFUSED).
   NODE_OPTIONS: "--max_old_space_size=16384 --dns-result-order=ipv4first"
+  # Per-test Jest retry count. Consumed by tools/e2e-tests/jest.setup.js.
+  METEOR_E2E_TEST_RETRIES: 1
 
 jobs:
   test:

--- a/tools/e2e-tests/helpers.js
+++ b/tools/e2e-tests/helpers.js
@@ -10,6 +10,73 @@ const REPO_ROOT = path.resolve(__dirname, '../..');
 const METEOR_EXECUTABLE = path.join(REPO_ROOT, 'meteor');
 
 /**
+ * Returns true when the current Jest test is a retry attempt.
+ */
+export function isRetryAttempt() {
+  return Boolean(globalThis.__e2eIsRetryAttempt);
+}
+
+/**
+ * Snapshot file contents so they can be restored after a test mutates them.
+ * @param {string} baseDir - Base directory for relative paths
+ * @param {string[]} relPaths - Relative paths to snapshot
+ * @returns {Promise<Map<string, {content: string|null, existed: boolean}>>}
+ */
+export async function snapshotFiles(baseDir, relPaths = []) {
+  const snapshot = new Map();
+  for (const relPath of relPaths) {
+    if (!relPath) continue;
+    const fullPath = path.join(baseDir, relPath);
+    if (await fs.pathExists(fullPath)) {
+      const content = await fs.readFile(fullPath, 'utf8');
+      snapshot.set(fullPath, { content, existed: true });
+    } else {
+      snapshot.set(fullPath, { content: null, existed: false });
+    }
+  }
+  return snapshot;
+}
+
+/**
+ * Restore files captured by snapshotFiles to their original state.
+ * @param {Map<string, {content: string|null, existed: boolean}>} snapshot
+ */
+export async function restoreFiles(snapshot) {
+  if (!snapshot || snapshot.size === 0) return;
+  for (const [fullPath, entry] of snapshot.entries()) {
+    if (entry.existed) {
+      await fs.writeFile(fullPath, entry.content, 'utf8');
+    } else if (await fs.pathExists(fullPath)) {
+      await fs.remove(fullPath);
+    }
+  }
+}
+
+/**
+ * Remove build artifacts and caches under a Meteor app directory.
+ * @param {string} appDir - Directory containing the Meteor app
+ */
+export async function clearBuildArtifacts(appDir) {
+  if (!appDir) return;
+  const targets = [
+    '_build',
+    '.meteor/local/build',
+    '.meteor/local/bundler-cache',
+    '.meteor/local/plugin-cache',
+    'node_modules/.cache/rspack',
+    'node_modules/.cache/meteor',
+  ];
+  for (const target of targets) {
+    const fullPath = path.join(appDir, target);
+    try {
+      await fs.remove(fullPath);
+    } catch (err) {
+      console.log(`Could not remove ${fullPath}: ${err.message}`);
+    }
+  }
+}
+
+/**
  * Helper function to set up a Meteor app in a temporary directory
  * Copies the app and runs npm install
  * @param {string} appName - Name of the app in the apps directory

--- a/tools/e2e-tests/jest.setup.js
+++ b/tools/e2e-tests/jest.setup.js
@@ -23,9 +23,15 @@ if (process.env.CI) {
   });
 }
 
-// Retries are only enabled on CI — local runs fail fast so flakes surface.
-if (process.env.CI) {
-  jest.retryTimes(2, { logErrorsBeforeRetry: true });
+// Retries are only enabled on CI by default — local runs fail fast so flakes
+// surface. Set METEOR_E2E_TEST_RETRIES to override (e.g. "0" to disable on CI,
+// "2" to allow more retries, any value forces the setting regardless of CI).
+const retryOverride = process.env.METEOR_E2E_TEST_RETRIES;
+const retryCount = retryOverride !== undefined
+  ? Number(retryOverride)
+  : (process.env.CI ? 1 : 0);
+if (retryCount > 0) {
+  jest.retryTimes(retryCount, { logErrorsBeforeRetry: true });
 }
 
 // Track attempts per test — Jest 29 doesn't expose currentTestRetryAttempt.

--- a/tools/e2e-tests/jest.setup.js
+++ b/tools/e2e-tests/jest.setup.js
@@ -23,9 +23,36 @@ if (process.env.CI) {
   });
 }
 
-// This runs before each test
+// Retries are only enabled on CI — local runs fail fast so flakes surface.
+if (process.env.CI) {
+  jest.retryTimes(2, { logErrorsBeforeRetry: true });
+}
+
+// Track attempts per test — Jest 29 doesn't expose currentTestRetryAttempt.
+const attemptCounts = new Map();
+
 beforeEach(() => {
-  const name = expect.getState().currentTestName;
-  // e.g. a bright cyan arrow and test name
-  console.log(chalk.cyan(`▶ ${name}`));
+  const name = expect.getState().currentTestName || '<unknown>';
+  const attemptIndex = attemptCounts.get(name) ?? 0;
+  attemptCounts.set(name, attemptIndex + 1);
+  globalThis.__e2eIsRetryAttempt = attemptIndex > 0;
+
+  const attemptLabel = attemptIndex > 0 ? chalk.yellow(` (retry ${attemptIndex})`) : '';
+  console.log(chalk.cyan(`▶ ${name}`) + attemptLabel);
+});
+
+// E2E_FORCE_FLAKY_TEST: force matching tests to fail on the first attempt
+// to validate retry isolation. Runs in afterEach so the test body completes
+// (including any mutations) before the forced failure.
+afterEach(() => {
+  const flakyPattern = process.env.E2E_FORCE_FLAKY_TEST;
+  if (!flakyPattern) return;
+  const name = expect.getState().currentTestName || '<unknown>';
+  const attemptsSoFar = attemptCounts.get(name) ?? 0;
+  if (attemptsSoFar === 1 && name.includes(flakyPattern)) {
+    throw new Error(
+      `[E2E_FORCE_FLAKY_TEST] Forcing first-attempt failure for "${name}" ` +
+      `(matches pattern "${flakyPattern}"). Retry should pass if isolation works.`
+    );
+  }
 });

--- a/tools/e2e-tests/test-helpers.js
+++ b/tools/e2e-tests/test-helpers.js
@@ -7,13 +7,17 @@ import {
   appendFileContent,
   buildMeteorApp,
   cleanupTempDir,
+  clearBuildArtifacts,
   createMeteorApp,
+  isRetryAttempt,
   killMeteorProcess,
   killProcessByPort,
+  restoreFiles,
   runMeteorApp,
   runMeteorCommand,
   runMeteorTests,
   setupMeteorApp,
+  snapshotFiles,
   wait,
   waitForMeteorOutput,
   waitForPlaywrightConsole
@@ -111,6 +115,11 @@ export function testMeteorBundler(options) {
     beforeEach(async () => {
       // Ensure any process on the port is killed
       await killProcessByPort([port, devServerPortStr]);
+
+      // On retry, purge build caches so the next attempt starts clean.
+      if (isRetryAttempt() && tempDir) {
+        await clearBuildArtifacts(tempDir);
+      }
     });
 
     afterEach(async () => {
@@ -235,6 +244,17 @@ export function testMeteorRspackBundler(options) {
     let tempDir;
     let appDir;
     let previousRspackDevServerPort;
+    let fileSnapshot;
+
+    // Paths the rspack bundler generator mutates via appendFileContent. Snapshotted
+    // in beforeEach and restored in afterEach so retries see pristine source files.
+    const mutatedPaths = [
+      filePaths.client,
+      filePaths.server,
+      filePaths.test,
+      filePaths.testClient,
+      filePaths.testServer,
+    ].filter(Boolean);
 
     beforeAll(async () => {
       // Route this test's rspack dev server to the configured port so it doesn't
@@ -324,12 +344,29 @@ export function testMeteorRspackBundler(options) {
     beforeEach(async () => {
       // Ensure any process on the port is killed
       await killProcessByPort([port, devServerPortStr]);
+
+      // On retry, purge build artifacts so the next attempt recompiles from a
+      // clean slate (guards against caches that encode the failed attempt's state).
+      if (isRetryAttempt() && appDir) {
+        await clearBuildArtifacts(appDir);
+      }
+
+      // Capture mutable source files so afterEach can restore them. This makes
+      // retries see pristine files even after appendFileContent calls.
+      fileSnapshot = tempDir ? await snapshotFiles(tempDir, mutatedPaths) : null;
     });
 
     afterEach(async () => {
       if (meteorProcess) {
         await killMeteorProcess(meteorProcess);
         meteorProcess = null;
+      }
+
+      // Restore mutated files regardless of pass/fail — idempotent on green runs,
+      // essential on retries.
+      if (fileSnapshot) {
+        await restoreFiles(fileSnapshot);
+        fileSnapshot = null;
       }
     });
 
@@ -818,6 +855,20 @@ export function testMeteorRspackBundler(options) {
         : '';
       const localDirSuffix = meteorLocalDirName ? `-${meteorLocalDirName}` : '';
 
+      // On retry, the prior attempt deleted the artifacts this test asserts on.
+      // Re-seed by running meteor briefly so the assertFileExist checks below hold.
+      if (isRetryAttempt()) {
+        console.log('[retry] re-seeding build artifacts for meteor reset test');
+        const seedResult = await runMeteorApp(tempDir, port, {
+          waitForOutput: "=> App running at",
+          isMonorepo,
+          skipWaitOn: skipClient,
+          env: { ...env, ...(env.meteorRun || {}) },
+        });
+        await killMeteorProcess(seedResult.meteorProcess);
+        await killProcessByPort([port, devServerPortStr]);
+      }
+
       // Verify build artifacts exist from previous tests
       await assertFileExist(appDir, buildDir);
       await assertFileExist(appDir, 'node_modules/.cache/rspack');
@@ -972,6 +1023,13 @@ export function testMeteorSkeleton(options) {
     beforeEach(async () => {
       // Ensure any process on the port is killed
       await killProcessByPort([port, devServerPortStr]);
+
+      // On retry, purge caches left by the failing attempt so the next one
+      // recompiles from scratch. Skip when tempDir isn't set yet (e.g. retry
+      // of the "meteor create" test, which allocates its own tempDir).
+      if (isRetryAttempt() && tempDir) {
+        await clearBuildArtifacts(tempDir);
+      }
     });
 
     afterEach(async () => {
@@ -1182,6 +1240,18 @@ export function testMeteorSkeleton(options) {
         ? path.basename(meteorLocalDirEnv.replace(/\\/g, '/'))
         : '';
       const localDirSuffix = meteorLocalDirName ? `-${meteorLocalDirName}` : '';
+
+      // On retry, the prior attempt deleted the artifacts this test asserts on.
+      // Re-seed by running meteor briefly when the skeleton produces build caches.
+      if (isRetryAttempt() && !skipBuildCacheCheck) {
+        console.log('[retry] re-seeding build artifacts for meteor reset test');
+        const seedResult = await runMeteorApp(tempDir, port, {
+          waitForOutput: "=> App running at",
+          env: env.meteorRun,
+        });
+        await killMeteorProcess(seedResult.meteorProcess);
+        await killProcessByPort([port, devServerPortStr]);
+      }
 
       // Verify build artifacts exist from previous tests
       if (!skipBuildCacheCheck) {

--- a/tools/tests/modern.js
+++ b/tools/tests/modern.js
@@ -4,6 +4,10 @@ var files = require('../fs/files');
 
 // No need for a high value since the asserts already wait long enough to pass tests
 const waitToStart = 5;
+// Budget for `meteor build` to fully exit. Doubled on CI where the container
+// is resource-constrained and the build can take substantially longer than
+// locally.
+const buildWaitSecs = process.env.CI ? 90 : 60;
 
 // Applies env var overrides for the duration of `fn`, then restores them on
 // every exit path. Required for retry-compatibility: without the try/finally,
@@ -53,13 +57,15 @@ selftest.define("modern build stack - legacy", async function () {
     run.waitSecs(waitToStart);
     await run.match("App running at");
 
+    const out = run.getMatcherFullBuffer();
+
     /* check legacy stack */
-    await run.match(/Babel\.compile/, false, true);
-    await run.match(/safeWatcher\.watchLegacy/, false, true);
-    await run.match(/_findSources for web\.browser.legacy/, false, true);
+    selftest.expectTrue(/Babel\.compile/.test(out));
+    selftest.expectTrue(/safeWatcher\.watchLegacy/.test(out));
+    selftest.expectTrue(/_findSources for web\.browser\.legacy/.test(out));
 
     /* check debug stack */
-    await run.match(/server\/main\.js:6:22/, false, true);
+    selftest.expectTrue(/server\/main\.js:6:22/.test(out));
 
     await run.stop();
   });
@@ -82,16 +88,18 @@ selftest.define("modern build stack", async function () {
     run.waitSecs(waitToStart);
     await run.match("App running at");
 
-    /* check modern stack */
-    await run.match(/SWC\.compile/, false, true);
-    await run.match(/safeWatcher\.watchModern/, false, true);
-    await run.match(/_findSources for web\.browser/, false, true);
+    const out = run.getMatcherFullBuffer();
 
-    run.forbid(/Babel\.compile/, false, true);
-    run.forbid(/_findSources for web\.browser\.legacy/, false, true);
+    /* check modern stack */
+    selftest.expectTrue(/SWC\.compile/.test(out));
+    selftest.expectTrue(/safeWatcher\.watchModern/.test(out));
+    selftest.expectTrue(/_findSources for web\.browser/.test(out));
+
+    selftest.expectFalse(/Babel\.compile/.test(out));
+    selftest.expectFalse(/_findSources for web\.browser\.legacy/.test(out));
 
     /* check debug stack */
-    await run.match(/server\/main\.js:6:22/, false, true);
+    selftest.expectTrue(/server\/main\.js:6:22/.test(out));
 
     await run.stop();
   });
@@ -114,14 +122,16 @@ selftest.define("modern build stack - disable transpiler", async function () {
     run.waitSecs(waitToStart);
     await run.match("App running at");
 
+    const out = run.getMatcherFullBuffer();
+
     /* disable transpiler */
-    run.forbid(/SWC\.compile/, false, true);
-    await run.match(/Babel\.compile/, false, true);
+    selftest.expectFalse(/SWC\.compile/.test(out));
+    selftest.expectTrue(/Babel\.compile/.test(out));
 
     /* Keep rest of modern build stack */
-    await run.match(/safeWatcher\.watchModern/, false, true);
-    await run.match(/_findSources for web\.browser/, false, true);
-    run.forbid(/_findSources for web\.browser\.legacy/, false, true);
+    selftest.expectTrue(/safeWatcher\.watchModern/.test(out));
+    selftest.expectTrue(/_findSources for web\.browser/.test(out));
+    selftest.expectFalse(/_findSources for web\.browser\.legacy/.test(out));
 
     await run.stop();
   });
@@ -144,14 +154,16 @@ selftest.define("modern build stack - disable watcher", async function () {
     run.waitSecs(waitToStart);
     await run.match("App running at");
 
+    const out = run.getMatcherFullBuffer();
+
     /* disable watcher */
-    run.forbid(/safeWatcher\.watchModern/, false, true);
-    await run.match(/safeWatcher\.watchLegacy/, false, true);
+    selftest.expectFalse(/safeWatcher\.watchModern/.test(out));
+    selftest.expectTrue(/safeWatcher\.watchLegacy/.test(out));
 
     /* Keep rest of modern build stack */
-    await run.match(/SWC\.compile/, false, true);
-    await run.match(/_findSources for web\.browser/, false, true);
-    run.forbid(/_findSources for web\.browser\.legacy/, false, true);
+    selftest.expectTrue(/SWC\.compile/.test(out));
+    selftest.expectTrue(/_findSources for web\.browser/.test(out));
+    selftest.expectFalse(/_findSources for web\.browser\.legacy/.test(out));
 
     await run.stop();
   });
@@ -174,13 +186,15 @@ selftest.define("modern build stack - disable webArchOnly", async function () {
     run.waitSecs(waitToStart);
     await run.match("App running at");
 
+    const out = run.getMatcherFullBuffer();
+
     /* disable webArchOnly */
-    await run.match(/_findSources for web\.browser/, false, true);
-    await run.match(/_findSources for web\.browser\.legacy/, false, true);
+    selftest.expectTrue(/_findSources for web\.browser/.test(out));
+    selftest.expectTrue(/_findSources for web\.browser\.legacy/.test(out));
 
     /* Keep rest of modern build stack */
-    await run.match(/safeWatcher\.watchModern/, false, true);
-    await run.match(/SWC\.compile/, false, true);
+    selftest.expectTrue(/safeWatcher\.watchModern/.test(out));
+    selftest.expectTrue(/SWC\.compile/.test(out));
 
     await run.stop();
   });
@@ -617,16 +631,19 @@ selftest.define("modern build stack - enable build", async function () {
     await writeModernConfig(s, true);
 
     const buildSwc = s.run("build", `../modern`);
-    buildSwc.waitSecs(waitToStart);
+    buildSwc.waitSecs(buildWaitSecs);
+    await buildSwc.expectExit(0);
+
+    const out = buildSwc.getMatcherFullBuffer();
 
     /* Perserve legacy and modern on build */
-    await buildSwc.match(/_findSources for web\.browser/, false, true);
-    await buildSwc.match(/_findSources for web\.browser\.legacy/, false, true);
+    selftest.expectTrue(/_findSources for web\.browser/.test(out));
+    selftest.expectTrue(/_findSources for web\.browser\.legacy/.test(out));
 
     /* Keep rest of modern build stack */
-    await buildSwc.match(/safeWatcher\.watchModern/, false, true);
-    await buildSwc.match(/SWC\.compile/, false, true);
-    await buildSwc.match("[DEBUG] Minifying using SWC", false, true);
+    selftest.expectTrue(/safeWatcher\.watchModern/.test(out));
+    selftest.expectTrue(/SWC\.compile/.test(out));
+    selftest.expectTrue(out.includes("[DEBUG] Minifying using SWC"));
   });
 });
 
@@ -649,15 +666,18 @@ selftest.define("modern build stack - disable build", async function () {
     });
 
     const buildLegacy = s.run("build", `../modern`);
-    buildLegacy.waitSecs(waitToStart);
+    buildLegacy.waitSecs(buildWaitSecs);
+    await buildLegacy.expectExit(0);
+
+    const out = buildLegacy.getMatcherFullBuffer();
 
     /* Perserve legacy and modern on build */
-    await buildLegacy.match(/_findSources for web\.browser/, false, true);
-    await buildLegacy.match(/_findSources for web\.browser\.legacy/, false, true);
+    selftest.expectTrue(/_findSources for web\.browser/.test(out));
+    selftest.expectTrue(/_findSources for web\.browser\.legacy/.test(out));
 
     /* Keep rest of modern build stack */
-    await buildLegacy.match(/safeWatcher\.watchLegacy/, false, true);
-    await buildLegacy.match(/Babel\.compile/, false, true);
-    await buildLegacy.match("[DEBUG] Minifying using Terser", false, true);
+    selftest.expectTrue(/safeWatcher\.watchLegacy/.test(out));
+    selftest.expectTrue(/Babel\.compile/.test(out));
+    selftest.expectTrue(out.includes("[DEBUG] Minifying using Terser"));
   });
 });

--- a/tools/tests/modern.js
+++ b/tools/tests/modern.js
@@ -5,6 +5,26 @@ var files = require('../fs/files');
 // No need for a high value since the asserts already wait long enough to pass tests
 const waitToStart = 5;
 
+// Applies env var overrides for the duration of `fn`, then restores them on
+// every exit path. Required for retry-compatibility: without the try/finally,
+// a mid-body failure would leak the mutated env into the subsequent retry and
+// into the Sandbox it spawns, producing a different starting state than the
+// first attempt.
+async function withEnv(overrides, fn) {
+  const saved = Object.fromEntries(
+    Object.keys(overrides).map(k => [k, process.env[k]])
+  );
+  Object.assign(process.env, overrides);
+  try {
+    return await fn();
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
 async function writeModernConfig(s, modernConfig) {
   const json = JSON.parse(s.read("package.json"));
 
@@ -17,359 +37,334 @@ async function writeModernConfig(s, modernConfig) {
 }
 
 selftest.define("modern build stack - legacy", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = 'false';
+  await withEnv({ METEOR_MODERN: 'false' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    s.set("METEOR_PROFILE", "0");
 
-  s.set("METEOR_PROFILE", "0");
+    await writeModernConfig(s, false);
 
-  await writeModernConfig(s, false);
+    const run = s.run();
 
-  const run = s.run();
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
 
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
+    /* check legacy stack */
+    await run.match(/Babel\.compile/, false, true);
+    await run.match(/safeWatcher\.watchLegacy/, false, true);
+    await run.match(/_findSources for web\.browser.legacy/, false, true);
 
-  /* check legacy stack */
-  await run.match(/Babel\.compile/, false, true);
-  await run.match(/safeWatcher\.watchLegacy/, false, true);
-  await run.match(/_findSources for web\.browser.legacy/, false, true);
+    /* check debug stack */
+    await run.match(/server\/main\.js:6:22/, false, true);
 
-  /* check debug stack */
-  await run.match(/server\/main\.js:6:22/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
+    await run.stop();
+  });
 });
 
 selftest.define("modern build stack", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    s.set("METEOR_PROFILE", "0");
 
-  s.set("METEOR_PROFILE", "0");
+    await writeModernConfig(s, true);
 
-  await writeModernConfig(s, true);
+    const run = s.run();
 
-  const run = s.run();
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
 
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
+    /* check modern stack */
+    await run.match(/SWC\.compile/, false, true);
+    await run.match(/safeWatcher\.watchModern/, false, true);
+    await run.match(/_findSources for web\.browser/, false, true);
 
-  /* check modern stack */
-  await run.match(/SWC\.compile/, false, true);
-  await run.match(/safeWatcher\.watchModern/, false, true);
-  await run.match(/_findSources for web\.browser/, false, true);
+    run.forbid(/Babel\.compile/, false, true);
+    run.forbid(/_findSources for web\.browser\.legacy/, false, true);
 
-  run.forbid(/Babel\.compile/, false, true);
-  run.forbid(/_findSources for web\.browser\.legacy/, false, true);
+    /* check debug stack */
+    await run.match(/server\/main\.js:6:22/, false, true);
 
-  /* check debug stack */
-  await run.match(/server\/main\.js:6:22/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
+    await run.stop();
+  });
 });
 
 selftest.define("modern build stack - disable transpiler", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    s.set("METEOR_PROFILE", "0");
 
-  s.set("METEOR_PROFILE", "0");
+    await writeModernConfig(s, { transpiler: false });
 
-  await writeModernConfig(s, { transpiler: false });
+    const run = s.run();
 
-  const run = s.run();
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
 
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
+    /* disable transpiler */
+    run.forbid(/SWC\.compile/, false, true);
+    await run.match(/Babel\.compile/, false, true);
 
-  /* disable transpiler */
-  run.forbid(/SWC\.compile/, false, true);
-  await run.match(/Babel\.compile/, false, true);
+    /* Keep rest of modern build stack */
+    await run.match(/safeWatcher\.watchModern/, false, true);
+    await run.match(/_findSources for web\.browser/, false, true);
+    run.forbid(/_findSources for web\.browser\.legacy/, false, true);
 
-  /* Keep rest of modern build stack */
-  await run.match(/safeWatcher\.watchModern/, false, true);
-  await run.match(/_findSources for web\.browser/, false, true);
-  run.forbid(/_findSources for web\.browser\.legacy/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
+    await run.stop();
+  });
 });
 
 selftest.define("modern build stack - disable watcher", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    s.set("METEOR_PROFILE", "0");
 
-  s.set("METEOR_PROFILE", "0");
+    await writeModernConfig(s, { watcher: false });
 
-  await writeModernConfig(s, { watcher: false });
+    const run = s.run();
 
-  const run = s.run();
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
 
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
+    /* disable watcher */
+    run.forbid(/safeWatcher\.watchModern/, false, true);
+    await run.match(/safeWatcher\.watchLegacy/, false, true);
 
-  /* disable watcher */
-  run.forbid(/safeWatcher\.watchModern/, false, true);
-  await run.match(/safeWatcher\.watchLegacy/, false, true);
+    /* Keep rest of modern build stack */
+    await run.match(/SWC\.compile/, false, true);
+    await run.match(/_findSources for web\.browser/, false, true);
+    run.forbid(/_findSources for web\.browser\.legacy/, false, true);
 
-  /* Keep rest of modern build stack */
-  await run.match(/SWC\.compile/, false, true);
-  await run.match(/_findSources for web\.browser/, false, true);
-  run.forbid(/_findSources for web\.browser\.legacy/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
+    await run.stop();
+  });
 });
 
 selftest.define("modern build stack - disable webArchOnly", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    s.set("METEOR_PROFILE", "0");
 
-  s.set("METEOR_PROFILE", "0");
+    await writeModernConfig(s, { webArchOnly: false });
 
-  await writeModernConfig(s, { webArchOnly: false });
+    const run = s.run();
 
-  const run = s.run();
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
 
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
+    /* disable webArchOnly */
+    await run.match(/_findSources for web\.browser/, false, true);
+    await run.match(/_findSources for web\.browser\.legacy/, false, true);
 
-  /* disable webArchOnly */
-  await run.match(/_findSources for web\.browser/, false, true);
-  await run.match(/_findSources for web\.browser\.legacy/, false, true);
+    /* Keep rest of modern build stack */
+    await run.match(/safeWatcher\.watchModern/, false, true);
+    await run.match(/SWC\.compile/, false, true);
 
-  /* Keep rest of modern build stack */
-  await run.match(/safeWatcher\.watchModern/, false, true);
-  await run.match(/SWC\.compile/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
+    await run.stop();
+  });
 });
 
 selftest.define("modern build stack - transpiler boolean-like options", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '', METEOR_DISABLE_COLORS: 'true' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    s.mkdir("config-package");
+    s.cd("config-package");
 
-  s.mkdir("config-package");
-  s.cd("config-package");
+    s.write(
+      "package.json",
+      JSON.stringify({
+        name: "config",
+        version: "1.2.3",
+        "private": true,
+        main: "index.js"
+      }, null, 2) + "\n"
+    );
 
-  s.write(
-    "package.json",
-    JSON.stringify({
-      name: "config",
-      version: "1.2.3",
-      "private": true,
-      main: "index.js"
-    }, null, 2) + "\n"
-  );
+    s.write(
+      "index.js",
+      "exports.id = module.id;\n"
+    );
 
-  s.write(
-    "index.js",
-    "exports.id = module.id;\n"
-  );
+    s.cd(s.home);
 
-  s.cd(s.home);
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
-
-  s.append(
-    "server/main.js",
-    `if (require('config')) {
+    s.append(
+      "server/main.js",
+      `if (require('config')) {
   console.log('Loaded NPM package "config"', require('config').id);
 }`);
 
-  process.env.METEOR_DISABLE_COLORS = true;
-
-  await writeModernConfig(s, {
-    transpiler: {
-      verbose: true,
-    },
-  });
-
-  const run = s.run();
-
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
-
-  /* check appended NPM package require */
-  await run.match(/Loaded NPM package "config"/, false, true);
-
-  /* check verbose logs */
-  await run.match(/SWC Custom Config/, false, true);
-  await run.match(/Meteor Config/, false, true);
-
-  /* check transpiler options */
-  await run.match(/\[Transpiler] Used SWC.*\(app\)/, false, true);
-  await run.match(/\[Transpiler] Used SWC.*\(package\)/, false, true);
-  run.forbid(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
-
-  await writeModernConfig(s, {
-    transpiler: {
-      verbose: true,
-      excludeApp: true,
-    },
-  });
-  await run.match(/\[Transpiler] Used Babel.*\(app\)/, false, true);
-
-  await writeModernConfig(s, {
-    transpiler: {
-      verbose: true,
-      excludePackages: true,
-    },
-  });
-  await run.match(/\[Transpiler] Used Babel.*\(package\)/, false, true);
-
-  await writeConfig(s, {
-    modern: {
+    await writeModernConfig(s, {
       transpiler: {
         verbose: true,
       },
-    },
-    nodeModules: {
-      recompile: {
-        config: true,
+    });
+
+    const run = s.run();
+
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
+
+    /* check appended NPM package require */
+    await run.match(/Loaded NPM package "config"/, false, true);
+
+    /* check verbose logs */
+    await run.match(/SWC Custom Config/, false, true);
+    await run.match(/Meteor Config/, false, true);
+
+    /* check transpiler options */
+    await run.match(/\[Transpiler] Used SWC.*\(app\)/, false, true);
+    await run.match(/\[Transpiler] Used SWC.*\(package\)/, false, true);
+    run.forbid(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
+
+    await writeModernConfig(s, {
+      transpiler: {
+        verbose: true,
+        excludeApp: true,
       },
-    },
+    });
+    await run.match(/\[Transpiler] Used Babel.*\(app\)/, false, true);
+
+    await writeModernConfig(s, {
+      transpiler: {
+        verbose: true,
+        excludePackages: true,
+      },
+    });
+    await run.match(/\[Transpiler] Used Babel.*\(package\)/, false, true);
+
+    await writeConfig(s, {
+      modern: {
+        transpiler: {
+          verbose: true,
+        },
+      },
+      nodeModules: {
+        recompile: {
+          config: true,
+        },
+      },
+    });
+    await run.match(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
+
+    await run.stop();
   });
-  await run.match(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
 });
 
 selftest.define("modern build stack - transpiler string-like options", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '', METEOR_DISABLE_COLORS: 'true' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    s.mkdir("config-package");
+    s.cd("config-package");
 
-  s.mkdir("config-package");
-  s.cd("config-package");
+    s.write(
+      "package.json",
+      JSON.stringify({
+        name: "config",
+        version: "1.2.3",
+        "private": true,
+        main: "index.js"
+      }, null, 2) + "\n"
+    );
 
-  s.write(
-    "package.json",
-    JSON.stringify({
-      name: "config",
-      version: "1.2.3",
-      "private": true,
-      main: "index.js"
-    }, null, 2) + "\n"
-  );
+    s.write(
+      "index.js",
+      "exports.id = module.id;\n"
+    );
 
-  s.write(
-    "index.js",
-    "exports.id = module.id;\n"
-  );
+    s.cd(s.home);
 
-  s.cd(s.home);
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
-
-  s.append(
-    "server/main.js",
-    `import { id } from 'config';
+    s.append(
+      "server/main.js",
+      `import { id } from 'config';
 console.log('Loaded NPM package "config"', require('config').id);`);
 
-  process.env.METEOR_DISABLE_COLORS = true;
-
-  await writeModernConfig(s, {
-    transpiler: {
-      verbose: true,
-    },
-  });
-
-  const run = s.run();
-
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
-
-  /* check appended NPM package imported */
-  await run.match(/Loaded NPM package "config"/, false, true);
-
-  /* check verbose logs */
-  await run.match(/SWC Custom Config/, false, true);
-  await run.match(/Meteor Config/, false, true);
-
-  /* check transpiler options */
-  await run.match(/\[Transpiler] Used SWC.*\(app\)/, false, true);
-  await run.match(/\[Transpiler] Used SWC.*\(package\)/, false, true);
-  run.forbid(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
-
-  await writeModernConfig(s, {
-    transpiler: {
-      verbose: true,
-      excludeApp: ['main.js'],
-    },
-  });
-  await run.match(/\[Transpiler] Used Babel.*\(app\)/, false, true);
-
-  await writeModernConfig(s, {
-    transpiler: {
-      verbose: true,
-      excludePackages: ['ejson'],
-    },
-  });
-  await run.match(/\[Transpiler] Used Babel.*\(package\)/, false, true);
-
-  await writeConfig(s, {
-    modern: {
+    await writeModernConfig(s, {
       transpiler: {
         verbose: true,
       },
-    },
-    nodeModules: {
-      recompile: {
-        config: true,
+    });
+
+    const run = s.run();
+
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
+
+    /* check appended NPM package imported */
+    await run.match(/Loaded NPM package "config"/, false, true);
+
+    /* check verbose logs */
+    await run.match(/SWC Custom Config/, false, true);
+    await run.match(/Meteor Config/, false, true);
+
+    /* check transpiler options */
+    await run.match(/\[Transpiler] Used SWC.*\(app\)/, false, true);
+    await run.match(/\[Transpiler] Used SWC.*\(package\)/, false, true);
+    run.forbid(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
+
+    await writeModernConfig(s, {
+      transpiler: {
+        verbose: true,
+        excludeApp: ['main.js'],
       },
-    },
+    });
+    await run.match(/\[Transpiler] Used Babel.*\(app\)/, false, true);
+
+    await writeModernConfig(s, {
+      transpiler: {
+        verbose: true,
+        excludePackages: ['ejson'],
+      },
+    });
+    await run.match(/\[Transpiler] Used Babel.*\(package\)/, false, true);
+
+    await writeConfig(s, {
+      modern: {
+        transpiler: {
+          verbose: true,
+        },
+      },
+      nodeModules: {
+        recompile: {
+          config: true,
+        },
+      },
+    });
+    await run.match(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
+
+    await run.stop();
   });
-  await run.match(/\[Transpiler] Used SWC.*\(node_modules\)/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
 });
 
 async function writeConfig(s, config) {
@@ -399,286 +394,270 @@ async function writeSwcConfigJs(s, config) {
 }
 
 selftest.define("modern build stack - transpiler custom .swcrc", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    await writeConfig(s, {
+      modern: true,
+      mainModule: {
+        client: 'client/main.js',
+        server: 'server/alias.js',
+      },
+    });
 
-  await writeConfig(s, {
-    modern: true,
-    mainModule: {
-      client: 'client/main.js',
-      server: 'server/alias.js',
-    },
+    const run = s.run();
+
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
+
+    /* custom .swcrc and alias resolution */
+    await run.match(/alias resolved/, false, true);
+
+    await run.stop();
   });
-
-  const run = s.run();
-
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
-
-  /* custom .swcrc and alias resolution */
-  await run.match(/alias resolved/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
 });
 
 selftest.define("modern build stack - transpiler custom swc.config.js", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    // Remove the .swcrc file to ensure we're using swc.config.js
+    s.unlink(".swcrc");
 
-  // Remove the .swcrc file to ensure we're using swc.config.js
-  s.unlink(".swcrc");
-
-  // Write the swc.config.js file with the same configuration
-  await writeSwcConfigJs(s, {
-    jsc: {
-      baseUrl: "./",
-      paths: {
-        "@swcAlias/*": ["swcAlias/*"]
+    // Write the swc.config.js file with the same configuration
+    await writeSwcConfigJs(s, {
+      jsc: {
+        baseUrl: "./",
+        paths: {
+          "@swcAlias/*": ["swcAlias/*"]
+        }
       }
-    }
+    });
+
+    await writeConfig(s, {
+      modern: true,
+      mainModule: {
+        client: 'client/main.js',
+        server: 'server/alias.js',
+      },
+    });
+
+    const run = s.run();
+
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
+
+    /* custom swc.config.js and alias resolution */
+    await run.match(/alias resolved/, false, true);
+
+    await run.stop();
   });
-
-  await writeConfig(s, {
-    modern: true,
-    mainModule: {
-      client: 'client/main.js',
-      server: 'server/alias.js',
-    },
-  });
-
-  const run = s.run();
-
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
-
-  /* custom swc.config.js and alias resolution */
-  await run.match(/alias resolved/, false, true);
-
-  await run.stop();
-
-  process.env.METEOR_MODERN = currentMeteorModern;
 });
 
 selftest.define("modern build stack - transpiler files", async function () {
-  process.env.METEOR_MODERN = 'true';
-  const s = new Sandbox();
-  await s.init();
+  await withEnv({ METEOR_MODERN: 'true' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await writeConfig(s, {
-    modern: true,
-    mainModule: {
-      client: 'client/main.js',
-      server: 'server/javascript.js',
-    },
-  });
-
-  const run = s.run();
-
-  run.waitSecs(waitToStart);
-  await run.match("App running at");
-
-  await run.match(/javascript\.js/, false, true);
-
-  await writeConfig(s, {
-    modern: true,
-    mainModule: {
-      client: 'client/main.js',
-      server: 'server/javascript-component.jsx',
-    },
-  });
-  await run.match(/javascript-component\.jsx/, false, true);
-
-  await writeConfig(s, {
-    modern: true,
-    mainModule: {
-      client: 'client/main.js',
-      server: 'server/typescript.ts',
-    },
-  });
-  await run.match(/typescript\.ts/, false, true);
-
-  await writeConfig(s, {
-    modern: true,
-    mainModule: {
-      client: 'client/main.js',
-      server: 'server/typescript-component.tsx',
-    },
-  });
-  await run.match(/typescript-component\.tsx/, false, true);
-
-  await writeSwcrcConfig(s, {
-    jsc: {
-      parser: {
-        syntax: 'typescript',
-        tsx: true,
-        jsx: true,
+    await writeConfig(s, {
+      modern: true,
+      mainModule: {
+        client: 'client/main.js',
+        server: 'server/javascript.js',
       },
-    },
-  });
-  await writeConfig(s, {
-    modern: true,
-    mainModule: {
-      client: 'client/main.js',
-      server: 'server/custom-component.js',
-    },
-  });
-  await run.match(/custom-component\.js/, false, true);
+    });
 
-  await run.stop();
+    const run = s.run();
 
+    run.waitSecs(waitToStart);
+    await run.match("App running at");
+
+    await run.match(/javascript\.js/, false, true);
+
+    await writeConfig(s, {
+      modern: true,
+      mainModule: {
+        client: 'client/main.js',
+        server: 'server/javascript-component.jsx',
+      },
+    });
+    await run.match(/javascript-component\.jsx/, false, true);
+
+    await writeConfig(s, {
+      modern: true,
+      mainModule: {
+        client: 'client/main.js',
+        server: 'server/typescript.ts',
+      },
+    });
+    await run.match(/typescript\.ts/, false, true);
+
+    await writeConfig(s, {
+      modern: true,
+      mainModule: {
+        client: 'client/main.js',
+        server: 'server/typescript-component.tsx',
+      },
+    });
+    await run.match(/typescript-component\.tsx/, false, true);
+
+    await writeSwcrcConfig(s, {
+      jsc: {
+        parser: {
+          syntax: 'typescript',
+          tsx: true,
+          jsx: true,
+        },
+      },
+    });
+    await writeConfig(s, {
+      modern: true,
+      mainModule: {
+        client: 'client/main.js',
+        server: 'server/custom-component.js',
+      },
+    });
+    await run.match(/custom-component\.js/, false, true);
+
+    await run.stop();
+  });
 });
 
 selftest.define("modern build stack - test terser minifier", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
-  const s = new Sandbox();  
-  await s.init();
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const appName = "terser-app";
+    const appName = "terser-app";
 
-  await s.createApp(appName, "modern");
-  await s.cd(appName);
+    await s.createApp(appName, "modern");
+    await s.cd(appName);
 
-  await writeConfig(s, {
-    modern: false
+    await writeConfig(s, {
+      modern: false
+    });
+
+    s.set("NODE_INSPECTOR_IPC", "1");
+
+    const runTerser = s.run();
+    runTerser.waitSecs(waitToStart);
+    await runTerser.match("App running at");
+    await runTerser.stop();
+
+    const buildTerser = s.run("build", `../${appName}`);
+    buildTerser.waitSecs(60);
+    await buildTerser.match("[DEBUG] Minifying using Terser", false, true);
+
+    const terserBuildPath = files.pathJoin(s.cwd, `../${appName}`);
+    selftest.expectEqual(files.exists(terserBuildPath), true);
   });
-
-  s.set("NODE_INSPECTOR_IPC", "1");
-
-  const runTerser = s.run();
-  runTerser.waitSecs(waitToStart);
-  await runTerser.match("App running at");
-  await runTerser.stop();
-
-  const buildTerser = s.run("build", `../${appName}`);
-  buildTerser.waitSecs(60);
-  await buildTerser.match("[DEBUG] Minifying using Terser", false, true);
-
-  const terserBuildPath = files.pathJoin(s.cwd, `../${appName}`);
-  selftest.expectEqual(files.exists(terserBuildPath), true);
-
-  process.env.METEOR_MODERN = currentMeteorModern;
 });
 
 selftest.define("modern build stack - test swc minifier", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = 'true';
-  const s = new Sandbox();
-  await s.init();
+  await withEnv({ METEOR_MODERN: 'true' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const appName = "modern-swc";
+    const appName = "modern-swc";
 
-  await s.createApp(appName, "modern");
-  await s.cd(appName);
+    await s.createApp(appName, "modern");
+    await s.cd(appName);
 
-  await writeConfig(s, {
-    modern: true,
-    mainModule: {
-      client: 'client/main.js',
-      server: 'server/main.js',
-    },
+    await writeConfig(s, {
+      modern: true,
+      mainModule: {
+        client: 'client/main.js',
+        server: 'server/main.js',
+      },
+    });
+
+    s.set("NODE_INSPECTOR_IPC", "1");
+
+    await writeModernConfig(s, {
+      minifier: true
+    });
+
+    const runSwc = s.run();
+    runSwc.waitSecs(waitToStart);
+    await runSwc.match("App running at");
+    await runSwc.stop();
+
+    const buildSwc = s.run("build", `../${appName}`);
+    buildSwc.waitSecs(60);
+    await buildSwc.match("[DEBUG] Minifying using SWC", false, true);
+
+    // Check what's in the build directory
+    const swcBuildPath = files.pathJoin(s.cwd, `../${appName}`);
+    selftest.expectEqual(files.exists(swcBuildPath), true);
   });
-
-  s.set("NODE_INSPECTOR_IPC", "1");
-
-  await writeModernConfig(s, {
-    minifier: true
-  });
-
-  const runSwc = s.run();
-  runSwc.waitSecs(waitToStart);
-  await runSwc.match("App running at");
-  await runSwc.stop();
-
-  const buildSwc = s.run("build", `../${appName}`);
-  buildSwc.waitSecs(60);
-  await buildSwc.match("[DEBUG] Minifying using SWC", false, true);
-
-  // Check what's in the build directory
-  const swcBuildPath = files.pathJoin(s.cwd, `../${appName}`);
-  selftest.expectEqual(files.exists(swcBuildPath), true);
-
-  process.env.METEOR_MODERN = currentMeteorModern;
 });
 
 selftest.define("modern build stack - enable build", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    s.set("METEOR_PROFILE", "0");
+    s.set("NODE_INSPECTOR_IPC", "1");
 
-  s.set("METEOR_PROFILE", "0");
-  s.set("NODE_INSPECTOR_IPC", "1");
+    await writeModernConfig(s, true);
 
-  await writeModernConfig(s, true);
+    const buildSwc = s.run("build", `../modern`);
+    buildSwc.waitSecs(waitToStart);
 
-  const buildSwc = s.run("build", `../modern`);
-  buildSwc.waitSecs(waitToStart);
+    /* Perserve legacy and modern on build */
+    await buildSwc.match(/_findSources for web\.browser/, false, true);
+    await buildSwc.match(/_findSources for web\.browser\.legacy/, false, true);
 
-  /* Perserve legacy and modern on build */
-  await buildSwc.match(/_findSources for web\.browser/, false, true);
-  await buildSwc.match(/_findSources for web\.browser\.legacy/, false, true);
-
-  /* Keep rest of modern build stack */
-  await buildSwc.match(/safeWatcher\.watchModern/, false, true);
-  await buildSwc.match(/SWC\.compile/, false, true);
-  await buildSwc.match("[DEBUG] Minifying using SWC", false, true);
-
-  process.env.METEOR_MODERN = currentMeteorModern;
+    /* Keep rest of modern build stack */
+    await buildSwc.match(/safeWatcher\.watchModern/, false, true);
+    await buildSwc.match(/SWC\.compile/, false, true);
+    await buildSwc.match("[DEBUG] Minifying using SWC", false, true);
+  });
 });
 
 selftest.define("modern build stack - disable build", async function () {
-  const currentMeteorModern = process.env.METEOR_MODERN;
-  process.env.METEOR_MODERN = '';
+  await withEnv({ METEOR_MODERN: '' }, async () => {
+    const s = new Sandbox();
+    await s.init();
 
-  const s = new Sandbox();
-  await s.init();
+    await s.createApp("modern", "modern");
+    await s.cd("modern");
 
-  await s.createApp("modern", "modern");
-  await s.cd("modern");
+    s.set("METEOR_PROFILE", "0");
+    s.set("NODE_INSPECTOR_IPC", "1");
 
-  s.set("METEOR_PROFILE", "0");
-  s.set("NODE_INSPECTOR_IPC", "1");
+    await writeModernConfig(s, {
+      watcher: false,
+      transpiler: false,
+      minifier: false,
+      webArchOnly: true, // Even when webArchOnly is true, the legacy build should be built
+    });
 
-  await writeModernConfig(s, {
-    watcher: false,
-    transpiler: false,
-    minifier: false,
-    webArchOnly: true, // Even when webArchOnly is true, the legacy build should be built
+    const buildLegacy = s.run("build", `../modern`);
+    buildLegacy.waitSecs(waitToStart);
+
+    /* Perserve legacy and modern on build */
+    await buildLegacy.match(/_findSources for web\.browser/, false, true);
+    await buildLegacy.match(/_findSources for web\.browser\.legacy/, false, true);
+
+    /* Keep rest of modern build stack */
+    await buildLegacy.match(/safeWatcher\.watchLegacy/, false, true);
+    await buildLegacy.match(/Babel\.compile/, false, true);
+    await buildLegacy.match("[DEBUG] Minifying using Terser", false, true);
   });
-
-  const buildLegacy = s.run("build", `../modern`);
-  buildLegacy.waitSecs(waitToStart);
-
-  /* Perserve legacy and modern on build */
-  await buildLegacy.match(/_findSources for web\.browser/, false, true);
-  await buildLegacy.match(/_findSources for web\.browser\.legacy/, false, true);
-
-  /* Keep rest of modern build stack */
-  await buildLegacy.match(/safeWatcher\.watchLegacy/, false, true);
-  await buildLegacy.match(/Babel\.compile/, false, true);
-  await buildLegacy.match("[DEBUG] Minifying using Terser", false, true);
-
-  process.env.METEOR_MODERN = currentMeteorModern;
 });


### PR DESCRIPTION
Continues: https://github.com/meteor/meteor/pull/14353

This PR is another attempt to improve test responsiveness on E2E and self-tests using the new runners.

- E2E: A reattempt mechanism that cleans properly the state to favor new retries properly.
- Self-test: Group 5 needed a better way to handle env changes to make reattempts possible.

Local retries are better than those from CI job level that takes more time into re-run a complete verification.