### PR TITLE
Add Windows-specific error handling to fix an Rspack dev server issue

### DIFF
--- a/dev/modern-tools/rspack/E2E_COVERAGE.md
+++ b/dev/modern-tools/rspack/E2E_COVERAGE.md
@@ -62,6 +62,7 @@ Full-featured React Router app with custom packages, Less, and advanced rspack c
 | Default + custom package loading | Run |
 | `resolve.extensions` loading (`.jsx`) | Run |
 | `rspack.config.override.js` custom plugin loading | Run, Test, Build |
+| User-level `devServer.onListening` composed with meteor-rspack default | Run |
 | React + TSX environment detection | Run, Prod, Test, Build |
 | Full-app test mode (`--full-app`) | Test |
 | Static assets in bundle (png, md) | Build |
@@ -277,6 +278,7 @@ Where each feature is tested across apps and skeletons.
 | Custom rspack config | react (.cjs), react-router, babel (.mjs), monorepo (.cjs), typescript (.ts) | |
 | Custom SWC config (.ts) | typescript | |
 | Config override file | react-router, monorepo | |
+| User-level `devServer.onListening` composition | react-router | |
 | Custom build dir | react, typescript | |
 | Custom asset/chunk context dirs | typescript | |
 | Custom env vars | react (METEOR_LOCAL_DIR), react-router (METEOR_PACKAGE_DIRS) | |

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.1.0-beta.36",
+  "version": "1.1.0-beta.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "1.1.0-beta.36",
+      "version": "1.1.0-beta.37",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.1.0-beta.37",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorjs/rspack",
-      "version": "1.1.0-beta.37",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.1.0-beta.36",
+  "version": "1.1.0-beta.37",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorjs/rspack",
-  "version": "1.1.0-beta.37",
+  "version": "2.0.1",
   "description": "Configuration logic for using Rspack in Meteor projects",
   "main": "index.js",
   "type": "commonjs",

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -562,6 +562,43 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       ? path.resolve(process.cwd(), testEntry)
       : path.resolve(process.cwd(), buildContext, entryPath);
   const clientNameConfig = `[${(isTest && "test-") || ""}client-rspack]`;
+
+  // Default onListening provided by meteor-rspack. Kept as a named
+  // reference so we can detect a user-supplied override after merge
+  // and compose (run default first, then user's).
+  const meteorDefaultOnListening = function (devServer) {
+    if (!devServer) return;
+    const { host, port } = devServer.options;
+    const protocol =
+      devServer.options.server?.type === "https" ? "https" : "http";
+    const devServerUrl = `${protocol}://${host || "localhost"}:${port}`;
+    outputMeteorRspack({ devServerUrl });
+
+    // Windows-only: webpack-dev-server tracks accepted sockets
+    // but doesn't attach 'error'. On Windows, teardown of a
+    // closed proxy connection sends RST, producing an unhandled
+    // ECONNRESET that crashes the dev server. Unix peers send
+    // FIN and never hit this.
+    if (process.platform !== "win32") return;
+
+    const server = devServer.server;
+    if (!server || server.__meteorRspackErrorGuard) return;
+    server.__meteorRspackErrorGuard = true;
+
+    server.on("connection", (socket) => {
+      if (!socket || socket.__meteorRspackGuarded) return;
+      socket.__meteorRspackGuarded = true;
+      socket.on("error", (err) => {
+        if (err && err.code === "ECONNRESET") return;
+        console.warn(
+          `[meteor-rspack] dev server socket error: ${
+            err && (err.code || err.message)
+          }`
+        );
+      });
+    });
+  };
+
   // Base client config
   let clientConfig = {
     name: clientNameConfig,
@@ -656,43 +693,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
         devMiddleware: {
           writeToDisk: createPersistCallback({ once: ['sw.js'], always: ['.html'] }),
         },
-        onListening(devServer) {
-          if (!devServer) return;
-          const { host, port } = devServer.options;
-          const protocol =
-            devServer.options.server?.type === "https" ? "https" : "http";
-          const devServerUrl = `${protocol}://${host || "localhost"}:${port}`;
-          outputMeteorRspack({ devServerUrl });
-
-          // Windows-only: webpack-dev-server tracks accepted sockets
-          // but doesn't attach 'error'. On Windows, teardown of a
-          // closed proxy connection sends RST, producing an unhandled
-          // ECONNRESET that crashes the dev server. Unix peers send
-          // FIN and never hit this.
-          if (process.platform !== "win32") return;
-
-          const server = devServer.server;
-          if (!server || server.__meteorRspackErrorGuard) return;
-          server.__meteorRspackErrorGuard = true;
-
-          const QUIET_CODES = new Set([
-            "ECONNRESET",
-            "ECONNABORTED",
-            "EPIPE",
-          ]);
-          server.on("connection", (socket) => {
-            if (!socket || socket.__meteorRspackGuarded) return;
-            socket.__meteorRspackGuarded = true;
-            socket.on("error", (err) => {
-              if (QUIET_CODES.has(err && err.code)) return;
-              console.warn(
-                `[meteor-rspack] dev server socket error: ${
-                  err && (err.code || err.message)
-                }`
-              );
-            });
-          });
-        },
+        onListening: meteorDefaultOnListening,
       },
     }),
     ...merge(cacheStrategy, { experiments: { css: true } }),
