### PR TITLE
fix(rspack): allocate dev-server ports from the OS to avoid collisions

### DIFF
--- a/npm-packages/meteor-rspack/lib/meteorRspackHelpers.js
+++ b/npm-packages/meteor-rspack/lib/meteorRspackHelpers.js
@@ -208,7 +208,6 @@ function disablePlugins(config, matchers) {
   }
 
   const plugins = Array.isArray(config.plugins) ? config.plugins : [];
-  const kept = [];
 
   const list = Array.isArray(matchers) ? matchers : [matchers];
 
@@ -336,6 +335,11 @@ function outputMeteorRspack(data) {
   console.log(output);
 }
 
+function formatDevServerHost(host) {
+  const value = host || "localhost";
+  return value.includes(":") && !value.startsWith("[") ? `[${value}]` : value;
+}
+
 module.exports = {
   compileWithMeteor,
   compileWithRspack,
@@ -346,6 +350,7 @@ module.exports = {
   makeWebNodeBuiltinsAlias,
   disablePlugins,
   outputMeteorRspack,
+  formatDevServerHost,
   enablePortableBuild,
   persistDevFiles,
   createPersistCallback,

--- a/npm-packages/meteor-rspack/lib/meteorRspackHelpers.js
+++ b/npm-packages/meteor-rspack/lib/meteorRspackHelpers.js
@@ -340,11 +340,6 @@ function formatDevServerHost(host) {
   return value.includes(":") && !value.startsWith("[") ? `[${value}]` : value;
 }
 
-function getRsdoctorPort(isClient, clientPort, serverPort) {
-  const configuredPort = isClient ? clientPort : serverPort;
-  return parseInt(configuredPort || (isClient ? "8888" : "8889"), 10);
-}
-
 module.exports = {
   compileWithMeteor,
   compileWithRspack,
@@ -356,7 +351,6 @@ module.exports = {
   disablePlugins,
   outputMeteorRspack,
   formatDevServerHost,
-  getRsdoctorPort,
   enablePortableBuild,
   persistDevFiles,
   createPersistCallback,

--- a/npm-packages/meteor-rspack/lib/meteorRspackHelpers.js
+++ b/npm-packages/meteor-rspack/lib/meteorRspackHelpers.js
@@ -340,6 +340,11 @@ function formatDevServerHost(host) {
   return value.includes(":") && !value.startsWith("[") ? `[${value}]` : value;
 }
 
+function getRsdoctorPort(isClient, clientPort, serverPort) {
+  const configuredPort = isClient ? clientPort : serverPort;
+  return parseInt(configuredPort || (isClient ? "8888" : "8889"), 10);
+}
+
 module.exports = {
   compileWithMeteor,
   compileWithRspack,
@@ -351,6 +356,7 @@ module.exports = {
   disablePlugins,
   outputMeteorRspack,
   formatDevServerHost,
+  getRsdoctorPort,
   enablePortableBuild,
   persistDevFiles,
   createPersistCallback,

--- a/npm-packages/meteor-rspack/plugins/MeteorRspackOutputPlugin.js
+++ b/npm-packages/meteor-rspack/plugins/MeteorRspackOutputPlugin.js
@@ -69,7 +69,7 @@ function extractDelegatedExtensions(stats, compiler) {
         if (folder) entryFolders.add(folder);
       }
     }
-  } catch (e) {
+  } catch {
     // If we can't read package.json, fall back to config-only
     return Array.from(configured);
   }
@@ -106,18 +106,21 @@ class MeteorRspackOutputPlugin {
       typeof options.getData === 'function'
         ? options.getData
         : () => options.data || {};
+    this.waitFor =
+      typeof options.waitFor === 'function' ? options.waitFor : null;
   }
 
   apply(compiler) {
     // Hook into the 'done' event which fires after each compilation completes
-    compiler.hooks.done.tap(this.pluginName, stats => {
+    compiler.hooks.done.tapPromise(this.pluginName, async stats => {
+      await this.waitFor?.();
       this.compilationCount++;
       const data = {
         ...(this.getData(stats, {
           compilationCount: this.compilationCount,
           isRebuild: this.compilationCount > 1,
           compiler,
-        }) || {}),
+        })),
       };
       outputMeteorRspack(data);
     });

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -22,6 +22,7 @@ const {
   makeWebNodeBuiltinsAlias,
   disablePlugins,
   outputMeteorRspack,
+  formatDevServerHost,
   enablePortableBuild,
   persistDevFiles,
   createPersistCallback,
@@ -195,7 +196,7 @@ function createRemoteDevServerConfig() {
           },
         };
       }
-    } catch (err) {
+    } catch {
       console.warn(`Invalid ROOT_URL "${rootUrl}", falling back to localhost`);
     }
   }
@@ -207,7 +208,7 @@ function createRemoteDevServerConfig() {
 // Keep files outside of build folders
 function keepOutsideBuild() {
   return (p) => {
-    const normalized = '/' + path.normalize(p).replaceAll(path.sep, '/').replace(/^\/+/, '');
+    const normalized = `/${path.normalize(p).replaceAll(path.sep, '/').replace(/^\/+/, '')}`;
     const isInBuildRoot = /\/build(\/|$)/.test(normalized);
     const isInBuildStar = /\/build-[^/]+(\/|$)/.test(normalized);
     return !(isInBuildRoot || isInBuildStar);
@@ -507,13 +508,14 @@ module.exports = async function (inMeteor = {}, argv = {}) {
   const rsdoctorModule = isBundleVisualizerEnabled
     ? safeRequire("@rsdoctor/rspack-plugin")
     : null;
+  const rsdoctorPort = isClient
+    ? Meteor.rsdoctorClientPort
+    : Meteor.rsdoctorServerPort;
   const doctorPluginConfig =
     isRun && isBundleVisualizerEnabled && rsdoctorModule?.RsdoctorRspackPlugin
       ? [
           new rsdoctorModule.RsdoctorRspackPlugin({
-            port: isClient
-              ? parseInt(Meteor.rsdoctorClientPort || "8888", 10)
-              : parseInt(Meteor.rsdoctorServerPort || "8889", 10),
+            ...(rsdoctorPort && { port: parseInt(rsdoctorPort, 10) }),
           }),
         ]
       : [];
@@ -571,7 +573,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
     if (address && typeof address !== "string") {
       const protocol =
         devServer.options.server?.type === "https" ? "https" : "http";
-      devServerUrl = `${protocol}://${host || "localhost"}:${address.port}`;
+      devServerUrl = `${protocol}://${formatDevServerHost(host)}:${address.port}`;
       outputMeteorRspack({ devServerUrl });
     }
 
@@ -601,7 +603,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
   };
 
   // Base client config
-  let clientConfig = {
+  const clientConfig = {
     name: clientNameConfig,
     target: "web",
     mode,
@@ -728,7 +730,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       : path.resolve(projectDir, buildContext, entryPath);
   const serverNameConfig = `[${(isTest && "test-") || ""}server-rspack]`;
   // Base server config
-  let serverConfig = {
+  const serverConfig = {
     name: serverNameConfig,
     target: "node",
     mode,

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -23,7 +23,6 @@ const {
   disablePlugins,
   outputMeteorRspack,
   formatDevServerHost,
-  getRsdoctorPort,
   enablePortableBuild,
   persistDevFiles,
   createPersistCallback,
@@ -509,17 +508,18 @@ module.exports = async function (inMeteor = {}, argv = {}) {
   const rsdoctorModule = isBundleVisualizerEnabled
     ? safeRequire("@rsdoctor/rspack-plugin")
     : null;
-  const rsdoctorPort = getRsdoctorPort(
-    isClient,
-    Meteor.rsdoctorClientPort,
-    Meteor.rsdoctorServerPort,
-  );
-  const doctorPluginConfig =
+  const configuredRsdoctorPort = isClient
+    ? Meteor.rsdoctorClientPort
+    : Meteor.rsdoctorServerPort;
+  const rsdoctorPlugin =
     isRun && isBundleVisualizerEnabled && rsdoctorModule?.RsdoctorRspackPlugin
-      ? [
-          new rsdoctorModule.RsdoctorRspackPlugin({ port: rsdoctorPort }),
-        ]
-      : [];
+      ? new rsdoctorModule.RsdoctorRspackPlugin({
+          ...(configuredRsdoctorPort && {
+            port: parseInt(configuredRsdoctorPort, 10),
+          }),
+        })
+      : null;
+  const doctorPluginConfig = rsdoctorPlugin ? [rsdoctorPlugin] : [];
   const bannerPluginConfig = !isBuild
     ? [
         new BannerPlugin({
@@ -919,8 +919,16 @@ module.exports = async function (inMeteor = {}, argv = {}) {
     );
   }
 
+  const activeRsdoctorPlugin =
+    isDevEnvironment &&
+    !rsdoctorPlugin?.options.disableClientServer &&
+    config.plugins?.includes(rsdoctorPlugin)
+      ? rsdoctorPlugin
+      : null;
+
   // Add MeteorRspackOutputPlugin as the last plugin to output compilation info
   const meteorRspackOutputPlugin = new MeteorRspackOutputPlugin({
+    waitFor: () => activeRsdoctorPlugin?._bootstrapTask,
     getData: (stats, { isRebuild, compilationCount, compiler }) => ({
       name: config.name,
       mode: config.mode,
@@ -930,6 +938,11 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       statsOverrided,
       compilationCount,
       isRebuild,
+      ...(!isRebuild &&
+        activeRsdoctorPlugin && {
+          [isClient ? "rsdoctorClientPort" : "rsdoctorServerPort"]:
+            activeRsdoctorPlugin.sdk.server.port,
+        }),
       ...(devServerUrl && { devServerUrl }),
       ...(!isRebuild && compiler && {
         delegatedExtensions: extractDelegatedExtensions(stats, compiler),

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -23,6 +23,7 @@ const {
   disablePlugins,
   outputMeteorRspack,
   formatDevServerHost,
+  getRsdoctorPort,
   enablePortableBuild,
   persistDevFiles,
   createPersistCallback,
@@ -508,15 +509,15 @@ module.exports = async function (inMeteor = {}, argv = {}) {
   const rsdoctorModule = isBundleVisualizerEnabled
     ? safeRequire("@rsdoctor/rspack-plugin")
     : null;
-  const rsdoctorPort = isClient
-    ? Meteor.rsdoctorClientPort
-    : Meteor.rsdoctorServerPort;
+  const rsdoctorPort = getRsdoctorPort(
+    isClient,
+    Meteor.rsdoctorClientPort,
+    Meteor.rsdoctorServerPort,
+  );
   const doctorPluginConfig =
     isRun && isBundleVisualizerEnabled && rsdoctorModule?.RsdoctorRspackPlugin
       ? [
-          new rsdoctorModule.RsdoctorRspackPlugin({
-            ...(rsdoctorPort && { port: parseInt(rsdoctorPort, 10) }),
-          }),
+          new rsdoctorModule.RsdoctorRspackPlugin({ port: rsdoctorPort }),
         ]
       : [];
   const bannerPluginConfig = !isBuild

--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -234,7 +234,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
   const isTestLike = !!Meteor.isTestLike;
   const swcExternalHelpers = !!Meteor.swcExternalHelpers;
   const isNative = !!Meteor.isNative;
-  const devServerPort = Meteor.devServerPort || 8080;
+  const devServerPort = Meteor.devServerPort || "auto";
 
   const projectDir = process.cwd();
   const projectConfigPath =
@@ -559,17 +559,21 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       ? path.resolve(process.cwd(), testEntry)
       : path.resolve(process.cwd(), buildContext, entryPath);
   const clientNameConfig = `[${(isTest && "test-") || ""}client-rspack]`;
+  let devServerUrl;
 
   // Default onListening provided by meteor-rspack. Kept as a named
   // reference so we can detect a user-supplied override after merge
   // and compose (run default first, then user's).
   const meteorDefaultOnListening = function (devServer) {
     if (!devServer) return;
-    const { host, port } = devServer.options;
-    const protocol =
-      devServer.options.server?.type === "https" ? "https" : "http";
-    const devServerUrl = `${protocol}://${host || "localhost"}:${port}`;
-    outputMeteorRspack({ devServerUrl });
+    const { host } = devServer.options;
+    const address = devServer.server?.address();
+    if (address && typeof address !== "string") {
+      const protocol =
+        devServer.options.server?.type === "https" ? "https" : "http";
+      devServerUrl = `${protocol}://${host || "localhost"}:${address.port}`;
+      outputMeteorRspack({ devServerUrl });
+    }
 
     // Windows-only: webpack-dev-server tracks accepted sockets
     // but doesn't attach 'error'. On Windows, teardown of a
@@ -923,6 +927,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
       statsOverrided,
       compilationCount,
       isRebuild,
+      ...(devServerUrl && { devServerUrl }),
       ...(!isRebuild && compiler && {
         delegatedExtensions: extractDelegatedExtensions(stats, compiler),
       }),

--- a/packages/rspack/lib/processes.js
+++ b/packages/rspack/lib/processes.js
@@ -35,7 +35,6 @@ const {
   getMeteorInitialAppEntrypoints,
   isMeteorAppConfigModernVerbose,
   isMeteorBundleVisualizerProject,
-  getMeteorAppPort,
   inheritMeteorToolNodeFlags,
 } = require('meteor/tools-core/lib/meteor');
 
@@ -71,52 +70,6 @@ import {
   stripRspackLabel,
 } from "./logging";
 import { isMeteorAppProfile } from "../../tools-core/lib/meteor";
-
-/**
- * Calculates the devServerPort based on process.env.PORT
- * Base port is 8077, and we add the sum of the digits of process.env.PORT
- * @returns {number} The calculated devServerPort
- */
-export function calculateDevServerPort() {
-  const port = getMeteorAppPort();
-  const basePort = 8077;
-
-  // Sum the digits of the port
-  const digitSum = port.split('').reduce((sum, digit) => sum + parseInt(digit, 10), 0);
-
-  return basePort + digitSum;
-}
-
-/**
- * Calculates the Rsdoctor client port based on process.env.PORT
- * Base port is 8885, and we add the sum of the digits of process.env.PORT
- * @returns {number} The calculated Rsdoctor client port
- */
-export function calculateRsdoctorClientPort() {
-  const port = getMeteorAppPort();
-  const basePort = 8885;
-
-  // Sum the digits of the port
-  const digitSum = port.split('').reduce((sum, digit) => sum + parseInt(digit, 10), 0);
-
-  return basePort + digitSum;
-}
-
-/**
- * Calculates the Rsdoctor server port based on process.env.PORT
- * Base port is 8885, and we add the sum of the digits of process.env.PORT + 1
- * @returns {number} The calculated Rsdoctor server port
- */
-export function calculateRsdoctorServerPort() {
-  const port = getMeteorAppPort();
-  const basePort = 8885;
-
-  // Sum the digits of the port
-  const digitSum = port.split('').reduce((sum, digit) => sum + parseInt(digit, 10), 0);
-
-  // Add 1 to differentiate from client port
-  return basePort + digitSum + 1;
-}
 
 /**
  * Helper function to check for a file with different extensions in order of priority
@@ -388,7 +341,9 @@ export function getRspackEnv({ isClient, isServer, isTest: inIsTest, isTestLike:
     ["buildContext", RSPACK_BUILD_CONTEXT],
     ["chunksContext", RSPACK_CHUNKS_CONTEXT],
     ["assetsContext", RSPACK_ASSETS_CONTEXT],
-    ["devServerPort", process.env.RSPACK_DEVSERVER_PORT],
+    ...(process.env.RSPACK_DEVSERVER_PORT
+      ? [["devServerPort", process.env.RSPACK_DEVSERVER_PORT]]
+      : []),
     ["projectConfigPath", projectConfigPath],
     ["configPath", configPath],
     ...((isTest &&
@@ -420,8 +375,12 @@ export function getRspackEnv({ isClient, isServer, isTest: inIsTest, isTestLike:
     ...((isJsxEnabled && [["isJsxEnabled", isJsxEnabled]]) || []),
     ...((isBundleVisualizerEnabled && [
       ["isBundleVisualizerEnabled", isBundleVisualizerEnabled],
-      ["rsdoctorClientPort", process.env.RSDOCTOR_CLIENT_PORT],
-      ["rsdoctorServerPort", process.env.RSDOCTOR_SERVER_PORT],
+      ...(process.env.RSDOCTOR_CLIENT_PORT
+        ? [["rsdoctorClientPort", process.env.RSDOCTOR_CLIENT_PORT]]
+        : []),
+      ...(process.env.RSDOCTOR_SERVER_PORT
+        ? [["rsdoctorServerPort", process.env.RSDOCTOR_SERVER_PORT]]
+        : []),
     ]) ||
       []),
   ].filter(Boolean);
@@ -472,7 +431,8 @@ export function startRspackClientServe(options = {}) {
       env: inheritMeteorToolNodeFlags({ ...process.env, ...getNodeBinEnv(), ...envs }),
       onStdout: (data) => {
         const { cleanedData, config } = parseMeteorRspackOutput(data);
-        if (config && !!config?.devServerUrl) {
+        if (config?.devServerUrl) {
+          process.env.RSPACK_DEVSERVER_PORT = new URL(config.devServerUrl).port;
           logHmrServerStarted(config);
         }
         if (onCompile && config && (config?.compilationCount || 0) > 0) {

--- a/packages/rspack/lib/processes.js
+++ b/packages/rspack/lib/processes.js
@@ -71,6 +71,22 @@ import {
 } from "./logging";
 import { isMeteorAppProfile } from "../../tools-core/lib/meteor";
 
+function recordRsdoctorPorts(config) {
+  const ports = [
+    ["rsdoctorClientPort", "RSDOCTOR_CLIENT_PORT", "client"],
+    ["rsdoctorServerPort", "RSDOCTOR_SERVER_PORT", "server"],
+  ];
+
+  for (const [configKey, envKey, label] of ports) {
+    const port = config?.[configKey];
+    if (!port) continue;
+    process.env[envKey] = String(port);
+    logRaw(
+      `=> Started Rsdoctor ${label} analyzer at http://localhost:${port}/`,
+    );
+  }
+}
+
 /**
  * Helper function to check for a file with different extensions in order of priority
  * @param {string} basePath - The base directory path (without 'rspack.config' and extension)
@@ -175,7 +191,7 @@ export function getRspackCliPath() {
     if (bin) {
       return path.join(path.dirname(pkgPath), bin);
     }
-  } catch (err) {
+  } catch {
     // Fall through to hardcoded fallback if package.json isn't exported
   }
 
@@ -431,6 +447,7 @@ export function startRspackClientServe(options = {}) {
       env: inheritMeteorToolNodeFlags({ ...process.env, ...getNodeBinEnv(), ...envs }),
       onStdout: (data) => {
         const { cleanedData, config } = parseMeteorRspackOutput(data);
+        recordRsdoctorPorts(config);
         if (config?.devServerUrl) {
           process.env.RSPACK_DEVSERVER_PORT = new URL(config.devServerUrl).port;
           logHmrServerStarted(config);
@@ -536,6 +553,7 @@ export function startRspackServerWatch(options = {}) {
     env: inheritMeteorToolNodeFlags({ ...process.env, ...getNodeBinEnv(), ...envs }),
     onStdout: (data) => {
       const { cleanedData, config } = parseMeteorRspackOutput(data);
+      recordRsdoctorPorts(config);
       if (onCompile && config && (config?.compilationCount || 0) > 0) {
         onCompile(cleanedData, config);
       }
@@ -626,6 +644,7 @@ export async function runRspackBuild({ isClient, isServer, isTest, isTestModule,
       env: inheritMeteorToolNodeFlags({ ...process.env, ...getNodeBinEnv(), ...envs }),
       onStdout: (data) => {
         const { cleanedData, config } = parseMeteorRspackOutput(data);
+        recordRsdoctorPorts(config);
         if (onCompile && config && (config?.compilationCount || 0) > 0) {
           onCompile(cleanedData, config);
         }

--- a/packages/rspack/rspack_plugin.js
+++ b/packages/rspack/rspack_plugin.js
@@ -39,9 +39,6 @@ const {
   runRspackBuild,
   cleanup,
   cleanupSync,
-  calculateDevServerPort,
-  calculateRsdoctorClientPort,
-  calculateRsdoctorServerPort,
   getConfigFilePath,
   getCustomConfigFilePath,
 } = require('./lib/processes');
@@ -73,7 +70,6 @@ const {
   isMeteorAppDebug,
   isMeteorAppConfigModernVerbose,
   isMeteorAppNative,
-  isMeteorBundleVisualizerProject,
 } = require('meteor/tools-core/lib/meteor');
 
 const {
@@ -183,36 +179,11 @@ if (isMeteorAppRun() || isMeteorAppBuild() || isMeteorAppTest()) {
       process.env.RSPACK_NATIVE = 'true';
     }
 
-    // Calculate and set the devServerPort at boot
-    if (!process.env.RSPACK_DEVSERVER_PORT) {
-      process.env.RSPACK_DEVSERVER_PORT = calculateDevServerPort();
-      if (isMeteorAppDebug() || isMeteorAppConfigModernVerbose()) {
-        logInfo(`[i] Rspack DevServer Port: ${process.env.RSPACK_DEVSERVER_PORT}`);
-      }
-    }
-
     if (isMeteorAppDebug() || isMeteorAppConfigModernVerbose()) {
       const configFile = getConfigFilePath();
       logInfo(`[i] Rspack default config: ${configFile}`);
       const projectConfigFile = getCustomConfigFilePath();
       logInfo(`[i] Rspack custom config: ${projectConfigFile}`);
-    }
-
-    // Calculate and set the Rsdoctor client and server ports at boot only if bundle visualizer is enabled
-    if (isMeteorBundleVisualizerProject()) {
-      if (!process.env.RSDOCTOR_CLIENT_PORT) {
-        process.env.RSDOCTOR_CLIENT_PORT = calculateRsdoctorClientPort();
-        if (isMeteorAppDebug() || isMeteorAppConfigModernVerbose()) {
-          logInfo(`[i] Rsdoctor Client Port: ${process.env.RSDOCTOR_CLIENT_PORT}`);
-        }
-      }
-
-      if (!process.env.RSDOCTOR_SERVER_PORT) {
-        process.env.RSDOCTOR_SERVER_PORT = calculateRsdoctorServerPort();
-        if (isMeteorAppDebug() || isMeteorAppConfigModernVerbose()) {
-          logInfo(`[i] Rsdoctor Server Port: ${process.env.RSDOCTOR_SERVER_PORT}`);
-        }
-      }
     }
 
     // Register cleanup handlers. SIGTERM is forwarded by orchestrators (Docker,

--- a/tools/e2e-tests/jest.setup.js
+++ b/tools/e2e-tests/jest.setup.js
@@ -9,8 +9,6 @@ process.env.NODE_ENV = '';
 // Individual tests may override via the `devServerPort` option in testMeteorSkeleton /
 // testMeteorBundler, which sets this env var per test run.
 process.env.RSPACK_DEVSERVER_PORT = '18080';
-process.env.RSDOCTOR_CLIENT_PORT = '8888';
-process.env.RSDOCTOR_SERVER_PORT = '8889';
 
 // Client-rendered frameworks (Angular, React, Vue, etc.) may take longer to
 // hydrate on slow CI runners. Increase Playwright's default selector/action

--- a/tools/e2e-tests/react.test.js
+++ b/tools/e2e-tests/react.test.js
@@ -4,9 +4,9 @@ import {
   killMeteorProcess,
   createMeteorApp,
   runMeteorApp,
-  waitForMeteorOutput, waitForPlaywrightConsole
+  waitForMeteorOutput
 } from "./helpers";
-import { testMeteorBundler, testMeteorRspackBundler } from './test-helpers';
+import { testMeteorRspackBundler } from './test-helpers';
 import fs from 'fs-extra';
 import path from 'path';
 import { assertMeteorReactApp, assertConsoleEval, assertFileExist } from "./assertions";
@@ -45,7 +45,7 @@ describe('React App Bundling /', () => {
       expect(packageJson.dependencies).toHaveProperty('react-dom');
 
       // Run the newly created app
-      let runAppProcess = (await runMeteorApp(newAppTempDir, PORT))?.meteorProcess;
+      const runAppProcess = (await runMeteorApp(newAppTempDir, PORT))?.meteorProcess;
 
       // Assert that the Meteor React app is running correctly
       await assertMeteorReactApp(PORT);
@@ -77,6 +77,7 @@ describe('React App Bundling /', () => {
       configFile: "rspack.config.cjs",
       buildDir: "_build-local-custom",
       env: { METEOR_LOCAL_DIR: ".meteor/local-custom" },
+      testBundleVisualizer: true,
       customAssertions: {
         afterInit: async ({ result }) => {
           // Verify unplugin transform hook is called on first run (fresh cache)

--- a/tools/e2e-tests/regressions/port-cleanup.test.js
+++ b/tools/e2e-tests/regressions/port-cleanup.test.js
@@ -9,6 +9,20 @@ import {
 } from '../helpers';
 import { assertMeteorReactApp } from '../assertions';
 import { setupMeteorRspackApp } from '../test-helpers';
+import { formatDevServerHost } from '../../../npm-packages/meteor-rspack/lib/meteorRspackHelpers';
+
+describe("Rspack dev-server URL /", () => {
+  test.each([
+    ["::", "[::]"],
+    ["::1", "[::1]"],
+    ["127.0.0.1", "127.0.0.1"],
+    ["localhost", "localhost"],
+  ])("formats host %s as %s", (host, expected) => {
+    const formattedHost = formatDevServerHost(host);
+    expect(formattedHost).toBe(expected);
+    expect(new URL(`http://${formattedHost}:49152`).port).toBe("49152");
+  });
+});
 
 function isPortAvailable(port) {
   return new Promise((resolve) => {

--- a/tools/e2e-tests/regressions/port-cleanup.test.js
+++ b/tools/e2e-tests/regressions/port-cleanup.test.js
@@ -3,12 +3,14 @@ import {
   cleanupTempDir,
   killMeteorProcess,
   killProcessByPort,
+  killStrayAppProcesses,
   runMeteorApp,
   wait,
 } from '../helpers';
+import { assertMeteorReactApp } from '../assertions';
 import { setupMeteorRspackApp } from '../test-helpers';
 
-function isPortAvailable(port, host = '127.0.0.1') {
+function isPortAvailable(port) {
   return new Promise((resolve) => {
     const server = net.createServer();
 
@@ -20,7 +22,22 @@ function isPortAvailable(port, host = '127.0.0.1') {
       server.close(() => resolve(true));
     });
 
-    server.listen(port, host);
+    server.listen(port);
+  });
+}
+
+function listenOnPort(port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(port, () => resolve(server));
+  });
+}
+
+function closeServer(server) {
+  if (!server?.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
   });
 }
 
@@ -45,8 +62,11 @@ async function waitForPortState(predicate, { timeout = 5000, interval = 100 } = 
 describe("Regressions / PortCleanup /", () => {
   const port = 3146;
   const rspackPort = 18146;
+  // origin/devel derives 8091 as 8077 + the digit sum of app port 3146.
+  const oldDerivedRspackPort = 8091;
   let tempDir;
   let meteorProcess;
+  let occupiedPortServer;
 
   beforeAll(async () => {
     ({ tempDir } = await setupMeteorRspackApp({ appName: "react" }));
@@ -54,18 +74,25 @@ describe("Regressions / PortCleanup /", () => {
 
   afterAll(async () => {
     await killMeteorProcess(meteorProcess);
-    await killProcessByPort([port, rspackPort]);
+    await closeServer(occupiedPortServer);
+    await killStrayAppProcesses();
+    await killProcessByPort([port, rspackPort, oldDerivedRspackPort]);
     await cleanupTempDir(tempDir);
   });
 
   beforeEach(async () => {
     meteorProcess = null;
-    await killProcessByPort([port, rspackPort]);
+    occupiedPortServer = null;
+    await killProcessByPort([port, rspackPort, oldDerivedRspackPort]);
   });
 
   afterEach(async () => {
     await killMeteorProcess(meteorProcess);
-    await killProcessByPort([port, rspackPort]);
+    meteorProcess = null;
+    await closeServer(occupiedPortServer);
+    occupiedPortServer = null;
+    await killStrayAppProcesses();
+    await killProcessByPort([port, rspackPort, oldDerivedRspackPort]);
   });
 
   test("releases rspack port after SIGTERM", async () => {
@@ -92,5 +119,35 @@ describe("Regressions / PortCleanup /", () => {
       timeout: 5000,
       interval: 100,
     });
+  });
+
+  test("starts on a different HMR port when the derived port is occupied", async () => {
+    occupiedPortServer = await listenOnPort(oldDerivedRspackPort);
+
+    const previousRspackDevServerPort = process.env.RSPACK_DEVSERVER_PORT;
+    delete process.env.RSPACK_DEVSERVER_PORT;
+    let result;
+    try {
+      result = await runMeteorApp(tempDir, port, {
+        waitForOutput: /=> Started Rspack HMR server at /,
+        failOnOutput: /EADDRINUSE/,
+      });
+    } finally {
+      if (previousRspackDevServerPort === undefined) {
+        delete process.env.RSPACK_DEVSERVER_PORT;
+      } else {
+        process.env.RSPACK_DEVSERVER_PORT = previousRspackDevServerPort;
+      }
+    }
+
+    meteorProcess = result.meteorProcess;
+    const hmrLine = result.outputLines.find((line) =>
+      line.includes("=> Started Rspack HMR server at ")
+    );
+    const hmrPortMatch = hmrLine?.match(/Started Rspack HMR server at .+:(\d+)\//);
+
+    expect(hmrPortMatch).not.toBeNull();
+    expect(Number(hmrPortMatch[1])).not.toBe(oldDerivedRspackPort);
+    await assertMeteorReactApp(port);
   });
 });

--- a/tools/e2e-tests/regressions/port-cleanup.test.js
+++ b/tools/e2e-tests/regressions/port-cleanup.test.js
@@ -6,13 +6,11 @@ import {
   killStrayAppProcesses,
   runMeteorApp,
   wait,
+  waitForMeteorOutput,
 } from '../helpers';
 import { assertMeteorReactApp } from '../assertions';
 import { setupMeteorRspackApp } from '../test-helpers';
-import {
-  formatDevServerHost,
-  getRsdoctorPort,
-} from '../../../npm-packages/meteor-rspack/lib/meteorRspackHelpers';
+import { formatDevServerHost } from '../../../npm-packages/meteor-rspack/lib/meteorRspackHelpers';
 
 describe("Rspack dev-server URL /", () => {
   test.each([
@@ -24,18 +22,6 @@ describe("Rspack dev-server URL /", () => {
     const formattedHost = formatDevServerHost(host);
     expect(formattedHost).toBe(expected);
     expect(new URL(`http://${formattedHost}:49152`).port).toBe("49152");
-  });
-});
-
-describe("Rsdoctor port selection /", () => {
-  test("keeps automatic client and server ports distinct", () => {
-    expect(getRsdoctorPort(true)).toBe(8888);
-    expect(getRsdoctorPort(false)).toBe(8889);
-  });
-
-  test("preserves configured client and server ports", () => {
-    expect(getRsdoctorPort(true, "9100", "9200")).toBe(9100);
-    expect(getRsdoctorPort(false, "9100", "9200")).toBe(9200);
   });
 });
 
@@ -53,6 +39,15 @@ function isPortAvailable(port) {
 
     server.listen(port);
   });
+}
+
+async function isUrlReachable(port) {
+  try {
+    await fetch(`http://127.0.0.1:${port}/`);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function listenOnPort(port) {
@@ -88,14 +83,26 @@ async function waitForPortState(predicate, { timeout = 5000, interval = 100 } = 
   }
 }
 
+async function stopMeteorAndAssertPortsReleased(meteorProcess, ports) {
+  const exitPromise = waitForProcessExit(meteorProcess);
+  meteorProcess.kill("SIGTERM");
+  await exitPromise;
+  await Promise.all(
+    ports.map((port) => waitForPortState(() => isPortAvailable(port))),
+  );
+}
+
 describe("Regressions / PortCleanup /", () => {
   const port = 3146;
   const rspackPort = 18146;
   // origin/devel derives 8091 as 8077 + the digit sum of app port 3146.
   const oldDerivedRspackPort = 8091;
+  const configuredRsdoctorPorts = [19100, 19200];
+  const occupiedRsdoctorPort = 19300;
   let tempDir;
   let meteorProcess;
   let occupiedPortServer;
+  let rsdoctorPorts;
 
   beforeAll(async () => {
     ({ tempDir } = await setupMeteorRspackApp({ appName: "react" }));
@@ -105,14 +112,28 @@ describe("Regressions / PortCleanup /", () => {
     await killMeteorProcess(meteorProcess);
     await closeServer(occupiedPortServer);
     await killStrayAppProcesses();
-    await killProcessByPort([port, rspackPort, oldDerivedRspackPort]);
+    await killProcessByPort([
+      port,
+      rspackPort,
+      oldDerivedRspackPort,
+      ...configuredRsdoctorPorts,
+      occupiedRsdoctorPort,
+      ...(rsdoctorPorts || []),
+    ]);
     await cleanupTempDir(tempDir);
   });
 
   beforeEach(async () => {
     meteorProcess = null;
     occupiedPortServer = null;
-    await killProcessByPort([port, rspackPort, oldDerivedRspackPort]);
+    rsdoctorPorts = [];
+    await killProcessByPort([
+      port,
+      rspackPort,
+      oldDerivedRspackPort,
+      ...configuredRsdoctorPorts,
+      occupiedRsdoctorPort,
+    ]);
   });
 
   afterEach(async () => {
@@ -121,7 +142,14 @@ describe("Regressions / PortCleanup /", () => {
     await closeServer(occupiedPortServer);
     occupiedPortServer = null;
     await killStrayAppProcesses();
-    await killProcessByPort([port, rspackPort, oldDerivedRspackPort]);
+    await killProcessByPort([
+      port,
+      rspackPort,
+      oldDerivedRspackPort,
+      ...configuredRsdoctorPorts,
+      occupiedRsdoctorPort,
+      ...rsdoctorPorts,
+    ]);
   });
 
   test("releases rspack port after SIGTERM", async () => {
@@ -148,6 +176,89 @@ describe("Regressions / PortCleanup /", () => {
       timeout: 5000,
       interval: 100,
     });
+  });
+
+  // REGRESSION: Meteor guessed Rsdoctor ports, so cleanup could target the wrong process.
+  test("reports Rsdoctor fallback ports and releases them", async () => {
+    occupiedPortServer = await listenOnPort(occupiedRsdoctorPort);
+    const result = await runMeteorApp(tempDir, port, {
+      commandOptions: ["--extra-packages", "bundle-visualizer"],
+      env: {
+        CI: "",
+        RSDOCTOR_CLIENT_PORT: String(occupiedRsdoctorPort),
+        RSDOCTOR_SERVER_PORT: "",
+      },
+      waitForOutput: /=> Started Rsdoctor (client|server) analyzer at /,
+      failOnOutput: /EADDRINUSE/,
+      timeout: 30000,
+    });
+
+    meteorProcess = result.meteorProcess;
+    await Promise.all([
+      waitForMeteorOutput(
+        result.outputLines,
+        /=> Started Rsdoctor client analyzer at http:\/\/localhost:\d+\//,
+        { meteorProcess, timeout: 30000 },
+      ),
+      waitForMeteorOutput(
+        result.outputLines,
+        /=> Started Rsdoctor server analyzer at http:\/\/localhost:\d+\//,
+        { meteorProcess, timeout: 30000 },
+      ),
+    ]);
+
+    rsdoctorPorts = result.outputLines.flatMap((line) => {
+      const match = line.match(
+        /=> Started Rsdoctor (?:client|server) analyzer at http:\/\/localhost:(\d+)\//,
+      );
+      return match ? [Number(match[1])] : [];
+    });
+
+    expect(rsdoctorPorts).toHaveLength(2);
+    expect(new Set(rsdoctorPorts).size).toBe(2);
+    expect(rsdoctorPorts).not.toContain(occupiedRsdoctorPort);
+    await Promise.all(
+      rsdoctorPorts.map((rsdoctorPort) =>
+        waitForPortState(() => isUrlReachable(rsdoctorPort)),
+      ),
+    );
+    await stopMeteorAndAssertPortsReleased(meteorProcess, rsdoctorPorts);
+    meteorProcess = null;
+  });
+
+  test("preserves configured Rsdoctor ports", async () => {
+    const [clientPort, serverPort] = configuredRsdoctorPorts;
+    const result = await runMeteorApp(tempDir, port, {
+      commandOptions: ["--extra-packages", "bundle-visualizer"],
+      env: {
+        CI: "",
+        RSDOCTOR_CLIENT_PORT: String(clientPort),
+        RSDOCTOR_SERVER_PORT: String(serverPort),
+      },
+      waitForOutput: /=> Started Rsdoctor (client|server) analyzer at /,
+      failOnOutput: /EADDRINUSE/,
+      timeout: 30000,
+    });
+
+    meteorProcess = result.meteorProcess;
+    await Promise.all([
+      waitForMeteorOutput(
+        result.outputLines,
+        `=> Started Rsdoctor client analyzer at http://localhost:${clientPort}/`,
+        { meteorProcess, timeout: 30000 },
+      ),
+      waitForMeteorOutput(
+        result.outputLines,
+        `=> Started Rsdoctor server analyzer at http://localhost:${serverPort}/`,
+        { meteorProcess, timeout: 30000 },
+      ),
+    ]);
+
+    await Promise.all(
+      configuredRsdoctorPorts.map((rsdoctorPort) =>
+        waitForPortState(() => isUrlReachable(rsdoctorPort)),
+      ),
+    );
   });
 
   test("starts on a different HMR port when the derived port is occupied", async () => {

--- a/tools/e2e-tests/regressions/port-cleanup.test.js
+++ b/tools/e2e-tests/regressions/port-cleanup.test.js
@@ -9,7 +9,10 @@ import {
 } from '../helpers';
 import { assertMeteorReactApp } from '../assertions';
 import { setupMeteorRspackApp } from '../test-helpers';
-import { formatDevServerHost } from '../../../npm-packages/meteor-rspack/lib/meteorRspackHelpers';
+import {
+  formatDevServerHost,
+  getRsdoctorPort,
+} from '../../../npm-packages/meteor-rspack/lib/meteorRspackHelpers';
 
 describe("Rspack dev-server URL /", () => {
   test.each([
@@ -21,6 +24,18 @@ describe("Rspack dev-server URL /", () => {
     const formattedHost = formatDevServerHost(host);
     expect(formattedHost).toBe(expected);
     expect(new URL(`http://${formattedHost}:49152`).port).toBe("49152");
+  });
+});
+
+describe("Rsdoctor port selection /", () => {
+  test("keeps automatic client and server ports distinct", () => {
+    expect(getRsdoctorPort(true)).toBe(8888);
+    expect(getRsdoctorPort(false)).toBe(8889);
+  });
+
+  test("preserves configured client and server ports", () => {
+    expect(getRsdoctorPort(true, "9100", "9200")).toBe(9100);
+    expect(getRsdoctorPort(false, "9100", "9200")).toBe(9200);
   });
 });
 

--- a/tools/e2e-tests/scripts/link-rspack.js
+++ b/tools/e2e-tests/scripts/link-rspack.js
@@ -6,8 +6,8 @@
  *
  * Steps:
  *   1. Run `meteor update --npm` in the app
- *   2. Install the matching @rspack/core and @rspack/cli versions into the
- *      local meteor-rspack package (read from packages/rspack/lib/constants.js)
+ *   2. Install the matching Rspack and Rsdoctor versions into the local
+ *      meteor-rspack package (read from packages/rspack/lib/constants.js)
  *   3. Install `ignore-loader` in the app
  *   4. `npm link` the local meteor-rspack into the app
  *
@@ -49,17 +49,25 @@ async function linkLocalRspack(appDir, { env } = {}) {
     /DEFAULT_RSPACK_VERSION\s*=\s*['"]([^'"]+)['"]/
   );
   const rspackVersion = rspackVersionMatch?.[1];
-  if (rspackVersion) {
-    console.log(`Installing @rspack/core@${rspackVersion} and @rspack/cli@${rspackVersion}...`);
+  const rsdoctorVersion = constantsContent.match(
+    /DEFAULT_RSDOCTOR_RSPACK_PLUGIN_VERSION\s*=\s*['"]([^'"]+)['"]/
+  )?.[1];
+  const localDependencies = [
+    ...(rspackVersion
+      ? [`@rspack/core@${rspackVersion}`, `@rspack/cli@${rspackVersion}`]
+      : []),
+    ...(rsdoctorVersion
+      ? [
+          `@rsdoctor/rspack-plugin@${rsdoctorVersion}`,
+          `@rsdoctor/core@${rsdoctorVersion}`,
+        ]
+      : []),
+  ];
+  if (localDependencies.length > 0) {
+    console.log(`Installing ${localDependencies.join(' and ')}...`);
     await execa(
       'npm',
-      [
-        'install',
-        `@rspack/core@${rspackVersion}`,
-        `@rspack/cli@${rspackVersion}`,
-        '--no-save',
-        '--no-package-lock',
-      ],
+      ['install', ...localDependencies, '--no-save', '--no-package-lock'],
       { cwd: RSPACK_PACKAGE_DIR }
     );
   }

--- a/tools/e2e-tests/test-helpers.js
+++ b/tools/e2e-tests/test-helpers.js
@@ -35,7 +35,6 @@ import {
 import fs from "fs-extra";
 import path from "path";
 import execa from "execa";
-import waitOn from "wait-on";
 
 const isCI = process.env.GITHUB_ACTIONS === "true";
 // Link local npm-packages/meteor-rspack so tests run against the latest dev version.
@@ -633,12 +632,13 @@ export function testMeteorRspackBundler(options) {
           waitForOutput: "=> App running at",
           commandOptions: ['--extra-packages', 'bundle-visualizer', '--production'],
           isMonorepo,
-          env: env.meteorRunProduction
+          env: { ...env, ...(env.meteorRunProduction || {}) },
         });
         meteorProcess = result.meteorProcess;
 
-        // Wait for a margin
-        await wait(WAIT_ON);
+        await waitForMeteorOutput(result.outputLines, /Rsdoctor v\d+\.\d+\.\d+/, {
+          meteorProcess,
+        });
 
         // Assert that the app files exists
         await assertFileExist(appDir, `${buildDir}/main-prod/client-entry.js`);
@@ -648,25 +648,11 @@ export function testMeteorRspackBundler(options) {
         await assertFileExist(appDir, `${buildDir}/main-prod/server-rspack.js`);
         await assertFileExist(appDir, `${buildDir}/main-prod/server-meteor.js`);
         await assertFileExist(appDir, `${buildDir}/main-prod/index.html`);
+        await assertFileExist(appDir, 'public/.rsdoctor/manifest.json');
+        await assertFileExist(appDir, 'private/.rsdoctor/manifest.json');
 
         // Assert that the Meteor app is running correctly
         await assertMeteorReactApp(port, { title: appName });
-
-        // Wait for bundle-visualizer ports to be available
-        console.log('Waiting for bundle-visualizer ports 8081 and 8082 to be available...');
-        try {
-          await waitOn({
-            resources: [
-              `http-get://localhost:8081`,
-              `http-get://localhost:8082`
-            ],
-            timeout: 30000
-          });
-          console.log('Bundle-visualizer ports 8081 and 8082 are available');
-        } catch (error) {
-          console.error('Error waiting for bundle-visualizer ports:', error);
-          throw error;
-        }
 
         // Run custom assertions if provided
         if (customAssertions && customAssertions.afterRunBundleVisualizer) {
@@ -989,10 +975,6 @@ export function testMeteorRspackBundler(options) {
  * @param {string} options.skeletonName - Name of the skeleton to test (e.g., 'react', 'apollo', 'vue')
  * @param {string} options.title - Title to use for assertions (defaults to skeletonName if not provided)
  * @param {number} options.port - Port to run the app on
- * @param {Object} options.filePaths - File paths for the app
- * @param {string} options.filePaths.client - Client file path (e.g., 'client/main.jsx')
- * @param {string} options.filePaths.server - Server file path (e.g., 'server/main.js')
- * @param {string} options.filePaths.test - Test file path (e.g., 'tests/main.js')
  * @param {Object} options.customAssertions - Custom assertions to run after each step
  * @param {Function} options.customAssertions.afterCreate - Custom assertions to run after creating the app
  * @param {Function} options.customAssertions.afterRun - Custom assertions to run after running the app
@@ -1016,11 +998,6 @@ export function testMeteorSkeleton(options) {
     // Rspack dev server port. Defaults to 18080 to avoid colliding with dev servers
     // that some skeletons bundle on :8080 (e.g. Angular CLI's webpack-dev-server).
     devServerPort = 18080,
-    filePaths = {
-      client: "client/main.jsx",
-      server: "server/main.js",
-      test: "tests/main.js"
-    },
     customAssertions = {},
     checkBodyStyles = true,
     checkAppTitle = true,


### PR DESCRIPTION
## Problem

Meteor derived the Rspack dev-server and Rsdoctor ports from the Meteor app port. The calculation used the sum of the app port's digits.

Two app ports with the same digit sum selected the same dev-server port. For example, `PORT=3000` and `PORT=1200` both selected port 8080. The second dev server then failed with `EADDRINUSE`, or its HMR client fetched assets from the other app.

## Fix

Use Rspack's native automatic port selection when `RSPACK_DEVSERVER_PORT` is not set. The dev server binds its listening socket once, so there is no probe-then-bind race.

The `onListening` callback reads the actual port from `devServer.server.address()`. It reports that port to the Meteor parent before the app proxy starts. The parent stores the port in `RSPACK_DEVSERVER_PORT` for the existing proxy and cleanup paths.

An explicit `RSPACK_DEVSERVER_PORT` still works. Dev-server URLs now bracket IPv6 literals before the URL reaches the parent process.

Meteor also stops predicting Rsdoctor ports. If an analyzer port is not configured, Rsdoctor selects an available port through its own allocation code. Meteor waits for Rsdoctor startup, reads each bound port from the plugin SDK, and reports it to the parent process. The parent stores both ports for logging and cleanup.

Explicit `RSDOCTOR_CLIENT_PORT` and `RSDOCTOR_SERVER_PORT` values still work. If a preferred port is occupied, Rsdoctor selects another port and Meteor tracks the selected port.

In production, Rsdoctor disables its HTTP servers and writes report manifests under `public/.rsdoctor` and `private/.rsdoctor`.

## Tests

The E2E regression covers these cases:

- Rspack selects a different HMR port when the old derived port is occupied.
- Meteor reports both automatic Rsdoctor ports and releases them after `SIGTERM`.
- Rsdoctor selects another port when a configured preferred port is occupied.
- Explicit Rsdoctor client and server ports remain unchanged.
- Dev-server URLs support IPv4 addresses, IPv6 addresses, and hostnames.

Focused results:

- Full port-cleanup regression: 8 passed with retries disabled
- `./packages/test-in-console/run.sh rspack`: 3 passed
- Changed-file Oxlint: 0 errors
- Oxfmt, Node syntax checks, and `git diff --check`: clean

No package version bump. Release commits handle package versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Development servers now automatically select an available port, reducing startup failures caused by port conflicts.
  * Correct development-server URLs are reported for IPv4 and IPv6 addresses.
  * Hot Module Reloading continues to work when a previously derived port is unavailable.
  * Improved cleanup prevents leftover processes and occupied ports from affecting subsequent runs.

* **Developer Experience**
  * Development startup output is more reliable with default or custom server configurations.
  * Bundle analysis now works more consistently across development and production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->