### PR TITLE
fix: repair PATH when re-running the installer with Meteor already installed (meteor/meteor#11808)

### DIFF
--- a/npm-packages/meteor-installer/exec-path.js
+++ b/npm-packages/meteor-installer/exec-path.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+
+// Whether meteorPath is already one of the entries in a PATH-like string.
+function isMeteorOnPath(pathEnv, meteorPath, delimiter) {
+  return (pathEnv || '')
+    .split(delimiter)
+    .filter(Boolean)
+    .includes(meteorPath);
+}
+
+// Append a line to a file unless it is already present, so re-running the
+// installer doesn't add duplicate `export PATH=...` entries. Returns true if it
+// wrote the line.
+function appendLineIfMissing(file, line) {
+  let existing = '';
+  try {
+    existing = fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    // File may not exist yet; treat as empty.
+  }
+  if (existing.includes(line)) {
+    return false;
+  }
+  fs.appendFileSync(file, `${line}\n`);
+  return true;
+}
+
+module.exports = { isMeteorOnPath, appendLineIfMissing };

--- a/npm-packages/meteor-installer/exec-path.test.js
+++ b/npm-packages/meteor-installer/exec-path.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { isMeteorOnPath, appendLineIfMissing } = require('./exec-path');
+
+test('isMeteorOnPath finds meteor already on PATH', () => {
+  const meteor = '/home/u/.meteor';
+  assert.equal(isMeteorOnPath(`/usr/bin:${meteor}:/bin`, meteor, ':'), true);
+  assert.equal(isMeteorOnPath('/usr/bin:/bin', meteor, ':'), false);
+  assert.equal(isMeteorOnPath('', meteor, ':'), false);
+  assert.equal(isMeteorOnPath(undefined, meteor, ':'), false);
+  // a prefix match must not count as present
+  assert.equal(isMeteorOnPath('/home/u/.meteorx:/bin', meteor, ':'), false);
+});
+
+test('appendLineIfMissing appends once and is idempotent', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-path-'));
+  const file = path.join(dir, '.bashrc');
+  const line = 'export PATH=/home/u/.meteor:$PATH';
+  try {
+    fs.writeFileSync(file, '# existing\n');
+    assert.equal(appendLineIfMissing(file, line), true, 'writes when missing');
+    assert.equal(appendLineIfMissing(file, line), false, 'skips when present');
+    const occurrences = fs.readFileSync(file, 'utf8').split(line).length - 1;
+    assert.equal(occurrences, 1, 'the line appears exactly once');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('appendLineIfMissing creates a missing file', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-path-'));
+  const file = path.join(dir, '.zshrc');
+  const line = 'export PATH=/home/u/.meteor:$PATH';
+  try {
+    assert.equal(appendLineIfMissing(file, line), true);
+    assert.equal(fs.readFileSync(file, 'utf8'), `${line}\n`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/npm-packages/meteor-installer/install.js
+++ b/npm-packages/meteor-installer/install.js
@@ -9,8 +9,6 @@ const path = require('path');
 const semver = require('semver');
 const tmp = require('tmp');
 
-const fsPromises = fs.promises;
-
 const {
   meteorPath,
   release,
@@ -31,6 +29,7 @@ const {
 } = require('./extract');
 const { engines } = require('./package.json');
 const { uninstall } = require('./uninstall');
+const { isMeteorOnPath, appendLineIfMissing } = require('./exec-path');
 
 const nodeVersion = engines.node;
 const npmVersion = engines.npm;
@@ -127,6 +126,20 @@ if (fs.existsSync(startedPath)) {
   console.log('');
 } else if (fs.existsSync(meteorPath)) {
   console.log('Meteor is already installed at', meteorPath);
+
+  // Repair the PATH if a previous install left it missing, instead of just
+  // bailing out. setupExecPath is idempotent, so it is safe to call again.
+  if (
+    !isWindows() &&
+    shouldSetupExecPath() &&
+    !isMeteorOnPath(process.env.PATH, meteorPath, path.delimiter)
+  ) {
+    setupExecPath();
+    console.log(
+      'Added Meteor to your PATH. Open a new terminal (or reload your shell profile) to use the `meteor` command.',
+    );
+  }
+
   console.log(
     `If you want to reinstall it, run:
 
@@ -320,14 +333,14 @@ async function setupExecPath() {
   }
   const exportCommand = `export PATH=${meteorPath}:$PATH`;
 
-  const appendPathToFile = async file =>
-    fsPromises.appendFile(`${rootPath}/${file}`, `${exportCommand}\n`);
+  const appendPathToFile = file =>
+    appendLineIfMissing(`${rootPath}/${file}`, exportCommand);
 
   if (process.env.SHELL && process.env.SHELL.includes('zsh')) {
-    await appendPathToFile('.zshrc');
+    appendPathToFile('.zshrc');
   } else {
-    await appendPathToFile('.bashrc');
-    await appendPathToFile('.bash_profile');
+    appendPathToFile('.bashrc');
+    appendPathToFile('.bash_profile');
   }
 }
 async function fixOwnership() {


### PR DESCRIPTION
## Issue
meteor/meteor#11808 — re-running the installer when Meteor is already installed just prints "already installed" and exits, so a broken/missing `~/.meteor` PATH entry can't be repaired via the installer.

## Root cause
`npm-packages/meteor-installer/install.js`:
- the `fs.existsSync(meteorPath)` branch calls `process.exit()` without ever calling `setupExecPath()`;
- `setupExecPath` appended `export PATH=...` to the shell rc file unconditionally, so repeated installs could add duplicate lines.

## Fix
- On the already-installed path, when `shouldSetupExecPath()` and `~/.meteor` is **not** on `process.env.PATH`, call `setupExecPath()` and print an "open a new terminal" note (scoped to non-Windows, whose registry PATH set isn't idempotent).
- `setupExecPath` now appends via `appendLineIfMissing`, skipping the write when the export line is already present.
- The PATH check (`isMeteorOnPath`) and idempotent append (`appendLineIfMissing`) are extracted to `exec-path.js` so they're unit-testable. (Matches the approach the reporter, zodern, proposed.)

## Reproduce
Repro branch: https://github.com/italojs/meteor-issue-repros/tree/issue-11808 (`node repro.js`)
- `meteor missing from PATH? true (repair triggers)`; `second append skipped (idemp)? true`; `line count in rc: 1`.

End-to-end: with Meteor installed but `~/.meteor` removed from your shell PATH, re-running the installer now appends the export (once) and tells you to open a new terminal, instead of doing nothing.

## Test
`npm-packages/meteor-installer/exec-path.test.js` (`node --test`) — 3 passing: PATH membership (incl. prefix-mismatch), idempotent append, and file creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer behavior when Meteor is already installed but missing from the system PATH.
  * Automatically restores the executable path when needed on supported platforms.
  * Prevented duplicate PATH entries during installation or repair.
  * Improved handling of missing configuration files by creating them as needed.
* **Reliability**
  * Added validation to ensure PATH detection matches exact entries and avoids false matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->