### PR TITLE
[Group 3 failure] Improve package catalog refresh logic in test-tools workflow

### DIFF
--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -69,7 +69,8 @@ jobs:
             ${{ runner.os }}-meteor-
 
       - name: Prepare Meteor
-        if: steps.meteor-cache.outputs.cache-hit != 'true'
+        # Run on every workflow so the package catalog at .meteor/package-metadata
+        # is refreshed and includes any release referenced by versionsFrom.
         timeout-minutes: 65
         run: ./meteor --get-ready
 

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -530,44 +530,54 @@ async function setUpBuiltPackageTropohouse() {
   if (builtPackageTropohouseDir) {
     return;
   }
-  builtPackageTropohouseDir = files.mkdtemp('built-package-tropohouse');
+  const dir = files.mkdtemp('built-package-tropohouse');
+  builtPackageTropohouseDir = dir;
 
-  if (getPackagesDirectoryName() !== 'packages') {
-    throw Error("running self-test with METEOR_PACKAGE_SERVER_URL set?");
-  }
+  // Reset module-scoped state on failure so --retries re-runs setup instead
+  // of reusing a half-initialized tropohouse dir.
+  try {
+    if (getPackagesDirectoryName() !== 'packages') {
+      throw Error("running self-test with METEOR_PACKAGE_SERVER_URL set?");
+    }
 
-  const tropohouse = new Tropohouse(builtPackageTropohouseDir);
-  tropohouseLocalCatalog = await newSelfTestCatalog();
-  const versions = {};
-  for (const packageName of tropohouseLocalCatalog.getAllNonTestPackageNames()) {
-    versions[packageName] =
-        await tropohouseLocalCatalog.getLatestVersion(packageName).version;
-  }
-  const packageMap = new PackageMap(versions, {
-    localCatalog: tropohouseLocalCatalog
-  });
-  // Make an isopack cache that doesn't automatically save isopacks to disk and
-  // has no access to versioned packages.
-  tropohouseIsopackCache = new IsopackCache({
-    packageMap: packageMap,
-    includeCordovaUnibuild: true
-  });
-  await doOrThrow(function () {
-    return enterJob("building self-test packages", () => {
-      // Build the packages into the in-memory IsopackCache.
-      return tropohouseIsopackCache.buildLocalPackages(
-        ROOT_PACKAGES_TO_BUILD_IN_SANDBOX);
+    const tropohouse = new Tropohouse(dir);
+    tropohouseLocalCatalog = await newSelfTestCatalog();
+    const versions = {};
+    for (const packageName of tropohouseLocalCatalog.getAllNonTestPackageNames()) {
+      versions[packageName] =
+          await tropohouseLocalCatalog.getLatestVersion(packageName).version;
+    }
+    const packageMap = new PackageMap(versions, {
+      localCatalog: tropohouseLocalCatalog
     });
-  });
+    // Make an isopack cache that doesn't automatically save isopacks to disk and
+    // has no access to versioned packages.
+    tropohouseIsopackCache = new IsopackCache({
+      packageMap: packageMap,
+      includeCordovaUnibuild: true
+    });
+    await doOrThrow(function () {
+      return enterJob("building self-test packages", () => {
+        // Build the packages into the in-memory IsopackCache.
+        return tropohouseIsopackCache.buildLocalPackages(
+          ROOT_PACKAGES_TO_BUILD_IN_SANDBOX);
+      });
+    });
 
-  // Save all the isopacks into builtPackageTropohouseDir/packages.  (Note that
-  // we are always putting them into the default 'packages' (assuming
-  // $METEOR_PACKAGE_SERVER_URL is not set in the self-test process itself) even
-  // though some tests will want them to be under
-  // 'packages-for-server/test-packages'; we'll fix this in _makeWarehouse.
-  await tropohouseIsopackCache.eachBuiltIsopack((name, isopack) => {
-    return tropohouse._saveIsopack(isopack, name);
-  });
+    // Save all the isopacks into builtPackageTropohouseDir/packages.  (Note that
+    // we are always putting them into the default 'packages' (assuming
+    // $METEOR_PACKAGE_SERVER_URL is not set in the self-test process itself) even
+    // though some tests will want them to be under
+    // 'packages-for-server/test-packages'; we'll fix this in _makeWarehouse.
+    await tropohouseIsopackCache.eachBuiltIsopack((name, isopack) => {
+      return tropohouse._saveIsopack(isopack, name);
+    });
+  } catch (err) {
+    builtPackageTropohouseDir = null;
+    tropohouseLocalCatalog = null;
+    tropohouseIsopackCache = null;
+    throw err;
+  }
 }
 
 // Our current strategy for running tests that need warehouses is to build all


### PR DESCRIPTION
This PR is an attempt to fix the issue recently happening that any CI check on the Group 3 on testing the tool fail, no matter what the PR is, based on release-3.4.1 or release-3.5.

I will base it on devel if this shows it fixed it.