### PR TITLE
fix: Change rspack target to es2024 for non-client builds

### DIFF
--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -135,7 +135,7 @@ function createSwcConfig({
         ...(isJsxEnabled && { jsx: true }),
         ...(isAngularEnabled && { decorators: true }),
       },
-      target: 'es2015',
+      target: isClient ? 'es2015' : 'es2024',
       ...(isReactEnabled && {
         transform: {
           react: {


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Meteor!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed by visiting:
          https://github.com/meteor/meteor/discussions
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Always follow https://github.com/meteor/meteor/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

We encountered some confusing runtime errors in our meteor based application recently, since updating to 3.4.0 and rspack.
One such issue: https://github.com/Sofie-Automation/sofie-core/pull/1772

The key line is: `[METEOR] Exception in callback of async function: TypeError: attempted to get private field on non-instance`.  
This code ran fine before switching to rspack, and runs fine in our jest unit tests.

Some digging identified that there was an excessive amount of polyfill in the code.
For example:
```
this.#rundownsLiveQuery = await RundownsObserver.create(activePlaylistId, async (rundownIds) => {
	logger.silly(`Creating new RundownContentObserver`)

	const obs1 = await RundownContentObserver.create(activePlaylistId, showStyleBaseId, rundownIds, (cache) => {
		return rundownContentChanged(showStyleBaseId, cache)
	})

	return () => {
		obs1.stop()
	}
})
```
in the built app.js would become:
```
_class_private_field_set(_this, _rundownsLiveQuery, (yield _RundownsObserver__rspack_import_7.RundownsObserver.create(activePlaylistId, (rundownIds)=>_async_to_generator(function*() {
    _logging__rspack_import_4.logger.silly(`Creating new RundownContentObserver`);
    const obs1 = yield _RundownContentObserver__rspack_import_6.RundownContentObserver.create(activePlaylistId, showStyleBaseId, rundownIds, (cache)=>{
        return _class_private_field_get(this, _rundownContentChanged).call(this, showStyleBaseId, cache);
    });
    return ()=>{
        obs1.stop();
    };
})())));
```
I believe our issue here stemmed from the `_async_to_generator(function*() {`, as that `function` will have changed what `this` referred to.

Digging into the rspack config, I identified this as being because swc is setup to translate the user code into es2015 syntax, which predates async functions, and private members.  
While I can understand the value in this for client code for backwards compatibility, it seems excessive to downlevel all code to es2015, especially when we know that the server version will run with node 22 (as that is the version meteor requires).

So this fix changes the compilation target for server code to node22 to minimise the unnecessary polyfills.  
I think there might want to be a discussion about the target for client code too, but we do not use meteor for building client code, so have left it unchanged.


With this change, that same block of code in the app.js is now:
```
this.#rundownsLiveQuery = await _RundownsObserver__rspack_import_7.RundownsObserver.create(activePlaylistId, async (rundownIds)=>{
    _logging__rspack_import_4.logger.silly(`Creating new RundownContentObserver`);
    const obs1 = await _RundownContentObserver__rspack_import_6.RundownContentObserver.create(activePlaylistId, showStyleBaseId, rundownIds, (cache)=>{
        return this.#rundownContentChanged(showStyleBaseId, cache);
    });
    return ()=>{
        obs1.stop();
    };
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to leverage modern JavaScript standards for server builds while maintaining client-side compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->