### PR TITLE
Hold _sendQueued messages sent while disconnected until reconnect

### DIFF
--- a/packages/ddp-client/common/connection_stream_handlers.js
+++ b/packages/ddp-client/common/connection_stream_handlers.js
@@ -133,6 +133,10 @@ export class ConnectionStreamHandlers {
     // the necessary RTT to know if we successfully reconnected.
     this._connection._callOnReconnectAndSendAppropriateOutstandingMethods();
     this._resendSubscriptions();
+
+    // Deliver messages that were passed to _sendQueued while disconnected
+    // (e.g. 'unsub' messages); the stream would have dropped them.
+    this._connection._flushMessagesQueuedUntilReconnect();
   }
 
   /**

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -246,6 +246,11 @@ export class Connection {
       });
     }
 
+    // Messages passed to _sendQueued while the stream was not connected.
+    // The stream drops data sent while disconnected, so these are flushed
+    // once the connection is (re-)established.
+    self._messagesQueuedUntilReconnect = [];
+
     this._streamHandlers = new ConnectionStreamHandlers(this);
 
     const onDisconnect = () => {
@@ -1037,14 +1042,28 @@ export class Connection {
     this._stream.send(DDPCommon.stringifyDDP(obj));
   }
 
-  // Always queues the call before sending the message
-  // Used, for example, on subscription.[id].stop() to make sure a "sub" message is always called before an "unsub" message
+  // Sends the message ordered behind any sends queued by in-flight async
+  // stubs (the second argument to _send routes through the client stub
+  // queue — see queue_stub_helpers.js). If the stream is not connected the
+  // message is held until the connection is (re-)established instead: the
+  // stream drops data sent while disconnected, and e.g. the 'unsub' from
+  // subscription.stop() removes its registry record, so nothing would ever
+  // re-send it.
   // https://github.com/meteor/meteor/issues/13212
-  //
-  // This is part of the actual fix for the rest check:
-  // https://github.com/meteor/meteor/pull/13236
   _sendQueued(obj) {
-    this._send(obj, true);
+    if (this._stream.status().status === 'connected') {
+      this._send(obj, true);
+    } else {
+      this._messagesQueuedUntilReconnect.push(obj);
+    }
+  }
+
+  // Called on stream reset, after subscriptions have been re-sent, so a
+  // queued 'unsub' can never precede its subscription's 'sub'.
+  _flushMessagesQueuedUntilReconnect() {
+    const queued = this._messagesQueuedUntilReconnect;
+    this._messagesQueuedUntilReconnect = [];
+    queued.forEach(obj => this._send(obj, true));
   }
 
   // We detected via DDP-level heartbeats that we've lost the

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2781,3 +2781,33 @@ Tinytest.addAsync('livedata connection - disconnect sends disconnect message', a
 // - restart on update flag
 // - on_update event
 // - reloading when the app changes, including session migration
+
+Tinytest.addAsync(
+  'livedata connection - unsub while disconnected is delivered after reconnect',
+  async function (test) {
+    const stream = new StubStream();
+    const conn = newConnection(stream);
+
+    await startAndConnect(test, stream);
+
+    const sub = conn.subscribe('queued-unsub-test');
+    const subMessage = testGotMessage(test, stream, {
+      msg: 'sub', id: '*', name: 'queued-unsub-test', params: []
+    });
+
+    // Stop the subscription while the stream is not connected. The stream
+    // drops data sent in this state, and the registry record is removed, so
+    // nothing would ever re-send the unsub — it must be queued.
+    stream.setStatus('waiting');
+    sub.stop();
+    test.length(stream.sent, 0);
+
+    // On reconnect the queued unsub goes out, after the connect message
+    // (and after any still-registered subscriptions would be re-sent).
+    stream.setStatus('connected');
+    await stream.reset();
+    testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
+    testGotMessage(test, stream, { msg: 'unsub', id: subMessage.id });
+    test.length(stream.sent, 0);
+  }
+);

--- a/packages/ddp-client/test/stub_stream.js
+++ b/packages/ddp-client/test/stub_stream.js
@@ -20,7 +20,12 @@ Object.assign(StubStream.prototype, {
   },
 
   status: function() {
-    return { status: 'connected', fake: true };
+    return { status: this._status || 'connected', fake: true };
+  },
+
+  // Test helper: simulate a stream status (e.g. 'waiting' while offline).
+  setStatus: function(status) {
+    this._status = status;
   },
 
   reconnect: function() {


### PR DESCRIPTION
## Summary

Fixes #14541

`_sendQueued` orders its messages behind in-flight async-stub sends (the `shouldQueue` argument consumed by `queue_stub_helpers`), but nothing persists those messages across a disconnection — the stream drops data sent while not connected. A subscription stopped while disconnected therefore lost its `unsub`, and since `stop()` removes the registry record, nothing re-sent it on reconnect. With session resumption (3.5+), the resumed server session keeps the ghost subscription streaming forever.

## Changes

- `livedata_connection.js`: `_sendQueued` holds messages in `_messagesQueuedUntilReconnect` while `status().status !== 'connected'`; a new `_flushMessagesQueuedUntilReconnect()` drains it. Both the connected path and the flush keep passing the stub-queue ordering flag, so client-side ordering relative to async stubs is unchanged (the existing "sub and unsub run in the correct order" test still passes).
- `connection_stream_handlers.js`: `onReset` flushes the held messages after `_resendSubscriptions()`, so a held `unsub` can never precede its subscription's `sub`
- `stub_stream.js`: test-only `setStatus()` helper
- Regression test (`unsub while disconnected is delivered after reconnect`): stop a subscription while the stub stream reports `waiting` — nothing may hit the wire; after reset the `unsub` follows the connect message. Fails on current `devel` (the unsub is handed to the disconnected stream immediately), passes with the fix.

## Verification

`ddp-client` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the whole suite passes — including the #13236 ordering regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a case where unsubscribe requests could be lost if sent while the connection was offline.
  * Buffered outgoing messages during disconnects and automatically sent them after reconnecting.
  * Improved reconnect behavior so pending requests are delivered in the correct order once the connection is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->