### PR TITLE
fix(roles): add @summary to getUserIdsInRoleAsync JSDoc so API docs CI builds

### DIFF
--- a/packages/roles/roles_common_async.js
+++ b/packages/roles/roles_common_async.js
@@ -1068,11 +1068,10 @@ Object.assign(Roles, {
   },
 
   /**
-   * Retrieve all userIds who are in target role.
-   *
-   * Options:
-   *
+   * @summary Retrieve all userIds who are in target role.
+   * @locus Anywhere
    * @method getUserIdsInRoleAsync
+   * @memberof Roles
    * @param {Array|String} roles Name of role or an array of roles. If array, users
    *                             returned will have at least one of the roles
    *                             specified but need not have _all_ roles.

--- a/v3-docs/docs/packages/facts-base.md
+++ b/v3-docs/docs/packages/facts-base.md
@@ -105,5 +105,5 @@ Only the public `Facts` API is documented here. Internal helpers prefixed with a
 
 ## See also
 
-- [`facts-ui`](./facts-ui.md) — a client package that subscribes to these facts and renders them with the <span v-pre>`{{> serverFacts}}`</span> template.
-- [`autopublish`](./autopublish.md) — when present, changes the default visibility of facts to all users.
+- [`facts-ui`](https://atmospherejs.com/meteor/facts-ui) — a client package that subscribes to these facts and renders them with the <span v-pre>`{{> serverFacts}}`</span> template.
+- [`autopublish`](https://atmospherejs.com/meteor/autopublish) — when present, changes the default visibility of facts to all users.


### PR DESCRIPTION
## Problem

The `v3-meteor-api-docs` Netlify deploy fails during VitePress SSR:

```
Error: jsdoc key: "Roles.getUserIdsInRoleAsync" not found.
Refer to data/data.js for available keys.
Error come from packages/roles.md
```

This reproduces locally on `devel` (`cd v3-docs/docs && npm run docs:build`).

## Root cause

The docs codegen only emits an API entry for a method whose JSDoc block carries a `@summary` tag — see [`v3-docs/docs/jsdoc/docdata-jsdoc-template/publish.js`](../blob/devel/v3-docs/docs/jsdoc/docdata-jsdoc-template/publish.js#L115-L116) (`if (!func.summary) { ... }` — "we use the @summary tag to indicate that an item is documented").

`getUserIdsInRoleAsync` (added in #14030) was documented with a plain description but **no `@summary`**, so the `Roles.getUserIdsInRoleAsync` key was never generated into the (gitignored, build-time) `data.js`. When `packages/roles.md` references it via `<ApiBox name="Roles.getUserIdsInRoleAsync" />`, the render throws and the deploy fails.

## Fix

Add `@summary` (plus `@locus`/`@memberof` to match sibling methods like `getScopesForUserAsync`) to the `getUserIdsInRoleAsync` JSDoc block.

## Verification

- `npm run codegen` now generates the `"Roles.getUserIdsInRoleAsync"` key in `data.js`.
- `npm run docs:build` completes: `rendering pages ✓` (previously errored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation metadata for an existing role-related asynchronous method, without changing any runtime behavior.
  * Updated “See also” documentation links to point to the correct AtmosphereJS pages instead of local files.
  * No user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->