### PR TITLE
Make local dev Mongo connection monitor sleep tolerant

### DIFF
--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -34,6 +34,14 @@ export const MongoConnection = function (url, options) {
     ignoreUndefined: true,
   }, userOptions);
 
+  if (
+    Meteor.isDevelopment &&
+    mongoOptions.connectTimeoutMS === undefined &&
+    /^mongodb:\/\/(?:127\.0\.0\.1|localhost):3001(?:\/|$)/.test(url)
+  ) {
+    mongoOptions.connectTimeoutMS = 86400000;
+  }
+
 
 
   // Internally the oplog connections specify their own maxPoolSize


### PR DESCRIPTION
### What this changes

When a Meteor app uses the embedded development MongoDB server (`127.0.0.1:3001` or `localhost:3001`), set a longer default `connectTimeoutMS` for the MongoDB driver monitor connection. This avoids treating ordinary machine sleep/standby as an immediate monitor timeout when the app process wakes.

The default is only applied when all of these are true:

- `Meteor.isDevelopment` is true
- the Mongo URL points at the embedded local dev Mongo port `3001`
- the app has not already configured `connectTimeoutMS` through `Mongo._connectionOptions` or `Meteor.settings.packages.mongo.options`

Production and custom Mongo deployments keep the existing driver defaults.

### Why

With recent Node/MongoDB driver versions, macOS sleep can resume with the monitor connection timing out against `127.0.0.1:3001`, clearing the pool and interrupting in-use connections with `PoolClearedOnNetworkError`. In local development this can crash the Meteor app process even though changing a file immediately restarts it successfully.

### Verification

- `node --check packages/mongo/mongo_connection.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved MongoDB connection stability for development environments by configuring extended timeout handling for local database instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->