### PR TITLE
Make reconnect() a no-op on permanently disconnected streams

### DIFF
--- a/packages/socket-stream-client/client-tests.js
+++ b/packages/socket-stream-client/client-tests.js
@@ -227,3 +227,22 @@ testAsyncMulti('stream - /websocket is a websocket endpoint', [
     );
   }
 ]);
+// The window 'online' handler calls reconnect() on any non-offline stream,
+// including permanently failed ones. reconnect() must be a true no-op there:
+// it used to decrement retryCount (compensating for a _retryNow that then
+// refused to run), drifting the counter negative on every online event.
+Tinytest.add(
+  'stream - reconnect on a permanently disconnected stream is a no-op',
+  function(test) {
+    var stream = new ClientStream('/');
+    stream.disconnect({ _permanent: true });
+    test.equal(stream.status().status, 'failed');
+
+    var before = stream.status().retryCount;
+    stream.reconnect();
+    stream.reconnect();
+
+    test.equal(stream.status().retryCount, before);
+    test.equal(stream.status().status, 'failed');
+  }
+);

--- a/packages/socket-stream-client/common.js
+++ b/packages/socket-stream-client/common.js
@@ -69,6 +69,13 @@ export class StreamClientCommon {
   reconnect(options) {
     options = options || Object.create(null);
 
+    // A permanently shut down stream (disconnect({_permanent: true}))
+    // cannot be revived — _retryNow refuses to relaunch it. Bail before
+    // touching retry bookkeeping: the window 'online' handler calls this
+    // on 'failed' streams, and the retryCount decrement below would
+    // otherwise drift further negative on every online event.
+    if (this._forcedToDisconnect) return;
+
     if (options.url) {
       this._changeUrl(options.url);
     }


### PR DESCRIPTION
## Summary

Fixes #14533

`reconnect()` decrements `retryCount` before calling `_retryNow` ("don't count manual retries"), relying on `_retryNow` to increment it back — but `_retryNow` refuses to relaunch a permanently disconnected stream (`_forcedToDisconnect`), so the decrement is never compensated. The browser `window 'online'` handler calls `reconnect()` on any non-`'offline'` stream, including permanently `'failed'` ones, so every online event drifted `retryCount` further negative on such streams.

## Changes

- `common.js`: `reconnect()` returns immediately when `_forcedToDisconnect` is set — a permanent disconnect has no revive path, so this mirrors `_retryNow`'s existing guard instead of corrupting retry bookkeeping on the way to it
- Regression test (`reconnect on a permanently disconnected stream is a no-op`): after `disconnect({_permanent: true})`, two `reconnect()` calls leave `retryCount` and status untouched. Fails on current `devel` (`retryCount` reaches −2), passes with the fix.

Non-permanent `retry: false` streams (status `'failed'` without the forced flag) are unaffected — the `'online'` handler still revives those, matching current behavior.

## Verification

`socket-stream-client` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reconnect now properly does nothing after a permanent disconnect, preserving the failed connection state and retry count.
  * Added test coverage to ensure repeated reconnect attempts do not change the stream status once it has been permanently disconnected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->