### PR TITLE
rspack integration: fix ROOT_URL path prefix handling, native addon bundling, and nested template/stylesheet dropping

### DIFF
--- a/npm-packages/meteor-rspack/lib/nativeAddonExternals.js
+++ b/npm-packages/meteor-rspack/lib/nativeAddonExternals.js
@@ -1,0 +1,257 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Externalize npm packages that ship compiled native addons.
+ *
+ * Rspack cannot parse `.node` binaries ("Module parse failed: JavaScript
+ * parse error: Unexpected character ...") and cannot statically resolve the
+ * dynamic lookups used by helpers such as `bindings` or `node-gyp-build`
+ * ("Module not found: Can't resolve './build/Release/...'"). Since
+ * `node_modules` is present at server runtime, these packages can always be
+ * loaded with a plain `require` instead of being bundled, so on the server we
+ * externalize them as commonjs.
+ */
+
+// Dependencies that only appear in packages that compile or load native code.
+const NATIVE_INDICATOR_DEPENDENCIES = [
+  'bindings',
+  'node-gyp-build',
+  'prebuild-install',
+  'node-pre-gyp',
+  '@mapbox/node-pre-gyp',
+  'nan',
+  'node-addon-api',
+];
+
+/**
+ * Extract the npm package name from a bare request
+ * (`@scope/name/sub/path` -> `@scope/name`, `name/sub/path` -> `name`)
+ * @param {string} request - Bare module request
+ * @returns {string|null} - Package name or null if it cannot be determined
+ */
+function getPackageName(request) {
+  const parts = request.split('/');
+  if (request.startsWith('@')) {
+    return parts.length >= 2 && parts[1] ? `${parts[0]}/${parts[1]}` : null;
+  }
+  return parts[0] || null;
+}
+
+/**
+ * Locate a package directory by walking up from the issuer context and
+ * checking `<dir>/node_modules/<pkgName>/package.json` at each level.
+ * @param {string} context - Directory of the issuing module
+ * @param {string} packageName - npm package name
+ * @returns {string|null} - Absolute package directory or null
+ */
+function findPackageDir(context, packageName) {
+  if (!context) {
+    return null;
+  }
+
+  let dir = context;
+  while (true) {
+    const candidate = path.join(dir, 'node_modules', packageName);
+    try {
+      if (fs.existsSync(path.join(candidate, 'package.json'))) {
+        return candidate;
+      }
+    } catch (error) {
+      // Ignore fs errors and keep walking up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
+  return null;
+}
+
+/**
+ * Check whether a directory contains any `*.node` file (shallow readdir).
+ * @param {string} dir - Directory to scan
+ * @returns {boolean}
+ */
+function hasDotNodeFile(dir) {
+  try {
+    return fs.readdirSync(dir).some((entry) => entry.endsWith('.node'));
+  } catch (error) {
+    // Missing or unreadable directory: treat as no .node files
+    return false;
+  }
+}
+
+/**
+ * Detect whether a package directory belongs to a native addon package.
+ * Any single indicator suffices; all fs access fails safe to "not native".
+ * @param {string} packageDir - Absolute package directory
+ * @returns {boolean}
+ */
+function isNativeAddonPackage(packageDir) {
+  try {
+    if (fs.existsSync(path.join(packageDir, 'binding.gyp'))) {
+      return true;
+    }
+    if (fs.existsSync(path.join(packageDir, 'prebuilds'))) {
+      return true;
+    }
+    if (hasDotNodeFile(packageDir)) {
+      return true;
+    }
+    if (hasDotNodeFile(path.join(packageDir, 'build', 'Release'))) {
+      return true;
+    }
+
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8')
+    );
+    if (pkgJson.gypfile === true) {
+      return true;
+    }
+    const dependencies = pkgJson.dependencies || {};
+    if (NATIVE_INDICATOR_DEPENDENCIES.some((dep) => dependencies[dep])) {
+      return true;
+    }
+  } catch (error) {
+    // Fail safe: bundle as before
+  }
+
+  return false;
+}
+
+/**
+ * Convert an absolute path inside a node_modules tree into the bare
+ * specifier that resolves to it at runtime (`.../node_modules/@scope/pkg/a.node`
+ * -> `@scope/pkg/a.node`). Returns null when the path is not inside
+ * node_modules — such a path cannot be required portably from a bundle
+ * built on another machine.
+ * @param {string} absolutePath - Absolute path to convert
+ * @returns {string|null} - Bare specifier or null
+ */
+function toBareSpecifier(absolutePath) {
+  const parts = absolutePath.split(path.sep);
+  const idx = parts.lastIndexOf('node_modules');
+  if (idx === -1 || idx === parts.length - 1) {
+    return null;
+  }
+  return parts.slice(idx + 1).join('/');
+}
+
+/**
+ * Create an async webpack/rspack externals function that externalizes
+ * native addon packages (and direct `.node` requests) as commonjs.
+ * @param {Object} options
+ * @param {Function} [options.onExternalized] - Called once per unique
+ *   externalized package name, e.g. for logging
+ * @returns {Function} - Externals function `(data, callback)`
+ */
+function createNativeAddonExternals(options = {}) {
+  // Native-or-not verdict keyed by resolved package directory
+  const verdictByDir = new Map();
+  // Located package directory (or null) keyed by issuer context + package
+  // name — resolution is context dependent (workspaces, nested
+  // node_modules), so misses must not be cached globally by name alone
+  const dirByContextName = new Map();
+  // Packages already reported through onExternalized
+  const reported = new Set();
+
+  function reportExternalized(packageName) {
+    if (typeof options.onExternalized !== 'function') {
+      return;
+    }
+    if (reported.has(packageName)) {
+      return;
+    }
+    reported.add(packageName);
+    options.onExternalized(packageName);
+  }
+
+  return function nativeAddonExternals(data, callback) {
+    const { context, request } = data;
+
+    if (typeof request !== 'string') {
+      return callback();
+    }
+
+    // Meteor packages are handled by another external
+    if (request.startsWith('meteor/')) {
+      return callback();
+    }
+
+    // Direct requests for compiled addon binaries are externalized as bare
+    // specifiers: rspack cannot parse them, and node_modules exists on disk
+    // at server runtime. Absolute build-machine paths must never be emitted
+    // into the bundle — they break as soon as the bundle is deployed to
+    // another path or machine.
+    if (request.endsWith('.node')) {
+      if (request.startsWith('.') || path.isAbsolute(request)) {
+        const absolutePath = path.isAbsolute(request)
+          ? request
+          : context
+          ? path.resolve(context, request)
+          : null;
+        const bareSpecifier = absolutePath && toBareSpecifier(absolutePath);
+        if (bareSpecifier) {
+          reportExternalized(bareSpecifier);
+          return callback(null, 'commonjs ' + bareSpecifier);
+        }
+        // Not inside node_modules (e.g. an app-level .node file): fall
+        // through to normal bundling so a build error surfaces instead of
+        // a bundle that silently breaks after deployment.
+        return callback();
+      }
+      // Bare specifier, e.g. `pkg/build/Release/foo.node`
+      reportExternalized(getPackageName(request) || request);
+      return callback(null, 'commonjs ' + request);
+    }
+
+    // Only bare package specifiers from here on
+    if (
+      request.startsWith('.') ||
+      request.startsWith('!') ||
+      path.isAbsolute(request)
+    ) {
+      return callback();
+    }
+
+    const packageName = getPackageName(request);
+    if (!packageName) {
+      return callback();
+    }
+
+    const dirCacheKey = `${context || ''}\0${packageName}`;
+    let packageDir;
+    if (dirByContextName.has(dirCacheKey)) {
+      packageDir = dirByContextName.get(dirCacheKey);
+    } else {
+      packageDir = findPackageDir(context, packageName);
+      dirByContextName.set(dirCacheKey, packageDir);
+    }
+    if (!packageDir) {
+      return callback();
+    }
+
+    let isNative;
+    if (verdictByDir.has(packageDir)) {
+      isNative = verdictByDir.get(packageDir);
+    } else {
+      isNative = isNativeAddonPackage(packageDir);
+      verdictByDir.set(packageDir, isNative);
+    }
+
+    if (isNative) {
+      reportExternalized(packageName);
+      // Externalize the full original request so subpath imports keep working
+      return callback(null, 'commonjs ' + request);
+    }
+
+    return callback();
+  };
+}
+
+module.exports = {
+  createNativeAddonExternals,
+};

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -30,6 +30,7 @@ const {
 const { loadUserAndOverrideConfig } = require('./lib/meteorRspackConfigHelpers.js');
 const { prepareMeteorRspackConfig } = require("./lib/meteorRspackConfigFactory");
 const { extractLocalDependencies } = require('./lib/localDependenciesHelpers.js');
+const { createNativeAddonExternals } = require('./lib/nativeAddonExternals.js');
 
 
 // Safe require that doesn't throw if the module isn't found
@@ -470,6 +471,17 @@ module.exports = async function (inMeteor = {}, argv = {}) {
     /^meteor\/.*/,
     ...(isReactEnabled ? [/^react$/, /^react-dom$/] : []),
     ...(isServer ? [/^bcrypt$/] : []),
+    ...(isServer
+      ? [
+          createNativeAddonExternals({
+            onExternalized: (pkgName) => {
+              if (isVerbose) {
+                console.log(`[i] Externalized native addon package: ${pkgName}`);
+              }
+            },
+          }),
+        ]
+      : []),
   ];
   const alias = {
     "/": path.resolve(process.cwd()),

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -178,12 +178,20 @@ function createRemoteDevServerConfig() {
   if (rootUrl) {
     try {
       const url = new URL(rootUrl);
+      // When ROOT_URL carries a path prefix (e.g. http://localhost:3000/live/),
+      // the HMR websocket must connect through the app origin so it reaches
+      // the /ws proxy Meteor mounts behind the prefix; connecting straight to
+      // the dev server would use the wrong path. See meteor/meteor#14523.
+      const pathPrefix = url.pathname.replace(/\/+$/, '');
+      const webSocketPathname = pathPrefix
+        ? { pathname: `${pathPrefix}/ws` }
+        : {};
       // Detect if it's remote (not localhost or 127.x)
       const isLocal =
         url.hostname.includes('localhost') ||
         url.hostname.startsWith('127.') ||
         url.hostname.endsWith('.local');
-      if (!isLocal) {
+      if (!isLocal || pathPrefix) {
         hostname = url.hostname;
         protocol = url.protocol === 'https:' ? 'wss' : 'ws';
         port = url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80);
@@ -194,6 +202,7 @@ function createRemoteDevServerConfig() {
               hostname,
               port,
               protocol,
+              ...webSocketPathname,
             },
           },
         };

--- a/packages/boilerplate-generator-tests/test-lib.js
+++ b/packages/boilerplate-generator-tests/test-lib.js
@@ -7,7 +7,7 @@ function streamToString (stream) {
   })
 }
 
-export async function generateHTMLForArch(arch, includeHead) {
+export async function generateHTMLForArch(arch, includeHead, extraData = {}) {
   // Use a dummy manifest. None of these paths will be read from the filesystem, but css / js should be handled differently
   const manifest = [
     {
@@ -59,7 +59,8 @@ export async function generateHTMLForArch(arch, includeHead) {
       bundledJsCssUrlRewriteHook,
       inlineScriptsAllowed,
       inline,
-      head
+      head,
+      ...extraData,
     },
   });
 

--- a/packages/boilerplate-generator-tests/web.browser-tests.js
+++ b/packages/boilerplate-generator-tests/web.browser-tests.js
@@ -58,6 +58,65 @@ Tinytest.addAsync(
   }
 );
 
+// https://github.com/meteor/meteor/issues/14523
+Tinytest.addAsync(
+  "boilerplate-generator-tests - web.browser - custom script URL receives " +
+    "the ROOT_URL path prefix",
+  async function (test) {
+    const originalUrl = process.env.METEOR_APP_CUSTOM_SCRIPT_URL;
+    try {
+      // Root-relative URLs are prefixed like every other bundled script
+      process.env.METEOR_APP_CUSTOM_SCRIPT_URL = '/__rspack__/client-rspack.js';
+      let html = await generateHTMLForArch('web.browser', false, {
+        rootUrlPathPrefix: '/prefix',
+      });
+      test.matches(
+        html,
+        /<script[^<>]*src="\/prefix\/__rspack__\/client-rspack\.js">/
+      );
+
+      // URLs already carrying the prefix are not prefixed twice
+      process.env.METEOR_APP_CUSTOM_SCRIPT_URL =
+        '/prefix/__rspack__/client-rspack.js';
+      html = await generateHTMLForArch('web.browser', false, {
+        rootUrlPathPrefix: '/prefix',
+      });
+      test.matches(
+        html,
+        /<script[^<>]*src="\/prefix\/__rspack__\/client-rspack\.js">/
+      );
+      test.isFalse(/src="\/prefix\/prefix\//.test(html));
+
+      // Absolute URLs pass through untouched
+      process.env.METEOR_APP_CUSTOM_SCRIPT_URL =
+        'https://cdn.example.com/client-rspack.js';
+      html = await generateHTMLForArch('web.browser', false, {
+        rootUrlPathPrefix: '/prefix',
+      });
+      test.matches(
+        html,
+        /<script[^<>]*src="https:\/\/cdn\.example\.com\/client-rspack\.js">/
+      );
+
+      // Without a prefix the URL is emitted verbatim
+      process.env.METEOR_APP_CUSTOM_SCRIPT_URL = '/__rspack__/client-rspack.js';
+      html = await generateHTMLForArch('web.browser', false, {
+        rootUrlPathPrefix: '',
+      });
+      test.matches(
+        html,
+        /<script[^<>]*src="\/__rspack__\/client-rspack\.js">/
+      );
+    } finally {
+      if (originalUrl === undefined) {
+        delete process.env.METEOR_APP_CUSTOM_SCRIPT_URL;
+      } else {
+        process.env.METEOR_APP_CUSTOM_SCRIPT_URL = originalUrl;
+      }
+    }
+  }
+);
+
 // https://github.com/meteor/meteor/issues/9149
 Tinytest.addAsync(
   "boilerplate-generator-tests - web.browser - properly render boilerplate " +

--- a/packages/boilerplate-generator/template-web.browser.js
+++ b/packages/boilerplate-generator/template-web.browser.js
@@ -3,6 +3,21 @@ import template from './template';
 const sri = (sri, mode) =>
   (sri && mode) ? ` integrity="sha512-${sri}" crossorigin="${mode}"` : '';
 
+// Root-relative custom script URLs receive the same ROOT_URL path prefix
+// as every other bundled script. Protocol-relative and absolute URLs pass
+// through untouched, as do URLs that already carry the prefix (apps that
+// worked around meteor/meteor#14523 prefix the env variable themselves).
+const prefixCustomScriptUrl = (url, rootUrlPathPrefix) => {
+  if (!rootUrlPathPrefix ||
+      !url.startsWith('/') ||
+      url.startsWith('//') ||
+      url === rootUrlPathPrefix ||
+      url.startsWith(rootUrlPathPrefix + '/')) {
+    return url;
+  }
+  return rootUrlPathPrefix + url;
+};
+
 export const headTemplate = ({
   css,
   htmlAttributes,
@@ -79,7 +94,10 @@ export const closeTemplate = ({
   )),
   process.env.METEOR_APP_CUSTOM_SCRIPT_URL ?
     template("  <script type=\"text/javascript\" src=\"<%- src %>\"></script>")({
-      src: process.env.METEOR_APP_CUSTOM_SCRIPT_URL
+      src: prefixCustomScriptUrl(
+        process.env.METEOR_APP_CUSTOM_SCRIPT_URL,
+        rootUrlPathPrefix
+      )
     })
     : '',
   '',

--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -152,6 +152,8 @@ export function ensureModuleFilesExist() {
 
   const moduleFiles = {
     /* Main module files for client and server */
+    [getBuildFilePath({ isMain: true, isClient: true, ...env, role: FILE_ROLE.publicPath })]:
+      getBuildFileContent({ isMain: true, isClient: true, ...env, role: FILE_ROLE.publicPath, ...mainClientFiles }),
     [getBuildFilePath({ isMain: true, isClient: true, ...env, ...commandRole })]:
       getBuildFileContent({ isMain: true, isClient: true, ...env, ...commandRole, ...mainClientFiles }),
     [getBuildFilePath({ isMain: true, isClient: true, ...env, role: FILE_ROLE.entry })]:
@@ -260,6 +262,8 @@ export function getBuildFilePath(config) {
     role = 'meteor';
   } else if ([FILE_ROLE.output].includes(role)) {
     role = 'rspack';
+  } else if ([FILE_ROLE.publicPath].includes(role)) {
+    role = 'public-path';
   }
 
   // 5. Get file extension (default to js)
@@ -396,6 +400,24 @@ ${AUTO_GENERATED_WARNING}
   }
 
   // For main modules (not test mode), use the new templates
+  // Public path files
+  if (role === FILE_ROLE.publicPath) {
+    return `/**
+* @file ${side}-public-path.js
+* @description Sets the Rspack public path from Meteor's runtime configuration
+* --------------------------------------------------------------------------
+* 🌐 Rspack ${sideDisplay} Public Path (${envDisplay})
+* --------------------------------------------------------------------------
+* Imported first by \`${side}-entry.js\` so that chunk, asset and hot-update
+* URLs constructed by the Rspack runtime honor the ROOT_URL path prefix
+* (\`__meteor_runtime_config__.ROOT_URL_PATH_PREFIX\`) when the app is served
+* under a sub-path, e.g. ROOT_URL=https://example.com/live/.
+* See meteor/meteor#14523.
+*
+${AUTO_GENERATED_WARNING}
+*/`;
+  }
+
   // Entry files
   if (role === FILE_ROLE.entry) {
     if (!config?.entryFile) {
@@ -525,6 +547,43 @@ function getImportContent(config, side, role) {
     return '';
   }
 
+  if (role === FILE_ROLE.publicPath) {
+    const isDevServer = config?.isDevelopment && !config?.isNative;
+    if (isDevServer) {
+      return `/* When the app is served under a ROOT_URL path prefix, load chunks,
+   assets and hot updates directly through Meteor's dev-server proxy
+   (mounted at /__rspack__) with the prefix applied. Without a prefix the
+   default public path is kept and the integration's compatibility
+   redirects apply, unchanged. */
+var rootUrlPathPrefix =
+  (typeof __meteor_runtime_config__ !== 'undefined' &&
+    __meteor_runtime_config__.ROOT_URL_PATH_PREFIX) ||
+  '';
+if (rootUrlPathPrefix) {
+  __webpack_public_path__ = rootUrlPathPrefix + '/__rspack__/';
+}`;
+    }
+    return `/* When the app is served under a ROOT_URL path prefix, prepend the
+   prefix to the public path so chunk and asset URLs constructed at
+   runtime resolve correctly. Absolute (e.g. CDN) public paths and
+   public paths already carrying the prefix are left untouched. */
+var rootUrlPathPrefix =
+  (typeof __meteor_runtime_config__ !== 'undefined' &&
+    __meteor_runtime_config__.ROOT_URL_PATH_PREFIX) ||
+  '';
+if (rootUrlPathPrefix) {
+  var currentPublicPath = __webpack_public_path__;
+  var isRootRelative =
+    currentPublicPath.charAt(0) === '/' && currentPublicPath.charAt(1) !== '/';
+  var isAlreadyPrefixed =
+    currentPublicPath === rootUrlPathPrefix ||
+    currentPublicPath.indexOf(rootUrlPathPrefix + '/') === 0;
+  if (isRootRelative && !isAlreadyPrefixed) {
+    __webpack_public_path__ = rootUrlPathPrefix + currentPublicPath;
+  }
+}`;
+  }
+
   if (role === FILE_ROLE.entry) {
     if (config?.isTest) {
       return `${
@@ -545,6 +604,18 @@ import '../../${config.entryFile}';`
     }
 
     if (config?.entryFile) {
+      if (config?.isClient) {
+        const publicPathFile = getBuildFilePath({
+          isClient: true,
+          role: FILE_ROLE.publicPath,
+          onlyFilename: true,
+        });
+        return `/* Link to 🌐 Rspack Client Public Path (must be imported first) */
+import './${publicPathFile}';
+
+/* Link to 🔌 Meteor ${capitalizeFirstLetter(side)} Entry */
+import '../../${config?.entryFile}';`;
+      }
       return `/* Link to 🔌 Meteor ${capitalizeFirstLetter(side)} Entry */
 import '../../${config?.entryFile}';`;
     }

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -194,12 +194,18 @@ export function configureMeteorForRspack() {
     extraFoldersToIgnore = [];
   }
 
-  // Skip CSS/HTML files in entrypoint contexts
+  // Skip CSS/HTML files in entrypoint contexts, including nested
+  // subdirectories (`client/**/*.css` also matches `client/a.css`
+  // since `**` matches zero or more directories). See meteor/meteor#14523.
   extraFilesToIgnore = [
     ...extraFilesToIgnore,
     ...initialEntrypointContexts.flatMap(entrypoint => {
-      const cssPattern = `${entrypoint}/*.css`;
-      const htmlPattern = `${entrypoint}/*.html`;
+      const cssPattern = `${entrypoint}/**/*.css`;
+      const htmlPattern = `${entrypoint}/**/*.html`;
+      // Legacy top-level pattern forms, so existing .meteorignore lines
+      // like `client/*.css` keep opting out of the unignore
+      const legacyCssPattern = `${entrypoint}/*.css`;
+      const legacyHtmlPattern = `${entrypoint}/*.html`;
 
       const cssFiles = glob.sync(cssPattern);
       const htmlFiles = glob.sync(htmlPattern);
@@ -207,13 +213,17 @@ export function configureMeteorForRspack() {
       const entriesToCheck = [
         cssPattern,
         htmlPattern,
+        legacyCssPattern,
+        legacyHtmlPattern,
         ...cssFiles,
         ...htmlFiles
       ];
 
       const entryResults = checkMeteorIgnoreExactEntries(entriesToCheck);
-      const hasMatchingCssPattern = entryResults[cssPattern];
-      const hasMatchingHtmlPattern = entryResults[htmlPattern];
+      const hasMatchingCssPattern =
+        entryResults[cssPattern] || entryResults[legacyCssPattern];
+      const hasMatchingHtmlPattern =
+        entryResults[htmlPattern] || entryResults[legacyHtmlPattern];
       const hasAnyCssFileInMeteorIgnore = cssFiles.some(file => entryResults[file]);
       const hasAnyHtmlFileInMeteorIgnore = htmlFiles.some(file => entryResults[file]);
 
@@ -393,8 +403,9 @@ export function configureMeteorForRspack() {
  * Since Meteor awaits rspack compilation before scanning files, these patterns
  * are in place before Meteor processes any application files.
  *
- * Uses gitignore semantics: a later positive pattern (client/*.css) overrides
- * an earlier negation (!client/*.css) that was set in configureMeteorForRspack.
+ * Uses gitignore semantics: a later positive nested pattern (client, then
+ * any subdirectories, then *.css) overrides the matching earlier negation
+ * that was set in configureMeteorForRspack.
  *
  * @param {string[]} extensions - Array of extensions like ['.css', '.less']
  */
@@ -412,8 +423,10 @@ export function applyDelegatedExtensions(extensions) {
   const ignorePatterns = [];
   for (const dir of entrypointContexts) {
     for (const ext of extensions) {
-      // ext comes as '.css', glob needs '*.css'
-      ignorePatterns.push(`${dir}/*${ext}`);
+      // ext comes as '.css'; use a nested-inclusive pattern so delegation
+      // also re-ignores nested files (`**` matches zero or more directories,
+      // so `client/**/*.css` covers `client/a.css` too). meteor/meteor#14523
+      ignorePatterns.push(`${dir}/**/*${ext}`);
     }
   }
 

--- a/packages/rspack/lib/constants.js
+++ b/packages/rspack/lib/constants.js
@@ -105,4 +105,5 @@ export const FILE_ROLE = {
   entry: 'entry',
   run: 'run',
   output: 'output',
+  publicPath: 'publicPath',
 };

--- a/packages/rspack/rspack_server.js
+++ b/packages/rspack/rspack_server.js
@@ -12,6 +12,23 @@ import {
 const rspackChunksContext = process.env.RSPACK_CHUNKS_CONTEXT || RSPACK_CHUNKS_CONTEXT;
 const rspackAssetsContext = process.env.RSPACK_ASSETS_CONTEXT || RSPACK_ASSETS_CONTEXT;
 
+// ROOT_URL path prefix (e.g. "/live" for ROOT_URL=https://example.com/live/).
+// Every URL the integration constructs must carry it, consistent with every
+// other URL Meteor emits. See meteor/meteor#14523.
+const rootUrlPathPrefix =
+  (typeof __meteor_runtime_config__ !== 'undefined' &&
+    __meteor_runtime_config__.ROOT_URL_PATH_PREFIX) ||
+  '';
+
+/**
+ * Escape a string for literal use inside a RegExp
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Regex pattern for rspack bundles
  * @constant {RegExp}
@@ -41,13 +58,30 @@ if (shouldEnableDevHMRProxy) {
   const target = `http://localhost:${process.env.RSPACK_DEVSERVER_PORT}`;
 
   // Proxy HMR websocket upgrade requests
-  WebApp.connectHandlers.use('/ws',
-    createProxyMiddleware( {
-      target,
-      ws: true,
-      logLevel: 'debug'
-    })
-  );
+  const hmrWebSocketProxy = createProxyMiddleware( {
+    target,
+    ws: true,
+    logLevel: 'debug'
+  });
+  WebApp.connectHandlers.use('/ws', hmrWebSocketProxy);
+
+  if (rootUrlPathPrefix) {
+    // Websocket upgrade requests bypass the Express middleware chain, so the
+    // ROOT_URL path prefix is never stripped from them and the '/ws' mount
+    // above cannot match. Proxy prefixed HMR websocket upgrades explicitly.
+    // See meteor/meteor#14523.
+    const prefixedWsPath = `${rootUrlPathPrefix}/ws`;
+    WebApp.httpServer.on('upgrade', (req, socket, head) => {
+      if (
+        req.url === prefixedWsPath ||
+        req.url.startsWith(`${prefixedWsPath}?`) ||
+        req.url.startsWith(`${prefixedWsPath}/`)
+      ) {
+        req.url = req.url.slice(rootUrlPathPrefix.length);
+        hmrWebSocketProxy.upgrade(req, socket, head);
+      }
+    });
+  }
 
   // Proxy all dev asset requests under the rspack prefix
   WebApp.connectHandlers.use('/__rspack__',
@@ -72,7 +106,9 @@ if (shouldEnableDevHMRProxy) {
     const hotUpdate = req.url.match(RSPACK_HOT_UPDATE_REGEX);
     if (hotUpdate) {
       // Redirect "/something.hot-update.js" → "/__rspack__/something.hot-update.js"
-      const target = `/__rspack__/${hotUpdate[1]}`;
+      // (with the ROOT_URL path prefix applied, so the redirected request
+      // reaches the proxy mounted under the prefix — see meteor/meteor#14523)
+      const target = `${rootUrlPathPrefix}/__rspack__/${hotUpdate[1]}`;
       res.writeHead(307, { Location: target });
       return res.end();
     }
@@ -81,7 +117,7 @@ if (shouldEnableDevHMRProxy) {
     const bundlesMatch = req.url.match(RSPACK_CHUNKS_REGEX);
     if (bundlesMatch) {
       // Redirect "/bundles/foo.js" → "/__rspack__/build-chunks/foo.js"
-      const target = `/__rspack__/${rspackChunksContext}/${bundlesMatch[1]}`;
+      const target = `${rootUrlPathPrefix}/__rspack__/${rspackChunksContext}/${bundlesMatch[1]}`;
       res.writeHead(307, { Location: target });
       return res.end();
     }
@@ -90,7 +126,7 @@ if (shouldEnableDevHMRProxy) {
     const assetsMatch = req.url.match(RSPACK_ASSETS_REGEX);
     if (assetsMatch) {
       // Redirect "/build-assets/foo.js" → "/__rspack__/build-assets/foo.js"
-      const target = `/__rspack__/${rspackAssetsContext}/${assetsMatch[1]}`;
+      const target = `${rootUrlPathPrefix}/__rspack__/${rspackAssetsContext}/${assetsMatch[1]}`;
       res.writeHead(307, { Location: target });
       return res.end();
     }
@@ -207,3 +243,56 @@ WebAppInternals.staticFilesMiddleware = async function(staticFilesByArch, req, r
   // Call the original middleware
   return originalStaticFilesMiddleware(staticFilesByArch, req, res, next);
 };
+
+// Rspack emits asset URLs into the app's HTML (e.g. the
+// <link href="/build-chunks/main.css"> injected through HtmlRspackPlugin) as
+// root-relative paths with no knowledge of ROOT_URL's path prefix. When a
+// prefix is configured, rewrite those URLs per request so they resolve under
+// the prefix. In development they are additionally routed straight to the
+// dev-server proxy mounted at /__rspack__, avoiding a redirect hop.
+// See meteor/meteor#14523.
+if (rootUrlPathPrefix) {
+  const devProxyBase = shouldEnableDevHMRProxy ? '/__rspack__' : '';
+  const assetTagPattern = new RegExp(
+    `(<(?:link|script)\\b[^>]*\\b(?:href|src)=")(/(?:${escapeRegExp(
+      rspackChunksContext
+    )}|${escapeRegExp(rspackAssetsContext)})/)`,
+    'g'
+  );
+  const proxyTagPattern = new RegExp(
+    '(<(?:link|script)\\b[^>]*\\b(?:href|src)=")(/__rspack__/)',
+    'g'
+  );
+
+  // Replacement callbacks (not strings): the prefix may legally contain
+  // characters like "$" that carry special meaning in replacement strings.
+  const rewriteRspackAssetUrls = html =>
+    typeof html === 'string'
+      ? html
+          .replace(
+            assetTagPattern,
+            (match, opening, assetPath) =>
+              `${opening}${rootUrlPathPrefix}${devProxyBase}${assetPath}`
+          )
+          .replace(
+            proxyTagPattern,
+            (match, opening, assetPath) =>
+              `${opening}${rootUrlPathPrefix}${assetPath}`
+          )
+      : html;
+
+  WebAppInternals.registerBoilerplateDataCallback(
+    'rspack-root-url-path-prefix',
+    (request, data) => {
+      let madeChanges = false;
+      for (const field of ['head', 'body', 'dynamicHead', 'dynamicBody']) {
+        const rewritten = rewriteRspackAssetUrls(data[field]);
+        if (rewritten !== data[field]) {
+          data[field] = rewritten;
+          madeChanges = true;
+        }
+      }
+      return madeChanges;
+    }
+  );
+}


### PR DESCRIPTION
Fixes #14523.

This PR addresses the three independent problems reported in #14523, all hit while migrating a real-world multi-directory Blaze app served under a ROOT_URL path prefix.

## 1. All Rspack asset URLs now honor `ROOT_URL_PATH_PREFIX`

Previously every URL the integration constructed omitted the ROOT_URL path prefix, so under e.g. `ROOT_URL=https://example.com/live/` the injected client bundle script 404'd and the app never booted.

- **`boilerplate-generator`**: root-relative `METEOR_APP_CUSTOM_SCRIPT_URL` values are now prefixed with `rootUrlPathPrefix`, consistent with every other bundled script. Absolute/protocol-relative URLs, and URLs already carrying the prefix (apps that worked around the bug themselves), pass through untouched.
- **`rspack` (server runtime)**: the compatibility 307 redirects for `/build-chunks/*`, `/build-assets/*` and `*.hot-update.*` now redirect to prefixed targets; a new boilerplate-data callback rewrites Rspack-emitted asset tags in the served HTML (e.g. the `<link href="/build-chunks/main.css">` injected via HtmlRspackPlugin) so they resolve under the prefix, routing straight to the dev-server proxy in development.
- **`rspack` (generated build files)**: the generated client entry now imports a new `client-public-path.js` module first, which sets `__webpack_public_path__` at runtime from `__meteor_runtime_config__.ROOT_URL_PATH_PREFIX`, so chunk/asset/hot-update URLs constructed by the Rspack runtime are correct in both development and production. Without a prefix, behavior is unchanged.
- **`@meteorjs/rspack`**: the dev-server client websocket URL now includes the path prefix (`<prefix>/ws`) so HMR/live-reload connects through the proxy Meteor mounts behind the prefix.

## 2. npm packages with native addons are auto-externalized on the server

The server build previously failed on any dependency shipping a compiled `.node` binary (`Module parse failed: Unexpected character '�'`) or using the node-gyp `require('./build/Release/x')` convention. Since `node_modules` is present at server runtime, `@meteorjs/rspack` now auto-externalizes such packages as `commonjs`:

- direct `.node` requests are externalized (relative ones resolved against the issuer);
- bare package requests are checked against native-addon indicators (`binding.gyp`, `gypfile: true`, `prebuilds/`, `*.node` in the package root or `build/Release/`, or dependencies on `bindings`, `node-gyp-build`, `prebuild-install`, `node-pre-gyp`, `@mapbox/node-pre-gyp`, `nan`, `node-addon-api`), with verdicts cached per package;
- externalizations are logged in verbose mode.

Manual `externals: { 'pkg': 'commonjs pkg' }` workarounds are no longer needed.

## 3. Nested `.html`/`.css` under entrypoint directories are no longer silently dropped

The integration's METEOR_IGNORE unignore patterns for the mainModule entrypoint directories only covered top-level files (`client/*.html`, `client/*.css`); anything deeper vanished from the Meteor-side build with no warning, which for Blaze apps meant `Template.x` was silently undefined at runtime. The unignore patterns and the matching CSS-delegation patterns are now nested-inclusive (`client/**/*.html`, `client/**/*.css`; `**` matches zero or more directories so top-level files are still covered). Listing every nested file in `meteor.modules` is no longer required. This is framework-neutral: it applies to Blaze, static-html and plain CSS handling alike.

Existing `.meteorignore` opt-outs using the old top-level pattern form keep working.

## Tests

- New tinytest in `boilerplate-generator-tests` covering custom script URL prefixing (prefixed, already-prefixed, absolute, no-prefix cases).
- Verified end-to-end with a Blaze app (`meteor create --blaze`) with a nested un-imported template + stylesheet and two synthetic native-addon packages, run from checkout with `ROOT_URL=http://localhost:3000/live/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `ROOT_URL` path prefixes across client assets, hot-module replacement, WebSocket connections, and development server redirects.
  - Custom script URLs now correctly include configured path prefixes without duplicating existing prefixes.
  - Server builds now automatically handle a broader range of native add-ons.

- **Bug Fixes**
  - Improved asset loading and development proxy behavior when applications are hosted under a URL subpath.
  - Updated file ignore handling to cover nested entrypoint and delegated-extension files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->