### PR TITLE
Centralize the client stream's status transitions

### DIFF
--- a/packages/socket-stream-client/browser.js
+++ b/packages/socket-stream-client/browser.js
@@ -64,29 +64,7 @@ export class ClientStream extends StreamClientCommon {
     this.rawUrl = url;
   }
 
-  _connected() {
-    if (this.connectionTimer) {
-      clearTimeout(this.connectionTimer);
-      this.connectionTimer = null;
-    }
-
-    if (this.currentStatus.connected) {
-      // already connected. do nothing. this probably shouldn't happen.
-      return;
-    }
-
-    // update status
-    this.currentStatus.status = 'connected';
-    this.currentStatus.connected = true;
-    this.currentStatus.retryCount = 0;
-    this.statusChanged();
-
-    // fire resets. This must come after status change so that clients
-    // can call send from within a reset callback.
-    this.forEachCallback('reset', callback => {
-      callback();
-    });
-  }
+  // The CONNECTED transition itself lives in StreamClientCommon._connected.
 
   _cleanup(maybeError) {
     this._clearConnectionAndHeartbeatTimers();
@@ -105,11 +83,15 @@ export class ClientStream extends StreamClientCommon {
     }
   }
 
-  _clearConnectionAndHeartbeatTimers() {
+  _clearConnectionTimer() {
     if (this.connectionTimer) {
       clearTimeout(this.connectionTimer);
       this.connectionTimer = null;
     }
+  }
+
+  _clearConnectionAndHeartbeatTimers() {
+    this._clearConnectionTimer();
     if (this.heartbeatTimer) {
       clearTimeout(this.heartbeatTimer);
       this.heartbeatTimer = null;
@@ -219,7 +201,7 @@ export class ClientStream extends StreamClientCommon {
       this._heartbeat_received();
     };
 
-    if (this.connectionTimer) clearTimeout(this.connectionTimer);
+    this._clearConnectionTimer();
     this.connectionTimer = setTimeout(() => {
       this._lostConnection(
         new this.ConnectionError("DDP connection timed out")

--- a/packages/socket-stream-client/client-tests.js
+++ b/packages/socket-stream-client/client-tests.js
@@ -299,3 +299,23 @@ Tinytest.add(
     }
   }
 );
+// The status object is managed by a single transition helper in
+// StreamClientCommon: statuses come from one enum, transient fields
+// (retryTime, reason) are added and removed with their statuses, and the
+// object is mutated in place so a reference from status() stays current.
+Tinytest.add('stream - status transitions are centralized', function(test) {
+  test.equal(ClientStream.STATUSES.CONNECTED, 'connected');
+
+  var stream = new ClientStream('/');
+  var statusObj = stream.status();
+  test.isFalse(stream.isForcedToDisconnect());
+
+  stream.disconnect({ _permanent: true, _error: 'version negotiation failed' });
+
+  test.isTrue(stream.isForcedToDisconnect());
+  // In-place mutation: the earlier reference observes the transition.
+  test.equal(statusObj.status, 'failed');
+  test.equal(statusObj.reason, 'version negotiation failed');
+  test.isFalse('retryTime' in statusObj);
+  test.equal(statusObj.retryCount, 0);
+});

--- a/packages/socket-stream-client/common.js
+++ b/packages/socket-stream-client/common.js
@@ -161,7 +161,8 @@ export class StreamClientCommon {
     }
 
     this._retry.clear();
-    this.currentStatus.retryCount -= 1; // don't count manual retries
+    // don't count manual retries
+    this._setStatus({ retryCount: this.currentStatus.retryCount - 1 });
     this._retryNow();
   }
 

--- a/packages/socket-stream-client/common.js
+++ b/packages/socket-stream-client/common.js
@@ -2,6 +2,23 @@ import { Retry } from 'meteor/retry';
 
 const forcedReconnectError = new Error("forced reconnect");
 
+// Every status the stream can be in. The values are part of the public API
+// (Meteor.status().status), so they are the historical lowercase strings.
+//
+//   CONNECTING ──socket open──► CONNECTED ──connection lost──► WAITING ──retry timer──► CONNECTING
+//        │                                                        │
+//        └──────────── connection lost, retry off ──► FAILED ◄────┘ (retry off)
+//
+//   disconnect()             → OFFLINE (revivable via reconnect / 'online')
+//   disconnect({_permanent}) → FAILED with _forcedToDisconnect latched (terminal)
+export const STATUS = Object.freeze({
+  CONNECTING: 'connecting',
+  CONNECTED: 'connected',
+  WAITING: 'waiting',
+  FAILED: 'failed',
+  OFFLINE: 'offline',
+});
+
 export class StreamClientCommon {
   constructor(options) {
     this.options = {
@@ -45,7 +62,7 @@ export class StreamClientCommon {
 
     //// Reactive status
     this.currentStatus = {
-      status: 'connecting',
+      status: STATUS.CONNECTING,
       connected: false,
       retryCount: 0
     };
@@ -63,6 +80,52 @@ export class StreamClientCommon {
     //// Retry logic
     this._retry = new Retry();
     this.connectionTimer = null;
+  }
+
+  // The single point through which every status change flows. Fields set to
+  // undefined are removed from the status object (retryTime and reason come
+  // and go with their statuses). The status object is mutated in place, so a
+  // reference returned by status() stays current across transitions.
+  _setStatus(fields) {
+    for (const [key, value] of Object.entries(fields)) {
+      if (value === undefined) {
+        delete this.currentStatus[key];
+      } else {
+        this.currentStatus[key] = value;
+      }
+    }
+    this.statusChanged();
+  }
+
+  // Transition to CONNECTED. Called by the platform implementations from
+  // their transport-level open events (after their own transport guards).
+  _connected() {
+    this._clearConnectionTimer();
+
+    if (this.currentStatus.connected) {
+      // already connected. do nothing. this probably shouldn't happen.
+      return;
+    }
+
+    this._setStatus({
+      status: STATUS.CONNECTED,
+      connected: true,
+      retryCount: 0,
+    });
+
+    // fire resets. This must come after status change so that clients
+    // can call send from within a reset callback.
+    this.forEachCallback('reset', callback => {
+      callback();
+    });
+  }
+
+  // True once the stream has been permanently shut down
+  // (disconnect({_permanent: true}), e.g. on DDP version negotiation
+  // failure). Such a stream can never reconnect. Public accessor for the
+  // layers above; the flag itself is internal.
+  isForcedToDisconnect() {
+    return this._forcedToDisconnect;
   }
 
   // Trigger a reconnect.
@@ -92,7 +155,7 @@ export class StreamClientCommon {
     }
 
     // if we're mid-connection, stop it.
-    if (this.currentStatus.status === 'connecting') {
+    if (this.currentStatus.status === STATUS.CONNECTING) {
       // Pretend it's a clean close.
       this._lostConnection();
     }
@@ -120,16 +183,15 @@ export class StreamClientCommon {
     this._cleanup();
     this._retry.clear();
 
-    this.currentStatus = {
-      status: options._permanent ? 'failed' : 'offline',
+    this._setStatus({
+      status: options._permanent ? STATUS.FAILED : STATUS.OFFLINE,
       connected: false,
-      retryCount: 0
-    };
-
-    if (options._permanent && options._error)
-      this.currentStatus.reason = options._error;
-
-    this.statusChanged();
+      retryCount: 0,
+      retryTime: undefined,
+      reason: options._permanent && options._error
+        ? options._error
+        : undefined,
+    });
   }
 
   // maybeError is set unless it's a clean protocol-level close.
@@ -142,7 +204,7 @@ export class StreamClientCommon {
   // immediately.
   _online() {
     // if we've requested to be offline by disconnecting, don't reconnect.
-    if (this.currentStatus.status != 'offline') this.reconnect();
+    if (this.currentStatus.status != STATUS.OFFLINE) this.reconnect();
   }
 
   _retryLater(maybeError) {
@@ -153,25 +215,29 @@ export class StreamClientCommon {
         this.currentStatus.retryCount,
         this._retryNow.bind(this)
       );
-      this.currentStatus.status = 'waiting';
-      this.currentStatus.retryTime = new Date().getTime() + timeout;
+      this._setStatus({
+        status: STATUS.WAITING,
+        connected: false,
+        retryTime: new Date().getTime() + timeout,
+      });
     } else {
-      this.currentStatus.status = 'failed';
-      delete this.currentStatus.retryTime;
+      this._setStatus({
+        status: STATUS.FAILED,
+        connected: false,
+        retryTime: undefined,
+      });
     }
-
-    this.currentStatus.connected = false;
-    this.statusChanged();
   }
 
   _retryNow() {
     if (this._forcedToDisconnect) return;
 
-    this.currentStatus.retryCount += 1;
-    this.currentStatus.status = 'connecting';
-    this.currentStatus.connected = false;
-    delete this.currentStatus.retryTime;
-    this.statusChanged();
+    this._setStatus({
+      status: STATUS.CONNECTING,
+      connected: false,
+      retryCount: this.currentStatus.retryCount + 1,
+      retryTime: undefined,
+    });
 
     this._launchConnection();
   }
@@ -184,3 +250,5 @@ export class StreamClientCommon {
     return this.currentStatus;
   }
 }
+
+StreamClientCommon.STATUSES = STATUS;

--- a/packages/socket-stream-client/node.js
+++ b/packages/socket-stream-client/node.js
@@ -69,19 +69,8 @@ export class ClientStream extends StreamClientCommon {
       throw new Error('Two parallel connections?');
     }
 
-    this._clearConnectionTimer();
-
-    // update status
-    this.currentStatus.status = 'connected';
-    this.currentStatus.connected = true;
-    this.currentStatus.retryCount = 0;
-    this.statusChanged();
-
-    // fire resets. This must come after status change so that clients
-    // can call send from within a reset callback.
-    this.forEachCallback('reset', callback => {
-      callback();
-    });
+    // The CONNECTED transition itself lives in StreamClientCommon.
+    this._connected();
   }
 
   _cleanup(maybeError) {


### PR DESCRIPTION
## Summary

Refactor: centralize the client stream's status handling. Draft — second in the state-machine series after #14547, following the bug wave in #14525–#14546 (four of those bugs — #14531, #14533, and the divergences behind them — lived in this file's gaps).

## Problem

`currentStatus` was written from five sites across three files, in two mutation styles:

- most transitions mutated fields in place, while `disconnect()` replaced the whole object — silently orphaning any reference obtained from `status()` earlier;
- the CONNECTED transition existed only as byte-duplicated blocks in `browser.js` and `node.js`, which had already drifted (double-connect: silent return vs throw; forced-disconnect check present only in node);
- the transient fields `retryTime` and `reason` appeared and vanished ad hoc;
- the browser file cleared the connection timer inline in three places.

## Changes

- **`_setStatus(fields)`** in `StreamClientCommon` — the single point through which every transition flows. In-place mutation; `undefined` removes a field, so `retryTime`/`reason` come and go with their statuses.
- **`_connected()` moves to the base class.** The platform implementations keep only their transport-level guards (node's stale-client/parallel-connection throws are unchanged) and call the shared transition.
- **`STATUS` enum** (exported, also as `ClientStream.STATUSES`) names the five statuses; the string values are unchanged — they are public API via `Meteor.status()`.
- **`isForcedToDisconnect()`** public accessor, so upper layers (e.g. the pending #14193) no longer need the private flag.
- Browser's connection-timer clearing deduplicated into `_clearConnectionTimer()`.

## Behavior notes

One observable delta, called out for review: `disconnect()` now mutates the status object in place like every other transition, instead of replacing it — a reference obtained from `status()` before a disconnect now observes the transition. Tracker reactivity is unchanged (`statusChanged` fires exactly as before). Everything else — statuses, fields, error messages, platform guard behavior — is preserved.

Relationship to pending PRs: this is purely structural against `devel` and does not include the behavioral fixes from #14532 (phantom disconnect event) or #14534 (reconnect on failed streams); it rebases cleanly in either order, and those fixes become one-liners in the centralized structure.

## Tests

- New "status transitions are centralized" test: STATUSES exposure, `isForcedToDisconnect()`, in-place mutation across a permanent disconnect, transient-field lifecycle.
- `socket-stream-client` and `ddp-client` suites pass.
