### PR TITLE
Harden DDP session resumption grace-period edge cases

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -141,6 +141,13 @@ var Session = function (server, version, socket, options) {
     close: function () {
       // Server-initiated close should not be resumable
       self._expectingDisconnect = true;
+      if (self._isClosing && self._pendingRemoveFunction) {
+        // close() already ran and the session is sitting in its resumption
+        // grace period; terminate it now instead of silently doing nothing.
+        Meteor.clearTimeout(self._removeTimeoutHandle);
+        self._pendingRemoveFunction();
+        return;
+      }
       self.close();
     },
     onClose: function (fn) {
@@ -1498,11 +1505,13 @@ Object.assign(Server.prototype, {
     // the right ID
     // a matching sent/received count
     // was disconnected and hasn't been reconnected to yet.
-    if (existingSession && existingSession.sentCount === msg.receivedCount && existingSession._removeTimeoutHandle) {
+    if (existingSession && existingSession.sentCount === msg.receivedCount &&
+        existingSession._removeTimeoutHandle && !existingSession._expectingDisconnect) {
       Meteor.clearTimeout(existingSession._removeTimeoutHandle);
       existingSession._removeTimeoutHandle = undefined;
       existingSession._pendingRemoveFunction = undefined;
       existingSession._isClosing = false; // Reset so session can be closed again later
+      existingSession._expectingDisconnect = undefined;
       socket._meteorSession = existingSession;
       const messageQueue = existingSession.messageQueue;
       existingSession.messageQueue = undefined;
@@ -1526,10 +1535,12 @@ Object.assign(Server.prototype, {
 
       // Send connected message so client can restart heartbeat and confirm resumption
       existingSession.send({ msg: 'connected', session: existingSession.id });
+      // Flush the messages buffered during the grace period synchronously,
+      // before anything else (e.g. a live observe callback) can send on the
+      // reattached socket — deferring the flush would let newer messages
+      // jump ahead of older buffered ones and break DDP's ordering.
       if (messageQueue) {
-        Meteor.defer(() => {
-          messageQueue.forEach(msg => existingSession.send(msg));
-        });
+        messageQueue.forEach(msg => existingSession.send(msg));
       }
       // Note: onConnectionHook is NOT called on session resume - the connection
       // is considered to be the same logical connection as before.
@@ -1651,6 +1662,11 @@ Object.assign(Server.prototype, {
         session._removeTimeoutHandle = null;
       }
       session._pendingRemoveFunction = null;
+      // Stop buffering: with the queue gone, send() falls through to the
+      // (null) socket and becomes a no-op. Leaving the queue in place would
+      // buffer into a removed session until overflow invoked the
+      // now-nulled _pendingRemoveFunction and threw.
+      session.messageQueue = null;
       self.sessions.delete(session.id);
       callback();
     };

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -970,6 +970,110 @@ Tinytest.addAsync(
   }
 );
 
+// Test that send() on a removed session is a safe no-op
+Tinytest.addAsync(
+  "livedata server - DDP resumption: send after session removal is a no-op",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const { clientConn, serverConn } = await getTestConnections(test);
+      const session = Meteor.server.sessions.get(serverConn.id);
+
+      // Unexpected disconnect: session enters its grace period and buffers.
+      clientConn._stream._lostConnection();
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+      test.isTrue(
+        Array.isArray(session.messageQueue),
+        "session should buffer messages during the grace period"
+      );
+
+      // Let the grace period expire — the session is removed.
+      await sleep(AFTER_GRACE_PERIOD_MS);
+      test.isFalse(Meteor.server.sessions.has(serverConn.id));
+
+      // The buffer must be gone, and a late send (e.g. a deferred
+      // write-fence callback) must not buffer toward an overflow that
+      // would invoke the nulled _pendingRemoveFunction and throw.
+      test.isNull(session.messageQueue);
+      session.send({ msg: 'added', collection: 'x', id: '1', fields: {} });
+      test.isNull(session.messageQueue);
+    });
+  }
+);
+
+// Test that a server-initiated close during the grace period removes the
+// session immediately instead of silently doing nothing
+Tinytest.addAsync(
+  "livedata server - DDP resumption: connection close during grace period removes session",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const { clientConn, serverConn } = await getTestConnections(test);
+      const sessionId = serverConn.id;
+      const session = Meteor.server.sessions.get(sessionId);
+
+      // Unexpected disconnect: session enters its grace period.
+      clientConn._stream._lostConnection();
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+      test.isTrue(
+        Meteor.server.sessions.has(sessionId),
+        "session should be in its grace period"
+      );
+
+      // Server explicitly closes the connection: the session must not
+      // remain resumable.
+      session.connectionHandle.close();
+      test.isFalse(
+        Meteor.server.sessions.has(sessionId),
+        "server-initiated close should remove the session immediately"
+      );
+    });
+  }
+);
+
+// Test that messages buffered during the grace period are delivered on
+// resume, and that the resumed session gets a fresh grace period later
+Tinytest.addAsync(
+  "livedata server - DDP resumption: grace-period messages delivered on resume",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const clientConn = DDP.connect(Meteor.absoluteUrl(), { retry: false });
+      await pollUntil(() => clientConn._lastSessionId);
+      const sessionId = clientConn._lastSessionId;
+      const session = Meteor.server.sessions.get(sessionId);
+
+      // Record raw messages arriving on the client stream.
+      const received = [];
+      clientConn._stream.on('message', raw => received.push(raw));
+
+      // Unexpected disconnect, then buffer a message during the grace period.
+      clientConn._stream._lostConnection();
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+      session.send({
+        msg: 'added', collection: 'resume-order', id: 'q1', fields: {}
+      });
+      test.isTrue(Array.isArray(session.messageQueue));
+
+      // Resume.
+      clientConn._stream.reconnect();
+      await pollUntil(() => clientConn.status().connected);
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+      test.equal(clientConn._lastSessionId, sessionId,
+        "session should have been resumed");
+
+      // The buffered message reached the client...
+      test.isTrue(
+        received.some(raw => raw.indexOf('"q1"') !== -1),
+        "message buffered during the grace period should be delivered on resume"
+      );
+      // ...the queue is detached...
+      test.isUndefined(session.messageQueue);
+      // ...and no stale flag denies the session its next grace period.
+      test.isFalse(!!session._expectingDisconnect);
+
+      clientConn.disconnect();
+    });
+  }
+);
+
 // ============================================================================
 // Async onStop cleanup tests (memory leak fix)
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #14527 — four related edge cases in the DDP session-resumption grace period (introduced with #14051).

