### PR TITLE
Share one MongoDB change stream per collection (fix #14453 fanout)

### DIFF
--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -23,7 +23,7 @@ export class ChangeStreamObserveDriver {
     this._cursorDescription = options.cursorDescription;
     this._mongoHandle = options.mongoHandle;
     this._multiplexer = options.multiplexer;
-    this._changeStream = null;
+    this._sharedStream = null;
     this._stopped = false;
     this._stopCallbacks = [];
     this._pendingWrites = [];
@@ -32,11 +32,6 @@ export class ChangeStreamObserveDriver {
     this._lastProcessedOperationTime = null;
     this._catchingUpResolvers = [];
     this._resolveTimeout = null;
-    // Tracked across restarts so we can resume the stream from where it left
-    // off instead of "now" — without this, events that arrived between an
-    // error/close and the restart are silently dropped, leaving fences waiting
-    // for clusterTimes that will never appear in the new stream.
-    this._resumeToken = null;
     this._matcher = options.matcher;
     this._id = options.id || Random.id();
 
@@ -152,132 +147,18 @@ export class ChangeStreamObserveDriver {
 
       const collection = this._mongoHandle.rawCollection(this._cursorDescription.collectionName);
 
-      // Capture the cluster time BEFORE opening the stream so we can pass
-      // startAtOperationTime to watch(). Without this, the change stream
-      // begins at whatever time mongo processes the aggregate $changeStream
-      // command — which under contention can be MILLISECONDS later than the
-      // call site, and any write that lands in that window is silently
-      // dropped from the stream. With startAtOperationTime set to a known
-      // earlier ts, mongo replays every event from that ts forward, closing
-      // the race. Skipped on resume (the prior token already pins the start).
-      let startAtOperationTime;
-      if (!this._resumeToken) {
-        try {
-          const pingRes = await this._mongoHandle.db.command({ ping: 1 });
-          startAtOperationTime = pingRes?.operationTime;
-        } catch (e) {
-          // Best-effort. If the ping fails the stream falls back to
-          // mongo's default of "now" — same as the pre-fix behaviour.
-        }
-      }
+      // Subscribe to the shared per-collection change stream. addDriver()
+      // resolves once the stream is open; from that point events are dispatched
+      // to this driver via _onChange and queued in _pendingWrites (held back
+      // until _isReady), so any write that lands during _sendInitialAdds below
+      // is captured and replayed — with _handleInsert deduping against the
+      // snapshot for overlapping docs.
+      this._sharedStream = this._mongoHandle._acquireSharedChangeStream(
+        this._cursorDescription.collectionName
+      );
+      await this._sharedStream.addDriver(this);
 
-      // Open the change stream BEFORE the snapshot read. Events emitted while
-      // _sendInitialAdds is running are queued by the driver (in
-      // _pendingWrites) and replayed once the multiplexer is ready, with
-      // _handleInsert deduping against the cache for any doc the snapshot
-      // already covered.
-      const pipeline = this._buildPipeline();
-      const changeStreamOptions = {
-        fullDocument: 'updateLookup',
-        fullDocumentBeforeChange: 'whenAvailable',
-      };
-      if (this._resumeToken) {
-        // Resuming after an error/close restart: startAfter replays every
-        // event since the last token we saw, so events emitted while the
-        // stream was reconnecting are not silently dropped.
-        changeStreamOptions.startAfter = this._resumeToken;
-      } else if (startAtOperationTime) {
-        changeStreamOptions.startAtOperationTime = startAtOperationTime;
-      }
-
-      this._changeStream = collection.watch(pipeline, changeStreamOptions);
-
-      // Register stop callback for the change stream
-      this._stopCallbacks.push(async () => {
-        if (this._changeStream) {
-          try {
-            await this._changeStream.close();
-          } catch (error) {
-            // Ignore errors when closing
-          }
-          this._changeStream = null;
-        }
-      });
-
-      // Handle change events. While _sendInitialAdds is still running these
-      // events get queued via _handleChange and only processed once the
-      // multiplexer is ready (see _flushPendingWrites guard below).
-      this._changeStream.on('change', Meteor.bindEnvironment((change) => {
-        if (this._stopped) return;
-        // Capture the resume token so a future restart picks up where this
-        // event left off (see startAfter in changeStreamOptions above).
-        if (change && change._id) {
-          this._resumeToken = change._id;
-        }
-        // Update last processed op time early so fences can unblock promptly
-        if (change && change.clusterTime) {
-          this._setLastProcessedOperationTime(change.clusterTime);
-        }
-        this._handleChange(change);
-
-        const fence = DDPServer._getCurrentFence();
-        if (fence && !fence.fired) {
-          this._flushPendingWrites();
-        } else {
-          Meteor.defer(() => {
-            if (!this._stopped) {
-              this._flushPendingWrites();
-            }
-          });
-        }
-      }));
-
-      // Handle errors and reconnection
-      this._changeStream.on('error', Meteor.bindEnvironment((error) => {
-        if (this._stopped) return;
-        console.error('ChangeStream error:', {
-          driverId: this._id,
-          collectionName: this._cursorDescription.collectionName,
-          resumeTokenPresent: !!this._resumeToken,
-          lastProcessedOperationTime: this._lastProcessedOperationTime,
-          catchingUpResolversCount: this._catchingUpResolvers.length,
-          error,
-        });
-        // Attempt to restart after a delay
-        const timeoutId = setTimeout(() => {
-          if (!this._stopped) {
-            this._restartChangeStream();
-          }
-        }, Meteor?.settings?.packages?.mongo?.changeStream?.delay?.error || 100);
-
-        // Register timeout cleanup
-        this._addStopCallback(() => {
-          clearTimeout(timeoutId);
-        });
-      }));
-
-      this._changeStream.on('close', Meteor.bindEnvironment(() => {
-        if (!this._stopped) {
-          console.error('ChangeStream closed unexpectedly, scheduling restart:', {
-            driverId: this._id,
-            collectionName: this._cursorDescription.collectionName,
-            resumeTokenPresent: !!this._resumeToken,
-            lastProcessedOperationTime: this._lastProcessedOperationTime,
-            catchingUpResolversCount: this._catchingUpResolvers.length,
-          });
-          // Unexpected close, attempt restart
-          const timeoutId = setTimeout(() => {
-            if (!this._stopped) {
-              this._restartChangeStream();
-            }
-          }, Meteor?.settings?.packages?.mongo?.changeStream?.delay?.close || 100);
-
-          // Register timeout cleanup
-          this._addStopCallback(() => {
-            clearTimeout(timeoutId);
-          });
-        }
-      }));
+      if (this._stopped) return;
 
       // Now read the snapshot. Events that arrived while we were getting
       // here are sitting in _pendingWrites and will be flushed below.
@@ -361,61 +242,29 @@ export class ChangeStreamObserveDriver {
     }
   }
 
-  async _restartChangeStream() {
-    const collectionName = this._cursorDescription.collectionName;
-    console.error('ChangeStream restart begin:', {
-      driverId: this._id,
-      collectionName,
-      resumeTokenPresent: !!this._resumeToken,
-      catchingUpResolversCount: this._catchingUpResolvers.length,
-    });
-    try {
-      // Close current stream using stop callbacks if they exist
-      if (this._changeStream) {
-        // Find and execute the change stream stop callback
-        const changeStreamCallback = this._stopCallbacks.find(cb =>
-          typeof cb._changeStream === 'function'
-        );
-        if (changeStreamCallback) {
-          await changeStreamCallback();
-          // Remove the old callback since we'll add a new one
-          this._stopCallbacks = this._stopCallbacks.filter(cb => cb !== changeStreamCallback);
+  // Called by the shared change stream for every raw change event on
+  // this collection. The multiplexer owns the resume token (it drives
+  // reconnection), so this only advances our processed time, runs the matcher,
+  // and flushes pending writes.
+  _onChange(change) {
+    if (this._stopped) return;
+
+    // Update last processed op time early so fences can unblock promptly.
+    if (change && change.clusterTime) {
+      this._setLastProcessedOperationTime(change.clusterTime);
+    }
+    this._handleChange(change);
+
+    const fence = DDPServer._getCurrentFence();
+    if (fence && !fence.fired) {
+      this._flushPendingWrites();
+    } else {
+      Meteor.defer(() => {
+        if (!this._stopped) {
+          this._flushPendingWrites();
         }
-      }
-      await this._startWatching();
-      console.error('ChangeStream restart done:', {
-        driverId: this._id,
-        collectionName,
-        catchingUpResolversCount: this._catchingUpResolvers.length,
-      });
-    } catch (error) {
-      console.error('Failed to restart ChangeStream:', {
-        driverId: this._id,
-        collectionName,
-        error,
       });
     }
-  }
-
-  _buildPipeline() {
-    // Always return an empty pipeline so mongo delivers EVERY change event
-    // (including drop, invalidate, create, modify, rename, ...). We filter
-    // unsupported operation types in _handleChange instead.
-    //
-    // Why: events filtered out server-side never reach our on('change')
-    // handler, so `_setLastProcessedOperationTime` does not advance for
-    // their clusterTime. Meanwhile fence write paths annotate
-    // `_csTargetTsByCollection` with `session.operationTime`, which
-    // includes increments from operations whose events the pipeline
-    // dropped — leaving _waitUntilCaughtUp pinned to a ts that this
-    // stream's lastProcessedOperationTime can never reach. Observed in
-    // CI as a `users` driver stuck on `{t:T, i:25}` while seeing only up
-    // to `{t:T, i:15}`, blocking removeUserByUsername forever.
-    //
-    // Per-document selector filtering still happens in _handleChange via
-    // the matcher; offloading that to the pipeline is a future
-    // optimization that needs to coexist with always-deliver semantics.
-    return [];
   }
 
   async _handleChange(change) {
@@ -633,8 +482,9 @@ export class ChangeStreamObserveDriver {
     // with subscriptions` failing with "Should receive CHANGED message").
     //
     // Liveness is guaranteed by:
-    //   1. The change stream resuming from this._resumeToken on error/close,
-    //      so events emitted while the stream was reconnecting are replayed.
+    //   1. The shared change stream resuming from its resume token on
+    //      error/close, so events emitted while the stream was reconnecting are
+    //      replayed and our lastProcessedOperationTime still advances to target.
     //   2. The watchdog below logging if the wait stalls past warnMs, which
     //      makes a genuinely-broken stream visible without masking it.
     const warnMs = Meteor?.settings?.packages?.mongo?.changeStream?.waitUntilCaughtUpWarnMs ?? 10000;
@@ -656,8 +506,8 @@ export class ChangeStreamObserveDriver {
           lastProcessedOperationTime: this._lastProcessedOperationTime,
           stopped: this._stopped,
           isReady: this._isReady,
-          changeStreamOpen: !!this._changeStream,
-          resumeTokenPresent: !!this._resumeToken,
+          changeStreamOpen: !!(this._sharedStream && this._sharedStream._changeStream),
+          resumeTokenPresent: !!(this._sharedStream && this._sharedStream._resumeToken),
           pendingWritesCount: this._pendingWrites.length,
           writesToCommitWhenReadyCount: this._writesToCommitWhenReady.length,
           catchingUpResolversCount: this._catchingUpResolvers.length,
@@ -708,6 +558,19 @@ export class ChangeStreamObserveDriver {
       } catch (error) {
         console.error('Error in stop callback:', error);
       }
+    }
+
+    // Detach from the shared per-collection change stream. The multiplexer
+    // closes the underlying cursor (and drops itself from the connection
+    // registry) once its last driver leaves, so the cursor lives exactly as
+    // long as there is an observer that needs it.
+    if (this._sharedStream) {
+      try {
+        await this._sharedStream.removeDriver(this);
+      } catch (error) {
+        console.error('Error detaching from shared change stream:', error);
+      }
+      this._sharedStream = null;
     }
 
     // Handle any remaining pending writes (following oplog driver pattern)

--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -147,12 +147,10 @@ export class ChangeStreamObserveDriver {
 
       const collection = this._mongoHandle.rawCollection(this._cursorDescription.collectionName);
 
-      // Subscribe to the shared per-collection change stream. addDriver()
-      // resolves once the stream is open; from that point events are dispatched
-      // to this driver via _onChange and queued in _pendingWrites (held back
-      // until _isReady), so any write that lands during _sendInitialAdds below
-      // is captured and replayed — with _handleInsert deduping against the
-      // snapshot for overlapping docs.
+      // Subscribe to the shared per-collection stream. addDriver() resolves once
+      // it's open; from then events dispatch here via _onChange and queue in
+      // _pendingWrites until ready, so writes during the snapshot below are
+      // captured and replayed (_handleInsert dedupes overlaps with the snapshot).
       this._sharedStream = this._mongoHandle._acquireSharedChangeStream(
         this._cursorDescription.collectionName
       );
@@ -242,9 +240,8 @@ export class ChangeStreamObserveDriver {
     }
   }
 
-  // Called by the shared change stream for every raw change event on
-  // this collection. The multiplexer owns the resume token (it drives
-  // reconnection), so this only advances our processed time, runs the matcher,
+  // Called by the shared stream for every raw change. The shared stream owns the
+  // resume token, so this just advances our processed time, runs the matcher,
   // and flushes pending writes.
   _onChange(change) {
     if (this._stopped) return;
@@ -483,8 +480,8 @@ export class ChangeStreamObserveDriver {
     //
     // Liveness is guaranteed by:
     //   1. The shared change stream resuming from its resume token on
-    //      error/close, so events emitted while the stream was reconnecting are
-    //      replayed and our lastProcessedOperationTime still advances to target.
+    //      error/close, so events missed while reconnecting are replayed and
+    //      our lastProcessedOperationTime still advances to target.
     //   2. The watchdog below logging if the wait stalls past warnMs, which
     //      makes a genuinely-broken stream visible without masking it.
     const warnMs = Meteor?.settings?.packages?.mongo?.changeStream?.waitUntilCaughtUpWarnMs ?? 10000;
@@ -560,10 +557,8 @@ export class ChangeStreamObserveDriver {
       }
     }
 
-    // Detach from the shared per-collection change stream. The multiplexer
-    // closes the underlying cursor (and drops itself from the connection
-    // registry) once its last driver leaves, so the cursor lives exactly as
-    // long as there is an observer that needs it.
+    // Detach from the shared stream. It closes the underlying cursor (and drops
+    // itself from the connection registry) once its last driver leaves.
     if (this._sharedStream) {
       try {
         await this._sharedStream.removeDriver(this);

--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -141,10 +141,8 @@ MongoConnection.prototype.rawCollection = function (collectionName) {
   return self.db.collection(collectionName);
 };
 
-// Returns the shared change stream for a collection, creating it on first use.
-// It removes itself from this registry once its last driver detaches, so a
-// later observer on the same collection opens a fresh shared stream rather than
-// reusing a torn-down one.
+// Shared change stream for a collection, created on first use. It deregisters
+// itself once its last driver detaches, so a later observer opens a fresh one.
 MongoConnection.prototype._acquireSharedChangeStream = function (collectionName) {
   const self = this;
   const existing = self._sharedChangeStreams[collectionName];

--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -13,6 +13,7 @@ import { OplogObserveDriver } from './oplog_observe_driver';
 import { OPLOG_COLLECTION, OplogHandle } from './oplog_tailing';
 import { PollingObserveDriver } from './polling_observe_driver';
 import { ChangeStreamObserveDriver } from './changestream_observe_driver';
+import { SharedChangeStream } from './shared_change_stream';
 
 const FILE_ASSET_SUFFIX = 'Asset';
 const ASSETS_FOLDER = 'assets';
@@ -35,6 +36,7 @@ export const MongoConnection = function (url, options) {
   var self = this;
   options = options || {};
   self._observeMultiplexers = {};
+  self._sharedChangeStreams = {};
   self._onFailoverHook = new Hook;
 
   const userOptions = {
@@ -137,6 +139,25 @@ MongoConnection.prototype.rawCollection = function (collectionName) {
     throw Error("rawCollection called before Connection created?");
 
   return self.db.collection(collectionName);
+};
+
+// Returns the shared change stream for a collection, creating it on first use.
+// It removes itself from this registry once its last driver detaches, so a
+// later observer on the same collection opens a fresh shared stream rather than
+// reusing a torn-down one.
+MongoConnection.prototype._acquireSharedChangeStream = function (collectionName) {
+  const self = this;
+  const existing = self._sharedChangeStreams[collectionName];
+  if (existing) {
+    return existing;
+  }
+  const sharedStream = new SharedChangeStream(self, collectionName, function () {
+    if (self._sharedChangeStreams[collectionName] === sharedStream) {
+      delete self._sharedChangeStreams[collectionName];
+    }
+  });
+  self._sharedChangeStreams[collectionName] = sharedStream;
+  return sharedStream;
 };
 
 MongoConnection.prototype.createCappedCollectionAsync = async function (

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -96,6 +96,7 @@ Package.onUse(function (api) {
       "mongo_common.js",
       "asynchronous_cursor.js",
       "cursor.ts",
+      "shared_change_stream.js",
       "changestream_observe_driver.js",
     ],
     "server"

--- a/packages/mongo/shared_change_stream.js
+++ b/packages/mongo/shared_change_stream.js
@@ -1,0 +1,250 @@
+import { Meteor } from 'meteor/meteor';
+
+/**
+ * SharedChangeStream — one shared MongoDB change stream per collection.
+ *
+ * Every ChangeStreamObserveDriver on a collection watches the whole collection
+ * (empty pipeline) with the same options (`fullDocument: 'updateLookup'`,
+ * `fullDocumentBeforeChange: 'whenAvailable'`) and filters per-document via its
+ * own matcher, so they share a single server-side cursor. This class opens one
+ * `collection.watch()` and multicasts each raw change event, in-process, to
+ * every subscribed driver — the same way the oplog driver shares a single tail
+ * and dispatches via a crossbar.
+ *
+ * It owns the cursor lifecycle: an error or close triggers a restart that
+ * resumes from the last resume token (`startAfter`), so events emitted while the
+ * stream was reconnecting are replayed rather than dropped. A restart replaces
+ * only the cursor; the subscribed drivers are left untouched.
+ */
+export class SharedChangeStream {
+  constructor(mongoHandle, collectionName, onEmpty) {
+    this._mongoHandle = mongoHandle;
+    this._collectionName = collectionName;
+    // Called when the last driver detaches so the owner (MongoConnection) can
+    // drop us from its registry.
+    this._onEmpty = onEmpty;
+
+    this._drivers = new Set();
+    this._changeStream = null;
+    this._stopped = false;
+    // Resume token of the last event we saw, so a restart replays everything
+    // emitted while the stream was reconnecting instead of dropping it.
+    this._resumeToken = null;
+    // Promise of the in-flight open, so concurrent addDriver()/restart calls
+    // for the same collection all await the same single watch() instead of
+    // racing a second cursor into existence.
+    this._startPromise = null;
+    this._restartTimer = null;
+  }
+
+  get size() {
+    return this._drivers.size;
+  }
+
+  // Subscribe a driver. Opens the shared stream on first subscriber. Resolves
+  // once the stream is open so the driver can safely read its snapshot knowing
+  // events emitted from here on are being queued for it.
+  async addDriver(driver) {
+    if (this._stopped) {
+      throw new Error('SharedChangeStream used after stop');
+    }
+    this._drivers.add(driver);
+    await this._ensureOpen();
+  }
+
+  // Open the shared stream if it isn't already open, coalescing concurrent
+  // callers onto a single in-flight open. Setting _startPromise is synchronous
+  // before any await, so two callers can never both start an _open().
+  _ensureOpen() {
+    if (this._changeStream || this._stopped) {
+      return Promise.resolve();
+    }
+    if (!this._startPromise) {
+      this._startPromise = this._open().finally(() => {
+        this._startPromise = null;
+      });
+    }
+    return this._startPromise;
+  }
+
+  // Unsubscribe a driver. Closes the shared stream (and asks the owner to drop
+  // us) once the last driver leaves.
+  async removeDriver(driver) {
+    this._drivers.delete(driver);
+    if (this._drivers.size === 0) {
+      await this._stop();
+    }
+  }
+
+  async _open() {
+    if (this._stopped) return;
+
+    const collection = this._mongoHandle.rawCollection(this._collectionName);
+
+    // Capture the cluster time BEFORE opening the stream so we can pass
+    // startAtOperationTime to watch(). Without this, the change stream begins
+    // at whatever time mongo processes the aggregate $changeStream command —
+    // which under contention can be milliseconds later than the call site, and
+    // any write that lands in that window is silently dropped. Skipped on
+    // resume (the prior token already pins the start).
+    let startAtOperationTime;
+    if (!this._resumeToken) {
+      try {
+        const pingRes = await this._mongoHandle.db.command({ ping: 1 });
+        startAtOperationTime = pingRes?.operationTime;
+      } catch (e) {
+        // Best-effort; falls back to mongo's default of "now".
+      }
+    }
+
+    if (this._stopped) return;
+
+    // Always an empty pipeline so mongo delivers EVERY change event (including
+    // drop/invalidate/rename). Events filtered out server-side would never
+    // reach our handler, so _setLastProcessedOperationTime would not advance
+    // for their clusterTime — while fence write paths annotate target ts from
+    // session.operationTime including those dropped ops, leaving
+    // _waitUntilCaughtUp pinned to a ts the stream can never reach. Per-document
+    // selector filtering happens in each driver's matcher instead.
+    const changeStreamOptions = {
+      fullDocument: 'updateLookup',
+      fullDocumentBeforeChange: 'whenAvailable',
+    };
+    if (this._resumeToken) {
+      changeStreamOptions.startAfter = this._resumeToken;
+    } else if (startAtOperationTime) {
+      changeStreamOptions.startAtOperationTime = startAtOperationTime;
+    }
+
+    const changeStream = collection.watch([], changeStreamOptions);
+    this._changeStream = changeStream;
+
+    changeStream.on('change', Meteor.bindEnvironment((change) => {
+      this._onChange(change);
+    }));
+
+    changeStream.on('error', Meteor.bindEnvironment((error) => {
+      if (this._stopped) return;
+      console.error('ChangeStream error:', {
+        collectionName: this._collectionName,
+        driverCount: this._drivers.size,
+        resumeTokenPresent: !!this._resumeToken,
+        error,
+      });
+      this._scheduleRestart(
+        Meteor?.settings?.packages?.mongo?.changeStream?.delay?.error || 100
+      );
+    }));
+
+    changeStream.on('close', Meteor.bindEnvironment(() => {
+      if (this._stopped) return;
+      console.error('ChangeStream closed unexpectedly, scheduling restart:', {
+        collectionName: this._collectionName,
+        driverCount: this._drivers.size,
+        resumeTokenPresent: !!this._resumeToken,
+      });
+      this._scheduleRestart(
+        Meteor?.settings?.packages?.mongo?.changeStream?.delay?.close || 100
+      );
+    }));
+  }
+
+  _onChange(change) {
+    if (this._stopped) return;
+
+    // Capture the resume token so a future restart picks up where this event
+    // left off (see startAfter in _open).
+    if (change && change._id) {
+      this._resumeToken = change._id;
+    }
+
+    // Multicast the raw event to every subscribed driver. Each driver updates
+    // its own lastProcessedOperationTime (for fence catch-up), runs its matcher
+    // and projection, and queues/flushes its pending writes.
+    for (const driver of this._drivers) {
+      if (driver._stopped) continue;
+      try {
+        driver._onChange(change);
+      } catch (error) {
+        console.error('[ChangeStreams] Error dispatching change to driver:', {
+          driverId: driver._id,
+          collectionName: this._collectionName,
+          error,
+        });
+      }
+    }
+  }
+
+  _scheduleRestart(delayMs) {
+    if (this._stopped || this._restartTimer) return;
+    this._restartTimer = setTimeout(() => {
+      this._restartTimer = null;
+      if (!this._stopped) {
+        this._restart();
+      }
+    }, delayMs);
+  }
+
+  async _restart() {
+    if (this._stopped) return;
+    console.error('ChangeStream restart begin:', {
+      collectionName: this._collectionName,
+      driverCount: this._drivers.size,
+      resumeTokenPresent: !!this._resumeToken,
+    });
+    try {
+      await this._closeStream();
+      if (this._stopped) return;
+      // Reopen through the shared guard so a driver subscribing mid-restart
+      // awaits this same reopen instead of racing a second cursor.
+      await this._ensureOpen();
+      console.error('ChangeStream restart done:', {
+        collectionName: this._collectionName,
+        driverCount: this._drivers.size,
+      });
+    } catch (error) {
+      console.error('Failed to restart ChangeStream:', {
+        collectionName: this._collectionName,
+        error,
+      });
+      // Try again so a single failed reopen doesn't permanently wedge the
+      // shared stream for every driver on this collection.
+      this._scheduleRestart(
+        Meteor?.settings?.packages?.mongo?.changeStream?.delay?.error || 100
+      );
+    }
+  }
+
+  async _closeStream() {
+    const stream = this._changeStream;
+    this._changeStream = null;
+    if (stream) {
+      try {
+        await stream.close();
+      } catch (error) {
+        // Ignore errors when closing.
+      }
+    }
+  }
+
+  async _stop() {
+    if (this._stopped) return;
+    this._stopped = true;
+    if (this._restartTimer) {
+      clearTimeout(this._restartTimer);
+      this._restartTimer = null;
+    }
+    // Deregister from the connection BEFORE awaiting the cursor close. Otherwise
+    // an observe on the same collection arriving during that await would acquire
+    // this now-stopped multiplexer (addDriver would throw "used after stop")
+    // instead of creating a fresh one.
+    if (typeof this._onEmpty === 'function') {
+      try {
+        this._onEmpty();
+      } catch (e) {
+        // Ignore registry-cleanup errors.
+      }
+    }
+    await this._closeStream();
+  }
+}

--- a/packages/mongo/shared_change_stream.js
+++ b/packages/mongo/shared_change_stream.js
@@ -124,7 +124,8 @@ export class SharedChangeStream {
     }));
 
     changeStream.on('error', Meteor.bindEnvironment((error) => {
-      if (this._stopped) return;
+      // Only the active stream restarts; ignore a superseded one.
+      if (this._stopped || this._changeStream !== changeStream) return;
       console.error('ChangeStream error:', {
         collectionName: this._collectionName,
         driverCount: this._drivers.size,
@@ -137,7 +138,9 @@ export class SharedChangeStream {
     }));
 
     changeStream.on('close', Meteor.bindEnvironment(() => {
-      if (this._stopped) return;
+      // _closeStream() replaces this._changeStream before closing, so a
+      // deliberate close fails this check and won't loop into a restart.
+      if (this._stopped || this._changeStream !== changeStream) return;
       console.error('ChangeStream closed unexpectedly, scheduling restart:', {
         collectionName: this._collectionName,
         driverCount: this._drivers.size,

--- a/packages/mongo/shared_change_stream.js
+++ b/packages/mongo/shared_change_stream.js
@@ -1,38 +1,32 @@
 import { Meteor } from 'meteor/meteor';
 
 /**
- * SharedChangeStream — one shared MongoDB change stream per collection.
+ * SharedChangeStream — one MongoDB change stream shared per collection.
  *
- * Every ChangeStreamObserveDriver on a collection watches the whole collection
- * (empty pipeline) with the same options (`fullDocument: 'updateLookup'`,
- * `fullDocumentBeforeChange: 'whenAvailable'`) and filters per-document via its
- * own matcher, so they share a single server-side cursor. This class opens one
- * `collection.watch()` and multicasts each raw change event, in-process, to
- * every subscribed driver — the same way the oplog driver shares a single tail
- * and dispatches via a crossbar.
+ * Every driver on a collection watches the whole collection with identical
+ * options and filters per-document in its own matcher, so they can share one
+ * server-side cursor. This opens a single collection.watch() and multicasts each
+ * raw event in-process to every subscribed driver — like the oplog driver
+ * sharing one tail via a crossbar.
  *
- * It owns the cursor lifecycle: an error or close triggers a restart that
- * resumes from the last resume token (`startAfter`), so events emitted while the
- * stream was reconnecting are replayed rather than dropped. A restart replaces
- * only the cursor; the subscribed drivers are left untouched.
+ * It owns the cursor lifecycle: an error/close restarts from the last resume
+ * token (startAfter), replaying events missed while reconnecting. A restart
+ * replaces only the cursor; drivers are untouched.
  */
 export class SharedChangeStream {
   constructor(mongoHandle, collectionName, onEmpty) {
     this._mongoHandle = mongoHandle;
     this._collectionName = collectionName;
-    // Called when the last driver detaches so the owner (MongoConnection) can
-    // drop us from its registry.
+    // Called when the last driver detaches so the owner can deregister us.
     this._onEmpty = onEmpty;
 
     this._drivers = new Set();
     this._changeStream = null;
     this._stopped = false;
-    // Resume token of the last event we saw, so a restart replays everything
-    // emitted while the stream was reconnecting instead of dropping it.
+    // Last seen resume token; a restart replays from here (startAfter).
     this._resumeToken = null;
-    // Promise of the in-flight open, so concurrent addDriver()/restart calls
-    // for the same collection all await the same single watch() instead of
-    // racing a second cursor into existence.
+    // In-flight open, so concurrent callers share one watch() instead of
+    // racing a second cursor.
     this._startPromise = null;
     this._restartTimer = null;
   }
@@ -41,9 +35,8 @@ export class SharedChangeStream {
     return this._drivers.size;
   }
 
-  // Subscribe a driver. Opens the shared stream on first subscriber. Resolves
-  // once the stream is open so the driver can safely read its snapshot knowing
-  // events emitted from here on are being queued for it.
+  // Subscribe a driver, opening the stream on the first one. Resolves once open
+  // so the driver can read its snapshot knowing events are now queued for it.
   async addDriver(driver) {
     if (this._stopped) {
       throw new Error('SharedChangeStream used after stop');
@@ -52,9 +45,8 @@ export class SharedChangeStream {
     await this._ensureOpen();
   }
 
-  // Open the shared stream if it isn't already open, coalescing concurrent
-  // callers onto a single in-flight open. Setting _startPromise is synchronous
-  // before any await, so two callers can never both start an _open().
+  // Open if needed, coalescing concurrent callers onto one in-flight open.
+  // _startPromise is set synchronously before any await, so no double open.
   _ensureOpen() {
     if (this._changeStream || this._stopped) {
       return Promise.resolve();
@@ -67,8 +59,7 @@ export class SharedChangeStream {
     return this._startPromise;
   }
 
-  // Unsubscribe a driver. Closes the shared stream (and asks the owner to drop
-  // us) once the last driver leaves.
+  // Unsubscribe a driver; tear down once the last one leaves.
   async removeDriver(driver) {
     this._drivers.delete(driver);
     if (this._drivers.size === 0) {
@@ -81,12 +72,9 @@ export class SharedChangeStream {
 
     const collection = this._mongoHandle.rawCollection(this._collectionName);
 
-    // Capture the cluster time BEFORE opening the stream so we can pass
-    // startAtOperationTime to watch(). Without this, the change stream begins
-    // at whatever time mongo processes the aggregate $changeStream command —
-    // which under contention can be milliseconds later than the call site, and
-    // any write that lands in that window is silently dropped. Skipped on
-    // resume (the prior token already pins the start).
+    // Pin the start time before opening: otherwise the stream begins whenever
+    // mongo processes the $changeStream command, and writes landing in that gap
+    // are dropped. Skipped on resume (the token already pins the start).
     let startAtOperationTime;
     if (!this._resumeToken) {
       try {
@@ -99,13 +87,10 @@ export class SharedChangeStream {
 
     if (this._stopped) return;
 
-    // Always an empty pipeline so mongo delivers EVERY change event (including
-    // drop/invalidate/rename). Events filtered out server-side would never
-    // reach our handler, so _setLastProcessedOperationTime would not advance
-    // for their clusterTime — while fence write paths annotate target ts from
-    // session.operationTime including those dropped ops, leaving
-    // _waitUntilCaughtUp pinned to a ts the stream can never reach. Per-document
-    // selector filtering happens in each driver's matcher instead.
+    // Empty pipeline so mongo delivers EVERY event: a server-side filter would
+    // skip events, so _setLastProcessedOperationTime wouldn't advance for their
+    // clusterTime while the fence still targets it — wedging _waitUntilCaughtUp.
+    // Per-document filtering happens in each driver's matcher instead.
     const changeStreamOptions = {
       fullDocument: 'updateLookup',
       fullDocumentBeforeChange: 'whenAvailable',
@@ -155,15 +140,13 @@ export class SharedChangeStream {
   _onChange(change) {
     if (this._stopped) return;
 
-    // Capture the resume token so a future restart picks up where this event
-    // left off (see startAfter in _open).
+    // Remember the resume token so a restart picks up here (see _open).
     if (change && change._id) {
       this._resumeToken = change._id;
     }
 
-    // Multicast the raw event to every subscribed driver. Each driver updates
-    // its own lastProcessedOperationTime (for fence catch-up), runs its matcher
-    // and projection, and queues/flushes its pending writes.
+    // Multicast to every driver; each runs its own matcher/projection, advances
+    // its lastProcessedOperationTime, and flushes pending writes.
     for (const driver of this._drivers) {
       if (driver._stopped) continue;
       try {
@@ -198,8 +181,7 @@ export class SharedChangeStream {
     try {
       await this._closeStream();
       if (this._stopped) return;
-      // Reopen through the shared guard so a driver subscribing mid-restart
-      // awaits this same reopen instead of racing a second cursor.
+      // Reopen via the shared guard so a mid-restart subscriber awaits it too.
       await this._ensureOpen();
       console.error('ChangeStream restart done:', {
         collectionName: this._collectionName,
@@ -210,8 +192,7 @@ export class SharedChangeStream {
         collectionName: this._collectionName,
         error,
       });
-      // Try again so a single failed reopen doesn't permanently wedge the
-      // shared stream for every driver on this collection.
+      // Retry so one failed reopen doesn't wedge the stream for all drivers.
       this._scheduleRestart(
         Meteor?.settings?.packages?.mongo?.changeStream?.delay?.error || 100
       );
@@ -237,10 +218,8 @@ export class SharedChangeStream {
       clearTimeout(this._restartTimer);
       this._restartTimer = null;
     }
-    // Deregister from the connection BEFORE awaiting the cursor close. Otherwise
-    // an observe on the same collection arriving during that await would acquire
-    // this now-stopped multiplexer (addDriver would throw "used after stop")
-    // instead of creating a fresh one.
+    // Deregister before awaiting close, else an observe arriving during the
+    // await would acquire this stopped stream (addDriver throws) not a fresh one.
     if (typeof this._onEmpty === 'function') {
       try {
         this._onEmpty();

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -2117,6 +2117,47 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
+  'changestream - a deliberate restart does not perpetuate a close→reopen loop (#14456)',
+  async function (test) {
+    const c = makeCollection();
+
+    const handle = await c.find({}).observeChanges({ added: function () { } });
+    test.isTrue(isChangeStreamDriver(handle));
+
+    const shared = handle._multiplexer._observeDriver._sharedStream;
+    test.isTrue(!!shared._changeStream, 'cursor is open before the restart');
+
+    // Count restarts that fire.
+    let restarts = 0;
+    const origRestart = shared._restart.bind(shared);
+    shared._restart = function () {
+      restarts++;
+      return origRestart();
+    };
+
+    // Trigger one restart; its deliberate close must not cascade into more.
+    shared._scheduleRestart(10);
+
+    // delay defaults to 100 ms — a cascade would fire several in this window.
+    await waitFor(() => restarts > 1, 800);
+
+    test.equal(restarts, 1, 'a single restart must not trigger further restarts');
+    test.isFalse(shared._stopped, 'shared stream stays alive after the restart');
+    test.isTrue(!!shared._changeStream, 'cursor is reopened and stays open');
+
+    // The reopened cursor must still deliver events to its drivers.
+    await c.insertAsync({ name: 'after-restart' });
+    const got = await waitFor(async () => {
+      const found = await c.findOneAsync({ name: 'after-restart' });
+      return !!found;
+    }, 3000);
+    test.isTrue(got, 'collection write succeeds after the restart');
+
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
   'changestream - _projectionFn works correctly',
   async function (test) {
     const c = makeCollection();

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -1990,7 +1990,7 @@ Tinytest.addAsync(
 // ============================================================================
 
 Tinytest.addAsync(
-  'changestream - _buildPipeline returns correct structure',
+  'changestream - driver subscribes to a shared per-collection change stream',
   async function (test) {
     const c = makeCollection();
 
@@ -2001,17 +2001,118 @@ Tinytest.addAsync(
     test.isTrue(isChangeStreamDriver(handle));
 
     const driver = handle._multiplexer._observeDriver;
-    const pipeline = driver._buildPipeline();
+    const shared = driver._sharedStream;
 
-    // Should be an array
-    test.isTrue(Array.isArray(pipeline));
+    // The cursor lifecycle lives on the shared change stream, not the driver.
+    test.isTrue(!!shared, 'driver should hold a shared change stream');
+    test.isTrue(!!shared._changeStream, 'shared stream should have an open cursor');
+    test.isTrue(shared._drivers.has(driver), 'driver should be registered on the shared stream');
 
-    // If there's a selector, should have a $match stage
-    if (pipeline.length > 0) {
-      test.isTrue(pipeline[0].$match !== undefined);
-    }
+    // The owning MongoConnection should track exactly one multiplexer for the
+    // collection.
+    test.equal(
+      shared._mongoHandle._sharedChangeStreams[c._name],
+      shared,
+      'connection registry should hold the shared stream for this collection'
+    );
 
     handle.stop();
+  }
+);
+
+// ============================================================================
+// CHANGE STREAM FANOUT (shared cursor per collection)
+// ============================================================================
+
+Tinytest.addAsync(
+  'changestream - many distinct selectors share ONE change stream cursor (#14453)',
+  async function (test) {
+    const c = makeCollection();
+    const N = 6;
+    const handles = [];
+    const seen = [];
+
+    // Open N observers, each with a DISTINCT selector on the SAME collection.
+    for (let i = 0; i < N; i++) {
+      const events = [];
+      seen.push(events);
+      // eslint-disable-next-line no-await-in-loop
+      const handle = await c.find({ envId: 'env-' + i }).observeChanges({
+        added: (id, fields) => events.push({ type: 'added', fields }),
+        changed: (id, fields) => events.push({ type: 'changed', fields }),
+        removed: (id) => events.push({ type: 'removed' }),
+      });
+      handles.push(handle);
+    }
+
+    test.isTrue(isChangeStreamDriver(handles[0]));
+
+    const drivers = handles.map(h => h._multiplexer._observeDriver);
+    const shared = drivers[0]._sharedStream;
+
+    // All drivers for distinct selectors on one collection share ONE
+    // SharedChangeStream with ONE underlying cursor.
+    for (const d of drivers) {
+      test.equal(d._sharedStream, shared, 'every driver shares the same change stream');
+    }
+    test.equal(shared._drivers.size, N, 'shared stream tracks all N drivers');
+    test.isTrue(!!shared._changeStream, 'exactly one underlying cursor is open');
+    test.equal(
+      Object.keys(shared._mongoHandle._sharedChangeStreams).filter(
+        k => k === c._name
+      ).length,
+      1,
+      'exactly one shared stream registered for the collection'
+    );
+
+    // Functional: a write to env-2 must reach ONLY env-2's observer through the
+    // single shared stream — proving in-process fanout still routes per selector.
+    await c.insertAsync({ envId: 'env-2', payload: 'a' });
+    await waitFor(() => seen[2].some(e => e.type === 'added'), 3000);
+
+    test.isTrue(seen[2].some(e => e.type === 'added'), 'env-2 observer saw its insert');
+    for (let i = 0; i < N; i++) {
+      if (i === 2) continue;
+      test.equal(seen[i].length, 0, `env-${i} observer must not see env-2's write`);
+    }
+
+    handles.forEach(h => h.stop());
+  }
+);
+
+Tinytest.addAsync(
+  'changestream - shared cursor closes only after the last driver stops (#14453)',
+  async function (test) {
+    const c = makeCollection();
+
+    const h1 = await c.find({ envId: 'a' }).observeChanges({ added: function () { } });
+    const h2 = await c.find({ envId: 'b' }).observeChanges({ added: function () { } });
+
+    test.isTrue(isChangeStreamDriver(h1));
+
+    const shared = h1._multiplexer._observeDriver._sharedStream;
+    const mongo = shared._mongoHandle;
+    test.equal(shared._drivers.size, 2, 'both drivers attached to one shared stream');
+
+    // Stopping the first observer must NOT close the shared cursor — the second
+    // observer still needs it.
+    h1.stop();
+    await waitFor(() => shared._drivers.size === 1, 2000);
+    test.equal(shared._drivers.size, 1, 'one driver remains');
+    test.isFalse(shared._stopped, 'shared stream stays open while a driver remains');
+    test.isTrue(!!shared._changeStream, 'cursor still open');
+    test.equal(mongo._sharedChangeStreams[c._name], shared, 'still registered');
+
+    // Stopping the last observer tears the shared stream down and drops it from
+    // the registry, so the server-side cursor is released.
+    h2.stop();
+    await waitFor(() => shared._stopped, 2000);
+    test.isTrue(shared._stopped, 'shared stream stopped after last driver left');
+    test.isTrue(!shared._changeStream, 'cursor closed');
+    test.isUndefined(
+      mongo._sharedChangeStreams[c._name],
+      'shared stream removed from the connection registry'
+    );
   }
 );
 


### PR DESCRIPTION
## Problem (#14453)

After upgrading to `3.5-rc.1`, apps with many distinct publication selectors on the same hot collection saw large method/publication latency increases, with "hundreds of active `$changeStream` cursors" in `currentOp`. Pinning `reactivity: ["oplog","polling"]` restored normal performance.

Root cause: each `ChangeStreamObserveDriver` opened its **own** `collection.watch()` cursor. Since every driver watches the whole collection (empty pipeline) with constant options (`fullDocument: "updateLookup"`, `fullDocumentBeforeChange: "whenAvailable"`) and filters per-document via its matcher, **N distinct selectors on one collection produced N identical server-side change stream cursors**. Every write then fanned out to all N cursors and `updateLookup` triggered N post-image lookups — O(selectors × writes) server load. The oplog driver does not have this problem because it shares a single tail and dispatches in-process via a crossbar.

## Fix

New `SharedChangeStream` — **one shared change stream per collection**, owned by the `MongoConnection` (registry keyed by collection name, acquired via `_acquireSharedChangeStream`). It opens a single `collection.watch([], …)` and multicasts each raw event in-process to every subscribed driver, which still runs its own matcher/projection — mirroring how the oplog driver shares one tail. The cursor is refcounted: it closes and deregisters when the last driver detaches.

The driver no longer owns a cursor: `_startWatching` subscribes to the shared stream before reading its snapshot, and `stop()` detaches via `removeDriver`. Restart (error/close → resume via `startAfter`) lives in the shared stream.

This is purely the fanout change; it does not include unrelated change-stream fixes.

## Verification

Reproduced with `quavedev/meteor-changestream-fanout-repro`, run against this branch with change streams forced:

| N distinct selectors on one collection | `$changeStream` cursors |
|---|---|
| before | **N** (one per selector — grows linearly) |
| after | **1** (constant, shared) |

Per-selector delivery stays correct: a write to one selector reaches only that selector's observer, with zero cross-selector leakage.

The `mongo` package's change-stream suite passes under `METEOR_REACTIVITY_ORDER=changeStreams` (0 failures). Adds regression tests for cursor sharing across distinct selectors and shared-cursor teardown on the last `stop()`.

## Notes

- No package version bump — left to the release process.

## How to test locally

Change streams need MongoDB 6+ as a replica set. Meteor's dev bundle Mongo runs as a single-node replica set automatically, so a checkout works out of the box.

**1. Build this branch from a checkout:**
```bash
git fetch origin pr/changestream-fanout-14453-only
git checkout pr/changestream-fanout-14453-only
```

**2. Get the reproduction app** (it opens many distinct publication selectors on one hot collection):
```bash
git clone https://github.com/quavedev/meteor-changestream-fanout-repro
cd meteor-changestream-fanout-repro
/path/to/meteor-checkout/meteor npm install
```

**3. Count the `$changeStream` cursors.** The repro PR [quavedev/meteor-changestream-fanout-repro#1](https://github.com/quavedev/meteor-changestream-fanout-repro/pull/1) adds a `REPRO_PROBE` env var that opens N distinct-selector observers and reports the cursor count via `$currentOp` (no DDP client needed):
```bash
REPRO_PROBE=25 /path/to/meteor-checkout/meteor run --settings settings-change-streams.json --port 3055
```
- **without this fix:** `[probe] ===> 25 change-stream cursor(s) for 25 distinct selectors` (one per selector — grows linearly)
- **with this fix:** `[probe] ===> 1 change-stream cursor(s) for 25 distinct selectors`

Either way the probe prints `FUNCTIONAL PASS` — the fix is about cursor count/performance, not correctness.

**Alternative without the probe** (uses the repro's built-in tooling): start the app, drive load, then inspect Mongo:
```bash
/path/to/meteor-checkout/meteor run --settings settings-change-streams.json
meteor npm run load -- --subscriptions=200 --envs=500
meteor npm run inspect:mongo   # totalChangeStreams: ~200 without the fix, 1 with it
```

**4. Run the package tests** under the change-streams driver:
```bash
TINYTEST_FILTER=changestream METEOR_REACTIVITY_ORDER=changeStreams \
  ./packages/test-in-console/run.sh mongo
```


## Related: #14452

This is one of two independent change-stream fixes branched from `release-3.5`; the other is #14457 (#14452, observer leaves the DDP write fence parked after `stop()`). Both touch `packages/mongo/changestream_observe_driver.js` and its test file from the same base.

They do not conflict textually as they stand, but **whichever merges second will need a rebase**: this PR refactors `stop()` (moving the cursor lifecycle into `SharedChangeStream`) in the same method where #14457 adds its `_catchingUpResolvers` drain. The reconciled state — both the drain and this PR's shared-stream `removeDriver()` coexisting in `stop()` — is already validated (full `mongo` suite green under change streams). Simplest order: merge #14457 first, then rebase this PR.
