### PR TITLE
Fix change-stream observe driver dropping documents matched by ObjectID selectors (#14460)

### DIFF
--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -5,7 +5,7 @@ import { MongoID } from 'meteor/mongo-id';
 import { DDPServer } from 'meteor/ddp-server';
 import { DiffSequence } from 'meteor/diff-sequence';
 import { listenAll } from './mongo_driver';
-import { replaceTypes, replaceMongoAtomWithMeteor } from './mongo_common';
+import { replaceTypes, replaceMongoAtomWithMeteor, replaceMeteorAtomWithMongo } from './mongo_common';
 import { compareOperationTimes } from './mongo_common';
 
 const SUPPORTED_OPERATIONS = ['insert', 'update', 'replace', 'delete'];
@@ -325,7 +325,10 @@ export class ChangeStreamObserveDriver {
 
     try {
       // Build the same selector and options that the cursor would use
-      const selector = this._cursorDescription.selector || {};
+      const selector = replaceTypes(
+        this._cursorDescription.selector || {},
+        replaceMeteorAtomWithMongo
+      );
       const options = { ...this._cursorDescription.options };
 
       // Find all existing documents
@@ -421,11 +424,17 @@ export class ChangeStreamObserveDriver {
   async _handleChange(change) {
     if (this._stopped) return;
 
-    const { operationType, documentKey, fullDocument, fullDocumentBeforeChange, clusterTime } = change;
+    const { operationType, documentKey, clusterTime } = change;
 
     if (!SUPPORTED_OPERATIONS.includes(operationType)) {
       return; // Ignore unsupported operations
     }
+
+    const fullDocument = replaceTypes(change.fullDocument, replaceMongoAtomWithMeteor);
+    const fullDocumentBeforeChange = replaceTypes(
+      change.fullDocumentBeforeChange,
+      replaceMongoAtomWithMeteor
+    );
 
     let id = documentKey._id;
     if (typeof documentKey._id?.toHexString === 'function') {

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -704,6 +704,111 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
+  'changestream - #14460 initial adds deliver a pre-existing doc matched by an ObjectID _id selector',
+  async function (test) {
+    const c = new Mongo.Collection(
+      'changestream_test_objectid_' + Random.id(),
+      { idGeneration: 'MONGO' }
+    );
+
+    const id1 = await c.insertAsync({ name: 'pet-1' });
+    await c.insertAsync({ name: 'pet-2' });
+    test.isTrue(id1 instanceof Mongo.ObjectID, 'MONGO idGeneration should yield an ObjectID');
+
+    const fetched = await c.find({ _id: id1 }).fetchAsync();
+    test.equal(fetched.length, 1, 'fetchAsync should find the doc by ObjectID');
+
+    const added = [];
+    const handle = await c.find({ _id: id1 }).observeChanges({
+      added(id, fields) { added.push({ id, fields }); },
+    });
+    test.isTrue(isChangeStreamDriver(handle), 'Should be using ChangeStream driver');
+
+    await waitFor(() => added.length > 0);
+    test.equal(added.length, 1, 'initial added should fire for the ObjectID-matched doc');
+    test.isTrue(added[0].id instanceof Mongo.ObjectID, 'delivered id should be an ObjectID');
+    test.equal(added[0].id.toHexString(), id1.toHexString());
+    test.equal(added[0].fields.name, 'pet-1');
+
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
+  'changestream - #14460 initial adds deliver pre-existing docs matched by { _id: { $in: [ObjectID, ...] } }',
+  async function (test) {
+    const c = new Mongo.Collection(
+      'changestream_test_objectid_in_' + Random.id(),
+      { idGeneration: 'MONGO' }
+    );
+
+    const id1 = await c.insertAsync({ name: 'pet-1' });
+    const id2 = await c.insertAsync({ name: 'pet-2' });
+    const id3 = await c.insertAsync({ name: 'pet-3' });
+
+    const selector = { _id: { $in: [id1, id3] } };
+
+    const fetched = await c.find(selector).fetchAsync();
+    test.equal(fetched.length, 2, 'fetchAsync should find both $in docs');
+
+    const added = [];
+    const handle = await c.find(selector).observeChanges({
+      added(id, fields) { added.push({ id, fields }); },
+    });
+    test.isTrue(isChangeStreamDriver(handle), 'Should be using ChangeStream driver');
+
+    await waitFor(() => added.length >= 2);
+    test.equal(added.length, 2, 'initial added should fire for both $in-matched docs');
+
+    const gotHex = added.map(a => a.id.toHexString()).sort();
+    const wantHex = [id1.toHexString(), id3.toHexString()].sort();
+    test.equal(gotHex, wantHex, 'should deliver exactly the $in-selected docs');
+    test.isFalse(
+      added.some(a => a.id.toHexString() === id2.toHexString()),
+      'a doc outside the $in must not be delivered'
+    );
+
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
+  'changestream - #14460 live update to an ObjectID-selected doc stays in the set (changed, not removed)',
+  async function (test) {
+    const c = new Mongo.Collection(
+      'changestream_test_objectid_live_' + Random.id(),
+      { idGeneration: 'MONGO' }
+    );
+
+    const id1 = await c.insertAsync({ name: 'pet-1', n: 1 });
+
+    const events = [];
+    const handle = await c.find({ _id: { $in: [id1] } }).observeChanges({
+      added(id, fields) { events.push({ type: 'added', id, fields }); },
+      changed(id, fields) { events.push({ type: 'changed', id, fields }); },
+      removed(id) { events.push({ type: 'removed', id }); },
+    });
+    test.isTrue(isChangeStreamDriver(handle), 'Should be using ChangeStream driver');
+
+    await waitFor(() => events.length > 0);
+    test.equal(events.length, 1, 'initial added for the selected doc');
+    test.equal(events[0].type, 'added');
+    events.length = 0;
+
+    await c.updateAsync(id1, { $set: { n: 2 } });
+    await waitFor(() => events.length > 0);
+    test.equal(events[0].type, 'changed', 'update to a selected doc should emit changed, not removed');
+    test.equal(events[0].fields.n, 2);
+    test.isFalse(
+      events.some(e => e.type === 'removed'),
+      'a selected doc must not be spuriously removed on update'
+    );
+
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
   'changestream - handles nested documents',
   async function (test) {
     const c = makeCollection();


### PR DESCRIPTION
## Problem

Fixes #14460.

Under the **change-streams** reactivity driver (new in 3.5), a publication / `observeChanges` whose selector targets an `ObjectID` `_id` delivers **nothing** to the client, even though the same selector works on the server with `fetchAsync()`:

```js
// Collection with idGeneration: 'MONGO' -> _id values are Mongo.ObjectID
// ACL pattern: resolve allowed ids from another collection, then publish:
return Pets.find({ _id: { $in: allowedIds } });
```

- Server `fetchAsync()` returns the docs ✅
- Client Minimongo stays empty ❌
- A control selector without an ObjectID (`{ deleted: false }`) works ✅

This breaks the common access-control pattern of "resolve allowed ObjectIDs → publish with `{ _id: { $in: ids } }`".

## Root cause

`ChangeStreamObserveDriver` compared **Meteor-typed** values against **native BSON** values in two places:

1. **Initial snapshot** — `_sendInitialAdds()` queried the raw collection with the *untranslated* Meteor selector. The native MongoDB driver compares against BSON `ObjectId`, so a `Mongo.ObjectID` in the selector matched nothing and the snapshot came back empty. Every other path (`fetch()`, oplog, polling) goes through `_createAsynchronousCursor`, which translates the selector with `replaceMeteorAtomWithMongo` first — this one did not.

2. **Live updates** — `_handleChange()` fed the native BSON change document straight into the Meteor-typed matcher, so a live update to a doc selected by an ObjectID field failed `documentMatches` and the doc was **spuriously `removed`** from the client.

## Fix

- Translate the selector with `replaceMeteorAtomWithMongo` before the initial snapshot query.
- Translate the change-stream payloads (`fullDocument` / `fullDocumentBeforeChange`) with `replaceMongoAtomWithMeteor` before they reach the matcher.

Both mirror the translation the rest of the Mongo layer already performs, so non-ObjectID selectors are unaffected.

## Tests

New regression tests in `changestream_observe_driver_tests.js` (run under `METEOR_REACTIVITY_ORDER=changeStreams`):

- initial snapshot delivers a pre-existing doc matched by `{ _id: <ObjectID> }`
- initial snapshot delivers pre-existing docs matched by `{ _id: { $in: [<ObjectID>, ...] } }`
- a live update to an ObjectID-selected doc stays in the set (`changed`, not `removed`)

All three fail on `release-3.5` and pass with this change; the full change-stream suite stays green (76/76).

## Reproduction (issue author's repo)

Verified end-to-end against the reporter's repro ([harry-73/objectId-meteor35](https://github.com/harry-73/objectId-meteor35)) running on this checkout, comparing `fetchAsync` (control) vs `observeChanges` initial adds for `{ _id: { $in: ids } }` on a MONGO collection:

```
# before (release-3.5)
REPRO[#14460] driver=changeStreams fetchAsync=2 observeInitialAdded=0  => FAIL
# after (this PR)
REPRO[#14460] driver=changeStreams fetchAsync=2 observeInitialAdded=2  => PASS
```

Targets `release-3.5` (change streams ship in 3.5-rc.1).