@@ -869,6 +870,23 @@ module.exports = async function (inMeteor = {}, argv = {}) {
     config = mergeSplitOverlap(config, nextOverrideConfig);
     if (nextOverrideConfig.stats != null) {
       statsOverrided = true;
+    }
+  }
+
+  // If the user or an override replaced devServer.onListening, compose
+  // so our default runs first (attaches the Windows socket guard and
+  // reports the dev server URL) and the user's hook runs second.
+  if (isClient && config.devServer) {
+    const finalOnListening = config.devServer.onListening;
+    if (
+      typeof finalOnListening === "function" &&
+      finalOnListening !== meteorDefaultOnListening
+    ) {
+      const userOnListening = finalOnListening;
+      config.devServer.onListening = function (devServer) {
+        meteorDefaultOnListening(devServer);
+        userOnListening(devServer);
+      };
     }
   }
 

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -579,24 +579,24 @@ module.exports = async function (inMeteor = {}, argv = {}) {
     // closed proxy connection sends RST, producing an unhandled
     // ECONNRESET that crashes the dev server. Unix peers send
     // FIN and never hit this.
-    if (process.platform !== "win32") return;
+    if (process.platform === "win32") {
+      const server = devServer.server;
+      if (!server || server.__meteorRspackErrorGuard) return;
+      server.__meteorRspackErrorGuard = true;
 
-    const server = devServer.server;
-    if (!server || server.__meteorRspackErrorGuard) return;
-    server.__meteorRspackErrorGuard = true;
-
-    server.on("connection", (socket) => {
-      if (!socket || socket.__meteorRspackGuarded) return;
-      socket.__meteorRspackGuarded = true;
-      socket.on("error", (err) => {
-        if (err && err.code === "ECONNRESET") return;
-        console.warn(
-          `[meteor-rspack] dev server socket error: ${
-            err && (err.code || err.message)
-          }`
-        );
+      server.on("connection", (socket) => {
+        if (!socket || socket.__meteorRspackGuarded) return;
+        socket.__meteorRspackGuarded = true;
+        socket.on("error", (err) => {
+          if (err && err.code === "ECONNRESET") return;
+          console.warn(
+            `[meteor-rspack] dev server socket error: ${
+              err && (err.code || err.message)
+            }`
+          );
+        });
       });
-    });
+    }
   };
 
   // Base client config

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -663,6 +663,35 @@ module.exports = async function (inMeteor = {}, argv = {}) {
             devServer.options.server?.type === "https" ? "https" : "http";
           const devServerUrl = `${protocol}://${host || "localhost"}:${port}`;
           outputMeteorRspack({ devServerUrl });
+
+          // Windows-only: webpack-dev-server tracks accepted sockets
+          // but doesn't attach 'error'. On Windows, teardown of a
+          // closed proxy connection sends RST, producing an unhandled
+          // ECONNRESET that crashes the dev server. Unix peers send
+          // FIN and never hit this.
+          if (process.platform !== "win32") return;
+
+          const server = devServer.server;
+          if (!server || server.__meteorRspackErrorGuard) return;
+          server.__meteorRspackErrorGuard = true;
+
+          const QUIET_CODES = new Set([
+            "ECONNRESET",
+            "ECONNABORTED",
+            "EPIPE",
+          ]);
+          server.on("connection", (socket) => {
+            if (!socket || socket.__meteorRspackGuarded) return;
+            socket.__meteorRspackGuarded = true;
+            socket.on("error", (err) => {
+              if (QUIET_CODES.has(err && err.code)) return;
+              console.warn(
+                `[meteor-rspack] dev server socket error: ${
+                  err && (err.code || err.message)
+                }`
+              );
+            });
+          });
         },
       },
     }),

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 export const DEFAULT_RSPACK_VERSION = '1.7.1';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '1.1.0-beta.37';
+export const DEFAULT_METEOR_RSPACK_VERSION = '2.0.1';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 export const DEFAULT_RSPACK_VERSION = '1.7.1';
 
