### PR TITLE
Add accounts session resolver hook

### DIFF
--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -126,6 +126,12 @@ export namespace Accounts {
   function onPageLoadLogin(func: Function): void;
 
   function loginWithTokenAsync(token: string): Promise<Meteor.LoginMethodResult>;
+
+  function registerSessionResolver(
+    resolver: (
+      connection: Meteor.Connection
+    ) => string | null | undefined | Promise<string | null | undefined>
+  ): void;
 }
 
 export namespace Accounts {

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -112,10 +112,17 @@ export class AccountsCommon {
     if (options.collection instanceof Mongo.Collection) {
       collection = options.collection;
     } else {
-      collection = new Mongo.Collection(collectionName, {
+      const collectionOptions = {
         _preventAutopublish: true,
         connection: this.connection,
-      });
+      };
+      // Allow packages to provide a custom collection driver (e.g., for
+      // PostgreSQL-backed users). The _driver option is an existing
+      // Mongo.Collection extension point.
+      if (options.collectionDriver) {
+        collectionOptions._driver = options.collectionDriver;
+      }
+      collection = new Mongo.Collection(collectionName, collectionOptions);
     }
 
     return collection;

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -78,6 +78,11 @@ export class AccountsServer extends AccountsCommon {
 
     this._skipCaseInsensitiveChecksForTest = {};
 
+    // Session resolvers: functions that resolve a userId from a DDP
+    // connection's cookies/headers without requiring a DDP login method call.
+    // Used by cookie-based auth packages (e.g., better-auth).
+    this._sessionResolvers = [];
+
     // Helper function to resolve promises if needed
     this._resolvePromise = async (value) => {
       return Meteor._isPromise(value) ? await value : value;
@@ -636,6 +641,20 @@ export class AccountsServer extends AccountsCommon {
     });
   };
 
+  /**
+   * @summary Register a session resolver that can authenticate DDP connections
+   * from cookies or headers without requiring a DDP login method call.
+   * Resolvers run when a new DDP connection is established. If a resolver
+   * returns a userId string, that user is logged in on the connection.
+   * @locus Server
+   * @param {Function} resolver A function that receives a connection object
+   * (with id, httpHeaders, cookies) and returns a userId string or null/undefined.
+   * May be async.
+   */
+  registerSessionResolver(resolver) {
+    this._sessionResolvers.push(resolver);
+  };
+
 
   // Checks a user's credentials against all the registered login
   // handlers, and returns a login token if the credentials are valid. It
@@ -832,7 +851,32 @@ export class AccountsServer extends AccountsCommon {
         this._removeTokenFromConnection(connection.id);
         delete this._accountData[connection.id];
       });
+
+      // Run session resolvers to authenticate from cookies/headers.
+      // This runs asynchronously after the connection is established.
+      // If a resolver returns a userId, set it on the DDP session
+      // which reruns all subscriptions with the authenticated userId.
+      if (this._sessionResolvers.length > 0) {
+        this._resolveSessionForConnection(connection);
+      }
     });
+  };
+
+  async _resolveSessionForConnection(connection) {
+    try {
+      for (const resolver of this._sessionResolvers) {
+        const userId = await resolver(connection);
+        if (userId && typeof userId === 'string') {
+          const session = this._server.sessions.get(connection.id);
+          if (session) {
+            await session._setUserId(userId);
+          }
+          break;
+        }
+      }
+    } catch (e) {
+      Meteor._debug('Error in session resolver:', e);
+    }
   };
 
   _initServerPublications() {

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -153,7 +153,23 @@ var Session = function (server, version, socket, options) {
       }
     },
     clientAddress: self._clientAddress(),
