### PR TITLE
Fire the browser stream's disconnect event only when a socket was closed

### DIFF
--- a/packages/socket-stream-client/browser.js
+++ b/packages/socket-stream-client/browser.js
@@ -94,11 +94,15 @@ export class ClientStream extends StreamClientCommon {
       this.socket.onmessage = this.socket.onclose = this.socket.onerror = this.socket.onheartbeat = () => {};
       this.socket.close();
       this.socket = null;
-    }
 
-    this.forEachCallback('disconnect', callback => {
-      callback(maybeError);
-    });
+      // Only fire disconnect callbacks when there was a socket to close,
+      // matching the node implementation. _cleanup also runs at the top of
+      // every (re)connection attempt, and firing here with no socket sent a
+      // phantom 'disconnect' event to consumers once per retry cycle.
+      this.forEachCallback('disconnect', callback => {
+        callback(maybeError);
+      });
+    }
   }
 
   _clearConnectionAndHeartbeatTimers() {

--- a/packages/socket-stream-client/client-tests.js
+++ b/packages/socket-stream-client/client-tests.js
@@ -227,3 +227,31 @@ testAsyncMulti('stream - /websocket is a websocket endpoint', [
     );
   }
 ]);
+// _cleanup runs both when tearing down a live socket and at the top of every
+// (re)connection attempt. Only the former is a disconnection: firing the
+// 'disconnect' event when there was no socket sent consumers a phantom event
+// once per retry cycle (and diverged from the node implementation).
+testAsyncMulti('stream - cleanup without a socket does not fire disconnect', [
+  function(test, expect) {
+    var stream = new ClientStream('/');
+    var disconnectCount = 0;
+    stream.on('disconnect', function() {
+      disconnectCount++;
+    });
+
+    var done = expect(function() {});
+    stream.on(
+      'reset',
+      once(function() {
+        // Connected: a real disconnect closes the socket and fires once.
+        stream.disconnect();
+        test.equal(disconnectCount, 1);
+
+        // A cleanup with no socket must not fire a phantom event.
+        stream._cleanup();
+        test.equal(disconnectCount, 1);
+        done();
+      })
+    );
+  }
+]);


### PR DESCRIPTION
## Summary

Fixes #14531

The browser `ClientStream._cleanup` fired `disconnect` callbacks unconditionally, while `_cleanup` also runs at the top of every (re)connection attempt — so browser consumers received a phantom `disconnect` event (with `undefined` payload) once per retry cycle. The node implementation only fires when a client existed; browser and node apps therefore observed different event sequences from the same network behavior.

## Changes

- `browser.js`: fire the `disconnect` callbacks inside the `if (this.socket)` teardown block, matching node's semantics — one event per actual disconnection
- Regression test (`cleanup without a socket does not fire disconnect`): a connected stream fires exactly one event on `disconnect()`, and a subsequent socketless `_cleanup()` fires none. Fails on current `devel` (count reaches 2), passes with the fix.

## Verification

`socket-stream-client` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an extra `disconnect` event from firing during cleanup when no socket is active.
  * Improved connection behavior so reconnect attempts no longer trigger a phantom disconnect notification.
* **Tests**
  * Added coverage to verify cleanup without an open socket does not emit an additional `disconnect` event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->