### PR TITLE
fix(types): correct wrong returns and async/sync mismatches

### DIFF
--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -158,11 +158,11 @@ export namespace Accounts {
 
   function logout(
     callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
-  ): Promise<void>;
+  ): void;
 
   function logoutOtherClients(
     callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
-  ): Promise<void>;
+  ): void;
 
   type PasswordSignupField = 'USERNAME_AND_EMAIL' | 'USERNAME_AND_OPTIONAL_EMAIL' | 'USERNAME_ONLY' | 'EMAIL_ONLY';
   type PasswordlessSignupField = 'USERNAME_AND_EMAIL' | 'EMAIL_ONLY';

--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -406,6 +406,6 @@ export namespace Accounts {
     userId: string,
     token: HashedStampedLoginToken,
     query?: Mongo.Selector<T> | Mongo.ObjectID | string
-  ): void;
+  ): Promise<void>;
   function _hashLoginToken(token: string): string;
 }

--- a/packages/ddp/ddp.d.ts
+++ b/packages/ddp/ddp.d.ts
@@ -49,7 +49,7 @@ export namespace DDPCommon {
      * Set the logged in user.
      * @param userId The value that should be returned by `userId` on this connection.
      */
-    setUserId(userId: string | null): void;
+    setUserId(userId: string | null): Promise<void>;
     /**
      * The id of the user that made this method call, or `null` if no user was logged in.
      */

--- a/packages/logging/logging.d.ts
+++ b/packages/logging/logging.d.ts
@@ -30,7 +30,7 @@ export declare namespace Log {
   function _intercepted(): string[];
   function _getCallerDetails(): { line: number; file: string };
   function parse(line: Record<string, unknown> | string): Record<string, unknown>;
-  function format(object: formatInput, options: { color: true }): Record<string, unknown> | string;
+  function format(object: formatInput, options?: { color?: boolean; metaColor?: string }): string;
   function objFromText(
     line: string,
     override: Record<string, unknown>

--- a/packages/logging/logging.d.ts
+++ b/packages/logging/logging.d.ts
@@ -28,7 +28,7 @@ export declare namespace Log {
   function _intercept(count: number): void;
   function _suppress(count: number): void;
   function _intercepted(): string[];
-  function _getCallerDetails(): { line: number; file: string };
+  function _getCallerDetails(): { line?: string; file?: string };
   function parse(line: Record<string, unknown> | string): Record<string, unknown> | null;
   function format(object: formatInput, options?: { color?: boolean; metaColor?: string }): string;
   function objFromText(

--- a/packages/logging/logging.d.ts
+++ b/packages/logging/logging.d.ts
@@ -29,7 +29,7 @@ export declare namespace Log {
   function _suppress(count: number): void;
   function _intercepted(): string[];
   function _getCallerDetails(): { line: number; file: string };
-  function parse(line: Record<string, unknown> | string): Record<string, unknown>;
+  function parse(line: Record<string, unknown> | string): Record<string, unknown> | null;
   function format(object: formatInput, options?: { color?: boolean; metaColor?: string }): string;
   function objFromText(
     line: string,

--- a/packages/logging/logging.test-d.ts
+++ b/packages/logging/logging.test-d.ts
@@ -28,20 +28,18 @@ expectTypeOf(Log._suppress).parameters.toEqualTypeOf<[number]>();
 expectTypeOf(Log._suppress).returns.toBeVoid();
 expectTypeOf(Log._intercepted).returns.toEqualTypeOf<string[]>();
 expectTypeOf(Log._getCallerDetails).returns.toEqualTypeOf<{
-  line: number;
-  file: string;
+  line?: string;
+  file?: string;
 }>();
 
 // parse / format / objFromText
 expectTypeOf(Log.parse).parameters.toEqualTypeOf<
   [Record<string, unknown> | string]
 >();
-expectTypeOf(Log.parse).returns.toEqualTypeOf<Record<string, unknown>>();
+expectTypeOf(Log.parse).returns.toEqualTypeOf<Record<string, unknown> | null>();
 
-expectTypeOf(Log.format).parameter(1).toEqualTypeOf<{ color: true }>();
-expectTypeOf(Log.format).returns.toEqualTypeOf<
-  Record<string, unknown> | string
->();
+expectTypeOf(Log.format).parameter(1).toEqualTypeOf<{ color?: boolean; metaColor?: string } | undefined>();
+expectTypeOf(Log.format).returns.toBeString();
 
 expectTypeOf(Log.objFromText).parameters.toEqualTypeOf<
   [string, Record<string, unknown>]

--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -537,8 +537,8 @@ export namespace Mongo {
       callbacks: ObserveChangesCallbacks<T>,
       options?: { nonMutatingCallbacks?: boolean | undefined }
     ): Meteor.LiveQueryHandle;
-    [Symbol.iterator](): Iterator<T>;
-    [Symbol.asyncIterator](): AsyncIterator<T>;
+    [Symbol.iterator](): Iterator<U>;
+    [Symbol.asyncIterator](): AsyncIterator<U>;
     /**
      * Watch a query. Receive callbacks as the result set changes. Only the differences between the old and new documents are passed to the callbacks.
      * @param callbacks Functions to call to deliver the result set as it changes

--- a/packages/tracker/tracker.d.ts
+++ b/packages/tracker/tracker.d.ts
@@ -19,7 +19,7 @@ export namespace Tracker {
     /**
      * Forces autorun blocks to be executed in synchronous-looking order by storing the value autorun promise thus making it awaitable.
      */
-    firstRunPromise: Promise<unknown>;
+    firstRunPromise: Promise<unknown> | undefined;
     /**
      * Invalidates this computation so that it will be rerun.
      */

--- a/packages/tracker/tracker.test-d.ts
+++ b/packages/tracker/tracker.test-d.ts
@@ -41,7 +41,7 @@ expectTypeOf(Tracker.onInvalidate).returns.toBeVoid();
 
 // Computation interface
 expectTypeOf<Tracker.Computation>().toHaveProperty("firstRun").toBeBoolean();
-expectTypeOf<Tracker.Computation>().toHaveProperty("firstRunPromise").toEqualTypeOf<Promise<unknown>>();
+expectTypeOf<Tracker.Computation>().toHaveProperty("firstRunPromise").toEqualTypeOf<Promise<unknown> | undefined>();
 expectTypeOf<Tracker.Computation>().toHaveProperty("invalidated").toBeBoolean();
 expectTypeOf<Tracker.Computation>().toHaveProperty("stopped").toBeBoolean();
 expectTypeOf<Tracker.Computation["invalidate"]>().toEqualTypeOf<() => void>();

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -84,8 +84,8 @@ export declare namespace WebAppInternals {
   };
   function registerBoilerplateDataCallback(
     key: string,
-    callback: Function
-  ): Function;
+    callback: Function | null
+  ): Function | null;
   function generateBoilerplateInstance(
     arch: string,
     manifest: Record<string, unknown>[],

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -63,7 +63,7 @@ export declare namespace WebApp {
     encodedCurrentConfig: string;
     updated: boolean;
   }) => string | undefined | null | false;
-  function addRuntimeConfigHook(callback: RuntimeConfigHookCallback): void;
+  function addRuntimeConfigHook(callback: RuntimeConfigHookCallback): { stop: () => void; callback: RuntimeConfigHookCallback };
   function decodeRuntimeConfig(rtimeConfigString: string): unknown;
   function encodeRuntimeConfig(rtimeConfig: unknown): string;
   function addHtmlAttributeHook(hook: Function): void;

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -98,7 +98,7 @@ export declare namespace WebAppInternals {
     res: http.ServerResponse,
     next: Function
   ): void;
-  function parsePort(port: string): number;
+  function parsePort(port: string | number): string | number;
   function reloadClientPrograms(): void;
   function generateBoilerplate(): void;
   var staticFiles: StaticFiles;

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -99,14 +99,14 @@ export declare namespace WebAppInternals {
     next: Function
   ): void;
   function parsePort(port: string | number): string | number;
-  function reloadClientPrograms(): void;
-  function generateBoilerplate(): void;
+  function reloadClientPrograms(): Promise<void>;
+  function generateBoilerplate(): Promise<void>;
   var staticFiles: StaticFiles;
   function inlineScriptsAllowed(): boolean;
-  function setInlineScriptsAllowed(inlineScriptsAllowed: boolean): void;
+  function setInlineScriptsAllowed(inlineScriptsAllowed: boolean): Promise<void>;
 
-  function setBundledJsCssUrlRewriteHook(hookFn: (url: string) => string): void;
-  function setBundledJsCssPrefix(bundledJsCssPrefix: string): void;
+  function setBundledJsCssUrlRewriteHook(hookFn: (url: string) => string): Promise<void>;
+  function setBundledJsCssPrefix(bundledJsCssPrefix: string): Promise<void>;
   function addStaticJs(contents: string): void;
   function getBoilerplate(request: http.IncomingMessage, arch: string): Promise<{
     stream: NodeJS.ReadableStream;

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -55,7 +55,7 @@ export declare namespace WebApp {
    * Should be used only for testing
    */
   function _suppressExpressErrors(): void;
-  function onListening(callback: Function): void;
+  function onListening(callback: () => void): void;
 
   type RuntimeConfigHookCallback = (options: {
     arch: "web.browser" | "web.browser.legacy" | "web.cordova";
@@ -66,7 +66,7 @@ export declare namespace WebApp {
   function addRuntimeConfigHook(callback: RuntimeConfigHookCallback): { stop: () => void; callback: RuntimeConfigHookCallback };
   function decodeRuntimeConfig(rtimeConfigString: string): unknown;
   function encodeRuntimeConfig(rtimeConfig: unknown): string;
-  function addHtmlAttributeHook(hook: Function): void;
+  function addHtmlAttributeHook(hook: (request: http.IncomingMessage) => Record<string, unknown> | null): void;
 }
 
 export declare namespace WebAppInternals {

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -107,7 +107,7 @@ export declare namespace WebAppInternals {
 
   function setBundledJsCssUrlRewriteHook(hookFn: (url: string) => string): void;
   function setBundledJsCssPrefix(bundledJsCssPrefix: string): void;
-  function addStaticJs(): void;
+  function addStaticJs(contents: string): void;
   function getBoilerplate(request: http.IncomingMessage, arch: string): Promise<{
     stream: NodeJS.ReadableStream;
     statusCode?: number;

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -108,6 +108,10 @@ export declare namespace WebAppInternals {
   function setBundledJsCssUrlRewriteHook(hookFn: (url: string) => string): void;
   function setBundledJsCssPrefix(bundledJsCssPrefix: string): void;
   function addStaticJs(): void;
-  function getBoilerplate(request: http.IncomingMessage, arch: string): string;
+  function getBoilerplate(request: http.IncomingMessage, arch: string): Promise<{
+    stream: NodeJS.ReadableStream;
+    statusCode?: number;
+    headers?: Record<string, string>;
+  }>;
   var additionalStaticJs: Record<string, string>;
 }


### PR DESCRIPTION
## Problem

Several declarations in #14319 return the wrong type or claim sync when the runtime is async. Consumers awaiting these calls (or not awaiting them) end up with silent wrong types.

## Fix

### ddp

| Symbol | Now | Why |
|---|---|---|
| `MethodInvocation.setUserId` | `Promise<void>` | runtime is `async`, `method_invocation.js:102` |

### logging

| Symbol | Now | Why |
|---|---|---|
| `Log.format` | returns `string`, `options` optional with `metaColor` | runtime always returns string via `Formatter.prettify`, `options` defaults to `{}` |
| `Log.parse` | `Record<string, unknown> \| null` | returns `null` on invalid input |
| `_getCallerDetails` | `{ line?: string; file?: string }` | line is a regex split (string), both keys optional when stack missing |

### tracker

| Symbol | Now | Why |
|---|---|---|
| `Computation.firstRunPromise` | `Promise<unknown> \| undefined` | initialized to `undefined` at `tracker.js:207`, only set during first autorun |

### webapp

| Symbol | Now | Why |
|---|---|---|
| `WebAppInternals.getBoilerplate` | `Promise<{ stream, statusCode?, headers? }>` | delegates to `getBoilerplateAsync` |
| `WebAppInternals.parsePort` | `string \| number` | returns original string when `parseInt` is NaN |
| `WebAppInternals.addStaticJs(contents: string)` | takes required arg | runtime takes the contents string |
| 5 async methods (`setInlineScriptsAllowed`, `enableSubresourceIntegrity`, `setBundledJsCssUrlRewriteHook`, `setBundledJsCssPrefix`, `reloadClientPrograms`, `generateBoilerplate`) | `Promise<void>` | all declared `async` in runtime |
| `WebApp.addRuntimeConfigHook` | `{ stop, callback }` | returns from `runtimeConfig.hooks.register` |
| `WebApp.onListening` callback | `() => void` | called with no args |
| `WebApp.addHtmlAttributeHook` callback | `(request) => Record<string, unknown> \| null` | hook receives request, may return null |
| `WebAppInternals.registerBoilerplateDataCallback` | accepts `Function \| null`, returns previous callback or `null` | runtime returns `previousCallback \|\| null` |

### accounts-base

| Symbol | Now | Why |
|---|---|---|
| `Accounts.logout`, `Accounts.logoutOtherClients` | `void` | runtime delivers success or error via callback, no Promise |
| `Accounts._insertHashedLoginToken` | `Promise<void>` | runtime is `async` |

### mongo

| Symbol | Now | Why |
|---|---|---|
| `Cursor[Symbol.iterator]`, `[Symbol.asyncIterator]` | yield post-transform `U` | matches `fetch`/`forEach`; restores devel parity |

`tracker.test-d.ts` and `logging.test-d.ts` updated to assert the corrected types.

## Files

- `packages/ddp/ddp.d.ts`
- `packages/logging/logging.d.ts`, `packages/logging/logging.test-d.ts`
- `packages/tracker/tracker.d.ts`, `packages/tracker/tracker.test-d.ts`
- `packages/webapp/webapp.d.ts`
- `packages/accounts-base/accounts-base.d.ts`
- `packages/mongo/mongo.d.ts`

## Verified

With #14447 cherry-picked locally:

| Step | Result |
|---|---|
| `npm run types:compile` | 0 errors |
| `npm run types:coverage` (`--at-least 99`) | 99.50% pass |