### PR TITLE
Fix store beginUpdate batch size: read updates by store name, not store._name

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -1151,10 +1151,12 @@ export class Connection {
     const self = this;
 
     if (self._resetStores || !isEmpty(updates)) {
-      // Start all store updates - keeping original loop structure
-      for (const store of Object.values(self._stores)) {
+      // Start all store updates - keeping original loop structure.
+      // Stores are keyed by name in _stores; the store wrapper object itself
+      // carries no _name property, so the batch size must come from the key.
+      for (const [name, store] of Object.entries(self._stores)) {
         await store.beginUpdate(
-          updates[store._name]?.length || 0,
+          updates[name]?.length || 0,
           self._resetStores
         );
       }
@@ -1202,10 +1204,12 @@ export class Connection {
     const self = this;
 
     if (self._resetStores || !isEmpty(updates)) {
-      // Synchronous store updates for client
-      Object.values(self._stores).forEach(store => {
+      // Synchronous store updates for client. Stores are keyed by name in
+      // _stores; the store wrapper object itself carries no _name property,
+      // so the batch size must come from the key.
+      Object.entries(self._stores).forEach(([name, store]) => {
         store.beginUpdate(
-          updates[store._name]?.length || 0,
+          updates[name]?.length || 0,
           self._resetStores
         );
       });

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2777,6 +2777,50 @@ Tinytest.addAsync('livedata connection - disconnect sends disconnect message', a
     "disconnect() should send a disconnect message to the server");
 });
 
+Tinytest.addAsync(
+  'livedata connection - store beginUpdate receives the real batch size',
+  async function (test) {
+    const stream = new StubStream();
+    const conn = newConnection(stream);
+
+    await startAndConnect(test, stream);
+
+    // Register a store that records every beginUpdate call. Stores receive
+    // batchSize > 1 (or reset) as the signal to pause observers, so a
+    // batchSize that is always 0 silently disables flicker prevention.
+    const beginUpdateCalls = [];
+    const storeApi = {
+      beginUpdate(batchSize, reset) {
+        beginUpdateCalls.push({ batchSize: batchSize, reset: reset });
+      },
+      update() {},
+      endUpdate() {},
+      saveOriginals() {},
+      retrieveOriginals() {}
+    };
+    if (Meteor.isServer) {
+      await conn.registerStoreServer('batch-test', storeApi);
+    } else {
+      conn.registerStoreClient('batch-test', storeApi);
+    }
+
+    // Three buffered writes for the store...
+    await stream.receive({ msg: 'added', collection: 'batch-test', id: '1', fields: { a: 1 } });
+    await stream.receive({ msg: 'added', collection: 'batch-test', id: '2', fields: { a: 2 } });
+    await stream.receive({ msg: 'added', collection: 'batch-test', id: '3', fields: { a: 3 } });
+    // ...then a non-write message, which forces an immediate flush.
+    await stream.receive({ msg: 'ready', subs: [] });
+
+    // However the flush batched the messages, the batch sizes reported to
+    // beginUpdate must account for all three writes.
+    const total = beginUpdateCalls.reduce(
+      (sum, call) => sum + call.batchSize,
+      0
+    );
+    test.equal(total, 3);
+  }
+);
+
 // XXX also test:
 // - restart on update flag
 // - on_update event


### PR DESCRIPTION
## Summary

Fixes #14525

Since `4e8c7cf181` (METEOR@3.1.1), every non-reset flush has called `store.beginUpdate(0, false)`: the flush loops read the batch size via `updates[store._name]`, but the store registry wrapper built by `createStoreMethods` carries only the whitelisted store methods — it has no `_name` — so the expression is always `updates[undefined]` → 0.

Minimongo only pauses observers when `batchSize > 1 || reset` (`packages/mongo/collection/methods_replication.js:40-46`), so multi-document batches have been applying unpaused: observers fire per document, and the flicker prevention that buffered writes exist for has been silently disabled.

## Changes

- `_performWritesServer` / `_performWritesClient`: iterate `Object.entries(self._stores)` and read `updates[name]` — the registry key is the same name the `updates` accumulator is keyed by
- Regression test (`livedata connection - store beginUpdate receives the real batch size`): a spy store receives three buffered `added` messages; the batch sizes reported to `beginUpdate` must sum to 3. On current `devel` the sum is 0 and the test fails; with the fix it passes. The summed assertion is deliberately robust to how the debounce timer happens to split the batch.

## Verification

Full `ddp-client` suite run twice: with the fix reverted it fails exactly on the new test; with the fix applied the whole suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how batched write updates are applied so stores receive the correct batch size before updates are processed.
  * Ensured write flushing stays consistent when multiple changes are queued, including on both client and server paths.

* **Tests**
  * Added coverage to verify stores are told the real number of queued updates during a flush.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->