### PR TITLE
Translate change-stream documents once per path

### DIFF
--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -35,12 +35,18 @@ export class ChangeStreamObserveDriver {
     this._matcher = options.matcher;
     this._id = options.id || Random.id();
 
-    // Projection function similar to oplog driver
+    // Projection function similar to oplog driver.
+    //
+    // `doc` is expected to already be Meteor-typed: native BSON is translated
+    // to Meteor types once at each path boundary (_sendInitialAdds for the
+    // snapshot, _handleChange for live change events) before any doc reaches
+    // the projection, the matcher or the multiplexer. Translating here as well
+    // would just re-walk an already-converted document.
     const projection = this._cursorDescription.options.projection || this._cursorDescription.options.fields;
     if (projection) {
       const baseProjectionFn = LocalCollection._compileProjection(projection);
       this._projectionFn = (doc) => {
-        const projected = baseProjectionFn(replaceTypes(doc, replaceMongoAtomWithMeteor));
+        const projected = baseProjectionFn(doc);
         if (projected && typeof projected === 'object') {
           const { _id, ...fields } = projected;
           return fields;
@@ -49,7 +55,7 @@ export class ChangeStreamObserveDriver {
       };
     } else {
       this._projectionFn = (doc) => {
-        const { _id, ...fields } = replaceTypes(doc, replaceMongoAtomWithMeteor);
+        const { _id, ...fields } = doc;
         return fields;
       };
     }
@@ -59,8 +65,8 @@ export class ChangeStreamObserveDriver {
   }
 
   _sendMultiplexerAdded(id, projectedDoc) {
-    // Apply EJSON transformation before sending to client
-    projectedDoc = replaceTypes(projectedDoc, replaceMongoAtomWithMeteor);
+    // projectedDoc is already Meteor-typed — its caller translated the source
+    // document at the path boundary (see the _projectionFn comment above).
     try {
       this._multiplexer.added(id, projectedDoc);
     } catch (error) {
@@ -233,8 +239,12 @@ export class ChangeStreamObserveDriver {
 
       // Send 'added' for each existing document that matches our matcher
       let docCount = 0;
-      for await (const doc of cursor) {
+      for await (const rawDoc of cursor) {
         if (this._stopped) return;
+        // The native driver yields BSON-typed docs. Translate once here so the
+        // projection and the multiplexer only ever see Meteor types — the same
+        // boundary _handleChange establishes for live change events.
+        const doc = replaceTypes(rawDoc, replaceMongoAtomWithMeteor);
         const id = typeof doc._id !== 'string' ? new MongoID.ObjectID(doc._id.toHexString()) : doc._id;
         const projectedDoc = this._projectionFn ? this._projectionFn(doc) : doc;
         this._sendMultiplexerAdded(id, projectedDoc);
@@ -425,16 +435,16 @@ export class ChangeStreamObserveDriver {
           const changedFields = DiffSequence.makeChangedFields(projectedNew, projectedOld);
 
           if (Object.keys(changedFields).length > 0) {
-            const transformedDoc = replaceTypes(changedFields, replaceMongoAtomWithMeteor);
-            this._multiplexer.changed(id, transformedDoc);
+            // changedFields is derived from already-translated docs via the
+            // projection, so it is already Meteor-typed.
+            this._multiplexer.changed(id, changedFields);
           }
           return;
         }
 
         // Without a pre-image we can't diff reliably; fall back to sending full doc
         const projectedDoc = this._projectionFn ? this._projectionFn(newDoc) : newDoc;
-        const transformedDoc = replaceTypes(projectedDoc, replaceMongoAtomWithMeteor);
-        this._multiplexer.changed(id, transformedDoc);
+        this._multiplexer.changed(id, projectedDoc);
       }
       return;
     }

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -2728,3 +2728,111 @@ Tinytest.addAsync(
     handle.stop();
   }
 );
+
+// ============================================================================
+// TRANSLATION BOUNDARY TESTS
+//
+// The driver translates native BSON <-> Meteor types exactly once per path:
+// the selector is translated to native types for the snapshot query, and
+// documents are translated back to Meteor types at two boundaries
+// (_sendInitialAdds for the snapshot, _handleChange for live events) before
+// they reach the projection, the matcher or the multiplexer. These tests guard
+// that boundary for special-typed *field values* (not just the _id), on every
+// path a document can take to the client: initial snapshot, live insert and
+// live changed. They fail if any boundary forwards a raw BSON atom.
+// ============================================================================
+
+Tinytest.addAsync(
+  'changestream - translation boundary: ObjectID/Binary fields survive the initial snapshot',
+  async function (test) {
+    const c = new Mongo.Collection('changestream_test_fieldtypes_snap_' + Random.id());
+
+    const ref = new Mongo.ObjectID();
+    const blob = EJSON.newBinary(3);
+    blob[0] = 10; blob[1] = 20; blob[2] = 30;
+
+    await c.insertAsync({ ref, blob, n: 1 });
+
+    const added = [];
+    const handle = await c.find({}).observeChanges({
+      added(id, fields) { added.push({ id, fields }); },
+    });
+    test.isTrue(isChangeStreamDriver(handle), 'Should be using ChangeStream driver');
+
+    await waitFor(() => added.length > 0);
+    test.equal(added.length, 1, 'initial added should fire');
+
+    const f = added[0].fields;
+    test.isTrue(
+      f.ref instanceof Mongo.ObjectID,
+      'snapshot must deliver an ObjectID field as Mongo.ObjectID, not a native BSON atom'
+    );
+    test.equal(f.ref.toHexString(), ref.toHexString());
+    test.isTrue(EJSON.isBinary(f.blob), 'snapshot must deliver a Binary field as a Meteor binary');
+    test.isTrue(EJSON.equals(f.blob, blob), 'Binary field bytes should round-trip');
+
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
+  'changestream - translation boundary: ObjectID field survives a live insert',
+  async function (test) {
+    const c = new Mongo.Collection('changestream_test_fieldtypes_ins_' + Random.id());
+
+    const added = [];
+    const handle = await c.find({}).observeChanges({
+      added(id, fields) { added.push({ id, fields }); },
+    });
+    test.isTrue(isChangeStreamDriver(handle), 'Should be using ChangeStream driver');
+
+    const ref = new Mongo.ObjectID();
+    await c.insertAsync({ ref, n: 1 });
+
+    await waitFor(() => added.length > 0);
+    test.equal(added.length, 1, 'live insert should fire added');
+    const f = added[0].fields;
+    test.isTrue(
+      f.ref instanceof Mongo.ObjectID,
+      'live insert must deliver an ObjectID field as Mongo.ObjectID, not a native BSON atom'
+    );
+    test.equal(f.ref.toHexString(), ref.toHexString());
+
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
+  'changestream - translation boundary: ObjectID field survives a live changed (diff path)',
+  async function (test) {
+    const c = new Mongo.Collection('changestream_test_fieldtypes_upd_' + Random.id());
+
+    const ref1 = new Mongo.ObjectID();
+    const id = await c.insertAsync({ ref: ref1, n: 1 });
+
+    const events = [];
+    const handle = await c.find({}).observeChanges({
+      added(docId, fields) { events.push({ type: 'added', fields }); },
+      changed(docId, fields) { events.push({ type: 'changed', fields }); },
+    });
+    test.isTrue(isChangeStreamDriver(handle), 'Should be using ChangeStream driver');
+
+    await waitFor(() => events.length > 0);
+    test.equal(events[0].type, 'added', 'initial added for the pre-existing doc');
+    events.length = 0;
+
+    const ref2 = new Mongo.ObjectID();
+    await c.updateAsync(id, { $set: { ref: ref2 } });
+
+    await waitFor(() => events.length > 0);
+    test.equal(events[0].type, 'changed', 'update should emit changed');
+    const f = events[0].fields;
+    test.isTrue(
+      f.ref instanceof Mongo.ObjectID,
+      'live changed must deliver an ObjectID field as Mongo.ObjectID, not a native BSON atom'
+    );
+    test.equal(f.ref.toHexString(), ref2.toHexString(), 'changed should carry the new ObjectID value');
+
+    handle.stop();
+  }
+);


### PR DESCRIPTION
> **Stacked on #14461.** This PR targets that PR's branch
> (`pr/changestream-objectid-selector-14460`), so the diff shows only the
> optimization. Once #14461 merges, retarget/rebase this onto `release-3.5`.

## Summary

Follow-up to #14461. That PR established that the change-stream observe driver
has to translate native BSON ↔ Meteor types by hand — it is the only observe
path that does not go through `_createAsynchronousCursor` — and fixed the two
missing boundaries by translating the change payloads in `_handleChange`.

With that in place, the conversions further downstream became redundant:
`_projectionFn`, `_sendMultiplexerAdded` and `_handleUpdate` were re-translating
documents that were already Meteor-typed. This PR collapses translation to a
**single boundary per path**.

## Change

Each document is translated exactly once, at the boundary of its path:

| Path | Boundary | Direction |
|------|----------|-----------|
| snapshot query | `_sendInitialAdds` (selector) | Meteor → BSON |
| snapshot result | `_sendInitialAdds` (doc) | BSON → Meteor |
| live events | `_handleChange` | BSON → Meteor |

`_projectionFn` and `_sendMultiplexerAdded` now assume Meteor-typed input, and
the redundant `replaceTypes(..., replaceMongoAtomWithMeteor)` calls in
`_handleUpdate` are removed.

## Why this is safe

The projection function already returned Meteor-typed output (it translated its
input internally), so every document handed to the multiplexer is identical to
before — `replaceMongoAtomWithMeteor` is a no-op on already-converted atoms.
This is a pure removal of repeated work on the hot path, not a behavior change.

## Tests

Added regression tests in `changestream_observe_driver_tests.js` covering
special-typed **field values** (ObjectID, Binary — not just the `_id`) on all
three paths a document can take to the client: initial snapshot, live insert,
live changed.

- Full change-stream suite: **83/83 green** (80 existing + 3 new) under
  `METEOR_REACTIVITY_ORDER=changeStreams`.
- Mutation-tested: disabling either BSON→Meteor boundary makes the 3 new tests
  fail, confirming they actually guard the boundary.
