### PR TITLE
Make crossbar listen-handle stop() idempotent

### DIFF
--- a/packages/ddp-server/crossbar.js
+++ b/packages/ddp-server/crossbar.js
@@ -59,8 +59,14 @@ Object.assign(DDPServer._Crossbar.prototype, {
         self.factPackage, self.factName, 1);
     }
 
+    var stopped = false;
     return {
       stop: function () {
+        // Idempotent: a second stop() used to decrement the count (and the
+        // server fact) again — silently dropping the collection's remaining
+        // listeners when the count hit zero, then throwing on later stops.
+        if (stopped) return;
+        stopped = true;
         if (self.factName && Package['facts-base']) {
           Package['facts-base'].Facts.incrementServerFact(
             self.factPackage, self.factName, -1);

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -1044,3 +1044,32 @@ Tinytest.addAsync(
     delete asyncCleanupTracker[trackerId];
   }
 );
+// A crossbar listen handle's stop() must be idempotent. A second stop()
+// used to decrement the listener count again, silently deleting the
+// collection's remaining listeners once it hit zero (and throwing on any
+// later stop). Observer teardown races make double-stop plausible.
+Tinytest.addAsync(
+  "livedata server - crossbar listen handle stop is idempotent",
+  async function (test) {
+    const crossbar = new DDPServer._Crossbar({});
+    let fired = 0;
+    const handleA = crossbar.listen(
+      { collection: 'crossbar-idempotent-stop' },
+      function () {}
+    );
+    const handleB = crossbar.listen(
+      { collection: 'crossbar-idempotent-stop' },
+      function () {
+        fired++;
+      }
+    );
+
+    handleA.stop();
+    handleA.stop(); // no-op, must not disturb other listeners
+
+    await crossbar.fire({ collection: 'crossbar-idempotent-stop', id: 'x' });
+    test.equal(fired, 1);
+
+    handleB.stop(); // must not throw
+  }
+);


### PR DESCRIPTION
## Summary

Fixes #14535

A crossbar listen handle's `stop()` was not idempotent: a second call decremented the collection's listener count (and the `invalidation-crossbar-listeners` server fact) again. Once the count hit zero early, the collection's whole listener map was deleted — silently unhooking every remaining listener on that collection (live observe drivers stop receiving invalidations) — and any later `stop()` threw a TypeError.

## Changes

- `crossbar.js`: latch the returned handle with a `stopped` flag; repeated stops are no-ops
- Regression test (`crossbar listen handle stop is idempotent`): two listeners on one collection, first handle stopped twice, then a matching `fire()` must still reach the second listener and stopping it must not throw. Fails on current `devel` (the second listener is silently dropped), passes with the fix.

## Verification

`ddp-server` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed listener handles so calling `stop()` multiple times no longer causes extra cleanup or affects other active listeners.
  * Improved stability when stopping collection listeners, preventing unexpected count changes after the first stop.
  
* **Tests**
  * Added coverage for repeated `stop()` calls to ensure they are safe and do not interfere with remaining listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->