-export const DEFAULT_METEOR_RSPACK_VERSION = '1.1.0-beta.36';
+export const DEFAULT_METEOR_RSPACK_VERSION = '1.1.0-beta.37';
 
 export const DEFAULT_METEOR_RSPACK_REACT_HMR_VERSION = '1.4.3';
 

--- a/tools/e2e-tests/apps/react-router/rspack.config.js
+++ b/tools/e2e-tests/apps/react-router/rspack.config.js
@@ -67,5 +67,14 @@ module.exports = defineConfig(Meteor => {
         },
       }),
     ],
+    // User-level devServer.onListening: verifies that meteor-rspack
+    // composes its default hook (which reports the dev server URL and
+    // installs the Windows socket guard) with a user-supplied hook
+    // instead of letting the user replace the default outright.
+    devServer: {
+      onListening(_devServer) {
+        console.log('[user-onListening] fired from rspack.config.js');
+      },
+    },
   };
 });

--- a/tools/e2e-tests/apps/solid/package.json
+++ b/tools/e2e-tests/apps/solid/package.json
@@ -22,7 +22,7 @@
     "modern": true
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "babel-loader": "10.0.0",

--- a/tools/e2e-tests/apps/solid/package.json
+++ b/tools/e2e-tests/apps/solid/package.json
@@ -22,7 +22,7 @@
     "modern": true
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "babel-loader": "10.0.0",

--- a/tools/e2e-tests/apps/svelte/package.json
+++ b/tools/e2e-tests/apps/svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "playwright": "1.59.0",

--- a/tools/e2e-tests/apps/svelte/package.json
+++ b/tools/e2e-tests/apps/svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "playwright": "1.59.0",

--- a/tools/e2e-tests/apps/vue/package.json
+++ b/tools/e2e-tests/apps/vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tools/e2e-tests/apps/vue/package.json
+++ b/tools/e2e-tests/apps/vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rspack/cli": "^1.4.8",
     "@rspack/core": "^1.4.8",
     "@tailwindcss/postcss": "^4.1.12",

