### PR TITLE
Make the write fence's phases explicit

### DIFF
--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -1220,3 +1220,33 @@ Tinytest.addAsync(
     }
   }
 );
+Tinytest.addAsync("livedata server - write fence phases", async function (test) {
+  const fence = new DDPServer._WriteFence();
+  test.equal(fence.phase, 'OPEN');
+  test.isFalse(fence.armed);
+  test.isFalse(fence.fired);
+  test.isFalse(fence.retired);
+
+  const write = fence.beginWrite();
+  const armPromise = fence.armAndWait();
+  test.equal(fence.phase, 'ARMED');
+  test.isTrue(fence.armed);
+  test.isFalse(fence.fired);
+
+  await write.committed();
+  await armPromise;
+  test.equal(fence.phase, 'FIRED');
+  test.isTrue(fence.fired);
+  test.isFalse(fence.retired);
+
+  fence.retire();
+  test.equal(fence.phase, 'RETIRED');
+  test.isTrue(fence.retired);
+  test.isTrue(fence.fired);
+
+  // Idempotent retire and no-op late writes, as before.
+  fence.retire();
+  const lateWrite = fence.beginWrite();
+  lateWrite.committed();
+  test.equal(fence.phase, 'RETIRED');
+});

--- a/packages/ddp-server/writefence.js
+++ b/packages/ddp-server/writefence.js
@@ -1,15 +1,66 @@
+// A write fence collects a group of writes, and provides a callback when all
+// of the writes are fully committed and propagated (all observers have been
+// notified of the write and acknowledged it).
+//
+// The fence advances through named phases:
+//
+//   OPEN ──arm()──► ARMED ──writes drained──► FIRING ──► FIRED ──retire()──► RETIRED
+//                     ▲                          │
+//                     └── writes began during ───┘
+//                         before-fire callbacks
+//
+//   OPEN     accepts writes and callbacks; never fires, even at zero writes.
+//   ARMED    accepts writes and callbacks; fires once outstanding writes
+//            reach zero.
+//   FIRING   before-fire callbacks are running; writes they begin hold the
+//            fence open (returning it to ARMED until they commit).
+//   FIRED    completion callbacks have run; beginning a write is an error.
+//   RETIRED  a late write (e.g. from a straggling timer) is a silent no-op.
+const PHASE = Object.freeze({
+  OPEN: 'OPEN',
+  ARMED: 'ARMED',
+  FIRING: 'FIRING',
+  FIRED: 'FIRED',
+  RETIRED: 'RETIRED',
+});
+
 DDPServer._WriteFence = class {
   constructor() {
-    this.armed = false;
-    this.fired = false;
-    this.retired = false;
+    this._phase = PHASE.OPEN;
     this.outstanding_writes = 0;
     this.before_fire_callbacks = [];
     this.completion_callbacks = [];
   }
 
+  get phase() {
+    return this._phase;
+  }
+
+  // Legacy flag accessors: external code reads these (e.g. the mongo observe
+  // drivers check fence.fired).
+  get armed() {
+    return this._phase !== PHASE.OPEN;
+  }
+
+  get fired() {
+    return this._phase === PHASE.FIRED || this._phase === PHASE.RETIRED;
+  }
+
+  get retired() {
+    return this._phase === PHASE.RETIRED;
+  }
+
+  _transition(to, legalFrom) {
+    if (!legalFrom.includes(this._phase)) {
+      throw new Error(
+        'invalid write fence transition: ' + this._phase + ' -> ' + to
+      );
+    }
+    this._phase = to;
+  }
+
   beginWrite() {
-    if (this.retired) {
+    if (this._phase === PHASE.RETIRED) {
       return { committed: () => {} };
     }
 
@@ -36,7 +87,9 @@ DDPServer._WriteFence = class {
     if (this === DDPServer._getCurrentFence()) {
       throw Error("Can't arm the current fence");
     }
-    this.armed = true;
+    if (this._phase === PHASE.OPEN) {
+      this._transition(PHASE.ARMED, [PHASE.OPEN]);
+    }
     return this._maybeFire();
   }
 
@@ -71,9 +124,11 @@ DDPServer._WriteFence = class {
       throw new Error("write fence already activated?");
     }
 
-    if (!this.armed || this.outstanding_writes > 0) {
+    if (this._phase !== PHASE.ARMED || this.outstanding_writes > 0) {
       return;
     }
+
+    this._transition(PHASE.FIRING, [PHASE.ARMED]);
 
     const invokeCallback = async (func) => {
       try {
@@ -83,6 +138,9 @@ DDPServer._WriteFence = class {
       }
     };
 
+    // Hold the fence open while the before-fire callbacks run: writes they
+    // begin (e.g. observe drivers acknowledging invalidations) must be able
+    // to commit before the fence fires.
     this.outstanding_writes++;
 
     // Process all before_fire callbacks in parallel
@@ -93,11 +151,15 @@ DDPServer._WriteFence = class {
     this.outstanding_writes--;
 
     if (this.outstanding_writes === 0) {
-      this.fired = true;
+      this._transition(PHASE.FIRED, [PHASE.FIRING]);
       // Process all completion callbacks in parallel
       const callbacks = [...this.completion_callbacks];
       this.completion_callbacks = [];
       await Promise.all(callbacks.map(cb => invokeCallback(cb)));
+    } else {
+      // Writes began during the before-fire callbacks; their commits will
+      // re-run _maybeFire (picking up any callbacks registered meanwhile).
+      this._transition(PHASE.ARMED, [PHASE.FIRING]);
     }
   }
 
@@ -105,8 +167,11 @@ DDPServer._WriteFence = class {
     if (!this.fired) {
       throw new Error("Can't retire a fence that hasn't fired.");
     }
-    this.retired = true;
+    // RETIRED -> RETIRED keeps retire() idempotent, as it always was.
+    this._transition(PHASE.RETIRED, [PHASE.FIRED, PHASE.RETIRED]);
   }
 };
+
+DDPServer._WriteFence.PHASES = PHASE;
 
 DDPServer._CurrentWriteFence = new Meteor.EnvironmentVariable;


### PR DESCRIPTION
## Summary

Refactor, no behavior change: make the write fence's lifecycle an explicit state machine.

`_WriteFence` encoded five phases implicitly across three booleans (`armed`, `fired`, `retired`) plus the `outstanding_writes` counter, with the legal combinations existing only in readers' heads. This PR names the phases — `OPEN → ARMED → FIRING → FIRED → RETIRED` — and advances them through a single `_transition(to, legalFrom)` helper that throws on an illegal move, so a future bug that would previously corrupt the flags silently now fails loudly at the transition.

## Compatibility

- `armed` / `fired` / `retired` remain readable as accessors derived from the phase — external readers (the mongo observe drivers check `fence.fired`) are unaffected. A repo-wide search found no external writes to the flags.
- Error messages, idempotent `retire()`, the `RETIRED` no-op write handle, and the `FIRING → ARMED` return path (writes begun by before-fire callbacks hold the fence open) are all preserved exactly.
- New read-only `fence.phase` and `_WriteFence.PHASES` for tests/diagnostics.

## Tests

- New "write fence phases" test walks the full lifecycle and pins the derived flags at each phase, plus idempotent retire and the late-write no-op.
- Full `ddp-server` suite passes; the mongo suite (heaviest fence consumer) runs in CI.

## Context

First of a short series making the DDP stack's implicit state machines explicit, following the bug wave in #14525–#14546 — several of those bugs lived precisely in the gaps between undeclared state flags. Opened as a draft for discussion of the idiom before broader use (client stream status and server session lifecycle are the natural next candidates).
