### PR TITLE
fix(types): make server-render Callback generic

### DIFF
--- a/packages/server-render/server-render.d.ts
+++ b/packages/server-render/server-render.d.ts
@@ -56,6 +56,6 @@ export interface ServerSink extends ClientSink {
 
 export type Sink = ClientSink | ServerSink;
 
-export type Callback = (sink: Sink) => Promise<void> | void;
+export type Callback<T = void> = (sink: Sink) => Promise<T> | T;
 
-export function onPageLoad<T extends Callback>(callback: T): T;
+export function onPageLoad<T extends Callback<any>>(callback: T): T;

--- a/packages/server-render/server-render.test-d.ts
+++ b/packages/server-render/server-render.test-d.ts
@@ -15,4 +15,24 @@ expectTypeOf<CategorizedRequest>().toBeObject();
 expectTypeOf<ServerSink>().toBeObject();
 expectTypeOf<Sink>().not.toBeNever();
 expectTypeOf<Callback>().toBeFunction();
+expectTypeOf<Callback<string>>().toBeFunction();
 expectTypeOf(onPageLoad).toBeFunction();
+
+expectTypeOf<Callback>().returns.toEqualTypeOf<Promise<void> | void>();
+expectTypeOf<Callback<string>>().returns.toEqualTypeOf<Promise<string> | string>();
+expectTypeOf<Callback>().parameter(0).toEqualTypeOf<Sink>();
+
+onPageLoad((sink) => {
+  expectTypeOf(sink).toEqualTypeOf<Sink>();
+});
+onPageLoad(async (sink) => {
+  expectTypeOf(sink).toEqualTypeOf<Sink>();
+});
+onPageLoad(async (sink) => {
+  expectTypeOf(sink).toEqualTypeOf<Sink>();
+  return "value";
+});
+onPageLoad((sink) => {
+  expectTypeOf(sink).toEqualTypeOf<Sink>();
+  return 42;
+});


### PR DESCRIPTION
## Problem

#14319 narrowed `Callback` in `server-render.d.ts` from `Promise<any> | any` to `Promise<void> | void`. That breaks consumer signatures like `onPageLoad(async sink => { return x })`. Runtime ignores the return value in all three call paths (`server.js`, `client.js`, `server-register.js`), so the narrowing is a TS-only break.

CodeRabbit flagged this at `server-render.d.ts:59`, thread still open.

## Fix

Generic with `void` default:

```ts
export type Callback<T = void> = (sink: Sink) => Promise<T> | T;
export function onPageLoad<T extends Callback<any>>(callback: T): T;
```

Bare `Callback` annotation stays `void`-returning (keeps the tightening intent). Callbacks returning values use `Callback<MyType>`, or just let `onPageLoad` infer `T` from what's passed.

## Tests

`server-render.test-d.ts` now covers the real shapes from `server-render-tests.js` and `v3-docs/packages/server-render.md`:

- sync void: `onPageLoad(sink => {...})`
- async void: `onPageLoad(async sink => {...})`
- async with return: `onPageLoad(async sink => "x")`
- sync with return: `onPageLoad(sink => 42)`

Plus `.returns.toEqualTypeOf` assertions locking the default `void` return and the threaded generic return.

## Files

- `packages/server-render/server-render.d.ts`
- `packages/server-render/server-render.test-d.ts`

## Verified

With #14447 cherry-picked locally:

| Step | Result |
|---|---|
| `npm run types:compile` | 0 errors |
| `npm run types:coverage` | 99.50% (7255/7291) |