### PR TITLE
docs: add v3-docs for facts-base package

### DIFF
--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -390,6 +390,10 @@ export default defineConfig({
                 link: "/packages/url",
               },
               {
+                text: "facts-base",
+                link: "/packages/facts-base",
+              },
+              {
                 text: "webapp",
                 link: "/packages/webapp",
               },

--- a/v3-docs/docs/packages/facts-base.md
+++ b/v3-docs/docs/packages/facts-base.md
@@ -1,0 +1,63 @@
+# facts-base
+
+`facts-base` collects and publishes internal application statistics ("facts") — named numeric counters grouped by package. Other packages use it to expose runtime metrics (for example, how many live-query observers or open sessions exist), which you can then read on the client and display with the `facts-ui` package.
+
+```bash
+meteor add facts-base
+```
+
+The package exports a `Facts` object (`api.export("Facts")`) and runs on the server.
+
+## How facts are stored and published
+
+Each fact belongs to a **package** and has a **name** and an integer **value**. Facts are published through a built-in publication named `meteor_facts`, which sends one document per package (the document `_id` is the package name; each remaining field is a fact name mapped to its value). On the client, `facts-ui` reads these from a collection named `meteor_Facts_server`.
+
+## Server API
+
+All of the following are methods on the exported `Facts` object and run on the server.
+
+### `Facts.incrementServerFact(pkg, fact, increment)`
+
+Increments the counter `fact` for package `pkg` by `increment`, creating it if it doesn't exist yet, and pushes the change to all active subscribers.
+
+- `pkg` **String** — the package the fact belongs to.
+- `fact` **String** — the name of the fact/counter.
+- `increment` **Number** — the amount to add (the first call for a fact initializes it to this value).
+
+```js
+import { Facts } from 'meteor/facts-base';
+
+Facts.incrementServerFact('my-package', 'active-jobs', 1);
+// ...later
+Facts.incrementServerFact('my-package', 'active-jobs', -1);
+```
+
+### `Facts.setUserIdFilter(filter)`
+
+Controls which users are allowed to subscribe to the facts publication.
+
+- `filter` **Function** — called as `filter(userId)` and should return a truthy value to allow that subscription.
+
+By default, facts are published to **no** users when `autopublish` is off, and to **all** users when `autopublish` is on. Use `setUserIdFilter` to expose facts only to, say, administrators:
+
+```js
+import { Facts } from 'meteor/facts-base';
+
+Facts.setUserIdFilter(userId => {
+  const user = Meteor.users.findOne(userId);
+  return user && user.isAdmin;
+});
+```
+
+### `Facts.resetServerFacts()`
+
+Clears all recorded facts for every package.
+
+## Notes
+
+> The package `README.md` describes `facts-base` as an internal Meteor package. It is documented here because it exports a public `Facts` API that app and package authors can call. The internal helpers prefixed with an underscore (e.g. `Facts._factsByPackage`) are intentionally **not** documented.
+
+## See also
+
+- `facts-ui` — a client package that subscribes to these facts and renders them with the <span v-pre>`{{> serverFacts}}`</span> template.
+- `autopublish` — when present, changes the default visibility of facts to all users.

--- a/v3-docs/docs/packages/facts-base.md
+++ b/v3-docs/docs/packages/facts-base.md
@@ -53,6 +53,45 @@ Facts.setUserIdFilter(userId => {
 
 Clears all recorded facts for every package.
 
+## A complete example
+
+Increment a counter from server code and restrict who may read the facts:
+
+```js
+import { Facts } from 'meteor/facts-base';
+
+Meteor.methods({
+  async runJob() {
+    Facts.incrementServerFact('my-app', 'jobs-run', 1);
+    try {
+      // ...do the work...
+    } finally {
+      Facts.incrementServerFact('my-app', 'jobs-run', -1);
+    }
+  },
+});
+
+// Expose the facts only to admins (otherwise, without autopublish, no one
+// can subscribe to them):
+Facts.setUserIdFilter((userId) => {
+  const user = userId && Meteor.users.findOne(userId);
+  return Boolean(user && user.isAdmin);
+});
+```
+
+To display these on the client, add the `facts-ui` package and render its `serverFacts` template.
+
+## Facts published by Meteor itself
+
+Even if you never call `incrementServerFact` yourself, several core packages report facts automatically once `facts-base` is installed. For example, the `mongo` package publishes the following under the `mongo-livedata` package name (verified in `packages/mongo/observe_multiplex.ts` and `packages/mongo/oplog_observe_driver.js`):
+
+- `observe-multiplexers` — number of active observe-multiplexers
+- `observe-handles` — number of active observe handles
+- `observe-drivers-oplog` — number of oplog-based observe drivers
+- `time-spent-in-<phase>-phase` — time spent in each oplog-observe phase
+
+This makes `facts-base` + `facts-ui` a quick way to watch live-query load on a running server.
+
 ## Notes
 
 > The package `README.md` describes `facts-base` as an internal Meteor package. It is documented here because it exports a public `Facts` API that app and package authors can call. The internal helpers prefixed with an underscore (e.g. `Facts._factsByPackage`) are intentionally **not** documented.

--- a/v3-docs/docs/packages/facts-base.md
+++ b/v3-docs/docs/packages/facts-base.md
@@ -6,7 +6,7 @@
 meteor add facts-base
 ```
 
-The package exports a `Facts` object (`api.export("Facts")`) and runs on the server.
+The package exports a `Facts` object and runs on the server.
 
 ## How facts are stored and published
 
@@ -43,15 +43,17 @@ By default, facts are published to **no** users when `autopublish` is off, and t
 ```js
 import { Facts } from 'meteor/facts-base';
 
-Facts.setUserIdFilter(userId => {
-  const user = Meteor.users.findOne(userId);
-  return user && user.isAdmin;
-});
+// The filter runs synchronously at subscribe time, so it cannot do an
+// async / DB lookup. Decide from data available synchronously, e.g. an
+// allowlist of admin user ids in your settings:
+Facts.setUserIdFilter(userId =>
+  (Meteor.settings.adminUserIds || []).includes(userId)
+);
 ```
 
 ### `Facts.resetServerFacts()`
 
-Clears all recorded facts for every package.
+Clears all recorded facts for every package. It clears the in-memory state but issues no `removed` messages to subscribers, so currently-connected clients keep showing the old facts until they resubscribe.
 
 ## A complete example
 
@@ -73,17 +75,16 @@ Meteor.methods({
 
 // Expose the facts only to admins (otherwise, without autopublish, no one
 // can subscribe to them):
-Facts.setUserIdFilter((userId) => {
-  const user = userId && Meteor.users.findOne(userId);
-  return Boolean(user && user.isAdmin);
-});
+Facts.setUserIdFilter((userId) =>
+  (Meteor.settings.adminUserIds || []).includes(userId)
+);
 ```
 
 To display these on the client, add the `facts-ui` package and render its `serverFacts` template.
 
 ## Facts published by Meteor itself
 
-Even if you never call `incrementServerFact` yourself, several core packages report facts automatically once `facts-base` is installed. For example, the `mongo` package publishes the following under the `mongo-livedata` package name (verified in `packages/mongo/observe_multiplex.ts` and `packages/mongo/oplog_observe_driver.js`):
+Even if you never call `incrementServerFact` yourself, several core packages report facts automatically once `facts-base` is installed. For example, the `mongo` package publishes the following under the `mongo-livedata` package name:
 
 - `observe-multiplexers` — number of active observe-multiplexers
 - `observe-handles` — number of active observe handles
@@ -100,9 +101,9 @@ This makes `facts-base` + `facts-ui` a quick way to watch live-query load on a r
 
 ## Notes
 
-> The package `README.md` describes `facts-base` as an internal Meteor package. It is documented here because it exports a public `Facts` API that app and package authors can call. The internal helpers prefixed with an underscore (e.g. `Facts._factsByPackage`) are intentionally **not** documented.
+Only the public `Facts` API is documented here. Internal helpers prefixed with an underscore (e.g. `Facts._factsByPackage`) are not part of the public API and may change without notice.
 
 ## See also
 
-- `facts-ui` — a client package that subscribes to these facts and renders them with the <span v-pre>`{{> serverFacts}}`</span> template.
-- `autopublish` — when present, changes the default visibility of facts to all users.
+- [`facts-ui`](./facts-ui.md) — a client package that subscribes to these facts and renders them with the <span v-pre>`{{> serverFacts}}`</span> template.
+- [`autopublish`](./autopublish.md) — when present, changes the default visibility of facts to all users.

--- a/v3-docs/docs/packages/facts-base.md
+++ b/v3-docs/docs/packages/facts-base.md
@@ -14,7 +14,7 @@ Each fact belongs to a **package** and has a **name** and an integer **value**. 
 
 ## Server API
 
-All of the following are methods on the exported `Facts` object and run on the server.
+All of the following are methods on the exported `Facts` object and run on the server. These methods exist only on the server; calling them on the client throws. Facts are held in memory per server process, so they reset on restart and are not aggregated across multiple instances. `Facts.setUserIdFilter` is evaluated once per subscription at subscribe time, so changing the filter (or a user's role) does not re-filter existing subscriptions.
 
 ### `Facts.incrementServerFact(pkg, fact, increment)`
 
@@ -89,6 +89,12 @@ Even if you never call `incrementServerFact` yourself, several core packages rep
 - `observe-handles` — number of active observe handles
 - `observe-drivers-oplog` — number of oplog-based observe drivers
 - `time-spent-in-<phase>-phase` — time spent in each oplog-observe phase
+
+The `mongo` package also reports `observe-drivers-polling` and `oplog-watchers` under `mongo-livedata`. And the `ddp-server` (livedata) package reports, under the `livedata` package name:
+
+- `sessions` — number of connected DDP sessions
+- `subscriptions` — number of active subscriptions
+- `invalidation-crossbar-listeners` — number of crossbar listeners
 
 This makes `facts-base` + `facts-ui` a quick way to watch live-query load on a running server.
 


### PR DESCRIPTION
## Package
Adds a v3-docs page for the `facts-base` package, which currently has no dedicated documentation page.

## What was added
- `v3-docs/docs/packages/facts-base.md` — a new package guide.
- Registered the page in the VitePress sidebar (`.vitepress/config.mts`) under **Packages → Developer tools**.

## Contents
- What `facts-base` does: collects and publishes internal app statistics ("facts").
- Public `Facts` API verified in source: `Facts.incrementServerFact(pkg, fact, increment)`, `Facts.setUserIdFilter(filter)`, `Facts.resetServerFacts()`, the `meteor_facts` publication and `meteor_Facts_server` collection.
- A worked example (record + restrict visibility) and the facts that core packages publish out of the box (`mongo-livedata` and `livedata` counters, verified in `packages/mongo/*` and `packages/ddp-server/*`).
- Notes that the API is server-only, facts are in-memory/per-process, and `setUserIdFilter` is evaluated per-subscription at subscribe time.

Internal underscore-prefixed members are intentionally not documented. Goes together with the companion `facts-ui` page (separate PR).

## Docs build
Plain Markdown; internal links resolve. A full `npm run docs:build` currently fails only on a pre-existing, unrelated error in `packages/roles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for the `facts-base` Meteor package, covering how it publishes internal numeric facts, the server-side API, subscription-time filtering, and an end-to-end usage example.
  * Documented built-in fact sources and added cross-references to related packages, including notes on what’s not part of the public API.

* **New Features**
  * Added a new sidebar entry for `facts-base` under the “Developer tools” package list for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->