-    httpHeaders: self.socket.headers
+    httpHeaders: self.socket.headers,
+    // Parsed cookies from the WebSocket handshake headers.
+    // Enables cookie-based auth packages to read session cookies
+    // from DDP connections.
+    get cookies() {
+      const cookieHeader = self.socket.headers.cookie || '';
+      const cookies = Object.create(null);
+      if (!cookieHeader) return cookies;
+      cookieHeader.split(';').forEach(pair => {
+        const eqIdx = pair.indexOf('=');
+        if (eqIdx < 0) return;
+        const key = pair.substring(0, eqIdx).trim();
+        const val = pair.substring(eqIdx + 1).trim();
+        if (key) cookies[key] = decodeURIComponent(val);
+      });
+      return cookies;
+    }
   };
 
   self.send({ msg: 'connected', session: self.id });

--- a/packages/ddp-server/transports/raw_connection.js
+++ b/packages/ddp-server/transports/raw_connection.js
@@ -22,7 +22,7 @@ export class RawWebSocketConnection extends EventEmitter {
       'referer', 'x-client-ip', 'x-forwarded-for',
       'x-forwarded-host', 'x-forwarded-port', 'x-cluster-client-ip',
       'via', 'x-real-ip', 'x-forwarded-proto', 'x-ssl', 'dnt',
-      'host', 'user-agent', 'accept-language'
+      'host', 'user-agent', 'accept-language', 'cookie'
     ];
     for (const key of headerKeys) {
       if (req.headers[key]) this.headers[key] = req.headers[key];

--- a/packages/meteor-accounts-better-auth/README.md
+++ b/packages/meteor-accounts-better-auth/README.md
@@ -1,0 +1,174 @@
+# meteor-accounts-better-auth
+
+`meteor-accounts-better-auth` bridges [Better Auth](https://www.better-auth.com/) with Meteor's accounts and DDP model.
+
+It lets you:
+
+- mount Better Auth HTTP endpoints inside a Meteor app
+- keep `Meteor.userId()` and method/publication auth in sync with Better Auth sessions
+- use Better Auth for email/password flows while still working with Meteor's account-facing APIs
+
+## Status
+
+This package is experimental, but already covers the first useful auth flows:
+
+- sign up
+- sign in
+- sign out
+- resend verification email
+- verify email from a token
+- request password reset
+- reset password
+- change password
+- restore DDP auth from the Better Auth session cookie on reconnect
+
+## How It Works
+
+On the server, the package:
+
+- mounts Better Auth under `/api/auth` by default
+- registers an Accounts session resolver for new DDP connections
+- reads the Better Auth signed session cookie from parsed DDP connection cookies
+- resolves the Meteor `userId` for that connection
+- exposes a Meteor method, `_betterAuth.syncSession`, for post-login and post-logout session syncing
+- publishes Better Auth-oriented user fields such as `email`, `emailVerified`, `name`, and `image`
+
+On the client, the package adds helpers to `Accounts` so your app can talk to Better Auth and then synchronize Meteor's connection state.
+
+## Installation
+
+Add the package to `.meteor/packages`:
+
+```text
+meteor-accounts-better-auth
+```
+
+Install the npm packages your app will use to create the Better Auth server and client:
+
+```bash
+npm install better-auth mongodb
+```
+
+## Server Setup
+
+Create the Better Auth instance in your Meteor app, then hand it to `Accounts.configureBetterAuth(...)`.
+
+```js
+import { Accounts } from "meteor/accounts-base";
+import { Random } from "meteor/random";
+import Module from "module";
+
+const nativeRequire = Module.createRequire(process.cwd() + "/package.json");
+const { betterAuth } = nativeRequire("better-auth");
+const { mongodbAdapter } = nativeRequire("better-auth/adapters/mongodb");
+const { toNodeHandler } = nativeRequire("better-auth/node");
+const { MongoClient } = nativeRequire("mongodb");
+
+const mongoClient = new MongoClient(process.env.MONGO_URL);
+const db = mongoClient.db();
+const rootUrl = process.env.ROOT_URL || "http://localhost:3000";
+
+const auth = betterAuth({
+  database: mongodbAdapter(db, { client: mongoClient }),
+  basePath: "/api/auth",
+  baseURL: rootUrl,
+  secret: process.env.BETTER_AUTH_SECRET,
+  advanced: {
+    database: {
+      generateId: () => Random.id(),
+    },
+  },
+  emailAndPassword: {
+    enabled: true,
+  },
+});
+
+Accounts.configureBetterAuth({
+  auth,
+  toNodeHandler,
+});
+```
+
+## Why The Extra MongoClient?
+
+Meteor bundles its own MongoDB driver internally, while Better Auth's Mongo adapter expects the app's npm `mongodb` driver objects.
+
+Using a fresh `MongoClient` created from the app's installed `mongodb` package avoids driver mismatch issues.
+
+## Client Setup
+
+Create a Better Auth client and register it once on the client:
+
+```js
+import { Accounts } from "meteor/accounts-base";
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+  baseURL: window.location.origin,
+});
+
+Accounts.setBetterAuthClient(authClient);
+```
+
+## Client API
+
+This package extends `Accounts` with the following helpers:
+
+- `Accounts.setBetterAuthClient(client)`
+- `Accounts.getBetterAuthClient()`
+- `Accounts.syncBetterAuthSession(sessionToken)`
+- `Accounts.refreshBetterAuthConnection()`
+- `Accounts.signInWithBetterAuth(email, password)`
+- `Accounts.signUpWithBetterAuth(email, password, name)`
+- `Accounts.signOutWithBetterAuth()`
+- `Accounts.sendVerificationEmailWithBetterAuth(email)`
+- `Accounts.requestPasswordResetWithBetterAuth(email, redirectTo)`
+- `Accounts.resetPasswordWithBetterAuth(token, newPassword)`
+- `Accounts.changePasswordWithBetterAuth(currentPassword, newPassword, options)`
+- `Accounts.verifyEmailWithBetterAuth(token)`
+
+## Server API
+
+The package adds:
+
+- `Accounts.configureBetterAuth({ auth, toNodeHandler, basePath, cookieName })`
+- `Accounts.getBetterAuth()`
+
+`Accounts.configureBetterAuth(...)` must be called exactly once on the server.
+
+Options:
+
+- `auth`: required Better Auth instance created by the app
+- `toNodeHandler`: optional Better Auth Node handler helper
+- `basePath`: optional HTTP mount path, defaults to `/api/auth`
+- `cookieName`: optional Better Auth session cookie name, defaults to `better-auth.session_token`
+
+## Published User Fields
+
+The package configures Meteor user publishing so Better Auth-oriented fields are available through `Meteor.user()`:
+
+- `email`
+- `emailVerified`
+- `emails`
+- `image`
+- `name`
+- `profile`
+- `username`
+
+For autopublish-style behavior, it also exposes:
+
+- logged-in user fields: `email`, `emailVerified`, `name`, `image`
+- other-user fields: `name`, `image`
+
+## Current Limitations
+
+- This package is experimental.
+- Social login, 2FA, and email-change flows are not included yet.
+- The package does not create the Better Auth instance for you; the Meteor app owns that setup.
+
+## Notes For Production
+
+- Set a real `BETTER_AUTH_SECRET`.
+- Replace dev-console email logging with a real mail transport.
+- Use a stable `ROOT_URL`.
+- Review Better Auth's cookie, trusted-origin, and deployment settings for your environment.

--- a/packages/meteor-accounts-better-auth/client/index.js
+++ b/packages/meteor-accounts-better-auth/client/index.js
@@ -1,0 +1,219 @@
+import { Meteor } from "meteor/meteor";
+import { Accounts } from "meteor/accounts-base";
+import { Tracker } from "meteor/tracker";
+
+const DEFAULT_COOKIE_NAME = "better-auth.session_token";
+const DEFAULT_RECONNECT_TIMEOUT_MS = 2000;
+
+let authClientInstance = null;
+
+function getCookie(name) {
+  const cookies = document.cookie.split(";");
+
+  for (const cookie of cookies) {
+    const eqIdx = cookie.indexOf("=");
+
+    if (eqIdx < 0) {
+      continue;
+    }
+
+    const key = cookie.substring(0, eqIdx).trim();
+
+    if (key === name) {
+      return decodeURIComponent(cookie.substring(eqIdx + 1).trim());
+    }
+  }
+
+  return null;
+}
+
+function unwrapBetterAuthError(result, fallbackMessage) {
+  if (result?.error) {
+    throw new Meteor.Error(
+      result.error.status || 400,
+      result.error.message || fallbackMessage
+    );
+  }
+
+  return result?.data ?? null;
+}
+
+Accounts.setBetterAuthClient = function setBetterAuthClient(client) {
+  authClientInstance = client;
+};
+
+Accounts.getBetterAuthClient = function getBetterAuthClient() {
+  if (!authClientInstance) {
+    throw new Error(
+      "better-auth client not set. Call Accounts.setBetterAuthClient(client) first."
+    );
+  }
+
+  return authClientInstance;
+};
+
+Accounts.syncBetterAuthSession = function syncBetterAuthSession(sessionToken) {
+  const token =
+    sessionToken !== undefined ? sessionToken : getCookie(DEFAULT_COOKIE_NAME);
+
+  return new Promise((resolve, reject) => {
+    Meteor.call("_betterAuth.syncSession", token || null, (error, result) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(result);
+    });
+  });
+};
+
+Accounts.refreshBetterAuthConnection = function refreshBetterAuthConnection() {
+  const connection = Meteor.connection;
+
+  return new Promise((resolve) => {
+    connection.disconnect();
+
+    const timeoutId = Meteor.setTimeout(() => {
+      computation.stop();
+      resolve();
+    }, DEFAULT_RECONNECT_TIMEOUT_MS);
+
+    const computation = Tracker.autorun(() => {
+      if (!connection.status().connected) {
+        return;
+      }
+
+      Meteor.clearTimeout(timeoutId);
+      computation.stop();
+      resolve();
+    });
+
+    connection.reconnect();
+  });
+};
+
+Accounts.signInWithBetterAuth = async function signInWithBetterAuth(
+  email,
+  password
+) {
+  const client = Accounts.getBetterAuthClient();
+  const data = unwrapBetterAuthError(
+    await client.signIn.email({ email, password }),
+    "Authentication failed"
+  );
+
+  await Accounts.syncBetterAuthSession(data?.token ?? null);
+  return data;
+};
+
+Accounts.signUpWithBetterAuth = async function signUpWithBetterAuth(
+  email,
+  password,
+  name
+) {
+  const client = Accounts.getBetterAuthClient();
+  const data = unwrapBetterAuthError(
+    await client.signUp.email({ email, password, name: name || "" }),
+    "Unable to create account"
+  );
+
+  await Accounts.syncBetterAuthSession(data?.token ?? null);
+  return data;
+};
+
+Accounts.signOutWithBetterAuth = async function signOutWithBetterAuth() {
+  const client = Accounts.getBetterAuthClient();
+
+  await client.signOut();
+  await Accounts.syncBetterAuthSession(null);
+};
+
+Accounts.sendVerificationEmailWithBetterAuth =
+  async function sendVerificationEmailWithBetterAuth(email) {
+    const client = Accounts.getBetterAuthClient();
+
+    return unwrapBetterAuthError(
+      await client.sendVerificationEmail({ email }),
+      "Unable to send verification email"
+    );
+  };
+
+Accounts.requestPasswordResetWithBetterAuth =
+  async function requestPasswordResetWithBetterAuth(email, redirectTo) {
+    const client = Accounts.getBetterAuthClient();
+
+    return unwrapBetterAuthError(
+      await client.requestPasswordReset({ email, redirectTo }),
+      "Unable to request password reset"
+    );
+  };
+
+Accounts.resetPasswordWithBetterAuth = async function resetPasswordWithBetterAuth(
+  token,
+  newPassword
+) {
+  const client = Accounts.getBetterAuthClient();
+
+  return unwrapBetterAuthError(
+    await client.resetPassword({ token, newPassword }),
+    "Unable to reset password"
+  );
+};
+
+Accounts.changePasswordWithBetterAuth =
+  async function changePasswordWithBetterAuth(
+    currentPassword,
+    newPassword,
+    options = {}
+  ) {
+    const client = Accounts.getBetterAuthClient();
+    const data = unwrapBetterAuthError(
+      await client.changePassword({
+        currentPassword,
+        newPassword,
+        revokeOtherSessions: options.revokeOtherSessions,
+      }),
+      "Unable to change password"
+    );
+
+    if (typeof data?.token === "string") {
+      await Accounts.syncBetterAuthSession(data.token);
+    } else {
+      await Accounts.refreshBetterAuthConnection();
+    }
+
+    return data;
+  };
+
+Accounts.verifyEmailWithBetterAuth = async function verifyEmailWithBetterAuth(
+  token
+) {
+  const response = await fetch(
+    `/api/auth/verify-email?token=${encodeURIComponent(token)}`,
+    {
+      credentials: "same-origin",
+      method: "GET",
+    }
+  );
+
+  let payload = null;
+
+  try {
+    payload = await response.json();
+  } catch (error) {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    throw new Meteor.Error(
+      response.status,
+      payload?.message || "Unable to verify email"
+    );
+  }
+
+  await Accounts.refreshBetterAuthConnection();
+  return payload;
+};
+
+export { Accounts };

--- a/packages/meteor-accounts-better-auth/meteor-accounts-better-auth.d.ts
+++ b/packages/meteor-accounts-better-auth/meteor-accounts-better-auth.d.ts
@@ -1,0 +1,43 @@
+export interface ConfigureBetterAuthOptions {
+  auth: any;
+  toNodeHandler?: (auth: any) => any;
+  basePath?: string;
+  cookieName?: string;
+}
+
+export interface BetterAuthPasswordOptions {
+  revokeOtherSessions?: boolean;
+}
+
+declare module "meteor/accounts-base" {
+  namespace Accounts {
+    function configureBetterAuth(options: ConfigureBetterAuthOptions): any;
+    function getBetterAuth(): any;
+    function setBetterAuthClient(client: any): void;
+    function getBetterAuthClient(): any;
+    function syncBetterAuthSession(sessionToken?: string | null): Promise<any>;
+    function refreshBetterAuthConnection(): Promise<void>;
+    function signInWithBetterAuth(email: string, password: string): Promise<any>;
+    function signUpWithBetterAuth(
+      email: string,
+      password: string,
+      name?: string
+    ): Promise<any>;
+    function signOutWithBetterAuth(): Promise<void>;
+    function sendVerificationEmailWithBetterAuth(email: string): Promise<any>;
+    function requestPasswordResetWithBetterAuth(
+      email: string,
+      redirectTo?: string
+    ): Promise<any>;
+    function resetPasswordWithBetterAuth(
+      token: string,
+      newPassword: string
+    ): Promise<any>;
+    function changePasswordWithBetterAuth(
+      currentPassword: string,
+      newPassword: string,
+      options?: BetterAuthPasswordOptions
+    ): Promise<any>;
+    function verifyEmailWithBetterAuth(token: string): Promise<any>;
+  }
+}

--- a/packages/meteor-accounts-better-auth/package-types.json
+++ b/packages/meteor-accounts-better-auth/package-types.json
@@ -1,0 +1,3 @@
+{
+  "typesEntry": "meteor-accounts-better-auth.d.ts"
+}

--- a/packages/meteor-accounts-better-auth/package.js
+++ b/packages/meteor-accounts-better-auth/package.js
@@ -1,0 +1,18 @@
+Package.describe({
+  summary: "Better Auth integration for Meteor accounts",
+  version: "0.1.0",
+});
+
+Package.onUse((api) => {
+  api.use("ecmascript");
+  api.use("accounts-base", ["client", "server"]);
+  api.imply("accounts-base", ["client", "server"]);
+  api.use("check", "server");
+  api.use("routepolicy", "server");
+  api.use("tracker", "client");
+  api.use("webapp", "server");
+
+  api.mainModule("server/index.js", "server");
+  api.mainModule("client/index.js", "client");
+  api.addAssets("meteor-accounts-better-auth.d.ts", "server");
+});

--- a/packages/meteor-accounts-better-auth/server/ddp-bridge.js
+++ b/packages/meteor-accounts-better-auth/server/ddp-bridge.js
@@ -1,0 +1,175 @@
+import { check, Match } from "meteor/check";
+import { Meteor } from "meteor/meteor";
+import { Accounts } from "meteor/accounts-base";
+
+const DEFAULT_COOKIE_NAME = "better-auth.session_token";
+
+export function parseCookieHeader(cookieHeader) {
+  const cookies = Object.create(null);
+
+  if (!cookieHeader) {
+    return cookies;
+  }
+
+  cookieHeader.split(";").forEach((pair) => {
+    const eqIdx = pair.indexOf("=");
+
+    if (eqIdx < 0) {
+      return;
+    }
+
+    const key = pair.substring(0, eqIdx).trim();
+    const value = pair.substring(eqIdx + 1).trim();
+
+    if (key) {
+      cookies[key] = decodeURIComponent(value);
+    }
+  });
+
+  return cookies;
+}
+
+export async function resolveSignedToken(auth, signedToken, cookieName) {
+  try {
+    const headers = new Headers();
+
+    headers.set("cookie", `${cookieName}=${signedToken}`);
+
+    const session = await auth.api.getSession({ headers });
+
+    return session?.user?.id || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function resolvePlainToken(auth, plainToken) {
+  try {
+    const ctx = await auth.$context;
+    const session = await ctx.adapter.findOne({
+      model: "session",
+      where: [{ field: "token", value: plainToken }],
+    });
+
+    if (
+      session?.userId &&
+      session.expiresAt &&
+      new Date(session.expiresAt) > new Date()
+    ) {
+      return session.userId;
+    }
+  } catch (error) {
+    return null;
+  }
+
+  return null;
+}
+
+export async function resolveConnectionUserId({
+  auth,
+  cookies,
+  cookieHeader,
+  cookieName = DEFAULT_COOKIE_NAME,
+}) {
+  const resolvedCookies = cookies || parseCookieHeader(cookieHeader);
+  const signedToken = resolvedCookies[cookieName];
+
+  if (!signedToken) {
+    return null;
+  }
+
+  return resolveSignedToken(auth, signedToken, cookieName);
+}
+
+export async function syncConnectionAuthState({
+  auth,
+  sessionToken,
+  invocation,
+}) {
+  if (!invocation) {
+    return null;
+  }
+
+  if (!sessionToken) {
+    if (invocation.userId) {
+      await invocation.setUserId(null);
+    }
+
+    return null;
+  }
+
+  const userId = await resolvePlainToken(auth, sessionToken);
+
+  if (userId) {
+    if (invocation.userId !== userId) {
+      await invocation.setUserId(userId);
+    }
+
+    return { userId };
+  }
+
+  if (invocation.userId) {
+    await invocation.setUserId(null);
+  }
+
+  return null;
+}
+
+async function attachConnectionUserId(connection, userId) {
+  const session = Meteor.server.sessions.get(connection.id);
+
+  if (session) {
+    await session._setUserId(userId);
+  }
+}
+
+export function configureDDPBridge(
+  auth,
+  { cookieName = DEFAULT_COOKIE_NAME } = {}
+) {
+  if (typeof Accounts.registerSessionResolver === "function") {
+    Accounts.registerSessionResolver((connection) =>
+      resolveConnectionUserId({
+        auth,
+        cookies: connection.cookies,
+        cookieHeader: connection.httpHeaders?.cookie || "",
+        cookieName,
+      })
+    );
+  } else {
+    Meteor.onConnection(async (connection) => {
+      const userId = await resolveConnectionUserId({
+        auth,
+        cookieHeader: connection.httpHeaders?.cookie || "",
+        cookieName,
+      });
+
+      if (!userId) {
+        return;
+      }
+
+      try {
+        // Compatibility fallback for Meteor versions without
+        // Accounts.registerSessionResolver.
+        await attachConnectionUserId(connection, userId);
+      } catch (error) {
+        Meteor._debug(
+          "[meteor-accounts-better-auth] Error setting userId on connection:",
+          error
+        );
+      }
+    });
+  }
+
+  Meteor.methods({
+    async "_betterAuth.syncSession"(sessionToken) {
+      check(sessionToken, Match.OneOf(String, null, undefined));
+
+      return syncConnectionAuthState({
+        auth,
+        invocation: this,
+        sessionToken,
+      });
+    },
+  });
+}

--- a/packages/meteor-accounts-better-auth/server/handler.js
+++ b/packages/meteor-accounts-better-auth/server/handler.js
@@ -1,0 +1,111 @@
+import { RoutePolicy } from "meteor/routepolicy";
+import { WebApp } from "meteor/webapp";
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    if (req.body !== undefined) {
+      if (typeof req.body === "string" || Buffer.isBuffer(req.body)) {
+        resolve(req.body);
+        return;
+      }
+
+      resolve(JSON.stringify(req.body));
+      return;
+    }
+
+    const chunks = [];
+
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+export function mountBetterAuthHandler(
+  auth,
+  basePath = "/api/auth",
+  toNodeHandler
+) {
+  RoutePolicy.declare(`${basePath}/`, "network");
+
+  if (toNodeHandler) {
+    WebApp.handlers.use(basePath, toNodeHandler(auth));
+    return;
+  }
+
+  WebApp.handlers.use(basePath, async (req, res) => {
+    try {
+      const protocol = req.headers["x-forwarded-proto"] || "http";
+      const host = req.headers.host;
+      const url = `${protocol}://${host}${basePath}${req.url}`;
+      const headers = new Headers();
+
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (!value) {
+          continue;
+        }
+
+        if (Array.isArray(value)) {
+          value.forEach((item) => headers.append(key, item));
+        } else {
+          headers.set(key, value);
+        }
+      }
+
+      const requestInit = {
+        headers,
+        method: req.method,
+      };
+
+      if (req.method !== "GET" && req.method !== "HEAD") {
+        requestInit.body = await readRequestBody(req);
+
+        if (!headers.has("content-type") && requestInit.body) {
+          headers.set("content-type", "application/json");
+        }
+      }
+
+      const response = await auth.handler(new Request(url, requestInit));
+
+      res.statusCode = response.status;
+      response.headers.forEach((value, key) => {
+        if (key.toLowerCase() === "set-cookie") {
+          const cookies = response.headers.getSetCookie
+            ? response.headers.getSetCookie()
+            : [value];
+
+          cookies.forEach((cookie) => res.appendHeader("Set-Cookie", cookie));
+          return;
+        }
+
+        res.setHeader(key, value);
+      });
+
+      if (!response.body) {
+        res.end();
+        return;
+      }
+
+      const reader = response.body.getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          break;
+        }
+
+        res.write(value);
+      }
+
+      res.end();
+    } catch (error) {
+      console.error("[meteor-accounts-better-auth] Handler error:", error);
+
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.end("Internal Server Error");
+      }
+    }
+  });
+}

