### PR TITLE
fix: skip autoupdate subscription on a cross-origin DDP connection (meteor/meteor#13653)

### DIFF
--- a/packages/autoupdate/autoupdate_client.js
+++ b/packages/autoupdate/autoupdate_client.js
@@ -76,7 +76,37 @@ const retry = new Retry({
 
 let failures = 0;
 
+// True when the DDP connection points at a different origin than the page
+// (DDP_DEFAULT_CONNECTION_URL set to another server). In that case the server's
+// client version documents describe a different app and never match this page's
+// baked-in version, so autoupdate would reload the page forever.
+Autoupdate._isCrossOriginConnection = () => {
+  if (typeof window === "undefined" || ! window.location) {
+    return false;
+  }
+  const configuredUrl =
+    (typeof __meteor_runtime_config__ !== "undefined" &&
+      __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL) || null;
+  if (! configuredUrl) {
+    return false;
+  }
+  try {
+    const pageOrigin =
+      window.location.origin ||
+      `${window.location.protocol}//${window.location.host}`;
+    return new URL(configuredUrl, window.location.href).origin !== pageOrigin;
+  } catch (e) {
+    return false;
+  }
+};
+
 Autoupdate._retrySubscription = () => {
+  if (Autoupdate._isCrossOriginConnection()) {
+    // Skip the version subscription: the remote server's versions never match
+    // this page, so subscribing would trigger an endless reload loop.
+    return;
+  }
+
   Meteor.subscribe("meteor_autoupdate_clientVersions", {
     onError(error) {
       Meteor._debug("autoupdate subscription failed", error);

--- a/packages/autoupdate/autoupdate_client_tests.js
+++ b/packages/autoupdate/autoupdate_client_tests.js
@@ -1,0 +1,38 @@
+import { Autoupdate } from 'meteor/autoupdate';
+
+// The autoupdate version subscription must be skipped when DDP points at a
+// different origin than the page, otherwise the server's version documents
+// never match this page and it reloads forever.
+Tinytest.add(
+  'autoupdate - _isCrossOriginConnection detects a different DDP origin',
+  function (test) {
+    const original = __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL;
+    try {
+      delete __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL;
+      test.isFalse(
+        Autoupdate._isCrossOriginConnection(),
+        'no configured DDP url is not cross-origin'
+      );
+
+      __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL =
+        window.location.origin;
+      test.isFalse(
+        Autoupdate._isCrossOriginConnection(),
+        'the page origin is not cross-origin'
+      );
+
+      __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL =
+        'https://some-other-host.example.com:9999';
+      test.isTrue(
+        Autoupdate._isCrossOriginConnection(),
+        'a different host/port is cross-origin'
+      );
+    } finally {
+      if (original === undefined) {
+        delete __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL;
+      } else {
+        __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL = original;
+      }
+    }
+  }
+);

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -18,3 +18,9 @@ Package.onUse(function(api) {
 
   api.export('Autoupdate');
 });
+
+Package.onTest(function(api) {
+  api.use(['ecmascript', 'tinytest']);
+  api.use('autoupdate');
+  api.addFiles('autoupdate_client_tests.js', 'client');
+});


### PR DESCRIPTION
## Issue
meteor/meteor#13653 — setting `__meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL` (or the env var) to a different origin makes the page reload endlessly.

## Root cause
`packages/autoupdate/autoupdate_client.js` subscribes to `meteor_autoupdate_clientVersions` over `Meteor.connection` **unconditionally**. When `DDP_DEFAULT_CONNECTION_URL` points at a different server, that connection is the remote server, whose client-version hashes describe a *different app* and never match this page's baked-in `autoupdateVersions`. `checkNewVersionDocument` sees the `versionNonRefreshable` mismatch → `Package.reload.Reload._reload()` → the same page loads and mismatches again → infinite reload loop.

## Fix
Add `Autoupdate._isCrossOriginConnection()` (compares `DDP_DEFAULT_CONNECTION_URL`'s origin to `window.location.origin`, client-only, handles protocol-relative URLs) and early-return from `Autoupdate._retrySubscription()` when it's true — the cross-origin server's versions can't apply to this page, so skipping the subscription is correct and stops the loop.

Scoped deliberately: **only the web client** (`autoupdate_client.js`). Cordova (`autoupdate_cordova.js`) is inherently cross-origin and updates via `WebAppLocalServer.onNewVersionReady`, so it is left untouched.

> Note: this is a clean re-implementation of the concept from the closed PR #13977 — it keeps the change to ~5 behavioral lines and drops the review-flagged cruft (no CI/env allowlist, no DDPCommon global-fallback shim, no duplicated livedata_connection change, no blanked comments).

## Reproduce
Repro branch: https://github.com/italojs/meteor-issue-repros/tree/issue-13653
- Two apps: server B on :3100, page app A run with `DDP_DEFAULT_CONNECTION_URL=http://localhost:3100 meteor run --port 3000`. Before the fix, `http://localhost:3000` reloads in a loop; after, it loads once and stays.
- `node origin-check.js` demonstrates the origin comparison across same-origin / different-host / port / protocol / protocol-relative (7/7).

## Test
Adds `Package.onTest` + `autoupdate_client_tests.js`: `autoupdate - _isCrossOriginConnection detects a different DDP origin` — **passes** (unset & same-origin → not cross-origin; different host/port → cross-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary reload loops when the application’s live-update connection uses a different origin from the current page.
  * Improved handling of missing, matching, or invalid connection settings.

* **Tests**
  * Added automated coverage for same-origin, cross-origin, and unspecified connection configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->