### PR TITLE
Deregister closed connections from DDP._allConnections

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -1091,6 +1091,10 @@ export class Connection {
   }
 
   close() {
+    // A closed connection can never reconnect; stop tracking it in
+    // DDP._allConnections (otherwise the registry grows forever and
+    // _allSubscriptionsReady consults dead connections).
+    DDP._removeConnection(this);
     // _permanent is used by the underlying stream to prevent reconnection attempts
     return this.disconnect({ _permanent: true });
   }

--- a/packages/ddp-client/common/namespace.js
+++ b/packages/ddp-client/common/namespace.js
@@ -72,6 +72,16 @@ DDP.connect = (url, options) => {
   return ret;
 };
 
+// Called by Connection#close(): a permanently closed connection must not
+// stay in allConnections, where _allSubscriptionsReady would consult it
+// forever.
+DDP._removeConnection = connection => {
+  const index = allConnections.indexOf(connection);
+  if (index !== -1) {
+    allConnections.splice(index, 1);
+  }
+};
+
 DDP._reconnectHook = new Hook({ bindEnvironment: false });
 
 /**

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2781,3 +2781,27 @@ Tinytest.addAsync('livedata connection - disconnect sends disconnect message', a
 // - restart on update flag
 // - on_update event
 // - reloading when the app changes, including session migration
+
+Tinytest.add(
+  'livedata connection - close() stops tracking the connection',
+  function (test) {
+    // Precondition: every already-tracked connection is fully ready, so
+    // this test's connection is the only thing that can flip the answer.
+    test.isTrue(DDP._allSubscriptionsReady());
+
+    // DDP.connect registers in the allConnections registry (the object
+    // form of `url` is the standard test-stream hook).
+    const stream = new StubStream();
+    const conn = DDP.connect(stream);
+
+    // A subscription that never becomes ready makes this connection the
+    // one blocking _allSubscriptionsReady.
+    conn.subscribe('never-ready-tracking-test');
+    test.isFalse(DDP._allSubscriptionsReady());
+
+    // Closing the connection must deregister it — a closed connection can
+    // never become ready and would otherwise be consulted forever.
+    conn.close();
+    test.isTrue(DDP._allSubscriptionsReady());
+  }
+);


### PR DESCRIPTION
## Summary

Fixes #14537

Every `DDP.connect` pushed into the module-level `allConnections` registry and nothing ever removed entries: the array grew for the lifetime of the process (one retained `Connection` per connect for server-to-server users), and `DDP._allSubscriptionsReady()` — the `spiderable` hook — consulted dead connections forever, so a closed connection with a pending subscription permanently reported "not ready".

## Changes

- `namespace.js`: add private `DDP._removeConnection(connection)` that splices the registry
- `livedata_connection.js`: `close()` calls it before permanently disconnecting — a closed connection can never become ready. Plain `disconnect()` is untouched (those connections can reconnect and legitimately stay tracked).
- Regression test (`close() stops tracking the connection`): a tracked connection with a never-ready subscription flips `_allSubscriptionsReady()` to false; `close()` must flip it back. Fails on current `devel`, passes with the fix.

## Verification

`ddp-client` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the whole suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closed client connections are now fully removed from internal tracking, preventing stale connections from affecting subscription readiness checks.
  * Subscription readiness can now update correctly after a connection is closed, avoiding cases where the app appeared to stay pending.
* **Tests**
  * Added coverage to verify that closing a connection clears it from readiness tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->