### PR TITLE
fix(rspack): server bridge file awaits the bundle's exports Promise (#14395)

### DIFF
--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -127,21 +127,12 @@ export function ensureRspackBuildContextExists() {
  * @returns {boolean} True if the bundle contains async modules.
  */
 function detectAsyncBundle(absBundlePath) {
-  let fd;
   try {
-    fd = fs.openSync(absBundlePath, 'r');
-    const stat = fs.fstatSync(fd);
-    const buf = Buffer.alloc(Math.max(stat.size, 1));
-    const bytes = fs.readSync(fd, buf, 0, buf.length, 0);
-    const text = buf.toString('utf8', 0, bytes);
+    const text = fs.readFileSync(absBundlePath, 'utf8');
     return text.includes('__webpack_require__.a ') ||
            text.includes('__rspack_load_async_deps');
   } catch (err) {
     return false;
-  } finally {
-    if (fd !== undefined) {
-      try { fs.closeSync(fd); } catch (_) {}
-    }
   }
 }
 

--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -558,7 +558,19 @@ import '../../${config?.entryFile}';`;
     return `/* Link to ⚡ Rspack ${capitalizeFirstLetter(side)} App */
 ${
   (isMeteorBlazeProject() && config?.isClient && '// In Blaze, import happens last so HTML files preload first') ||
-  `import './${config?.outputFile || ''}';`
+  (config?.isServer
+    // fix(meteor#14395): on the server, use `import * as` + top-level await so
+    // reify wraps this bridge file with wrapAsync(). Without that, the rspack
+    // bundle's `module.exports = Promise` (when the bundle has TLA in its dep
+    // graph) is never awaited, mocha runs against an empty suite, and
+    // `meteor test` reports 0 passing. Non-TLA server bundles see a
+    // `Promise.resolve(<obj>)` microtask that's effectively a no-op.
+    // Client/native bundles keep the static import: Meteor's terser-based
+    // minifier doesn't accept top-level await, and the TLA race only manifests
+    // server-side.
+    ? `import * as __rspackBundleNs from './${config?.outputFile || ''}';
+await Promise.resolve(__rspackBundleNs && __rspackBundleNs.default);`
+    : `import './${config?.outputFile || ''}';`)
 }`;
   }
 

--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -111,13 +111,17 @@ export function ensureRspackBuildContextExists() {
  * Returns true if the rspack-emitted bundle at the given absolute path contains
  * async modules (top-level await in its transitive dep graph).
  *
- * Detection signal: rspack injects the runtime helper
- * `__webpack_handle_async_dependencies__` into a chunk's preamble only when
- * that chunk contains at least one async module. Reading the first 64 KB is
- * sufficient since the helper sits near the top of the chunk. If the file
- * doesn't exist yet (first run, before rspack has emitted anything) or read
- * fails, we conservatively report false; a subsequent post-compile refresh
- * will re-evaluate.
+ * Detection signals: rspack only emits the async-module wrapper helper
+ * `__webpack_require__.a = (module, body, hasAwait) => { ... }` and the
+ * per-async-import await helper `__rspack_load_async_deps([...])` when at
+ * least one module in the chunk is async. Either signal is sufficient.
+ *
+ * The helpers live in the runtime-helpers section near the END of the bundle
+ * (after all module bodies), so we read the whole file rather than a head
+ * window. Bundles are typically a few hundred KB; reading the full content
+ * is acceptable. If the file doesn't exist yet (first run, before rspack has
+ * emitted anything) or read fails, we conservatively report false; a
+ * subsequent post-compile refresh will re-evaluate.
  *
  * @param {string} absBundlePath - Absolute path to the emitted bundle file.
  * @returns {boolean} True if the bundle contains async modules.
@@ -126,11 +130,12 @@ function detectAsyncBundle(absBundlePath) {
   let fd;
   try {
     fd = fs.openSync(absBundlePath, 'r');
-    const buf = Buffer.alloc(64 * 1024);
+    const stat = fs.fstatSync(fd);
+    const buf = Buffer.alloc(Math.max(stat.size, 1));
     const bytes = fs.readSync(fd, buf, 0, buf.length, 0);
-    return buf.toString('utf8', 0, bytes).includes(
-      '__webpack_handle_async_dependencies__'
-    );
+    const text = buf.toString('utf8', 0, bytes);
+    return text.includes('__webpack_require__.a ') ||
+           text.includes('__rspack_load_async_deps');
   } catch (err) {
     return false;
   } finally {
@@ -246,8 +251,14 @@ export function ensureModuleFilesExist() {
         return;
       }
 
-      // 3. If it doesn't already start with the new defaultContent, overwrite it
-      if (!existing.includes(defaultContent)) {
+      // 3. If it doesn't already start with the new defaultContent, overwrite it.
+      //    Skip output-role bundle files (`*-rspack.js`) once rspack has populated
+      //    them with the real bundle — re-invocation from the post-compile hook
+      //    would otherwise clobber the emitted bundle with the placeholder.
+      //    See meteor#14395.
+      const looksLikeRspackBundle = filename.endsWith('-rspack.js') &&
+        existing.length > defaultContent.length * 2;
+      if (!looksLikeRspackBundle && !existing.includes(defaultContent)) {
         try {
           fs.writeFileSync(filePath, defaultContent, 'utf8');
         } catch (err) {

--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -108,6 +108,39 @@ export function ensureRspackBuildContextExists() {
 }
 
 /**
+ * Returns true if the rspack-emitted bundle at the given absolute path contains
+ * async modules (top-level await in its transitive dep graph).
+ *
+ * Detection signal: rspack injects the runtime helper
+ * `__webpack_handle_async_dependencies__` into a chunk's preamble only when
+ * that chunk contains at least one async module. Reading the first 64 KB is
+ * sufficient since the helper sits near the top of the chunk. If the file
+ * doesn't exist yet (first run, before rspack has emitted anything) or read
+ * fails, we conservatively report false; a subsequent post-compile refresh
+ * will re-evaluate.
+ *
+ * @param {string} absBundlePath - Absolute path to the emitted bundle file.
+ * @returns {boolean} True if the bundle contains async modules.
+ */
+function detectAsyncBundle(absBundlePath) {
+  let fd;
+  try {
+    fd = fs.openSync(absBundlePath, 'r');
+    const buf = Buffer.alloc(64 * 1024);
+    const bytes = fs.readSync(fd, buf, 0, buf.length, 0);
+    return buf.toString('utf8', 0, bytes).includes(
+      '__webpack_handle_async_dependencies__'
+    );
+  } catch (err) {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch (_) {}
+    }
+  }
+}
+
+/**
  * Ensures module files exist in the build context directory
  * Creates default module files if they don't exist
  * @returns {void}
@@ -132,6 +165,12 @@ export function ensureModuleFilesExist() {
   const mainServerFiles = {
     entryFile: initialEntrypoints.mainServer || '',
     outputFile: getBuildFilePath({ isMain: true, isServer: true, ...env, role: FILE_ROLE.output, onlyFilename: true }),
+    // See meteor#14395.
+    bundleHasAsync: detectAsyncBundle(path.join(
+      appDir,
+      RSPACK_BUILD_CONTEXT,
+      getBuildFilePath({ isMain: true, isServer: true, ...env, role: FILE_ROLE.output })
+    )),
   };
   const isTestEager =
     initialEntrypoints.testModule == null &&
@@ -147,6 +186,11 @@ export function ensureModuleFilesExist() {
     entryFile: initialEntrypoints.testServer || '',
     outputFile: getBuildFilePath({ isTest: true, isTestModule, isServer: true, role: FILE_ROLE.output, onlyFilename: true }),
     mainEntryFile: mainServerFiles.entryFile,
+    bundleHasAsync: detectAsyncBundle(path.join(
+      appDir,
+      RSPACK_BUILD_CONTEXT,
+      getBuildFilePath({ isTest: true, isTestModule, isServer: true, role: FILE_ROLE.output })
+    )),
   };
   const isTestFullApp = isMeteorAppTestFullApp();
 
@@ -558,16 +602,9 @@ import '../../${config?.entryFile}';`;
     return `/* Link to ⚡ Rspack ${capitalizeFirstLetter(side)} App */
 ${
   (isMeteorBlazeProject() && config?.isClient && '// In Blaze, import happens last so HTML files preload first') ||
-  (config?.isServer
-    // fix(meteor#14395): on the server, use `import * as` + top-level await so
-    // reify wraps this bridge file with wrapAsync(). Without that, the rspack
-    // bundle's `module.exports = Promise` (when the bundle has TLA in its dep
-    // graph) is never awaited, mocha runs against an empty suite, and
-    // `meteor test` reports 0 passing. Non-TLA server bundles see a
-    // `Promise.resolve(<obj>)` microtask that's effectively a no-op.
-    // Client/native bundles keep the static import: Meteor's terser-based
-    // minifier doesn't accept top-level await, and the TLA race only manifests
-    // server-side.
+  // TLA bridge form is server-only and gated on detected async-ness
+  // of the bundle; see meteor#14395.
+  (config?.isServer && config?.bundleHasAsync
     ? `import * as __rspackBundleNs from './${config?.outputFile || ''}';
 await Promise.resolve(__rspackBundleNs && __rspackBundleNs.default);`
     : `import './${config?.outputFile || ''}';`)

--- a/packages/rspack/lib/compilation.js
+++ b/packages/rspack/lib/compilation.js
@@ -17,6 +17,7 @@ const {
 } = require('meteor/tools-core/lib/global-state');
 
 const { applyDelegatedExtensions } = require('./config');
+const { ensureModuleFilesExist } = require('./build-context');
 
 // Helper function to format milliseconds with comma separators
 function formatMilliseconds(ms) {
@@ -153,6 +154,13 @@ export function setupCompilationTracking() {
   };
 
   const onCompileServer = (data) => {
+    // Re-emit bridges now the server bundle exists; see meteor#14395.
+    try {
+      ensureModuleFilesExist();
+    } catch (err) {
+      // Bridge refresh shouldn't block server start.
+    }
+
     // Resolve the promise if it's the first compilation
     const serverState = getGlobalState(GLOBAL_STATE_KEYS.SERVER_FIRST_COMPILE, serverFirstCompile);
     if (!serverState?.resolved) {


### PR DESCRIPTION
## Summary

Fixes #14395. The auto-generated `_build/<env>/<side>-meteor.js` bridge does
`import './<output>';`. When the rspack bundle's transitive dep graph contains
TLA (top-level await), rspack wraps the bundle in an async-module IIFE that
sets `module.exports = Promise`. Reify only flags imports as async when their
*source* was wrapped by `wrapAsync()` — so the bridge never awaits the bundle,
core-runtime advances to mocha while the bundle's Promise is still pending,
and `meteor test --full-app` reports `0 passing (0ms)` against an empty suite.

This PR makes the bridge codegen detect async-ness of the emitted server
bundle and conditionally emit the TLA-aware import only when needed:

```js
// async server bundle:
import * as __rspackBundleNs from './<output>';
await Promise.resolve(__rspackBundleNs && __rspackBundleNs.default);

// non-async server bundle (and all client/native bundles):
import './<output>';
```

The top-level `await` (when emitted) makes the bridge file itself a TLA
module — reify wraps *it* with `wrapAsync({ async: true })`, sets
`entry.asyncEvaluation = true`, and the bundle's Promise propagates up the
eager-load loop correctly. When the bundle is sync, the bridge stays a plain
static import — reify still wraps it with `wrapAsync({ async: false })` on
server arch, but no extra microtask is introduced and the bridge isn't
promoted to a TLA module.

## How detection works

`detectAsyncBundle(absBundlePath)` scans the rspack-emitted bundle for either:

- `__webpack_require__.a ` — the async-module wrapper helper definition
  (`__webpack_require__.a = (module, body, hasAwait) => { ... }`), or
- `__rspack_load_async_deps` — the per-async-import await helper.

Rspack only emits these when at least one module in the chunk is async.
Either signal is sufficient. Reading the whole file is needed because the
runtime helpers section sits near the END of the bundle (after all module
bodies), not the top.

## When detection runs

Bridge codegen at plugin startup (`ensureModuleFilesExist`) runs detection
too, but the bundle hasn't been emitted yet — detection returns false and
the bridge starts as a plain static import. After each rspack server compile,
`onCompileServer` calls `ensureModuleFilesExist()` again to refresh the
bridge with the now-known `bundleHasAsync` flag. The existing "rewrite if
content differs" loop makes the rewrite idempotent and watch-mode-safe.

A guard in that loop skips files matching `*-rspack.js` whose existing
content is substantially larger than the placeholder default — that's
rspack's own bundle output, not something the bridge codegen should ever
overwrite.

## Why server-only

Client and native (Cordova/iOS/Android) bridges always use the static import
regardless of bundle async-ness, for two reasons:

1. **Meteor's terser-based minifier doesn't accept top-level await syntax.**
   Emitting the TLA wrapper into the client production bridge breaks
   `meteor build` with `SyntaxError: Unexpected token: name (Promise)`.
2. **The TLA race only manifests server-side.** The eager-load loop that
   advances to mocha before the bundle's Promise resolves runs on the
   server; client-side composition isn't affected.

`config.isNative` is the global app-mode flag set on both client and server
bridge configs in mobile builds, so the gate is `config?.isServer &&
config?.bundleHasAsync` — the actual client/server distinction is in
`isClient`/`isServer`, set per-build-target.

## Why the bridge is wrapped at all

On server arch, Meteor passes `topLevelAwait: true` to reify
(`packages/babel-compiler/babel-compiler.js:297`:
`features.topLevelAwait = inputFile.supportsTopLevelAwait && (arch.startsWith('os.') || enableClientTLA)`).
With that option, reify wraps any module-with-imports in
`module.wrapAsync(async function (...) { ... }, { async: <hasTLA> })`. The
bridge has `import './<output>';`, so it gets wrapped. Without the TLA
form in the bridge source, `async: false` is passed and the bridge body
calls `__reifyWaitForDeps__()` synchronously — which returns null because
reify's link-time logic doesn't recognize the rspack bundle (a non-reify
module exporting a plain Promise) as an async dep. The await form flips
`async: true`, which sets `entry.asyncEvaluation` and propagates correctly.

A more spec-pure fix would teach reify to recognize foreign Promise-exports
modules as async deps via the existing `__reifyAsyncModule` /
`addAsyncDep` machinery; the bridge could then stay sync even for TLA
bundles. That's a larger reify-side change with wider blast radius and
would target `devel` rather than `release-3.4.1`. This PR is the practical
patch-line workaround.

## Pairs with #14371

#14371 (the `forEach(ctx)` → `await Promise.all(... .map(ctx))` patch on
`@meteorjs/rspack/lib/test.js`) is the other half of the fix. Without it,
the inline eager loader discards the test files' Promises and the bundle's
`module.exports` ends up `undefined`, so the bridge has nothing to await.
Both #14371 and this PR are needed for full coverage; this PR depends on
#14371 being applied (or already merged).

## Test plan

- [x] Reproduce on a clean app: clone `perbergland/meteor-monorepo`, branch
      `chore/fullapp-repro`, and run
      `meteor test --full-app --once --driver-package meteortesting:mocha`.
      Expect `0 passing (0ms)` against the unfixed meteor.
- [x] With this PR applied, the same command reports `2 passing`.
- [x] Repeat without `--full-app`: also `2 passing`.
- [ ] Confirm `detectAsyncBundle` returns `true` for a TLA-using server
      bundle and `false` for a non-TLA one. Verify by inspecting the
      generated bridge file (`_build/<env>/<side>-meteor.js`) — TLA bundles
      should produce the `import * as __rspackBundleNs ... await Promise.resolve(...)`
      form; non-TLA bundles should produce the plain `import './<output>';`
      form.
- [ ] Verify non-TLA server apps aren't penalised: `meteor create test-app`
      followed by `meteor test --once --driver-package meteortesting:mocha`
      should still pass cleanly with no extra microtasks added.
- [ ] **Confirm `meteor build` (client production) still works** — the
      server-only gate exists specifically so the terser-based client
      minifier doesn't choke on TLA. Smoke-check `meteor build` on an app
      that exercises both sides.
- [ ] Confirm `meteor run` dev mode still works on both sides.
- [ ] After a server compile, confirm `_build/<env>/server-rspack.js` still
      contains rspack's actual bundle (not the placeholder) — the
      post-compile bridge refresh must not clobber the bundle.

## Out of scope

- The eager-loader patch itself is tracked separately as #14371. Maintainer
  may want both PRs to land together.
- A fully spec-pure fix at the reify link-time async-dep layer is the
  natural follow-up against `devel`.

---

*(AI-assisted in writing the implementation and this description.)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of asynchronous modules in bundled outputs
  * Enhanced server-side compilation to correctly manage asynchronous module imports
  * Prevented unintended overwrites of compiled bundle files during build refresh operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->