--- a/packages/meteor-accounts-better-auth/server/index.js
+++ b/packages/meteor-accounts-better-auth/server/index.js
@@ -1,0 +1,68 @@
+import { Accounts } from "meteor/accounts-base";
+import { configureDDPBridge } from "./ddp-bridge";
+import { mountBetterAuthHandler } from "./handler";
+
+const DEFAULT_BASE_PATH = "/api/auth";
+const DEFAULT_COOKIE_NAME = "better-auth.session_token";
+const DEFAULT_PUBLISH_FIELDS = {
+  email: 1,
+  emailVerified: 1,
+  emails: 1,
+  image: 1,
+  name: 1,
+  profile: 1,
+  username: 1,
+};
+
+let authInstance = null;
+
+function configureUserPublishing() {
+  if (typeof Accounts.setDefaultPublishFields === "function") {
+    Accounts.setDefaultPublishFields(DEFAULT_PUBLISH_FIELDS);
+  }
+
+  if (typeof Accounts.addAutopublishFields === "function") {
+    Accounts.addAutopublishFields({
+      forLoggedInUser: ["email", "emailVerified", "name", "image"],
+      forOtherUsers: ["name", "image"],
+    });
+  }
+}
+
+Accounts.configureBetterAuth = function configureBetterAuth(options = {}) {
+  if (authInstance) {
+    throw new Error("Accounts.configureBetterAuth() can only be called once");
+  }
+
+  if (!options.auth) {
+    throw new Error(
+      "Accounts.configureBetterAuth() requires an `auth` option created in the app."
+    );
+  }
+
+  authInstance = options.auth;
+
+  mountBetterAuthHandler(
+    authInstance,
+    options.basePath || DEFAULT_BASE_PATH,
+    options.toNodeHandler
+  );
+  configureDDPBridge(authInstance, {
+    cookieName: options.cookieName || DEFAULT_COOKIE_NAME,
+  });
+  configureUserPublishing();
+
+  return authInstance;
+};
+
+Accounts.getBetterAuth = function getBetterAuth() {
+  if (!authInstance) {
+    throw new Error(
+      "better-auth is not configured. Call Accounts.configureBetterAuth({ auth }) first."
+    );
+  }
+
+  return authInstance;
+};
+
+export { Accounts };

