### PR TITLE
Add built-app boot validation to e2e tests

### DIFF
--- a/tools/e2e-tests/helpers.js
+++ b/tools/e2e-tests/helpers.js
@@ -3,6 +3,7 @@ const waitOn = require('wait-on');
 const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');
+const net = require('net');
 const rimraf = require('rimraf');
 
 // Get the absolute path to the meteor executable
@@ -897,4 +898,144 @@ export async function buildMeteorApp(tempDir, options = {}) {
   console.log(`Successfully built Meteor app to ${buildOutputDir}`);
 
   return { buildOutputDir, processResult: result.processResult };
+}
+
+/**
+ * Ask the OS for a free TCP port on the loopback interface.
+ * @returns {Promise<number>}
+ */
+export function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * Start a throwaway MongoDB instance for running a built bundle.
+ *
+ * Reuses the `mongod` binary shipped in Meteor's dev bundle, so no extra
+ * download or system MongoDB is required. Falls back to the MONGO_URL
+ * environment variable when the binary is unavailable, and returns null when
+ * neither is available so callers can skip gracefully.
+ *
+ * @param {Object} options
+ * @param {number} options.port - Port for mongod (default: a free port)
+ * @returns {Promise<{mongoUrl: string, port?: number, stop: Function}|null>}
+ */
+export async function startMongo(options = {}) {
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  const mongodPath = path.join(REPO_ROOT, 'dev_bundle', 'mongodb', 'bin', `mongod${ext}`);
+
+  if (!fs.existsSync(mongodPath)) {
+    if (process.env.MONGO_URL) {
+      console.log('Bundled mongod not found; using MONGO_URL from environment.');
+      return { mongoUrl: process.env.MONGO_URL, stop: async () => {} };
+    }
+    console.warn(`Bundled mongod not found at ${mongodPath} and no MONGO_URL set.`);
+    return null;
+  }
+
+  const port = options.port || (await getFreePort());
+  const randomSuffix = Math.random().toString(36).substring(2, 10);
+  const dbPath = path.join(os.tmpdir(), `meteor-e2e-mongo-${randomSuffix}`);
+  await fs.mkdir(dbPath, { recursive: true });
+
+  console.log(`Starting bundled mongod on port ${port} (dbpath ${dbPath})...`);
+  const mongoProcess = execa(mongodPath, [
+    '--port', String(port),
+    '--dbpath', dbPath,
+    '--bind_ip', '127.0.0.1',
+    '--wiredTigerCacheSizeGB', '0.25',
+  ], { stdio: ['ignore', 'ignore', 'inherit'] });
+
+  let exited = false;
+  mongoProcess.on('exit', () => { exited = true; });
+
+  const stop = async () => {
+    if (!exited) {
+      try { mongoProcess.kill('SIGKILL'); } catch (err) { /* already gone */ }
+    }
+    try { await mongoProcess; } catch (err) { /* killed by signal */ }
+    await fs.remove(dbPath).catch(() => {});
+  };
+
+  try {
+    await waitOn({
+      resources: [`tcp:127.0.0.1:${port}`],
+      timeout: process.env.CI ? 120000 : 60000,
+    });
+  } catch (err) {
+    await stop();
+    throw new Error(`Bundled mongod failed to become ready on port ${port}: ${err.message}`);
+  }
+
+  return { mongoUrl: `mongodb://127.0.0.1:${port}/meteor`, port, stop };
+}
+
+/**
+ * Boot a bundle produced by `meteor build --directory` and wait until it serves
+ * HTTP, verifying the build output is actually runnable.
+ *
+ * @param {string} buildOutputDir - Directory passed to buildMeteorApp
+ * @param {Object} options
+ * @param {number} options.port - Port for the built app (required)
+ * @param {string} options.mongoUrl - MONGO_URL for the built app (required)
+ * @param {boolean} options.skipNpmInstall - Skip `npm install` in the server dir
+ * @param {Object} options.env - Extra environment variables
+ * @returns {Promise<{appProcess: Object, port: number, stop: Function}>}
+ */
+export async function runBuiltApp(buildOutputDir, options = {}) {
+  const { port, mongoUrl, skipNpmInstall = false, env = {} } = options;
+
+  if (!port) throw new Error('runBuiltApp requires a port');
+  if (!mongoUrl) throw new Error('runBuiltApp requires a mongoUrl');
+
+  const bundleDir = path.join(buildOutputDir, 'bundle');
+  const serverDir = path.join(bundleDir, 'programs', 'server');
+
+  if (!skipNpmInstall) {
+    console.log('Running npm install in the built server directory...');
+    await execa('npm', ['install'], { cwd: serverDir, stdio: 'inherit', shell: true });
+  }
+
+  console.log(`Starting built app (node main.js) on port ${port}...`);
+  const appProcess = execa('node', ['main.js'], {
+    cwd: bundleDir,
+    stdio: ['ignore', 'inherit', 'inherit'],
+    env: {
+      ...process.env,
+      ROOT_URL: `http://localhost:${port}`,
+      PORT: String(port),
+      MONGO_URL: mongoUrl,
+      ...env,
+    },
+  });
+
+  let exited = false;
+  appProcess.on('exit', () => { exited = true; });
+
+  const stop = async () => {
+    if (!exited) {
+      try { appProcess.kill('SIGKILL'); } catch (err) { /* already gone */ }
+    }
+    try { await appProcess; } catch (err) { /* killed by signal */ }
+  };
+
+  try {
+    await waitOn({
+      resources: [`http-get://localhost:${port}`],
+      timeout: process.env.CI ? 300000 : 90000,
+    });
+  } catch (err) {
+    await stop();
+    throw new Error(`Built app failed to become ready on port ${port}: ${err.message}`);
+  }
+
+  return { appProcess, port, stop };
 }

