### PR TITLE
fix(tools,rspack): remove Node url.parse/util._extend deprecation warnings (#13491)

### DIFF
--- a/packages/rspack/package.js
+++ b/packages/rspack/package.js
@@ -17,7 +17,7 @@ Package.registerBuildPlugin({
 });
 
 Npm.devDepends({
-  'http-proxy-middleware': '3.0.5',
+  'http-proxy-3': '1.22.0',
 });
 
 Package.onUse(function (api) {

--- a/packages/rspack/rspack_server.js
+++ b/packages/rspack/rspack_server.js
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { WebApp, WebAppInternals } from 'meteor/webapp';
 import path from 'path';
-import { parse as parseUrl } from 'url';
 import {
   RSPACK_CHUNKS_CONTEXT,
   RSPACK_ASSETS_CONTEXT,
@@ -35,29 +34,46 @@ const shouldEnableDevHMRProxy =
   !process.env.RSPACK_NATIVE;
 if (shouldEnableDevHMRProxy) {
   const { shuffleString } = require('meteor/tools-core/lib/string');
-  const { createProxyMiddleware } = require('http-proxy-middleware');
+  const httpProxy = require('http-proxy-3');
 
   // Target URL for the Rspack dev server
   const target = `http://localhost:${process.env.RSPACK_DEVSERVER_PORT}`;
 
-  // Proxy HMR websocket upgrade requests
-  WebApp.connectHandlers.use('/ws',
-    createProxyMiddleware( {
-      target,
-      ws: true,
-      logLevel: 'debug'
-    })
-  );
+  const rspackProxy = httpProxy.createProxyServer({});
 
-  // Proxy all dev asset requests under the rspack prefix
-  WebApp.connectHandlers.use('/__rspack__',
-    createProxyMiddleware({
-      target,
-      changeOrigin: true,
-      ws: true,
-      logLevel: 'debug',
-    })
-  );
+  // Don't let a transient dev-server hiccup (e.g. during a restart) crash the
+  // app process; respond with a 502 / close the socket instead.
+  rspackProxy.on('error', (err, req, resOrSocket) => {
+    if (resOrSocket && typeof resOrSocket.writeHead === 'function') {
+      if (!resOrSocket.headersSent) {
+        resOrSocket.writeHead(502, { 'Content-Type': 'text/plain' });
+      }
+      resOrSocket.end('Rspack dev server proxy error.');
+    } else if (resOrSocket && typeof resOrSocket.destroy === 'function') {
+      resOrSocket.destroy();
+    }
+  });
+
+  // Proxy all dev asset requests under the rspack prefix. connect strips the
+  // mount prefix from req.url before calling the handler, so this proxies
+  // "/__rspack__/foo" -> "<devserver>/foo".
+  WebApp.connectHandlers.use('/__rspack__', (req, res) => {
+    rspackProxy.web(req, res, { target, changeOrigin: true });
+  });
+  WebApp.connectHandlers.use('/ws', (req, res) => {
+    rspackProxy.web(req, res, { target });
+  });
+
+  // Proxy HMR WebSocket upgrades. Scope to Rspack's own paths so Meteor's
+  // DDP/sockjs websockets are left untouched.
+  WebApp.httpServer.on('upgrade', (req, socket, head) => {
+    const url = req.url || '';
+    if (url.startsWith('/__rspack__')) {
+      rspackProxy.ws(req, socket, head, { target, changeOrigin: true });
+    } else if (url === '/ws' || url.startsWith('/ws?') || url.startsWith('/ws/')) {
+      rspackProxy.ws(req, socket, head, { target });
+    }
+  });
 
   WebApp.rawConnectHandlers.use((req, res, next) => {
     // If this request is already under /__rspack__/, don't redirect it again.
@@ -179,7 +195,7 @@ const originalStaticFilesMiddleware = WebAppInternals.staticFilesMiddleware;
 
 // Handle rspack assets on-demand to add Meteor's static files headers
 WebAppInternals.staticFilesMiddleware = async function(staticFilesByArch, req, res, next) {
-  const pathname = parseUrl(req.url).pathname;
+  const pathname = new URL(req.url, 'http://localhost').pathname;
 
   try {
     // Check if this is a rspack asset request

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -619,8 +619,14 @@ makeGlobalAsyncLocalStorage().run({}, async function () {
   // first time we do a isopack.load, it will fail due to the check in the
   // meteor package, and that'll look a lot uglier.
   if (process.env.ROOT_URL) {
-    var parsedUrl = require('url').parse(process.env.ROOT_URL);
-    if (!parsedUrl.host || ['http:', 'https:'].indexOf(parsedUrl.protocol) === -1) {
+    let parsedUrl = null;
+    try {
+      parsedUrl = new URL(process.env.ROOT_URL);
+    } catch (e) {
+      // Not a parseable URL; handled by the check below.
+    }
+    if (!parsedUrl || !parsedUrl.host ||
+        ['http:', 'https:'].indexOf(parsedUrl.protocol) === -1) {
       Console.error('$ROOT_URL, if specified, must be an URL.');
       process.exit(1);
     }

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1806,8 +1806,13 @@ class ClientTarget extends Target {
 
         // Use a SHA to make this cacheable.
         const sourceMapBaseName = file.hash() + '.map';
-        manifestItem.sourceMapUrl = require('url').resolve(
-          file.url, sourceMapBaseName);
+        // Resolve the source map URL relative to the file's URL by replacing
+        // its last path segment (and dropping any query string). file.url is
+        // always an absolute path starting with "/".
+        const fileUrlPath = file.url.split('?')[0];
+        manifestItem.sourceMapUrl =
+          fileUrlPath.slice(0, fileUrlPath.lastIndexOf('/') + 1) +
+          sourceMapBaseName;
       }
 
       // Set this now, in case we mutated the file's contents.

--- a/tools/meteor-services/config.js
+++ b/tools/meteor-services/config.js
@@ -1,4 +1,3 @@
-import { parse as urlParse } from 'url';
 import {
   pathJoin,
   getCurrentToolsDir,
@@ -37,7 +36,7 @@ export function getBuildFarmUrl() {
 }
 
 export function getBuildFarmDomain() {
-  return urlParse(getBuildFarmUrl()).host;
+  return new URL(getBuildFarmUrl()).host;
 }
 
 // URL for the DDP interface to the package server, typically
@@ -48,7 +47,7 @@ export function getPackageServerUrl() {
 }
 
 export function getPackageServerDomain() {
-  return urlParse(getPackageServerUrl()).host;
+  return new URL(getPackageServerUrl()).host;
 }
 
 export function getPackageStatsServerUrl() {
@@ -57,7 +56,7 @@ export function getPackageStatsServerUrl() {
 }
 
 export function getPackageStatsServerDomain() {
-  return urlParse(getPackageStatsServerUrl()).host;
+  return new URL(getPackageStatsServerUrl()).host;
 }
 
 // Note: this is NOT guaranteed to return a distinct prefix for every


### PR DESCRIPTION
Fixes the Node deprecation warnings still shown on `meteor run`, tracked in #13491.

## Background

The original `util._extend` warning in #13491 came from the CLI dev proxy (`tools/runners/run-proxy.js`), which used the unmaintained `http-proxy`. That was fixed in Meteor 3.5 by switching to `http-proxy-3` (#13916). However, users still report a deprecation warning on `meteor run`, and there are two remaining, distinct sources:

### 1. `util._extend` re-introduced by the rspack integration

`packages/rspack` proxies HMR/dev-asset requests with `http-proxy-middleware@3.0.5`, which pulls the **old `http-proxy@1.18.1`** back in transitively. So rspack users hit the exact original warning again on every proxied request:

```
(node:…) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated.
    at ProxyServer.<anonymous> (…/http-proxy/lib/http-proxy/index.js:50:26)
    at HttpProxyMiddleware.middleware (…/http-proxy-middleware/dist/http-proxy-middleware.js:23:32)
```

### 2. Legacy `url.parse()` / `url.resolve()` in the tool (all users)

The tool itself still uses the deprecated legacy URL API (`DEP0169`), which prints on `meteor run`:

```
(node:…) Warning: `url.parse()` behavior is not standardized and prone to errors…
    at Object.getPackageStatsServerDomain (/tools/meteor-services/config.js:60:10)
    at Object.recordPackages (/tools/meteor-services/stats.js:76:18)
```

(Node only prints each deprecation once per process, so whichever call fires first hides the others — `config.js` via `stats.recordPackages`, or `bundler.js` via source-map URLs.)

## Changes

- **rspack** — replace `http-proxy-middleware` with `http-proxy-3` (a maintained, drop-in replacement) used directly in `rspack_server.js`. Mount-path stripping, `changeOrigin` and WebSocket upgrades are preserved; upgrades are now scoped to rspack's own paths (`/__rspack__`, `/ws`) so Meteor's DDP/sockjs websockets are untouched.
- **tool** — replace `url.parse()`/`url.resolve()` with the WHATWG `URL` API in:
  - `tools/meteor-services/config.js` (`getBuildFarmDomain`, `getPackageServerDomain`, `getPackageStatsServerDomain`)
  - `tools/isobuild/bundler.js` (source-map URL)
  - `tools/cli/main.js` (`ROOT_URL` validation)
- `packages/rspack/rspack_server.js` also had its own `url.parse` in the static-files middleware — migrated to `new URL()`.

## Reproduction

1. `meteor create repro --minimal`
2. `TOOL_NODE_FLAGS=--trace-warnings meteor run`
3. On startup you get the `url.parse()` `DEP0169` warning; with rspack, a proxied request also triggers the `util._extend` `DEP0060` warning.

## Verification

- Output equivalence unit-checked for every changed call (`.host`, source-map URL, `ROOT_URL` validation) across all realistic inputs — identical to the previous behavior.
- End-to-end on a checkout build: a fresh `meteor run` prints **no** deprecation warning with this change, whereas the same checkout without it still prints the `url.parse()` warning.
- `http-proxy-3` verified to proxy the identical target path as `http-proxy-middleware` under a connect mount, with no `util._extend`.

> Note: the rspack proxy rewrite was verified in isolation (path equivalence, no `util._extend`, upgrade scoping). A smoke test of HMR in a real rspack app is recommended before release. `.npm/devPackage` is gitignored and regenerates on the next rspack build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rspack dev-server proxying for Rspack asset traffic and WebSocket connections, including clearer failure handling when proxying isn’t available.
  * Enhanced URL parsing and validation for root URL and server/domain configuration to reduce startup issues from malformed values.
  * Fixed generated source map link generation so they resolve more consistently in browser debugging.
* **Maintenance**
  * Updated the development proxy dependency to a newer equivalent/version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->