--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -549,6 +549,7 @@ export namespace Meteor {
     onClose: (callback: () => void) => void;
     clientAddress: string;
     httpHeaders: Record<string, string>;
+    cookies: Record<string, string>;
   }
 
   function onConnection(callback: (connection: Connection) => void): void;


### PR DESCRIPTION
## Summary

This adds a Better Auth integration package plus the small server-side Accounts/DDP extension points it needs to restore DDP user identity from initial connection metadata instead of a DDP login method call.

This draft is based on `release-3.5` / `meteor/meteor#14112` so it is evaluated against the pending accounts-system changes in that branch.

Changes included here:

- add `packages/meteor-accounts-better-auth`, an experimental Better Auth bridge package for Meteor accounts and DDP auth
- allow `AccountsServer` collection creation to receive a custom `collectionDriver`, so packages can back `Meteor.users` with an alternate collection driver
- expose parsed WebSocket handshake cookies on the DDP connection handle as `connection.cookies`
- add `Accounts.registerSessionResolver(resolver)`, which lets server packages resolve a `userId` from a new DDP connection headers/cookies and apply it to the session
- update the TypeScript declarations for `Meteor.Connection.cookies`, the Accounts resolver hook, and the Better Auth package APIs
- preserve cookies in 3.5's raw WebSocket transport header whitelist so `connection.cookies` works outside SockJS/uWS too

## Better Auth package

The new `meteor-accounts-better-auth` package bridges Better Auth HTTP sessions into Meteor accounts and DDP auth. It mounts Better Auth handlers, registers the new Accounts session resolver when available, exposes a sync method for post-login/logout state, and adds client helpers on `Accounts`.

