### PR TITLE
test(e2e): fail fast when the test app directory is missing

### DIFF
--- a/tools/e2e-tests/scripts/link-rspack.js
+++ b/tools/e2e-tests/scripts/link-rspack.js
@@ -23,6 +23,18 @@ const RSPACK_PACKAGE_DIR = path.join(REPO_ROOT, 'npm-packages', 'meteor-rspack')
 const CONSTANTS_PATH = path.join(REPO_ROOT, 'packages', 'rspack', 'lib', 'constants.js');
 
 async function linkLocalRspack(appDir, { env } = {}) {
+  if (!appDir || !fs.existsSync(appDir)) {
+    // Fail fast with the real story: when an earlier app-creation phase
+    // fails or times out, the suite's shared tempDir stays undefined and
+    // this used to surface as a confusing "missing projectDir!" from a
+    // `meteor update --npm` spawned with cwd undefined (i.e. the jest
+    // working directory), burying the initiating error.
+    throw new Error(
+      `linkLocalRspack: invalid app directory (${appDir}). ` +
+      'The test app was probably never created - look at the earlier ' +
+      'app-creation step in this suite for the initiating failure.'
+    );
+  }
   const execOpts = env ? { env: { ...process.env, ...env } } : {};
 
   console.log(`Running meteor update --npm in ${appDir}...`);

--- a/tools/e2e-tests/test-helpers.js
+++ b/tools/e2e-tests/test-helpers.js
@@ -91,6 +91,9 @@ export function testMeteorBundler(options) {
 
       // Setup the Meteor app
       tempDir = (await setupMeteorApp(appName))?.tempDir;
+      if (!tempDir) {
+        throw new Error(`setupMeteorApp("${appName}") did not return an app directory`);
+      }
 
       // Link local meteor-rspack so the app picks up the latest dev version
       await linkLocalRspack(tempDir);
@@ -276,6 +279,9 @@ export function testMeteorRspackBundler(options) {
 
       // Setup the Meteor app
       tempDir = (await setupMeteorApp(appName, { isMonorepo }))?.tempDir;
+      if (!tempDir) {
+        throw new Error(`setupMeteorApp("${appName}") did not return an app directory`);
+      }
 
       // Wait for a margin
       await wait(WAIT_ON);


### PR DESCRIPTION
Small e2e-harness hardening, split out from the rspack PR series.

When an app-creation phase in a skeleton suite fails or times out, the suite's shared `tempDir` stays `undefined`, and later phases call `linkLocalRspack(undefined)`. `meteor update --npm` then runs from the jest working directory and dies with a cryptic `Error: missing projectDir!` (thrown from `ProjectContext`), burying the failure that actually started the cascade - we hit exactly this while triaging e2e failures on #14567.

Two guards:

- `tools/e2e-tests/scripts/link-rspack.js`: validate the app directory before spawning anything, with an error message that points at the earlier app-creation step.
- `tools/e2e-tests/test-helpers.js`: stop optional-chaining away a failed `setupMeteorApp` - throw with the app name instead.

No behavior change for passing suites; failing suites now report the initiating phase instead of a misleading downstream error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test diagnostics when temporary test applications are not created successfully.
  * Added clear validation errors for missing or invalid application directories, preventing confusing failures in later setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->