### PR TITLE
CI: fix issue with runs-on

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -20,7 +20,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.reactivity_order }}
       cancel-in-progress: true
-    runs-on: oss-vm
     timeout-minutes: 90
     env:
       CXX: g++-12


### PR DESCRIPTION
.github/workflows/test-packages.yml was not running because we had 2 runs on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package test workflow configuration to use a cleaner job structure.
  * Adjusted job settings placement to improve consistency in automated test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->