### PR TITLE
feat(instrumentation): read-only lifecycle seam for methods, publications & connections

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -622,6 +622,12 @@ Object.assign(Session.prototype, {
         fence,
       });
 
+      const Instrumentation = Package['instrumentation'] && Package['instrumentation'].Instrumentation;
+      const instrStartedAt = Instrumentation ? Date.now() : 0;
+      if (Instrumentation) {
+        Instrumentation._emit('method.start', { invocation, name: msg.method, args: msg.params });
+      }
+
       async function finish() {
         await fence.arm();
         unblock();
@@ -673,6 +679,12 @@ Object.assign(Session.prototype, {
         if (result !== undefined) {
           payload.result = result;
         }
+        if (Instrumentation) {
+          Instrumentation._emit('method.end', {
+            invocation, name: msg.method, args: msg.params, result,
+            durationMs: Date.now() - instrStartedAt,
+          });
+        }
         self.send(payload);
       } catch (exception) {
         await finish();
@@ -680,6 +692,12 @@ Object.assign(Session.prototype, {
           exception,
           `while invoking method '${msg.method}'`
         );
+        if (Instrumentation) {
+          Instrumentation._emit('method.error', {
+            invocation, name: msg.method, args: msg.params, error: exception,
+            durationMs: Date.now() - instrStartedAt,
+          });
+        }
         self.send(payload);
       };
     }
@@ -987,6 +1005,13 @@ Object.assign(Subscription.prototype, {
     }
 
     const self = this;
+
+    const Instrumentation = Package['instrumentation'] && Package['instrumentation'].Instrumentation;
+    if (Instrumentation) {
+      self._instrStartedAt = Date.now();
+      Instrumentation._emit('publication.start', { subscription: self, name: self._name, args: self._params });
+    }
+
     let resultOrThenable = null;
     try {
       resultOrThenable = DDP._CurrentPublicationInvocation.withValue(
@@ -1106,6 +1131,13 @@ Object.assign(Subscription.prototype, {
     if (this._deactivated)
       return;
     this._deactivated = true;
+    const Instrumentation = Package['instrumentation'] && Package['instrumentation'].Instrumentation;
+    if (Instrumentation) {
+      Instrumentation._emit('publication.stop', {
+        subscription: this, name: this._name, args: this._params,
+        durationMs: this._instrStartedAt ? Date.now() - this._instrStartedAt : undefined,
+      });
+    }
     this._callStopCallbacks().then(() => {
       // Break reference chains to allow GC of the Session and its data.
       // Without this, deactivated subscriptions retain live references
@@ -1167,6 +1199,13 @@ Object.assign(Subscription.prototype, {
     var self = this;
     if (self._isDeactivated())
       return;
+    const Instrumentation = Package['instrumentation'] && Package['instrumentation'].Instrumentation;
+    if (Instrumentation) {
+      Instrumentation._emit('publication.error', {
+        subscription: self, name: self._name, args: self._params, error,
+        durationMs: self._instrStartedAt ? Date.now() - self._instrStartedAt : undefined,
+      });
+    }
     self._session._stopSubscription(self._subscriptionId, error);
   },
 
@@ -1296,6 +1335,13 @@ Object.assign(Subscription.prototype, {
     if (!self._ready) {
       self._session.sendReady([self._subscriptionId]);
       self._ready = true;
+      const Instrumentation = Package['instrumentation'] && Package['instrumentation'].Instrumentation;
+      if (Instrumentation) {
+        Instrumentation._emit('publication.ready', {
+          subscription: self, name: self._name, args: self._params,
+          durationMs: self._instrStartedAt ? Date.now() - self._instrStartedAt : undefined,
+        });
+      }
     }
   }
 });
@@ -1814,7 +1860,13 @@ Object.assign(Server.prototype, {
       randomSeed
     });
 
-    return new Promise((resolve, reject) => {
+    const Instrumentation = Package['instrumentation'] && Package['instrumentation'].Instrumentation;
+    const instrStartedAt = Instrumentation ? Date.now() : 0;
+    if (Instrumentation) {
+      Instrumentation._emit('method.start', { invocation, name, args });
+    }
+
+    const resultPromise = new Promise((resolve, reject) => {
       let result;
       try {
         result = DDP._CurrentMethodInvocation.withValue(invocation, () =>
@@ -1833,6 +1885,24 @@ Object.assign(Server.prototype, {
       }
       result.then(r => resolve(r)).catch(reject);
     }).then(EJSON.clone);
+
+    if (!Instrumentation) {
+      return resultPromise;
+    }
+    return resultPromise.then(
+      (result) => {
+        Instrumentation._emit('method.end', {
+          invocation, name, args, result, durationMs: Date.now() - instrStartedAt,
+        });
+        return result;
+      },
+      (error) => {
+        Instrumentation._emit('method.error', {
+          invocation, name, args, error, durationMs: Date.now() - instrStartedAt,
+        });
+        throw error;
+      }
+    );
   },
 
   _urlForSession: function (sessionId) {

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1132,7 +1132,7 @@ Object.assign(Subscription.prototype, {
       return;
     this._deactivated = true;
     const Instrumentation = Package['instrumentation'] && Package['instrumentation'].Instrumentation;
-    if (Instrumentation) {
+    if (Instrumentation && !this._instrErrored) {
       Instrumentation._emit('publication.stop', {
         subscription: this, name: this._name, args: this._params,
         durationMs: this._instrStartedAt ? Date.now() - this._instrStartedAt : undefined,
@@ -1201,6 +1201,9 @@ Object.assign(Subscription.prototype, {
       return;
     const Instrumentation = Package['instrumentation'] && Package['instrumentation'].Instrumentation;
     if (Instrumentation) {
+      // publication.error is this path's terminal event; flag the imminent
+      // _deactivate() so it doesn't also emit a duplicate publication.stop.
+      self._instrErrored = true;
       Instrumentation._emit('publication.error', {
         subscription: self, name: self._name, args: self._params, error,
         durationMs: self._instrStartedAt ? Date.now() - self._instrStartedAt : undefined,

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -32,6 +32,7 @@ Package.onUse(function (api) {
   // common functionality
   api.use("ddp-common", "server"); // heartbeat
   api.use("ddp-rate-limiter", "server", { weak: true });
+  api.use("instrumentation", "server", { weak: true });
   // Transport
   api.use("ddp-client", "server");
   api.imply("ddp-client");

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -1,0 +1,28 @@
+# instrumentation
+[Source code of released version](https://github.com/meteor/meteor/tree/master/packages/instrumentation) | [Source code of development version](https://github.com/meteor/meteor/tree/devel/packages/instrumentation)
+***
+
+A read-only, best-effort stream of lifecycle events for the three server-side
+primitives of a Meteor app — methods, publications, and DDP connections —
+without patching Meteor's internals. It is the supported foundation that
+observability tools (OpenTelemetry adapters, APMs, custom logging) build on.
+
+```js
+import { Instrumentation } from 'meteor/instrumentation';
+
+Instrumentation.on('method.end', (event) => {
+  console.log(`${event.name} took ${event.durationMs}ms`, event.traceId);
+});
+```
+
+Events: `method.start` / `method.end` / `method.error`,
+`publication.start` / `publication.ready` / `publication.stop` / `publication.error`,
+`ddp.connection.open` / `ddp.connection.close`.
+
+Payloads are bounded and redacted by default: arguments and results are only
+included as bounded previews when explicitly opted in, and the Accounts methods
+that carry credentials or tokens are always fully redacted.
+
+See the [full API documentation](https://docs.meteor.com/api/instrumentation)
+for `Instrumentation.configure`, per-method capture policies, and the complete
+event reference.

--- a/packages/instrumentation/context.js
+++ b/packages/instrumentation/context.js
@@ -1,0 +1,53 @@
+import { DDP } from 'meteor/ddp-client';
+import { Random } from 'meteor/random';
+
+// Per-invocation trace context. We read the invocation Meteor 3 already set up
+// (DDP._Current*Invocation are AsyncLocalStorage-backed) and lazily cache a
+// traceId/spanId on it via a PRIVATE, module-local Symbol — so the same
+// invocation always reports the same ids, and a `*.start` event matches what the
+// handler later reads through currentContext(). Needs no core change.
+
+const INSTRUMENTATION_CONTEXT = Symbol('meteor.instrumentation.context');
+const newId = () => Random.id();
+// Frozen: returned by reference from currentContext() outside any invocation,
+// so a misbehaving consumer must not be able to mutate it for everyone else.
+const EMPTY = Object.freeze({ traceId: null, spanId: null, userId: null, connectionId: null, kind: null, name: null });
+
+function currentInvocation() {
+  const m = DDP._CurrentMethodInvocation.get();
+  if (m) return { inv: m, kind: 'method' };
+  const p = DDP._CurrentPublicationInvocation.get();
+  if (p) return { inv: p, kind: 'publication' };
+  return null;
+}
+
+// Mint once per invocation, then reuse.
+function traceIds(inv) {
+  let ids = inv[INSTRUMENTATION_CONTEXT];
+  if (!ids) ids = inv[INSTRUMENTATION_CONTEXT] = { traceId: newId(), spanId: newId() };
+  return ids;
+}
+
+export function currentContext() {
+  const found = currentInvocation();
+  if (!found) return EMPTY;
+  const { inv, kind } = found;
+  const ids = traceIds(inv);
+  return {
+    traceId: ids.traceId,
+    spanId: ids.spanId,
+    userId: inv.userId ?? null,
+    connectionId: inv.connection?.id ?? null,
+    kind,
+    // Note: a server-initiated Meteor.callAsync has no `name` on its invocation
+    // until meteor/meteor#14478 lands; the event `name` comes from the seam, not here.
+    name: kind === 'method' ? (inv.name ?? null) : (inv._name ?? null),
+  };
+}
+
+// Used by the emission layer: the trace ids of the specific invocation/subscription
+// an event is about, so the event's traceId/spanId match currentContext().
+export function traceContextFor(invocation) {
+  if (!invocation) return { traceId: null, spanId: null };
+  return traceIds(invocation);
+}

--- a/packages/instrumentation/emitter.js
+++ b/packages/instrumentation/emitter.js
@@ -1,0 +1,63 @@
+// Read-only event emitter for the instrumentation seam.
+//
+// Two guarantees the rest of the package relies on:
+//   - Lazy: a payload is built only when at least one listener is registered for
+//     the event type (the build callback is not even called otherwise).
+//   - Best-effort: a listener that throws synchronously, or returns a rejected
+//     promise, can never break the emitting method/publication, and never
+//     produces an unhandledRejection.
+
+const listeners = new Map(); // type -> Set<listener>
+let listenerErrorHandler = null;
+
+export function setListenerErrorHandler(fn) {
+  listenerErrorHandler = typeof fn === 'function' ? fn : null;
+}
+
+export function on(type, listener) {
+  let set = listeners.get(type);
+  if (!set) {
+    set = new Set();
+    listeners.set(type, set);
+  }
+  set.add(listener);
+  return {
+    stop() {
+      const current = listeners.get(type);
+      if (current) current.delete(listener);
+    },
+  };
+}
+
+function reportListenerError(error, event) {
+  if (!listenerErrorHandler) return;
+  // The error reporter itself must never throw into the framework.
+  try {
+    listenerErrorHandler(error, event);
+  } catch (_ignored) {
+    // swallow — instrumentation observes, it never breaks the caller.
+  }
+}
+
+function callListener(listener, event) {
+  try {
+    const result = listener(event);
+    // Two-arg .then so a rejection is captured without swallowing success-path
+    // bugs, and no unhandledRejection escapes. We never await the listener.
+    if (result && typeof result.then === 'function') {
+      result.then(undefined, (error) => reportListenerError(error, event));
+    }
+  } catch (error) {
+    reportListenerError(error, event);
+  }
+}
+
+// buildEvent: () => payload. Only invoked when listeners exist (lazy).
+export function emit(type, buildEvent) {
+  const set = listeners.get(type);
+  if (!set || set.size === 0) return;
+  const event = buildEvent();
+  for (const listener of set) {
+    callListener(listener, event);
+  }
+}

--- a/packages/instrumentation/emitter.js
+++ b/packages/instrumentation/emitter.js
@@ -56,8 +56,21 @@ function callListener(listener, event) {
 export function emit(type, buildEvent) {
   const set = listeners.get(type);
   if (!set || set.size === 0) return;
-  const event = buildEvent();
-  for (const listener of set) {
+  // The build runs on the observed method's stack: a throwing payload builder
+  // must be contained here too — the never-throw guarantee covers construction,
+  // not just listener calls. The failure is reported like a listener's; the
+  // event is dropped rather than half-delivered.
+  let event;
+  try {
+    event = buildEvent();
+  } catch (error) {
+    reportListenerError(error, { type });
+    return;
+  }
+  // Snapshot: a listener registered during this emission only sees subsequent
+  // events. Iterating the live Set would call it with the current event — and a
+  // listener that keeps registering listeners would never let the loop end.
+  for (const listener of [...set]) {
     callListener(listener, event);
   }
 }

--- a/packages/instrumentation/events.js
+++ b/packages/instrumentation/events.js
@@ -1,6 +1,6 @@
 import { emit } from './emitter.js';
 import { traceContextFor } from './context.js';
-import { captureArgs, captureResult, eventPrefix, isEnabled } from './policy.js';
+import { captureArgs, captureResult, captureClientAddress, eventPrefix, isEnabled } from './policy.js';
 import { previewError } from './preview.js';
 
 // Builds the public event from the RAW materials the seam hands over (the live
@@ -32,6 +32,8 @@ function methodPayload(type, raw) {
     const result = captureResult(raw.name, raw.result);
     if (result !== undefined) event.result = result;
   }
+  // previewError returns a fresh, bounded plain object (capped strings, no stack,
+  // no .details, never the raw Error reference) — safe to hand to listeners.
   if (type === 'method.error') event.error = previewError(raw.error);
   return event;
 }
@@ -59,7 +61,11 @@ function publicationPayload(type, raw) {
 
 function connectionPayload(type, raw) {
   const event = { ...envelope(type), connectionId: raw.connectionId };
-  if (raw.clientAddress !== undefined) event.clientAddress = raw.clientAddress;
+  // clientAddress is the client IP (PII): only attach it when explicitly opted in,
+  // and only when the transport actually gave us one (a non-empty string).
+  if (captureClientAddress() && typeof raw.clientAddress === 'string' && raw.clientAddress) {
+    event.clientAddress = raw.clientAddress;
+  }
   if (raw.durationMs !== undefined) event.durationMs = raw.durationMs;
   return event;
 }

--- a/packages/instrumentation/events.js
+++ b/packages/instrumentation/events.js
@@ -1,0 +1,78 @@
+import { emit } from './emitter.js';
+import { traceContextFor } from './context.js';
+import { captureArgs, captureResult, eventPrefix, isEnabled } from './policy.js';
+import { previewError } from './preview.js';
+
+// Builds the public event from the RAW materials the seam hands over (the live
+// invocation/subscription, the name, args, etc.). All policy lives here — context,
+// redaction, bounded preview, and the export prefix — so the core seam stays tiny.
+
+function envelope(type) {
+  const prefix = eventPrefix();
+  return { type, eventName: prefix ? `${prefix}.${type}` : type, ts: Date.now() };
+}
+
+function methodPayload(type, raw) {
+  const inv = raw.invocation;
+  const ids = traceContextFor(inv);
+  const event = {
+    ...envelope(type),
+    traceId: ids.traceId,
+    spanId: ids.spanId,
+    connectionId: inv?.connection?.id ?? null,
+    userId: inv?.userId ?? null,
+    name: raw.name, // from the seam — correct on both invocation paths
+    argsCount: raw.args ? raw.args.length : 0,
+  };
+  if (raw.durationMs !== undefined) event.durationMs = raw.durationMs;
+
+  const args = captureArgs(raw.name, raw.args);
+  if (args !== undefined) event.args = args;
+  if (type === 'method.end') {
+    const result = captureResult(raw.name, raw.result);
+    if (result !== undefined) event.result = result;
+  }
+  if (type === 'method.error') event.error = previewError(raw.error);
+  return event;
+}
+
+function publicationPayload(type, raw) {
+  const sub = raw.subscription;
+  const ids = traceContextFor(sub);
+  const event = {
+    ...envelope(type),
+    traceId: ids.traceId,
+    spanId: ids.spanId,
+    connectionId: sub?.connection?.id ?? null,
+    userId: sub?.userId ?? null,
+    name: raw.name,
+    subscriptionId: sub?._subscriptionId ?? null,
+    argsCount: raw.args ? raw.args.length : 0,
+  };
+  if (raw.durationMs !== undefined) event.durationMs = raw.durationMs;
+
+  const args = captureArgs(raw.name, raw.args);
+  if (args !== undefined) event.args = args;
+  if (type === 'publication.error') event.error = previewError(raw.error);
+  return event;
+}
+
+function connectionPayload(type, raw) {
+  const event = { ...envelope(type), connectionId: raw.connectionId };
+  if (raw.clientAddress !== undefined) event.clientAddress = raw.clientAddress;
+  if (raw.durationMs !== undefined) event.durationMs = raw.durationMs;
+  return event;
+}
+
+function buildPayload(type, raw) {
+  if (type.startsWith('method.')) return methodPayload(type, raw);
+  if (type.startsWith('publication.')) return publicationPayload(type, raw);
+  return connectionPayload(type, raw);
+}
+
+// Called by the core seam (and by our own connection wiring). The payload is built
+// lazily — only when at least one listener is registered for `type`.
+export function _emit(type, raw) {
+  if (!isEnabled()) return; // global kill-switch, independent of listeners
+  emit(type, () => buildPayload(type, raw));
+}

--- a/packages/instrumentation/events.js
+++ b/packages/instrumentation/events.js
@@ -1,6 +1,6 @@
 import { emit } from './emitter.js';
 import { traceContextFor } from './context.js';
-import { captureArgs, captureResult, captureClientAddress, eventPrefix, isEnabled } from './policy.js';
+import { captureArgs, captureResult, capturePublicationArgs, captureClientAddress, eventPrefix, isEnabled } from './policy.js';
 import { previewError } from './preview.js';
 
 // Builds the public event from the RAW materials the seam hands over (the live
@@ -53,7 +53,7 @@ function publicationPayload(type, raw) {
   };
   if (raw.durationMs !== undefined) event.durationMs = raw.durationMs;
 
-  const args = captureArgs(raw.name, raw.args);
+  const args = capturePublicationArgs(raw.name, raw.args);
   if (args !== undefined) event.args = args;
   if (type === 'publication.error') event.error = previewError(raw.error);
   return event;

--- a/packages/instrumentation/events.js
+++ b/packages/instrumentation/events.js
@@ -62,8 +62,8 @@ function publicationPayload(type, raw) {
 function connectionPayload(type, raw) {
   const event = { ...envelope(type), connectionId: raw.connectionId };
   // clientAddress is the client IP (PII): only attach it when explicitly opted in,
-  // and only when the transport actually gave us one (a non-empty string).
-  if (captureClientAddress() && typeof raw.clientAddress === 'string' && raw.clientAddress) {
+  // and only when the transport actually gave us a non-empty value.
+  if (captureClientAddress() && !!raw.clientAddress) {
     event.clientAddress = raw.clientAddress;
   }
   if (raw.durationMs !== undefined) event.durationMs = raw.durationMs;

--- a/packages/instrumentation/instrumentation_tests.js
+++ b/packages/instrumentation/instrumentation_tests.js
@@ -16,6 +16,12 @@ Meteor.methods({
 
 const collect = (type, into) => Instrumentation.on(type, (e) => into.push(e));
 
+// Promisified makeTestConnection, keeping BOTH ends (the test-helpers
+// createTestConnectionPromise resolves with the client side only).
+const connect = (test) => new Promise((resolve) => {
+  makeTestConnection(test, (clientConn, serverConn) => resolve([clientConn, serverConn]));
+});
+
 Tinytest.addAsync('instrumentation - method start/end events + traceId consistency', async function (test) {
   const events = [];
   const a = collect('method.start', events);
@@ -127,6 +133,45 @@ Tinytest.addAsync('instrumentation - method.error bounds oversized Meteor.Error 
     test.isTrue(err.error.reason.length <= 201, `reason should be bounded, got ${err.error.reason.length}`);
     test.isTrue(err.error.reason.endsWith('…'), 'reason was truncated');
   } finally { a.stop(); }
+});
+
+// The two tests below go through a REAL DDP connection: methods received from a
+// client run through Session.method (the protocol handler), a different code
+// path from the server-initiated Server.apply the tests above exercise. They
+// pin the seam's hooks on that path, so a botched hook re-placement (e.g. while
+// rebasing over a refactored livedata_server.js) fails loudly here.
+Tinytest.addAsync('instrumentation - DDP client method call emits start/end on the session path', async function (test) {
+  const events = [];
+  const a = collect('method.start', events);
+  const b = collect('method.end', events);
+  try {
+    const [clientConn, serverConn] = await connect(test);
+    test.equal(await clientConn.callAsync('instr_test.echo', 21), 42);
+    const start = events.find((e) => e.type === 'method.start' && e.name === 'instr_test.echo' && e.connectionId === serverConn.id);
+    const end = events.find((e) => e.type === 'method.end' && e.name === 'instr_test.echo' && e.connectionId === serverConn.id);
+    test.isTrue(!!start, 'method.start emitted on the DDP session path');
+    test.isTrue(!!end, 'method.end emitted on the DDP session path');
+    test.equal(start.traceId, end.traceId);
+    test.equal(start.argsCount, 1);
+    test.equal(typeof end.durationMs, 'number');
+    clientConn.disconnect();
+  } finally { a.stop(); b.stop(); }
+});
+
+Tinytest.addAsync('instrumentation - DDP client method error emits method.error and still reaches the client', async function (test) {
+  const events = [];
+  const c = collect('method.error', events);
+  try {
+    const [clientConn, serverConn] = await connect(test);
+    let clientErr = null;
+    try { await clientConn.callAsync('instr_test.boom'); } catch (e) { clientErr = e; }
+    test.isTrue(!!clientErr, 'the client still received the error reply');
+    test.equal(clientErr.error, 'nope');
+    const ev = events.find((e) => e.name === 'instr_test.boom' && e.connectionId === serverConn.id);
+    test.isTrue(!!ev, 'method.error emitted on the DDP session path');
+    test.equal(ev.error && ev.error.error, 'nope');
+    clientConn.disconnect();
+  } finally { c.stop(); }
 });
 
 // A publication whose handler calls this.error(). On the error path the

--- a/packages/instrumentation/instrumentation_tests.js
+++ b/packages/instrumentation/instrumentation_tests.js
@@ -191,3 +191,59 @@ Tinytest.addAsync(
     });
   }
 );
+
+// clientAddress is PII (the client IP) and must be opt-in: absent from
+// ddp.connection.open by default, present only after configure({ captureClientAddress: true }).
+Tinytest.addAsync(
+  'instrumentation - clientAddress is absent from connection.open by default',
+  function (test, onComplete) {
+    const opens = [];
+    const off = Instrumentation.on('ddp.connection.open', (e) => opens.push(e));
+    makeTestConnection(test, (clientConn, serverConn) => {
+      off.stop();
+      const ev = opens.find((e) => e.connectionId === serverConn.id);
+      test.isTrue(!!ev, 'ddp.connection.open emitted for the new connection');
+      test.isUndefined(ev.clientAddress, 'clientAddress is not captured unless opted in');
+      clientConn.disconnect();
+      onComplete();
+    });
+  }
+);
+
+Tinytest.addAsync(
+  'instrumentation - clientAddress is captured once opted in',
+  function (test, onComplete) {
+    Instrumentation.configure({ captureClientAddress: true });
+    const opens = [];
+    const off = Instrumentation.on('ddp.connection.open', (e) => opens.push(e));
+    makeTestConnection(test, (clientConn, serverConn) => {
+      off.stop();
+      Instrumentation.configure({ captureClientAddress: false }); // restore default
+      const ev = opens.find((e) => e.connectionId === serverConn.id);
+      test.isTrue(!!ev, 'ddp.connection.open emitted for the new connection');
+      test.equal(typeof ev.clientAddress, 'string', 'clientAddress is a string when opted in');
+      clientConn.disconnect();
+      onComplete();
+    });
+  }
+);
+
+// onListenerError: a configured handler must receive (error, event) when a
+// listener throws — the failure is reported, never propagated to the caller.
+Tinytest.addAsync(
+  'instrumentation - configure({ onListenerError }) receives listener failures',
+  async function (test) {
+    const caught = [];
+    Instrumentation.configure({ onListenerError: (err, event) => caught.push({ err, event }) });
+    const a = Instrumentation.on('method.start', () => { throw new Error('listener kaboom'); });
+    try {
+      await Meteor.callAsync('instr_test.echo', 21);
+      const hit = caught.find((c) => c.event && c.event.name === 'instr_test.echo' && c.event.type === 'method.start');
+      test.isTrue(!!hit, 'onListenerError handler was invoked');
+      test.equal(hit.err.message, 'listener kaboom');
+    } finally {
+      a.stop();
+      Instrumentation.configure({ onListenerError: null }); // restore: no handler
+    }
+  }
+);

--- a/packages/instrumentation/instrumentation_tests.js
+++ b/packages/instrumentation/instrumentation_tests.js
@@ -3,15 +3,27 @@ import { Meteor } from 'meteor/meteor';
 import { Instrumentation } from 'meteor/instrumentation';
 import { makeTestConnection } from 'meteor/test-helpers';
 
+// What the instr_test.mutate handler actually SAW — proves projector mutations
+// of the args never reach the handler.
+const mutateSeen = [];
+
 Meteor.methods({
   'instr_test.echo': async (x) => x * 2,
   'instr_test.boom': async () => { throw new Meteor.Error('nope', 'on purpose'); },
   'instr_test.bigError': () => { throw new Meteor.Error('big', 'x'.repeat(1000000)); },
   'instr_test.ctx': function () { return Instrumentation.currentContext(); },
+  'instr_test.mutate': async (obj) => { mutateSeen.push(obj.value); return { value: obj.value }; },
   'instr_test.captured': function (data) { return data; },
   // A method literally named `login` is treated as the Accounts login by the
   // hard-coded denylist — args/result must never be captured.
   'login': function (creds) { return 'ok'; },
+  // An application error whose `reason` getter throws: building its preview must
+  // not break the reply path (the caller still gets THIS error, not the getter's).
+  'instr_test.evilError': () => {
+    const err = new Meteor.Error('evil-original', 'legit reason');
+    Object.defineProperty(err, 'reason', { get() { throw new Error('reason getter boom'); } });
+    throw err;
+  },
 });
 
 const collect = (type, into) => Instrumentation.on(type, (e) => into.push(e));
@@ -105,6 +117,66 @@ Tinytest.addAsync('instrumentation - a throwing listener never breaks the method
   } finally { a.stop(); }
 });
 
+Tinytest.addAsync('instrumentation - listeners registered during an emission do not receive the current event', async function (test) {
+  const calls = [];
+  const added = [];
+  let off2 = null;
+  const off1 = Instrumentation.on('method.start', (e) => {
+    if (e.name !== 'instr_test.echo') return;
+    calls.push('outer');
+    if (!off2) {
+      off2 = Instrumentation.on('method.start', (e2) => {
+        if (e2.name !== 'instr_test.echo') return;
+        added.push('inner');
+      });
+    }
+  });
+  try {
+    await Meteor.callAsync('instr_test.echo', 2);
+    test.equal(calls.length, 1, 'outer listener ran once');
+    test.equal(added.length, 0, 'a listener added mid-emission must not see the current event');
+    await Meteor.callAsync('instr_test.echo', 2);
+    test.equal(added.length, 1, 'it does see subsequent events');
+  } finally { off1.stop(); if (off2) off2.stop(); }
+});
+
+Tinytest.addAsync('instrumentation - an error with throwing getters still reaches the caller intact', async function (test) {
+  const events = [];
+  const a = collect('method.error', events);
+  try {
+    let caught = null;
+    try { await Meteor.callAsync('instr_test.evilError'); } catch (e) { caught = e; }
+    test.isTrue(!!caught, 'the caller received an error');
+    test.equal(caught && caught.error, 'evil-original', 'the ORIGINAL application error reached the caller');
+    const ev = events.find((e) => e.name === 'instr_test.evilError');
+    test.isTrue(!!ev, 'method.error was still emitted (degraded, not dropped)');
+    test.equal(ev && ev.error && ev.error.error, 'evil-original', 'the readable fields survived');
+  } finally { a.stop(); }
+});
+
+Tinytest.addAsync('instrumentation - a payload-build failure is reported, never propagated', async function (test) {
+  const reported = [];
+  Instrumentation.configure({ captureMethodArgs: 'preview', onListenerError: (err) => reported.push(err) });
+  const events = [];
+  const a = Instrumentation.on('method.start', (e) => { if (e.name === 'instr_test.echo') events.push(e); });
+  try {
+    // The benign custom clone() bypasses the framework's own EJSON.clone of
+    // applyAsync args; previewValue still walks into the proxy, whose ownKeys
+    // trap throws — failing OUR payload build and nothing else.
+    const evil = {
+      clone: () => ({}),
+      inner: new Proxy({}, { ownKeys() { throw new Error('ownKeys boom'); } }),
+    };
+    test.equal(await Meteor.callAsync('instr_test.echo', 5, evil), 10, 'the method call succeeded untouched');
+    test.equal(events.length, 0, 'the unbuildable event was dropped, not half-delivered');
+    test.isTrue(reported.length > 0, 'the build failure was reported to onListenerError');
+    test.equal(reported[0] && reported[0].message, 'ownKeys boom');
+  } finally {
+    a.stop();
+    Instrumentation.configure({ captureMethodArgs: false, onListenerError: null });
+  }
+});
+
 Tinytest.addAsync('instrumentation - configure({ enabled:false }) silences emission, listeners aside', async function (test) {
   const events = [];
   const a = collect('method.start', events);
@@ -133,6 +205,81 @@ Tinytest.addAsync('instrumentation - method.error bounds oversized Meteor.Error 
     test.isTrue(err.error.reason.length <= 201, `reason should be bounded, got ${err.error.reason.length}`);
     test.isTrue(err.error.reason.endsWith('…'), 'reason was truncated');
   } finally { a.stop(); }
+});
+
+Tinytest.addAsync('instrumentation - previews bound key names, bigints and getter failure messages', async function (test) {
+  Instrumentation.configure({ captureMethodArgs: 'preview' });
+  const events = [];
+  const a = collect('method.start', events);
+  try {
+    // clone() bypasses the framework's EJSON.clone of the args (which tolerates
+    // neither bigints nor throwing getters); the preview walk sees everything.
+    const payload = { clone: () => ({}), ['k'.repeat(10000)]: 1, big: 10n ** 500n };
+    Object.defineProperty(payload, 'trap', {
+      enumerable: true,
+      get() { throw new Error('x'.repeat(10000)); },
+    });
+    test.equal(await Meteor.callAsync('instr_test.echo', 5, payload), 10);
+    const ev = events.find((e) => e.name === 'instr_test.echo');
+    const arg = ev && ev.args && ev.args[1];
+    test.isTrue(!!arg, 'the payload preview was captured');
+    test.isTrue(Object.keys(arg).every((k) => k.length <= 201), 'key names are bounded');
+    test.isTrue(String(arg.big).length <= 210, 'bigint rendering is bounded');
+    test.isTrue(String(arg.trap).length <= 250, 'the getter-failure marker is bounded');
+  } finally {
+    a.stop();
+    Instrumentation.configure({ captureMethodArgs: false });
+  }
+});
+
+// A publication homonymous with a name someone passed to configureMethod:
+// per-method projectors are method-scoped by contract and must never run here.
+Meteor.publish('instr_test.homonym', function (arg) {
+  this.ready();
+});
+
+Tinytest.addAsync(
+  'instrumentation - configureMethod does not leak to a same-named publication',
+  function (test, onComplete) {
+    Instrumentation.configureMethod('instr_test.homonym', { captureArgs: () => ({ leaked: true }) });
+    const events = [];
+    const off = Instrumentation.on('publication.start', (e) => { if (e.name === 'instr_test.homonym') events.push(e); });
+    makeTestConnection(test, (clientConn) => {
+      clientConn.subscribe('instr_test.homonym', 'secret-arg', {
+        onReady: () => {
+          off.stop();
+          Instrumentation.configureMethod('instr_test.homonym', {});
+          test.equal(events.length, 1, 'publication.start emitted');
+          test.isUndefined(events[0] && events[0].args, 'a method-scoped projector must not capture publication args');
+          clientConn.disconnect();
+          onComplete();
+        },
+      });
+    });
+  }
+);
+
+Tinytest.addAsync('instrumentation - a configureMethod projector cannot mutate the live call', async function (test) {
+  Instrumentation.configureMethod('instr_test.mutate', {
+    captureArgs: (args) => { args[0].value = 'TAMPERED-ARGS'; return { projected: args[0].value }; },
+    captureResult: (result) => { result.value = 'TAMPERED-RESULT'; return { projected: result.value }; },
+  });
+  const events = [];
+  const a = collect('method.start', events);
+  const b = collect('method.end', events);
+  mutateSeen.length = 0;
+  try {
+    const result = await Meteor.callAsync('instr_test.mutate', { value: 'original' });
+    test.equal(mutateSeen[0], 'original', 'the handler saw the original args');
+    test.equal(result.value, 'original', 'the caller got the untouched result');
+    const start = events.find((e) => e.type === 'method.start' && e.name === 'instr_test.mutate');
+    const end = events.find((e) => e.type === 'method.end' && e.name === 'instr_test.mutate');
+    test.equal(start && start.args && start.args.projected, 'TAMPERED-ARGS', 'the projector worked on its own copy');
+    test.equal(end && end.result && end.result.projected, 'TAMPERED-RESULT', 'the result projector too');
+  } finally {
+    a.stop(); b.stop();
+    Instrumentation.configureMethod('instr_test.mutate', {});
+  }
 });
 
 // The two tests below go through a REAL DDP connection: methods received from a

--- a/packages/instrumentation/instrumentation_tests.js
+++ b/packages/instrumentation/instrumentation_tests.js
@@ -14,9 +14,6 @@ Meteor.methods({
   'instr_test.ctx': function () { return Instrumentation.currentContext(); },
   'instr_test.mutate': async (obj) => { mutateSeen.push(obj.value); return { value: obj.value }; },
   'instr_test.captured': function (data) { return data; },
-  // A method literally named `login` is treated as the Accounts login by the
-  // hard-coded denylist — args/result must never be captured.
-  'login': function (creds) { return 'ok'; },
   // An application error whose `reason` getter throws: building its preview must
   // not break the reply path (the caller still gets THIS error, not the getter's).
   'instr_test.evilError': () => {
@@ -25,6 +22,17 @@ Meteor.methods({
     throw err;
   },
 });
+
+// A method literally named `login` is treated as the Accounts login by the
+// hard-coded denylist — args/result must never be captured. In the
+// all-packages test app (test-in-console) accounts-base already defines
+// `login`, and a duplicate registration crashes the server at boot; the
+// denylist test then exercises the real login method instead.
+try {
+  Meteor.methods({ 'login': function (creds) { return 'ok'; } });
+} catch (e) {
+  // already defined by accounts-base
+}
 
 const collect = (type, into) => Instrumentation.on(type, (e) => into.push(e));
 
@@ -84,7 +92,10 @@ Tinytest.addAsync('instrumentation - Accounts denylist suppresses args, others c
   const seen = {};
   const a = Instrumentation.on('method.start', (e) => { seen[e.name] = e; });
   try {
-    await Meteor.callAsync('login', { password: 'secret' });
+    // The real accounts `login` (all-packages test app) rejects these fake
+    // credentials — irrelevant here: method.start fires either way, and the
+    // denylist must redact the args in both worlds.
+    await Meteor.callAsync('login', { password: 'secret' }).then(() => {}, () => {});
     await Meteor.callAsync('instr_test.captured', { hello: 'world' });
     test.isUndefined(seen['login'].args, 'login args suppressed by denylist');
     test.equal(seen['login'].argsCount, 1);

--- a/packages/instrumentation/instrumentation_tests.js
+++ b/packages/instrumentation/instrumentation_tests.js
@@ -1,6 +1,7 @@
 import { Tinytest } from 'meteor/tinytest';
 import { Meteor } from 'meteor/meteor';
 import { Instrumentation } from 'meteor/instrumentation';
+import { makeTestConnection } from 'meteor/test-helpers';
 
 Meteor.methods({
   'instr_test.echo': async (x) => x * 2,
@@ -127,3 +128,66 @@ Tinytest.addAsync('instrumentation - method.error bounds oversized Meteor.Error 
     test.isTrue(err.error.reason.endsWith('…'), 'reason was truncated');
   } finally { a.stop(); }
 });
+
+// A publication whose handler calls this.error(). On the error path the
+// subscription tears down (error → _stopSubscription → _deactivate), which must
+// emit ONE terminal event — publication.error — not also publication.stop.
+Meteor.publish('instr_test.brokenPub', function () {
+  this.error(new Meteor.Error('pub-fail', 'on purpose'));
+});
+
+Tinytest.addAsync(
+  'instrumentation - publication.error is the only terminal event (no duplicate stop)',
+  function (test, onComplete) {
+    const terminal = [];
+    const onErr = Instrumentation.on('publication.error', (e) => {
+      if (e.name === 'instr_test.brokenPub') terminal.push('error');
+    });
+    const onStop = Instrumentation.on('publication.stop', (e) => {
+      if (e.name === 'instr_test.brokenPub') terminal.push('stop');
+    });
+    makeTestConnection(test, (clientConn) => {
+      clientConn.subscribe('instr_test.brokenPub', {
+        onStop: () => {
+          onErr.stop();
+          onStop.stop();
+          // Both server-side emissions ran before the client received the nosub.
+          test.equal(terminal, ['error'], 'single terminal event: error, not error+stop');
+          clientConn.disconnect();
+          onComplete();
+        },
+      });
+    });
+  }
+);
+
+// The mirror of the above: a normal teardown must still emit publication.stop
+// (and never publication.error) — guards the error-path flag from suppressing
+// legitimate stops.
+Meteor.publish('instr_test.okPub', function () {
+  this.stop();
+});
+
+Tinytest.addAsync(
+  'instrumentation - normal teardown emits publication.stop, never error',
+  function (test, onComplete) {
+    const terminal = [];
+    const onErr = Instrumentation.on('publication.error', (e) => {
+      if (e.name === 'instr_test.okPub') terminal.push('error');
+    });
+    const onStop = Instrumentation.on('publication.stop', (e) => {
+      if (e.name === 'instr_test.okPub') terminal.push('stop');
+    });
+    makeTestConnection(test, (clientConn) => {
+      clientConn.subscribe('instr_test.okPub', {
+        onStop: () => {
+          onErr.stop();
+          onStop.stop();
+          test.equal(terminal, ['stop'], 'single terminal event: stop, not error');
+          clientConn.disconnect();
+          onComplete();
+        },
+      });
+    });
+  }
+);

--- a/packages/instrumentation/instrumentation_tests.js
+++ b/packages/instrumentation/instrumentation_tests.js
@@ -1,0 +1,129 @@
+import { Tinytest } from 'meteor/tinytest';
+import { Meteor } from 'meteor/meteor';
+import { Instrumentation } from 'meteor/instrumentation';
+
+Meteor.methods({
+  'instr_test.echo': async (x) => x * 2,
+  'instr_test.boom': async () => { throw new Meteor.Error('nope', 'on purpose'); },
+  'instr_test.bigError': () => { throw new Meteor.Error('big', 'x'.repeat(1000000)); },
+  'instr_test.ctx': function () { return Instrumentation.currentContext(); },
+  'instr_test.captured': function (data) { return data; },
+  // A method literally named `login` is treated as the Accounts login by the
+  // hard-coded denylist — args/result must never be captured.
+  'login': function (creds) { return 'ok'; },
+});
+
+const collect = (type, into) => Instrumentation.on(type, (e) => into.push(e));
+
+Tinytest.addAsync('instrumentation - method start/end events + traceId consistency', async function (test) {
+  const events = [];
+  const a = collect('method.start', events);
+  const b = collect('method.end', events);
+  try {
+    test.equal(await Meteor.callAsync('instr_test.echo', 21), 42);
+    const start = events.find((e) => e.type === 'method.start' && e.name === 'instr_test.echo');
+    const end = events.find((e) => e.type === 'method.end' && e.name === 'instr_test.echo');
+    test.isTrue(!!start, 'method.start emitted');
+    test.isTrue(!!end, 'method.end emitted');
+    test.equal(start.traceId, end.traceId);
+    test.isTrue(typeof start.traceId === 'string' && start.traceId.length > 0, 'traceId is set');
+    test.equal(start.argsCount, 1);
+    test.isUndefined(start.args);            // not captured by default
+    test.isTrue(typeof end.durationMs === 'number', 'durationMs set on end');
+  } finally { a.stop(); b.stop(); }
+});
+
+Tinytest.addAsync('instrumentation - currentContext matches the start event', async function (test) {
+  const events = [];
+  const a = collect('method.start', events);
+  try {
+    const handlerCtx = await Meteor.callAsync('instr_test.ctx');
+    const start = events.find((e) => e.name === 'instr_test.ctx');
+    test.equal(handlerCtx.kind, 'method');
+    test.isTrue(typeof handlerCtx.traceId === 'string' && handlerCtx.traceId.length > 0);
+    test.equal(start.traceId, handlerCtx.traceId);   // the consistency guarantee
+    test.isNull(handlerCtx.connectionId);            // server-initiated callAsync
+  } finally { a.stop(); }
+});
+
+Tinytest.addAsync('instrumentation - method error event (sanitized)', async function (test) {
+  const errors = [];
+  const a = collect('method.error', errors);
+  try {
+    let threw = false;
+    try { await Meteor.callAsync('instr_test.boom'); } catch (_e) { threw = true; }
+    test.isTrue(threw, 'method threw');
+    const err = errors.find((e) => e.name === 'instr_test.boom');
+    test.isTrue(!!err, 'method.error emitted');
+    test.equal(err.error.error, 'nope');
+    test.equal(err.error.reason, 'on purpose');
+  } finally { a.stop(); }
+});
+
+Tinytest.addAsync('instrumentation - Accounts denylist suppresses args, others can be captured', async function (test) {
+  Instrumentation.configure({ captureMethodArgs: 'preview' });
+  const seen = {};
+  const a = Instrumentation.on('method.start', (e) => { seen[e.name] = e; });
+  try {
+    await Meteor.callAsync('login', { password: 'secret' });
+    await Meteor.callAsync('instr_test.captured', { hello: 'world' });
+    test.isUndefined(seen['login'].args, 'login args suppressed by denylist');
+    test.equal(seen['login'].argsCount, 1);
+    test.isTrue(!!seen['instr_test.captured'].args, 'non-denylisted args captured');
+    test.equal(seen['instr_test.captured'].args[0].hello, 'world');
+  } finally {
+    a.stop();
+    Instrumentation.configure({ captureMethodArgs: false });
+  }
+});
+
+Tinytest.addAsync('instrumentation - eventPrefix sets eventName, not the canonical type', async function (test) {
+  Instrumentation.configure({ eventPrefix: 'myapp' });
+  let ev;
+  const a = Instrumentation.on('method.start', (e) => { if (e.name === 'instr_test.echo') ev = e; });
+  try {
+    await Meteor.callAsync('instr_test.echo', 1);
+    test.equal(ev.type, 'method.start');
+    test.equal(ev.eventName, 'myapp.method.start');
+  } finally {
+    a.stop();
+    Instrumentation.configure({ eventPrefix: '' });
+  }
+});
+
+Tinytest.addAsync('instrumentation - a throwing listener never breaks the method', async function (test) {
+  const a = Instrumentation.on('method.start', () => { throw new Error('listener boom'); });
+  try {
+    test.equal(await Meteor.callAsync('instr_test.echo', 3), 6);  // method still succeeds
+  } finally { a.stop(); }
+});
+
+Tinytest.addAsync('instrumentation - configure({ enabled:false }) silences emission, listeners aside', async function (test) {
+  const events = [];
+  const a = collect('method.start', events);
+  try {
+    Instrumentation.configure({ enabled: false });
+    test.equal(await Meteor.callAsync('instr_test.echo', 7), 14);
+    test.equal(events.length, 0, 'no events while disabled, even with a listener registered');
+
+    Instrumentation.configure({ enabled: true });
+    await Meteor.callAsync('instr_test.echo', 8);
+    test.isTrue(events.some((e) => e.name === 'instr_test.echo'), 'emission resumes once re-enabled');
+  } finally {
+    a.stop();
+    Instrumentation.configure({ enabled: true });
+  }
+});
+
+Tinytest.addAsync('instrumentation - method.error bounds oversized Meteor.Error strings', async function (test) {
+  const errors = [];
+  const a = collect('method.error', errors);
+  try {
+    try { await Meteor.callAsync('instr_test.bigError'); } catch (_e) { /* expected */ }
+    const err = errors.find((e) => e.name === 'instr_test.bigError');
+    test.isTrue(!!err, 'method.error emitted');
+    test.equal(err.error.error, 'big');
+    test.isTrue(err.error.reason.length <= 201, `reason should be bounded, got ${err.error.reason.length}`);
+    test.isTrue(err.error.reason.endsWith('…'), 'reason was truncated');
+  } finally { a.stop(); }
+});

--- a/packages/instrumentation/package.js
+++ b/packages/instrumentation/package.js
@@ -8,7 +8,7 @@ Package.onUse(function (api) {
   // Note: deliberately NO dependency on ddp-server (which weakly depends on us).
   // The connection wiring uses Meteor.onConnection at startup, by which point
   // ddp-server is loaded — avoiding a build-time cycle.
-  api.use(['ecmascript', 'ddp-client', 'random'], 'server');
+  api.use(['ecmascript', 'ddp-client', 'random', 'ejson'], 'server');
   api.mainModule('server.js', 'server');
   api.export('Instrumentation', 'server');
 });

--- a/packages/instrumentation/package.js
+++ b/packages/instrumentation/package.js
@@ -1,0 +1,20 @@
+Package.describe({
+  name: 'instrumentation',
+  version: '0.0.1',
+  summary: 'Read-only lifecycle instrumentation seam (methods, publications, DDP connections)',
+});
+
+Package.onUse(function (api) {
+  // Note: deliberately NO dependency on ddp-server (which weakly depends on us).
+  // The connection wiring uses Meteor.onConnection at startup, by which point
+  // ddp-server is loaded — avoiding a build-time cycle.
+  api.use(['ecmascript', 'ddp-client', 'random'], 'server');
+  api.mainModule('server.js', 'server');
+  api.export('Instrumentation', 'server');
+});
+
+Package.onTest(function (api) {
+  api.use(['ecmascript', 'tinytest', 'random', 'ddp-server', 'ddp-client', 'mongo'], 'server');
+  api.use('instrumentation', 'server');
+  api.mainModule('instrumentation_tests.js', 'server');
+});

--- a/packages/instrumentation/package.js
+++ b/packages/instrumentation/package.js
@@ -14,7 +14,7 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use(['ecmascript', 'tinytest', 'random', 'ddp-server', 'ddp-client', 'mongo'], 'server');
+  api.use(['ecmascript', 'tinytest', 'random', 'ddp-server', 'ddp-client', 'mongo', 'test-helpers'], 'server');
   api.use('instrumentation', 'server');
   api.mainModule('instrumentation_tests.js', 'server');
 });

--- a/packages/instrumentation/policy.js
+++ b/packages/instrumentation/policy.js
@@ -1,3 +1,4 @@
+import { EJSON } from 'meteor/ejson';
 import { previewValue } from './preview.js';
 
 // Hard-coded denylist of every Accounts DDP method whose args OR result carry a
@@ -67,12 +68,15 @@ export const captureClientAddress = () => config.captureClientAddress;
 // captureArgs/captureResult (still bounded by previewValue) · 3. global 'preview'
 // → bounded preview · 4. default → nothing. A throwing override yields nothing
 // rather than breaking emission.
-function resolveCapture(name, value, kind /* 'captureArgs' | 'captureResult' */, globalKey) {
+function resolveCapture(name, value, kind /* 'captureArgs' | 'captureResult' */, globalKey, perMethodOverrides) {
   if (ACCOUNTS_DENYLIST.has(name)) return undefined;
-  const m = perMethod.get(name);
+  const m = perMethodOverrides && perMethodOverrides.get(name);
   if (m && typeof m[kind] === 'function') {
     try {
-      return previewValue(m[kind](value));
+      // Full-fidelity defensive copy: the projector can inspect everything but
+      // can never mutate the live invocation (the args the handler is about to
+      // receive, or the result about to be sent/returned).
+      return previewValue(m[kind](EJSON.clone(value)));
     } catch (_ignored) {
       return undefined;
     }
@@ -81,5 +85,9 @@ function resolveCapture(name, value, kind /* 'captureArgs' | 'captureResult' */,
   return undefined;
 }
 
-export const captureArgs = (name, args) => resolveCapture(name, args, 'captureArgs', 'captureMethodArgs');
-export const captureResult = (name, result) => resolveCapture(name, result, 'captureResult', 'captureMethodResult');
+export const captureArgs = (name, args) => resolveCapture(name, args, 'captureArgs', 'captureMethodArgs', perMethod);
+export const captureResult = (name, result) => resolveCapture(name, result, 'captureResult', 'captureMethodResult', perMethod);
+// Publications share the global preview policy (captureMethodArgs is documented
+// to cover method AND publication events) but never the per-METHOD overrides:
+// a projector configured for a method must not run on a same-named publication.
+export const capturePublicationArgs = (name, args) => resolveCapture(name, args, 'captureArgs', 'captureMethodArgs', null);

--- a/packages/instrumentation/policy.js
+++ b/packages/instrumentation/policy.js
@@ -34,8 +34,9 @@ function envDisabled() {
 
 const config = {
   enabled: !envDisabled(),
-  captureMethodArgs: false,   // false | 'preview'
-  captureMethodResult: false, // false | 'preview'
+  captureMethodArgs: false,    // false | 'preview'
+  captureMethodResult: false,  // false | 'preview'
+  captureClientAddress: false, // include the client IP on ddp.connection.open (PII)
   eventPrefix: '',
 };
 const perMethod = new Map(); // name -> { captureArgs?, captureResult? }
@@ -48,6 +49,7 @@ export function configure(options) {
   if ('enabled' in options) config.enabled = !!options.enabled;
   if ('captureMethodArgs' in options) config.captureMethodArgs = normalizeCapture(options.captureMethodArgs);
   if ('captureMethodResult' in options) config.captureMethodResult = normalizeCapture(options.captureMethodResult);
+  if ('captureClientAddress' in options) config.captureClientAddress = !!options.captureClientAddress;
   if ('eventPrefix' in options) config.eventPrefix = String(options.eventPrefix || '');
 }
 
@@ -58,6 +60,8 @@ export function configureMethod(name, options) {
 }
 
 export const eventPrefix = () => config.eventPrefix;
+
+export const captureClientAddress = () => config.captureClientAddress;
 
 // Resolution order (highest wins): 1. Accounts denylist → nothing · 2. per-method
 // captureArgs/captureResult (still bounded by previewValue) · 3. global 'preview'

--- a/packages/instrumentation/policy.js
+++ b/packages/instrumentation/policy.js
@@ -1,0 +1,81 @@
+import { previewValue } from './preview.js';
+
+// Hard-coded denylist of every Accounts DDP method whose args OR result carry a
+// secret — passwords/digests, resume & login tokens, OAuth secrets, 2FA secrets
+// and codes. Args AND result are dropped for these regardless of config. Audited
+// against accounts-base / -password / -2fa / -passwordless; the OAuth provider
+// packages register no DDP methods of their own (they log in through `login`).
+const ACCOUNTS_DENYLIST = new Set([
+  // accounts-base
+  'login',                       // credentials in, login token out
+  'getNewToken',                 // fresh login token out
+  'configureLoginService',       // OAuth service secret in
+  // accounts-password
+  'createUser',                  // password in, login token out
+  'changePassword',              // old/new password digests in
+  'forgotPassword',              // account email in
+  'resetPassword',               // reset token + new password in
+  'verifyEmail',                 // verification token in
+  // accounts-2fa
+  'generate2faActivationQrCode', // 2FA secret + otpauth URI out
+  'enableUser2fa',               // one-time 2FA code in
+  // accounts-passwordless
+  'requestLoginTokenForUser',    // login-token flow
+]);
+
+// Global kill-switch default, read once from the environment: an operator can
+// ship the package but silence all emission (e.g. in production, or when a
+// third-party library has registered listeners) without a code change.
+// configure({ enabled }) overrides it at runtime.
+function envDisabled() {
+  const v = (process.env.METEOR_INSTRUMENTATION_DISABLED || '').toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+const config = {
+  enabled: !envDisabled(),
+  captureMethodArgs: false,   // false | 'preview'
+  captureMethodResult: false, // false | 'preview'
+  eventPrefix: '',
+};
+const perMethod = new Map(); // name -> { captureArgs?, captureResult? }
+
+// 'preview' (or true, accepted as an alias) means a bounded preview — never raw.
+const normalizeCapture = (v) => (v === 'preview' || v === true ? 'preview' : false);
+
+export function configure(options) {
+  if (!options) return;
+  if ('enabled' in options) config.enabled = !!options.enabled;
+  if ('captureMethodArgs' in options) config.captureMethodArgs = normalizeCapture(options.captureMethodArgs);
+  if ('captureMethodResult' in options) config.captureMethodResult = normalizeCapture(options.captureMethodResult);
+  if ('eventPrefix' in options) config.eventPrefix = String(options.eventPrefix || '');
+}
+
+export const isEnabled = () => config.enabled;
+
+export function configureMethod(name, options) {
+  perMethod.set(name, options || {});
+}
+
+export const eventPrefix = () => config.eventPrefix;
+
+// Resolution order (highest wins): 1. Accounts denylist → nothing · 2. per-method
+// captureArgs/captureResult (still bounded by previewValue) · 3. global 'preview'
+// → bounded preview · 4. default → nothing. A throwing override yields nothing
+// rather than breaking emission.
+function resolveCapture(name, value, kind /* 'captureArgs' | 'captureResult' */, globalKey) {
+  if (ACCOUNTS_DENYLIST.has(name)) return undefined;
+  const m = perMethod.get(name);
+  if (m && typeof m[kind] === 'function') {
+    try {
+      return previewValue(m[kind](value));
+    } catch (_ignored) {
+      return undefined;
+    }
+  }
+  if (config[globalKey] === 'preview') return previewValue(value);
+  return undefined;
+}
+
+export const captureArgs = (name, args) => resolveCapture(name, args, 'captureArgs', 'captureMethodArgs');
+export const captureResult = (name, result) => resolveCapture(name, result, 'captureResult', 'captureMethodResult');

--- a/packages/instrumentation/preview.js
+++ b/packages/instrumentation/preview.js
@@ -1,0 +1,74 @@
+// Bounded, JSON-safe preview of an arbitrary value. Never emits raw application
+// objects: it caps depth, key count, string length and array length, breaks
+// cycles, and renders non-JSON values (function/symbol/bigint/undefined, Error,
+// Date) as safe markers. This is the global-capture serializer AND the final
+// safety bound applied to whatever a per-method captureArgs/captureResult returns,
+// so a careless override can never blow up a consumer.
+
+const DEFAULTS = { maxDepth: 4, maxKeys: 32, maxStringLength: 200, maxArrayLength: 32 };
+
+const truncate = (str, max) => (str.length > max ? str.slice(0, max) + '…' : str);
+// Strings only; a non-string (e.g. a numeric Meteor.Error code) passes through.
+const capString = (value, max) => (typeof value === 'string' ? truncate(value, max) : value);
+
+export function previewError(error) {
+  const max = DEFAULTS.maxStringLength;
+  if (!(error instanceof Error)) {
+    return { name: 'Error', message: truncate(String(error), max) };
+  }
+  // message/reason/error are bounded just like any other captured string, so a
+  // huge Meteor.Error('code', hugeReason) can't smuggle an unbounded payload in.
+  const out = { name: capString(error.name, max), message: capString(error.message, max) };
+  if (error.error !== undefined) out.error = capString(error.error, max);   // Meteor.Error code
+  if (error.reason !== undefined) out.reason = capString(error.reason, max); // Meteor.Error reason
+  return out;
+}
+
+function walk(value, opts, depth, seen) {
+  if (value === null) return null;
+  const t = typeof value;
+  if (t === 'string') {
+    return truncate(value, opts.maxStringLength);
+  }
+  if (t === 'number' || t === 'boolean') return value;
+  if (t === 'undefined') return '[undefined]';
+  if (t === 'function') return `[Function ${value.name || 'anonymous'}]`;
+  if (t === 'symbol') return value.toString();
+  if (t === 'bigint') return `${value}n`;
+  if (value instanceof Error) return previewError(value);
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isNaN(ms) ? '[Invalid Date]' : value.toISOString();
+  }
+
+  if (depth >= opts.maxDepth) return Array.isArray(value) ? '[Array]' : '[Object]';
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+
+  let out;
+  if (Array.isArray(value)) {
+    out = value.slice(0, opts.maxArrayLength).map((v) => walk(v, opts, depth + 1, seen));
+    if (value.length > opts.maxArrayLength) out.push(`… +${value.length - opts.maxArrayLength} more`);
+  } else {
+    out = {};
+    const keys = Object.keys(value);
+    for (const k of keys.slice(0, opts.maxKeys)) {
+      let v;
+      try {
+        v = value[k]; // an enumerable getter may throw
+      } catch (err) {
+        out[k] = `[Getter threw: ${err && err.message ? err.message : 'error'}]`;
+        continue;
+      }
+      out[k] = walk(v, opts, depth + 1, seen);
+    }
+    if (keys.length > opts.maxKeys) out['…'] = `+${keys.length - opts.maxKeys} more keys`;
+  }
+
+  seen.delete(value); // allow the same object in sibling branches (DAG, not a cycle)
+  return out;
+}
+
+export function previewValue(value, options) {
+  return walk(value, { ...DEFAULTS, ...(options || {}) }, 0, new WeakSet());
+}

--- a/packages/instrumentation/preview.js
+++ b/packages/instrumentation/preview.js
@@ -11,16 +11,40 @@ const truncate = (str, max) => (str.length > max ? str.slice(0, max) + '…' : s
 // Strings only; a non-string (e.g. a numeric Meteor.Error code) passes through.
 const capString = (value, max) => (typeof value === 'string' ? truncate(value, max) : value);
 
+// Reading a property of an application error can itself throw (getters), and
+// the reply path must survive that: degrade to a marker, never propagate.
+function safeGet(obj, key) {
+  try {
+    return obj[key];
+  } catch (_ignored) {
+    return '[Getter threw]';
+  }
+}
+
 export function previewError(error) {
   const max = DEFAULTS.maxStringLength;
-  if (!(error instanceof Error)) {
-    return { name: 'Error', message: truncate(String(error), max) };
+  let isError;
+  try {
+    isError = error instanceof Error;
+  } catch (_ignored) {
+    isError = false;
+  }
+  if (!isError) {
+    let str;
+    try {
+      str = String(error);
+    } catch (_ignored) {
+      str = '[unstringifiable value]';
+    }
+    return { name: 'Error', message: truncate(str, max) };
   }
   // message/reason/error are bounded just like any other captured string, so a
   // huge Meteor.Error('code', hugeReason) can't smuggle an unbounded payload in.
-  const out = { name: capString(error.name, max), message: capString(error.message, max) };
-  if (error.error !== undefined) out.error = capString(error.error, max);   // Meteor.Error code
-  if (error.reason !== undefined) out.reason = capString(error.reason, max); // Meteor.Error reason
+  const out = { name: capString(safeGet(error, 'name'), max), message: capString(safeGet(error, 'message'), max) };
+  const code = safeGet(error, 'error');
+  if (code !== undefined) out.error = capString(code, max);     // Meteor.Error code
+  const reason = safeGet(error, 'reason');
+  if (reason !== undefined) out.reason = capString(reason, max); // Meteor.Error reason
   return out;
 }
 
@@ -32,9 +56,9 @@ function walk(value, opts, depth, seen) {
   }
   if (t === 'number' || t === 'boolean') return value;
   if (t === 'undefined') return '[undefined]';
-  if (t === 'function') return `[Function ${value.name || 'anonymous'}]`;
-  if (t === 'symbol') return value.toString();
-  if (t === 'bigint') return `${value}n`;
+  if (t === 'function') return `[Function ${truncate(String(value.name || 'anonymous'), 50)}]`;
+  if (t === 'symbol') return truncate(value.toString(), opts.maxStringLength);
+  if (t === 'bigint') return truncate(`${value}n`, opts.maxStringLength);
   if (value instanceof Error) return previewError(value);
   if (value instanceof Date) {
     const ms = value.getTime();
@@ -53,14 +77,21 @@ function walk(value, opts, depth, seen) {
     out = {};
     const keys = Object.keys(value);
     for (const k of keys.slice(0, opts.maxKeys)) {
+      // Bounded key: two long keys sharing a 200-char prefix collide in the
+      // preview (last one wins) — acceptable for observability output.
+      const boundedKey = truncate(k, opts.maxStringLength);
       let v;
       try {
         v = value[k]; // an enumerable getter may throw
       } catch (err) {
-        out[k] = `[Getter threw: ${err && err.message ? err.message : 'error'}]`;
+        let msg = 'error';
+        try {
+          if (err && err.message) msg = truncate(String(err.message), opts.maxStringLength);
+        } catch (_ignored) { /* reading .message threw too — keep the generic marker */ }
+        out[boundedKey] = `[Getter threw: ${msg}]`;
         continue;
       }
-      out[k] = walk(v, opts, depth + 1, seen);
+      out[boundedKey] = walk(v, opts, depth + 1, seen);
     }
     if (keys.length > opts.maxKeys) out['…'] = `+${keys.length - opts.maxKeys} more keys`;
   }

--- a/packages/instrumentation/server.js
+++ b/packages/instrumentation/server.js
@@ -1,0 +1,42 @@
+import { Meteor } from 'meteor/meteor';
+import { on, setListenerErrorHandler } from './emitter.js';
+import { currentContext } from './context.js';
+import { configure as configurePolicy, configureMethod } from './policy.js';
+import { _emit } from './events.js';
+
+function configure(options) {
+  configurePolicy(options);
+  if (options && 'onListenerError' in options) {
+    setListenerErrorHandler(options.onListenerError);
+  }
+}
+
+// DDP connection open/close — the public, transport-agnostic API. No core change.
+// Wired at startup (not load) so we don't need a build-time dependency on
+// ddp-server (which weakly depends on us); by startup it is loaded and
+// Meteor.onConnection is available, with no connection opened yet.
+Meteor.startup(() => {
+  Meteor.onConnection((connection) => {
+    const openedAt = Date.now();
+    _emit('ddp.connection.open', {
+      connectionId: connection.id,
+      clientAddress: connection.clientAddress,
+    });
+    connection.onClose(() => {
+      _emit('ddp.connection.close', {
+        connectionId: connection.id,
+        durationMs: Date.now() - openedAt,
+      });
+    });
+  });
+});
+
+export const Instrumentation = {
+  on,
+  currentContext,
+  configure,
+  configureMethod,
+  // Internal: the emission entry point the ddp-server seam calls via
+  // Package['instrumentation'].Instrumentation._emit(type, raw).
+  _emit,
+};

--- a/packages/instrumentation/server.js
+++ b/packages/instrumentation/server.js
@@ -20,6 +20,8 @@ Meteor.startup(() => {
     const openedAt = Date.now();
     _emit('ddp.connection.open', {
       connectionId: connection.id,
+      // Raw material only; emitted just when the captureClientAddress policy is
+      // on (gated in events.js). PII, off by default.
       clientAddress: connection.clientAddress,
     });
     connection.onClose(() => {

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -243,6 +243,10 @@ export default defineConfig({
             link: "/api/DDPRateLimiter",
           },
           {
+            text: "Instrumentation",
+            link: "/api/instrumentation",
+          },
+          {
             text: "Check",
             link: "/api/check",
           },

--- a/v3-docs/docs/api/instrumentation.md
+++ b/v3-docs/docs/api/instrumentation.md
@@ -46,9 +46,12 @@ const handle = Instrumentation.on('method.error', (e) => {
 
 Listeners are **read-only and best-effort**: one that throws, or returns a
 rejected promise, can never break the method or publication it observes, and is
-never awaited. A payload is built only when at least one listener is registered
-for that type, so events you don't listen to cost nothing — and with the package
-not added, the hooks don't exist at all.
+never awaited. The same guarantee covers building the event itself: if a payload
+cannot be constructed (say, an application error whose getters throw), the event
+is emitted in a degraded form or dropped — never propagated into the observed
+call. A payload is built only when at least one listener is registered for that
+type, so events you don't listen to cost nothing — and with the package not
+added, the hooks don't exist at all.
 
 There are nine event types:
 
@@ -132,6 +135,7 @@ Instrumentation.configure({
   captureMethodResult: 'preview', // include a bounded preview of method results
   captureClientAddress: false,    // include the client IP on ddp.connection.open (PII)
   eventPrefix: 'orders-svc',      // namespace eventName per app/process/container
+  onListenerError: (error, event) => console.error('instrumentation:', error),
 });
 ```
 
@@ -148,6 +152,9 @@ Instrumentation.configure({
 - **`eventPrefix`** — prefixes each event's `eventName` (e.g.
   `orders-svc.method.start`). The canonical `type` stays unprefixed so generic
   consumers still match on it.
+- **`onListenerError`** — called with `(error, event)` when a listener throws or
+  rejects, and when a payload could not be built at all (the second argument
+  then only carries the event `type`). Silent by default.
 
 To override capture for a single method — for example to record only a safe
 projection of a sensitive payload — use `Instrumentation.configureMethod`:
@@ -159,7 +166,11 @@ Instrumentation.configureMethod('orders.create', {
 ```
 
 Whatever your function returns is still passed through the bounded preview, so a
-careless override can never produce an oversized or unserializable payload.
+careless override can never produce an oversized or unserializable payload. The
+projector receives a defensive copy (`EJSON.clone`) of the arguments or result:
+inspect anything, but mutations never reach the live call. Overrides are
+method-scoped — a publication with the same name is not affected (publications
+follow only the global `captureMethodArgs` policy).
 
 ## Putting it to work
 

--- a/v3-docs/docs/api/instrumentation.md
+++ b/v3-docs/docs/api/instrumentation.md
@@ -1,0 +1,309 @@
+# Instrumentation
+
+Watch what your server is doing — every method call, every publication, every
+DDP connection — as a stream of **read-only** events, without patching Meteor's
+internals. It is the supported foundation that observability tools (OpenTelemetry,
+APMs, custom logging) build on.
+
+Reach for it when you want to answer questions like:
+
+- How long does a given method take, and which ones fail?
+- Why is a subscription stuck, or erroring?
+- How many clients are connected right now?
+- Where does my OpenTelemetry / APM / tracing data come from?
+
+It is a _seam, not a stack_: core only emits events; what you do with them — log,
+count, trace, export — is up to you.
+
+To use it, add the `instrumentation` package to your project:
+
+```bash
+meteor add instrumentation
+```
+
+All the API lives on the server-only `Instrumentation` export:
+
+```js
+import { Instrumentation } from 'meteor/instrumentation';
+```
+
+## Listening to events
+
+`Instrumentation.on(type, listener)` registers a listener for one event type and
+returns a handle with a `stop()` method.
+
+```js
+// Time every method, and log the ones that fail.
+Instrumentation.on('method.end', (e) => {
+  console.log(`✓ ${e.name} took ${e.durationMs}ms`);
+});
+
+const handle = Instrumentation.on('method.error', (e) => {
+  console.error(`✗ ${e.name} failed:`, e.error.message);
+});
+// handle.stop()
+```
+
+Listeners are **read-only and best-effort**: one that throws, or returns a
+rejected promise, can never break the method or publication it observes, and is
+never awaited. A payload is built only when at least one listener is registered
+for that type, so events you don't listen to cost nothing — and with the package
+not added, the hooks don't exist at all.
+
+There are nine event types:
+
+| Event | Fires when |
+| --- | --- |
+| `method.start` | a method invocation begins (before the handler runs) |
+| `method.end` | a method invocation resolves successfully |
+| `method.error` | a method invocation throws |
+| `publication.start` | a publication's handler begins |
+| `publication.ready` | a publication signals it is ready (`this.ready()`) |
+| `publication.stop` | a subscription is torn down |
+| `publication.error` | a publication errors (`this.error()`) |
+| `ddp.connection.open` | a client opens a DDP connection |
+| `ddp.connection.close` | a DDP connection closes |
+
+A method or publication event looks like this:
+
+```js
+{
+  type: 'method.start',           // canonical type — never prefixed
+  eventName: 'method.start',      // = type, optionally prefixed (see configure)
+  ts: 1750000000000,              // emit time, ms since epoch
+  traceId: 'jhqfY9ETQsPLCHxJg',   // identifies the invocation; shared start↔end
+  spanId: 'JhyAKkZmJDJzHkXH2',    // identifies this single event
+  name: 'orders.create',          // the method / publication name
+  connectionId: 'ML8NkBJoadu…',   // the client's DDP connection, or null
+  userId: 'abc123',               // the logged-in user, or null
+  argsCount: 1,                   // number of arguments passed
+}
+```
+
+The `traceId` is shared between an invocation's `start` and its `end`/`error`, so
+you can correlate them. Beyond the fields above:
+
+- `durationMs` is added on `method.end`, `method.error`, `publication.ready`,
+  `publication.stop` and `publication.error`.
+- `subscriptionId` is added on every `publication.*` event.
+- `args` and `result` appear only if you opt in — see [configuration](#configuration).
+- `error` is a safe, structured summary on `*.error` (never the raw value): e.g.
+  `{ name, message, error, reason }`, where `error`/`reason` come from `Meteor.Error`.
+
+Connection events are lighter — there is no invocation behind them. They carry
+`type`, `eventName`, `ts` and `connectionId`, plus `clientAddress` on open and
+`durationMs` (the connection's lifetime) on close.
+
+## Reading the current context
+
+Inside a method handler or a publication, `Instrumentation.currentContext()`
+returns the identifiers of the running invocation — including the **same
+`traceId`** its `*.start` event carried. Use it to tie your own logs to the
+emitted events.
+
+```js
+Meteor.methods({
+  async 'orders.create'(order) {
+    const { traceId } = Instrumentation.currentContext();
+    console.log(traceId, 'creating order'); // same traceId as the method.start event
+    // ...
+  },
+});
+```
+
+It returns `{ traceId, spanId, userId, connectionId, kind, name }`, where `kind`
+is `'method'` or `'publication'`. Called outside any invocation, every field is
+`null`.
+
+> A server-initiated `Meteor.callAsync` (no client behind it) reports
+> `connectionId: null`, and for now `name: null`, in `currentContext()`. The
+> event's `name` is always populated.
+
+## Configuration
+
+`Instrumentation.configure(options)` sets global behaviour. Every option is
+optional, and you can call it more than once.
+
+```js
+Instrumentation.configure({
+  enabled: true,                  // master on/off switch
+  captureMethodArgs: 'preview',   // include a bounded preview of args
+  captureMethodResult: 'preview', // include a bounded preview of method results
+  eventPrefix: 'orders-svc',      // namespace eventName per app/process/container
+});
+```
+
+- **`enabled`** — when `false`, nothing is emitted, regardless of registered
+  listeners. It defaults from the `METEOR_INSTRUMENTATION_DISABLED` environment
+  variable (set it to `1`, `true`, `yes` or `on`), so an operator can ship the
+  package and silence it in production without a code change.
+- **`captureMethodArgs`** — `'preview'` adds a bounded `args` preview to method
+  **and publication** events. Off by default.
+- **`captureMethodResult`** — `'preview'` adds a bounded `result` preview to
+  `method.end`. Off by default.
+- **`eventPrefix`** — prefixes each event's `eventName` (e.g.
+  `orders-svc.method.start`). The canonical `type` stays unprefixed so generic
+  consumers still match on it.
+
+To override capture for a single method — for example to record only a safe
+projection of a sensitive payload — use `Instrumentation.configureMethod`:
+
+```js
+Instrumentation.configureMethod('orders.create', {
+  captureArgs: (args) => ({ orderId: args[0]?._id }),
+});
+```
+
+Whatever your function returns is still passed through the bounded preview, so a
+careless override can never produce an oversized or unserializable payload.
+
+## Putting it to work
+
+Register your listeners once, in server code that runs at startup — a file under
+`server/`, or inside `Meteor.startup`. A few common uses:
+
+**Spot slow methods**
+
+```js
+Instrumentation.on('method.end', (e) => {
+  if (e.durationMs > 200) console.warn(`slow: ${e.name} (${e.durationMs}ms)`);
+});
+```
+
+**Catch failing publications**
+
+```js
+Instrumentation.on('publication.error', (e) => {
+  console.error(`publication ${e.name} failed:`, e.error.message);
+});
+```
+
+**Track how many clients are connected**
+
+```js
+let live = 0;
+Instrumentation.on('ddp.connection.open', () => { live += 1; });
+Instrumentation.on('ddp.connection.close', () => { live -= 1; });
+// expose `live` on a health check, a metric, a dashboard…
+```
+
+**Keep an audit trail of sensitive actions** — pair a safe projection (so no
+secrets are stored) with the `userId` already on the event:
+
+```js
+Instrumentation.configureMethod('orders.refund', {
+  captureArgs: (args) => ({ orderId: args[0], amount: args[1] }),
+});
+
+Instrumentation.on('method.end', (e) => {
+  if (e.name === 'orders.refund') {
+    AuditLog.insertAsync({ at: new Date(), userId: e.userId, action: e.name, args: e.args });
+  }
+});
+```
+
+**Roll up per-method timing stats** — turn the stream into your own lightweight
+metrics, no external service required:
+
+```js
+const stats = new Map(); // name -> { count, totalMs, maxMs }
+
+Instrumentation.on('method.end', (e) => {
+  const s = stats.get(e.name) ?? { count: 0, totalMs: 0, maxMs: 0 };
+  s.count += 1;
+  s.totalMs += e.durationMs;
+  s.maxMs = Math.max(s.maxMs, e.durationMs);
+  stats.set(e.name, s);
+});
+// stats.get('orders.create') → { count, totalMs, maxMs }; average = totalMs / count
+```
+
+**Export to OpenTelemetry or an APM** — because a method shares one `traceId`
+across `start` and `end`/`error`, turning the stream into spans is a few lines.
+This is how a tracing layer consumes the lifecycle without reaching into
+`Meteor.server`:
+
+```js
+const open = new Map();
+
+Instrumentation.on('method.start', (e) => open.set(e.traceId, e.ts));
+Instrumentation.on('method.end', (e) => {
+  open.delete(e.traceId);
+  reportSpan({ name: e.name, ok: true, durationMs: e.durationMs });
+});
+Instrumentation.on('method.error', (e) => {
+  open.delete(e.traceId);
+  reportSpan({ name: e.name, ok: false, durationMs: e.durationMs, error: e.error });
+});
+```
+
+The same shape applies to `publication.*` and `ddp.connection.*`.
+
+## Spotting anomalies
+
+Two ids let you correlate events: `traceId` ties one invocation's `start` to its
+`end`/`error`, and `connectionId` ties together every call from the same client.
+That is enough to catch things that _shouldn't_ happen.
+
+**A server-only method invoked over DDP** — server-initiated calls have
+`connectionId: null`, so a non-null one means a real client reached a method that
+was meant to be internal:
+
+```js
+Instrumentation.on('method.start', (e) => {
+  if (e.name === 'db.reindex' && e.connectionId !== null) {
+    console.error(`⚠ ${e.name} called by a client (${e.connectionId})`);
+  }
+});
+```
+
+**A method that starts but never finishes** — every `start` should be matched by
+an `end` or `error` with the same `traceId`; if it isn't, the method is hung:
+
+```js
+const inflight = new Map(); // traceId -> timer
+
+Instrumentation.on('method.start', (e) => {
+  inflight.set(e.traceId, Meteor.setTimeout(() => {
+    console.error(`⚠ ${e.name} (${e.traceId}) still running after 30s`);
+  }, 30_000));
+});
+
+const settle = (e) => {
+  Meteor.clearTimeout(inflight.get(e.traceId));
+  inflight.delete(e.traceId);
+};
+Instrumentation.on('method.end', settle);
+Instrumentation.on('method.error', settle);
+```
+
+**A step that ran without its prerequisite** — because `connectionId` is shared
+across a client's calls, you can spot a sequence that skipped a required step:
+
+```js
+// payment.capture must come after payment.authorize on the same connection.
+const authorized = new Set(); // connectionId
+
+Instrumentation.on('method.end', (e) => {
+  if (e.name === 'payment.authorize') authorized.add(e.connectionId);
+  if (e.name === 'payment.capture' && !authorized.has(e.connectionId)) {
+    console.error(`⚠ capture without authorize on ${e.connectionId}`);
+  }
+});
+```
+
+## Safety and privacy
+
+The seam is designed so that turning it on cannot leak data or hurt performance:
+
+- **Nothing is captured by default.** `args` and `result` are omitted unless you
+  opt in.
+- **Captured values are always a bounded preview**, never the raw object: depth,
+  key count, string length and array length are capped, cycles are broken, and
+  non-JSON values (functions, symbols, `bigint`, `Date`, `Error`) become short
+  markers.
+- **Accounts methods are always redacted.** `login`, `createUser`,
+  `changePassword`, `resetPassword`, `verifyEmail`, `enableUser2fa`,
+  `requestLoginTokenForUser` and `configureLoginService` never expose their args
+  or result, no matter how capture is configured.
+- **Read-only and best-effort**, as above.

--- a/v3-docs/docs/api/instrumentation.md
+++ b/v3-docs/docs/api/instrumentation.md
@@ -91,8 +91,9 @@ you can correlate them. Beyond the fields above:
   `{ name, message, error, reason }`, where `error`/`reason` come from `Meteor.Error`.
 
 Connection events are lighter — there is no invocation behind them. They carry
-`type`, `eventName`, `ts` and `connectionId`, plus `clientAddress` on open and
-`durationMs` (the connection's lifetime) on close.
+`type`, `eventName`, `ts` and `connectionId`, plus `durationMs` (the connection's
+lifetime) on close. The client IP is **opt-in** — `clientAddress` appears on
+`ddp.connection.open` only after `configure({ captureClientAddress: true })`.
 
 ## Reading the current context
 
@@ -129,6 +130,7 @@ Instrumentation.configure({
   enabled: true,                  // master on/off switch
   captureMethodArgs: 'preview',   // include a bounded preview of args
   captureMethodResult: 'preview', // include a bounded preview of method results
+  captureClientAddress: false,    // include the client IP on ddp.connection.open (PII)
   eventPrefix: 'orders-svc',      // namespace eventName per app/process/container
 });
 ```
@@ -141,6 +143,8 @@ Instrumentation.configure({
   **and publication** events. Off by default.
 - **`captureMethodResult`** — `'preview'` adds a bounded `result` preview to
   `method.end`. Off by default.
+- **`captureClientAddress`** — when `true`, `ddp.connection.open` carries the
+  client IP as `clientAddress`. Off by default, since the IP is personal data.
 - **`eventPrefix`** — prefixes each event's `eventName` (e.g.
   `orders-svc.method.start`). The canonical `type` stays unprefixed so generic
   consumers still match on it.


### PR DESCRIPTION
## Summary

Adds a small, stable, **read-only** instrumentation seam to Meteor core: a new
`instrumentation` package plus a thin, fully-guarded emission layer in
`ddp-server`. It gives observability tooling (and apps) a supported way to watch
the server lifecycle — **methods, publications and DDP connections** — instead of
monkey-patching `Meteor.server` internals.

**Seam, not stack:** core only emits; all policy (trace context, redaction,
bounded preview, prefix, on/off) lives in the package.

Motivation & discussion: https://forums.meteor.com/t/meteor-needs-a-standard-instrumentation-seam-the-design-is-done-and-de-risked-read-only-lifecycle-events-for-methods-publications-ddp/64673

## Events

- `method.start` / `method.end` / `method.error`
- `publication.start` / `publication.ready` / `publication.stop` / `publication.error`
- `ddp.connection.open` / `ddp.connection.close`

Each event carries a consistent `traceId` / `spanId`, `name`, `connectionId`,
`userId`, `durationMs`, and — only when explicitly opted in — a **bounded
preview** of args/result.

## API

```js
import { Instrumentation } from 'meteor/instrumentation';

const handle = Instrumentation.on('method.error', (e) => {
  console.error(e.name, e.durationMs, e.error);
});
// handle.stop()

// The same ids the *.start event carries — readable inside a handler/publication:
Instrumentation.currentContext(); // { traceId, spanId, userId, connectionId, kind, name }

Instrumentation.configure({
  enabled: true,                // global kill-switch (default: METEOR_INSTRUMENTATION_DISABLED env)
  captureMethodArgs: 'preview', // opt-in, bounded preview — never raw
  eventPrefix: 'orders-svc',    // prefixes eventName, not the canonical type
});
Instrumentation.configureMethod('orders.create', { captureArgs: (a) => ({ id: a[0]?._id }) });
```

## Relationship to `meteor-otel` (#14086)

This is the seam that an OpenTelemetry / APM layer consumes. The in-flight
`meteor-otel` PR currently has to patch core itself (`livedata_server.js`,
`ddp-common/method_invocation.js`, session-send hooks) to reach the DDP
lifecycle — the exact "MeteorX" problem. With this seam, such a layer registers
`Instrumentation.on('method.start', …)` and drops its core patches: one reviewed
touch-point in core, many consumers on top.

## Why it's safe

- **Guarded, zero-overhead when off.** The seam is wrapped in
  `Package['instrumentation'] && …` (the same weak-dependency pattern as
  `ddp-rate-limiter` and `facts-base`). With the package not added, every emit is
  a no-op and `Date.now()` is never called.
- **No core invocation change.** Trace ids are minted lazily on the existing
  Meteor 3 invocation through a private module-local `Symbol`, so a `*.start`
  event and what the handler reads via `currentContext()` always match.
- **No build-time cycle.** The package does not depend on `ddp-server` (which
  weakly depends on it); connections are wired via the public
  `Meteor.onConnection` at `Meteor.startup`.
- **Read-only & best-effort.** Events are snapshots; a listener that throws or
  returns a rejected promise can never break the emitting method/publication and
  never produces an `unhandledRejection`.
- **Safe defaults.** Args/results are not captured unless opted in, and only as a
  bounded preview (depth/keys/length/array caps, cycle-safe, non-JSON markers) —
  never raw. Official Accounts methods (`login`, `createUser`, `changePassword`,
  …) are hard-denylisted. A global `enabled` switch (env
  `METEOR_INSTRUMENTATION_DISABLED` + `configure`) lets operators silence it
  without a code change.

## Diff surface

- `packages/instrumentation/` — new core package (emitter, context, policy,
  preview, events, server, tests).
- `packages/ddp-server/livedata_server.js` — guarded emits at the method (both
  `Session.method` and `Server.applyAsync`) and publication lifecycle points
  (+72 / −1).
- `packages/ddp-server/package.js` — `instrumentation` weak dependency (+1).

## Tests

- `instrumentation` tinytest: **7/7** (start/end + traceId consistency,
  `currentContext()` agreement, sanitized error, Accounts denylist, eventPrefix,
  throwing-listener isolation, enable/disable toggle).
- `ddp-server` regression: **41/41**, unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `meteor/instrumentation` server instrumentation API to emit `method.*`, `publication.*`, and `ddp.connection.open/close` lifecycle events with timing and tracing identifiers.
  * Added `Instrumentation.currentContext()` so handlers can read the active trace/span details.
  * Added configurable enable/disable plus args/result capture with bounded preview and sensitive-method redaction, including optional event name prefixing.
* **Documentation**
  * Documented the instrumentation events, payload shapes, and configuration options.
* **Tests**
  * Added Tinytest coverage for method tracing, context matching, capture behavior, and listener error isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->