### PR TITLE
fix(rspack): await eager test webpackContext to discover async test files

### DIFF
--- a/npm-packages/meteor-rspack/lib/test.js
+++ b/npm-packages/meteor-rspack/lib/test.js
@@ -74,14 +74,14 @@ const generateEagerTestFile = ({
     exclude: ${excludeFoldersRegex.toString()},
     mode: 'eager',
   });
-  ctx.keys().filter((k) => {
+  await Promise.all(ctx.keys().filter((k) => {
     ${
       excludeMeteorIgnoreRegex
         ? `// Only exclude based on *relative* path segments.
     return !MeteorIgnoreRegex.test(k);`
         : "return true;"
     }
-  }).forEach(ctx);
+  }).map(ctx));
   ${
     extraEntry
       ? `const extra = import.meta.webpackContext('${toPosix(path.dirname(
@@ -91,7 +91,7 @@ const generateEagerTestFile = ({
     regExp: ${new RegExp(`${path.basename(extraEntry)}$`).toString()},
     mode: 'eager',
   });
-  extra.keys().forEach(extra);`
+  await Promise.all(extra.keys().map(extra));`
       : ""
   }
 }`;


### PR DESCRIPTION
## Summary

Closes #14371.

`generateEagerTestFile` in `npm-packages/meteor-rspack/lib/test.js` produces an eager-test entry that calls `ctx.keys().forEach(ctx)` on a `webpackContext`. When the matched test files transitively depend on async modules (e.g. `await createCollection(...)` in a Meteor app), rspack emits the context as async and each `ctx(k)` returns a Promise. `forEach` discards them, so the entry resolves before any test file finishes evaluating. mocha then runs against an empty suite and reports 0 passing.

In the built bundle this is visible as:

```js
__webpack_require__.a(__webpack_module__, async function (..., __rspack_async_done) {
  const ctx = __webpack_require__("./. eager recursive ...");
  ctx.keys().filter(...).forEach(ctx);   // <-- not awaited
  __rspack_async_done();
});
```

with the matching context module shaped as `__rspack_async_context_resolve(req).then(__webpack_require__)`.

## Change

Replace `forEach(ctx)` / `forEach(extra)` with `await Promise.all(... .map(ctx))` in both branches of the generated entry. Top-level `await` is valid in the generated `.mjs` module and rspack already wraps it in an async-module wrapper when async deps are present, so this works whether the matched files are async or not.

When no async deps are present, `mode: 'eager'` resolves synchronously and `Promise.all([syncValue, ...])` adds at most one microtask — unobservable in test runs.

## Test plan

- [ ] `meteor test --full-app` on a project whose app-tests transitively `await` an async module now discovers them (previously: 0 passing).
- [ ] `meteor test --full-app` on a project without async deps continues to discover and run tests.
- [ ] Existing CI passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test module loading to use concurrent execution instead of sequential processing, improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->