### PR TITLE
Fix getUsersInRoleAsync dropping 'user' field when queryOptions.fields is set

### DIFF
--- a/packages/roles/roles_common_async.js
+++ b/packages/roles/roles_common_async.js
@@ -1052,13 +1052,22 @@ Object.assign(Roles, {
    * @return {Promise<Cursor>} Cursor of users in roles.
    */
   getUsersInRoleAsync: async function (roles, options, queryOptions) {
+    const effectiveOptions = options || {}
+    const effectiveQueryOptions = effectiveOptions.queryOptions || queryOptions || {}
+
+    // Strip queryOptions so it is not passed to getUserAssignmentsForRole,
+    // which would otherwise apply its field projection to role-assignment
+    // documents and drop the 'user' field needed for a.user._id.
+    const roleOptions = Object.assign({}, effectiveOptions)
+    delete roleOptions.queryOptions
+
     const ids = (
-      await Roles.getUserAssignmentsForRole(roles, options).fetchAsync()
+      await Roles.getUserAssignmentsForRole(roles, roleOptions).fetchAsync()
     ).map((a) => a.user._id)
 
     return Meteor.users.find(
       { _id: { $in: ids } },
-      (options && options.queryOptions) || queryOptions || {}
+      effectiveQueryOptions
     )
   },
 


### PR DESCRIPTION
## Summary

Closes #13873.

## Problem

When calling `Roles.getUsersInRoleAsync` with `options.queryOptions` that include a `fields` projection, the projection was incorrectly applied to the **RoleAssignment** documents returned by `getUserAssignmentsForRole`. This caused the `user` field to be dropped from those documents, making `a.user._id` throw a `TypeError: Cannot read properties of undefined (reading '_id')`.

## Root Cause

`getUsersInRoleAsync(roles, options)` passed the entire `options` object (including `queryOptions`) directly to `getUserAssignmentsForRole`. That function then passed `options.queryOptions` as a projection to the RoleAssignmentCollection query. Since RoleAssignment documents don't have the projected fields as top-level keys (the `user` field is a sub-object), the projection dropped it.

## Fix

1. Extract `queryOptions` from `options` (supports both documented style `options.queryOptions` and code style 3rd argument)
2. Create a `roleOptions` copy with `queryOptions` stripped out, and pass that to `getUserAssignmentsForRole`
3. Pass the real `queryOptions` (with field projections) only to `Meteor.users.find()`, where they belong

## Example - now works as documented:

```js
const users = await (await Roles.getUsersInRoleAsync(
  'some-role',
  { queryOptions: { fields: { createdAt: 1, username: 1 } } }
)).fetchAsync();
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update (code now matches documented API)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/meteor/meteor/blob/devel/CONTRIBUTING.md) document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of query options when retrieving users assigned to roles. Query options are now properly applied to the appropriate query components, preventing incorrect projection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->