### PR TITLE
FEATURE: add meteor shell-completion command for bash and zsh

### DIFF
--- a/tools/cli/commands-completion.js
+++ b/tools/cli/commands-completion.js
@@ -200,7 +200,9 @@ function installCompletion(shellType) {
   );
   Console.info(Console.command(`source ${autocompletePath}`));
   Console.info(
-    "Re-run this command after updating your Meteor checkout to refresh the embedded top-level command list."
+    "Note: option and subcommand completions are always resolved dynamically from " +
+    "the running meteor binary. Only re-run this command if new top-level commands " +
+    "were added in a Meteor update and are missing from completion."
   );
 }
 

--- a/tools/cli/commands-completion.js
+++ b/tools/cli/commands-completion.js
@@ -262,9 +262,23 @@ function getOptionCommand(node, word) {
   return optionCommands[optionCommandName];
 }
 
+const GLOBAL_OPTIONS_TAKING_VALUE = new Set(["release"]);
+
 function isCompletingOptionValue(words, index, command) {
   const previousWord = words[index - 1];
-  if (!previousWord || !previousWord.startsWith("-") || !command) {
+  if (!previousWord || !previousWord.startsWith("-")) {
+    return false;
+  }
+
+  // Check global options that take a value (e.g. --release <version>)
+  if (previousWord.startsWith("--")) {
+    const optionName = previousWord.slice(2);
+    if (GLOBAL_OPTIONS_TAKING_VALUE.has(optionName)) {
+      return true;
+    }
+  }
+
+  if (!command) {
     return false;
   }
 
@@ -510,7 +524,15 @@ function shellCompletionCommand(options) {
     return 0;
   }
 
+  const SUPPORTED_SHELLS = ["bash", "zsh"];
   const shellType = options.shell || detectShell();
+
+  if (!SUPPORTED_SHELLS.includes(shellType)) {
+    Console.error(
+      `Unsupported shell: ${shellType}. Supported shells are: ${SUPPORTED_SHELLS.join(", ")}.`
+    );
+    return 1;
+  }
 
   if (options.install) {
     installCompletion(shellType);

--- a/tools/cli/commands-completion.js
+++ b/tools/cli/commands-completion.js
@@ -1,0 +1,550 @@
+const main = require("./main.js");
+const { Console } = require("../console/console.js");
+const files = require("../fs/files");
+const catalog = require("../packaging/catalog/catalog.js");
+const { ProjectContext } = require("../project-context.js");
+
+const GLOBAL_OPTION_SUGGESTIONS = ["--release", "--help", "-h"];
+const MOBILE_PLATFORMS = ["ios", "android"];
+const COMPLETION_FILENAME = "meteor-completion.sh";
+const COMPLETION_MARKER = "# Meteor autocompletion";
+const TOP_LEVEL_COMMANDS_PLACEHOLDER = "__METEOR_TOP_LEVEL_COMMANDS__";
+const COMPLETION_SOURCE_LINE =
+  '[ -f "$HOME/.meteor/meteor-completion.sh" ] && source "$HOME/.meteor/meteor-completion.sh"';
+
+function hasOwn(object, key) {
+  return Boolean(object) && Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function isCommandNode(node) {
+  return Boolean(node && typeof node.func === "function");
+}
+
+function mergeUnique(...lists) {
+  return [...new Set(lists.flat())];
+}
+
+function excludeItems(items, itemsToExclude) {
+  const excludedItems = new Set(itemsToExclude);
+  return items.filter((item) => !excludedItems.has(item));
+}
+
+function intersectItems(items, allowedItems) {
+  const allowedItemsSet = new Set(allowedItems);
+  return items.filter((item) => allowedItemsSet.has(item));
+}
+
+function readMeteorProjectFile(appDir, fileName) {
+  if (!appDir) {
+    return null;
+  }
+
+  const filePath = files.pathJoin(appDir, ".meteor", fileName);
+  if (!files.exists(filePath)) {
+    return null;
+  }
+
+  return files.readFile(filePath, "utf8");
+}
+
+function getInstalledPackages(appDir) {
+  const content = readMeteorProjectFile(appDir, "packages");
+  if (content === null) {
+    return [];
+  }
+
+  return content
+    .split("\n")
+    .map((line) => line.split("#")[0].trim())
+    .filter(Boolean)
+    .map((line) => line.split("@")[0].trim())
+    .filter(Boolean);
+}
+
+function getInstalledPlatforms(appDir) {
+  const content = readMeteorProjectFile(appDir, "platforms");
+  if (content === null) {
+    return [];
+  }
+
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+}
+
+function printCompletions(suggestions, currentWord) {
+  const visibleSuggestions = [...new Set(suggestions)]
+    .sort()
+    .filter((suggestion) => !currentWord || suggestion.startsWith(currentWord));
+
+  for (const suggestion of visibleSuggestions) {
+    Console.rawInfo(`${suggestion}\n`);
+  }
+}
+
+function detectShell() {
+  const shellEnv = process.env.SHELL || "";
+  return shellEnv.includes("zsh") ? "zsh" : "bash";
+}
+
+function quoteShellWord(word) {
+  return `'${String(word).replace(/'/g, `'\\''`)}'`;
+}
+
+function getTopLevelCommandsLiteral() {
+  return main.getTopLevelCommandNames().map(quoteShellWord).join(" ");
+}
+
+function getScriptContent(shellType) {
+  const filename = shellType === "zsh" ? "completion.zsh" : "completion.bash";
+  const scriptPath = files.pathJoin(
+    files.convertToStandardPath(__dirname),
+    filename
+  );
+
+  return files
+    .readFile(scriptPath, "utf8")
+    .replace(TOP_LEVEL_COMMANDS_PLACEHOLDER, getTopLevelCommandsLiteral());
+}
+
+function getRcPaths(shellType, home) {
+  if (shellType === "zsh") {
+    return [files.pathJoin(home, ".zshrc")];
+  }
+
+  if (process.platform === "darwin") {
+    const rcPaths = [files.pathJoin(home, ".bash_profile")];
+    const bashrc = files.pathJoin(home, ".bashrc");
+    if (files.exists(bashrc)) {
+      rcPaths.push(bashrc);
+    }
+
+    return rcPaths;
+  }
+
+  return [files.pathJoin(home, ".bashrc")];
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripCompletionBlock(content) {
+  const completionBlockPattern = new RegExp(
+    `\\n?${escapeRegExp(COMPLETION_MARKER)}\\n${escapeRegExp(
+      COMPLETION_SOURCE_LINE
+    )}\\n?`,
+    "g"
+  );
+
+  let updatedContent = content.replace(completionBlockPattern, "\n");
+  updatedContent = updatedContent.replace(/\n{3,}/g, "\n\n");
+
+  if (!updatedContent.endsWith("\n") && content.endsWith("\n")) {
+    updatedContent += "\n";
+  }
+
+  return updatedContent;
+}
+
+function ensureCompletionConfigured(rcPath) {
+  const completionSnippet = `\n${COMPLETION_MARKER}\n${COMPLETION_SOURCE_LINE}\n`;
+
+  if (files.exists(rcPath)) {
+    const content = files.readFile(rcPath, "utf8");
+    if (content.includes(COMPLETION_FILENAME)) {
+      Console.info(`Already configured in ${rcPath}`);
+      return;
+    }
+
+    files.writeFile(rcPath, content + completionSnippet, "utf8");
+  } else {
+    files.writeFile(rcPath, completionSnippet, "utf8");
+  }
+
+  Console.info(`Configured completion in ${rcPath}`);
+}
+
+function removeCompletionConfiguration(rcPath) {
+  if (!files.exists(rcPath)) {
+    return;
+  }
+
+  const content = files.readFile(rcPath, "utf8");
+  if (!content.includes(COMPLETION_FILENAME)) {
+    return;
+  }
+
+  files.writeFile(rcPath, stripCompletionBlock(content), "utf8");
+  Console.info(`Removed configuration from ${rcPath}`);
+}
+
+function installCompletion(shellType) {
+  const home = files.getHomeDir();
+  const meteorDir = files.pathJoin(home, ".meteor");
+  if (!files.exists(meteorDir)) {
+    files.mkdir_p(meteorDir);
+  }
+
+  const autocompletePath = files.pathJoin(meteorDir, COMPLETION_FILENAME);
+  files.writeFile(autocompletePath, getScriptContent(shellType), "utf8");
+
+  for (const rcPath of getRcPaths(shellType, home)) {
+    ensureCompletionConfigured(rcPath);
+  }
+
+  Console.info("\nSuccessfully installed Meteor autocomplete!");
+  Console.info(
+    "Please run the following command to activate it in your current terminal session:"
+  );
+  Console.info(Console.command(`source ${autocompletePath}`));
+  Console.info(
+    "Re-run this command after updating your Meteor checkout to refresh the embedded top-level command list."
+  );
+}
+
+function uninstallCompletion() {
+  const home = files.getHomeDir();
+  const autocompletePath = files.pathJoin(home, ".meteor", COMPLETION_FILENAME);
+
+  if (files.exists(autocompletePath)) {
+    files.unlink(autocompletePath);
+    Console.info(`Removed ${autocompletePath}`);
+  }
+
+  const rcPaths = [
+    files.pathJoin(home, ".zshrc"),
+    files.pathJoin(home, ".bashrc"),
+    files.pathJoin(home, ".bash_profile"),
+  ];
+
+  for (const rcPath of rcPaths) {
+    removeCompletionConfiguration(rcPath);
+  }
+
+  Console.info("Successfully uninstalled completion.");
+}
+
+function getOptionConfig(command, word) {
+  if (!command || !command.options || typeof word !== "string") {
+    return null;
+  }
+
+  const optionName = word.replace(/^--?/, "");
+  if (hasOwn(command.options, optionName)) {
+    return command.options[optionName];
+  }
+
+  return (
+    Object.values(command.options).find(
+      (option) => option.short === optionName
+    ) || null
+  );
+}
+
+function optionTakesValue(command, word) {
+  const optionConfig = getOptionConfig(command, word);
+  return Boolean(optionConfig && optionConfig.type !== Boolean);
+}
+
+function getOptionCommand(node, word) {
+  if (!word.startsWith("--")) {
+    return null;
+  }
+
+  const optionCommands = node && node["--"];
+  const optionCommandName = word.slice(2);
+  if (!optionCommands || !hasOwn(optionCommands, optionCommandName)) {
+    return null;
+  }
+
+  return optionCommands[optionCommandName];
+}
+
+function isCompletingOptionValue(words, index, command) {
+  const previousWord = words[index - 1];
+  if (!previousWord || !previousWord.startsWith("-") || !command) {
+    return false;
+  }
+
+  return optionTakesValue(command, previousWord);
+}
+
+function walkCommandTree(words, index) {
+  let node = main.commands;
+  let matchedCommand = null;
+
+  for (let position = 1; position < index; position += 1) {
+    const word = words[position];
+
+    if (word === "--release") {
+      position += 1;
+      continue;
+    }
+
+    if (word.startsWith("-")) {
+      const optionCommand = getOptionCommand(node, word);
+      if (optionCommand) {
+        node = optionCommand;
+        if (isCommandNode(node)) {
+          matchedCommand = node;
+        }
+
+        break;
+      }
+
+      if (optionTakesValue(matchedCommand, word)) {
+        position += 1;
+      }
+
+      continue;
+    }
+
+    if (!hasOwn(node, word)) {
+      break;
+    }
+
+    node = node[word];
+    if (isCommandNode(node)) {
+      matchedCommand = node;
+    }
+  }
+
+  return { node, matchedCommand };
+}
+
+function getCommandSuggestions(node, prefix = "") {
+  if (!node) {
+    return [];
+  }
+
+  let suggestions = [];
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "--" || !value) {
+      continue;
+    }
+
+    const fullName = prefix ? `${prefix} ${key}` : key;
+    if (isCommandNode(value)) {
+      if (!value.hidden) {
+        suggestions.push(fullName);
+      }
+
+      continue;
+    }
+
+    suggestions.push(fullName);
+    suggestions = suggestions.concat(getCommandSuggestions(value, fullName));
+  }
+
+  return suggestions;
+}
+
+async function getOfficialPackageNames() {
+  try {
+    return await catalog.official.getAllPackageNames();
+  } catch {
+    return [];
+  }
+}
+
+async function getLocalPackageNames(appDir) {
+  try {
+    const projectContext = new ProjectContext({ projectDir: appDir });
+    await projectContext.initializeCatalog();
+    return projectContext.localCatalog.getAllPackageNames();
+  } catch {
+    return [];
+  }
+}
+
+async function getAddPackageSuggestions(appDir) {
+  let packageNames = await getOfficialPackageNames();
+
+  if (!appDir) {
+    return packageNames;
+  }
+
+  packageNames = mergeUnique(packageNames, await getLocalPackageNames(appDir));
+  return excludeItems(packageNames, getInstalledPackages(appDir));
+}
+
+function getAddPlatformSuggestions(appDir) {
+  if (!appDir) {
+    return [...MOBILE_PLATFORMS];
+  }
+
+  return excludeItems(MOBILE_PLATFORMS, getInstalledPlatforms(appDir));
+}
+
+function getRemovePlatformSuggestions(appDir) {
+  return intersectItems(getInstalledPlatforms(appDir), MOBILE_PLATFORMS);
+}
+
+async function getArgumentSuggestions(commandName, options) {
+  switch (commandName) {
+    case "add":
+      return getAddPackageSuggestions(options.appDir);
+    case "remove":
+      return options.appDir ? getInstalledPackages(options.appDir) : [];
+    case "add-platform":
+      return getAddPlatformSuggestions(options.appDir);
+    case "remove-platform":
+      return options.appDir ? getRemovePlatformSuggestions(options.appDir) : [];
+    case "help":
+      return getCommandSuggestions(main.commands);
+    default:
+      return [];
+  }
+}
+
+function getCommandOptionSuggestions(command) {
+  const suggestions = [];
+
+  for (const [optionName, optionConfig] of Object.entries(
+    command.options || {}
+  )) {
+    suggestions.push(`--${optionName}`);
+    if (optionConfig.short) {
+      suggestions.push(`-${optionConfig.short}`);
+    }
+  }
+
+  return suggestions.concat(GLOBAL_OPTION_SUGGESTIONS);
+}
+
+function getGlobalSuggestions(node) {
+  const suggestions = [...GLOBAL_OPTION_SUGGESTIONS];
+  const optionCommands = node && node["--"];
+
+  if (!optionCommands) {
+    return suggestions;
+  }
+
+  for (const [optionName, optionCommand] of Object.entries(optionCommands)) {
+    if (!optionCommand.hidden) {
+      suggestions.push(`--${optionName}`);
+    }
+  }
+
+  return suggestions;
+}
+
+function getSubcommandSuggestions(node) {
+  if (!node) {
+    return [];
+  }
+
+  const suggestions = [];
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "--" || !value) {
+      continue;
+    }
+
+    if (isCommandNode(value)) {
+      if (!value.hidden) {
+        suggestions.push(key);
+      }
+
+      continue;
+    }
+
+    suggestions.push(key);
+  }
+
+  return suggestions;
+}
+
+async function getSuggestions(commandContext, currentWord, options) {
+  if (commandContext.matchedCommand) {
+    if (currentWord.startsWith("-")) {
+      return getCommandOptionSuggestions(commandContext.matchedCommand);
+    }
+
+    return getArgumentSuggestions(commandContext.matchedCommand.name, options);
+  }
+
+  if (currentWord.startsWith("-")) {
+    return getGlobalSuggestions(commandContext.node);
+  }
+
+  if (commandContext.node === main.commands) {
+    return main.getTopLevelCommandNames();
+  }
+
+  return getSubcommandSuggestions(commandContext.node);
+}
+
+function printUsage() {
+  Console.info("Meteor Shell Completion Tool");
+  Console.info("Usage:");
+  Console.info("  meteor shell-completion --install [--shell bash|zsh]");
+  Console.info("  meteor shell-completion --uninstall");
+  Console.info("  meteor shell-completion --script [--shell bash|zsh]");
+}
+
+async function handleCompletionQuery(options) {
+  const words = options.args ?? [];
+  const index = options.index;
+  const currentWord = words[index] ?? "";
+  const commandContext = walkCommandTree(words, index);
+
+  if (isCompletingOptionValue(words, index, commandContext.matchedCommand)) {
+    return 0;
+  }
+
+  const suggestions = await getSuggestions(
+    commandContext,
+    currentWord,
+    options
+  );
+  printCompletions(suggestions, currentWord);
+  return 0;
+}
+
+function shellCompletionCommand(options) {
+  if (options.uninstall) {
+    uninstallCompletion();
+    return 0;
+  }
+
+  const shellType = options.shell || detectShell();
+
+  if (options.install) {
+    installCompletion(shellType);
+    return 0;
+  }
+
+  if (options.script) {
+    Console.rawInfo(getScriptContent(shellType));
+    return 0;
+  }
+
+  if (options.index === undefined) {
+    printUsage();
+    return 0;
+  }
+
+  return handleCompletionQuery(options);
+}
+
+main.registerCommand(
+  {
+    name: "shell-completion",
+    options: {
+      index: { type: Number },
+      install: { type: Boolean },
+      uninstall: { type: Boolean },
+      script: { type: Boolean },
+      shell: { type: String },
+    },
+    minArgs: 0,
+    maxArgs: Infinity,
+    catalogRefresh: new catalog.Refresh.Never(),
+    requiresRelease: false,
+    hidden: true,
+  },
+  shellCompletionCommand
+);

--- a/tools/cli/completion.bash
+++ b/tools/cli/completion.bash
@@ -22,7 +22,7 @@ _meteor_alias_targets_cli() {
 }
 
 _meteor_complete() {
-  local cur prev words cword
+  local cur
   local -a completion_cmd
   local -a static_top_level_commands=(__METEOR_TOP_LEVEL_COMMANDS__)
   local alias_definition alias_value
@@ -33,12 +33,15 @@ _meteor_complete() {
   _meteor_completion_log "bash start cmd=${meteor_cmd} words=${COMP_WORDS[*]} index=${COMP_CWORD}"
 
   cur="${COMP_WORDS[COMP_CWORD]}"
-  prev="${COMP_WORDS[COMP_CWORD-1]}"
 
   if [ "$COMP_CWORD" -eq 1 ] && [[ "$cur" != -* ]]; then
     local oldifs=$IFS
     IFS=$'\n'
-    COMPREPLY=( $(compgen -W "$(printf '%s\n' "${static_top_level_commands[@]}")" -- "$cur") )
+    local -a _compreply_tmp
+    IFS=$'\n' read -r -d '' -a _compreply_tmp < <(
+      set -f; compgen -W "$(printf '%s\n' "${static_top_level_commands[@]}")" -- "$cur"; printf '\0'
+    )
+    COMPREPLY=("${_compreply_tmp[@]}")
     IFS=$oldifs
     _meteor_completion_log "bash static-top-level count=${#COMPREPLY[@]}"
     return 0
@@ -62,12 +65,21 @@ _meteor_complete() {
   local completions
   completions=$("${completion_cmd[@]}" shell-completion --index "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null)
   completion_status=$?
-  _meteor_completion_log "bash result status=${completion_status} count=$(printf '%s\n' "$completions" | sed '/^$/d' | wc -l | tr -d ' ') output=${completions//$'\n'/,}"
+  if [[ -n "${METEOR_COMPLETION_DEBUG:-}" ]]; then
+    local _debug_count _debug_output
+    _debug_count=$(printf '%s\n' "$completions" | sed '/^$/d' | wc -l | tr -d ' ')
+    _debug_output=${completions//$'\n'/,}
+    _meteor_completion_log "bash result status=${completion_status} count=${_debug_count} output=${_debug_output}"
+  fi
 
   if [ $completion_status -eq 0 ] && [ -n "$completions" ]; then
     local oldifs=$IFS
     IFS=$'\n'
-    COMPREPLY=( $(compgen -W "$completions" -- "$cur") )
+    local -a _compreply_tmp
+    IFS=$'\n' read -r -d '' -a _compreply_tmp < <(
+      set -f; compgen -W "$completions" -- "$cur"; printf '\0'
+    )
+    COMPREPLY=("${_compreply_tmp[@]}")
     IFS=$oldifs
     _meteor_completion_log "bash compreply count=${#COMPREPLY[@]}"
     return 0
@@ -76,7 +88,9 @@ _meteor_complete() {
   return 0
 }
 
-if type complete &>/dev/null; then
+_meteor_register_completions() {
+  local alias_definition alias_name alias_value
+
   complete -o default -o bashdefault -F _meteor_complete meteor mymeteor
 
   while IFS= read -r alias_definition; do
@@ -90,4 +104,8 @@ if type complete &>/dev/null; then
       complete -o default -o bashdefault -F _meteor_complete "$alias_name"
     fi
   done < <(alias -p 2>/dev/null)
+}
+
+if type complete &>/dev/null; then
+  _meteor_register_completions
 fi

--- a/tools/cli/completion.bash
+++ b/tools/cli/completion.bash
@@ -1,0 +1,93 @@
+# Meteor bash completion
+
+_meteor_completion_log() {
+  if [[ -z "${METEOR_COMPLETION_DEBUG:-}" ]]; then
+    return 0
+  fi
+
+  local log_file="${METEOR_COMPLETION_DEBUG_LOG:-${TMPDIR:-/tmp}/meteor-completion.log}"
+  printf '%s\n' "$*" >> "$log_file"
+}
+
+_meteor_alias_targets_cli() {
+  local alias_value="$1"
+
+  case "$alias_value" in
+    meteor|meteor\ *|mymeteor|mymeteor\ *|*/meteor|*/meteor\ *)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+_meteor_complete() {
+  local cur prev words cword
+  local -a completion_cmd
+  local -a static_top_level_commands=(__METEOR_TOP_LEVEL_COMMANDS__)
+  local alias_definition alias_value
+  local COMP_WORDBREAKS=${COMP_WORDBREAKS//:/}
+  local meteor_cmd="${COMP_WORDS[0]}"
+  local completion_status
+
+  _meteor_completion_log "bash start cmd=${meteor_cmd} words=${COMP_WORDS[*]} index=${COMP_CWORD}"
+
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  if [ "$COMP_CWORD" -eq 1 ] && [[ "$cur" != -* ]]; then
+    local oldifs=$IFS
+    IFS=$'\n'
+    COMPREPLY=( $(compgen -W "$(printf '%s\n' "${static_top_level_commands[@]}")" -- "$cur") )
+    IFS=$oldifs
+    _meteor_completion_log "bash static-top-level count=${#COMPREPLY[@]}"
+    return 0
+  fi
+
+  if alias "$meteor_cmd" >/dev/null 2>&1; then
+    alias_definition=$(alias "$meteor_cmd")
+    alias_value=${alias_definition#*=}
+    alias_value=${alias_value#\'}
+    alias_value=${alias_value%\'}
+    read -r -a completion_cmd <<< "$alias_value"
+    _meteor_completion_log "bash alias cmd=${meteor_cmd} resolved=${completion_cmd[*]}"
+  elif command -v "$meteor_cmd" >/dev/null 2>&1; then
+    completion_cmd=("$meteor_cmd")
+    _meteor_completion_log "bash command cmd=${meteor_cmd} resolved=${completion_cmd[*]}"
+  else
+    _meteor_completion_log "bash missing cmd=${meteor_cmd}"
+    return 0
+  fi
+
+  local completions
+  completions=$("${completion_cmd[@]}" shell-completion --index "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null)
+  completion_status=$?
+  _meteor_completion_log "bash result status=${completion_status} count=$(printf '%s\n' "$completions" | sed '/^$/d' | wc -l | tr -d ' ') output=${completions//$'\n'/,}"
+
+  if [ $completion_status -eq 0 ] && [ -n "$completions" ]; then
+    local oldifs=$IFS
+    IFS=$'\n'
+    COMPREPLY=( $(compgen -W "$completions" -- "$cur") )
+    IFS=$oldifs
+    _meteor_completion_log "bash compreply count=${#COMPREPLY[@]}"
+    return 0
+  fi
+
+  return 0
+}
+
+if type complete &>/dev/null; then
+  complete -o default -o bashdefault -F _meteor_complete meteor mymeteor
+
+  while IFS= read -r alias_definition; do
+    alias_name=${alias_definition#alias }
+    alias_name=${alias_name%%=*}
+    alias_value=${alias_definition#*=}
+    alias_value=${alias_value#\'}
+    alias_value=${alias_value%\'}
+
+    if _meteor_alias_targets_cli "$alias_value"; then
+      complete -o default -o bashdefault -F _meteor_complete "$alias_name"
+    fi
+  done < <(alias -p 2>/dev/null)
+fi

--- a/tools/cli/completion.zsh
+++ b/tools/cli/completion.zsh
@@ -1,0 +1,87 @@
+# Meteor zsh completion
+
+_meteor_completion_log() {
+  if [[ -z "${METEOR_COMPLETION_DEBUG:-}" ]]; then
+    return 0
+  fi
+
+  local log_file="${METEOR_COMPLETION_DEBUG_LOG:-${TMPDIR:-/tmp}/meteor-completion.log}"
+  print -r -- "$*" >> "$log_file"
+}
+
+_meteor_alias_targets_cli() {
+  local alias_name="$1"
+  local -a alias_words
+
+  alias_words=(${=aliases[$alias_name]})
+  if (( ${#alias_words[@]} == 0 )); then
+    return 1
+  fi
+
+  case "${alias_words[1]}" in
+    meteor|mymeteor|*/meteor)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+_meteor() {
+  local -a completions
+  local -a completion_cmd
+  local -a static_top_level_commands=(__METEOR_TOP_LEVEL_COMMANDS__)
+  local index=$((CURRENT - 1))
+  local meteor_cmd="${words[1]}"
+  local completion_output
+  local completion_status
+
+  _meteor_completion_log "zsh start cmd=${meteor_cmd} words=${(j:|:)words} index=${index}"
+
+  if (( index == 1 )) && [[ "${words[CURRENT]}" != -* ]]; then
+    completions=("${static_top_level_commands[@]}")
+    _meteor_completion_log "zsh static-top-level count=${#completions}"
+    if [[ -n "${completions[(r)?*]}" ]]; then
+      compadd -a completions
+      _meteor_completion_log "zsh compadd count=${#completions}"
+      return 0
+    fi
+  fi
+
+  if (( ${+aliases[$meteor_cmd]} )); then
+    completion_cmd=(${=aliases[$meteor_cmd]})
+    _meteor_completion_log "zsh alias cmd=${meteor_cmd} resolved=${(j:|:)completion_cmd}"
+  elif command -v "$meteor_cmd" >/dev/null 2>&1; then
+    completion_cmd=("$meteor_cmd")
+    _meteor_completion_log "zsh command cmd=${meteor_cmd} resolved=${(j:|:)completion_cmd}"
+  else
+    _meteor_completion_log "zsh missing cmd=${meteor_cmd}"
+    return 0
+  fi
+
+  completion_output=$("${completion_cmd[@]}" shell-completion --index "$index" -- "${words[@]}" 2>/dev/null)
+  completion_status=$?
+  completions=("${(@f)${completion_output}}")
+  _meteor_completion_log "zsh result status=${completion_status} count=${#completions} output=${completion_output//$'\n'/,}"
+
+  if [[ -n "${completions[(r)?*]}" ]]; then
+    compadd -a completions
+    _meteor_completion_log "zsh compadd count=${#completions}"
+    return 0
+  fi
+
+  if (( $+functions[_default] )); then
+    _meteor_completion_log "zsh fallback=_default"
+    _default
+  fi
+}
+
+if type compdef &>/dev/null; then
+  compdef _meteor meteor mymeteor
+
+  for alias_name in ${(k)aliases}; do
+    if _meteor_alias_targets_cli "$alias_name"; then
+      compdef _meteor "$alias_name"
+    fi
+  done
+fi

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -971,7 +971,7 @@ Options:
              constraints.
   --no-lint  don't run linters on the published package and its local
              dependencies before publishing
-  --release <version> Specify the release of Meteor to resolve top-level version 
+  --release <version> Specify the release of Meteor to resolve top-level version
              conflicts. This option is particularly useful during the migration
              process when dealing with packages that have conflicting version
              requirements.
@@ -1204,3 +1204,24 @@ Options:
 The rest of options for this command are the same as those for the meteor run command.
 You can pass typical runtime options (such as --settings, --exclude-archs, etc.)
 to customize the profiling process.
+
+
+>>> shell-completion
+Install and configure tab completion for meteor commands.
+Usage: meteor shell-completion [options]
+
+Installs tab completion for the 'meteor' command to your shell profile
+(supporting Bash and Zsh on macOS and Linux).
+
+When installed, pressing tab will automatically autocomplete Meteor commands,
+options, platforms, and package names.
+
+The installed script embeds the current top-level command list. Re-run
+'meteor shell-completion --install' after updating your Meteor checkout to
+refresh that list.
+
+Options:
+  --install      Install completion to your shell profile configuration
+  --uninstall    Uninstall completion from your shell profile configuration
+  --script       Print the shell completion script to stdout
+  --shell        Specify the shell type (bash or zsh) for --install or --script

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -100,7 +100,17 @@ Command.prototype.evaluateOption = function (optionName, options) {
 //
 // Options that function as commands (eg, "meteor --arch") are treated
 // as subcommands of "--".
-var commands = {};
+var commands = main.commands = {};
+
+main.getTopLevelCommandNames = function () {
+  const names = [];
+  Object.entries(commands).forEach(([name, cmd]) => {
+    if (name !== "--" && cmd && !cmd.hidden) {
+      names.push(name);
+    }
+  });
+  return names;
+};
 
 // Exception to throw from a command to bail out and show command
 // usage information.
@@ -296,6 +306,7 @@ require('./commands-packages.js');
 require('./commands-packages-query.js');
 require('./commands-cordova.js');
 require('./commands-aliases.js');
+require('./commands-completion.js');
 
 ///////////////////////////////////////////////////////////////////////////////
 // Record all the top-level commands as JSON

--- a/tools/tests/shell-completion.js
+++ b/tools/tests/shell-completion.js
@@ -1,0 +1,69 @@
+const assert = require("assert");
+
+const selftest = require("../tool-testing/selftest.js");
+const Sandbox = selftest.Sandbox;
+
+selftest.define("shell-completion", async function () {
+  const s = new Sandbox();
+  await s.init();
+  s.set("HOME", s.home);
+
+  // Test top-level commands suggestions
+  let run = s.run("shell-completion", "--index", "1", "--", "meteor", "");
+  await run.match("add");
+  await run.match("admin");
+  await run.match("create");
+  await run.match("remove");
+  await run.match("run");
+  run.forbid("recommend-release");
+  run.forbid("shell-completion");
+  await run.expectExit(0);
+
+  // Test option completion for 'run' command
+  run = s.run("shell-completion", "--index", "2", "--", "meteor", "run", "--p");
+  await run.match("--port");
+  await run.match("--production");
+  await run.expectExit(0);
+
+  // Test subcommand suggestions (e.g. admin)
+  run = s.run("shell-completion", "--index", "2", "--", "meteor", "admin", "");
+  await run.match("recommend-release");
+  await run.expectExit(0);
+
+  // Test script output for bash
+  run = s.run("shell-completion", "--script", "--shell", "bash");
+  await run.match("# Meteor bash completion");
+  await run.match("static_top_level_commands=");
+  await run.match("'admin'");
+  await run.match("COMP_WORDS[0]");
+  await run.match('if _meteor_alias_targets_cli "$alias_value"; then');
+  await run.match('complete -o default -o bashdefault -F _meteor_complete "$alias_name"');
+  await run.expectExit(0);
+
+  // Test script output for zsh
+  run = s.run("shell-completion", "--script", "--shell", "zsh");
+  await run.match("# Meteor zsh completion");
+  await run.match("static_top_level_commands=");
+  await run.match("'admin'");
+  await run.match("words[1]");
+  await run.match('if _meteor_alias_targets_cli "$alias_name"; then');
+  await run.match('compdef _meteor "$alias_name"');
+  await run.expectExit(0);
+
+  // Test install/uninstall cycles keep shell rc files clean.
+  run = s.run("shell-completion", "--install", "--shell", "zsh");
+  await run.expectExit(0);
+  let zshrc = s.read(".zshrc");
+  assert.strictEqual((zshrc.match(/# Meteor autocompletion/g) || []).length, 1);
+
+  run = s.run("shell-completion", "--uninstall");
+  await run.expectExit(0);
+  zshrc = s.read(".zshrc");
+  assert.ok(!zshrc.includes("# Meteor autocompletion"));
+  assert.ok(!zshrc.includes("meteor-completion.sh"));
+
+  run = s.run("shell-completion", "--install", "--shell", "zsh");
+  await run.expectExit(0);
+  zshrc = s.read(".zshrc");
+  assert.strictEqual((zshrc.match(/# Meteor autocompletion/g) || []).length, 1);
+});

--- a/tools/tests/shell-completion.js
+++ b/tools/tests/shell-completion.js
@@ -50,10 +50,16 @@ selftest.define("shell-completion", async function () {
   await run.match('compdef _meteor "$alias_name"');
   await run.expectExit(0);
 
-  // Test install/uninstall cycles keep shell rc files clean.
+  // Test install/uninstall cycles keep shell rc files clean (zsh).
   run = s.run("shell-completion", "--install", "--shell", "zsh");
   await run.expectExit(0);
   let zshrc = s.read(".zshrc");
+  assert.strictEqual((zshrc.match(/# Meteor autocompletion/g) || []).length, 1);
+
+  // Double-install must not duplicate the block.
+  run = s.run("shell-completion", "--install", "--shell", "zsh");
+  await run.expectExit(0);
+  zshrc = s.read(".zshrc");
   assert.strictEqual((zshrc.match(/# Meteor autocompletion/g) || []).length, 1);
 
   run = s.run("shell-completion", "--uninstall");
@@ -62,8 +68,35 @@ selftest.define("shell-completion", async function () {
   assert.ok(!zshrc.includes("# Meteor autocompletion"));
   assert.ok(!zshrc.includes("meteor-completion.sh"));
 
+  // Uninstall when nothing is installed must be a safe no-op.
+  run = s.run("shell-completion", "--uninstall");
+  await run.expectExit(0);
+
   run = s.run("shell-completion", "--install", "--shell", "zsh");
   await run.expectExit(0);
   zshrc = s.read(".zshrc");
   assert.strictEqual((zshrc.match(/# Meteor autocompletion/g) || []).length, 1);
+
+  // Test install/uninstall cycle for bash.
+  run = s.run("shell-completion", "--install", "--shell", "bash");
+  await run.expectExit(0);
+  // On non-darwin or when .bashrc exists, completion is written to .bashrc.
+  const bashrc = s.read(".bashrc");
+  assert.strictEqual(
+    (bashrc.match(/# Meteor autocompletion/g) || []).length,
+    1
+  );
+
+  // Double-install must not duplicate the bash block.
+  run = s.run("shell-completion", "--install", "--shell", "bash");
+  await run.expectExit(0);
+  assert.strictEqual(
+    (s.read(".bashrc").match(/# Meteor autocompletion/g) || []).length,
+    1
+  );
+
+  run = s.run("shell-completion", "--uninstall");
+  await run.expectExit(0);
+  assert.ok(!s.read(".bashrc").includes("# Meteor autocompletion"));
+  assert.ok(!s.read(".bashrc").includes("meteor-completion.sh"));
 });

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -24,6 +24,98 @@ meteor help <command>
 
 Prints detailed help about the specific command.
 
+## meteor shell-completion {#meteorshellcompletion}
+
+Install shell completion for Meteor commands in bash or zsh.
+
+```bash
+meteor shell-completion --install
+```
+
+This command writes the completion script to `~/.meteor/meteor-completion.sh`
+and adds a source line to your shell startup file so completion is loaded
+automatically in future terminal sessions.
+
+The generated script embeds the current top-level Meteor command list at install
+time for faster and more reliable first-argument completion. Re-run
+`meteor shell-completion --install` after updating your Meteor checkout to
+refresh that embedded list.
+
+### Supported Shells
+
+Meteor currently supports `zsh` and `bash`. By default, Meteor detects the
+current shell from the `SHELL` environment variable. Use `--shell` when you
+want to install completion for a different shell explicitly.
+
+```bash
+meteor shell-completion --install --shell zsh
+meteor shell-completion --install --shell bash
+```
+
+### What Gets Completed
+
+- Top-level commands such as `run`, `create`, `add`, and `update`
+- Subcommands such as `help` and `admin`
+- Command options such as `--port` and `--production`
+- Selected command arguments when Meteor can infer them, including package names
+  for `meteor add` and `meteor remove`, plus mobile platforms for
+  `meteor add-platform` and `meteor remove-platform`
+
+### Activate It In The Current Terminal
+
+After installing completion, load it in your current terminal session:
+
+```bash
+source ~/.meteor/meteor-completion.sh
+```
+
+New terminal sessions will pick it up automatically from your shell startup
+file.
+
+If you define Meteor aliases in your shell before sourcing the completion
+script, Meteor will register completion for aliases that resolve to the Meteor
+CLI as well.
+
+### Startup Files Meteor Updates
+
+- `zsh`: `~/.zshrc`
+- `bash` on macOS: `~/.bash_profile`, and `~/.bashrc` if that file already exists
+- `bash` on Linux and other Unix-like systems: `~/.bashrc`
+
+### Print The Script Without Installing
+
+If you prefer to manage shell configuration yourself, print the completion
+script directly:
+
+```bash
+meteor shell-completion --script
+meteor shell-completion --script --shell zsh
+```
+
+You can redirect that output to a file or source it manually from your own shell
+configuration.
+
+If you add or change shell aliases after sourcing the script, source it again so
+those aliases are registered for completion.
+
+### Uninstall
+
+```bash
+meteor shell-completion --uninstall
+```
+
+This removes `~/.meteor/meteor-completion.sh` and deletes the
+`# Meteor autocompletion` block that Meteor added to your startup files.
+
+### Troubleshooting
+
+- Run `source ~/.meteor/meteor-completion.sh` after reinstalling the script in
+  your current shell.
+- Re-run `meteor shell-completion --install` after updating your Meteor checkout
+  so the embedded top-level command list is refreshed.
+- If a custom alias still does not complete, define the alias before sourcing
+  `~/.meteor/meteor-completion.sh`, then source the file again.
+
 ## meteor run {#meteorrun}
 
 Run a meteor development server in the current project.


### PR DESCRIPTION
For a long time, we had the need for these shell completion scripts flowing around, and every now and then I somewhat found the need to have completions(I do press a lot of <tab>)

  • Exposes  `main.commands`  and exports  `getTopLevelCommandNames()` from main.js (filtering out hidden commands and the internal namespace), maybe we could have an api for adding your own commands(like rails rake?!).
  • Registers the new  shell-completion  command in commands-completion.js supporting  --install ,  --uninstall , and  --script  flags.
  • Implements completion hooks in completion.bash and completion.zsh.

I think I've added docs for this in  all necessary places too

Here is a demo of it working 😁 :


https://github.com/user-attachments/assets/5a3f1ed6-15c6-4987-8a26-b0c9d2aab615


## How to install:

```sh
  meteor shell-completion --install [--shell bash|zsh] # Install completion to your shell profile configuration
  meteor shell-completion --uninstall # Uninstall completion from your shell profile configuration
  meteor shell-completion --script [--shell bash|zsh] # Print the shell completion script to stdout
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `meteor shell-completion` with install, uninstall, and script-generation options.
  * Enabled interactive shell autocompletion for Bash and Zsh, including `mymeteor` and matching aliases.
  * Autocomplete now suggests top-level commands, subcommands, options, and context-specific arguments (for example packages and platforms).

* **Bug Fixes**
  * Improved completion installation/uninstallation to keep shell startup files clean, with safe idempotent install/uninstall behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->