### PR TITLE
fix(rspack): guard meteor.mainModule entry writes against transient ENOENT during HMR

### DIFF
--- a/npm-packages/meteor-rspack/plugins/RequireExtenalsPlugin.js
+++ b/npm-packages/meteor-rspack/plugins/RequireExtenalsPlugin.js
@@ -67,7 +67,12 @@ class RequireExternalsPlugin {
       fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
       fs.writeFileSync(this.filePath, data, 'utf-8');
     } catch (err) {
-      if (err && err.code === 'ENOENT') return;
+      if (err && err.code === 'ENOENT') {
+        // Transient: the build dir was reinitialised mid-rebuild. Don't crash — the next
+        // compile regenerates the file. Warn so the skip is visible when diagnosing HMR.
+        console.warn(`[meteor-rspack] skipped a transient ENOENT writing ${this.filePath}; the next rebuild will regenerate it`);
+        return;
+      }
       throw err;
     }
   }

--- a/npm-packages/meteor-rspack/plugins/RequireExtenalsPlugin.js
+++ b/npm-packages/meteor-rspack/plugins/RequireExtenalsPlugin.js
@@ -57,6 +57,21 @@ class RequireExternalsPlugin {
     this._funcCount = this._computeNextFuncCount();
   }
 
+  // The *-meteor.js entry's parent dir can transiently vanish during an HMR rebuild
+  // (a server-restart reinitialises the build paths) — a bare writeFileSync then throws
+  // ENOENT and stalls the dev build ("Could not resolve meteor.mainModule …"). Ensure the
+  // dir exists before writing, and never let a transient race crash the build; the next
+  // rebuild regenerates the file.
+  _safeWrite(data) {
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      fs.writeFileSync(this.filePath, data, 'utf-8');
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return;
+      throw err;
+    }
+  }
+
   // Helper method to check if a module name matches the externals or default prefix
   _isExternalModule(name) {
     if (typeof name !== 'string') return false;
@@ -201,7 +216,7 @@ class RequireExternalsPlugin {
         content = content.replace(emptyLastFnRe, '');
 
         // Write the cleaned file back
-        fs.writeFileSync(this.filePath, content, 'utf-8');
+        this._safeWrite(content);
 
         // Re-populate `existing` so the add-diff is accurate
         existing.clear();
@@ -330,9 +345,9 @@ class RequireExternalsPlugin {
         if (existingLastImports.length > 0) {
           const body = existingLastImports.join('\n');
           const fnCode = `\n// (function lastImports() {\n${body}\n// })\n`;
-          fs.writeFileSync(this.filePath, content + fnCode);
+          this._safeWrite(content + fnCode);
         } else {
-          fs.writeFileSync(this.filePath, content);
+          this._safeWrite(content);
         }
       }
       // If lastImports don't exist, add them if needed
@@ -401,7 +416,7 @@ class RequireExternalsPlugin {
             `// (function lastImports() {\n${newBody}// })`
           );
 
-          fs.writeFileSync(this.filePath, updatedContent);
+          this._safeWrite(updatedContent);
         }
       }
     });
@@ -468,11 +483,11 @@ class RequireExternalsPlugin {
       content = fs.readFileSync(this.filePath, 'utf-8');
       if (!content.includes(`typeof globalThis.module === 'undefined'`)) {
         // Prepend so it lives at the very top
-        fs.writeFileSync(this.filePath, content + '\n' + block, 'utf-8');
+        this._safeWrite(content + '\n' + block);
       }
     } else {
       // File doesn’t exist yet: create with just the block
-      fs.writeFileSync(this.filePath, block, 'utf-8');
+      this._safeWrite(block);
     }
   }
 


### PR DESCRIPTION
## Problem

During development, an HMR rebuild intermittently crashes the dev build:

```
[webpack-dev-middleware] Error: ENOENT: no such file or directory,
  open '/opt/app/_build/main-dev/client-meteor.js'
    at RequireExternalsPlugin._ensureGlobalThisModule (.../meteor-rspack/plugins/RequireExtenalsPlugin.js)
...
Could not resolve meteor.mainModule "_build/main-dev/server-meteor.js"
```

The build then stalls (`Waiting for file change`) until the next edit. It is **not** a
cold-start failure — only rebuilds triggered by editing a file hit it, and it is
timing-dependent (hard to catch live). It surfaces much more frequently under forced
file-watch polling — e.g. a dev server running in Docker with
`METEOR_WATCH_FORCE_POLLING=true` — where client-refresh and server-restart rebuilds get
batched and overlap.

## Root cause

`RequireExternalsPlugin` maintains the generated `<side>-meteor.js` bridge entry (the
`meteor.mainModule` shim) by writing it with a bare `fs.writeFileSync(this.filePath, …)`
and **no `fs.mkdirSync` guard**, at six call sites including `_ensureGlobalThisModule`.

When an HMR rebuild collides with a server-restart, the build paths are reinitialised and
the parent dir `_build/<env>/` is **transiently absent** at the moment of the write.
`writeFileSync` then throws `ENOENT`, and because the write is unguarded the whole build
aborts instead of recovering on the next compile. (`output.clean` is prod-only, so the
dir is never intentionally deleted in dev — the absence is purely the rebuild window.)

## Fix

Route the six `this.filePath` writes through a small `_safeWrite()` helper that ensures the
parent dir exists and tolerates a transient `ENOENT` (the next rebuild regenerates the
file). No behavioural change on the happy path — `mkdirSync(…, { recursive: true })` is a
no-op when the dir already exists.

```js
_safeWrite(data) {
  try {
    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
    fs.writeFileSync(this.filePath, data, 'utf-8');
  } catch (err) {
    if (err && err.code === 'ENOENT') return; // transient rebuild race; next compile rewrites
    throw err;
  }
}
```

## Reproduction & verification

A standalone, **deterministic** repro (a real Meteor-app repro of the race is flaky; this
recreates the exact failure mode — entry written into a missing parent dir — every time):

**https://github.com/boomfly/meteor-rspack-enoent-repro**

- On stock `@meteorjs/rspack@2.0.1`: `node repro.cjs` → throws `ENOENT`, exit 1.
- With this fix applied: exit 0 (dir created, entry written).

Verified locally against a Meteor 3.4.1 app (dockerized dev server): with the patched
plugin the server boots, writes `_build/main-dev/{client,server}-meteor.js`, and HMR no
longer crashes; logs are clean.

Happy to sign the contributor agreement if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during hot module rebuilds by preventing transient file write failures when updating generated helper content.
  * Automatically ensures required directories exist before writing, reducing intermittent build interruptions.
  * Made generated import/require helper updates more resilient when existing files are modified or created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->