### PR TITLE
Share one MongoDB change stream per collection (fix #14453 fanout)

### DIFF
--- a/packages/mongo/changestream_multiplexer.js
+++ b/packages/mongo/changestream_multiplexer.js
@@ -1,0 +1,258 @@
+import { Meteor } from 'meteor/meteor';
+
+/**
+ * ChangeStreamMultiplexer — one shared MongoDB change stream per collection.
+ *
+ * Before this existed, every ChangeStreamObserveDriver opened its OWN
+ * `collection.watch()` cursor. Because the driver always watches the whole
+ * collection (empty pipeline) with constant options (`fullDocument:
+ * 'updateLookup'`, `fullDocumentBeforeChange: 'whenAvailable'`) and does all
+ * selector filtering in-process via its matcher, N distinct publication
+ * selectors on the same hot collection produced N identical server-side change
+ * stream cursors. Every write then fanned out to all N cursors and, with
+ * updateLookup, triggered N post-image lookups — the meteor/meteor#14453
+ * production latency regression.
+ *
+ * This class collapses that fanout: it opens exactly ONE change stream per
+ * collection and multicasts each raw change event, in-process, to every
+ * subscribed driver (which still runs its own matcher/projection). This mirrors
+ * how the oplog driver shares a single oplog tail and dispatches via a crossbar.
+ *
+ * It also owns the stream lifecycle — error/close driven restarts with
+ * `startAfter: resumeToken` resume — in ONE place. Drivers are never re-opened
+ * on a restart, which is what made the old per-driver restart path corrupt
+ * (duplicate `added`, "ready twice", and a leaked cursor per restart).
+ */
+export class ChangeStreamMultiplexer {
+  constructor(mongoHandle, collectionName, onEmpty) {
+    this._mongoHandle = mongoHandle;
+    this._collectionName = collectionName;
+    // Called when the last driver detaches so the owner (MongoConnection) can
+    // drop us from its registry.
+    this._onEmpty = onEmpty;
+
+    this._drivers = new Set();
+    this._changeStream = null;
+    this._stopped = false;
+    // Resume token of the last event we saw, so a restart replays everything
+    // emitted while the stream was reconnecting instead of dropping it.
+    this._resumeToken = null;
+    // Promise of the in-flight open, so concurrent addDriver()/restart calls
+    // for the same collection all await the same single watch() instead of
+    // racing a second cursor into existence.
+    this._startPromise = null;
+    this._restartTimer = null;
+  }
+
+  get size() {
+    return this._drivers.size;
+  }
+
+  // Subscribe a driver. Opens the shared stream on first subscriber. Resolves
+  // once the stream is open so the driver can safely read its snapshot knowing
+  // events emitted from here on are being queued for it.
+  async addDriver(driver) {
+    if (this._stopped) {
+      throw new Error('ChangeStreamMultiplexer used after stop');
+    }
+    this._drivers.add(driver);
+    await this._ensureOpen();
+  }
+
+  // Open the shared stream if it isn't already open, coalescing concurrent
+  // callers onto a single in-flight open. Setting _startPromise is synchronous
+  // before any await, so two callers can never both start an _open().
+  _ensureOpen() {
+    if (this._changeStream || this._stopped) {
+      return Promise.resolve();
+    }
+    if (!this._startPromise) {
+      this._startPromise = this._open().finally(() => {
+        this._startPromise = null;
+      });
+    }
+    return this._startPromise;
+  }
+
+  // Unsubscribe a driver. Closes the shared stream (and asks the owner to drop
+  // us) once the last driver leaves.
+  async removeDriver(driver) {
+    this._drivers.delete(driver);
+    if (this._drivers.size === 0) {
+      await this._stop();
+    }
+  }
+
+  async _open() {
+    if (this._stopped) return;
+
+    const collection = this._mongoHandle.rawCollection(this._collectionName);
+
+    // Capture the cluster time BEFORE opening the stream so we can pass
+    // startAtOperationTime to watch(). Without this, the change stream begins
+    // at whatever time mongo processes the aggregate $changeStream command —
+    // which under contention can be milliseconds later than the call site, and
+    // any write that lands in that window is silently dropped. Skipped on
+    // resume (the prior token already pins the start).
+    let startAtOperationTime;
+    if (!this._resumeToken) {
+      try {
+        const pingRes = await this._mongoHandle.db.command({ ping: 1 });
+        startAtOperationTime = pingRes?.operationTime;
+      } catch (e) {
+        // Best-effort; falls back to mongo's default of "now".
+      }
+    }
+
+    if (this._stopped) return;
+
+    // Always an empty pipeline so mongo delivers EVERY change event (including
+    // drop/invalidate/rename). Events filtered out server-side would never
+    // reach our handler, so _setLastProcessedOperationTime would not advance
+    // for their clusterTime — while fence write paths annotate target ts from
+    // session.operationTime including those dropped ops, leaving
+    // _waitUntilCaughtUp pinned to a ts the stream can never reach. Per-document
+    // selector filtering happens in each driver's matcher instead.
+    const changeStreamOptions = {
+      fullDocument: 'updateLookup',
+      fullDocumentBeforeChange: 'whenAvailable',
+    };
+    if (this._resumeToken) {
+      changeStreamOptions.startAfter = this._resumeToken;
+    } else if (startAtOperationTime) {
+      changeStreamOptions.startAtOperationTime = startAtOperationTime;
+    }
+
+    const changeStream = collection.watch([], changeStreamOptions);
+    this._changeStream = changeStream;
+
+    changeStream.on('change', Meteor.bindEnvironment((change) => {
+      this._onChange(change);
+    }));
+
+    changeStream.on('error', Meteor.bindEnvironment((error) => {
+      if (this._stopped) return;
+      console.error('ChangeStream error:', {
+        collectionName: this._collectionName,
+        driverCount: this._drivers.size,
+        resumeTokenPresent: !!this._resumeToken,
+        error,
+      });
+      this._scheduleRestart(
+        Meteor?.settings?.packages?.mongo?.changeStream?.delay?.error || 100
+      );
+    }));
+
+    changeStream.on('close', Meteor.bindEnvironment(() => {
+      if (this._stopped) return;
+      console.error('ChangeStream closed unexpectedly, scheduling restart:', {
+        collectionName: this._collectionName,
+        driverCount: this._drivers.size,
+        resumeTokenPresent: !!this._resumeToken,
+      });
+      this._scheduleRestart(
+        Meteor?.settings?.packages?.mongo?.changeStream?.delay?.close || 100
+      );
+    }));
+  }
+
+  _onChange(change) {
+    if (this._stopped) return;
+
+    // Capture the resume token so a future restart picks up where this event
+    // left off (see startAfter in _open).
+    if (change && change._id) {
+      this._resumeToken = change._id;
+    }
+
+    // Multicast the raw event to every subscribed driver. Each driver updates
+    // its own lastProcessedOperationTime (for fence catch-up), runs its matcher
+    // and projection, and queues/flushes its pending writes — exactly as it did
+    // when it owned the stream, only now the cursor is shared.
+    for (const driver of this._drivers) {
+      if (driver._stopped) continue;
+      try {
+        driver._onChange(change);
+      } catch (error) {
+        console.error('[ChangeStreams] Error dispatching change to driver:', {
+          driverId: driver._id,
+          collectionName: this._collectionName,
+          error,
+        });
+      }
+    }
+  }
+
+  _scheduleRestart(delayMs) {
+    if (this._stopped || this._restartTimer) return;
+    this._restartTimer = setTimeout(() => {
+      this._restartTimer = null;
+      if (!this._stopped) {
+        this._restart();
+      }
+    }, delayMs);
+  }
+
+  async _restart() {
+    if (this._stopped) return;
+    console.error('ChangeStream restart begin:', {
+      collectionName: this._collectionName,
+      driverCount: this._drivers.size,
+      resumeTokenPresent: !!this._resumeToken,
+    });
+    try {
+      await this._closeStream();
+      if (this._stopped) return;
+      // Reopen through the shared guard so a driver subscribing mid-restart
+      // awaits this same reopen instead of racing a second cursor.
+      await this._ensureOpen();
+      console.error('ChangeStream restart done:', {
+        collectionName: this._collectionName,
+        driverCount: this._drivers.size,
+      });
+    } catch (error) {
+      console.error('Failed to restart ChangeStream:', {
+        collectionName: this._collectionName,
+        error,
+      });
+      // Try again so a single failed reopen doesn't permanently wedge the
+      // shared stream for every driver on this collection.
+      this._scheduleRestart(
+        Meteor?.settings?.packages?.mongo?.changeStream?.delay?.error || 100
+      );
+    }
+  }
+
+  async _closeStream() {
+    const stream = this._changeStream;
+    this._changeStream = null;
+    if (stream) {
+      try {
+        await stream.close();
+      } catch (error) {
+        // Ignore errors when closing.
+      }
+    }
+  }
+
+  async _stop() {
+    if (this._stopped) return;
+    this._stopped = true;
+    if (this._restartTimer) {
+      clearTimeout(this._restartTimer);
+      this._restartTimer = null;
+    }
+    // Deregister from the connection BEFORE awaiting the cursor close. Otherwise
+    // an observe on the same collection arriving during that await would acquire
+    // this now-stopped multiplexer (addDriver would throw "used after stop")
+    // instead of creating a fresh one.
+    if (typeof this._onEmpty === 'function') {
+      try {
+        this._onEmpty();
+      } catch (e) {
+        // Ignore registry-cleanup errors.
+      }
+    }
+    await this._closeStream();
+  }
+}

--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -23,7 +23,11 @@ export class ChangeStreamObserveDriver {
     this._cursorDescription = options.cursorDescription;
     this._mongoHandle = options.mongoHandle;
     this._multiplexer = options.multiplexer;
-    this._changeStream = null;
+    // The shared per-collection change stream we subscribe to in _startWatching.
+    // The cursor and its resume/restart lifecycle live there, not here, so that
+    // many drivers on one collection share a single server-side cursor
+    // (meteor/meteor#14453).
+    this._sharedStream = null;
     this._stopped = false;
     this._stopCallbacks = [];
     this._pendingWrites = [];
@@ -32,11 +36,6 @@ export class ChangeStreamObserveDriver {
     this._lastProcessedOperationTime = null;
     this._catchingUpResolvers = [];
     this._resolveTimeout = null;
-    // Tracked across restarts so we can resume the stream from where it left
-    // off instead of "now" — without this, events that arrived between an
-    // error/close and the restart are silently dropped, leaving fences waiting
-    // for clusterTimes that will never appear in the new stream.
-    this._resumeToken = null;
     this._matcher = options.matcher;
     this._id = options.id || Random.id();
 
@@ -164,132 +163,24 @@ export class ChangeStreamObserveDriver {
 
       const collection = this._mongoHandle.rawCollection(this._cursorDescription.collectionName);
 
-      // Capture the cluster time BEFORE opening the stream so we can pass
-      // startAtOperationTime to watch(). Without this, the change stream
-      // begins at whatever time mongo processes the aggregate $changeStream
-      // command — which under contention can be MILLISECONDS later than the
-      // call site, and any write that lands in that window is silently
-      // dropped from the stream. With startAtOperationTime set to a known
-      // earlier ts, mongo replays every event from that ts forward, closing
-      // the race. Skipped on resume (the prior token already pins the start).
-      let startAtOperationTime;
-      if (!this._resumeToken) {
-        try {
-          const pingRes = await this._mongoHandle.db.command({ ping: 1 });
-          startAtOperationTime = pingRes?.operationTime;
-        } catch (e) {
-          // Best-effort. If the ping fails the stream falls back to
-          // mongo's default of "now" — same as the pre-fix behaviour.
-        }
-      }
+      // Subscribe to the SHARED per-collection change stream instead of opening
+      // our own cursor. Every driver on a collection watches the whole
+      // collection (empty pipeline) with identical options and filters
+      // per-document via its matcher, so N distinct selectors can share one
+      // server-side cursor — collapsing the meteor/meteor#14453 fanout where N
+      // selectors meant N cursors and N updateLookup post-image reads per write.
+      //
+      // addDriver() resolves once the stream is open. From that point events
+      // are dispatched to this driver via _onChange and queued in
+      // _pendingWrites (held back until _isReady), so any write that lands
+      // during _sendInitialAdds below is captured and replayed — with
+      // _handleInsert deduping against the snapshot for overlapping docs.
+      this._sharedStream = this._mongoHandle._acquireChangeStreamMultiplexer(
+        this._cursorDescription.collectionName
+      );
+      await this._sharedStream.addDriver(this);
 
-      // Open the change stream BEFORE the snapshot read. Events emitted while
-      // _sendInitialAdds is running are queued by the driver (in
-      // _pendingWrites) and replayed once the multiplexer is ready, with
-      // _handleInsert deduping against the cache for any doc the snapshot
-      // already covered.
-      const pipeline = this._buildPipeline();
-      const changeStreamOptions = {
-        fullDocument: 'updateLookup',
-        fullDocumentBeforeChange: 'whenAvailable',
-      };
-      if (this._resumeToken) {
-        // Resuming after an error/close restart: startAfter replays every
-        // event since the last token we saw, so events emitted while the
-        // stream was reconnecting are not silently dropped.
-        changeStreamOptions.startAfter = this._resumeToken;
-      } else if (startAtOperationTime) {
-        changeStreamOptions.startAtOperationTime = startAtOperationTime;
-      }
-
-      this._changeStream = collection.watch(pipeline, changeStreamOptions);
-
-      // Register stop callback for the change stream
-      this._stopCallbacks.push(async () => {
-        if (this._changeStream) {
-          try {
-            await this._changeStream.close();
-          } catch (error) {
-            // Ignore errors when closing
-          }
-          this._changeStream = null;
-        }
-      });
-
-      // Handle change events. While _sendInitialAdds is still running these
-      // events get queued via _handleChange and only processed once the
-      // multiplexer is ready (see _flushPendingWrites guard below).
-      this._changeStream.on('change', Meteor.bindEnvironment((change) => {
-        if (this._stopped) return;
-        // Capture the resume token so a future restart picks up where this
-        // event left off (see startAfter in changeStreamOptions above).
-        if (change && change._id) {
-          this._resumeToken = change._id;
-        }
-        // Update last processed op time early so fences can unblock promptly
-        if (change && change.clusterTime) {
-          this._setLastProcessedOperationTime(change.clusterTime);
-        }
-        this._handleChange(change);
-
-        const fence = DDPServer._getCurrentFence();
-        if (fence && !fence.fired) {
-          this._flushPendingWrites();
-        } else {
-          Meteor.defer(() => {
-            if (!this._stopped) {
-              this._flushPendingWrites();
-            }
-          });
-        }
-      }));
-
-      // Handle errors and reconnection
-      this._changeStream.on('error', Meteor.bindEnvironment((error) => {
-        if (this._stopped) return;
-        console.error('ChangeStream error:', {
-          driverId: this._id,
-          collectionName: this._cursorDescription.collectionName,
-          resumeTokenPresent: !!this._resumeToken,
-          lastProcessedOperationTime: this._lastProcessedOperationTime,
-          catchingUpResolversCount: this._catchingUpResolvers.length,
-          error,
-        });
-        // Attempt to restart after a delay
-        const timeoutId = setTimeout(() => {
-          if (!this._stopped) {
-            this._restartChangeStream();
-          }
-        }, Meteor?.settings?.packages?.mongo?.changeStream?.delay?.error || 100);
-
-        // Register timeout cleanup
-        this._addStopCallback(() => {
-          clearTimeout(timeoutId);
-        });
-      }));
-
-      this._changeStream.on('close', Meteor.bindEnvironment(() => {
-        if (!this._stopped) {
-          console.error('ChangeStream closed unexpectedly, scheduling restart:', {
-            driverId: this._id,
-            collectionName: this._cursorDescription.collectionName,
-            resumeTokenPresent: !!this._resumeToken,
-            lastProcessedOperationTime: this._lastProcessedOperationTime,
-            catchingUpResolversCount: this._catchingUpResolvers.length,
-          });
-          // Unexpected close, attempt restart
-          const timeoutId = setTimeout(() => {
-            if (!this._stopped) {
-              this._restartChangeStream();
-            }
-          }, Meteor?.settings?.packages?.mongo?.changeStream?.delay?.close || 100);
-
-          // Register timeout cleanup
-          this._addStopCallback(() => {
-            clearTimeout(timeoutId);
-          });
-        }
-      }));
+      if (this._stopped) return;
 
       // Now read the snapshot. Events that arrived while we were getting
       // here are sitting in _pendingWrites and will be flushed below.
@@ -373,61 +264,32 @@ export class ChangeStreamObserveDriver {
     }
   }
 
-  async _restartChangeStream() {
-    const collectionName = this._cursorDescription.collectionName;
-    console.error('ChangeStream restart begin:', {
-      driverId: this._id,
-      collectionName,
-      resumeTokenPresent: !!this._resumeToken,
-      catchingUpResolversCount: this._catchingUpResolvers.length,
-    });
-    try {
-      // Close current stream using stop callbacks if they exist
-      if (this._changeStream) {
-        // Find and execute the change stream stop callback
-        const changeStreamCallback = this._stopCallbacks.find(cb =>
-          typeof cb._changeStream === 'function'
-        );
-        if (changeStreamCallback) {
-          await changeStreamCallback();
-          // Remove the old callback since we'll add a new one
-          this._stopCallbacks = this._stopCallbacks.filter(cb => cb !== changeStreamCallback);
+  // Entry point called by the shared ChangeStreamMultiplexer for every raw
+  // change event on this collection. This is the body that used to live in the
+  // per-driver `changeStream.on('change', ...)` handler; only the cursor moved
+  // to the multiplexer, the per-driver processing is unchanged.
+  //
+  // The multiplexer owns the resume token (it drives reconnection), so unlike
+  // the old handler we do not track it here.
+  _onChange(change) {
+    if (this._stopped) return;
+
+    // Update last processed op time early so fences can unblock promptly.
+    if (change && change.clusterTime) {
+      this._setLastProcessedOperationTime(change.clusterTime);
+    }
+    this._handleChange(change);
+
+    const fence = DDPServer._getCurrentFence();
+    if (fence && !fence.fired) {
+      this._flushPendingWrites();
+    } else {
+      Meteor.defer(() => {
+        if (!this._stopped) {
+          this._flushPendingWrites();
         }
-      }
-      await this._startWatching();
-      console.error('ChangeStream restart done:', {
-        driverId: this._id,
-        collectionName,
-        catchingUpResolversCount: this._catchingUpResolvers.length,
-      });
-    } catch (error) {
-      console.error('Failed to restart ChangeStream:', {
-        driverId: this._id,
-        collectionName,
-        error,
       });
     }
-  }
-
-  _buildPipeline() {
-    // Always return an empty pipeline so mongo delivers EVERY change event
-    // (including drop, invalidate, create, modify, rename, ...). We filter
-    // unsupported operation types in _handleChange instead.
-    //
-    // Why: events filtered out server-side never reach our on('change')
-    // handler, so `_setLastProcessedOperationTime` does not advance for
-    // their clusterTime. Meanwhile fence write paths annotate
-    // `_csTargetTsByCollection` with `session.operationTime`, which
-    // includes increments from operations whose events the pipeline
-    // dropped — leaving _waitUntilCaughtUp pinned to a ts that this
-    // stream's lastProcessedOperationTime can never reach. Observed in
-    // CI as a `users` driver stuck on `{t:T, i:25}` while seeing only up
-    // to `{t:T, i:15}`, blocking removeUserByUsername forever.
-    //
-    // Per-document selector filtering still happens in _handleChange via
-    // the matcher; offloading that to the pipeline is a future
-    // optimization that needs to coexist with always-deliver semantics.
-    return [];
   }
 
   async _handleChange(change) {
@@ -645,8 +507,9 @@ export class ChangeStreamObserveDriver {
     // with subscriptions` failing with "Should receive CHANGED message").
     //
     // Liveness is guaranteed by:
-    //   1. The change stream resuming from this._resumeToken on error/close,
-    //      so events emitted while the stream was reconnecting are replayed.
+    //   1. The shared change stream resuming from its resume token on
+    //      error/close, so events emitted while the stream was reconnecting are
+    //      replayed and our lastProcessedOperationTime still advances to target.
     //   2. The watchdog below logging if the wait stalls past warnMs, which
     //      makes a genuinely-broken stream visible without masking it.
     const warnMs = Meteor?.settings?.packages?.mongo?.changeStream?.waitUntilCaughtUpWarnMs ?? 10000;
@@ -668,8 +531,8 @@ export class ChangeStreamObserveDriver {
           lastProcessedOperationTime: this._lastProcessedOperationTime,
           stopped: this._stopped,
           isReady: this._isReady,
-          changeStreamOpen: !!this._changeStream,
-          resumeTokenPresent: !!this._resumeToken,
+          changeStreamOpen: !!(this._sharedStream && this._sharedStream._changeStream),
+          resumeTokenPresent: !!(this._sharedStream && this._sharedStream._resumeToken),
           pendingWritesCount: this._pendingWrites.length,
           writesToCommitWhenReadyCount: this._writesToCommitWhenReady.length,
           catchingUpResolversCount: this._catchingUpResolvers.length,
@@ -746,6 +609,19 @@ export class ChangeStreamObserveDriver {
       } catch (error) {
         console.error('Error in stop callback:', error);
       }
+    }
+
+    // Detach from the shared per-collection change stream. The multiplexer
+    // closes the underlying cursor (and drops itself from the connection
+    // registry) once its last driver leaves, so the cursor lives exactly as
+    // long as there is an observer that needs it.
+    if (this._sharedStream) {
+      try {
+        await this._sharedStream.removeDriver(this);
+      } catch (error) {
+        console.error('Error detaching from shared change stream:', error);
+      }
+      this._sharedStream = null;
     }
 
     // Handle any remaining pending writes (following oplog driver pattern)

--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -109,6 +109,18 @@ export class ChangeStreamObserveDriver {
             // return undefined here and miss the fence._csTargetTs annotation.
             await driver._waitUntilCaughtUp(fence);
 
+            // The driver may have been stopped while we were parked in
+            // _waitUntilCaughtUp (stop() drains the waiter so we don't hang —
+            // meteor/meteor#14452). Once stopped, neither branch below can be
+            // trusted to release this write: the multiplexer is being torn
+            // down, and a push to _writesToCommitWhenReady can race stop()'s
+            // own drain of that array and be lost. Commit directly so the
+            // fence still fires.
+            if (driver._stopped) {
+              await write.committed();
+              continue;
+            }
+
             // Process any pending writes immediately
             driver._flushPendingWrites();
 
@@ -680,7 +692,12 @@ export class ChangeStreamObserveDriver {
         clearTimeout(warnTimeoutId);
         if (warnCount > 0) {
           console.error(
-            `Meteor: change stream caught up after warn`,
+            // When stop() drains this resolver the stream never reached
+            // targetTs — say so rather than claiming we caught up, so the logs
+            // reflect that the wait was released by teardown (#14452).
+            this._stopped
+              ? `Meteor: change stream wait released because observer stopped`
+              : `Meteor: change stream caught up after warn`,
             {
               driverId: this._id,
               collectionName,
@@ -700,6 +717,27 @@ export class ChangeStreamObserveDriver {
     if (this._stopped) return;
 
     this._stopped = true;
+
+    // Release any fence waiters still parked in _waitUntilCaughtUp before we
+    // close the change stream below. Those resolvers are waiting for an event
+    // with clusterTime >= targetTs, but once the stream is closed that event
+    // will never arrive, so leaving them parked hangs the fence's
+    // onBeforeFire (which awaits _waitUntilCaughtUp) forever — the DDP method
+    // that issued the write never gets its `updated` message and the client
+    // call hangs until timeout (meteor/meteor#14452). Resolve (don't reject):
+    // the fence may carry writes from other, still-healthy drivers, and the
+    // continuation just commits this driver's already-begun write so the fence
+    // can fire. The driver is being torn down, so not reaching targetTs on it
+    // is harmless — its handles are gone.
+    const pendingCatchUp = this._catchingUpResolvers;
+    this._catchingUpResolvers = [];
+    for (const entry of pendingCatchUp) {
+      try {
+        entry.resolver();
+      } catch (e) {
+        // ignore resolver errors
+      }
+    }
 
     // Execute all stop callbacks
     for (const callback of this._stopCallbacks) {

--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -13,6 +13,7 @@ import { OplogObserveDriver } from './oplog_observe_driver';
 import { OPLOG_COLLECTION, OplogHandle } from './oplog_tailing';
 import { PollingObserveDriver } from './polling_observe_driver';
 import { ChangeStreamObserveDriver } from './changestream_observe_driver';
+import { ChangeStreamMultiplexer } from './changestream_multiplexer';
 
 const FILE_ASSET_SUFFIX = 'Asset';
 const ASSETS_FOLDER = 'assets';
@@ -35,6 +36,11 @@ export const MongoConnection = function (url, options) {
   var self = this;
   options = options || {};
   self._observeMultiplexers = {};
+  // One shared MongoDB change stream per collection, keyed by collection name.
+  // Lazily created/removed by _acquireChangeStreamMultiplexer so N distinct
+  // observe drivers on the same collection share a single server-side cursor
+  // (meteor/meteor#14453) instead of one cursor each.
+  self._changeStreamMultiplexers = {};
   self._onFailoverHook = new Hook;
 
   const userOptions = {
@@ -137,6 +143,25 @@ MongoConnection.prototype.rawCollection = function (collectionName) {
     throw Error("rawCollection called before Connection created?");
 
   return self.db.collection(collectionName);
+};
+
+// Returns the shared ChangeStreamMultiplexer for a collection, creating it on
+// first use. The multiplexer removes itself from this registry once its last
+// driver detaches, so a later observer on the same collection opens a fresh
+// shared stream rather than reusing a torn-down one.
+MongoConnection.prototype._acquireChangeStreamMultiplexer = function (collectionName) {
+  var self = this;
+  var existing = self._changeStreamMultiplexers[collectionName];
+  if (existing) {
+    return existing;
+  }
+  var multiplexer = new ChangeStreamMultiplexer(self, collectionName, function () {
+    if (self._changeStreamMultiplexers[collectionName] === multiplexer) {
+      delete self._changeStreamMultiplexers[collectionName];
+    }
+  });
+  self._changeStreamMultiplexers[collectionName] = multiplexer;
+  return multiplexer;
 };
 
 MongoConnection.prototype.createCappedCollectionAsync = async function (

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -96,6 +96,7 @@ Package.onUse(function (api) {
       "mongo_common.js",
       "asynchronous_cursor.js",
       "cursor.ts",
+      "changestream_multiplexer.js",
       "changestream_observe_driver.js",
     ],
     "server"

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -2345,6 +2345,65 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
+  'changestream- stop() releases a fence waiter parked in _waitUntilCaughtUp (#14452)',
+  async function (test) {
+    // Regression for meteor/meteor#14452. If the driver is stopped while a
+    // write fence is still parked in _waitUntilCaughtUp, the change-stream
+    // event that would advance _lastProcessedOperationTime to targetTs never
+    // arrives (the stream is being closed), so the parked resolver would hang
+    // forever. The fence's onBeforeFire awaits that resolver, so the DDP
+    // method that issued the write never gets its `updated` message and the
+    // client call hangs until timeout. stop() must release the waiter.
+    const c = makeCollection();
+    const handle = await c.find({}).observeChanges({ added: function () { } });
+    test.isTrue(isChangeStreamDriver(handle));
+    const driver = handle._multiplexer._observeDriver;
+
+    // Seed so _lastProcessedOperationTime is non-null, then build a fence with
+    // a target ts far in the future. The stream will never deliver an event
+    // with clusterTime >= this, so the wait parks a resolver and blocks.
+    // The ts must be a real BSON Timestamp (not a plain {t, i}) — Timestamp's
+    // compare() mishandles plain objects, which would send _waitUntilCaughtUp
+    // down its already-caught-up early return instead of parking.
+    await c.insertAsync({ n: 1 });
+    await waitFor(() => driver._lastProcessedOperationTime !== null, 2000);
+
+    const Timestamp = driver._lastProcessedOperationTime.constructor;
+    const farFutureTs = new Timestamp({ t: Math.floor(Date.now() / 1000) + 3600, i: 1 });
+    const fakeFence = { _csTargetTsByCollection: { [c._name]: farFutureTs } };
+
+    // Park the waiter. Do NOT await — it must not resolve until stop().
+    let resolved = false;
+    const waitPromise = driver
+      ._waitUntilCaughtUp(fakeFence)
+      .then(() => { resolved = true; });
+
+    await waitFor(() => driver._catchingUpResolvers.length === 1, 1000);
+    test.equal(
+      driver._catchingUpResolvers.length,
+      1,
+      'a resolver should be parked while the fence waits for a future ts'
+    );
+    test.isFalse(resolved, 'wait must not resolve before stop');
+
+    // Stop the driver. This must drain the parked resolver rather than leaving
+    // it (and its watchdog) running forever.
+    await driver.stop();
+
+    const released = await waitFor(() => resolved, 3000);
+    test.isTrue(released, 'stop() should release the parked fence waiter (#14452)');
+    test.equal(
+      driver._catchingUpResolvers.length,
+      0,
+      'catching-up resolvers should be drained on stop'
+    );
+
+    await waitPromise;
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
   'changestream- annotation is cleared after fence fires (with active observer)',
   async function (test) {
     const c = makeCollection();

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -1990,7 +1990,7 @@ Tinytest.addAsync(
 // ============================================================================
 
 Tinytest.addAsync(
-  'changestream - _buildPipeline returns correct structure',
+  'changestream - driver subscribes to a shared per-collection change stream',
   async function (test) {
     const c = makeCollection();
 
@@ -2001,17 +2001,118 @@ Tinytest.addAsync(
     test.isTrue(isChangeStreamDriver(handle));
 
     const driver = handle._multiplexer._observeDriver;
-    const pipeline = driver._buildPipeline();
+    const shared = driver._sharedStream;
 
-    // Should be an array
-    test.isTrue(Array.isArray(pipeline));
+    // The cursor lifecycle now lives on the shared multiplexer, not the driver.
+    test.isTrue(!!shared, 'driver should hold a shared change stream');
+    test.isTrue(!!shared._changeStream, 'shared stream should have an open cursor');
+    test.isTrue(shared._drivers.has(driver), 'driver should be registered on the shared stream');
 
-    // If there's a selector, should have a $match stage
-    if (pipeline.length > 0) {
-      test.isTrue(pipeline[0].$match !== undefined);
-    }
+    // The owning MongoConnection should track exactly one multiplexer for the
+    // collection.
+    test.equal(
+      shared._mongoHandle._changeStreamMultiplexers[c._name],
+      shared,
+      'connection registry should hold the shared stream for this collection'
+    );
 
     handle.stop();
+  }
+);
+
+// ============================================================================
+// CHANGE STREAM FANOUT (meteor/meteor#14453)
+// ============================================================================
+
+Tinytest.addAsync(
+  'changestream - many distinct selectors share ONE change stream cursor (#14453)',
+  async function (test) {
+    const c = makeCollection();
+    const N = 6;
+    const handles = [];
+    const seen = [];
+
+    // Open N observers, each with a DISTINCT selector on the SAME collection.
+    for (let i = 0; i < N; i++) {
+      const events = [];
+      seen.push(events);
+      // eslint-disable-next-line no-await-in-loop
+      const handle = await c.find({ envId: 'env-' + i }).observeChanges({
+        added: (id, fields) => events.push({ type: 'added', fields }),
+        changed: (id, fields) => events.push({ type: 'changed', fields }),
+        removed: (id) => events.push({ type: 'removed' }),
+      });
+      handles.push(handle);
+    }
+
+    test.isTrue(isChangeStreamDriver(handles[0]));
+
+    const drivers = handles.map(h => h._multiplexer._observeDriver);
+    const shared = drivers[0]._sharedStream;
+
+    // Pre-fix: N drivers → N distinct collection.watch() cursors. Post-fix:
+    // they all share ONE multiplexer with ONE underlying cursor.
+    for (const d of drivers) {
+      test.equal(d._sharedStream, shared, 'every driver shares the same change stream');
+    }
+    test.equal(shared._drivers.size, N, 'shared stream tracks all N drivers');
+    test.isTrue(!!shared._changeStream, 'exactly one underlying cursor is open');
+    test.equal(
+      Object.keys(shared._mongoHandle._changeStreamMultiplexers).filter(
+        k => k === c._name
+      ).length,
+      1,
+      'exactly one shared stream registered for the collection'
+    );
+
+    // Functional: a write to env-2 must reach ONLY env-2's observer through the
+    // single shared stream — proving in-process fanout still routes per selector.
+    await c.insertAsync({ envId: 'env-2', payload: 'a' });
+    await waitFor(() => seen[2].some(e => e.type === 'added'), 3000);
+
+    test.isTrue(seen[2].some(e => e.type === 'added'), 'env-2 observer saw its insert');
+    for (let i = 0; i < N; i++) {
+      if (i === 2) continue;
+      test.equal(seen[i].length, 0, `env-${i} observer must not see env-2's write`);
+    }
+
+    handles.forEach(h => h.stop());
+  }
+);
+
+Tinytest.addAsync(
+  'changestream - shared cursor closes only after the last driver stops (#14453)',
+  async function (test) {
+    const c = makeCollection();
+
+    const h1 = await c.find({ envId: 'a' }).observeChanges({ added: function () { } });
+    const h2 = await c.find({ envId: 'b' }).observeChanges({ added: function () { } });
+
+    test.isTrue(isChangeStreamDriver(h1));
+
+    const shared = h1._multiplexer._observeDriver._sharedStream;
+    const mongo = shared._mongoHandle;
+    test.equal(shared._drivers.size, 2, 'both drivers attached to one shared stream');
+
+    // Stopping the first observer must NOT close the shared cursor — the second
+    // observer still needs it.
+    h1.stop();
+    await waitFor(() => shared._drivers.size === 1, 2000);
+    test.equal(shared._drivers.size, 1, 'one driver remains');
+    test.isFalse(shared._stopped, 'shared stream stays open while a driver remains');
+    test.isTrue(!!shared._changeStream, 'cursor still open');
+    test.equal(mongo._changeStreamMultiplexers[c._name], shared, 'still registered');
+
+    // Stopping the last observer tears the shared stream down and drops it from
+    // the registry, so the server-side cursor is released.
+    h2.stop();
+    await waitFor(() => shared._stopped, 2000);
+    test.isTrue(shared._stopped, 'shared stream stopped after last driver left');
+    test.isTrue(!shared._changeStream, 'cursor closed');
+    test.isUndefined(
+      mongo._changeStreamMultiplexers[c._name],
+      'shared stream removed from the connection registry'
+    );
   }
 );
 


### PR DESCRIPTION
## Problem (#14453)

After upgrading to `3.5-rc.1`, apps with many distinct publication selectors on the same hot collection saw large method/publication latency increases, with "hundreds of active `$changeStream` cursors" in `currentOp`. Pinning `reactivity: ["oplog","polling"]` restored normal performance.

Root cause: each `ChangeStreamObserveDriver` opened its **own** `collection.watch()` cursor. Since every driver watches the whole collection (empty pipeline) with constant options (`fullDocument: "updateLookup"`, `fullDocumentBeforeChange: "whenAvailable"`) and filters per-document via its matcher, **N distinct selectors on one collection produced N identical server-side change stream cursors**. Every write then fanned out to all N cursors and `updateLookup` triggered N post-image lookups — O(selectors × writes) server load. The oplog driver does not have this problem because it shares a single tail and dispatches in-process via a crossbar.

## Fix

New `ChangeStreamMultiplexer` — **one shared change stream per collection**, owned by the `MongoConnection` (registry keyed by collection name, acquired via `_acquireChangeStreamMultiplexer`). It opens a single `collection.watch([], …)` and multicasts each raw event in-process to every subscribed driver, which still runs its own matcher/projection — mirroring how the oplog driver shares one tail. The cursor is refcounted: it closes and deregisters when the last driver detaches.

The driver no longer owns a cursor: `_startWatching` subscribes to the shared stream before reading its snapshot; `stop()` detaches via `removeDriver`. The per-driver `_changeStream` / `_resumeToken` / `_buildPipeline` / `_restartChangeStream` are gone.

Because restart (error/close → resume via `startAfter: resumeToken`) now lives only in the multiplexer and never re-runs per-driver init, this also removes the previous restart-path corruption (the `can't make ObserveMultiplex ready twice!` exception, duplicate `added`, and a leaked server cursor per restart).

## Verification

Reproduced with `quavedev/meteor-changestream-fanout-repro`, run against this branch with change streams forced:

| 25 distinct selectors | `$changeStream` cursors on the collection |
|---|---|
| before | **50** (linear, ~2/observer) |
| after | **1** (constant) |

Per-selector delivery stays correct: a write to one env reaches only that env's observer, with zero cross-selector leakage.

The full `mongo` package suite passes under `METEOR_REACTIVITY_ORDER=changeStreams` (**522 passed / 0 failed**). Adds regression tests for cursor sharing across distinct selectors and shared-cursor teardown on the last `stop()`.

## Notes

- The first commit is the separate `#14452` fence-teardown fix, which this work builds on (it is not yet on `release-3.5`); the fanout change preserves that behavior.
- No package version bump — left to the release process.