### PR TITLE
[E2E flakiness] Clean up orphan processes during E2E retries

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,6 +105,17 @@ jobs:
         timeout-minutes: 15
         run: METEOR_ALLOW_SUPERUSER=1 npm run test:e2e -- -t="${{ matrix.category }}"
 
+      - name: Clean up stray processes before retry
+        if: steps.test-run.outcome == 'failure'
+        run: |
+          # The first attempt shares this container; orphaned processes still
+          # hold ports and would fail the retry with EADDRINUSE. Matched by the
+          # "meteortest-" temp dir in their argv.
+          echo "Killing stray e2e processes left by the failed attempt..."
+          pkill -9 -f 'meteortest-' || true
+          sleep 3
+          echo "Stray process cleanup done."
+
       - name: Retry failed tests for ${{ matrix.category }}
         if: steps.test-run.outcome == 'failure'
         timeout-minutes: 20

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,16 +105,20 @@ jobs:
         timeout-minutes: 15
         run: METEOR_ALLOW_SUPERUSER=1 npm run test:e2e -- -t="${{ matrix.category }}"
 
-      - name: Clean up stray processes before retry
+      - name: Clean up before retry
         if: steps.test-run.outcome == 'failure'
         run: |
-          # The first attempt shares this container; orphaned processes still
-          # hold ports and would fail the retry with EADDRINUSE. Matched by the
-          # "meteortest-" temp dir in their argv.
-          echo "Killing stray e2e processes left by the failed attempt..."
+          # First attempt and retry share this container; a hard timeout can
+          # orphan processes (EADDRINUSE) and temp dirs. The retry recreates
+          # each app fresh, so only container leftovers need clearing.
+          echo "Cleaning up after the failed attempt..."
           pkill -9 -f 'meteortest-' || true
+          # Detached bundler/db children may not carry the temp path in argv.
+          pkill -9 -f mongod || true
+          pkill -9 -f rspack || true
+          rm -rf /tmp/meteortest-* /tmp/meteor-build-* || true
           sleep 3
-          echo "Stray process cleanup done."
+          echo "Cleanup done."
 
       - name: Retry failed tests for ${{ matrix.category }}
         if: steps.test-run.outcome == 'failure'

--- a/tools/e2e-tests/helpers.js
+++ b/tools/e2e-tests/helpers.js
@@ -203,18 +203,97 @@ export async function runMeteorApp(tempDir, port, options = {}) {
 }
 
 /**
- * Helper function to kill a Meteor process
+ * Resolves true if the process exits within the timeout.
+ * @private
+ */
+function waitForProcessExit(proc, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    proc.once('exit', () => finish(true));
+    // execa subprocess is also a promise; covers an exit before this listener.
+    if (typeof proc.then === 'function') {
+      proc.then(() => finish(true), () => finish(true));
+    }
+  });
+}
+
+/**
+ * Kills a Meteor process. SIGTERM first so its shutdown hooks run (the rspack
+ * plugin's handler releases the dev server port); SIGKILL only as a fallback.
  * @param {Object} meteorProcess - The Meteor process to kill
+ * @param {Object} [options]
+ * @param {number} [options.graceMs=12000] - Time to wait for a graceful exit
  * @returns {Promise<void>}
  */
