### PR TITLE
Fix race in Accounts HttpOnly cookie login completion

### DIFF
--- a/packages/accounts-base/accounts_client.js
+++ b/packages/accounts-base/accounts_client.js
@@ -438,7 +438,9 @@ export class AccountsClient extends AccountsCommon {
       }
 
       // Make the client logged in. (The user data should already be loaded!)
-      this.makeClientLoggedIn(result.id, result.token, result.tokenExpires);
+      // When HttpOnly cookies are enabled, wait for the cookie sync before
+      // resolving login completion so downstream auth fetches can rely on it.
+      await this.makeClientLoggedIn(result.id, result.token, result.tokenExpires);
 
       // use Tracker to make we sure have a user before calling the callbacks
       Tracker.autorun(async (computation) => {
@@ -498,12 +500,12 @@ export class AccountsClient extends AccountsCommon {
     }
   }
 
-  makeClientLoggedIn(userId, token, tokenExpires) {
+  async makeClientLoggedIn(userId, token, tokenExpires) {
     this._storeLoginToken(userId, token, tokenExpires);
     this.connection.setUserId(userId);
     // Sync HttpOnly cookie if enabled
     if (this._useHttpOnlyCookies) {
-      this._setHttpOnlyCookie(token, tokenExpires);
+      await this._setHttpOnlyCookie(token, tokenExpires);
     }
   }
 


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/pull/14112#issuecomment-4720367219

This PR fixes a race in the `accounts-base` HttpOnly cookie login flow on `release-3.5`.

<img width="1590" height="653" alt="image" src="https://github.com/user-attachments/assets/5b80b3fb-9f1c-496b-94a0-9d0abeea9d09" />

The recent `Accounts` E2E failures were all on the cookie-backed path, not on login itself. The app was successfully logging users in, but a small timing gap remained between the point where the client considered login complete and the point where the `meteor_login_token` HttpOnly cookie had actually been written. That was enough to break the tests that immediately checked cookie-backed behavior after `await login(...)`, including the `/_accounts/cookie/refresh` assertions and the `accounts-express` route that depends on cookie auth being available right away.

The root cause was in `makeClientLoggedIn`. That method stored the token and updated `Meteor.userId()` synchronously, but it started the HttpOnly cookie sync as fire-and-forget async work. As a result, `Meteor.loginWithPasswordAsync()` could resolve while the cookie write was still in flight. Local token-based behavior already looked correct, but cookie-backed resume and cookie-backed HTTP auth could still observe a request before the cookie existed.

This change makes login completion wait for that cookie sync when HttpOnly cookies are enabled. `loggedInAndDataReadyCallback` now awaits `makeClientLoggedIn(...)`, and `makeClientLoggedIn(...)` now awaits `_setHttpOnlyCookie(...)` on the HttpOnly-cookie path. The local token flow remains the same, but the login contract is now consistent: once login resolves, the cookie-backed auth path is ready too.

I verified the change with:

```bash
npm run test:e2e -- -t="Accounts"
```

That run now passes cleanly, including the previously failing HttpOnly cookie persistence tests and the `accounts-express` `_CurrentEndpointInvocation` route case.
