### PR TITLE
fix(types): use 'declare namespace' in mongo and webapp .d.ts

### DIFF
--- a/packages/mongo/mongo.d.ts
+++ b/packages/mongo/mongo.d.ts
@@ -666,7 +666,7 @@ export namespace Mongo {
   }
 }
 
-export declare module MongoInternals {
+export declare namespace MongoInternals {
   interface MongoConnection {
     db: NpmModuleMongodb.Db;
     client: NpmModuleMongodb.MongoClient;

--- a/packages/webapp/webapp.d.ts
+++ b/packages/webapp/webapp.d.ts
@@ -22,7 +22,7 @@ type ExpressModule = {
   urlencoded: typeof express.urlencoded;
 };
 
-export declare module WebApp {
+export declare namespace WebApp {
   var defaultArch: string;
   var clientPrograms: {
     [key: string]: {
@@ -69,7 +69,7 @@ export declare module WebApp {
   function addHtmlAttributeHook(hook: Function): void;
 }
 
-export declare module WebAppInternals {
+export declare namespace WebAppInternals {
   var NpmModules: {
     [key: string]: {
       version: string;


### PR DESCRIPTION
`packages/mongo/mongo.d.ts` and `packages/webapp/webapp.d.ts` declare `MongoInternals`, `WebApp`, and `WebAppInternals` using the non-quoted `declare module Identifier` form. That's a legacy syntax that became an error with [TypeScript 6.0](https://github.com/microsoft/TypeScript/pull/62876) (TS1540) and the tsgo / TypeScript 7 rewrite. This blocks any project that type checks declaration files (skipLibCheck: false, TypeScript's default, although overridden to skipLibCheck: true in the Meteor TS skeleton) from upgrading past TS 5 while consuming these types via zodern:types.

Fortunately it's an easy, one-word, behaviorally-identical fix (that also works with older versions of TypeScript), and matches the existing syntax in `logging.d.ts` and `roles/definitions.d.ts`.

There have been a bunch of attempts to fix this bug previously (for reference, #14347, #14108, #14175, #14264, #14340, #14342, #14343; also #14263 which landed in ts/type-coverage, but that feature branch hasn't landed), but they've all stalled out due to issues with other changes in the PRs (or other workflow issues), so I'm opening this extremely focused PR to try and get this longstanding issue closed out.

Fixes #14253.

## Verification

You can verify that the fix works (and doesn't regress TS 5) with:

```bash

npx tsc --noEmit packages/mongo/mongo.d.ts

npx --yes -p 'typescript@^6' tsc --noEmit --ignoreConfig packages/mongo/mongo.d.ts

npx --yes -p '@typescript/native-preview' tsgo --noEmit --ignoreConfig packages/mongo/mongo.d.ts
```

Since the tree isn't setup normally, this generates some module resolution errors ("Cannot find module..."), but the main thing to pay attention to is the TS1540 error ("A 'namespace' declaration should not be declared using the 'module' keyword").

Before:

```
$ npx tsc --noEmit packages/mongo/mongo.d.ts | grep -v TS2307
$ npx --yes -p 'typescript@^6' tsc --noEmit --ignoreConfig packages/mongo/mongo.d.ts | grep -v TS2307
packages/mongo/mongo.d.ts(669,23): error TS1540: A 'namespace' declaration should not be declared using the 'module' keyword. Please use the 'namespace' keyword instead.
$ npx --yes -p '@typescript/native-preview' tsgo --noEmit --ignoreConfig packages/mongo/mongo.d.ts | grep -v TS2307
packages/mongo/mongo.d.ts(669,23): error TS1540: A 'namespace' declaration should not be declared using the 'module' keyword. Please use the 'namespace' keyword instead.
```

After:
```
$ npx tsc --noEmit packages/mongo/mongo.d.ts | grep -v TS2307
$ npx --yes -p 'typescript@^6' tsc --noEmit --ignoreConfig packages/mongo/mongo.d.ts | grep -v TS2307
$ npx --yes -p '@typescript/native-preview' tsgo --noEmit --ignoreConfig packages/mongo/mongo.d.ts | grep -v TS2307
$
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated public TypeScript declarations for core web app and Mongo packages to use namespace-style exports, improving compatibility for type consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->