### PR TITLE
Arm the legacy heartbeat watchdog only on the sockjs transport

### DIFF
--- a/packages/socket-stream-client/browser.js
+++ b/packages/socket-stream-client/browser.js
@@ -122,6 +122,11 @@ export class ClientStream extends StreamClientCommon {
   }
 
   _heartbeat_received() {
+    // The watchdog exists to detect missing SockJS heartbeat frames, which
+    // the server emits every 45s. Native WebSocket transports have no such
+    // frames, so on a quiet connection (e.g. DDP heartbeats disabled) the
+    // timer would be guaranteed to fire and kill a healthy connection.
+    if (this._transport !== 'sockjs') return;
     // If we've already permanently shut down this stream, the timeout is
     // already cleared, and we don't need to set it again.
     if (this._forcedToDisconnect) return;
@@ -163,6 +168,7 @@ export class ClientStream extends StreamClientCommon {
     this._cleanup(); // cleanup the old socket, if there was one.
 
     const transport = __meteor_runtime_config__.DDP_TRANSPORT || 'sockjs';
+    this._transport = transport;
 
     if (transport === 'sockjs') {
       const options = {

--- a/packages/socket-stream-client/client-tests.js
+++ b/packages/socket-stream-client/client-tests.js
@@ -275,3 +275,27 @@ Tinytest.add(
     test.equal(stream.status().status, 'failed');
   }
 );
+
+// The 100s legacy watchdog detects missing SockJS heartbeat frames. Native
+// WebSocket transports have no such frames, so arming it there guarantees a
+// healthy-but-quiet connection (DDP heartbeats disabled) is killed after
+// 100s of silence.
+Tinytest.add(
+  'stream - legacy heartbeat watchdog only arms on the sockjs transport',
+  function(test) {
+    let stream = new ClientStream('/');
+    try {
+      // Simulate a message arriving on a native-WebSocket stream.
+      stream._transport = 'websocket';
+      stream._heartbeat_received();
+      test.isFalse(!!stream.heartbeatTimer);
+
+      // The sockjs transport keeps its watchdog.
+      stream._transport = 'sockjs';
+      stream._heartbeat_received();
+      test.isTrue(!!stream.heartbeatTimer);
+    } finally {
+      stream.disconnect();
+    }
+  }
+);


### PR DESCRIPTION
## Summary

Fixes #14545

The 100-second legacy watchdog detects missing SockJS heartbeat frames (emitted by the server every 45s). It was armed on every inbound message regardless of transport — and native WebSocket has no such frames, so a healthy connection that goes quiet (e.g. `heartbeatInterval: 0`) was killed after 100 seconds of silence with "No sockjs heartbeat received".

## Changes

- `browser.js`: `_launchConnection` records the chosen transport; `_heartbeat_received` returns early for non-SockJS transports, so the watchdog only arms where SockJS heartbeat frames actually exist
- Regression test (`legacy heartbeat watchdog only arms on the sockjs transport`): `_heartbeat_received` must not arm `heartbeatTimer` under the websocket transport and must under sockjs. Fails on current `devel`, passes with the fix.

## Verification

`socket-stream-client` suite run twice: with the fix reverted it fails exactly on the new test; with it applied, the suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability: heartbeat watchdog now applies only when using the legacy SockJS transport.
  * Fixed phantom disconnect signals during cleanup, and made permanent disconnect reconnect attempts a true no-op.
  * Improved DDP livedata message queuing/flush ordering across disconnects and resumes; server-side listener stop is now idempotent.
  * Change Streams now gracefully fall back when a cursor projection isn’t supported.

* **Performance / Behavior**
  * Web compression now skips gzip when a `Content-Length` header is already present (preserving header correctness).

* **Tests**
  * Added regression coverage for heartbeat behavior, queued/unqueued messaging correctness, and new fallback/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->