### PR TITLE
Discard malformed DDP frames without crashing the message handler

### DIFF
--- a/packages/ddp-client/common/connection_stream_handlers.js
+++ b/packages/ddp-client/common/connection_stream_handlers.js
@@ -26,8 +26,10 @@ export class ConnectionStreamHandlers {
     }
 
     if (msg === null || !msg.msg) {
-      if(!msg || !msg.testMessageOnConnect) {
-        if (Object.keys(msg).length === 1 && msg.server_id) return;
+      if (!msg || !msg.testMessageOnConnect) {
+        // msg is null when parseDDP discarded the frame (invalid JSON, or
+        // JSON that is not an object) — guard before inspecting its keys.
+        if (msg && Object.keys(msg).length === 1 && msg.server_id) return;
         Meteor._debug('discarding invalid livedata message', msg);
       }
       return;

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2777,6 +2777,34 @@ Tinytest.addAsync('livedata connection - disconnect sends disconnect message', a
     "disconnect() should send a disconnect message to the server");
 });
 
+Tinytest.addAsync(
+  'livedata connection - malformed frames are discarded without crashing',
+  async function (test) {
+    const stream = new StubStream();
+    const conn = newConnection(stream);
+
+    await startAndConnect(test, stream);
+
+    // parseDDP returns null both for invalid JSON and for valid JSON that
+    // is not an object. Neither may throw out of the message handler.
+    await stream.receive('this is not json');
+    await stream.receive('"a bare string"');
+    await stream.receive('42');
+
+    // The connection still processes real messages afterwards.
+    let callbackFired = false;
+    conn.call('stillAlive', function () {
+      callbackFired = true;
+    });
+    const message = testGotMessage(test, stream, {
+      msg: 'method', method: 'stillAlive', params: [], id: '*'
+    });
+    await stream.receive({ msg: 'result', id: message.id, result: 'ok' });
+    await stream.receive({ msg: 'updated', methods: [message.id] });
+    test.isTrue(callbackFired);
+  }
+);
+
 // XXX also test:
 // - restart on update flag
 // - on_update event


### PR DESCRIPTION
## Summary

Fixes #14529

`parseDDP` returns `null` for frames that are invalid JSON or valid JSON that is not an object. `onMessage`'s invalid-message branch called `Object.keys(msg)` on that `null` and threw a TypeError, which escaped the un-awaited async handler as an unhandled rejection — a single malformed frame silently killed that message's processing with no connection-level signal.

## Changes

- `connection_stream_handlers.js`: guard the `server_id` single-key check with `msg &&`, so a `null` message falls through to the existing `Meteor._debug('discarding invalid livedata message', ...)` path
- Regression test (`malformed frames are discarded without crashing`): delivers raw `not json`, `"a bare string"`, and `42` frames, then verifies a subsequent method call completes normally. Fails on current `devel` (the receive throws), passes with the fix.

## Verification

Full `ddp-client` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the whole suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed connection messages so invalid frames are discarded without crashing.
  - Added coverage to confirm the app continues working normally after receiving bad or non-object data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->