### PR TITLE
fix: serve runtime updates to Meteor.settings.public to new clients (meteor/meteor#13489)

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -457,6 +457,7 @@ function refreshRuntimeConfigPublicSettings(arch) {
   }
 
   let changed = false;
+  let failed = false;
 
   const boilerplate = boilerplateByArch[arch];
   if (boilerplate && boilerplate.baseData &&
@@ -473,7 +474,13 @@ function refreshRuntimeConfigPublicSettings(arch) {
       });
       changed = true;
     } catch (e) {
-      // Leave the cached config untouched if it cannot be decoded.
+      // Leave the cached config untouched if it cannot be decoded, and keep
+      // the snapshot stale so the refresh is retried on the next request.
+      failed = true;
+      Log.debug(
+        'refreshRuntimeConfigPublicSettings: could not decode boilerplate ' +
+        'runtime config for arch ' + arch + ': ' + e
+      );
     }
   }
 
@@ -485,7 +492,13 @@ function refreshRuntimeConfigPublicSettings(arch) {
       program.meteorRuntimeConfig = JSON.stringify(parsed);
       changed = true;
     } catch (e) {
-      // Leave the cached config untouched if it cannot be parsed.
+      // Leave the cached config untouched if it cannot be parsed, and keep
+      // the snapshot stale so the refresh is retried on the next request.
+      failed = true;
+      Log.debug(
+        'refreshRuntimeConfigPublicSettings: could not parse client program ' +
+        'runtime config for arch ' + arch + ': ' + e
+      );
     }
   }
 
@@ -494,7 +507,12 @@ function refreshRuntimeConfigPublicSettings(arch) {
     // caches they keep are refreshed on this request.
     runtimeConfig.isUpdatedByArch[arch] = true;
   }
