### PR TITLE
Fix an issue with Meteor.loggingIn being false before awaiting hooks

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -425,21 +425,15 @@ export class AccountsClient extends AccountsCommon {
         error = error || new Error(
           `No result from call to ${options.methodName}`
         );
-        try {
-          await loginCallbacks({ error });
-        } finally {
-          this._setLoggingIn(false);
-        }
+        this._setLoggingIn(false);
+        await loginCallbacks({ error });
         return;
       }
       try {
         options.validateResult(result);
       } catch (e) {
-        try {
-          await loginCallbacks({ error: e });
-        } finally {
-          this._setLoggingIn(false);
-        }
+        this._setLoggingIn(false);
+        await loginCallbacks({ error: e });
         return;
       }
 
@@ -453,10 +447,12 @@ export class AccountsClient extends AccountsCommon {
         );
 
         if (user) {
+          // Flip before awaiting userCallback so the caller observes
+          // loggingIn() === false on the microtask after their await.
+          this._setLoggingIn(false);
           try {
             await loginCallbacks({ loginDetails: result });
           } finally {
-            this._setLoggingIn(false);
             computation.stop();
           }
         }

--- a/tools/e2e-tests/accounts.test.js
+++ b/tools/e2e-tests/accounts.test.js
@@ -195,6 +195,37 @@ function defineAccountsScenarios(storageMode, getCtx) {
       expect(transitions).toContain(true);
       expect(transitions[transitions.length - 1]).toBe(false);
     });
