### PR TITLE
fix(types): add set(object) overload to Session

### DIFF
--- a/packages/session/session.d.ts
+++ b/packages/session/session.d.ts
@@ -30,6 +30,13 @@ export namespace Session {
    * @param value The new value for `key`
    */
   function set(key: string, value: SessionValue): void;
+  /**
+   * Set multiple session variables at once. Equivalent to calling
+   * `Session.set` individually on each key/value pair.
+   * @param object An object whose keys are session variable names and
+   *   whose values are the new values for those variables.
+   */
+  function set(object: Record<string, SessionValue>): void;
 
   /**
    * Set a variable in the session if it hasn't been set before.

--- a/packages/session/session.test-d.ts
+++ b/packages/session/session.test-d.ts
@@ -22,7 +22,8 @@ expectTypeOf(Session.equals).returns.toBeBoolean();
 expectTypeOf(Session.get).parameters.toEqualTypeOf<[string]>();
 expectTypeOf(Session.get).returns.toEqualTypeOf<SessionValue>();
 
-expectTypeOf(Session.set).parameters.toEqualTypeOf<[string, SessionValue]>();
+expectTypeOf(Session.set).toBeCallableWith("key", "value");
+expectTypeOf(Session.set).toBeCallableWith({ k: "v" });
 expectTypeOf(Session.set).returns.toBeVoid();
 
 expectTypeOf(Session.setDefault).parameters.toEqualTypeOf<[string, SessionValue]>();

--- a/packages/session/session.test-d.ts
+++ b/packages/session/session.test-d.ts
@@ -22,8 +22,16 @@ expectTypeOf(Session.equals).returns.toBeBoolean();
 expectTypeOf(Session.get).parameters.toEqualTypeOf<[string]>();
 expectTypeOf(Session.get).returns.toEqualTypeOf<SessionValue>();
 
-expectTypeOf(Session.set).toBeCallableWith("key", "value");
-expectTypeOf(Session.set).toBeCallableWith({ k: "v" });
+expectTypeOf(Session.set).toBeCallableWith("k", "value");
+expectTypeOf(Session.set).toBeCallableWith("k", 42);
+expectTypeOf(Session.set).toBeCallableWith("k", true);
+expectTypeOf(Session.set).toBeCallableWith("k", null);
+expectTypeOf(Session.set).toBeCallableWith("k", undefined);
+expectTypeOf(Session.set).toBeCallableWith("k", new Date());
+expectTypeOf(Session.set).toBeCallableWith("k", new Uint8Array());
+expectTypeOf(Session.set).toBeCallableWith("k", { nested: 1 });
+expectTypeOf(Session.set).toBeCallableWith("k", [1, 2, 3]);
+expectTypeOf(Session.set).toBeCallableWith({ s: "v", n: 1, b: true, x: null });
 expectTypeOf(Session.set).returns.toBeVoid();
 
 expectTypeOf(Session.setDefault).parameters.toEqualTypeOf<[string, SessionValue]>();


### PR DESCRIPTION
## Problem

`Session.set(object)` is documented (`v3-docs/docs/api/session.md:39-43`) and supported by the runtime (`ReactiveDict.set`, `reactive-dict.js:84-89` dispatches on `value === undefined`), but `session.d.ts` only declares the `(key, value)` form. TS consumers calling the object form get a type error.

## Fix

Add the overload:

```ts
function set(key: string, value: SessionValue): void;
function set(object: Record<string, SessionValue>): void;
```

`Record<string, SessionValue>` keeps the narrowing #14319 applied across the file.

## Tests

Strict `.parameters` assertion was incompatible with the overload. Replaced with `.toBeCallableWith` for both forms and expanded to every `SessionValue` variant (string, number, boolean, null, undefined, Date, Uint8Array, object, array, multi-key object).

## Files

- `packages/session/session.d.ts`
- `packages/session/session.test-d.ts`

## Verified

With #14447 cherry-picked locally:

| Step | Result |
|---|---|
| `npm run types:compile` | 0 errors |
| `npm run types:coverage` | 99.50% (7256/7292) |