### PR TITLE
Fix operator precedence bug in passwordValidator (closes #14072)

### DIFF
--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -290,7 +290,7 @@ Accounts._checkPasswordAsync = checkPasswordAsync;
 
 
 const passwordValidator = Match.OneOf(
-  Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256), {
+  Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)), {
     digest: Match.Where(str => Match.test(str, String) && str.length === 64),
     algorithm: Match.OneOf('sha-256')
   }
@@ -472,7 +472,7 @@ Meteor.methods(
 Accounts.setPasswordAsync =
   async (userId, newPlaintextPassword, options) => {
     check(userId, String);
-    check(newPlaintextPassword, Match.Where(str => Match.test(str, String) && str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256));
+    check(newPlaintextPassword, Match.Where(str => Match.test(str, String) && str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)));
     check(options, Match.Maybe({ logout: Boolean }));
     options = { logout: true, ...options };
 


### PR DESCRIPTION
## Summary

Closes #14072.

## Problem

`passwordValidator` in `packages/accounts-password/password_server.js` has an operator precedence bug:

```js
str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength || 256
```

Due to JavaScript operator precedence, this is parsed as:
```js
(str.length <= Meteor.settings?.packages?.accounts?.passwordMaxLength) || 256
```

Since `256` is always truthy, **password length validation always passes**, regardless of the configured `passwordMaxLength`.

## Fix

Add parentheses to ensure correct evaluation:

```js
str.length <= (Meteor.settings?.packages?.accounts?.passwordMaxLength || 256)
```

## Security Impact

- **Before**: Passwords of any length (including 10000+ chars) pass validation, posing a DoS risk during SHA256 hashing.
- **After**: Passwords longer than `passwordMaxLength` (default 256) are correctly rejected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/meteor/meteor/blob/devel/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password length validation logic to ensure the maximum length constraint is correctly enforced during password operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->