--- a/tools/e2e-tests/react-router.test.js
+++ b/tools/e2e-tests/react-router.test.js
@@ -100,6 +100,16 @@ describe('R.Router App Bundling /', () => {
         // Check custom plugin gets loaded from rspack.config.override.js file
         await waitForMeteorOutput(result.outputLines, /.*CustomConsoleLogPlugin.*/);
       },
+      afterRunBuiltApp: async ({ port }) => {
+        // Routing, Less styles and custom meta tags must survive the build
+        await assert404Page(port, { isProductionMode: true });
+        await assertBodyStyles({
+          'white-space': 'break-spaces',
+        });
+        await assertMetaTags({
+          'theme-color': '#4285f4',
+        });
+      },
     }
   }));
 });

--- a/tools/e2e-tests/test-helpers.js
+++ b/tools/e2e-tests/test-helpers.js
@@ -13,11 +13,13 @@ import {
   killMeteorProcess,
   killProcessByPort,
   restoreFiles,
+  runBuiltApp,
   runMeteorApp,
   runMeteorCommand,
   runMeteorTests,
   setupMeteorApp,
   snapshotFiles,
+  startMongo,
   wait,
   waitForMeteorOutput,
   waitForPlaywrightConsole
@@ -219,6 +221,9 @@ export function testMeteorRspackBundler(options) {
     testBundleVisualizer = false,
     // Array of file paths to check for existence in the bundle
     checkBundleFilePaths = [],
+    // Whether to boot the built bundle (node main.js) and verify it serves HTTP.
+    // Requires MongoDB; uses the dev bundle's mongod, falling back to MONGO_URL.
+    testBuiltApp = true,
     // Additional behavior for beforeAll and afterAll
     beforeAllBehavior,
     afterAllBehavior,
@@ -850,6 +855,48 @@ export function testMeteorRspackBundler(options) {
         if (customAssertions && customAssertions.afterBuild) {
           await customAssertions.afterBuild({ tempDir, buildOutputDir, result, fileCheckResults });
         }
+
+        // Boot the built bundle to verify it actually runs, not just that the
+        // expected files exist. Needs a MongoDB; startMongo reuses the dev
+        // bundle's mongod and skips gracefully when neither it nor MONGO_URL
+        // is available.
+        if (testBuiltApp) {
+          const mongo = await startMongo();
+          if (!mongo) {
+            console.warn('Skipping built-app boot check: no bundled mongod and no MONGO_URL set.');
+          } else {
+            let builtApp;
+            try {
+              builtApp = await runBuiltApp(buildOutputDir, {
+                port,
+                mongoUrl: mongo.mongoUrl,
+                skipNpmInstall: true, // npm install already ran above
+                env: env.builtApp,
+              });
+              console.log('Built app booted and is serving HTTP.');
+
+              // Minimal common check: the built bundle renders the app in a
+              // real browser (production assets load, app mounts, CSS applies).
+              if (!skipClient) {
+                await assertMeteorApp(port, { title: appName });
+                await assertBodyStyles({
+                  'padding': '10px',
+                  'font-family': 'sans-serif',
+                });
+              }
+
+              if (customAssertions && customAssertions.afterRunBuiltApp) {
+                await customAssertions.afterRunBuiltApp({
+                  tempDir, buildOutputDir, port, mongoUrl: mongo.mongoUrl,
+                });
+              }
+            } finally {
+              if (builtApp) await builtApp.stop();
+              await mongo.stop();
+              await killProcessByPort(port);
+            }
+          }
+        }
       } finally {
         // Clean up the build output directory
         await cleanupTempDir(buildOutputDir);
@@ -989,6 +1036,9 @@ export function testMeteorSkeleton(options) {
     assetsContext = 'build-assets',
     // Chunks context directory (default: 'build-chunks')
     chunksContext = 'build-chunks',
+    // Whether to boot the built bundle (node main.js) and verify it serves HTTP.
+    // Requires MongoDB; uses the dev bundle's mongod, falling back to MONGO_URL.
+    testBuiltApp = true,
   } = options;
   const devServerPortStr = String(devServerPort);
 
@@ -1236,6 +1286,49 @@ export function testMeteorSkeleton(options) {
         // Run custom assertions if provided
         if (customAssertions.afterBuild) {
           await customAssertions.afterBuild({ tempDir, buildOutputDir, result, fileCheckResults });
+        }
+
+        // Boot the built bundle to verify it actually runs, not just that the
+        // expected files exist. Needs a MongoDB; startMongo reuses the dev
+        // bundle's mongod and skips gracefully when neither it nor MONGO_URL
+        // is available.
+        if (testBuiltApp) {
+          const mongo = await startMongo();
+          if (!mongo) {
+            console.warn('Skipping built-app boot check: no bundled mongod and no MONGO_URL set.');
+          } else {
+            let builtApp;
+            try {
+              builtApp = await runBuiltApp(buildOutputDir, {
+                port,
+                mongoUrl: mongo.mongoUrl,
+                env: env.builtApp,
+              });
+              console.log('Built app booted and is serving HTTP.');
+
+              // Minimal common check: the built bundle renders the app in a
+              // real browser (production assets load, app mounts, CSS applies).
+              if (checkAppTitle) {
+                await assertMeteorApp(port, { title });
+              }
+              if (checkBodyStyles) {
+                await assertBodyStyles(bodyStyles || {
+                  'padding': '10px',
+                  'font-family': 'sans-serif',
+                });
+              }
+
+              if (customAssertions.afterRunBuiltApp) {
+                await customAssertions.afterRunBuiltApp({
+                  tempDir, buildOutputDir, port, mongoUrl: mongo.mongoUrl,
+                });
+              }
+            } finally {
+              if (builtApp) await builtApp.stop();
+              await mongo.stop();
+              await killProcessByPort(port);
+            }
+          }
         }
       } finally {
         // Clean up the build output directory

--- a/tools/e2e-tests/test-helpers.js
+++ b/tools/e2e-tests/test-helpers.js
@@ -775,7 +775,7 @@ export function testMeteorRspackBundler(options) {
       await killProcessByPort(port);
     });
 
-    test(`"meteor build" / should build the app with Rspack`, async () => {
+    test(`"meteor build" / should build and run the app with Rspack`, async () => {
       // Build the app with Rspack
       const { buildOutputDir, processResult: result } = await buildMeteorApp(tempDir, {
         commandOptions: ['--directory'],
@@ -1235,7 +1235,7 @@ export function testMeteorSkeleton(options) {
       await killProcessByPort(port);
     });
 
-    test(`"meteor build" / should build the ${skeletonName} app`, async () => {
+    test(`"meteor build" / should build and run the ${skeletonName} app`, async () => {
       // Build the app
       const { buildOutputDir, processResult: result } = await buildMeteorApp(tempDir, {
         commandOptions: ["--directory"],

--- a/tools/e2e-tests/typescript.test.js
+++ b/tools/e2e-tests/typescript.test.js
@@ -101,6 +101,12 @@ describe('TypeScript App Bundling /', () => {
           { negate: true }
         );
       },
+      afterRunBuiltApp: async () => {
+        // SCSS styles must survive the production build
+        await assertBodyStyles({
+          'white-space': 'break-spaces',
+        });
+      },
     }
   }));
 });

--- a/tools/e2e-tests/vue.test.js
+++ b/tools/e2e-tests/vue.test.js
@@ -34,6 +34,12 @@ describe('Vue App Bundling /', () => {
         // Check for HMR to not be enabled in production-like mode
         await waitForMeteorOutput(allConsoleLogs, /.*HMR.*Updated modules:*/, { negate: true });
       },
+      afterRunBuiltApp: async () => {
+        // Tailwind utility styles must survive the production build
+        await assertStyles('.p-8', {
+          ['padding']: '32px',
+        });
+      },
     }
   }));
 });


### PR DESCRIPTION
Continues: https://github.com/meteor/meteor/pull/14421

This PR ensures the E2E tests can also run the app after the `meteor build` phase, with minimal assertions to check that the app not only loads, but also serves the client properly with the app contents.

This is useful to ensure production bundles are created properly for all app examples, and that there are no production-only edge cases causing crashes. This required to create new E2E helpers to manage MongoDB.