### PR TITLE
Fix change-stream observer leaving DDP write fence waiting after stop (#14452)

### DIFF
--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -109,6 +109,18 @@ export class ChangeStreamObserveDriver {
             // return undefined here and miss the fence._csTargetTs annotation.
             await driver._waitUntilCaughtUp(fence);
 
+            // The driver may have been stopped while we were parked in
+            // _waitUntilCaughtUp (stop() drains the waiter so we don't hang —
+            // meteor/meteor#14452). Once stopped, neither branch below can be
+            // trusted to release this write: the multiplexer is being torn
+            // down, and a push to _writesToCommitWhenReady can race stop()'s
+            // own drain of that array and be lost. Commit directly so the
+            // fence still fires.
+            if (driver._stopped) {
+              await write.committed();
+              continue;
+            }
+
             // Process any pending writes immediately
             driver._flushPendingWrites();
 
@@ -680,7 +692,12 @@ export class ChangeStreamObserveDriver {
         clearTimeout(warnTimeoutId);
         if (warnCount > 0) {
           console.error(
-            `Meteor: change stream caught up after warn`,
+            // When stop() drains this resolver the stream never reached
+            // targetTs — say so rather than claiming we caught up, so the logs
+            // reflect that the wait was released by teardown (#14452).
+            this._stopped
+              ? `Meteor: change stream wait released because observer stopped`
+              : `Meteor: change stream caught up after warn`,
             {
               driverId: this._id,
               collectionName,
@@ -700,6 +717,27 @@ export class ChangeStreamObserveDriver {
     if (this._stopped) return;
 
     this._stopped = true;
+
+    // Release any fence waiters still parked in _waitUntilCaughtUp before we
+    // close the change stream below. Those resolvers are waiting for an event
+    // with clusterTime >= targetTs, but once the stream is closed that event
+    // will never arrive, so leaving them parked hangs the fence's
+    // onBeforeFire (which awaits _waitUntilCaughtUp) forever — the DDP method
+    // that issued the write never gets its `updated` message and the client
+    // call hangs until timeout (meteor/meteor#14452). Resolve (don't reject):
+    // the fence may carry writes from other, still-healthy drivers, and the
+    // continuation just commits this driver's already-begun write so the fence
+    // can fire. The driver is being torn down, so not reaching targetTs on it
+    // is harmless — its handles are gone.
+    const pendingCatchUp = this._catchingUpResolvers;
+    this._catchingUpResolvers = [];
+    for (const entry of pendingCatchUp) {
+      try {
+        entry.resolver();
+      } catch (e) {
+        // ignore resolver errors
+      }
+    }
 
     // Execute all stop callbacks
     for (const callback of this._stopCallbacks) {

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -2345,6 +2345,65 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
+  'changestream- stop() releases a fence waiter parked in _waitUntilCaughtUp (#14452)',
+  async function (test) {
+    // Regression for meteor/meteor#14452. If the driver is stopped while a
+    // write fence is still parked in _waitUntilCaughtUp, the change-stream
+    // event that would advance _lastProcessedOperationTime to targetTs never
+    // arrives (the stream is being closed), so the parked resolver would hang
+    // forever. The fence's onBeforeFire awaits that resolver, so the DDP
+    // method that issued the write never gets its `updated` message and the
+    // client call hangs until timeout. stop() must release the waiter.
+    const c = makeCollection();
+    const handle = await c.find({}).observeChanges({ added: function () { } });
+    test.isTrue(isChangeStreamDriver(handle));
+    const driver = handle._multiplexer._observeDriver;
+
+    // Seed so _lastProcessedOperationTime is non-null, then build a fence with
+    // a target ts far in the future. The stream will never deliver an event
+    // with clusterTime >= this, so the wait parks a resolver and blocks.
+    // The ts must be a real BSON Timestamp (not a plain {t, i}) — Timestamp's
+    // compare() mishandles plain objects, which would send _waitUntilCaughtUp
+    // down its already-caught-up early return instead of parking.
+    await c.insertAsync({ n: 1 });
+    await waitFor(() => driver._lastProcessedOperationTime !== null, 2000);
+
+    const Timestamp = driver._lastProcessedOperationTime.constructor;
+    const farFutureTs = new Timestamp({ t: Math.floor(Date.now() / 1000) + 3600, i: 1 });
+    const fakeFence = { _csTargetTsByCollection: { [c._name]: farFutureTs } };
+
+    // Park the waiter. Do NOT await — it must not resolve until stop().
+    let resolved = false;
+    const waitPromise = driver
+      ._waitUntilCaughtUp(fakeFence)
+      .then(() => { resolved = true; });
+
+    await waitFor(() => driver._catchingUpResolvers.length === 1, 1000);
+    test.equal(
+      driver._catchingUpResolvers.length,
+      1,
+      'a resolver should be parked while the fence waits for a future ts'
+    );
+    test.isFalse(resolved, 'wait must not resolve before stop');
+
+    // Stop the driver. This must drain the parked resolver rather than leaving
+    // it (and its watchdog) running forever.
+    await driver.stop();
+
+    const released = await waitFor(() => resolved, 3000);
+    test.isTrue(released, 'stop() should release the parked fence waiter (#14452)');
+    test.equal(
+      driver._catchingUpResolvers.length,
+      0,
+      'catching-up resolvers should be drained on stop'
+    );
+
+    await waitPromise;
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
   'changestream- annotation is cleared after fence fires (with active observer)',
   async function (test) {
     const c = makeCollection();


### PR DESCRIPTION
## Problem (#14452)

When a `ChangeStreamObserveDriver` is stopped while a DDP write fence is still parked in `_waitUntilCaughtUp`, the change-stream event that would advance `_lastProcessedOperationTime` to the fence's `targetTs` never arrives — `stop()` is closing the stream. The parked resolver was never released, so the fence's `onBeforeFire` awaited forever and the DDP method that issued the write never received its `updated` message: **the client call hung until timeout**, while the watchdog logged `change stream catching up took too long` (`{ stopped: true, changeStreamOpen: false, catchingUpResolversCount: 1 }`) on a loop.

## Fix

`stop()` now drains `_catchingUpResolvers`, resolving each parked waiter — *resolve*, not reject: the fence may carry writes from other healthy drivers, and the continuation just commits this driver's already-begun write so the fence can fire.

The `onBeforeFire` continuation also commits the write directly when it finds the driver stopped, closing a narrower race where a push to `_writesToCommitWhenReady` could lose to `stop()`'s own drain of that array. The watchdog log now distinguishes a stop-release from a real catch-up.

## Verification

Adds a regression test that parks a waiter via `_waitUntilCaughtUp` and asserts `stop()` releases it and drains `_catchingUpResolvers`.

Run it under the change-streams driver:
```bash
TINYTEST_FILTER="14452" METEOR_REACTIVITY_ORDER=changeStreams \
  ./packages/test-in-console/run.sh mongo
```
With the fix the test passes; reverting the `stop()` drain makes it fail (~3s timeout) because the parked waiter is never released.

End-to-end against the reporter's reproduction app on a local checkout: without the fix, 18 method timeouts and 82+ stuck diagnostics; with the fix, 500/500 stress cycles pass with zero stuck diagnostics.

## Notes

- No package version bump — left to the release process.

## Related: #14453

This is one of two independent change-stream fixes branched from `release-3.5`; the other is #14456 (#14453, one shared change-stream cursor per collection). Both touch `packages/mongo/changestream_observe_driver.js` and its test file from the same base.

They do not conflict textually as they stand, but **whichever merges second will need a rebase**: #14456 refactors `stop()` in the same method where this PR adds its `_catchingUpResolvers` drain. The reconciled state — both the drain and #14456's shared-stream `removeDriver()` coexisting in `stop()` — is already validated. Simplest order: merge this PR first, then rebase #14456.
