### PR TITLE
Fix/self test catalog cold cache

### DIFF
--- a/tools/isobuild/package-api.js
+++ b/tools/isobuild/package-api.js
@@ -75,6 +75,7 @@ export class PackageAPI {
     options = options || {};
 
     this.buildingIsopackets = !!options.buildingIsopackets;
+    this.buildingSelfTestCatalog = !!options.buildingSelfTestCatalog;
 
     // source files used.
     // It's a multi-level map structured as:
@@ -529,6 +530,17 @@ export class PackageAPI {
       buildmessage.error(
         "packages in isopackets may not use versionsFrom");
       // recover by ignoring
+      return;
+    }
+
+    if (self.buildingSelfTestCatalog) {
+      // The self-test catalog is built from a checkout-only set of packages
+      // where the local catalog has exactly one version of each package.
+      // versionsFrom's release records would only fill in unspecified
+      // version constraints (see package-source.js:727), which has no effect
+      // when there is exactly one candidate version. Skipping the lookup
+      // avoids a hard dependency on catalog.official having every Meteor
+      // release cached on disk, which is fragile in CI.
       return;
     }
 

--- a/tools/isobuild/package-api.js
+++ b/tools/isobuild/package-api.js
@@ -537,8 +537,9 @@ export class PackageAPI {
       // The self-test catalog is built from a checkout-only set of packages
       // where the local catalog has exactly one version of each package.
       // versionsFrom's release records would only fill in unspecified
-      // version constraints (see package-source.js:727), which has no effect
-      // when there is exactly one candidate version. Skipping the lookup
+      // version constraints (see the !_.isEmpty(api.releaseRecords) check
+      // in package-source.js), which has no effect when there is exactly
+      // one candidate version. Skipping the lookup
       // avoids a hard dependency on catalog.official having every Meteor
       // release cached on disk, which is fragile in CI.
       return;

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -500,6 +500,9 @@ Object.assign(PackageSource.prototype, {
   // - name: override the name of this package with a different name.
   // - buildingIsopackets: true if this is being scanned in the process
   //   of building isopackets
+  // - buildingSelfTestCatalog: true if this is being scanned by
+  //   newSelfTestCatalog. Causes versionsFrom() to no-op so the scan
+  //   does not depend on catalog.official being warm.
   initFromPackageDir: Profile((dir, options) => {
     return `PackageSource#initFromPackageDir for ${
       options?.name || dir.split(files.pathSep).pop()
@@ -664,7 +667,9 @@ Object.assign(PackageSource.prototype, {
     // exist in the field, if not every single one. #OldStylePackageSupport
 
     var api = new PackageAPI({
-      buildingIsopackets: !! initFromPackageDirOptions.buildingIsopackets
+      buildingIsopackets: !! initFromPackageDirOptions.buildingIsopackets,
+      buildingSelfTestCatalog:
+        !! initFromPackageDirOptions.buildingSelfTestCatalog,
     });
 
     if (Package._fileAndDepLoader) {

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -668,8 +668,7 @@ Object.assign(PackageSource.prototype, {
 
     var api = new PackageAPI({
       buildingIsopackets: !! initFromPackageDirOptions.buildingIsopackets,
-      buildingSelfTestCatalog:
-        !! initFromPackageDirOptions.buildingSelfTestCatalog,
+      buildingSelfTestCatalog: !! initFromPackageDirOptions.buildingSelfTestCatalog,
     });
 
     if (Package._fileAndDepLoader) {

--- a/tools/packaging/catalog/catalog-local.js
+++ b/tools/packaging/catalog/catalog-local.js
@@ -138,6 +138,9 @@ Object.assign(LocalCatalog.prototype, {
   //    are package source trees.  Takes precedence over packages found
   //    via localPackageSearchDirs.
   //  - buildingIsopackets: true if we are building isopackets
+  //  - buildingSelfTestCatalog: true if this catalog is being built for
+  //    use by `meteor self-test` sandboxes. Forwarded to PackageSource so
+  //    that versionsFrom() in scanned package.js files no-ops.
   async initialize(options) {
     var self = this;
     buildmessage.assertInCapture();
@@ -172,7 +175,10 @@ Object.assign(LocalCatalog.prototype, {
     );
 
     await self._computeEffectiveLocalPackages();
-    await self._loadLocalPackages(options.buildingIsopackets);
+    await self._loadLocalPackages(
+      options.buildingIsopackets,
+      options.buildingSelfTestCatalog,
+    );
     self.initialized = true;
   },
 
@@ -378,7 +384,7 @@ Object.assign(LocalCatalog.prototype, {
     });
   },
 
-  async _loadLocalPackages(buildingIsopackets) {
+  async _loadLocalPackages(buildingIsopackets, buildingSelfTestCatalog) {
     var self = this;
     buildmessage.assertInCapture();
 
@@ -399,7 +405,8 @@ Object.assign(LocalCatalog.prototype, {
         rootPath: packageDir
       }, async function () {
         var initFromPackageDirOptions = {
-          buildingIsopackets: !! buildingIsopackets
+          buildingIsopackets: !! buildingIsopackets,
+          buildingSelfTestCatalog: !! buildingSelfTestCatalog,
         };
         // If we specified a name, then we know what we want to get and should
         // pass that into the options. Otherwise, we will use the 'name'

--- a/tools/tests/sandbox-cold-catalog.js
+++ b/tools/tests/sandbox-cold-catalog.js
@@ -1,8 +1,8 @@
-var selftest = require('../tool-testing/selftest.js');
-var catalog = require('../packaging/catalog/catalog.js');
-var catalogLocal = require('../packaging/catalog/catalog-local.js');
-var buildmessage = require('../utils/buildmessage.js');
-var files = require('../fs/files');
+const selftest = require('../tool-testing/selftest.js');
+const catalog = require('../packaging/catalog/catalog.js');
+const catalogLocal = require('../packaging/catalog/catalog-local.js');
+const buildmessage = require('../utils/buildmessage.js');
+const files = require('../fs/files');
 
 selftest.define("self-test catalog scan tolerates cold official catalog",
 async function () {
@@ -10,16 +10,16 @@ async function () {
   // lookup come back empty. Without buildingSelfTestCatalog, this causes
   // versionsFrom() in scanned packages (e.g. packages/non-core/jquery) to
   // raise a fatal "Unknown release …" buildmessage.
-  var originalGetReleaseVersion = catalog.official.getReleaseVersion;
-  catalog.official.getReleaseVersion = async function () { return null; };
+  const originalGetReleaseVersion = catalog.official.getReleaseVersion;
+  catalog.official.getReleaseVersion = async () => null;
 
   try {
-    var localCatalog = new catalogLocal.LocalCatalog();
-    var packagesDir = files.pathJoin(files.getCurrentToolsDir(), 'packages');
+    const localCatalog = new catalogLocal.LocalCatalog();
+    const packagesDir = files.pathJoin(files.getCurrentToolsDir(), 'packages');
 
-    var messages = await buildmessage.capture({
+    const messages = await buildmessage.capture({
       title: "scanning core packages for cold-catalog regression test",
-    }, async function () {
+    }, async () => {
       await localCatalog.initialize({
         localPackageSearchDirs: [
           packagesDir,
@@ -32,8 +32,7 @@ async function () {
 
     if (messages.hasMessages()) {
       selftest.fail(
-        "scan errored despite buildingSelfTestCatalog=true:\n" +
-        messages.formatMessages(0)
+        `scan errored despite buildingSelfTestCatalog=true:\n${messages.formatMessages(0)}`,
       );
     }
   } finally {

--- a/tools/tests/sandbox-cold-catalog.js
+++ b/tools/tests/sandbox-cold-catalog.js
@@ -1,0 +1,42 @@
+var selftest = require('../tool-testing/selftest.js');
+var catalog = require('../packaging/catalog/catalog.js');
+var catalogLocal = require('../packaging/catalog/catalog-local.js');
+var buildmessage = require('../utils/buildmessage.js');
+var files = require('../fs/files');
+
+selftest.define("self-test catalog scan tolerates cold official catalog",
+async function () {
+  // Simulate a cold ~/.meteor/package-metadata cache by making every release
+  // lookup come back empty. Without buildingSelfTestCatalog, this causes
+  // versionsFrom() in scanned packages (e.g. packages/non-core/jquery) to
+  // raise a fatal "Unknown release …" buildmessage.
+  var originalGetReleaseVersion = catalog.official.getReleaseVersion;
+  catalog.official.getReleaseVersion = async function () { return null; };
+
+  try {
+    var localCatalog = new catalogLocal.LocalCatalog();
+    var packagesDir = files.pathJoin(files.getCurrentToolsDir(), 'packages');
+
+    var messages = await buildmessage.capture({
+      title: "scanning core packages for cold-catalog regression test",
+    }, async function () {
+      await localCatalog.initialize({
+        localPackageSearchDirs: [
+          packagesDir,
+          files.pathJoin(packagesDir, 'non-core'),
+          files.pathJoin(packagesDir, 'non-core', '*', 'packages'),
+        ],
+        buildingSelfTestCatalog: true,
+      });
+    });
+
+    if (messages.hasMessages()) {
+      selftest.fail(
+        "scan errored despite buildingSelfTestCatalog=true:\n" +
+        messages.formatMessages(0)
+      );
+    }
+  } finally {
+    catalog.official.getReleaseVersion = originalGetReleaseVersion;
+  }
+});

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -631,6 +631,7 @@ async function newSelfTestCatalog() {
           files.pathJoin(packagesDir, "non-core"),
           files.pathJoin(packagesDir, "non-core", "*", "packages"),
         ],
+        buildingSelfTestCatalog: true,
       });
     });
   if (messages.hasMessages()) {

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -553,17 +553,16 @@ async function setUpBuiltPackageTropohouse() {
 
   const versions = {};
   for (const packageName of localCatalog.getAllNonTestPackageNames()) {
-    versions[packageName] =
-      await localCatalog.getLatestVersion(packageName).version;
+    versions[packageName] = localCatalog.getLatestVersion(packageName).version;
   }
   const packageMap = new PackageMap(versions, {
-    localCatalog: localCatalog,
+    localCatalog: localCatalog
   });
   // An isopack cache that doesn't automatically save isopacks to disk and
   // has no access to versioned packages.
   const isopackCache = new IsopackCache({
     packageMap: packageMap,
-    includeCordovaUnibuild: true,
+    includeCordovaUnibuild: true
   });
   await doOrThrow(function () {
     return enterJob("building self-test packages", () => {

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -556,28 +556,26 @@ async function setUpBuiltPackageTropohouse() {
     versions[packageName] = localCatalog.getLatestVersion(packageName).version;
   }
   const packageMap = new PackageMap(versions, {
-    localCatalog: localCatalog
+    localCatalog,
   });
   // An isopack cache that doesn't automatically save isopacks to disk and
   // has no access to versioned packages.
   const isopackCache = new IsopackCache({
-    packageMap: packageMap,
-    includeCordovaUnibuild: true
+    packageMap,
+    includeCordovaUnibuild: true,
   });
-  await doOrThrow(function () {
-    return enterJob("building self-test packages", () => {
-      return isopackCache.buildLocalPackages(ROOT_PACKAGES_TO_BUILD_IN_SANDBOX);
-    });
-  });
+  await doOrThrow(() => enterJob("building self-test packages",
+    () => isopackCache.buildLocalPackages(ROOT_PACKAGES_TO_BUILD_IN_SANDBOX),
+  ));
 
   // Save all the isopacks into localDir/packages.  (Note that we are always
   // putting them into the default 'packages' (assuming
   // $METEOR_PACKAGE_SERVER_URL is not set in the self-test process itself)
   // even though some tests will want them to be under
   // 'packages-for-server/test-packages'; we'll fix this in _makeWarehouse.
-  await isopackCache.eachBuiltIsopack((name, isopack) => {
-    return tropohouse._saveIsopack(isopack, name);
-  });
+  await isopackCache.eachBuiltIsopack(
+    (name, isopack) => tropohouse._saveIsopack(isopack, name),
+  );
 
   // Atomic publish: assign module-level state only after every step above
   // has succeeded. tropohouseIsopackCache must be assigned LAST because the

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -527,47 +527,65 @@ async function doOrThrow(f) {
 }
 
 async function setUpBuiltPackageTropohouse() {
-  if (builtPackageTropohouseDir) {
+  // Use tropohouseIsopackCache (the *last* variable assigned) as the
+  // success sentinel. Earlier this guard checked builtPackageTropohouseDir
+  // (the *first* variable assigned), which meant a mid-setup throw would
+  // leave the dir set but empty — and every subsequent call would
+  // early-return as if setup had completed, causing _makeWarehouse to
+  // ENOENT on a missing 'packages' subdirectory inside the empty tmpdir.
+  if (tropohouseIsopackCache) {
     return;
   }
-  builtPackageTropohouseDir = files.mkdtemp('built-package-tropohouse');
 
   if (getPackagesDirectoryName() !== 'packages') {
     throw Error("running self-test with METEOR_PACKAGE_SERVER_URL set?");
   }
 
-  const tropohouse = new Tropohouse(builtPackageTropohouseDir);
-  tropohouseLocalCatalog = await newSelfTestCatalog();
+  // Build into local variables. Module-level state is published only at
+  // the very end, so a throw anywhere above leaves the module state
+  // untouched and the next call retries the full setup from scratch.
+  // The orphaned tmpdir is intentionally left in place — METEOR_SAVE_TMPDIRS
+  // is set in CI for debugging, and we don't want to delete a half-built
+  // tmpdir that someone might want to inspect.
+  const localDir = files.mkdtemp('built-package-tropohouse');
+  const tropohouse = new Tropohouse(localDir);
+  const localCatalog = await newSelfTestCatalog();
+
   const versions = {};
-  for (const packageName of tropohouseLocalCatalog.getAllNonTestPackageNames()) {
+  for (const packageName of localCatalog.getAllNonTestPackageNames()) {
     versions[packageName] =
-        await tropohouseLocalCatalog.getLatestVersion(packageName).version;
+      await localCatalog.getLatestVersion(packageName).version;
   }
   const packageMap = new PackageMap(versions, {
-    localCatalog: tropohouseLocalCatalog
+    localCatalog: localCatalog,
   });
-  // Make an isopack cache that doesn't automatically save isopacks to disk and
+  // An isopack cache that doesn't automatically save isopacks to disk and
   // has no access to versioned packages.
-  tropohouseIsopackCache = new IsopackCache({
+  const isopackCache = new IsopackCache({
     packageMap: packageMap,
-    includeCordovaUnibuild: true
+    includeCordovaUnibuild: true,
   });
   await doOrThrow(function () {
     return enterJob("building self-test packages", () => {
-      // Build the packages into the in-memory IsopackCache.
-      return tropohouseIsopackCache.buildLocalPackages(
-        ROOT_PACKAGES_TO_BUILD_IN_SANDBOX);
+      return isopackCache.buildLocalPackages(ROOT_PACKAGES_TO_BUILD_IN_SANDBOX);
     });
   });
 
-  // Save all the isopacks into builtPackageTropohouseDir/packages.  (Note that
-  // we are always putting them into the default 'packages' (assuming
-  // $METEOR_PACKAGE_SERVER_URL is not set in the self-test process itself) even
-  // though some tests will want them to be under
+  // Save all the isopacks into localDir/packages.  (Note that we are always
+  // putting them into the default 'packages' (assuming
+  // $METEOR_PACKAGE_SERVER_URL is not set in the self-test process itself)
+  // even though some tests will want them to be under
   // 'packages-for-server/test-packages'; we'll fix this in _makeWarehouse.
-  await tropohouseIsopackCache.eachBuiltIsopack((name, isopack) => {
+  await isopackCache.eachBuiltIsopack((name, isopack) => {
     return tropohouse._saveIsopack(isopack, name);
   });
+
+  // Atomic publish: assign module-level state only after every step above
+  // has succeeded. tropohouseIsopackCache must be assigned LAST because the
+  // guard at the top of this function uses it as the success sentinel.
+  builtPackageTropohouseDir = localDir;
+  tropohouseLocalCatalog = localCatalog;
+  tropohouseIsopackCache = isopackCache;
 }
 
 // Our current strategy for running tests that need warehouses is to build all


### PR DESCRIPTION
  - Self-test sandbox setup (`tools/tests/create.js → test:create main` and friends) flakes on CI runners with a cold `~/.meteor/package-metadata` cache. Root cause: scanning `packages/non-core/jquery/package.js` runs `api.versionsFrom(['2.16','3.0.3'])`, which calls `catalog.official.getReleaseVersion()`. With a cold catalog, the lookup returns null and the scan dies with "Unknown release METEOR@3.0.3".
  - Skipping `versionsFrom` release validation during self-test catalog scans (new `buildingSelfTestCatalog` flag, mirroring the existing `buildingIsopackets` precedent) eliminates the dependency on warm `catalog.official`. `releaseRecords` are only consumed at `tools/isobuild/package-source.js:727` to fill in unspecified version constraints — irrelevant in a checkout-only build where each package has exactly one version.
  - Also fixes a latent retry bug in `setUpBuiltPackageTropohouse`: the success guard read the *first* module-level variable assigned (`builtPackageTropohouseDir`) rather than the *last* (`tropohouseIsopackCache`), so a mid-setup throw left the function falsely "completed" and every retry ENOENTed on the empty tmpdir. Now publishes all three module variables atomically only after success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog scanning now proceeds reliably when the official catalog is unavailable by skipping version-resolution during self-test catalog builds.

* **Tests**
  * Added a self-test ensuring catalog scans tolerate a "cold" official catalog (no release-version lookup).

* **Chores**
  * Hardened test setup and initialization to avoid leaving partially-populated state after failures and to ensure consistent local catalog construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->