### PR TITLE
fix(mongo): don't select Change Streams on a standalone MongoDB

### DIFF
--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -1032,9 +1032,14 @@ MongoConnection.prototype._observeChanges = async function (
               if (!hasMinVersion) {
                 serverReasons.push(`Change Streams feature require MongoDB 6+ (current ${versionString})`);
               } else {
-                // Check if we're running on a replica set or sharded cluster
+                // Check if we're running on a replica set or sharded cluster.
+                // `isMaster.ismaster` is true on a standalone too (it only means
+                // the node accepts writes), so it is NOT a replica-set signal:
+                // including it made standalone deployments select Change Streams
+                // and then fail at watch() with "$changeStream is only supported
+                // on replica sets". `setName` is the replica-set signal.
                 const isMaster = await isMasterPromise;
-                const isReplicaSet = Boolean(isMaster.setName || isMaster.ismaster || isMaster.secondary);
+                const isReplicaSet = Boolean(isMaster.setName || isMaster.secondary);
                 const isSharded = isMaster.msg === 'isdbgrid';
 
                 if (!(isReplicaSet || isSharded)) {


### PR DESCRIPTION
## Problem

On `3.5-rc.1`, an app pointed at a **standalone** `mongod` (MongoDB 6+) wrongly selects the Change Streams observe driver. `collection.watch()` then fails with `The $changeStream stage is only supported on replica sets` (Mongo error `40573`); the `error` handler treats this **permanent** error as transient and reschedules a restart (~every 100 ms) with no fallback to oplog/polling. Each restart re-readies the multiplexer → `can't make ObserveMultiplex ready twice!`. The result is an endless loop that floods the server log and pegs the CPU.

Reported on the forum by @paulishca ("replica set errors" + CPU fan) and @filipenevola (standalone notes): https://forums.meteor.com/t/meteor-3-5-rc-available-change-streams-performance-improvements/64461

**Minimal reproduction** (server log floods within seconds, ~33k errors per 10 s): https://github.com/dupontbertrand/meteor-3.5-changestream-bug

## Root cause

`packages/mongo/mongo_connection.js` gates Change Streams support on:

```js
const isReplicaSet = Boolean(isMaster.setName || isMaster.ismaster || isMaster.secondary);
```

`isMaster.ismaster` is `true` on a **standalone** too — it only means "this node accepts writes" (true for a standalone *and* a replica-set primary), so it is not a replica-set signal. On a standalone the check passes, Change Streams are selected, and `watch()` later fails with `40573`.

The replica-set signal is `setName` (present only on a replica-set member); sharded clusters report `msg: 'isdbgrid'`.

## Fix

Drop `|| isMaster.ismaster` from the check:

```js
const isReplicaSet = Boolean(isMaster.setName || isMaster.secondary);
```

A standalone now correctly reports "no Change Streams support" and reactivity falls back to oplog/polling as intended.

## Verification

- **Standalone** mongod v7.0.16: `isMaster` → `{ ismaster: true }`, no `setName`; `db.coll.watch()` → error `40573`. Before this change the driver selected = Change Streams → restart loop (33,572 `40573` + 33,566 `ready twice` in a 10 s window). After: Change Streams not selected, falls back to oplog/polling.
- **Replica set** (including Meteor's built-in dev mongo, which is a single-node replica set via `--replSet`): `setName` present → still detected, Change Streams still used. No behavior change.

## Notes

- Independent of #14456 (which fixes the *fanout* in #14453 and does not touch this topology check).
- Related: #14453, #14454.
- No automated test is added here (the linked repro app demonstrates the failure); happy to add one if preferred.