--- a/tools/e2e-tests/react-router.test.js
+++ b/tools/e2e-tests/react-router.test.js
@@ -55,6 +55,11 @@ describe('R.Router App Bundling /', () => {
         await waitForMeteorOutput(result.outputLines, /.*first\.jsx loaded.*/);
         // Check custom plugin gets loaded from rspack.config.override.js file
         await waitForMeteorOutput(result.outputLines, /.*CustomConsoleLogPlugin.*/);
+        // User-level devServer.onListening composes with meteor-rspack's
+        // default: the default emits the HMR server URL, and the user's
+        // hook emits its own marker. Both must appear.
+        await waitForMeteorOutput(result.outputLines, /.*Started Rspack HMR server at.*/);
+        await waitForMeteorOutput(result.outputLines, /.*\[user-onListening\] fired from rspack\.config\.js.*/);
       },
       afterRunRebuildClient: async ({ allConsoleLogs }) => {
         // Check for HMR output as enabled by default

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^20.0.0",
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@nx/angular-rspack": "^21.1.0",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^20.0.0",
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@nx/angular-rspack": "^21.1.0",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@graphql-tools/webpack-loader": "^7.0.0",
     "@rsdoctor/rspack-plugin": "^1.5.7",
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",
     "@rspack/plugin-react-refresh": "^1.4.3",

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@graphql-tools/webpack-loader": "^7.0.0",
     "@rsdoctor/rspack-plugin": "^1.5.7",
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",
     "@rspack/plugin-react-refresh": "^1.4.3",

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.23.3",
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.23.3",
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -14,7 +14,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -12,7 +12,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -12,7 +12,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -14,7 +14,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -14,7 +14,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -13,7 +13,7 @@
     "meteor-node-stubs": "^1.2.12"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.36",
+    "@meteorjs/rspack": "^1.1.0-beta.37",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -17,7 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@meteorjs/rspack": "^1.1.0-beta.37",
+    "@meteorjs/rspack": "^2.0.1",
     "@rsdoctor/rspack-plugin": "^1.5.7",
     "@rspack/cli": "^1.7.1",
     "@rspack/core": "^1.7.1",

--- a/v3-docs/docs/generators/changelog/versions/3.4.1.md
+++ b/v3-docs/docs/generators/changelog/versions/3.4.1.md
@@ -129,7 +129,7 @@ If you find any issues, please report them to the [Meteor issues tracker](https:
 
 #### Bumped NPM Packages
 
-- @meteorjs/rspack@1.1.0-beta.37
+- @meteorjs/rspack@2.0.1
 
 #### Special thanks to
 

--- a/v3-docs/docs/generators/changelog/versions/3.4.1.md
+++ b/v3-docs/docs/generators/changelog/versions/3.4.1.md
@@ -129,7 +129,7 @@ If you find any issues, please report them to the [Meteor issues tracker](https:
 
 #### Bumped NPM Packages
 
-- @meteorjs/rspack@1.1.0-beta.36
+- @meteorjs/rspack@1.1.0-beta.37
 
 #### Special thanks to
 


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/issues/14246

On Windows, the rspack dev server spawned by `meteor run` crashes with an unhandled `Error: read ECONNRESET` whenever a server-side file change triggers a Meteor restart. Subsequent restarts then hit `EADDRINUSE` because the port is not released. Linux and macOS are unaffected.

Inside the `rspack serve` child process, `webpack-dev-server` tracks every accepted TCP socket via `server.on('connection')` for shutdown but never attaches an `'error'` listener. When Meteor tears down its proxy connections on restart, Windows emits a TCP RST. The resulting ECONNRESET on the accepted socket fires as an unhandled event and crashes the process. Unix peers send a clean FIN and never trigger it.

The fix extends the existing `devServer.onListening` hook in `npm-packages/meteor-rspack/rspack.config.js` to attach an `'error'` listener to each accepted socket. `ECONNRESET` is swallowed silently; any other code logs via `console.warn` every time, so real problems remain visible. The guard is gated on `process.platform === "win32"`, so Linux and macOS behavior is byte for byte identical to before. This is a workaround for a missing listener in `webpack-dev-server`. The proper fix belongs upstream and, once released, this block can be removed.

To verify: [clone `jmarks-joshua/rspack_test`](https://github.com/jmarks-joshua/rspack_test), run `meteor npm install && meteor`, open the app in a browser, confirm the HMR socket is connected, then edit `server/main.js` and save. Before the fix the dev server crashes with `Error: read ECONNRESET` and the next restart fails with `EADDRINUSE`. After the fix the restart completes cleanly, the browser reconnects, and the dev server PID stays stable across repeated save cycles.