+
+    // Regression for PR #13369: a useTracker subscriber on Meteor.user() +
+    // Meteor.loggingIn() must not render `{user:null, loggingIn:false}` after
+    // the loading frame. Harness: apps/accounts/client/react-mount.jsx.
+    it('React useTracker never observes {loggingIn:false,user:null} mid-login', async () => {
+      const { page } = getCtx();
+      await seedUser(page, { email: 'react@example.com', password: 'pw12345' });
+      await page.waitForFunction(
+        () => Array.isArray(window.__reactRenders) && window.__reactRenders.length > 0,
+        { timeout: 10_000 },
+      );
+      await page.evaluate(() => window.__accountsE2E.resetReactRenders());
+      await login(page, { email: 'react@example.com' }, 'pw12345');
+      await page.waitForFunction(
+        () => {
+          const r = window.__reactRenders;
+          if (!r || r.length === 0) return false;
+          const last = r[r.length - 1];
+          return last.user === true && last.loggingIn === false;
+        },
+        { timeout: 5_000 },
+      );
+      const renders = await page.evaluate(() => window.__accountsE2E.reactRenders());
+      expect(renders.some((r) => r.loggingIn === true && r.user === false)).toBe(true);
+      const firstLoadingIdx = renders.findIndex((r) => r.loggingIn === true);
+      const after = renders.slice(firstLoadingIdx + 1);
+      const flicker = after.filter((r) => r.loggingIn === false && r.user === false);
+      expect(flicker).toEqual([]);
+      const last = renders[renders.length - 1];
+      expect(last).toEqual({ user: true, loggingIn: false });
+    });
   });
 
   if (storageMode === 'localStorage') {

--- a/tools/e2e-tests/apps/accounts/.meteor/packages
+++ b/tools/e2e-tests/apps/accounts/.meteor/packages
@@ -3,6 +3,7 @@ mongo                   # The database Meteor supports right now
 ecmascript              # Enable ECMAScript2015+ syntax in app code
 static-html             # Define static page content in .html files
 tracker                 # Reactive programming primitives
+react-meteor-data       # useTracker, used by the React mount in the harness
 
 standard-minifier-css   # CSS minifier run for production mode
 standard-minifier-js    # JS minifier run for production mode

--- a/tools/e2e-tests/apps/accounts/client/main.html
+++ b/tools/e2e-tests/apps/accounts/client/main.html
@@ -16,4 +16,5 @@
   <h1>Accounts E2E harness</h1>
   <pre id="state"></pre>
   <div id="ready" data-ready="false"></div>
+  <div id="react-target"></div>
 </body>

--- a/tools/e2e-tests/apps/accounts/client/main.js
+++ b/tools/e2e-tests/apps/accounts/client/main.js
@@ -2,6 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { Accounts, AccountsTest } from 'meteor/accounts-base';
 import { Tracker } from 'meteor/tracker';
 
+import './react-mount.jsx';
+
 // Playwright strips custom fields off Errors thrown in page.evaluate, so the
 // `error`/`reason`/`details` properties of a Meteor.Error don't survive the
 // page-to-node hop. Re-throw as a plain Error whose message embeds the
@@ -103,6 +105,12 @@ const api = {
     callbackLog.resetPasswordLink.length = 0;
     callbackLog.enrollmentLink.length = 0;
     callbackLog.emailVerificationLink.length = 0;
+  },
+
+  reactRenders: () => (window.__reactRenders || []).slice(),
+  resetReactRenders: () => {
+    if (Array.isArray(window.__reactRenders)) window.__reactRenders.length = 0;
+    else window.__reactRenders = [];
   },
 
   storedToken: () => {

--- a/tools/e2e-tests/apps/accounts/client/react-mount.jsx
+++ b/tools/e2e-tests/apps/accounts/client/react-mount.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Meteor } from 'meteor/meteor';
+import { useTracker } from 'meteor/react-meteor-data';
+
+// PR #13369 regression: each render is pushed so the e2e suite can assert
+// no `{loggingIn:false, user:null}` frame slips between the loading frame
+// and the final logged-in frame.
+window.__reactRenders = [];
+
+function LoginStatus() {
+  const { user, loggingIn } = useTracker(() => ({
+    user: Meteor.user(),
+    loggingIn: Meteor.loggingIn(),
+  }), []);
+
+  window.__reactRenders.push({
+    user: !!user,
+    loggingIn,
+  });
+
+  return (
+    <pre id="react-state">
+      {JSON.stringify({ user: !!user, loggingIn })}
+    </pre>
+  );
+}
+
+Meteor.startup(() => {
+  const container = document.getElementById('react-target');
+  if (!container) return;
+  createRoot(container).render(<LoginStatus />);
+});

--- a/tools/e2e-tests/apps/accounts/package.json
+++ b/tools/e2e-tests/apps/accounts/package.json
@@ -7,7 +7,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
-    "meteor-node-stubs": "^1.2.12"
+    "meteor-node-stubs": "^1.2.12",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "playwright": "1.59.0"


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/pull/14069

This PR fixes a likely refregression in Meteor 3.5. [While adding browser-driven E2E coverage for `accounts-*` packages on the `accounts-e2e-app` branch](https://github.com/meteor/meteor/pull/14413), a test asserting the contract of `Meteor.loggingIn()` after login could only be kept green by polling and forcing a `Tracker.flush`. That workaround was hiding a real regression. This PR removes the cause.

## Bug

On `release-3.5`, this code is broken:

```js
await Meteor.loginWithPasswordAsync(email, password);
Meteor.loggingIn();  // returns true, should be false
```

The login finished, the user is signed in, but `loggingIn()` still reports `true` for a brief moment. Any UI binding that hides a spinner based on `loggingIn()` keeps the spinner up after login completes.

## When it broke

[PR #14069](https://github.com/meteor/meteor/pull/14069) (`accounts-async-client`, merged into `release-3.5`) changed `callLoginMethod` in `packages/accounts-base/accounts_client.js` so that async `onLogin` hooks could throw errors back to the caller. To do that, the code now `await`s the callback chain.

Before the PR:

```js
loginCallbacks({ loginDetails: result });   // not awaited
this._setLoggingIn(false);                  // runs immediately
```

After the PR:

```js
await loginCallbacks({ loginDetails: result });   // resolves caller's promise
this._setLoggingIn(false);                        // runs one tick later
```

The `await` is what resolves the caller's `loginWithPasswordAsync` promise. So the caller wakes up before the flag is flipped.

## Fix

Move the flag flip to before the `await` in `packages/accounts-base/accounts_client.js`. Three places:

1. Server error / no result.
2. `validateResult` threw.
3. Success (inside the `Tracker.autorun`).

Error propagation from hooks still works the same way: the awaited promise still rejects, the rejection still reaches the caller.

The reconnect path was not touched because it never sets the flag in the first place.
