### PR TITLE
fix(isobuild): don't re-discover addAssets files as compilable sources

### DIFF
--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -844,12 +844,8 @@ Object.assign(PackageSource.prototype, {
           // wrong compiler and aborts the build with a spurious compile error
           // (see spacebars-tests' assets/markdown_basic.html). Gather asset paths
           // across all arches; an explicit asset declaration always wins.
-          const assetRelPaths = new Set();
-          Object.keys(api.files).forEach(fileArch => {
-            (api.files[fileArch].assets || []).forEach(asset => {
-              assetRelPaths.add(asset.relPath);
-            });
-          });
+          const assets = Object.values(api.files).flatMap(files => (files.assets || []).map(asset => asset.relPath));
+          const assetRelPaths = new Set(assets);
 
           self._findSources({
             sourceProcessorSet,
@@ -870,7 +866,7 @@ Object.assign(PackageSource.prototype, {
                 fileOptions.lazy = false;
               }
 
-            } else if (! assetRelPaths.has(relPath)) {
+            } else if (!assetRelPaths.has(relPath)) {
               const fileOptions = Object.create(null);
 
               // Since this file was not explicitly added with

--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -835,6 +835,22 @@ Object.assign(PackageSource.prototype, {
             relPathToSourceObj[source.relPath] = source;
           });
 
+          // Files explicitly declared as assets (api.addAssets) must not be
+          // re-discovered as compilable sources by _findSources below. Assets are
+          // tracked per-arch, but an asset declared on ANY arch (e.g. a `.html`
+          // fixture added for 'server') must never be scanned back in as a source
+          // on a DIFFERENT arch where its extension is claimed by a compiler (e.g.
+          // the web/templating html compiler) — that hands a raw asset to the
+          // wrong compiler and aborts the build with a spurious compile error
+          // (see spacebars-tests' assets/markdown_basic.html). Gather asset paths
+          // across all arches; an explicit asset declaration always wins.
+          const assetRelPaths = new Set();
+          Object.keys(api.files).forEach(fileArch => {
+            (api.files[fileArch].assets || []).forEach(asset => {
+              assetRelPaths.add(asset.relPath);
+            });
+          });
+
           self._findSources({
             sourceProcessorSet,
             watchSet,
@@ -854,7 +870,7 @@ Object.assign(PackageSource.prototype, {
                 fileOptions.lazy = false;
               }
 
-            } else {
+            } else if (! assetRelPaths.has(relPath)) {
               const fileOptions = Object.create(null);
 
               // Since this file was not explicitly added with


### PR DESCRIPTION
## Problem (blocks release-3.5.1)

`Test Packages` is **deterministically red** on release-3.5.1 with:

```
_get "hash" called for file with pending errors | ERROR: {"message":"Expected one of: <body>, <head>, <template>","info":{"file":"packages/local-test:spacebars-tests/assets/markdown_basic.html","line":1}}
```
→ `meteor exited before becoming ready`. Runs [29094729320](https://github.com/meteor/meteor/actions/runs/29094729320), [29095492420](https://github.com/meteor/meteor/actions/runs/29095492420), [29102750424](https://github.com/meteor/meteor/actions/runs/29102750424).

## Root cause

`assets/markdown_basic.html` (and its 4 markdown siblings) are declared as **server assets** via `api.addAssets([...], 'server')` — raw markdown, intentionally *not* templates. But `spacebars-tests` also does `api.use('templating', 'client')`, which activates the HTML/spacebars compiler (`extensions:['html'], archMatching:'web'`) on the **web** arch.

`PackageSource#_findSources` recursively scans the whole package tree for files matching a registered compiler extension, so it re-discovers `assets/markdown_basic.html` on the web arch. `getFiles` then merges those discovered paths into `sources`, deduping **only against explicitly-added sources — never against declared assets**. The asset therefore gets pushed in as a lazy `.html` source, handed to `CachingHtmlCompiler`, and the scanner rejects the markdown → compile error. Because the source is lazy, the error becomes a *pending* error and later aborts the build when the bundler calls `_get('hash')`.

Assets are tracked per-arch (declared for `server`) while the collision happens on a *different* arch (`web`), so a naive same-arch dedup does not catch it.

This was **silently swallowed before #10366** (`c9a0552988`). #10366 correctly surfaces lazy compile errors, which turned this latent isobuild bug into a hard, deterministic build abort. #10366 is on release-3.5.1 but not devel, which is exactly why devel is (silently) green and release-3.5.1 is red.

## Fix

In `getFiles`, gather asset relPaths across **all arches** and skip any auto-discovered path already declared as an asset. An explicit `api.addAssets` declaration wins over source auto-discovery. ~10 lines, no behavior change for any file that wasn't both an explicit asset *and* wrongly re-discovered as a source.

## Verification (local)

`./meteor test-packages --driver-package test-in-console ./packages/non-core/blaze/packages/spacebars-tests`:
- **before:** aborts with the `markdown_basic.html … Expected one of: <body>, <head>, <template>` error above.
- **after:** builds cleanly — reaches `[[[[[ Tests ]]]]] → Started proxy → Started MongoDB` (the compile no longer aborts).

> Note: `Test Packages` is path-filtered to `packages/**`, so it won't auto-run on this `tools/`-only change — hence the local verification above. Happy to add `tools/**` to that workflow's triggers in a follow-up so isobuild changes are covered.

## devel

The same latent bug exists on devel (just swallowed pre-#10366). This is a general isobuild correctness fix and should be forward-ported to devel.