## Changes

All in `packages/ddp-server/livedata_server.js`:

- **`sessionRemoveFunction` nulls `messageQueue`.** After removal, `send()` falls through to the (null) socket and becomes the documented no-op. Previously a late send — e.g. a deferred write-fence callback — kept buffering into the dead queue until overflow invoked the already-nulled `_pendingRemoveFunction` and threw a TypeError into the sender.
- **`connectionHandle.close()` terminates a grace-period session immediately.** When `close()` already ran (`_isClosing` latched) and the session is awaiting resumption, the handle now cancels the removal timer and runs the pending remove, honoring "server-initiated close should not be resumable". Previously it silently did nothing.
- **Resume flushes the buffered queue synchronously.** Deferring the flush let messages sent between `connected` and the deferred callback (live observe callbacks) jump ahead of older buffered messages, breaking DDP ordering. The queue is bounded by `maxMessageQueueLength`, so the synchronous flush is bounded work.
- **`_expectingDisconnect` handling:** the resume check refuses flagged sessions, and a successful resume clears the flag so the session's next disconnect gets its grace period.

## Tests

Three new tests alongside the existing DDP-resumption suite:

- `send after session removal is a no-op` — fails on current `devel` (queue retained, send keeps buffering)
- `connection close during grace period removes session` — fails on current `devel` (close is a no-op)
- `grace-period messages delivered on resume` — pins the flush behavior, queue detachment, and flag reset

Verification: full `ddp-server` suite run twice — with the fixes reverted it fails exactly on the two regression tests; with them applied, 59/59 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session reconnection handling so disconnected sessions resume more reliably and stale disconnect state is cleared.
  * Ensured buffered messages are delivered in the correct order after reconnecting.
  * Prevented late messages from being buffered after a session has been removed.
  * Made server-initiated disconnects during the grace period remove sessions immediately.

* **Tests**
  * Added coverage for late sends after session removal, immediate cleanup during grace-period disconnects, and message delivery on resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->