### PR TITLE
fix: opt-in to keep Content-Length on built assets (meteor/meteor#12772)

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -75,6 +75,15 @@ function shouldCompress(req, res) {
     return false;
   }
 
+  if (
+    Meteor.settings.packages?.webapp?.skipCompressionWithContentLength &&
+    res.getHeader('Content-Length')
+  ) {
+    // Leave responses that already declare a Content-Length uncompressed, so the
+    // header survives (compressing switches them to chunked and removes it).
+    return false;
+  }
+
   // fallback to standard filter function
   return compress.filter(req, res);
 }

--- a/packages/webapp/webapp_tests.js
+++ b/packages/webapp/webapp_tests.js
@@ -536,6 +536,54 @@ Tinytest.addAsync(
   }
 );
 
+Tinytest.addAsync(
+  'webapp - skipCompressionWithContentLength setting keeps Content-Length',
+  async function (test) {
+    const arch = 'web.browser';
+    const staticPath = '/skip-compression-test.js';
+    const original =
+      Meteor.settings.packages?.webapp?.skipCompressionWithContentLength;
+
+    if (!Meteor.settings.packages) Meteor.settings.packages = {};
+    if (!Meteor.settings.packages.webapp) Meteor.settings.packages.webapp = {};
+
+    // Large enough to be past the compression module's default threshold.
+    const content = 'console.log("skip-compression-test");\n'.repeat(80);
+    WebAppInternals.staticFilesByArch[arch][staticPath] = {
+      content,
+      absolutePath: '/tmp/mock-skip-compression.js',
+      cacheable: true,
+      hash: 'skip-compression-hash',
+      type: 'js',
+    };
+
+    const reqOpts = { headers: { 'Accept-Encoding': 'gzip' } };
+    try {
+      Meteor.settings.packages.webapp.skipCompressionWithContentLength = false;
+      const off = await asyncGet(Meteor.absoluteUrl(staticPath), reqOpts);
+      test.equal(
+        (off.headers['content-encoding'] || '').toLowerCase(),
+        'gzip',
+        'should compress (and drop Content-Length) when the setting is off'
+      );
+
+      Meteor.settings.packages.webapp.skipCompressionWithContentLength = true;
+      const on = await asyncGet(Meteor.absoluteUrl(staticPath), reqOpts);
+      test.isFalse(
+        (on.headers['content-encoding'] || '').toLowerCase().includes('gzip'),
+        'should not compress when the setting is on'
+      );
+      test.isTrue(
+        !!on.headers['content-length'],
+        'Content-Length should be preserved when the setting is on'
+      );
+    } finally {
+      delete WebAppInternals.staticFilesByArch[arch][staticPath];
+      Meteor.settings.packages.webapp.skipCompressionWithContentLength = original;
+    }
+  }
+);
+
 // Verification: Ensure that a URL containing a specific hash serves the exact same
 // content and headers to all browsers (Modern vs Legacy).
 // This proves that removing 'Vary: User-Agent' is safe because the file content


### PR DESCRIPTION
## Issue
meteor/meteor#12772 — built JS/CSS assets are served without a `Content-Length` header, which breaks CDN/proxy setups that want the origin to serve uncompressed-with-Content-Length and compress themselves.

## Root cause
`packages/webapp/webapp_server.js` `shouldCompress()` compresses JS/CSS via the default filter. The `compression` middleware, when it compresses, sets `Content-Encoding` and calls `res.removeHeader('Content-Length')` — so hashed bundle assets (which the static middleware gave a `Content-Length`) go out chunked with no length.

## Fix (opt-in, default off)
New setting `Meteor.settings.packages.webapp.skipCompressionWithContentLength`, following the existing `alwaysReturnContent` / `includeVaryUserAgent` precedent. When enabled, `shouldCompress` returns false for any response that already has a `Content-Length`, leaving it uncompressed so the header survives:

```js
if (Meteor.settings.packages?.webapp?.skipCompressionWithContentLength && res.getHeader('Content-Length')) {
  return false;
}
```

Default behavior is unchanged (this matches the maintainer note on the issue that it should be optional, not default).

## Reproduce
Repro branch: https://github.com/italojs/meteor-issue-repros/tree/issue-12772
```
curl -sI -H 'Accept-Encoding: gzip' http://localhost:3000/<hashed-bundle>.js
```
- **default/off:** `content-encoding: gzip`, no `content-length`
- **with the setting on:** keeps `content-length`, not gzipped

## Test
Tinytest `webapp - skipCompressionWithContentLength setting keeps Content-Length` (injects a static JS asset, toggles the setting, asserts gzip+no-length when off vs no-gzip+length when on) — **passes** in the webapp suite. (The unrelated `socket usage - inter-process communication` test flaked in the run; it doesn't touch compression.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to preserve the `Content-Length` header for eligible responses by skipping compression.

* **Bug Fixes**
  * Prevented compressed responses from losing their original `Content-Length` when the new option is enabled.

* **Tests**
  * Added coverage verifying response compression and header behavior with the option enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->