### PR TITLE
bundler: compute client manifest size/hash/sri from the written bytes (after //# sourceMappingURL strip) — fixes #10710

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1780,6 +1780,21 @@ class ClientTarget extends Target {
         replaceable: file.replaceable
       };
 
+      // writeFile() (below) strips //# sourceMappingURL / //# sourceURL comments from
+      // non-asset, non-dynamic client files before writing them (removeSourceMappingURLs,
+      // added for #9894). Bake that strip into the file's contents *now*, before its
+      // size/hash/sri are read, so the manifest describes the bytes actually written and
+      // served. Otherwise size/hash/sri (and the SRI / integrity= attribute) describe the
+      // pre-strip contents and never match the served file — e.g. packages/modules.js under
+      // @meteorjs/rspack, which ships un-minified with per-module //# sourceURL= comments,
+      // ends up off by exactly the stripped bytes (#10710).
+      if (type !== 'asset' && ! file.targetPath.startsWith("dynamic/")) {
+        const stripped = removeSourceMappingURLs(file.contents());
+        if (stripped !== file.contents()) {
+          file.setContents(stripped);
+        }
+      }
+
       const antiXSSIPrepend = Profile("anti-XSSI header for source-maps", function (sourceMap) {
         // Add anti-XSSI header to this file which will be served over
         // HTTP. Note that the Mozilla and WebKit implementations differ as to

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1789,8 +1789,10 @@ class ClientTarget extends Target {
       // @meteorjs/rspack, which ships un-minified with per-module //# sourceURL= comments,
       // ends up off by exactly the stripped bytes (#10710).
       if (type !== 'asset' && ! file.targetPath.startsWith("dynamic/")) {
-        const stripped = removeSourceMappingURLs(file.contents());
-        if (stripped !== file.contents()) {
+        const original = file.contents();
+        const stripped = removeSourceMappingURLs(original);
+        if (stripped !== original &&
+            (stripped.length !== original.length || ! stripped.equals(original))) {
           file.setContents(stripped);
         }
       }


### PR DESCRIPTION
Fixes #10710. cc @nachocodoner — per your offer to help guide this to a release 🙏

### Problem

In `tools/isobuild/bundler.js`, `ClientTarget.write()` records each client manifest entry's `size`/`hash`/`sri` from `file.contents()`, but then `writeFile()` strips `//# sourceMappingURL` / `//# sourceURL` comments from the bytes it actually writes (`removeSourceMappingURLs`, added for #9894). So for any non-asset client JS file that still carries such a comment at write time, `program.json` — and the dev-mode `integrity=` attribute — describe the **pre-strip** file while the server serves the **post-strip** file. The digests never match.

```js
// devel, ClientTarget.write()
manifestItem.size = file.size();   // ── from file.contents() (pre-strip)
manifestItem.hash = file.hash();
manifestItem.sri  = file.sri();
if (! file.targetPath.startsWith("dynamic/")) {
  await writeFile(file, builder, { leaveSourceMapUrls: type === 'asset' });
  // └─ writeFile → removeSourceMappingURLs(data) mutates the WRITTEN bytes
```

This is #10710 ("SRI hashes are sometimes not valid"), and it explains @mitar's long-standing open question there — *"why only that package?"*: it's always the one file whose served bytes still carry source-URL comments that get stripped **after** the digest is taken; every other file matches.

### Real-world evidence

A Meteor 3.4.1 app built with [@meteorjs/rspack](https://github.com/zodern/meteor-rspack) serves `packages/modules.js` whose `program.json` says `size 480185 / sri 6nh/Frn4…`, but the served bytes are `475020 / sri 6+HXTKr…`. **All 274 other client entries match** — only `modules.js` mismatches, because rspack emits it un-minified with per-module `//# sourceURL=` comments, and the ~5165-byte delta is exactly those stripped comments. The served file is valid, complete JS; the manifest is simply stale. (We hit it building a desktop hot-code-push per-asset integrity check; the web app tolerates it only because it ships no `integrity=` attributes.)

### Fix

Bake the same source-map-URL strip into the file's contents **before** its `size`/`hash`/`sri` are read, so the manifest describes the bytes actually written:

```js
if (type !== 'asset' && ! file.targetPath.startsWith("dynamic/")) {
  const stripped = removeSourceMappingURLs(file.contents());
  if (stripped !== file.contents()) {
    file.setContents(stripped);
  }
}
```

`File#setContents` already busts the `_hash`/`_sri` cache, so `size()`/`hash()`/`sri()`, the source-map cache-busting basename (`file.hash() + '.map'`), and `writeFile`'s `usePreviousWrite`/`builder.write` hash all then see the same post-strip contents — and `writeFile`'s own `removeSourceMappingURLs` becomes a no-op. Manifest, served bytes, `ETag`, and source-map URL stay mutually consistent.

It's scoped to `type !== 'asset' && !dynamic/` to match exactly what `writeFile` strips at the call below; for files with nothing to strip, `removeSourceMappingURLs` returns the same buffer and nothing changes (so non-affected builds are byte-identical).

### Testing / next steps

I've root-caused this thoroughly (confirmed on `devel`), but I haven't run Meteor's full bundler self-tests against this branch locally, and the `dynamic/` write path may warrant the same check. Happy to:

- add a regression test (a pointer to the right harness would help), and/or
- share a minimal `@meteorjs/rspack` reproduction repo.

Let me know what's most useful and I'll iterate per your guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed how source map URL and source URL comments are handled during bundling, ensuring they’re removed before file integrity data (hash/SRI) and manifest entries are generated. This makes build outputs consistent with the actual contents that are written and served at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->