### PR TITLE
fix(e2e): install a current docker CLI (not Debian's docker.io 20.10)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,8 +64,19 @@ jobs:
     steps:
       - name: Install Docker CLI
         run: |
+          # Install a current docker CLI from Docker's official repo. Debian
+          # bookworm's `docker.io` is 20.10 (API 1.41), which the self-hosted
+          # host daemon (Docker 29+, minimum API 1.44) rejects with
+          # "client version 1.41 is too old. Minimum supported API version is 1.44".
           apt-get update
-          apt-get install -y docker.io
+          apt-get install -y ca-certificates curl
+          install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+          chmod a+r /etc/apt/keyrings/docker.asc
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+            > /etc/apt/sources.list.d/docker.list
+          apt-get update
+          apt-get install -y docker-ce-cli
           docker version
           docker ps
           docker system df


### PR DESCRIPTION
## Problem

The **E2E Tests** job container installs Debian bookworm's `docker.io` (**20.10**, API **1.41**) and runs `docker version` / `docker ps` / `docker system df` against the self-hosted **host** daemon over the mounted `/var/run/docker.sock`.

The self-hosted hosts' Docker daemon has moved to **Docker 29** (`docker.io 29.1.3`, minimum API **1.44**). Docker 29 raised the minimum client API, so the ancient 20.10 client is now rejected:

```
Error response from daemon: client version 1.41 is too old.
Minimum supported API version is 1.44, please upgrade your client to a newer version
```

Every E2E category fails at the **Install Docker CLI** step. (Example: [run 29251362982, Angular](https://github.com/meteor/meteor/actions/runs/29251362982/job/86823355144).) The daemon on the hosts had been running 28.2.2 (which still accepted API 1.41) and only picked up the pending 29.1.3 upgrade on its next restart — so this is a latent incompatibility that would surface on any daemon restart/reboot.

## Fix

Install **`docker-ce-cli`** from Docker's official apt repo instead of Debian's `docker.io`. That tracks a current CLI (API ≥ 1.44) compatible with a Docker 28/29 daemon. CLI only — the container just needs a client to talk to the host daemon over the mounted socket; it doesn't run its own engine.

```yaml
- name: Install Docker CLI
  run: |
    apt-get update
    apt-get install -y ca-certificates curl
    install -m 0755 -d /etc/apt/keyrings
    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
    chmod a+r /etc/apt/keyrings/docker.asc
    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
      > /etc/apt/sources.list.d/docker.list
    apt-get update
    apt-get install -y docker-ce-cli
    docker version && docker ps && docker system df
```

This keeps the hosts on current Docker (the right place to be) and makes the workflow robust to future daemon upgrades. Should be backported to any active release branch whose E2E runs on the same self-hosted fleet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end test environment setup to use a compatible Docker CLI version.
  * Improved compatibility with the configured Docker daemon, helping prevent workflow failures caused by outdated tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->