### PR TITLE
Clearer oplog error for an uninitialized replica set

### DIFF
--- a/packages/mongo/oplog_replica_set_error.js
+++ b/packages/mongo/oplog_replica_set_error.js
@@ -1,0 +1,18 @@
+// Given the result of the Mongo `ismaster` command run against the oplog
+// connection, return an error message explaining why the oplog cannot be
+// tailed, or null if it can.
+export function replicaSetOplogError(isMasterDoc) {
+  if (isMasterDoc && isMasterDoc.setName) {
+    return null;
+  }
+
+  if (isMasterDoc && isMasterDoc.isreplicaset === true) {
+    // The server belongs to a replica set that has not been initialized yet, so
+    // it has no name. Point at the actual cause instead of the generic message.
+    return "$MONGO_OPLOG_URL points at a Mongo replica set that has not been " +
+      "initialized. Run rs.initiate() on the server, then restart." +
+      (isMasterDoc.info ? " (server reported: " + isMasterDoc.info + ")" : "");
+  }
+
+  return "$MONGO_OPLOG_URL must be set to the 'local' database of a Mongo replica set";
+}

--- a/packages/mongo/oplog_tailing.ts
+++ b/packages/mongo/oplog_tailing.ts
@@ -2,6 +2,7 @@ import isEmpty from 'lodash.isempty';
 import { Meteor } from 'meteor/meteor';
 import { CursorDescription } from './cursor_description';
 import { MongoConnection } from './mongo_connection';
+import { replicaSetOplogError } from './oplog_replica_set_error';
 
 import { NpmModuleMongodb } from "meteor/npm-mongo";
 const { Long } = NpmModuleMongodb;
@@ -325,8 +326,9 @@ export class OplogHandle {
         .admin()
         .command({ ismaster: 1 });
 
-      if (!(isMasterDoc && isMasterDoc.setName)) {
-        throw new Error("$MONGO_OPLOG_URL must be set to the 'local' database of a Mongo replica set");
+      const oplogError = replicaSetOplogError(isMasterDoc);
+      if (oplogError) {
+        throw new Error(oplogError);
       }
 
       const lastOplogEntry = await this._oplogLastEntryConnection.findOneAsync(

--- a/packages/mongo/package.js
+++ b/packages/mongo/package.js
@@ -85,6 +85,7 @@ Package.onUse(function (api) {
   api.addFiles(
     [
       "mongo_driver.js",
+      "oplog_replica_set_error.js",
       "oplog_tailing.ts",
       "observe_multiplex.ts",
       "doc_fetcher.js",
@@ -136,6 +137,7 @@ Package.onTest(function (api) {
   api.addFiles("tests/observe_changes_tests.js", ["client", "server"]);
   api.addFiles("tests/collection_extensions_tests.js", ["client", "server"]);
   api.addFiles("tests/oplog_tests.js", "server");
+  api.addFiles("tests/oplog_replica_set_error_tests.js", "server");
   api.addFiles("tests/changestream_observe_driver_tests.js", "server");
   api.addFiles("tests/oplog_v2_converter_tests.js", "server");
   api.addFiles("tests/doc_fetcher_tests.js", "server");

--- a/packages/mongo/tests/oplog_replica_set_error_tests.js
+++ b/packages/mongo/tests/oplog_replica_set_error_tests.js
@@ -1,0 +1,22 @@
+import { replicaSetOplogError } from '../oplog_replica_set_error';
+
+Tinytest.add('mongo-livedata - oplog - replicaSetOplogError', function (test) {
+  // An initialized replica set has a setName: tailing is allowed.
+  test.equal(replicaSetOplogError({ setName: 'rs0', ismaster: true }), null);
+
+  // A replica set member whose set has not been initialized yet reports
+  // isreplicaset:true with no setName. Point at that specific cause.
+  const uninitialized = replicaSetOplogError({
+    isreplicaset: true,
+    info: 'Does not have a valid replica set config',
+  });
+  test.matches(uninitialized, /has not been initialized/);
+  test.matches(uninitialized, /rs\.initiate\(\)/);
+  test.matches(uninitialized, /Does not have a valid replica set config/);
+
+  // A standalone server (not a replica set) keeps the original message.
+  test.matches(
+    replicaSetOplogError({ ismaster: true }),
+    /must be set to the 'local' database of a Mongo replica set/
+  );
+});


### PR DESCRIPTION
## Problem
Pointing `MONGO_OPLOG_URL` at the correct `local` database of a replica set that hasn't been initialized yet produces the misleading error *"MONGO_OPLOG_URL must be set to the 'local' database of a Mongo replica set"*, which sends users the wrong way.

## Root cause
`OplogHandle._startTailing` (`packages/mongo/oplog_tailing.ts`) checked only for `setName`. A replica-set member started with `--replSet` but never `rs.initiate()`-d reports `ismaster` as `{ isreplicaset: true, info: "Does not have a valid replica set config", … }` — no `setName` — so the correct-but-uninitialized case got the generic message.

## Fix
Classify the `ismaster` response with a small pure helper `replicaSetOplogError(isMasterDoc)`:

- has `setName` → tail it;
- `isreplicaset === true` with no `setName` → a clear "replica set has not been initialized, run `rs.initiate()`" message (including the server's `info`);
- otherwise → the original message.

## Test
Adds `mongo-livedata - oplog - replicaSetOplogError` in `packages/mongo/tests`. Ran the full `mongo` package suite via `test-in-console`: the new test passes and there are no failures.

Fixes #10923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mongo oplog tailing error handling so users now get clearer, more specific messages when a replica set is not ready or when the oplog URL points to the wrong database.
  * Preserved the existing error behavior for standalone servers while making replica set initialization issues easier to understand.

* **Tests**
  * Added coverage for oplog error message behavior across initialized replica sets, uninitialized replica sets, and standalone Mongo servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->