### PR TITLE
Extract the buffered-writes machinery into UpdateBuffer

### DIFF
--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -17,6 +17,7 @@ import { ConnectionStreamHandlers } from './connection_stream_handlers';
 import { MongoIDMap } from './mongo_id_map';
 import { MessageProcessors } from './message_processors';
 import { DocumentProcessors } from './document_processors';
+import { UpdateBuffer } from './update_buffer';
 
 // @param url {String|Object} URL to Meteor app,
 //   or an object as a test hook (see code)
@@ -205,15 +206,13 @@ export class Connection {
     self._updatesForUnknownStores = {};
     // if we're blocking a migration, the retry func
     self._retryMigrate = null;
-    // Collection name -> array of messages.
-    self._bufferedWrites = {};
-    // When current buffer of updates must be flushed at, in ms timestamp.
-    self._bufferedWritesFlushAt = null;
-    // Timeout handle for the next processing of all pending writes
-    self._bufferedWritesFlushHandle = null;
-
-    self._bufferedWritesInterval = options.bufferedWritesInterval;
-    self._bufferedWritesMaxAge = options.bufferedWritesMaxAge;
+    // Buffers incoming data-message writes per collection and owns the
+    // debounce/max-age flush policy. See update_buffer.js.
+    self._updateBuffer = new UpdateBuffer({
+      interval: options.bufferedWritesInterval,
+      maxAge: options.bufferedWritesMaxAge,
+      flush: () => self._flushBufferedWrites(),
+    });
 
     // metadata for subscriptions.  Map from sub ID to object with keys:
     //   - id
@@ -1153,20 +1152,9 @@ export class Connection {
     return Object.values(invokers).some((invoker) => !!invoker.sentMessage);
   }
 
-  _prepareBuffersToFlush() {
-    const self = this;
-    if (self._bufferedWritesFlushHandle) {
-      clearTimeout(self._bufferedWritesFlushHandle);
-      self._bufferedWritesFlushHandle = null;
-    }
-
-    self._bufferedWritesFlushAt = null;
-    // We need to clear the buffer before passing it to
-    //  performWrites. As there's no guarantee that it
-    //  will exit cleanly.
-    const writes = self._bufferedWrites;
-    self._bufferedWrites = Object.create(null);
-    return writes;
+  // Tests await this to observe completion of a debounce-timer flush.
+  get _liveDataWritesPromise() {
+    return this._updateBuffer.pendingWritesPromise;
   }
 
   /**
@@ -1265,7 +1253,7 @@ export class Connection {
    */
   async _flushBufferedWrites() {
     const self = this;
-    const writes = self._prepareBuffersToFlush();
+    const writes = self._updateBuffer.takeAll();
 
     return Meteor.isClient
       ? self._performWritesClient(writes)

--- a/packages/ddp-client/common/message_processors.js
+++ b/packages/ddp-client/common/message_processors.js
@@ -163,46 +163,23 @@ export class MessageProcessors {
       for (const bufferedMessage of Object.values(bufferedMessages)) {
         await this._processOneDataMessage(
           bufferedMessage,
-          self._bufferedWrites
+          self._updateBuffer.writes
         );
       }
       self._messagesBufferedUntilQuiescence = [];
     } else {
-      await this._processOneDataMessage(msg, self._bufferedWrites);
+      await this._processOneDataMessage(msg, self._updateBuffer.writes);
     }
 
-    // Immediately flush writes when:
-    //  1. Buffering is disabled. Or;
-    //  2. any non-(added/changed/removed) message arrives.
+    // The buffer owns the flush policy: immediate when buffering is disabled
+    // or for any non-(added/changed/removed) message, otherwise debounced
+    // and capped by the max-age deadline.
     const standardWrite =
       msg.msg === "added" ||
       msg.msg === "changed" ||
       msg.msg === "removed";
 
-    if (self._bufferedWritesInterval === 0 || !standardWrite) {
-      await self._flushBufferedWrites();
-      return;
-    }
-
-    if (self._bufferedWritesFlushAt === null) {
-      self._bufferedWritesFlushAt =
-        new Date().valueOf() + self._bufferedWritesMaxAge;
-    } else if (self._bufferedWritesFlushAt < new Date().valueOf()) {
-      await self._flushBufferedWrites();
-      return;
-    }
-
-    if (self._bufferedWritesFlushHandle) {
-      clearTimeout(self._bufferedWritesFlushHandle);
-    }
-    self._bufferedWritesFlushHandle = setTimeout(() => {
-      self._liveDataWritesPromise = self._flushBufferedWrites();
-      if (Meteor._isPromise(self._liveDataWritesPromise)) {
-        self._liveDataWritesPromise.finally(
-          () => (self._liveDataWritesPromise = undefined)
-        );
-      }
-    }, self._bufferedWritesInterval);
+    await self._updateBuffer.afterMessage(standardWrite);
   }
 
   /**
@@ -244,7 +221,7 @@ export class MessageProcessors {
     const self = this._connection;
 
     // Lets make sure there are no buffered writes before returning result.
-    if (!isEmpty(self._bufferedWrites)) {
+    if (!self._updateBuffer.isEmpty()) {
       await self._flushBufferedWrites();
     }
 

--- a/packages/ddp-client/common/update_buffer.js
+++ b/packages/ddp-client/common/update_buffer.js
@@ -1,0 +1,88 @@
+import { Meteor } from 'meteor/meteor';
+import { isEmpty } from "meteor/ddp-common/utils";
+
+// Collects incoming data-message writes per collection and owns the decision
+// of when to flush them to the stores:
+//
+//   - a non-batched message (anything but added/changed/removed), or
+//     batching disabled (interval 0)          → flush immediately
+//   - writes arriving within `interval` ms    → debounced into one flush
+//   - continuous writes                       → flushed at least every
+//                                               `maxAge` ms
+//
+// The buffer owns its two timers (the debounce handle and the max-age
+// deadline) and the atomic take-and-clear used by the flush, so the whole
+// batching lifecycle lives in one place.
+export class UpdateBuffer {
+  // flush: called (and awaited where the caller awaits) to drain the buffer;
+  //        it must call takeAll() to claim the pending writes.
+  constructor({ interval, maxAge, flush }) {
+    this._interval = interval;
+    this._maxAge = maxAge;
+    this._flush = flush;
+
+    // Collection name -> array of messages.
+    this._writes = Object.create(null);
+    // When the current buffer must be flushed by, in ms timestamp.
+    this._flushAt = null;
+    // Timeout handle for the next processing of all pending writes.
+    this._flushHandle = null;
+
+    // The flush promise from a debounce-timer flush, exposed so tests can
+    // await write completion (Connection._liveDataWritesPromise aliases it).
+    this.pendingWritesPromise = undefined;
+  }
+
+  // The accumulator that message processors push writes into.
+  get writes() {
+    return this._writes;
+  }
+
+  isEmpty() {
+    return isEmpty(this._writes);
+  }
+
+  // Apply the flush policy after a message has been processed into the
+  // buffer. Immediate flushes are awaited; a scheduled flush returns at
+  // once and records its promise in pendingWritesPromise when it runs.
+  async afterMessage(isBatchedWrite) {
+    if (this._interval === 0 || !isBatchedWrite) {
+      await this._flush();
+      return;
+    }
+
+    if (this._flushAt === null) {
+      this._flushAt = new Date().valueOf() + this._maxAge;
+    } else if (this._flushAt < new Date().valueOf()) {
+      await this._flush();
+      return;
+    }
+
+    if (this._flushHandle) {
+      clearTimeout(this._flushHandle);
+    }
+    this._flushHandle = setTimeout(() => {
+      this.pendingWritesPromise = this._flush();
+      if (Meteor._isPromise(this.pendingWritesPromise)) {
+        this.pendingWritesPromise.finally(
+          () => (this.pendingWritesPromise = undefined)
+        );
+      }
+    }, this._interval);
+  }
+
+  // Atomically claim the pending writes and reset the batching state. The
+  // buffer is cleared before the writes are applied because there is no
+  // guarantee the store updates will exit cleanly.
+  takeAll() {
+    if (this._flushHandle) {
+      clearTimeout(this._flushHandle);
+      this._flushHandle = null;
+    }
+    this._flushAt = null;
+
+    const writes = this._writes;
+    this._writes = Object.create(null);
+    return writes;
+  }
+}

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2947,3 +2947,37 @@ Tinytest.addAsync(
     test.length(stream.sent, 0);
   }
 );
+
+Tinytest.addAsync(
+  'livedata connection - update buffer owns the flush policy',
+  async function (test) {
+    const stream = new StubStream();
+    // The suite-wide newConnection helper disables batching
+    // (bufferedWritesInterval: 0); this test needs the real policy.
+    const conn = newConnection(stream, {
+      bufferedWritesInterval: 5,
+      bufferedWritesMaxAge: 500
+    });
+
+    await startAndConnect(test, stream);
+
+    const buffer = conn._updateBuffer;
+    test.isTrue(!!buffer);
+    test.isTrue(buffer.isEmpty());
+
+    // A batched write is debounced: the buffer holds it...
+    buffer.writes['buffer-policy-test'] = [{ msg: 'added' }];
+    await buffer.afterMessage(true);
+    test.isFalse(buffer.isEmpty());
+
+    // ...and a non-batched message flushes everything immediately.
+    await buffer.afterMessage(false);
+    test.isTrue(buffer.isEmpty());
+
+    // takeAll claims the pending writes atomically.
+    buffer.writes['buffer-policy-test-2'] = [{ msg: 'added' }];
+    const taken = buffer.takeAll();
+    test.equal(Object.keys(taken), ['buffer-policy-test-2']);
+    test.isTrue(buffer.isEmpty());
+  }
+);


### PR DESCRIPTION
## Summary

Refactor, no behavior change: extract the client's buffered-writes machinery into a single owner. Draft — third in the state-machine/encapsulation series (#14547 write fence, #14548 stream status), and the first slice of making ddp-client's connection satellites own their state instead of sharing ~20 underscore fields.

## Problem

The write-batching state was spread across two files with split ownership:

- five `Connection` fields (`_bufferedWrites`, `_bufferedWritesFlushAt`, `_bufferedWritesFlushHandle`, plus the two config values) — and a sixth, `_liveDataWritesPromise`, that was never declared in the constructor at all (born inside a timer callback in another file, then frozen into de-facto API by tests)
- the flush-policy decision and the debounce timer armed in `message_processors.js`
- the same timer cleared, the max-age deadline reset, and the buffer swapped in `livedata_connection.js` (`_prepareBuffersToFlush`)

Understanding one timer required reading two files; the wall-clock max-age logic had no single owner.

## Changes

- **New `update_buffer.js`**: `UpdateBuffer` owns the per-collection accumulator, the debounce handle, the max-age deadline, the flush-policy decision (`afterMessage`), and the atomic take-and-clear (`takeAll`). The flush itself stays on the connection and is injected.
- `livedata_connection.js`: constructor builds the buffer from the existing options; `_flushBufferedWrites` drains via `takeAll()`; `_prepareBuffersToFlush` is gone; `_liveDataWritesPromise` survives as a getter over the buffer's pending flush promise, so existing tests (and any app code peeking at it) keep working.
- `message_processors.js`: threads `buffer.writes` where it threaded the raw object, and delegates the flush decision to `buffer.afterMessage(standardWrite)` — the immediate/debounce/max-age semantics are unchanged, timings identical.
- One normalization, called out for review: the initial buffer is now a null-prototype object like its post-flush reset always was (previously a plain `{}` until the first flush, so a collection named `toString` behaved differently before vs after the first reconnect).

## Tests

- New "update buffer owns the flush policy" test: debounce-holds, immediate-flush on non-batched messages, atomic `takeAll`.
- Existing buffered-writes tests exercise the getter and timer paths; full `ddp-client` suite passes.
