### PR TITLE
fix(e2e): give setup-heavy beforeAll hooks their own timeout

### DIFF
--- a/tools/e2e-tests/test-helpers.js
+++ b/tools/e2e-tests/test-helpers.js
@@ -49,6 +49,13 @@ if (!npmLinkLocalRspack) {
 
 const WAIT_ON = isCI ? 2000 : 500;
 
+// The setup beforeAll hooks below do a full `meteor create` + npm install + rspack
+// build, which on a loaded CI runner can exceed Jest's per-test testTimeout (240s on
+// CI, from jest.config.js). The hook then dies at exactly 240000ms and the test
+// bodies never run. Give the setup hooks their own, larger budget; individual test
+// bodies keep the tighter testTimeout.
+const SETUP_HOOK_TIMEOUT_MS = isCI ? 600_000 : 300_000;
+
 const { linkLocalRspack: _linkLocalRspack } = require('./scripts/link-rspack');
 
 async function linkLocalRspack(appDir) {
@@ -94,7 +101,7 @@ export function testMeteorBundler(options) {
 
       // Link local meteor-rspack so the app picks up the latest dev version
       await linkLocalRspack(tempDir);
-    });
+    }, SETUP_HOOK_TIMEOUT_MS);
 
     afterAll(async () => {
       // Clean up the temporary directory
@@ -326,7 +333,7 @@ export function testMeteorRspackBundler(options) {
 
       // Ensure any process on the port is killed
       await killProcessByPort([port, devServerPortStr]);
-    });
+    }, SETUP_HOOK_TIMEOUT_MS);
 
     afterAll(async () => {
       // Clean up the temporary directory
@@ -1006,7 +1013,7 @@ export function testMeteorSkeleton(options) {
 
       // Ensure any process on the port is killed
       await killProcessByPort(port);
-    });
+    }, SETUP_HOOK_TIMEOUT_MS);
 
     afterAll(async () => {
       // Clean up the temporary directory


### PR DESCRIPTION
## Problem

The rspack e2e `beforeAll` hooks in `tools/e2e-tests/test-helpers.js` do a full `meteor create` + `npm install` (root + app) + `meteor add rspack` + a full `meteor` build to install rspack. On a loaded self-hosted CI runner that setup routinely approaches — and sometimes exceeds — Jest's per-test `testTimeout` (`240_000` on CI, from `jest.config.js`). The hook then dies at **exactly 240000ms** and the test bodies never run.

Recurring e2e infra flake — e.g. runs [29035554757](https://github.com/meteor/meteor/actions/runs/29035554757), [29035544468](https://github.com/meteor/meteor/actions/runs/29035544468), [28972278869](https://github.com/meteor/meteor/actions/runs/28972278869) (all `beforeAll` timing out at 240000ms in `test-helpers.js`).

## Fix

Give the three setup `beforeAll` hooks their **own** budget via Jest's per-hook timeout argument (`beforeAll(fn, timeout)`):

```js
const SETUP_HOOK_TIMEOUT_MS = isCI ? 600_000 : 300_000;
```

Individual **test bodies keep the tighter `testTimeout`** (240s), so a genuinely hung test still fails fast — only the known-heavy setup gets more room. No test logic changes; this is purely a timeout budget for the setup hooks.

Alternative considered: bumping the global `testTimeout` — rejected because it would also slacken every test body, making hung tests take longer to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test setup reliability by allowing longer setup operations to complete without timing out, especially in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->