-export async function killMeteorProcess(meteorProcess) {
-  if (meteorProcess) {
-    try {
-      await meteorProcess.kill('SIGKILL');
-      console.log('Successfully killed meteor process');
-    } catch (err) {
-      console.log(`Error killing meteor process: ${err.message}`);
-    }
+export async function killMeteorProcess(meteorProcess, options = {}) {
+  if (!meteorProcess) return;
+
+  const { graceMs = 12000 } = options;
+
+  // Already exited (signalled exits set signalCode, not exitCode).
+  if (meteorProcess.exitCode != null || meteorProcess.signalCode != null) {
+    return;
+  }
+
+  // Swallow the rejection a signalled exit produces on the execa promise.
+  if (typeof meteorProcess.catch === 'function') {
+    meteorProcess.catch(() => {});
+  }
+
+  let exitedCleanly = false;
+  try {
+    meteorProcess.kill('SIGTERM');
+    exitedCleanly = await waitForProcessExit(meteorProcess, graceMs);
+  } catch (err) {
+    console.log(`Error sending SIGTERM to meteor process: ${err.message}`);
+  }
+
+  if (exitedCleanly) {
+    console.log('Meteor process exited gracefully after SIGTERM');
+    return;
+  }
+
+  try {
+    meteorProcess.kill('SIGKILL');
+    console.log('Force-killed meteor process with SIGKILL');
+  } catch (err) {
+    console.log(`Error killing meteor process: ${err.message}`);
+  }
+}
+
+// Live Meteor processes from runMeteorCommand, so the sweep can reap one even
+// when a test timed out before capturing its handle.
+const activeMeteorProcesses = new Set();
+
+/**
+ * Safety net: kills anything an e2e test left running. Stops tracked Meteor
+ * processes, then sweeps detached descendants (rspack dev server, mongod) by
+ * the "meteortest-" temp dir in their argv. The "[-]" stops the sweep matching
+ * its own command.
+ * @returns {Promise<void>}
+ */
+export async function killStrayAppProcesses() {
+  const tracked = [...activeMeteorProcesses];
+  await Promise.all(
+    tracked.map((proc) => killMeteorProcess(proc, { graceMs: 8000 }))
+  );
+
+  if (process.platform === 'win32') return;
+  try {
+    await execa.command(
+      `ps -eo pid=,args= | grep -E 'meteortest[-]' | awk '{print $1}' | xargs -r kill -9`,
+      { shell: true, reject: false }
+    );
+  } catch (err) {
+    // Best-effort cleanup; never fail a test because the sweep errored.
+    console.log(`Error sweeping stray app processes: ${err.message}`);
   }
 }
 
@@ -250,76 +329,131 @@ async function killSingleProcessByPort(port) {
 
     if (process.platform === 'win32') {
       const command = `FOR /F "tokens=5" %a in ('netstat -ano ^| find "LISTENING" ^| find ":${port}"') do taskkill /F /PID %a`;
-      try {
-        await execa.command(command, { shell: true, reject: false });
-      } catch (err) {
-        console.log(`Error executing kill command: ${err.message}`);
-      }
-    } else {
-      // Kill any process listening on this port (IPv4 and IPv6).
-      // Try multiple tools because minimal Docker images (e.g. node:22-bookworm)
-      // may not have lsof or fuser installed.
-      // 1) lsof — available on most full Linux installs and macOS
-      try {
-        const result = await execa.command(
-          `lsof -i :${port} -t 2>/dev/null | grep -v ^${process.pid}$ | xargs -r kill -9`,
-          { shell: true, reject: false }
-        );
-        if (!result.failed && result.stdout) {
-          console.log(`Killed process(es) via lsof on port ${port}`);
-        }
-      } catch (err) {
-        // lsof not available; continue to next method
+      await execa.command(command, { shell: true, reject: false });
+      console.log(`Successfully ensured no process is running on port ${port}`);
+      return;
+    }
+
+    // Kill whatever listens on this port, retrying until the socket is verified
+    // free — claiming success without checking lets an orphan survive.
+    const maxAttempts = 5;
+    let portFree = false;
+
+    // Resolved once so a group kill can never signal the group Jest runs in.
+    const ownGroupId = await getOwnProcessGroupId();
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const pids = await findPidsOnPort(port);
+
+      // Fast path: nothing holds the port (common in beforeEach).
+      if (pids.length === 0 && await isPortFree(port)) {
+        portFree = true;
+        break;
       }
 
-      // 2) ss + kill — ss is from iproute2, available on virtually all Linux containers.
-      //    Use awk instead of grep -oP to extract PIDs (grep -P needs libpcre2,
-      //    which is absent in minimal Docker images like node:22-bookworm).
-      try {
-        const ssResult = await execa.command(
-          `ss -tlnp sport = :${port} 2>/dev/null | awk '{while(match($0,/pid=[0-9]+/)){print substr($0,RSTART+4,RLENGTH-4);$0=substr($0,RSTART+RLENGTH)}}' | grep -v ^${process.pid}$ | sort -u | xargs -r kill -9`,
+      for (const pid of pids) {
+        // Kill the process group too, so a detached child (the rspack dev
+        // server) dies with it. Skipped unless our own group is known and
+        // differs, so it can't take down Jest; the PID kill alone frees the
+        // socket regardless.
+        const pgidResult = await execa.command(
+          `ps -o pgid= -p ${pid} 2>/dev/null`,
           { shell: true, reject: false }
         );
-        if (!ssResult.failed && ssResult.stdout) {
-          console.log(`Killed process(es) via ss on port ${port}`);
+        const pgid = (pgidResult.stdout || '').trim();
+        if (/^\d+$/.test(pgid) && ownGroupId && pgid !== ownGroupId) {
+          await execa.command(`kill -9 -${pgid} 2>/dev/null`, { shell: true, reject: false });
         }
-      } catch (err) {
-        // ss not available or no matches; continue
+        await execa.command(`kill -9 ${pid} 2>/dev/null`, { shell: true, reject: false });
       }
 
-      // 3) fuser — fallback, may not be installed in minimal images
-      try {
-        await execa.command(`fuser -k ${port}/tcp 2>/dev/null`, { shell: true, reject: false });
-      } catch (err) {
-        // fuser not installed; that's fine
-      }
+      // fuser fallback for when lsof/ss miss the socket owner.
+      await execa.command(`fuser -k ${port}/tcp 2>/dev/null`, { shell: true, reject: false });
 
-      // Wait briefly for the OS to release the socket (TIME_WAIT / close propagation)
-      const maxWait = 3000;
-      const interval = 300;
-      let waited = 0;
-      while (waited < maxWait) {
-        // Use ss to verify the port is free (works in minimal containers).
-        // Pipe through grep to skip the header line; avoids relying on -H flag.
-        const check = await execa.command(
-          `ss -tln sport = :${port} 2>/dev/null | grep -i listen | head -1`,
-          { shell: true, reject: false }
-        );
-        if (!check.stdout || check.stdout.trim() === '') {
-          break;
-        }
-        await new Promise(r => setTimeout(r, interval));
-        waited += interval;
-      }
-      if (waited >= maxWait) {
-        console.log(`Warning: port ${port} may still be in use after ${maxWait}ms`);
+      // Let the OS release the socket before re-checking.
+      await new Promise(r => setTimeout(r, 400));
+
+      if (await isPortFree(port)) {
+        portFree = true;
+        break;
       }
     }
 
-    console.log(`Successfully ensured no process is running on port ${port}`);
+    if (portFree) {
+      console.log(`Successfully ensured no process is running on port ${port}`);
+    } else {
+      console.warn(`Warning: port ${port} is still in use after ${maxAttempts} kill attempts`);
+    }
   } catch (error) {
     console.error(`Error killing process on port ${port}:`, error);
   }
+}
+
+/**
+ * Process group id of the test runner, read from `ps` (Node has no API) and
+ * cached. Null if unknown, in which case callers must skip group kills.
+ * @returns {Promise<string|null>}
+ * @private
+ */
+let ownProcessGroupIdPromise;
+function getOwnProcessGroupId() {
+  if (!ownProcessGroupIdPromise) {
+    ownProcessGroupIdPromise = (async () => {
+      if (process.platform === 'win32') return null;
+      const result = await execa.command(
+        `ps -o pgid= -p ${process.pid} 2>/dev/null`,
+        { shell: true, reject: false }
+      );
+      const pgid = (result.stdout || '').trim();
+      return /^\d+$/.test(pgid) ? pgid : null;
+    })();
+  }
+  return ownProcessGroupIdPromise;
+}
+
+/**
+ * PIDs listening on a port, via lsof and ss merged (minimal images may lack
+ * one). The test runner's own PID is never returned.
+ * @param {number} port - The port to inspect
+ * @returns {Promise<string[]>}
+ * @private
+ */
+async function findPidsOnPort(port) {
+  const pids = new Set();
+
+  const lsof = await execa.command(
+    `lsof -i :${port} -t 2>/dev/null`,
+    { shell: true, reject: false }
+  );
+  for (const line of (lsof.stdout || '').split('\n')) {
+    const pid = line.trim();
+    if (/^\d+$/.test(pid)) pids.add(pid);
+  }
+
+  const ss = await execa.command(
+    `ss -tlnp sport = :${port} 2>/dev/null`,
+    { shell: true, reject: false }
+  );
+  const pidPattern = /pid=(\d+)/g;
+  let match;
+  while ((match = pidPattern.exec(ss.stdout || '')) !== null) {
+    pids.add(match[1]);
+  }
+
+  pids.delete(String(process.pid));
+  return [...pids];
+}
+
+/**
+ * Resolves true if nothing is listening on the port.
+ * @private
+ */
+async function isPortFree(port) {
+  const check = await execa.command(
+    `ss -tln sport = :${port} 2>/dev/null | grep -i listen | head -1`,
+    { shell: true, reject: false }
+  );
+  return !check.stdout || check.stdout.trim() === '';
 }
 
 /**
@@ -355,6 +489,10 @@ export async function runMeteorCommand(command, args = [], cwd, options = {}) {
   }
 
   const meteorProcess = execa(METEOR_EXECUTABLE, [command, ...args], execaOptions);
+
+  // Track so the sweep can reap it if a test times out before grabbing it.
+  activeMeteorProcesses.add(meteorProcess);
+  meteorProcess.once('exit', () => activeMeteorProcesses.delete(meteorProcess));
 
   // If we're capturing output, set up the output collection
   let outputLines = [];

--- a/tools/e2e-tests/helpers.js
+++ b/tools/e2e-tests/helpers.js
@@ -142,6 +142,45 @@ export async function setupMeteorApp(appName, options = {}) {
 }
 
 /**
+ * Waits for `pattern`, but fails fast (~90s) if MongoDB never starts: a hung
+ * `mongod` otherwise burns the full 240s output wait silently. Skipped when an
+ * external Mongo is set, since Meteor starts no local instance then.
+ * @private
+ */
+async function waitForOutputWithMongoWatchdog(outputLines, pattern, options, meteorProcess, env) {
+  const mainWait = waitForMeteorOutput(
+    outputLines,
+    pattern,
+    { ...options, meteorProcess }
+  );
+
+  const usesExternalMongo = !!(env.MONGO_URL || process.env.MONGO_URL);
+  if (options.mongoWatchdog === false || usesExternalMongo) {
+    return mainWait;
+  }
+
+  const mongoTimeout = options.mongoTimeout || (process.env.CI ? 90000 : 45000);
+  const mongoWait = waitForMeteorOutput(
+    outputLines,
+    '=> Started MongoDB.',
+    { timeout: mongoTimeout, meteorProcess }
+  ).catch((err) => {
+    // A process exit isn't a Mongo fault; reframe only a genuine timeout.
+    if (/process exited/i.test(err.message)) throw err;
+    throw new Error(
+      `MongoDB did not start within ${mongoTimeout}ms; likely a stale ` +
+      `mongod or lock file on the (reused) CI container. (${err.message})`
+    );
+  });
+
+  // Mark both handled so the race's loser can't reject unhandled later.
+  mainWait.catch(() => {});
+  mongoWait.catch(() => {});
+  await Promise.race([mainWait, mongoWait]);
+  return mainWait;
+}
+
+/**
  * Helper function to run a Meteor app
  * @param {string} tempDir - Path to the directory containing the app
  * @param {number} port - Port to run the app on
@@ -183,10 +222,12 @@ export async function runMeteorApp(tempDir, port, options = {}) {
 
   // If a specific output pattern is requested, wait for it
   if (options.waitForOutput) {
-    await waitForMeteorOutput(
+    await waitForOutputWithMongoWatchdog(
       outputLines,
       options.waitForOutput,
-      { ...options, meteorProcess }
+      options,
+      meteorProcess,
+      env
     );
   }
 
@@ -855,10 +896,12 @@ export async function runMeteorTests(tempDir, port, options = {}) {
 
   // If a specific output pattern is requested, wait for it
   if (options.waitForOutput) {
-    await waitForMeteorOutput(
+    await waitForOutputWithMongoWatchdog(
       outputLines,
       options.waitForOutput,
-      { ...options, meteorProcess }
+      options,
+      meteorProcess,
+      env
     );
   }
 

--- a/tools/e2e-tests/helpers.js
+++ b/tools/e2e-tests/helpers.js
@@ -644,11 +644,25 @@ export async function waitForMeteorOutput(outputLines, pattern, options = {}) {
       });
     }
 
+    const lineMatches = (line) =>
+      (typeof pattern === 'string' && line.includes(pattern)) ||
+      (pattern instanceof RegExp && pattern.test(line));
+
     // Function to check for the pattern in the output lines
     const checkForPattern = () => {
       // Check if we've exceeded the timeout
       if (Date.now() - startTime > timeout) {
-        reject(new Error(`Timeout waiting for output ${negate ? 'NOT ' : ''}matching: ${pattern}`));
+        // In negate mode the wait can only fail because some line matched.
+        // Surface those lines so the failure is diagnosable instead of a
+        // bare timeout.
+        let detail = '';
+        if (negate) {
+          const offending = outputLines.filter(lineMatches);
+          detail = `\nOffending line(s):\n${offending.slice(-20).join('\n')}`;
+        }
+        reject(new Error(
+          `Timeout waiting for output ${negate ? 'NOT ' : ''}matching: ${pattern}${detail}`
+        ));
         return;
       }
 
@@ -656,16 +670,7 @@ export async function waitForMeteorOutput(outputLines, pattern, options = {}) {
         // In negation mode, we need to check all lines and make sure none match
         // If we've processed all lines and none match, we can resolve
         if (outputLines.length > 0) {
-          let allLinesPass = true;
-          for (const line of outputLines) {
-            const matches = (typeof pattern === 'string' && line.includes(pattern)) ||
-                           (pattern instanceof RegExp && pattern.test(line));
-            if (matches) {
-              allLinesPass = false;
-              break;
-            }
-          }
-          if (allLinesPass) {
+          if (!outputLines.some(lineMatches)) {
             console.log(`Confirmed no output matching: ${pattern}`);
             resolve(null);
             return;

--- a/tools/e2e-tests/react-router.test.js
+++ b/tools/e2e-tests/react-router.test.js
@@ -32,8 +32,10 @@ describe('R.Router App Bundling /', () => {
       },
       afterRun: async ({ result, port }) => {
         await waitForReactEnvs(result.outputLines, { isTsxEnabled: true });
-        // negated as cached output (babel.config.js)
-        await waitForMeteorOutput(result.outputLines, /.*babel-plugin-react-compiler.*/, { negate: true });
+        // Do not assert babel.config.js output is absent on the second run:
+        // rspack persistent-cache reuse across separate `meteor run`
+        // invocations is not deterministic in CI, so a negated wait here can
+        // hang for the full test timeout. See afterInit for the positive check.
         await assert404Page(port);
         // Less styles support
         await assertBodyStyles({

--- a/tools/e2e-tests/test-helpers.js
+++ b/tools/e2e-tests/test-helpers.js
@@ -12,6 +12,7 @@ import {
   isRetryAttempt,
   killMeteorProcess,
   killProcessByPort,
+  killStrayAppProcesses,
   restoreFiles,
   runMeteorApp,
   runMeteorCommand,
@@ -127,6 +128,9 @@ export function testMeteorBundler(options) {
         await killMeteorProcess(meteorProcess);
         meteorProcess = null;
       }
+
+      // Safety net: reap anything the test orphaned before the next one runs.
+      await killStrayAppProcesses();
     });
 
     test(`"meteor run" / should start the app`, async () => {
@@ -361,6 +365,9 @@ export function testMeteorRspackBundler(options) {
         await killMeteorProcess(meteorProcess);
         meteorProcess = null;
       }
+
+      // Safety net: reap anything the test orphaned before the next one runs.
+      await killStrayAppProcesses();
 
       // Restore mutated files regardless of pass/fail — idempotent on green runs,
       // essential on retries.
@@ -1039,6 +1046,9 @@ export function testMeteorSkeleton(options) {
         await killMeteorProcess(meteorProcess);
         meteorProcess = null;
       }
+
+      // Safety net: reap anything the test orphaned before the next one runs.
+      await killStrayAppProcesses();
     });
 
     test(`"meteor create --${skeletonName}" / should create a new Meteor ${skeletonName} app`, async () => {


### PR DESCRIPTION
The E2E suite is flaky: many categories kept failing with `EADDRINUSE` and `Can't listen on port 3122` ([example](https://github.com/meteor/meteor/actions/runs/26165291982/job/76967642035?pr=14406)).

https://github.com/meteor/meteor/pull/14406 fixed how the Rspack dev server shuts down. On `SIGTERM`, the Rspack plugin now stops the dev server and releases its port, and a regression test proves it. That fix is correct and we keep it.

However, the issue with E2E flakiness and caused by `EADDRINUSE` keep happening, and after a research the reason is that the E2E harness killed Meteor with `SIGKILL`. `SIGKILL` cannot be caught, so Meteor never runs its shutdown hooks, including the Rspack handler #14406 added. The dev server orphans, keeps its port, and the next test fails to bind it. The retry runs in the same container, inherits the orphan, and fails instantly. So #14406 fixed the `SIGTERM` path, but the suite only ever used `SIGKILL`.

This change moves the suite onto that fixed path. `killMeteorProcess` now sends `SIGTERM` first and waits for a clean exit, using `SIGKILL` only as a fallback. `killProcessByPort` now kills the listener and its process group, then verifies the port is actually free before reporting success. A new `killStrayAppProcesses` helper reaps leftover Meteor processes and sweeps orphaned children (dev server, `mongod`) by their `meteortest-` temp dir; the suite calls it in `afterEach`. A pre-retry CI step kills stray processes so a poisoned container cannot doom the retry; it also kills detached `mongod` and `rspack` children, which may not carry the `meteortest-` temp path in their argv, and clears `/tmp/meteortest-*` and `/tmp/meteor-build-*` so the retry starts from a clean container.

While chasing the port leak, the same reused containers exposed a second flakiness mode: tests that hang for the full 240s output timeout instead of failing fast. A stale `mongod` or lock file could keep MongoDB from starting, and the output wait would burn the full timeout silently. `runMeteorApp` and `runMeteorTests` now wait through `waitForOutputWithMongoWatchdog`, which races the main wait against a `=> Started MongoDB.` wait that fails at ~90s in CI with a diagnosable error; it is skipped when an external `MONGO_URL` is set, since Meteor starts no local Mongo then. A negated `waitForMeteorOutput` could also hang silently, since it can only fail by timing out: the timeout error now reports the offending line(s). One such assertion was itself non-deterministic, in `react-router.test.js`, asserting that `babel-plugin-react-compiler` output was absent on the second `meteor run`; Rspack cache reuse is not deterministic across two separate `meteor run` invocations, so on a cold cache the line prints, the negated wait never resolves, and the test hangs. That assertion is dropped, while `afterInit` still verifies the output on a fresh build.

I will ensure to retry the jobs and try to see if we finally see the E2E flakiness solved and spread through all branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced E2E test workflow with improved cleanup mechanisms before retries to ensure cleaner test state
  * Strengthened process termination and cleanup handling to reliably remove orphaned processes from failed test runs
  * Improved MongoDB startup detection and process management for more stable test execution
  * Added automatic process cleanup between tests to reduce interference between test runs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meteor/meteor/pull/14424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->