### PR TITLE
Fire the subscription record's current stopCallback on local stop

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -485,8 +485,11 @@ export class Connection {
           this.connection._sendQueued({ msg: 'unsub', id: id });
           this.remove();
 
-          if (callbacks.onStop) {
-            callbacks.onStop();
+          // Use the record's current stopCallback — an autorun rerun may
+          // have replaced the one captured when this record was created,
+          // and the server-initiated stop path (nosub) already uses it.
+          if (this.stopCallback) {
+            this.stopCallback();
           }
         }
       };

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2781,3 +2781,43 @@ Tinytest.addAsync('livedata connection - disconnect sends disconnect message', a
 // - restart on update flag
 // - on_update event
 // - reloading when the app changes, including session migration
+
+Tinytest.addAsync(
+  'livedata connection - replaced stop callback fires on local stop',
+  async function (test) {
+    const stream = new StubStream();
+    const conn = newConnection(stream);
+
+    await startAndConnect(test, stream);
+
+    let firstStopCalls = 0;
+    let secondStopCalls = 0;
+
+    // Initial subscribe, as an autorun's first run would do.
+    const sub = conn.subscribe('replace-stop-test', {
+      onStop() {
+        firstStopCalls++;
+      }
+    });
+    testGotMessage(test, stream, {
+      msg: 'sub', id: '*', name: 'replace-stop-test', params: []
+    });
+
+    // Simulate the autorun rerun reuse path: the record is marked inactive
+    // and a matching subscribe reactivates it, replacing its callbacks.
+    conn._subscriptions[sub.subscriptionId].inactive = true;
+    conn.subscribe('replace-stop-test', {
+      onStop() {
+        secondStopCalls++;
+      }
+    });
+    test.length(stream.sent, 0); // record reused — no second 'sub' message
+
+    // A local stop must fire the record's CURRENT callback, exactly like
+    // the server-initiated stop path (nosub) does — not the callback
+    // captured when the record was first created.
+    sub.stop();
+    test.equal(secondStopCalls, 1);
+    test.equal(firstStopCalls, 0);
+  }
+);


### PR DESCRIPTION
## Summary

Fixes #14543

An autorun rerun reuses an inactive subscription record and replaces its `readyCallback`/`errorCallback`/`stopCallback` — but the record's `stop()` closed over the `callbacks` object captured when the record was first created. After a rerun, a local stop fired the stale original `onStop` while the server-initiated stop path (`nosub`) fired the replacement: two sources of truth for the same event.

## Changes

- `livedata_connection.js`: `stop()` fires `this.stopCallback` — the record's current callback, matching the `nosub` path
- Regression test (`replaced stop callback fires on local stop`): subscribe with `onStop` A, simulate the autorun reuse path replacing it with B, then `stop()` — B must fire exactly once and A not at all. Fails on current `devel` (A fires, B doesn't), passes with the fix.

## Verification

`ddp-client` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the whole suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription stops now honor the most recently registered stop callback, ensuring the correct handler runs after a subscription is reused or updated.
  * Fixed local stop behavior so the latest callback is called when a subscription is stopped.
* **Tests**
  * Added coverage for subscription reuse and stop handling to verify the updated callback is used and no extra subscription is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->