### PR TITLE
Fix/uws transport settings and port collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,4 @@ coverage-ts/
 .cursorrules
 
 # claude code
-.claude/skills/
-.claude/settings.local.json
+.claude/*

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -83,4 +83,5 @@ Package.onTest(function (api) {
   api.addFiles("session_view_tests.js", ["server"]);
   api.addFiles("crossbar_tests.js", ["server"]);
   api.addFiles("raw_websocket_tests.js", "server");
+  api.addFiles("transports/uws_tests.js", "server");
 });

--- a/packages/ddp-server/transports/index.js
+++ b/packages/ddp-server/transports/index.js
@@ -37,7 +37,7 @@ export function getTransport() {
 
 function resolveTransportName() {
   // 1. Meteor settings
-  var settings = __meteor_runtime_config__?.meteorSettings?.packages?.['ddp-server'];
+  var settings = Meteor.settings?.packages?.['ddp-server'];
   if (settings && settings.transport) {
     return settings.transport;
   }

--- a/packages/ddp-server/transports/uws.js
+++ b/packages/ddp-server/transports/uws.js
@@ -2,41 +2,8 @@ import { EventEmitter } from 'events';
 import net from 'node:net';
 
 /**
- * uWebSockets.js transport — high-performance WebSocket via uWebSockets.js.
- *
- * Unlike other transports, uWebSockets.js runs its own internal server on a
- * separate port. HTTP upgrade requests on /websocket are proxied from the
- * main Meteor HTTP server to the uWS server via a raw TCP connection.
- *
- * Configuration via Meteor.settings (read on the server from
- * `Meteor.settings.packages["ddp-server"].uws`):
- *
- *   {
- *     "packages": {
- *       "ddp-server": {
- *         "transport": "uws",
- *         "uws": {
- *           "port": 5001,            // internal listen port
- *           "host": "127.0.0.1",      // internal listen address
- *           "payloadLength": 48,     // max WS payload, in KiB
- *           "timeout": 45            // idle timeout in seconds
- *         }
- *       }
- *     }
- *   }
- *
- * Per-process configuration is required when running multiple Meteor
- * instances on a single host that share a Linux network namespace —
- * multi-tenant containers under `network_mode: "host"`, multi-process
- * scaling on one VM, Galaxy multi-pod nodes, or simply two local
- * Meteor projects running with `DDP_TRANSPORT=uws` at the same time.
- * Each process must declare a distinct `uws.port` (or `uws.host`):
- * the listen socket is now bound with `LIBUS_LISTEN_EXCLUSIVE_PORT`,
- * so a second instance trying to bind the default `127.0.0.1:5001`
- * throws EADDRINUSE at startup instead of silently SO_REUSEPORT-sharing
- * the port and load-balancing inbound WebSocket traffic across
- * unrelated app processes. See packages/ddp-server/MULTITENANCY-BUG.md
- * for the full bug history.
+ * Configuration via Meteor.settings:
+ *   { "packages": { "ddp-server": { "transport": "uws", "uws": { "port": 5001, "host": "127.0.0.1", "payloadLength": 48, "timeout": 45 } } } }
  */
 export function createUwsTransport() {
   return {

--- a/packages/ddp-server/transports/uws.js
+++ b/packages/ddp-server/transports/uws.js
@@ -8,8 +8,35 @@ import net from 'node:net';
  * separate port. HTTP upgrade requests on /websocket are proxied from the
  * main Meteor HTTP server to the uWS server via a raw TCP connection.
  *
- * Configuration via Meteor.settings:
- *   { "packages": { "ddp-server": { "transport": "uws", "uws": { "port": 5001, "host": "127.0.0.1", "payloadLength": 48, "timeout": 45 } } } }
+ * Configuration via Meteor.settings (read on the server from
+ * `Meteor.settings.packages["ddp-server"].uws`):
+ *
+ *   {
+ *     "packages": {
+ *       "ddp-server": {
+ *         "transport": "uws",
+ *         "uws": {
+ *           "port": 5001,            // internal listen port
+ *           "host": "127.0.0.1",      // internal listen address
+ *           "payloadLength": 48,     // max WS payload, in KiB
+ *           "timeout": 45            // idle timeout in seconds
+ *         }
+ *       }
+ *     }
+ *   }
+ *
+ * Per-process configuration is required when running multiple Meteor
+ * instances on a single host that share a Linux network namespace —
+ * multi-tenant containers under `network_mode: "host"`, multi-process
+ * scaling on one VM, Galaxy multi-pod nodes, or simply two local
+ * Meteor projects running with `DDP_TRANSPORT=uws` at the same time.
+ * Each process must declare a distinct `uws.port` (or `uws.host`):
+ * the listen socket is now bound with `LIBUS_LISTEN_EXCLUSIVE_PORT`,
+ * so a second instance trying to bind the default `127.0.0.1:5001`
+ * throws EADDRINUSE at startup instead of silently SO_REUSEPORT-sharing
+ * the port and load-balancing inbound WebSocket traffic across
+ * unrelated app processes. See packages/ddp-server/MULTITENANCY-BUG.md
+ * for the full bug history.
  */
 export function createUwsTransport() {
   return {
@@ -18,7 +45,7 @@ export function createUwsTransport() {
       const emitter = new EventEmitter();
       const uws = Npm.require('uWebSockets.js');
 
-      const settings = __meteor_runtime_config__?.meteorSettings?.packages?.['ddp-server']?.uws || {};
+      const settings = Meteor.settings?.packages?.['ddp-server']?.uws || {};
       const uwsPort = Number(settings.port) || 5001;
       const uwsPayloadLength = Number(settings.payloadLength) || 48;
       const uwsSocketTimeout = Number(settings.timeout) || 45;
@@ -53,7 +80,7 @@ export function createUwsTransport() {
           socket.on = function (event, callback) {
             const map = event === 'close' ? closeListeners
               : event === 'data' ? messageListeners
-              : null;
+                : null;
             if (!map) return;
             const list = map.get(socket);
             if (list) {
@@ -111,10 +138,25 @@ export function createUwsTransport() {
         }
       });
 
-      uwsApp.listen(uwsHost, uwsPort, (token) => {
+      // Pass LIBUS_LISTEN_EXCLUSIVE_PORT so uWS does not enable SO_REUSEPORT
+      // on this listening socket. With SO_REUSEPORT (uWS's default), two
+      // Meteor processes in the same kernel network namespace will both
+      // succeed in binding the same `(host, port)` tuple, and the kernel
+      // will then load-balance inbound connections between them — splitting
+      // WS upgrade traffic across unrelated app processes. With EXCLUSIVE,
+      // the second instance gets EADDRINUSE and `token` is false here, so
+      // we throw a loud, actionable error instead of silently leaking
+      // traffic. Operators running multiple Meteor instances on one host
+      // must pick a distinct `Meteor.settings.packages["ddp-server"].uws.port`
+      // (or `host`) per process.
+      uwsApp.listen(uwsHost, uwsPort, uws.LIBUS_LISTEN_EXCLUSIVE_PORT, (token) => {
         if (!token) {
           throw new Error(
-            'uWebSockets.js: failed to listen on ' + uwsHost + ':' + uwsPort
+            'uWebSockets.js: failed to listen on ' + uwsHost + ':' + uwsPort +
+            ' (address already in use). Another Meteor instance in this ' +
+            'network namespace is already bound to this port. Set a ' +
+            'distinct Meteor.settings.packages["ddp-server"].uws.port ' +
+            '(or .host) for each instance.'
           );
         }
       });
@@ -123,7 +165,7 @@ export function createUwsTransport() {
       WebApp.rawConnectHandlers.use(function (req, res, next) {
         const pathname = new URL(req.url, 'http://localhost').pathname;
         if (pathname === pathPrefix + '/websocket' ||
-            pathname === pathPrefix + '/websocket/') {
+          pathname === pathPrefix + '/websocket/') {
           res.writeHead(400, { 'Content-Type': 'text/plain' });
           res.end('Not a valid websocket request');
         } else {
@@ -152,7 +194,7 @@ function proxyWebsocketToUws(httpServer, pathPrefix, uwsHost, uwsPort) {
     const pathname = new URL(req.url, 'http://localhost').pathname;
 
     if (pathname === pathPrefix + '/websocket' ||
-        pathname === pathPrefix + '/websocket/') {
+      pathname === pathPrefix + '/websocket/') {
 
       // Build the raw HTTP upgrade request to forward to uWS
       const uwsSocket = net.createConnection(uwsPort, uwsHost, function () {

--- a/packages/ddp-server/transports/uws_tests.js
+++ b/packages/ddp-server/transports/uws_tests.js
@@ -1,22 +1,3 @@
-// Regression tests for the multitenancy cross-routing bug fixed in
-// commit ae176b9bbb (see packages/ddp-server/MULTITENANCY-BUG.md).
-//
-// Two angles are covered here:
-//
-//   1. LIBUS_LISTEN_EXCLUSIVE_PORT really disables SO_REUSEPORT on the
-//      uWebSockets.js listen socket. Pre-fix, two Meteor instances in
-//      the same kernel netns would silently share the uws internal
-//      port (default 127.0.0.1:5001) and have inbound WS upgrade
-//      traffic load-balanced between them by the kernel. With the
-//      EXCLUSIVE flag, the second listen call returns a falsy token
-//      so the transport's existing throw fires loudly instead.
-//
-//   2. The uws transport reads its configuration from `Meteor.settings`
-//      (server-side global), not from `__meteor_runtime_config__.meteorSettings`
-//      (a client-side-only object). Pre-fix, settings users put in
-//      `Meteor.settings.packages["ddp-server"].uws` were silently
-//      ignored and the hard-coded defaults always won.
-
 const uws = Npm.require('uWebSockets.js');
 
 // Pick a random high port to avoid clashing with anything else on the
@@ -82,10 +63,7 @@ Tinytest.addAsync(
 Tinytest.addAsync(
   'ddp-server/uws - LIBUS_LISTEN_EXCLUSIVE_PORT enum exists and equals 1',
   function (test, onComplete) {
-    // Sanity check on the uws binding contract this fix depends on.
-    // If uws ever renamed or removed this constant we'd want the
-    // test suite to flag the breakage explicitly instead of the fix
-    // silently degrading back to SO_REUSEPORT semantics.
+
     test.equal(
       uws.LIBUS_LISTEN_EXCLUSIVE_PORT,
       1,
@@ -99,20 +77,6 @@ Tinytest.addAsync(
 Tinytest.add(
   'ddp-server/uws - settings read path goes through Meteor.settings',
   function (test) {
-    // We can't trivially exercise createUwsTransport() inside a test
-    // (it has side effects on the global httpServer and WebApp
-    // routes), so instead this test asserts the *structural*
-    // invariant the fix relies on: an object placed at
-    // `Meteor.settings.packages["ddp-server"].uws` is visible via
-    // the same optional-chain expression the transport now uses.
-    //
-    // Pre-fix the transport used `__meteor_runtime_config__.meteorSettings.*`,
-    // which the server boot script never populates — so even when
-    // operators set METEOR_SETTINGS correctly the transport saw
-    // `undefined` and silently fell back to its defaults. The
-    // regression we want to catch is the read path drifting back to
-    // the dead-code object.
-
     const savedSettings = Meteor.settings;
     try {
       Meteor.settings = {
@@ -165,15 +129,6 @@ Tinytest.add(
 Tinytest.add(
   'ddp-server/transport-selection - transport setting honoured via Meteor.settings',
   function (test) {
-    // Same invariant as above, applied to transports/index.js
-    // `resolveTransportName()`. The function picks the transport
-    // name by reading Meteor.settings.packages["ddp-server"].transport
-    // (priority 1), then DDP_TRANSPORT env var (priority 2). Pre-fix
-    // it read from __meteor_runtime_config__.meteorSettings.packages
-    // ["ddp-server"], which is never populated server-side, so the
-    // env-var fallback was the only path that worked in practice and
-    // the documented Meteor.settings configuration was dead.
-
     const savedSettings = Meteor.settings;
     try {
       Meteor.settings = {

--- a/packages/ddp-server/transports/uws_tests.js
+++ b/packages/ddp-server/transports/uws_tests.js
@@ -1,0 +1,192 @@
+// Regression tests for the multitenancy cross-routing bug fixed in
+// commit ae176b9bbb (see packages/ddp-server/MULTITENANCY-BUG.md).
+//
+// Two angles are covered here:
+//
+//   1. LIBUS_LISTEN_EXCLUSIVE_PORT really disables SO_REUSEPORT on the
+//      uWebSockets.js listen socket. Pre-fix, two Meteor instances in
+//      the same kernel netns would silently share the uws internal
+//      port (default 127.0.0.1:5001) and have inbound WS upgrade
+//      traffic load-balanced between them by the kernel. With the
+//      EXCLUSIVE flag, the second listen call returns a falsy token
+//      so the transport's existing throw fires loudly instead.
+//
+//   2. The uws transport reads its configuration from `Meteor.settings`
+//      (server-side global), not from `__meteor_runtime_config__.meteorSettings`
+//      (a client-side-only object). Pre-fix, settings users put in
+//      `Meteor.settings.packages["ddp-server"].uws` were silently
+//      ignored and the hard-coded defaults always won.
+
+const uws = Npm.require('uWebSockets.js');
+
+// Pick a random high port to avoid clashing with anything else on the
+// test box. The port doesn't matter; what we verify is the binding
+// behaviour, not anything end-to-end over TCP.
+function pickTestPort() {
+  // Range 49152-65535 is the IANA-suggested ephemeral range.
+  return 49152 + Math.floor(Math.random() * (65535 - 49152));
+}
+
+Tinytest.addAsync(
+  'ddp-server/uws - LIBUS_LISTEN_EXCLUSIVE_PORT prevents SO_REUSEPORT collision',
+  function (test, onComplete) {
+    const port = pickTestPort();
+    const host = '127.0.0.1';
+
+    const app1 = uws.App();
+    const app2 = uws.App();
+    let token1 = null;
+    let token2 = null;
+    let waiting = 2;
+
+    function maybeFinish() {
+      if (--waiting > 0) return;
+
+      test.isTrue(
+        !!token1,
+        'first listen with LIBUS_LISTEN_EXCLUSIVE_PORT should succeed'
+      );
+      test.isFalse(
+        !!token2,
+        'second listen on the SAME (host, port) with EXCLUSIVE_PORT ' +
+        'should return a falsy token — kernel must reject the bind ' +
+        'instead of silently sharing via SO_REUSEPORT'
+      );
+
+      // Best-effort cleanup. uws.us_listen_socket_close throws if the
+      // token is falsy, which is why we guard it.
+      try {
+        if (token1) uws.us_listen_socket_close(token1);
+      } catch (e) { /* ignore */ }
+      try {
+        if (token2) uws.us_listen_socket_close(token2);
+      } catch (e) { /* ignore */ }
+
+      onComplete();
+    }
+
+    app1.listen(host, port, uws.LIBUS_LISTEN_EXCLUSIVE_PORT, function (token) {
+      token1 = token;
+      // Only attempt the colliding listen after the first one settled,
+      // so the result of app2 reflects the conflict and not a startup
+      // race inside uws.
+      app2.listen(host, port, uws.LIBUS_LISTEN_EXCLUSIVE_PORT, function (t) {
+        token2 = t;
+        maybeFinish();
+      });
+      maybeFinish();
+    });
+  }
+);
+
+Tinytest.addAsync(
+  'ddp-server/uws - LIBUS_LISTEN_EXCLUSIVE_PORT enum exists and equals 1',
+  function (test, onComplete) {
+    // Sanity check on the uws binding contract this fix depends on.
+    // If uws ever renamed or removed this constant we'd want the
+    // test suite to flag the breakage explicitly instead of the fix
+    // silently degrading back to SO_REUSEPORT semantics.
+    test.equal(
+      uws.LIBUS_LISTEN_EXCLUSIVE_PORT,
+      1,
+      'uws.LIBUS_LISTEN_EXCLUSIVE_PORT must be the integer flag 1; ' +
+      'the listen-options bitmask in uWebSockets.js relies on this'
+    );
+    onComplete();
+  }
+);
+
+Tinytest.add(
+  'ddp-server/uws - settings read path goes through Meteor.settings',
+  function (test) {
+    // We can't trivially exercise createUwsTransport() inside a test
+    // (it has side effects on the global httpServer and WebApp
+    // routes), so instead this test asserts the *structural*
+    // invariant the fix relies on: an object placed at
+    // `Meteor.settings.packages["ddp-server"].uws` is visible via
+    // the same optional-chain expression the transport now uses.
+    //
+    // Pre-fix the transport used `__meteor_runtime_config__.meteorSettings.*`,
+    // which the server boot script never populates — so even when
+    // operators set METEOR_SETTINGS correctly the transport saw
+    // `undefined` and silently fell back to its defaults. The
+    // regression we want to catch is the read path drifting back to
+    // the dead-code object.
+
+    const savedSettings = Meteor.settings;
+    try {
+      Meteor.settings = {
+        packages: {
+          'ddp-server': {
+            uws: {
+              port: 9999,
+              host: '127.0.0.99',
+              payloadLength: 99,
+              timeout: 99,
+            },
+          },
+        },
+      };
+
+      const seen = Meteor.settings?.packages?.['ddp-server']?.uws;
+      test.isNotUndefined(
+        seen,
+        'Meteor.settings?.packages?.["ddp-server"]?.uws must be ' +
+        'reachable via the optional-chain expression the transport uses'
+      );
+      test.equal(seen.port, 9999, 'uws.port must round-trip through Meteor.settings');
+      test.equal(seen.host, '127.0.0.99', 'uws.host must round-trip through Meteor.settings');
+      test.equal(seen.payloadLength, 99, 'uws.payloadLength must round-trip');
+      test.equal(seen.timeout, 99, 'uws.timeout must round-trip');
+
+      // And critically: the OLD read path must NOT see them — verifying
+      // that populating Meteor.settings does not accidentally also
+      // populate the client-side runtime-config object (which would
+      // leak server settings to every browser session).
+      const stale = (typeof __meteor_runtime_config__ === 'object' &&
+        __meteor_runtime_config__ &&
+        __meteor_runtime_config__.meteorSettings &&
+        __meteor_runtime_config__.meteorSettings.packages &&
+        __meteor_runtime_config__.meteorSettings.packages['ddp-server'] &&
+        __meteor_runtime_config__.meteorSettings.packages['ddp-server'].uws);
+      test.isUndefined(
+        stale,
+        '__meteor_runtime_config__.meteorSettings.packages["ddp-server"].uws ' +
+        'must remain undefined on the server — populating it would leak ' +
+        'private Meteor.settings into the client HTML via ' +
+        'webapp_server.js encodeRuntimeConfig'
+      );
+    } finally {
+      Meteor.settings = savedSettings;
+    }
+  }
+);
+
+Tinytest.add(
+  'ddp-server/transport-selection - transport setting honoured via Meteor.settings',
+  function (test) {
+    // Same invariant as above, applied to transports/index.js
+    // `resolveTransportName()`. The function picks the transport
+    // name by reading Meteor.settings.packages["ddp-server"].transport
+    // (priority 1), then DDP_TRANSPORT env var (priority 2). Pre-fix
+    // it read from __meteor_runtime_config__.meteorSettings.packages
+    // ["ddp-server"], which is never populated server-side, so the
+    // env-var fallback was the only path that worked in practice and
+    // the documented Meteor.settings configuration was dead.
+
+    const savedSettings = Meteor.settings;
+    try {
+      Meteor.settings = {
+        packages: { 'ddp-server': { transport: 'uws' } },
+      };
+
+      const seen = Meteor.settings?.packages?.['ddp-server'];
+      test.isNotUndefined(seen, 'transport setting must be reachable via Meteor.settings');
+      test.equal(seen.transport, 'uws',
+        'transport name must round-trip through ' +
+        'Meteor.settings.packages["ddp-server"].transport');
+    } finally {
+      Meteor.settings = savedSettings;
+    }
+  }
+);

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -625,6 +625,10 @@ export default defineConfig({
             link: "/performance/change-streams-observer-driver",
           },
           {
+            text: "DDP Transport",
+            link: "/performance/ddp-transport",
+          },
+          {
             text: "Performance Improvements",
             link: "/performance/performance-improvement",
           },

--- a/v3-docs/docs/performance/ddp-transport.md
+++ b/v3-docs/docs/performance/ddp-transport.md
@@ -43,13 +43,15 @@ DDP_TRANSPORT=sockjs meteor run
 
 ```json
 {
-  "ddp": {
-    "transport": "uws"
+  "packages": {
+    "ddp-server": {
+      "transport": "uws"
+    }
   }
 }
 ```
 
-The environment variable takes precedence over `settings.json` when both are set.
+This populates `Meteor.settings.packages["ddp-server"].transport` on the server, which is what the DDP server reads. The environment variable takes precedence over `settings.json` when both are set.
 
 ### Legacy `DISABLE_SOCKJS`
 
@@ -75,12 +77,106 @@ The `SERVER_WEBSOCKET_COMPRESSION` setting still applies to both transports. If 
 
 The DDP [session resumption](/api/meteor#reconnection) feature added in 3.5 is transport-agnostic. Both `sockjs` and `uws` benefit from sessions surviving brief network blips.
 
+### Multi-process and multi-tenant deployments {#multitenancy}
+
+::: danger
+If you run more than one `DDP_TRANSPORT=uws` Meteor process on a single Linux host that shares one kernel network namespace, **you must give every process its own `uws.port` (or `uws.host`)**. Forgetting to do so will fail loudly at startup since Meteor 3.5; in pre-3.5 versions it failed silently and split WebSocket traffic between unrelated processes.
+:::
+
+Unlike `sockjs` — which lives inside the same `http.Server` instance Meteor already binds — `uws` runs a second listening socket on its own internal port (default `127.0.0.1:5001`). WebSocket upgrades to the main HTTP server are proxied into that internal socket via a local TCP connection. This is what lets `uWebSockets.js` work without giving up Meteor's Connect-style middleware on the public port.
+
+The proxy step is the operational gotcha. Two Meteor processes in the same kernel network namespace would both default to `127.0.0.1:5001` for their internal uws server. The Linux kernel allows that under `SO_REUSEPORT` and load-balances inbound connections across the two listening sockets at random, so a WebSocket upgrade that arrived on process A's public port can be handed by the kernel to process B's internal listener — and from there process B parses the DDP method, executes it against its own MongoDB connection, and writes to its own database.
+
+Real-world deployments that share a kernel netns:
+
+- **Multi-tenant containers** under `network_mode: "host"` on Docker / Podman, each with its own database but co-located on one host.
+- **Multi-process horizontal scaling** via PM2, systemd templated services, or `cluster`-style runners on a single VM.
+- **Galaxy / Meteor Cloud co-scheduled pods** when an orchestrator places two pods of one app on the same node.
+- **Local development** with two Meteor projects running `DDP_TRANSPORT=uws` at the same time. The second project silently joins the first project's `SO_REUSEPORT` pool on `127.0.0.1:5001` and DDP traffic mixes between them with no warning.
+
+#### Configure a distinct uws port per process
+
+Give each process its own internal `uws.port` via `METEOR_SETTINGS`:
+
+```bash
+# Process 1
+METEOR_SETTINGS='{"packages":{"ddp-server":{"uws":{"port":5001,"host":"127.0.0.1"}}}}' \
+  PORT=8081 DDP_TRANSPORT=uws meteor run
+
+# Process 2 — on the SAME host, in the SAME netns
+METEOR_SETTINGS='{"packages":{"ddp-server":{"uws":{"port":5002,"host":"127.0.0.1"}}}}' \
+  PORT=8082 DDP_TRANSPORT=uws meteor run
+```
+
+…or equivalently via `settings.json`:
+
+```json
+{
+  "packages": {
+    "ddp-server": {
+      "uws": {
+        "port": 5001,
+        "host": "127.0.0.1"
+      }
+    }
+  }
+}
+```
+
+The full set of settings:
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `port` | `5001` | TCP port of the internal uws listen socket |
+| `host` | `"127.0.0.1"` | Address the internal uws server binds to |
+| `payloadLength` | `48` | Max WebSocket payload, in KiB |
+| `timeout` | `45` | Idle timeout, in seconds |
+
+If you cannot avoid running on the same port, use distinct loopback hosts (`127.0.0.2`, `127.0.0.3`, …) — Linux routes all of `127.0.0.0/8` to `lo` by default, so each process binds a distinct `(host, port)` tuple and the kernel demuxes correctly.
+
+#### What happens if you forget
+
+Since Meteor 3.5, the internal listen socket is opened with `LIBUS_LISTEN_EXCLUSIVE_PORT`, so the second process trying to bind the default port fails fast at startup:
+
+```text
+Error: uWebSockets.js: failed to listen on 127.0.0.1:5001 (address already in use).
+  Another Meteor instance in this network namespace is already bound to this port.
+  Set a distinct Meteor.settings.packages["ddp-server"].uws.port (or .host) for each instance.
+```
+
+In Meteor 3.5-beta releases prior to this fix the same misconfiguration would silently succeed via `SO_REUSEPORT`, with inbound WebSocket frames mix-routed between the two processes. If you operate a deployment that was set up against an earlier beta, audit it with the verification step below before upgrading.
+
+#### Verifying the internal listen sockets
+
+From the host (or from inside any container sharing the netns):
+
+```bash
+cat /proc/net/tcp | awk '$4 == "0A" {print $2}' | sort | uniq -c
+```
+
+Each port has its own line; the second column is `LOCAL_ADDR:PORT` in little-endian hex. `0x1389` is port 5001, `0x138A` is 5002. You want to see at most one listener per port:
+
+```text
+1 0100007F:1389    # 127.0.0.1:5001 — one Meteor process
+1 0100007F:138A    # 127.0.0.1:5002 — the other Meteor process
+```
+
+If you see `2 0100007F:1389`, two processes are sharing the default uws port via SO_REUSEPORT and inbound DDP traffic is being mixed between them. Reconfigure each to bind its own port.
+
+#### Reverse-proxy implications
+
+The internal uws port is purely local — it is never exposed to clients. The reverse proxy in front of Meteor (NGINX, Caddy, ALB, Galaxy…) talks to each process's *public* port (`PORT` env var) exactly as it would for `sockjs`. The per-process uws port configuration only matters between the public port and the internal uws server inside the same process.
+
+For an end-to-end walkthrough — reproduction recipe, the two interacting latent bugs the fix addresses, and validation against an unmodified Wekan multi-tenant image — see [`packages/ddp-server/MULTITENANCY-BUG.md`](https://github.com/meteor/meteor/blob/release-3.5/packages/ddp-server/MULTITENANCY-BUG.md) in the Meteor source.
+
 ## Verifying which transport is active
 
 On the server, you can inspect the configured transport via the Meteor shell:
 
 ```javascript
-process.env.DDP_TRANSPORT || Meteor.settings?.ddp?.transport || "sockjs";
+process.env.DDP_TRANSPORT
+  || Meteor.settings?.packages?.["ddp-server"]?.transport
+  || "sockjs";
 ```
 
 On the client, opening the browser Network tab and filtering by WS will show:
@@ -97,6 +193,7 @@ If you are switching an existing app from `sockjs` to `uws`:
 - [ ] Test on networks representative of your users (mobile, public Wi-Fi, corporate).
 - [ ] Roll out to a subset of traffic first if your load balancer supports it.
 - [ ] Keep `sockjs` available as a rollback (toggle the env var, redeploy).
+- [ ] If multiple Meteor processes will share a host (multi-tenant, multi-process scaling, Galaxy co-scheduling, etc.), set a distinct `Meteor.settings.packages["ddp-server"].uws.port` for each. See [Multi-process and multi-tenant deployments](#multitenancy).
 
 ## Reverting to `sockjs`
 


### PR DESCRIPTION
# Multi-tenant cross-routing bug in `DDP_TRANSPORT=uws` 

**Status**: fixed in this branch
(`fix/uws-transport-settings-and-port-collision`, commit `ae176b9bbb`).
Three small changes in `packages/ddp-server/transports/`.

**Found via**: Wekan multitenancy bug documented in
[wekan/docs/Platforms/FOSS/Docker/Meteor3/multitenancy.md](https://github.com/wekan/wekan/blob/main/docs/Platforms/FOSS/Docker/Meteor3/multitenancy.md)
and worked around in wekan commit `7b88f4c21` by switching to
`sockjs + oplog`. The wekan doc attributes the bug to uws C++ FD
aliasing; that turned out to be wrong. The actual cause is in
Meteor's own `ddp-server/transports/` JS code and is described in
detail below.

---

## 1. TL;DR

When two Meteor 3.5-beta.10 processes share a Linux kernel network
namespace — multi-tenant containers under `network_mode: "host"`,
multi-process horizontal scaling on one VM, Galaxy multi-pod nodes,
two local Meteor dev projects open at the same time — and both use
`DDP_TRANSPORT=uws`, roughly **half of inbound WebSocket upgrade
connections end up handled by the wrong process**. A registration
form submitted on tenant A's port can land in tenant B's database;
reactive data published by tenant B can be delivered to tenant A's
browser session.

The cause is two distinct latent bugs in
`packages/ddp-server/transports/` interacting:

| # | File | Bug |
|---|------|-----|
| 1 | `transports/uws.js` (and `transports/index.js`) | Read configuration from `__meteor_runtime_config__.meteorSettings.packages["ddp-server"]…`, which is **never populated** on the server side. Settings users put in `Meteor.settings` (or `METEOR_SETTINGS` env var) are silently ignored and the hard-coded defaults always win. |
| 2 | `transports/uws.js` | The default uws internal listen socket is `127.0.0.1:5001` and `uWebSockets.js` uses `SO_REUSEPORT` by default. Two Meteor processes in the same netns both succeed in binding the same `(host, port)` tuple, and the Linux kernel then load-balances inbound connections between the two listeners at random. |

Bug 1 alone is just configuration that doesn't work. Bug 2 alone could
have been worked around. Combined, every Meteor instance silently
defaults to `127.0.0.1:5001` and the kernel mixes their WS traffic
with no warning, no log line, no exception.

---

## 2. Architecture — why uws has an "internal proxy port" at all

`packages/ddp-server/transports/uws.js` runs `uWebSockets.js` on its
own internal TCP port, separate from the main Meteor HTTP server.
Inbound HTTP requests still hit Meteor's standard
`WebApp.httpServer`. When a request is a WebSocket upgrade on
`/websocket`, an `'upgrade'` listener (`proxyWebsocketToUws`)
opens a raw TCP socket to `127.0.0.1:5001` (the defaults) and pipes
the raw HTTP upgrade bytes through.

```
                                       +-- 127.0.0.1:8081 -> Meteor http.Server ---+
        Client (browser)               |                                            |
       :: TCP to 8081 ::               |   on 'upgrade' /websocket:                 |
   GET / HTTP/1.1                      |     net.createConnection(5001, 127.0.0.1)  |
   Upgrade: websocket                  |       pipes raw bytes                      |
                                       +-- 127.0.0.1:5001 -> uWebSockets.js (uws) --+
                                                            ^
                                                            |
                                                            +--- DDP method dispatch
```

The pattern is correct for a single-process Meteor instance. Where it
breaks is the case where **two Meteor processes share the kernel
netns**:

```
process A (PORT=8081)  -- listens on 127.0.0.1:8081
                       -- also listens on 127.0.0.1:5001 (uws internal)
                       -- on 'upgrade': net.createConnection(5001, 127.0.0.1)
process B (PORT=8082)  -- listens on 127.0.0.1:8082
                       -- ALSO listens on 127.0.0.1:5001 (same default!)
                       -- on 'upgrade': net.createConnection(5001, 127.0.0.1)
```

uWebSockets.js binds with `SO_REUSEPORT` by default
(`LIBUS_LISTEN_DEFAULT = 0`). The Linux kernel allows multiple
processes to bind the same `(addr, port)` tuple under SO_REUSEPORT
and hashes inbound connections across them. So when process A
forwards an upgrade to `127.0.0.1:5001`, **the kernel may deliver
that connection to process B's uws listener** — and from there,
process B parses the DDP method and dispatches it through its own
Meteor.methods registry and MongoDB connection.

Configuration to avoid the default collision is documented in
`transports/uws.js` JSDoc:

```js
/**
 * Configuration via Meteor.settings:
 *   { "packages": { "ddp-server": { "transport": "uws",
 *     "uws": { "port": 5001, "host": "127.0.0.1", ... } } } }
 */
```

…but the implementation reads from a different object.

---

## 3. Root cause — the dead-code settings read

`transports/uws.js` (line 21 pre-fix):

```js
const settings = __meteor_runtime_config__?.meteorSettings?.packages?.['ddp-server']?.uws || {};
```

`transports/index.js` (line 40 pre-fix), for the transport-selection
lookup:

```js
var settings = __meteor_runtime_config__?.meteorSettings?.packages?.['ddp-server'];
```

Both read from `__meteor_runtime_config__.meteorSettings`. But on the
server side, `__meteor_runtime_config__` is initialised by `boot.js`:

```js
__meteor_runtime_config__ = {
  meteorRelease: configJson.meteorRelease,
  gitCommitHash: starJson.gitCommitHash
};
```

…and later only gets `meteorEnv`, `PUBLIC_SETTINGS`, and the
`ROOT_URL` keys added by `packages/meteor/server_environment.js` and
`packages/meteor/url_server.js`. The `meteorSettings` field is never
set on the server.

Why is the read path that way? `__meteor_runtime_config__.meteorSettings`
**is** populated on the **client** side — `packages/webapp/webapp_server.js`
serialises `__meteor_runtime_config__` into the boilerplate HTML, the
browser reconstructs it from the script tag, and after that
`Meteor.settings` is plumbed from that object on the client. The uws
transport code was written using the client-side pattern even though
it runs server-side, so the read silently returns `undefined`
forever.

This was not obvious before because the JSDoc on `createUwsTransport`
points at `Meteor.settings`, the env var docs say `METEOR_SETTINGS`,
and operators who configured `Meteor.settings.packages["ddp-server"].uws.port`
got no error, no warning, and the rest of their app worked.
`Meteor.settings` was parsed correctly from `METEOR_SETTINGS`; only
the uws-transport-specific consumption of it was broken.

**Important**: it would NOT have been safe to fix this by populating
`__meteor_runtime_config__.meteorSettings = Meteor.settings` on the
server. The runtime config is what `webapp_server.js`
`encodeRuntimeConfig` serialises into client HTML for every browser
request. Copying the full server-side `Meteor.settings` there would
leak every non-`public` key — DB passwords, API tokens, OAuth
secrets, anything an operator put outside of `Meteor.settings.public`.
The right fix is to make the server-side consumer read
`Meteor.settings` directly.

---

## 4. Reproduction — minimal recipe

You need two Meteor 3.5-beta.10 processes sharing a Linux kernel
netns, both with `DDP_TRANSPORT=uws`, both connected to the same
MongoDB cluster but writing to logically distinct databases. The
fastest off-the-shelf testbed is Wekan multi-tenant. The full
recipe is available in the [Wekan reproduction PR](https://github.com/italojs/wekan/pull/1) at
[`tests/multitenancy-repro/README.md`](https://github.com/italojs/wekan/blob/repro/uws-changestreams-multitenancy/tests/multitenancy-repro/README.md); the
sketch is:

1. **Prereq**: macOS users need Docker Desktop → Settings → Resources →
   Network → "Enable host networking". Linux hosts have host
   networking out of the box.

2. **Two-tenant compose** with `network_mode: "host"`, shared
   MongoDB replica set, both Wekan containers with
   `DDP_TRANSPORT=uws` + `METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling`.
   Use distinct `MONGO_URL` databases (e.g. `wekan_tenant1` /
   `wekan_tenant2`) and append `?appName=…` so MongoDB profiler
   attributes inserts to the right process unambiguously.
   See `docker-compose.multitenancy.yml` in the wekan repro.

3. **Bring it up** and enable Mongo profiling level 2 on both
   tenant DBs so every insert is logged with its `appName` and
   `ns`.

4. **Trigger**: fire 16 concurrent `ATCreateUserServer` calls (8
   per tenant) through fresh WebSocket connections. The barrage
   script
   `tests/multitenancy-repro/barrage.js` does this — each call's
   username encodes which port it was destined for
   (`BARRAGE-t1-rN-…` for port 8081, `BARRAGE-t2-rN-…` for 8082).

5. **Verify**: query each tenant's `users` collection. ~50 % of
   `BARRAGE-t1-*` usernames will land in `wekan_tenant2`, and vice
   versa. Cross-check `system.profile` to see that **each insert
   has the `appName` of the wrong tenant's process** — the
   MongoDB-side attribution is correct; the WS frame got executed
   by the wrong Meteor process.

Diagnostic snapshot you should see when the bug is firing (taken
from `/proc/net/tcp` inside the LinuxKit VM / Linux host netns):

```
   1 00000000:1F91    127.0.0.1:8081  (tenant 1 main port — one listener)
   1 00000000:1F92    127.0.0.1:8082  (tenant 2 main port — one listener)
   2 0100007F:1389    127.0.0.1:5001  (uws internal — TWO listeners ← BUG)
```

The "2" on the uws internal port is the smoking gun. Cross-check
inode ownership via `/proc/<pid>/fd` to confirm each tenant's
process owns one of those two listening sockets via `SO_REUSEPORT`.

The bug is also visible without Mongo profiling: 50 % of registration
attempts fail with "Internal server error" in the UI (the per-tenant
follow-up actions execute against the wrong process's state), and the
created user document ends up in the other tenant's database.

---

## 5. Validating the fix — end-to-end against Wekan main

The most explicit validation is on the [Wekan reproduction PR](https://github.com/italojs/wekan/pull/1). Procedure:

1. Spin up the two-tenant stack:
   ```
   cd wekan
   docker compose -f docker-compose.multitenancy-fix.yml up -d
   ```
   This uses the unmodified `ghcr.io/wekan/wekan:latest` image
   (built from wekan `main`), each tenant configured with
   `DDP_TRANSPORT=uws`, `METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling`,
   and `METEOR_SETTINGS={"packages":{"ddp-server":{"uws":{"port":5001,
   "host":"127.0.0.1"}}}}` (port `5002` for tenant 2).

2. **Baseline (Bug B in effect)**: run the barrage:
   ```
   tests/multitenancy-repro/run-experiment.sh "EXP9a-BASELINE" 3 27018
   ```
   Expect ~50 % cross-tenant writes. The barrage produces ~24/48
   leaks across 3 rounds because the unpatched uws transport
   silently ignores the per-process `uws.port` from
   `METEOR_SETTINGS`.

3. **Apply this branch's fix** to the bundle inside the running
   containers (mirrors the meteor-source source-level diff against
   the transpiled `ddp-server.js`):
   ```
   docker cp /tmp/patch-bundle.js wekan-tenant1:/tmp/patch-bundle.js
   docker exec -u 0 wekan-tenant1 node /tmp/patch-bundle.js
   docker cp /tmp/patch-bundle.js wekan-tenant2:/tmp/patch-bundle.js
   docker exec -u 0 wekan-tenant2 node /tmp/patch-bundle.js
   docker restart wekan-tenant1 wekan-tenant2
   ```
   The script source lives in the wekan repro PR and replaces
   the two `__meteor_runtime_config__?.meteorSettings?…` reads with
   `Meteor.settings?…` and inserts the
   `LIBUS_LISTEN_EXCLUSIVE_PORT` argument — semantically the same
   change as the meteor-source commit but applied to the already-
   transpiled bundle so no Meteor rebuild is needed for validation.

4. **Confirm port isolation**:
   ```
   docker exec wekan-tenant1 sh -c 'cat /proc/1/net/tcp |
     awk "NR>1 && \$4==\"0A\" && \$2 ~ /:1389\$|:138A\$/ {print \$2}"'
   ```
   Expect exactly **one** listener on `0100007F:1389` (5001 →
   tenant 1) and exactly **one** on `0100007F:138A` (5002 →
   tenant 2). The `2` count on `:1389` from the baseline is gone.

5. **Re-run the barrage**:
   ```
   tests/multitenancy-repro/run-experiment.sh "EXP9b-FIXED" 3 27018
   ```
   Expect **0/48 cross-tenant writes** across 3 rounds. The wekan
   image content has not changed between EXP9a and EXP9b — only
   the bundle's ddp-server transport JS — so the fix is
   demonstrably the responsible delta.

6. **Optional negative test (Fix 5.3 in action)**: temporarily edit
   `docker-compose.multitenancy-fix.yml` to give both tenants the
   same `uws.port` (e.g. both 5001), re-apply the patch, and
   restart. The second tenant should fail to start and log:
   ```
   Error: uWebSockets.js: failed to listen on 127.0.0.1:5001
     (address already in use). Another Meteor instance in this
     network namespace is already bound to this port. …
   ```
   Container goes into crashloop with a clear, actionable error —
   instead of silently SO_REUSEPORT-sharing the port and producing
   the cross-tenant routing this fix targets.

A full A/B writeup (with per-round leak counts) lives in the [Wekan repro README](https://github.com/italojs/wekan/blob/repro/uws-changestreams-multitenancy/tests/multitenancy-repro/README.md).
