### PR TITLE
fix(tools-core): getGlobalState reads the wrong store and always returns the default

### DIFF
--- a/packages/tools-core/lib/global-state.js
+++ b/packages/tools-core/lib/global-state.js
@@ -1,6 +1,10 @@
 /**
  * Global state management for Meteor packages.
  * This module provides a way to store and retrieve global state that persists across file changes.
+ *
+ * State lives on `Package.meteor.global.persistentState`. The `meteor`
+ * package's exported `global` object survives build-plugin re-instantiation
+ * on rebuilds, which is what makes this state "persistent".
  */
 
 /**
@@ -10,9 +14,8 @@
  * @returns {any} The value associated with the key, or the default value if not found.
  */
 export function getGlobalState(key, defaultValue) {
-  return Package.meteor?.global?.[key] !== undefined
-    ? Package.meteor.global.persistentState[key]
-    : defaultValue;
+  const value = Package.meteor?.global?.persistentState?.[key];
+  return value !== undefined ? value : defaultValue;
 }
 
 /**
@@ -21,12 +24,17 @@ export function getGlobalState(key, defaultValue) {
  * @param {any} value - The value to associate with the key.
  */
 export function setGlobalState(key, value) {
-  // Create a namespace for our global state if it doesn't exist
-  if (!Package?.meteor.global.persistentState) {
-    Package.meteor.global.persistentState = {};
+  const meteorGlobal = Package.meteor?.global;
+  if (!meteorGlobal) {
+    return;
   }
 
-  Package.meteor.global.persistentState[key] = value;
+  // Create a namespace for our global state if it doesn't exist
+  if (!meteorGlobal.persistentState) {
+    meteorGlobal.persistentState = {};
+  }
+
+  meteorGlobal.persistentState[key] = value;
 }
 
 /**
@@ -34,12 +42,18 @@ export function setGlobalState(key, value) {
  * @param {string} key - The key to remove.
  */
 export function removeGlobalState(key) {
-  delete Package.meteor.global.persistentState[key];
+  const state = Package.meteor?.global?.persistentState;
+  if (state) {
+    delete state[key];
+  }
 }
 
 /**
  * Clears all keys from the global state.
  */
 export function clearGlobalState() {
-  Package.meteor.global.persistentState = {};
+  const meteorGlobal = Package.meteor?.global;
+  if (meteorGlobal) {
+    meteorGlobal.persistentState = {};
+  }
 }

--- a/packages/tools-core/package.js
+++ b/packages/tools-core/package.js
@@ -18,5 +18,6 @@ Package.onTest(function (api) {
   // This structure allows easy addition of tests for other lib/ categories
   api.addFiles([
     'tests/meteor_tests.js',
+    'tests/global_state_tests.js',
   ], 'server');
 });

--- a/packages/tools-core/tests/global_state_tests.js
+++ b/packages/tools-core/tests/global_state_tests.js
@@ -1,0 +1,143 @@
+import {
+  getGlobalState,
+  setGlobalState,
+  removeGlobalState,
+  clearGlobalState,
+} from "../lib/global-state.js";
+
+// Each test starts from a pristine state, including the "module has never
+// been written to" case where the persistentState namespace does not exist.
+function resetPersistentState() {
+  delete Package.meteor.global.persistentState;
+}
+
+Tinytest.add(
+  "tools-core - global-state - set then get returns the stored value",
+  function (test) {
+    // Regression: getGlobalState used to guard on
+    // Package.meteor.global[key] while values are only ever written to
+    // Package.meteor.global.persistentState[key], so every read returned
+    // the default value and stored state was invisible to all consumers.
+    resetPersistentState();
+
+    setGlobalState("someKey", "stored");
+
+    test.equal(
+      getGlobalState("someKey", "fallback"),
+      "stored",
+      "get should return the value previously stored with set"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - global-state - falsy stored values are returned, not the default",
+  function (test) {
+    resetPersistentState();
+
+    setGlobalState("boolKey", false);
+    setGlobalState("zeroKey", 0);
+    setGlobalState("nullKey", null);
+    setGlobalState("emptyKey", "");
+
+    test.equal(getGlobalState("boolKey", true), false, "false should round-trip");
+    test.equal(getGlobalState("zeroKey", 42), 0, "0 should round-trip");
+    test.equal(getGlobalState("nullKey", "default"), null, "null should round-trip");
+    test.equal(getGlobalState("emptyKey", "default"), "", "empty string should round-trip");
+  }
+);
+
+Tinytest.add(
+  "tools-core - global-state - missing key returns the default value",
+  function (test) {
+    resetPersistentState();
+
+    setGlobalState("otherKey", "value");
+
+    test.equal(
+      getGlobalState("missingKey", "fallback"),
+      "fallback",
+      "get should fall back to the default for keys that were never set"
+    );
+    test.isUndefined(
+      getGlobalState("missingKey"),
+      "get without a default should return undefined for missing keys"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - global-state - get before any set returns the default without throwing",
+  function (test) {
+    resetPersistentState();
+
+    test.equal(
+      getGlobalState("neverSet", "fallback"),
+      "fallback",
+      "get should work even when the persistentState namespace does not exist yet"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - global-state - remove deletes only the given key",
+  function (test) {
+    resetPersistentState();
+
+    setGlobalState("keepMe", "kept");
+    setGlobalState("removeMe", "gone");
+
+    removeGlobalState("removeMe");
+
+    test.equal(
+      getGlobalState("removeMe", "fallback"),
+      "fallback",
+      "removed key should fall back to the default"
+    );
+    test.equal(
+      getGlobalState("keepMe", "fallback"),
+      "kept",
+      "other keys should be untouched by remove"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - global-state - remove before any set does not throw",
+  function (test) {
+    // Regression: removeGlobalState dereferenced
+    // Package.meteor.global.persistentState unconditionally and threw a
+    // TypeError when nothing had been stored yet.
+    resetPersistentState();
+
+    removeGlobalState("neverSet");
+
+    test.equal(
+      getGlobalState("neverSet", "fallback"),
+      "fallback",
+      "state should still behave normally after a no-op remove"
+    );
+  }
+);
+
+Tinytest.add(
+  "tools-core - global-state - clear removes all keys",
+  function (test) {
+    resetPersistentState();
+
+    setGlobalState("a", 1);
+    setGlobalState("b", 2);
+
+    clearGlobalState();
+
+    test.equal(getGlobalState("a", "fallback"), "fallback", "cleared key a");
+    test.equal(getGlobalState("b", "fallback"), "fallback", "cleared key b");
+
+    setGlobalState("c", 3);
+    test.equal(
+      getGlobalState("c", "fallback"),
+      3,
+      "state should be writable again after clear"
+    );
+  }
+);


### PR DESCRIPTION
## Problem

`getGlobalState` in `packages/tools-core/lib/global-state.js` guards on
`Package.meteor?.global?.[key]` but returns `Package.meteor.global.persistentState[key]`.
Since `setGlobalState` only ever writes into `persistentState`, the guard is
always `undefined`, so **every read returns the default value** — stored state
is invisible to all consumers.

This silently breaks every `getGlobalState` caller. In the rspack build plugin
alone that's the `CLIENT_PROCESS`/`SERVER_PROCESS` reuse guards, the
`*_CHECKED` install flags, first-compile tracking, `INITIAL_ENTRYPONTS`, and
`BUILD_CONTEXT_FILES_CLEANED` — all dead reads. It's likely why other code
falls back to `process.env` flags (e.g. `RSPACK_FIRST_COMPILATION_COMPLETE`)
for cross-execution persistence.

`removeGlobalState`/`clearGlobalState` and `setGlobalState`'s namespace guard
have a related issue: they throw `TypeError` when nothing has ever been stored
(the `persistentState` namespace doesn't exist yet).

## Fix

- `getGlobalState` reads `Package.meteor?.global?.persistentState?.[key]` — the
  same store `setGlobalState` writes to.
- `setGlobalState` guards the full path before creating the namespace.
- `removeGlobalState`/`clearGlobalState` no-op safely when nothing was stored.

## Tests

New tinytest suite `packages/tools-core/tests/global_state_tests.js` (wired via
the existing `Package.onTest`): set/get roundtrip, falsy-value roundtrip,
missing-key default, remove, clear, and the "never written" edge cases.

Against unpatched `devel`: `5 / 19` fail (roundtrip returns the default; remove
throws `TypeError`). With the fix: `19 / 19` pass. Also smoke-tested that the
rspack build plugin builds and runs against the fixed module.

## Notes

No package version bump — following the convention that `packages/tools-core`
versions are bumped only in release commits.

_Draft: opening for early feedback; happy to adjust._
