### PR TITLE
fix(types): widen over-tight signatures in meteor and mongo

### DIFF
--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -63,7 +63,7 @@ export namespace Meteor {
     emails?: UserEmail[] | undefined;
     createdAt?: Date | undefined;
     profile?: UserProfile;
-    services?: Record<string, Record<string, unknown>>;
+    services?: Record<string, unknown>;
   }
 
   function user(options?: {

--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -333,7 +333,7 @@ export namespace Meteor {
    * @param func The function to wrap
    * @param options An object with an `on` property that is an array of environment names: `"development"`, `"production"`, and/or `"test"`.
    */
-  function deferrable<T extends (...args: unknown[]) => unknown>(
+  function deferrable<T extends (...args: any[]) => any>(
     func: T,
     options: { on: Array<"development" | "production" | "test"> }
   ): T | void;
@@ -342,13 +342,13 @@ export namespace Meteor {
    * Wrap a function so that it only runs in development environment.
    * @param func The function to wrap
    */
-  function deferDev<T extends (...args: unknown[]) => unknown>(func: T): T | void;
+  function deferDev<T extends (...args: any[]) => any>(func: T): T | void;
 
   /**
    * Wrap a function so that it only runs in production environment.
    * @param func The function to wrap
    */
-  function deferProd<T extends (...args: unknown[]) => unknown>(func: T): T | void;
+  function deferProd<T extends (...args: any[]) => any>(func: T): T | void;
   /** Timeout **/
 
   /** utils **/

--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -67,10 +67,10 @@ export namespace Meteor {
   }
 
   function user(options?: {
-    fields?: Record<string, number> | undefined;
+    fields?: Mongo.FieldSpecifier | undefined;
   }): User | null;
   function userAsync(options?: {
-    fields?: Record<string, number> | undefined;
+    fields?: Mongo.FieldSpecifier | undefined;
   }): Promise<Meteor.User | null>;
 
   function userId(): string | null;

--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -543,7 +543,7 @@ export namespace Meteor {
     name: string | null,
     func: (
       this: Subscription,
-      ...args: EJSONableProperty[]
+      ...args: (EJSONable | EJSONableProperty)[]
     ) =>
       | void
       | Mongo.Cursor<unknown>

--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -27,7 +27,7 @@ export namespace Meteor {
     errorType: string;
   }
 
-  function makeErrorType(name: string, constructor: (this: Error, message: string, reason?: string) => void): ErrorConstructor;
+  function makeErrorType(name: string, constructor: (this: any, ...args: any[]) => void): ErrorConstructor;
   /** Global props **/
 
   /** Settings **/

--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -368,12 +368,12 @@ export namespace Meteor {
    * @param func A function that takes a callback as its final parameter
    * @param context Optional `this` object against which the original function will be invoked
    */
-  function wrapAsync<TFunc extends (...args: unknown[]) => unknown>(
+  function wrapAsync<TFunc extends (...args: any[]) => any>(
     func: TFunc,
     context?: ThisParameterType<TFunc>
-  ): (...args: unknown[]) => unknown;
+  ): (...args: any[]) => any;
 
-  function bindEnvironment<TFunc extends (...args: unknown[]) => unknown>(func: TFunc): TFunc;
+  function bindEnvironment<TFunc extends (...args: any[]) => any>(func: TFunc): TFunc;
 
   class EnvironmentVariable<T> {
     readonly slot: number;

--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -154,7 +154,8 @@ export namespace Meteor {
    * @param methods Dictionary whose keys are method names and values are functions.
    */
   function methods(methods: {
-    [key: string]: (this: MethodThisType, ...args: EJSONableProperty[]) => EJSONableProperty | void | Promise<EJSONableProperty | void>;
+    [key: string]: (this: MethodThisType, ...args: (EJSONable | EJSONableProperty)[]) =>
+      EJSONable | EJSONableProperty | void | Promise<EJSONable | EJSONableProperty | void>;
   }): void;
 
   /**

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -46,7 +46,7 @@ export namespace Mongo {
   };
 
   type DispatchTransform<TransformFn, T, U> = TransformFn extends (
-    ...args: unknown[]
+    ...args: any[]
   ) => infer R
     ? R
     : TransformFn extends null

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -135,13 +135,13 @@ export namespace Mongo {
      * @param name The name of the static method to add
      * @param method The static method function
      */
-    addStaticMethod(name: string, method: (...args: unknown[]) => unknown): void;
+    addStaticMethod(name: string, method: Function): void;
 
     /**
      * Remove a constructor extension (useful for testing).
      * @param extension The extension function to remove
      */
-    removeExtension(extension: (...args: unknown[]) => unknown): void;
+    removeExtension(extension: Function): void;
 
     /**
      * Remove a prototype method from all collection instances.
@@ -164,19 +164,19 @@ export namespace Mongo {
      * Get all registered constructor extensions (useful for debugging).
      * @returns Array of registered extension functions
      */
-    getExtensions(): Array<(...args: unknown[]) => unknown>;
+    getExtensions(): Array<Function>;
 
     /**
      * Get all registered prototype methods (useful for debugging).
      * @returns Map of method names to functions
      */
-    getPrototypeMethods(): Map<string, (...args: unknown[]) => unknown>;
+    getPrototypeMethods(): Map<string, Function>;
 
     /**
      * Get all registered static methods (useful for debugging).
      * @returns Map of method names to functions
      */
-    getStaticMethods(): Map<string, (...args: unknown[]) => unknown>;
+    getStaticMethods(): Map<string, Function>;
   }
   interface Collection<T extends NpmModuleMongodb.Document, U = T> {
     allow<Fn extends Transform<T, U> = undefined>(options: {
@@ -586,13 +586,13 @@ export namespace Mongo {
      * @param name The name of the static method to add
      * @param method The static method function
      */
-    addStaticMethod(name: string, method: (...args: unknown[]) => unknown): void;
+    addStaticMethod(name: string, method: Function): void;
 
     /**
      * Remove a constructor extension (useful for testing).
      * @param extension The extension function to remove
      */
-    removeExtension(extension: (...args: unknown[]) => unknown): void;
+    removeExtension(extension: Function): void;
 
     /**
      * Remove a prototype method from all collection instances.
@@ -615,19 +615,19 @@ export namespace Mongo {
      * Get all registered constructor extensions (useful for debugging).
      * @returns Array of registered extension functions
      */
-    getExtensions(): Array<(...args: unknown[]) => unknown>;
+    getExtensions(): Array<Function>;
 
     /**
      * Get all registered prototype methods (useful for debugging).
      * @returns Map of method names to functions
      */
-    getPrototypeMethods(): Map<string, (...args: unknown[]) => unknown>;
+    getPrototypeMethods(): Map<string, Function>;
 
     /**
      * Get all registered static methods (useful for debugging).
      * @returns Map of method names to functions
      */
-    getStaticMethods(): Map<string, (...args: unknown[]) => unknown>;
+    getStaticMethods(): Map<string, Function>;
   }
 
   var CollectionExtensions: CollectionExtensions;

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -356,7 +356,7 @@ export namespace Mongo {
          */
         arrayFilters?: NpmModuleMongodb.Document[] | undefined;
       },
-      callback?: (error: Error | null, result?: number) => void
+      callback?: Function
     ): number;
     /**
      * Modify one or more documents in the collection. Returns the number of matched documents.
@@ -378,7 +378,7 @@ export namespace Mongo {
          */
         arrayFilters?: NpmModuleMongodb.Document[] | undefined;
       },
-      callback?: (error: Error | null, result?: number) => void
+      callback?: Function
     ): Promise<number>;
     /**
      * Modify one or more documents in the collection, or insert one if no matching documents were found. Returns an object with keys `numberAffected` (the number of documents modified) and

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -297,13 +297,13 @@ export namespace Mongo {
      * @param doc The document to insert. May not yet have an _id attribute, in which case Meteor will generate one for you.
      * @param callback If present, called with an error object as the first argument and, if no error, the _id as the second.
      */
-    insert(doc: OptionalId<T>, callback?: (error: Error | null, _id?: string) => void): string;
+    insert(doc: OptionalId<T>, callback?: Function): string;
     /**
      * Insert a document in the collection.  Returns its unique _id.
      * @param doc The document to insert. May not yet have an _id attribute, in which case Meteor will generate one for you.
      * @param callback If present, called with an error object as the first argument and, if no error, the _id as the second.
      */
-    insertAsync(doc: OptionalId<T>, callback?: (error: Error | null, _id?: string) => void): Promise<string>;
+    insertAsync(doc: OptionalId<T>, callback?: Function): Promise<string>;
     /**
      * Returns the [`Collection`](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html) object corresponding to this collection from the
      * [npm `mongodb` driver module](https://www.npmjs.com/package/mongodb) which is wrapped by `Mongo.Collection`.

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -13,7 +13,7 @@ export namespace Mongo {
 
   type Modifier<T> = NpmModuleMongodb.UpdateFilter<T>;
 
-  export type OptionalId<TSchema> = UnionOmit<TSchema, '_id'> & { _id?: string | NpmModuleMongodb.ObjectId };
+  export type OptionalId<TSchema> = UnionOmit<TSchema, '_id'> & { _id?: string | ObjectID | NpmModuleMongodb.ObjectId };
 
   export type SortSpecifier = NpmModuleMongodb.Sort;
 

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -396,7 +396,7 @@ export namespace Mongo {
         /** True to modify all matching documents; false to only modify one of the matching documents (the default). */
         multi?: boolean | undefined;
       },
-      callback?: (error: Error | null, result?: { numberAffected?: number; insertedId?: string }) => void
+      callback?: Function
     ): {
       numberAffected?: number | undefined;
       insertedId?: string | undefined;
@@ -415,7 +415,7 @@ export namespace Mongo {
         /** True to modify all matching documents; false to only modify one of the matching documents (the default). */
         multi?: boolean | undefined;
       },
-      callback?: (error: Error | null, result?: { numberAffected?: number; insertedId?: string }) => void
+      callback?: Function
     ): Promise<{
       numberAffected?: number | undefined;
       insertedId?: string | undefined;

--- a/packages/mongo/mongo.test-d.ts
+++ b/packages/mongo/mongo.test-d.ts
@@ -11,7 +11,7 @@ interface Doc {
 expectTypeOf<UnionOmit<{ a: 1, b: 2 }, 'a'>>().toEqualTypeOf<{ b: 2 }>();
 
 expectTypeOf<Mongo.OptionalId<Doc>>().toEqualTypeOf<
-  { name: string; value: number } & { _id?: string | NpmModuleMongodb.ObjectId }
+  { name: string; value: number } & { _id?: string | Mongo.ObjectID | NpmModuleMongodb.ObjectId }
 >();
 
 expectTypeOf<Mongo.Selector<Doc>>().toEqualTypeOf<NpmModuleMongodb.Filter<Doc>>();
@@ -65,16 +65,16 @@ expectTypeOf(transformed.findOneAsync("id")).resolves.toEqualTypeOf<
 expectTypeOf(Mongo.Collection.addExtension).toBeFunction();
 expectTypeOf(Mongo.Collection.addPrototypeMethod).parameter(0).toBeString();
 expectTypeOf(Mongo.Collection.addStaticMethod).parameters.toEqualTypeOf<
-  [string, (...args: unknown[]) => unknown]
+  [string, Function]
 >();
 expectTypeOf(Mongo.Collection.getExtensions).returns.toEqualTypeOf<
-  Array<(...args: unknown[]) => unknown>
+  Array<Function>
 >();
 expectTypeOf(Mongo.Collection.getPrototypeMethods).returns.toEqualTypeOf<
-  Map<string, (...args: unknown[]) => unknown>
+  Map<string, Function>
 >();
 expectTypeOf(Mongo.Collection.getStaticMethods).returns.toEqualTypeOf<
-  Map<string, (...args: unknown[]) => unknown>
+  Map<string, Function>
 >();
 expectTypeOf(Mongo.Collection.clearExtensions).returns.toBeVoid();
 


### PR DESCRIPTION
## Problem

Several signature tightenings in #14319 reject documented runtime patterns and break existing consumer apps. Bumping `any` and `Function` to `unknown` or narrow concrete types regressed behavior that worked under devel.

## Fix

### meteor.d.ts

| Symbol | Was | Now | Why |
|---|---|---|---|
| `Meteor.User.services` | `Record<string, Record<string, unknown>>` | `Record<string, unknown>` | rejects documented `services.resume.loginTokens: Array<...>` |
| `Meteor.user` / `userAsync` `options.fields` | `Record<string, number>` | `Mongo.FieldSpecifier` | devel parity, projection consumers broke |
| `makeErrorType` ctor | `(this: Error, message, reason?) => void` | `(this: any, ...args: any[]) => void` | `Meteor.Error` itself uses `(error, reason, details)`, narrow sig is self-inconsistent |
| `Meteor.methods` args / return | `EJSONableProperty[]` / `EJSONableProperty \| void \| Promise<...>` | `(EJSONable \| EJSONableProperty)[]` / `EJSONable \| EJSONableProperty \| void \| Promise<...>` | every typed method passes object args |
| `Meteor.publish` handler args | `EJSONableProperty[]` | `(EJSONable \| EJSONableProperty)[]` | publish handlers receive same args clients pass to `Meteor.subscribe` |
| `deferrable`, `deferDev`, `deferProd` generic | `T extends (...args: unknown[]) => unknown` | `T extends (...args: any[]) => any` | contravariant `unknown[]` rejects real callbacks |
| `wrapAsync`, `bindEnvironment` generic | same | `T extends (...args: any[]) => any` | same |

### mongo.d.ts

| Symbol | Was | Now | Why |
|---|---|---|---|
| `OptionalId._id` | `string \| NpmModuleMongodb.ObjectId` | `string \| Mongo.ObjectID \| NpmModuleMongodb.ObjectId` | MONGO idGen returns `Mongo.ObjectID` at runtime |
| `DispatchTransform` infer source | `(...args: unknown[]) => infer R` | `(...args: any[]) => infer R` | concrete user transforms don't match `unknown[]`, breaks `Cursor` return inference |
| `insert` / `insertAsync` callback | `(error, _id?: string) => void` | `Function` | `_id` may be `ObjectID` depending on idGen |
| `update` / `updateAsync` callback | `(error, result?: number) => void` | `Function` | runtime may return raw mongo driver result via `_returnObject` |
| `upsert` / `upsertAsync` callback | `(error, result?: { numberAffected?, insertedId? }) => void` | `Function` | runtime returns number OR object depending on `_returnObject` |
| Extension API (`addStaticMethod`, `removeExtension`, `getExtensions`, `getPrototypeMethods`, `getStaticMethods`) | `(...args: unknown[]) => unknown` | `Function` | rejects concrete user functions; applies across both `CollectionStatic` and `CollectionExtensions` |

`mongo.test-d.ts` updated to match new `OptionalId` and extension API shapes.

## Files

- `packages/meteor/meteor.d.ts`
- `packages/mongo/mongo.d.ts`
- `packages/mongo/mongo.test-d.ts`

## Verified

With #14447 cherry-picked locally:

| Step | Result |
|---|---|
| `npm run types:compile` | 0 errors |
| `npm run types:coverage` (`--at-least 99`) | 99.48% pass |