### PR TITLE
fix(tools,rspack): remove Node url.parse/util._extend deprecation warnings

### DIFF
--- a/packages/rspack/package.js
+++ b/packages/rspack/package.js
@@ -17,7 +17,10 @@ Package.registerBuildPlugin({
 });
 
 Npm.devDepends({
-  'http-proxy-middleware': '3.0.5',
+  // Maintained, drop-in replacement for the unmaintained http-proxy that
+  // http-proxy-middleware relied on, which used the deprecated util._extend and
+  // legacy url.parse APIs (meteor/meteor#13491).
+  'http-proxy-3': '1.22.0',
 });
 
 Package.onUse(function (api) {

--- a/packages/rspack/rspack_server.js
+++ b/packages/rspack/rspack_server.js
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { WebApp, WebAppInternals } from 'meteor/webapp';
 import path from 'path';
-import { parse as parseUrl } from 'url';
 import {
   RSPACK_CHUNKS_CONTEXT,
   RSPACK_ASSETS_CONTEXT,
@@ -35,29 +34,52 @@ const shouldEnableDevHMRProxy =
   !process.env.RSPACK_NATIVE;
 if (shouldEnableDevHMRProxy) {
   const { shuffleString } = require('meteor/tools-core/lib/string');
-  const { createProxyMiddleware } = require('http-proxy-middleware');
+  // http-proxy-3 is a maintained, drop-in replacement for the unmaintained
+  // http-proxy that http-proxy-middleware pulls in. The old http-proxy uses the
+  // deprecated `util._extend` and legacy `url.parse` APIs, which print Node
+  // deprecation warnings on every proxied request. See
+  // https://github.com/meteor/meteor/issues/13491.
+  const httpProxy = require('http-proxy-3');
 
   // Target URL for the Rspack dev server
   const target = `http://localhost:${process.env.RSPACK_DEVSERVER_PORT}`;
 
-  // Proxy HMR websocket upgrade requests
-  WebApp.connectHandlers.use('/ws',
-    createProxyMiddleware( {
-      target,
-      ws: true,
-      logLevel: 'debug'
-    })
-  );
+  const rspackProxy = httpProxy.createProxyServer({});
 
-  // Proxy all dev asset requests under the rspack prefix
-  WebApp.connectHandlers.use('/__rspack__',
-    createProxyMiddleware({
-      target,
-      changeOrigin: true,
-      ws: true,
-      logLevel: 'debug',
-    })
-  );
+  // Don't let a transient dev-server hiccup (e.g. during a restart) crash the
+  // app process; respond with a 502 / close the socket instead.
+  rspackProxy.on('error', (err, req, resOrSocket) => {
+    if (resOrSocket && typeof resOrSocket.writeHead === 'function') {
+      if (!resOrSocket.headersSent) {
+        resOrSocket.writeHead(502, { 'Content-Type': 'text/plain' });
+      }
+      resOrSocket.end('Rspack dev server proxy error.');
+    } else if (resOrSocket && typeof resOrSocket.destroy === 'function') {
+      resOrSocket.destroy();
+    }
+  });
+
+  // Proxy all dev asset requests under the rspack prefix. connect strips the
+  // mount prefix from req.url before calling the handler, so this proxies
+  // "/__rspack__/foo" -> "<devserver>/foo", matching the previous
+  // http-proxy-middleware behavior.
+  WebApp.connectHandlers.use('/__rspack__', (req, res) => {
+    rspackProxy.web(req, res, { target, changeOrigin: true });
+  });
+  WebApp.connectHandlers.use('/ws', (req, res) => {
+    rspackProxy.web(req, res, { target });
+  });
+
+  // Proxy HMR WebSocket upgrades. Scope to Rspack's own paths so Meteor's
+  // DDP/sockjs websockets are left untouched.
+  WebApp.httpServer.on('upgrade', (req, socket, head) => {
+    const url = req.url || '';
+    if (url.startsWith('/__rspack__')) {
+      rspackProxy.ws(req, socket, head, { target, changeOrigin: true });
+    } else if (url === '/ws' || url.startsWith('/ws?') || url.startsWith('/ws/')) {
+      rspackProxy.ws(req, socket, head, { target });
+    }
+  });
 
   WebApp.rawConnectHandlers.use((req, res, next) => {
     // If this request is already under /__rspack__/, don't redirect it again.
@@ -179,7 +201,7 @@ const originalStaticFilesMiddleware = WebAppInternals.staticFilesMiddleware;
 
 // Handle rspack assets on-demand to add Meteor's static files headers
 WebAppInternals.staticFilesMiddleware = async function(staticFilesByArch, req, res, next) {
-  const pathname = parseUrl(req.url).pathname;
+  const pathname = new URL(req.url, 'http://localhost').pathname;
 
   try {
     // Check if this is a rspack asset request

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -619,7 +619,7 @@ makeGlobalAsyncLocalStorage().run({}, async function () {
   // first time we do a isopack.load, it will fail due to the check in the
   // meteor package, and that'll look a lot uglier.
   if (process.env.ROOT_URL) {
-    var parsedUrl = null;
+    let parsedUrl = null;
     try {
       parsedUrl = new URL(process.env.ROOT_URL);
     } catch (e) {

--- a/tools/cli/main.js
+++ b/tools/cli/main.js
@@ -619,8 +619,14 @@ makeGlobalAsyncLocalStorage().run({}, async function () {
   // first time we do a isopack.load, it will fail due to the check in the
   // meteor package, and that'll look a lot uglier.
   if (process.env.ROOT_URL) {
-    var parsedUrl = require('url').parse(process.env.ROOT_URL);
-    if (!parsedUrl.host || ['http:', 'https:'].indexOf(parsedUrl.protocol) === -1) {
+    var parsedUrl = null;
+    try {
+      parsedUrl = new URL(process.env.ROOT_URL);
+    } catch (e) {
+      // Not a parseable URL; handled by the check below.
+    }
+    if (!parsedUrl || !parsedUrl.host ||
+        ['http:', 'https:'].indexOf(parsedUrl.protocol) === -1) {
       Console.error('$ROOT_URL, if specified, must be an URL.');
       process.exit(1);
     }

--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -1806,8 +1806,14 @@ class ClientTarget extends Target {
 
         // Use a SHA to make this cacheable.
         const sourceMapBaseName = file.hash() + '.map';
-        manifestItem.sourceMapUrl = require('url').resolve(
-          file.url, sourceMapBaseName);
+        // Resolve the source map URL relative to the file's URL by replacing
+        // its last path segment (and dropping any query string). This matches
+        // the previous url.resolve() behavior without the deprecated legacy
+        // url API (file.url is always an absolute path starting with "/").
+        const fileUrlPath = file.url.split('?')[0];
+        manifestItem.sourceMapUrl =
+          fileUrlPath.slice(0, fileUrlPath.lastIndexOf('/') + 1) +
+          sourceMapBaseName;
       }
 
       // Set this now, in case we mutated the file's contents.

--- a/tools/meteor-services/config.js
+++ b/tools/meteor-services/config.js
@@ -1,4 +1,3 @@
-import { parse as urlParse } from 'url';
 import {
   pathJoin,
   getCurrentToolsDir,
@@ -37,7 +36,7 @@ export function getBuildFarmUrl() {
 }
 
 export function getBuildFarmDomain() {
-  return urlParse(getBuildFarmUrl()).host;
+  return new URL(getBuildFarmUrl()).host;
 }
 
 // URL for the DDP interface to the package server, typically
@@ -48,7 +47,7 @@ export function getPackageServerUrl() {
 }
 
 export function getPackageServerDomain() {
-  return urlParse(getPackageServerUrl()).host;
+  return new URL(getPackageServerUrl()).host;
 }
 
 export function getPackageStatsServerUrl() {
@@ -57,7 +56,7 @@ export function getPackageStatsServerUrl() {
 }
 
 export function getPackageStatsServerDomain() {
-  return urlParse(getPackageStatsServerUrl()).host;
+  return new URL(getPackageStatsServerUrl()).host;
 }
 
 // Note: this is NOT guaranteed to return a distinct prefix for every

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -333,16 +333,19 @@ function canonicalizeSite(site) {
     url = 'http://' + url;
   }
 
-  var parsed = require('url').parse(url);
+  let parsed = null;
+  try {
+    parsed = new URL(url);
+  } catch (e) {}
 
-  if (! parsed.hostname) {
+  if (! parsed || ! parsed.hostname) {
     Console.info(
       "Please specify a domain to connect to, such as www.example.com or " +
       "http://www.example.com/");
     return false;
   }
 
-  if (parsed.pathname != '/' || parsed.hash || parsed.query) {
+  if (parsed.pathname !== '/' || parsed.hash || parsed.search) {
     Console.info(
       "Sorry, Meteor does not yet support specific path URLs, such as " +
       Console.url("http://www.example.com/blog") + " .  Please specify the root of a domain.");

--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -11,11 +11,9 @@ var Console = require('../console/console.js').Console;
 // Given a Mongo URL, open an interactive Mongo shell on this terminal
 // on that database.
 var runMongoShell = function (url, err) {
-  // XXX mongo URLs are not real URLs (notably, the comma-separation for
-  // multiple hosts). We've had a little better luck using the mongodb-uri npm
-  // package.
-  var mongoUrl = require('url').parse(url);
-  const ls = child_process.spawn('mongosh', [mongoUrl.href], {
+  // Mongo URLs are not real URLs (notably, the comma-separation for multiple
+  // hosts), so don't parse them; pass the raw URL through to mongosh.
+  const ls = child_process.spawn('mongosh', [url], {
     stdio: 'inherit',
   });
   ls.on('error', err);


### PR DESCRIPTION
## Problem

On a normal `meteor run` (and other tool commands), Node 20+ prints deprecation
warnings straight into users' terminals. The most visible one — reported against
`METEOR@3.5` — is `DEP0169` (`url.parse()`), which the tool triggers while recording
package stats at startup:

```
(node:XXXXX) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and
prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are
not issued for `url.parse()` vulnerabilities.
    at Object.getPackageStatsServerDomain (tools/meteor-services/config.js:60:10)
    at Object.recordPackages (tools/meteor-services/stats.js:76:18)
```

The Rspack dev proxy is a second source: the unmaintained `http-proxy` pulled in by
`http-proxy-middleware` uses both `util._extend` (the original subject of #13491) and the
legacy `url.parse` on every proxied request.

## Root cause

Several spots in the tool and the `rspack` package still use the legacy Node URL API
(`url.parse` / `url.resolve`), and the Rspack HMR proxy depends on `http-proxy-middleware`
→ `http-proxy`, which is unmaintained and calls the deprecated `util._extend`.

## Fix

Replace the deprecated APIs with their supported equivalents:

- **`tools/meteor-services/config.js`** — `url.parse().host` → `new URL().host` in the
  `getBuildFarmDomain` / `getPackageServerDomain` / `getPackageStatsServerDomain` helpers.
- **`tools/cli/main.js`** — validate `ROOT_URL` via `new URL()` wrapped in `try/catch`
  (equivalent accept/reject behavior; verified against the old `url.parse` checks).
- **`tools/isobuild/bundler.js`** — `url.resolve(file.url, base)` → manual last-segment
  path resolution (verified byte-identical to `url.resolve` for the absolute `file.url`
  values used here, including query strings).
- **`packages/rspack`** — swap `http-proxy-middleware` for the maintained drop-in
  `http-proxy-3` (already used elsewhere in the codebase since #13916), and
  `parseUrl(req.url)` → `new URL(req.url, 'http://localhost')`. The new proxy wiring keeps
  the previous `/__rspack__` and `/ws` behavior, scopes WebSocket upgrades to Rspack's own
  paths (leaving Meteor's DDP/sockjs sockets untouched), and adds an `error` handler so a
  transient dev-server hiccup returns a 502 instead of crashing the app process.

## Verification

- Reproduced `DEP0169` in isolation from the exact `getPackageStatsServerDomain` code path
  and confirmed `new URL()` emits no warning.
- Verified the `bundler.js` and `cli/main.js` transformations are behavior-preserving
  across representative inputs (source-map URLs with/without query strings; valid, invalid,
  and non-http `ROOT_URL` values).

## Not covered (follow-up)

`tools/runners/run-mongo.js` and `tools/meteor-services/deploy.js` still call `url.parse`,
but only on `meteor mongo` / `meteor deploy` — not in the `meteor run` hot path — so they
are out of scope here and can be cleaned up separately.

Fixes #13491
