### PR TITLE
docs: clarify native module rebuild on custom deployment (fixes #11682)

### DIFF
--- a/v3-docs/docs/tutorials/deployment/deployment.md
+++ b/v3-docs/docs/tutorials/deployment/deployment.md
@@ -201,6 +201,19 @@ MONGO_URL=mongodb://localhost:27017/myapp ROOT_URL=http://my-app.com PORT=3000 n
 - `PORT` is the port at which the application is running
 - `MONGO_URL` is a [Mongo connection string URI](https://docs.mongodb.com/manual/reference/connection-string/)
 
+::: warning Don't skip `npm install` on the target machine
+The `(cd programs/server && npm install)` step above is **not optional**. It runs the bundle's
+`npm-rebuild.js` script, which recompiles native (C/C++) addons for the operating system and
+CPU architecture of the machine that will *run* the app. Skipping it — or copying a
+`node_modules` directory built on a different OS/arch — leads to the "invalid ELF header" error
+:::
+
+#### Key rule
+
+Never copy a built `node_modules` (or an entire bundle's `programs/server/node_modules`) between
+machines with different operating systems or CPU architectures. Always let `npm install` rebuild
+native addons on the machine where the app will actually run.
+
 ## MongoDB options
 
 When you deploy your Meteor server, you need a `MONGO_URL` that points to your MongoDB database. You can either use a hosted MongoDB service or set up and run your own MongoDB server. We recommend using a hosted service, as the time saved and peace of mind are usually worth the cost.


### PR DESCRIPTION
## Problem

Issue #11682 reports an `invalid ELF header` crash when a bundle built on macOS/Windows is run on a Linux server. The deployment guide already showed the `(cd programs/server && npm install)` step but never explained that it is **mandatory** or what happens when it is skipped, so users hit the error without knowing the cause.

This is not a code bug — native addons (e.g. `bcrypt`, shipped by every app using `accounts-password` since #11467) are compiled per OS/arch, so the bundle must be rebuilt on the machine that will run it.

## Change

In the **Custom deployment** section of the deployment guide:

- Added a warning making it explicit that `(cd programs/server && npm install)` is not optional — it runs `npm-rebuild.js`, which recompiles native addons for the target OS/arch.
- Added a "Key rule" note: never copy a built `node_modules` between machines with different OS/CPU architectures.

Closes #11682


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification in the deployment tutorial that `npm install` must be executed on the target machine to properly recompile native dependencies for the host OS/CPU architecture.
  * Added guidance warning against copying pre-built `node_modules` across machines with different operating systems or CPU architectures, which can cause runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->