### PR TITLE
Null-guard the accounting set in Subscription.removed()

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1269,7 +1269,13 @@ Object.assign(Subscription.prototype, {
     if (this._session.server.getPublicationStrategy(collectionName).doAccountingForCollection) {
       // We don't bother to delete sets of things in a collection if the
       // collection is empty.  It could break _removeAllDocuments.
-      this._documents.get(collectionName).delete(id);
+      // The set may not exist: accounting may have been off when the
+      // document was added (publication strategies can change per
+      // collection at runtime), mirroring the null-guard in added().
+      const ids = this._documents.get(collectionName);
+      if (ids != null) {
+        ids.delete(id);
+      }
     }
 
     this._session.removed(this._subscriptionHandle, collectionName, id);

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -1196,10 +1196,9 @@ Meteor.publish('livedata_server_test_strategy_flip', function () {
     );
     this.removed(collection, 'doc1');
   } finally {
-    Meteor.server.setPublicationStrategy(
-      collection,
-      DDPServer.publicationStrategies.SERVER_MERGE
-    );
+    // Fully restore global state: remove the per-collection override rather
+    // than leaving an explicit (if default-equivalent) entry behind.
+    delete Meteor.server._publicationStrategies[collection];
   }
   this.ready();
 });

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -1177,3 +1177,44 @@ Tinytest.addAsync(
     handleB.stop(); // must not throw
   }
 );
+
+// added() lazily creates the per-collection accounting Set; removed() read it
+// unguarded. Publication strategies can change per collection at runtime, so
+// an add under a no-accounting strategy followed by a remove under an
+// accounting one threw a TypeError out of the publish handler.
+Meteor.publish('livedata_server_test_strategy_flip', function () {
+  const collection = 'strategy-flip-collection';
+  Meteor.server.setPublicationStrategy(
+    collection,
+    DDPServer.publicationStrategies.NO_MERGE_NO_HISTORY
+  );
+  try {
+    this.added(collection, 'doc1', { a: 1 });
+    Meteor.server.setPublicationStrategy(
+      collection,
+      DDPServer.publicationStrategies.SERVER_MERGE
+    );
+    this.removed(collection, 'doc1');
+  } finally {
+    Meteor.server.setPublicationStrategy(
+      collection,
+      DDPServer.publicationStrategies.SERVER_MERGE
+    );
+  }
+  this.ready();
+});
+
+Tinytest.addAsync(
+  "livedata server - removed() after publication strategy change does not throw",
+  async function (test) {
+    const { clientConn } = await getTestConnections(test);
+    await new Promise((resolve, reject) => {
+      clientConn.subscribe('livedata_server_test_strategy_flip', {
+        onReady: resolve,
+        onError: reject,
+      });
+    });
+    test.isTrue(true, 'subscription became ready without a handler error');
+    clientConn.disconnect();
+  }
+);

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -1208,13 +1208,16 @@ Tinytest.addAsync(
   "livedata server - removed() after publication strategy change does not throw",
   async function (test) {
     const { clientConn } = await getTestConnections(test);
-    await new Promise((resolve, reject) => {
-      clientConn.subscribe('livedata_server_test_strategy_flip', {
-        onReady: resolve,
-        onError: reject,
+    try {
+      await new Promise((resolve, reject) => {
+        clientConn.subscribe('livedata_server_test_strategy_flip', {
+          onReady: resolve,
+          onError: reject,
+        });
       });
-    });
-    test.isTrue(true, 'subscription became ready without a handler error');
-    clientConn.disconnect();
+      test.isTrue(true, 'subscription became ready without a handler error');
+    } finally {
+      clientConn.disconnect();
+    }
   }
 );


### PR DESCRIPTION
## Summary

Fixes #14539

`Subscription#added()` lazily creates the per-collection accounting Set and null-guards it; `Subscription#removed()` read the same structure unguarded (`this._documents.get(collectionName).delete(id)`). The Set only exists if `doAccountingForCollection` was true at add time, and publication strategies can change per collection at runtime through the public `setPublicationStrategy` API — so an add under a no-accounting strategy followed by a remove under an accounting one threw a TypeError out of the publish handler.

## Changes

- `livedata_server.js`: null-guard the accounting Set in `removed()`, mirroring `added()`
- Regression test (`removed() after publication strategy change does not throw`): a publish handler adds under `NO_MERGE_NO_HISTORY`, flips the collection to `SERVER_MERGE`, removes, and calls `ready()`. Pre-fix the handler throws and the subscription errors; post-fix it becomes ready.

## Verification

`ddp-server` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash during subscription cleanup when per-collection publication tracking data is missing.
  * Ensured stability when changing a publication’s per-collection strategy between `added` and `removed`.
* **Tests**
  * Added a regression test covering `removed()` after a publication strategy change to confirm subscriptions become ready without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->