-  lastPublicSettingsByArch[arch] = serialized;
+  // Only advance the snapshot when the refresh fully succeeded. If a decode or
+  // parse step threw, leaving the snapshot stale ensures the next request
+  // retries instead of short-circuiting on a value that was never applied.
+  if (!failed) {
+    lastPublicSettingsByArch[arch] = serialized;
+  }
 }
 
 async function getBoilerplateAsync(request, arch, response) {

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -437,7 +437,68 @@ WebApp.addRuntimeConfigHook = function(callback) {
   return runtimeConfig.hooks.register(callback);
 };
 
+// Per-arch snapshot of the PUBLIC_SETTINGS that are currently baked into the
+// cached runtime config, so we only re-encode when they actually change.
+const lastPublicSettingsByArch = Object.create(null);
+
+// The encoded runtime config (including PUBLIC_SETTINGS) is generated once at
+// startup and cached per arch. Apps are documented to be able to mutate
+// `Meteor.settings.public` at runtime and have the change picked up by new
+// client connections, so before serving we refresh the cached config whenever
+// the live public settings differ from what was last encoded. See #13489.
+function refreshRuntimeConfigPublicSettings(arch) {
+  const livePublicSettings =
+    (typeof __meteor_runtime_config__ === 'object' &&
+      __meteor_runtime_config__.PUBLIC_SETTINGS) ||
+    {};
+  const serialized = JSON.stringify(livePublicSettings);
+  if (lastPublicSettingsByArch[arch] === serialized) {
+    return;
+  }
+
+  let changed = false;
+
+  const boilerplate = boilerplateByArch[arch];
+  if (boilerplate && boilerplate.baseData &&
+      boilerplate.baseData.meteorRuntimeConfig) {
+    try {
+      const decoded = WebApp.decodeRuntimeConfig(
+        boilerplate.baseData.meteorRuntimeConfig
+      );
+      decoded.PUBLIC_SETTINGS = livePublicSettings;
+      const encoded = WebApp.encodeRuntimeConfig(decoded);
+      boilerplate.baseData = Object.assign({}, boilerplate.baseData, {
+        meteorRuntimeConfig: encoded,
+        meteorRuntimeHash: sha1(encoded),
+      });
+      changed = true;
+    } catch (e) {
+      // Leave the cached config untouched if it cannot be decoded.
+    }
+  }
+
+  const program = WebApp.clientPrograms[arch];
+  if (program && typeof program.meteorRuntimeConfig === 'string') {
+    try {
+      const parsed = JSON.parse(program.meteorRuntimeConfig);
+      parsed.PUBLIC_SETTINGS = livePublicSettings;
+      program.meteorRuntimeConfig = JSON.stringify(parsed);
+      changed = true;
+    } catch (e) {
+      // Leave the cached config untouched if it cannot be parsed.
+    }
+  }
+
+  if (changed) {
+    // Let runtime-config hooks know the config changed for this arch so any
+    // caches they keep are refreshed on this request.
+    runtimeConfig.isUpdatedByArch[arch] = true;
+  }
+  lastPublicSettingsByArch[arch] = serialized;
+}
+
 async function getBoilerplateAsync(request, arch, response) {
+  refreshRuntimeConfigPublicSettings(arch);
   let boilerplate = boilerplateByArch[arch];
   await runtimeConfig.hooks.forEachAsync(async hook => {
     const meteorRuntimeConfig = await hook({
@@ -646,6 +707,7 @@ WebAppInternals.staticFilesMiddleware = async function(
     path === '/meteor_runtime_config.js' &&
     !WebAppInternals.inlineScriptsAllowed()
   ) {
+    refreshRuntimeConfigPublicSettings(arch);
     serveStaticJs(
       `__meteor_runtime_config__ = ${program.meteorRuntimeConfig};`
     );

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -318,6 +318,42 @@ Tinytest.addAsync(
   }
 );
 
+// Regression test for #13489: mutating Meteor.settings.public (which mutates
+// __meteor_runtime_config__.PUBLIC_SETTINGS) after the boilerplate has been
+// generated and cached at startup should still be reflected for clients that
+// connect afterwards.
+Tinytest.addAsync(
+  "webapp - runtime updates to public settings reach new clients",
+  async function (test) {
+    const original = __meteor_runtime_config__.PUBLIC_SETTINGS;
+    __meteor_runtime_config__.PUBLIC_SETTINGS = {
+      ...(original || {}),
+      webappRuntimePublicSetting: "set-after-startup",
+    };
+
+    try {
+      const req = new http.IncomingMessage();
+      req.url = "http://example.com";
+      req.browser = { name: "headless" };
+
+      const { stream } = await WebAppInternals.getBoilerplate(
+        req,
+        "web.browser"
+      );
+      const html = await streamToString(stream);
+
+      test.isTrue(
+        html.indexOf("webappRuntimePublicSetting") >= 0 &&
+          html.indexOf("set-after-startup") >= 0,
+        "boilerplate served to a new client should include public settings " +
+          "that were set after startup"
+      );
+    } finally {
+      __meteor_runtime_config__.PUBLIC_SETTINGS = original;
+    }
+  }
+);
+
 // Support 'named pipes' (strings) as ports for support of Windows Server /
 // Azure deployments
 Tinytest.add(


### PR DESCRIPTION
Upstream issue: meteor/meteor#13489

## Bug
The [`Meteor.settings` docs](https://docs.meteor.com/api/meteor.html#Meteor-settings) state that changes made to `Meteor.settings.public` at runtime are picked up by **new client connections**. In practice, any mutation made **after server startup has finished** never reaches newly-connecting clients — it's visible on the server but absent from the `__meteor_runtime_config__.PUBLIC_SETTINGS` blob served in the HTML. A contributor confirmed this worked in Meteor 2.0 and regressed around 2.14 (after Fibers were dropped); it still reproduces on `devel`.

## Root cause
`packages/webapp/webapp_server.js` encodes the runtime config (which embeds `PUBLIC_SETTINGS`) **once**, inside `generateBoilerplateInstance` at startup, and caches the resulting `Boilerplate` per arch in `boilerplateByArch` (and the parallel JSON string in `WebApp.clientPrograms[arch].meteorRuntimeConfig`). `getBoilerplateAsync` then serves the cached, frozen config on every request, so post-startup mutations of `Meteor.settings.public` are never re-encoded for new connections.

## Fix
Before serving, refresh the cached runtime config from the **live** `Meteor.settings.public`, but only re-encode when the public settings actually changed (tracked per arch via a serialized snapshot) so the common no-change path stays cheap. Both serving paths are covered:
- inline boilerplate (`getBoilerplateAsync`)
- external `/meteor_runtime_config.js` (used when inline scripts are disabled by CSP)

A regression test is added asserting that a public setting set after startup appears in the boilerplate served to a new client.

Scope is intentionally limited to **new** connections (what the docs promise); existing clients reloading on settings change is out of scope.

## How to reproduce
Versioned repro: https://github.com/italojs/meteor-issue-repros/tree/issue-13489

A minimal app whose `server/main.js` mutates `Meteor.settings.public` at three points: top-level, inside `Meteor.startup()`, and 3s after startup (`fooThird`).

```bash
meteor run --port 3100
# wait for "App running", then ~3s
curl -s http://localhost:3100/ | grep -o 'fooThird' || echo 'fooThird NOT served'
```

**Before (bug):** server log shows all three set, but the served HTML `PUBLIC_SETTINGS` only contains `fooFirst` + `fooSecond` — `fooThird` is ABSENT.

**After (this fix):** the served HTML `PUBLIC_SETTINGS` contains all three, including `fooThird` set after startup. Verified end-to-end against this checkout (see the repro branch README for the before/after terminal output).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime public settings changes made after startup are now detected and reflected in newly generated pages and served runtime configuration.
  * Updates are applied per architecture using refreshed cached runtime data so clients receive the latest values.
  * If cached runtime data can’t be decoded, the refresh is skipped safely and retried later.
* **Tests**
  * Added a regression test that mutates public runtime settings after startup and verifies the updated boilerplate content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->