### PR TITLE
ci: add actionlint guard for workflow files

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,22 @@
+# actionlint configuration — consumed by .github/workflows/lint-workflows.yml.
+#
+# Declares the self-hosted runner labels so `runs-on:` on our own fleet is not
+# flagged as an unknown label, and carries a baseline of pre-existing findings so
+# the guard is green on devel today and fails only on NEW issues. The point of the
+# guard is to catch structural/parse errors that make GitHub dispatch 0 jobs
+# (e.g. a duplicate `runs-on:` key) — not to enforce run-script style.
+self-hosted-runner:
+  labels:
+    - oss-vm
+    - windows-2019-meteor
+
+# Pre-existing findings on devel, kept out of the gate so the check starts green.
+# Burn these down in follow-ups; new occurrences of anything NOT listed here fail.
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - 'action is too old to run on GitHub Actions'
+      - 'property "node-version" is not defined'
+      - 'is potentially untrusted'
+      - 'input "submodules" is not defined in action'
+      - '"on" section is missing in workflow'

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,40 @@
+name: Lint workflows
+
+# Guards against malformed workflow YAML that GitHub silently rejects (dispatching
+# 0 jobs, run created_at == updated_at, logs 404) — e.g. a duplicate `runs-on:` key,
+# which took "Test Packages" red across many branches until commit 296c65e. actionlint
+# catches duplicate keys and other structural/parse errors before merge.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          curl -sSfL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          tar -xzf actionlint.tar.gz actionlint
+          # shellcheck/pyflakes are disabled on purpose: this guard's job is to catch
+          # structural/parse errors that make GitHub dispatch 0 jobs (duplicate keys,
+          # invalid YAML), not run-script style. The pre-existing-issue baseline lives
+          # in .github/actionlint.yaml (paths.ignore) so this stays green on devel.
+          ./actionlint -color -shellcheck= -pyflakes=


### PR DESCRIPTION
## Problem

A duplicate `runs-on:` key in `test-packages.yml` made GitHub **silently reject the workflow and dispatch 0 jobs** — the run completes as `failure` with `created_at == updated_at` and its logs 404. It showed up as red **Test Packages** across many branches until the key was removed in `296c65e` ("CI: fix issue with runs-on"). Nothing in CI caught the malformed YAML before merge.

Triage found this pattern accounted for a large share of recent red runs (0-job "Test Packages" failures across ~7 branches). Example: run [29023325441](https://github.com/meteor/meteor/actions/runs/29023325441) (commit `fa20c29`).

## What this adds

A **`Lint workflows`** check (GitHub-hosted `ubuntu-latest`) that runs [`actionlint`](https://github.com/rhysd/actionlint) on any change to `.github/workflows/**`. actionlint catches **duplicate keys** and other structural/parse errors before merge, so a malformed workflow can never again silently dispatch 0 jobs.

- **`.github/actionlint.yaml`** declares our self-hosted runner labels (`oss-vm`, `windows-2019-meteor`) so real `runs-on:` values aren't flagged as unknown, and carries a `paths.ignore` **baseline of the current pre-existing findings** so the check is **green on `devel` today** and fails only on *new* issues.
- **shellcheck / pyflakes disabled** on purpose: this guards *dispatch* (parse/structure), not `run:` script style. The baseline items (old action versions, `head_ref` in inline scripts, etc.) are follow-ups to burn down separately.
- actionlint pinned to `1.7.12`.

## Verification

- Green on current `devel` (0 findings).
- Re-introducing a duplicate `runs-on:` is caught: `key "runs-on" is duplicated in "test-packages" job … [syntax-check]` → job fails.
- The new `lint-workflows.yml` lints clean itself.

## Follow-ups (not in this PR)

Burn down the `paths.ignore` baseline (bump `actions/checkout@v3`→v4 etc., pass `github.head_ref` via env, remove the stray `submodules:` input on `setup-node`), then optionally enable shellcheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated linting for GitHub Actions workflow files.
  * Workflow checks run when workflow configurations or lint settings change.

* **Chores**
  * Configured recognized self-hosted runner labels.
  * Existing workflow lint findings are documented so future checks focus on newly introduced issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->