### PR TITLE
fix(isobuild): don't re-discover addAssets files as compilable sources

### DIFF
--- a/tools/isobuild/package-source.js
+++ b/tools/isobuild/package-source.js
@@ -835,6 +835,22 @@ Object.assign(PackageSource.prototype, {
             relPathToSourceObj[source.relPath] = source;
           });
 
+          // Files explicitly declared as assets (api.addAssets) must not be
+          // re-discovered as compilable sources by _findSources below. Assets are
+          // tracked per-arch, but an asset declared on ANY arch (e.g. a `.html`
+          // fixture added for 'server') must never be scanned back in as a source
+          // on a DIFFERENT arch where its extension is claimed by a compiler (e.g.
+          // the web/templating html compiler) — that hands a raw asset to the
+          // wrong compiler and aborts the build with a spurious compile error
+          // (see spacebars-tests' assets/markdown_basic.html). Gather asset paths
+          // across all arches; an explicit asset declaration always wins.
+          const assetRelPaths = new Set();
+          Object.keys(api.files).forEach(fileArch => {
+            (api.files[fileArch].assets || []).forEach(asset => {
+              assetRelPaths.add(asset.relPath);
+            });
+          });
+
           self._findSources({
             sourceProcessorSet,
             watchSet,
@@ -854,7 +870,7 @@ Object.assign(PackageSource.prototype, {
                 fileOptions.lazy = false;
               }
 
-            } else {
+            } else if (! assetRelPaths.has(relPath)) {
               const fileOptions = Object.create(null);
 
               // Since this file was not explicitly added with


### PR DESCRIPTION
Forward-port of #14566 to `devel`.

## Why devel needs it too

The same isobuild bug is latent on `devel`: a file declared via `api.addAssets` (e.g. spacebars-tests' `assets/markdown_basic.html`) is re-discovered by `PackageSource#_findSources` as a compilable source on any arch whose compiler claims its extension (the web templating compiler claims `.html`), because `getFiles` dedups auto-discovered paths only against explicitly-added sources, never against declared assets — and assets are tracked per-arch while the collision happens on another arch.

On `devel` the resulting lazy compile error is currently **swallowed** (pre-#10366), so the build silently succeeds; the only symptom would be a runtime "Cannot find module". Once `devel` picks up #10366 ("stop swallowing lazy compilation errors", `c9a0552988`), the same deterministic build abort would appear here too. Fixing the root cause now keeps `devel` correct regardless.

## Fix

Identical to #14566: in `getFiles`, gather asset relPaths across **all arches** and skip any auto-discovered path already declared as an asset. An explicit `api.addAssets` declaration wins over source auto-discovery.

## Verification

Verified on release-3.5.1 (which carries #10366 and so surfaces the abort): `meteor test-packages ./packages/non-core/blaze/packages/spacebars-tests` aborts on `markdown_basic.html` before the change and builds cleanly (reaches `Started proxy / Started MongoDB`) after it. See #14566 for the before/after logs. The `tools/isobuild/package-source.js` file is byte-identical on devel and release-3.5.1, so the fix applies unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where files declared as assets could be incorrectly detected and processed as compilable source files.
  * Asset files are now consistently excluded from source compilation across supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->