### PR TITLE
feat(types): OAuth provider packages (tier 2)

### DIFF
--- a/packages/facebook-oauth/facebook-oauth.d.ts
+++ b/packages/facebook-oauth/facebook-oauth.d.ts
@@ -1,0 +1,52 @@
+/** Options accepted by `Facebook.requestCredential`. */
+interface RequestCredentialOptions {
+  /** Whether the login flow uses a popup or a full-page redirect. */
+  loginStyle?: "popup" | "redirect";
+  /** OAuth scopes to request in addition to the defaults. */
+  requestPermissions?: string[];
+  /** Extra parameters appended to the provider's login URL. */
+  loginUrlParameters?: { [key: string]: unknown };
+  /** URL to redirect back to after a redirect-style login. */
+  redirectUrl?: string;
+}
+
+/**
+ * Called when a credential request completes. Receives the credential token
+ * (a string) on success, or an `Error` on failure.
+ */
+type CredentialRequestCompleteCallback = (tokenOrError?: string | Error) => void;
+
+/** The pending OAuth credential resolved server-side. */
+interface OAuthCredential {
+  serviceName: string;
+  serviceData: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export namespace Facebook {
+  /**
+   * (Client) Start the Facebook OAuth flow and obtain a credential token.
+   * Accepts either `(options, callback)` or `(callback)`.
+   */
+  export function requestCredential(
+    options?: RequestCredentialOptions | CredentialRequestCompleteCallback,
+    credentialRequestCompleteCallback?: CredentialRequestCompleteCallback
+  ): void;
+
+  /**
+   * (Server) Retrieve the pending credential for a completed OAuth flow.
+   */
+  export function retrieveCredential(
+    credentialToken: string,
+    credentialSecret: string
+  ): OAuthCredential;
+
+  /**
+   * (Server) Build a service-data object directly from a Facebook access
+   * token, bypassing the interactive OAuth flow.
+   */
+  export function handleAuthFromAccessToken(
+    accessToken: string,
+    expiresAt: number
+  ): Promise<Record<string, unknown>>;
+}

--- a/packages/facebook-oauth/facebook-oauth.test-d.ts
+++ b/packages/facebook-oauth/facebook-oauth.test-d.ts
@@ -1,0 +1,15 @@
+import { expectTypeOf } from "expect-type";
+import { Facebook } from "./facebook-oauth";
+
+expectTypeOf(Facebook).toBeObject();
+
+expectTypeOf(Facebook.requestCredential).toBeFunction();
+expectTypeOf(Facebook.requestCredential).returns.toBeVoid();
+
+expectTypeOf(Facebook.retrieveCredential).parameters.toEqualTypeOf<[string, string]>();
+expectTypeOf(Facebook.retrieveCredential).returns.toBeObject();
+
+expectTypeOf(Facebook.handleAuthFromAccessToken).parameters.toEqualTypeOf<[string, number]>();
+expectTypeOf(Facebook.handleAuthFromAccessToken).returns.toEqualTypeOf<
+  Promise<Record<string, unknown>>
+>();

--- a/packages/facebook-oauth/package.js
+++ b/packages/facebook-oauth/package.js
@@ -14,6 +14,7 @@ Package.onUse(api => {
   api.addFiles('facebook_server.js', 'server');
 
   api.export('Facebook');
+  api.addAssets('facebook-oauth.d.ts', 'server');
 });
 
 Package.onTest(function(api) {

--- a/packages/github-oauth/github-oauth.d.ts
+++ b/packages/github-oauth/github-oauth.d.ts
@@ -1,0 +1,43 @@
+/** Options accepted by `Github.requestCredential`. */
+interface RequestCredentialOptions {
+  /** Whether the login flow uses a popup or a full-page redirect. */
+  loginStyle?: "popup" | "redirect";
+  /** OAuth scopes to request in addition to the defaults. */
+  requestPermissions?: string[];
+  /** Extra parameters appended to the provider's login URL. */
+  loginUrlParameters?: { [key: string]: unknown };
+  /** URL to redirect back to after a redirect-style login. */
+  redirectUrl?: string;
+}
+
+/**
+ * Called when a credential request completes. Receives the credential token
+ * (a string) on success, or an `Error` on failure.
+ */
+type CredentialRequestCompleteCallback = (tokenOrError?: string | Error) => void;
+
+/** The pending OAuth credential resolved server-side. */
+interface OAuthCredential {
+  serviceName: string;
+  serviceData: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export namespace Github {
+  /**
+   * (Client) Start the GitHub OAuth flow and obtain a credential token.
+   * Accepts either `(options, callback)` or `(callback)`.
+   */
+  export function requestCredential(
+    options?: RequestCredentialOptions | CredentialRequestCompleteCallback,
+    credentialRequestCompleteCallback?: CredentialRequestCompleteCallback
+  ): void;
+
+  /**
+   * (Server) Retrieve the pending credential for a completed OAuth flow.
+   */
+  export function retrieveCredential(
+    credentialToken: string,
+    credentialSecret: string
+  ): OAuthCredential;
+}

--- a/packages/github-oauth/github-oauth.test-d.ts
+++ b/packages/github-oauth/github-oauth.test-d.ts
@@ -1,0 +1,10 @@
+import { expectTypeOf } from "expect-type";
+import { Github } from "./github-oauth";
+
+expectTypeOf(Github).toBeObject();
+
+expectTypeOf(Github.requestCredential).toBeFunction();
+expectTypeOf(Github.requestCredential).returns.toBeVoid();
+
+expectTypeOf(Github.retrieveCredential).parameters.toEqualTypeOf<[string, string]>();
+expectTypeOf(Github.retrieveCredential).returns.toBeObject();

--- a/packages/github-oauth/package.js
+++ b/packages/github-oauth/package.js
@@ -16,6 +16,7 @@ Package.onUse(api => {
   api.addFiles('github_server.js', 'server');
 
   api.export('Github');
+  api.addAssets('github-oauth.d.ts', 'server');
 });
 
 Package.onTest(function(api) {

--- a/packages/google-oauth/google-oauth.d.ts
+++ b/packages/google-oauth/google-oauth.d.ts
@@ -1,0 +1,66 @@
+/** Options accepted by `Google.requestCredential`. */
+interface RequestCredentialOptions {
+  /** Whether the login flow uses a popup or a full-page redirect. */
+  loginStyle?: "popup" | "redirect";
+  /** OAuth scopes to request in addition to the defaults. */
+  requestPermissions?: string[];
+  /** Extra parameters appended to the provider's login URL. */
+  loginUrlParameters?: { [key: string]: unknown };
+  /** URL to redirect back to after a redirect-style login. */
+  redirectUrl?: string;
+  /** Request an offline (refresh) token. */
+  requestOfflineToken?: boolean;
+  /** Force the Google consent screen. */
+  forceApprovalPrompt?: boolean;
+  /** Value for Google's `prompt` login parameter. */
+  prompt?: string;
+  /** Pre-fill the account chooser with this email. */
+  loginHint?: string;
+}
+
+/**
+ * Called when a credential request completes. Receives the credential token
+ * (a string) on success, or an `Error` on failure.
+ */
+type CredentialRequestCompleteCallback = (tokenOrError?: string | Error) => void;
+
+/** The pending OAuth credential resolved server-side. */
+interface OAuthCredential {
+  serviceName: string;
+  serviceData: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export namespace Google {
+  /**
+   * (Client) Start the Google OAuth flow and obtain a credential token.
+   * Accepts either `(options, callback)` or `(callback)`.
+   */
+  export function requestCredential(
+    options?: RequestCredentialOptions | CredentialRequestCompleteCallback,
+    credentialRequestCompleteCallback?: CredentialRequestCompleteCallback
+  ): void;
+
+  /**
+   * (Server) Retrieve the pending credential for a completed OAuth flow.
+   */
+  export function retrieveCredential(
+    credentialToken: string,
+    credentialSecret: string
+  ): OAuthCredential;
+
+  /**
+   * (Cordova) Sign in using the native Google Sign-In SDK.
+   * Accepts either `(options, callback)` or `(callback)`.
+   */
+  export function signIn(
+    options?: RequestCredentialOptions | CredentialRequestCompleteCallback,
+    callback?: CredentialRequestCompleteCallback
+  ): void;
+
+  /** (Cordova) Sign out of the native Google Sign-In session. */
+  export function signOut(): Promise<void>;
+
+  /** Google profile fields copied into the user's `services.google`. */
+  export const whitelistedFields: string[];
+}

--- a/packages/google-oauth/google-oauth.test-d.ts
+++ b/packages/google-oauth/google-oauth.test-d.ts
@@ -1,0 +1,15 @@
+import { expectTypeOf } from "expect-type";
+import { Google } from "./google-oauth";
+
+expectTypeOf(Google).toBeObject();
+
+expectTypeOf(Google.requestCredential).toBeFunction();
+expectTypeOf(Google.requestCredential).returns.toBeVoid();
+
+expectTypeOf(Google.retrieveCredential).parameters.toEqualTypeOf<[string, string]>();
+expectTypeOf(Google.retrieveCredential).returns.toBeObject();
+
+expectTypeOf(Google.signIn).toBeFunction();
+expectTypeOf(Google.signOut).returns.toEqualTypeOf<Promise<void>>();
+
+expectTypeOf(Google.whitelistedFields).toEqualTypeOf<string[]>();

--- a/packages/google-oauth/package.js
+++ b/packages/google-oauth/package.js
@@ -22,6 +22,7 @@ Package.onUse(api => {
   api.mainModule('namespace.js');
 
   api.export('Google');
+  api.addAssets('google-oauth.d.ts', 'server');
 });
 
 Package.onTest(function(api) {

--- a/packages/meetup-oauth/meetup-oauth.d.ts
+++ b/packages/meetup-oauth/meetup-oauth.d.ts
@@ -1,0 +1,43 @@
+/** Options accepted by `Meetup.requestCredential`. */
+interface RequestCredentialOptions {
+  /** Whether the login flow uses a popup or a full-page redirect. */
+  loginStyle?: "popup" | "redirect";
+  /** OAuth scopes to request in addition to the defaults. */
+  requestPermissions?: string[];
+  /** Extra parameters appended to the provider's login URL. */
+  loginUrlParameters?: { [key: string]: unknown };
+  /** URL to redirect back to after a redirect-style login. */
+  redirectUrl?: string;
+}
+
+/**
+ * Called when a credential request completes. Receives the credential token
+ * (a string) on success, or an `Error` on failure.
+ */
+type CredentialRequestCompleteCallback = (tokenOrError?: string | Error) => void;
+
+/** The pending OAuth credential resolved server-side. */
+interface OAuthCredential {
+  serviceName: string;
+  serviceData: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export namespace Meetup {
+  /**
+   * (Client) Start the Meetup OAuth flow and obtain a credential token.
+   * Accepts either `(options, callback)` or `(callback)`.
+   */
+  export function requestCredential(
+    options?: RequestCredentialOptions | CredentialRequestCompleteCallback,
+    credentialRequestCompleteCallback?: CredentialRequestCompleteCallback
+  ): void;
+
+  /**
+   * (Server) Retrieve the pending credential for a completed OAuth flow.
+   */
+  export function retrieveCredential(
+    credentialToken: string,
+    credentialSecret: string
+  ): OAuthCredential;
+}

--- a/packages/meetup-oauth/meetup-oauth.test-d.ts
+++ b/packages/meetup-oauth/meetup-oauth.test-d.ts
@@ -1,0 +1,10 @@
+import { expectTypeOf } from "expect-type";
+import { Meetup } from "./meetup-oauth";
+
+expectTypeOf(Meetup).toBeObject();
+
+expectTypeOf(Meetup.requestCredential).toBeFunction();
+expectTypeOf(Meetup.requestCredential).returns.toBeVoid();
+
+expectTypeOf(Meetup.retrieveCredential).parameters.toEqualTypeOf<[string, string]>();
+expectTypeOf(Meetup.retrieveCredential).returns.toBeObject();

--- a/packages/meetup-oauth/package.js
+++ b/packages/meetup-oauth/package.js
@@ -14,6 +14,7 @@ Package.onUse(api => {
   api.addFiles('meetup_client.js', 'client');
 
   api.export('Meetup');
+  api.addAssets('meetup-oauth.d.ts', 'server');
 });
 
 Package.onTest(function(api) {

--- a/packages/meteor-developer-oauth/meteor-developer-oauth.d.ts
+++ b/packages/meteor-developer-oauth/meteor-developer-oauth.d.ts
@@ -1,0 +1,43 @@
+/** Options accepted by `MeteorDeveloperAccounts.requestCredential`. */
+interface RequestCredentialOptions {
+  /** Whether the login flow uses a popup or a full-page redirect. */
+  loginStyle?: "popup" | "redirect";
+  /** OAuth scopes to request in addition to the defaults. */
+  requestPermissions?: string[];
+  /** Extra parameters appended to the provider's login URL. */
+  loginUrlParameters?: { [key: string]: unknown };
+  /** URL to redirect back to after a redirect-style login. */
+  redirectUrl?: string;
+}
+
+/**
+ * Called when a credential request completes. Receives the credential token
+ * (a string) on success, or an `Error` on failure.
+ */
+type CredentialRequestCompleteCallback = (tokenOrError?: string | Error) => void;
+
+/** The pending OAuth credential resolved server-side. */
+interface OAuthCredential {
+  serviceName: string;
+  serviceData: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export namespace MeteorDeveloperAccounts {
+  /**
+   * (Client) Start the Meteor Developer Accounts OAuth flow and obtain a
+   * credential token. Accepts either `(options, callback)` or `(callback)`.
+   */
+  export function requestCredential(
+    options?: RequestCredentialOptions | CredentialRequestCompleteCallback,
+    credentialRequestCompleteCallback?: CredentialRequestCompleteCallback
+  ): void;
+
+  /**
+   * (Server) Retrieve the pending credential for a completed OAuth flow.
+   */
+  export function retrieveCredential(
+    credentialToken: string,
+    credentialSecret: string
+  ): OAuthCredential;
+}

--- a/packages/meteor-developer-oauth/meteor-developer-oauth.test-d.ts
+++ b/packages/meteor-developer-oauth/meteor-developer-oauth.test-d.ts
@@ -1,0 +1,12 @@
+import { expectTypeOf } from "expect-type";
+import { MeteorDeveloperAccounts } from "./meteor-developer-oauth";
+
+expectTypeOf(MeteorDeveloperAccounts).toBeObject();
+
+expectTypeOf(MeteorDeveloperAccounts.requestCredential).toBeFunction();
+expectTypeOf(MeteorDeveloperAccounts.requestCredential).returns.toBeVoid();
+
+expectTypeOf(MeteorDeveloperAccounts.retrieveCredential).parameters.toEqualTypeOf<
+  [string, string]
+>();
+expectTypeOf(MeteorDeveloperAccounts.retrieveCredential).returns.toBeObject();

--- a/packages/meteor-developer-oauth/package.js
+++ b/packages/meteor-developer-oauth/package.js
@@ -14,6 +14,7 @@ Package.onUse(api => {
   api.addFiles('meteor_developer_client.js', 'client');
 
   api.export('MeteorDeveloperAccounts');
+  api.addAssets('meteor-developer-oauth.d.ts', 'server');
 });
 
 Package.onTest(function(api) {

--- a/packages/twitter-oauth/package.js
+++ b/packages/twitter-oauth/package.js
@@ -15,4 +15,5 @@ Package.onUse(function(api) {
   api.addFiles('twitter_server.js', 'server');
 
   api.export('Twitter');
+  api.addAssets('twitter-oauth.d.ts', 'server');
 });

--- a/packages/twitter-oauth/twitter-oauth.d.ts
+++ b/packages/twitter-oauth/twitter-oauth.d.ts
@@ -1,0 +1,49 @@
+/** Options accepted by `Twitter.requestCredential`. */
+interface RequestCredentialOptions {
+  /** Whether the login flow uses a popup or a full-page redirect. */
+  loginStyle?: "popup" | "redirect";
+  /** OAuth scopes to request in addition to the defaults. */
+  requestPermissions?: string[];
+  /** Extra parameters appended to the provider's login URL. */
+  loginUrlParameters?: { [key: string]: unknown };
+  /** URL to redirect back to after a redirect-style login. */
+  redirectUrl?: string;
+}
+
+/**
+ * Called when a credential request completes. Receives the credential token
+ * (a string) on success, or an `Error` on failure.
+ */
+type CredentialRequestCompleteCallback = (tokenOrError?: string | Error) => void;
+
+/** The pending OAuth credential resolved server-side. */
+interface OAuthCredential {
+  serviceName: string;
+  serviceData: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export namespace Twitter {
+  /**
+   * (Client) Start the Twitter OAuth flow and obtain a credential token.
+   * Accepts either `(options, callback)` or `(callback)`.
+   */
+  export function requestCredential(
+    options?: RequestCredentialOptions | CredentialRequestCompleteCallback,
+    credentialRequestCompleteCallback?: CredentialRequestCompleteCallback
+  ): void;
+
+  /**
+   * (Server) Retrieve the pending credential for a completed OAuth flow.
+   */
+  export function retrieveCredential(
+    credentialToken: string,
+    credentialSecret: string
+  ): OAuthCredential;
+
+  /** Query parameters allowed on Twitter's `authenticate` endpoint. */
+  export const validParamsAuthenticate: string[];
+
+  /** Twitter profile fields copied into the user's `services.twitter`. */
+  export const whitelistedFields: string[];
+}

--- a/packages/twitter-oauth/twitter-oauth.test-d.ts
+++ b/packages/twitter-oauth/twitter-oauth.test-d.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf } from "expect-type";
+import { Twitter } from "./twitter-oauth";
+
+expectTypeOf(Twitter).toBeObject();
+
+expectTypeOf(Twitter.requestCredential).toBeFunction();
+expectTypeOf(Twitter.requestCredential).returns.toBeVoid();
+
+expectTypeOf(Twitter.retrieveCredential).parameters.toEqualTypeOf<[string, string]>();
+expectTypeOf(Twitter.retrieveCredential).returns.toBeObject();
+
+expectTypeOf(Twitter.validParamsAuthenticate).toEqualTypeOf<string[]>();
+expectTypeOf(Twitter.whitelistedFields).toEqualTypeOf<string[]>();

--- a/packages/weibo-oauth/package.js
+++ b/packages/weibo-oauth/package.js
@@ -13,6 +13,7 @@ Package.onUse(api => {
   api.addFiles('weibo_server.js', 'server');
 
   api.export('Weibo');
+  api.addAssets('weibo-oauth.d.ts', 'server');
 });
 
 Package.onTest(function(api) {

--- a/packages/weibo-oauth/weibo-oauth.d.ts
+++ b/packages/weibo-oauth/weibo-oauth.d.ts
@@ -1,0 +1,43 @@
+/** Options accepted by `Weibo.requestCredential`. */
+interface RequestCredentialOptions {
+  /** Whether the login flow uses a popup or a full-page redirect. */
+  loginStyle?: "popup" | "redirect";
+  /** OAuth scopes to request in addition to the defaults. */
+  requestPermissions?: string[];
+  /** Extra parameters appended to the provider's login URL. */
+  loginUrlParameters?: { [key: string]: unknown };
+  /** URL to redirect back to after a redirect-style login. */
+  redirectUrl?: string;
+}
+
+/**
+ * Called when a credential request completes. Receives the credential token
+ * (a string) on success, or an `Error` on failure.
+ */
+type CredentialRequestCompleteCallback = (tokenOrError?: string | Error) => void;
+
+/** The pending OAuth credential resolved server-side. */
+interface OAuthCredential {
+  serviceName: string;
+  serviceData: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export namespace Weibo {
+  /**
+   * (Client) Start the Weibo OAuth flow and obtain a credential token.
+   * Accepts either `(options, callback)` or `(callback)`.
+   */
+  export function requestCredential(
+    options?: RequestCredentialOptions | CredentialRequestCompleteCallback,
+    credentialRequestCompleteCallback?: CredentialRequestCompleteCallback
+  ): void;
+
+  /**
+   * (Server) Retrieve the pending credential for a completed OAuth flow.
+   */
+  export function retrieveCredential(
+    credentialToken: string,
+    credentialSecret: string
+  ): OAuthCredential;
+}

--- a/packages/weibo-oauth/weibo-oauth.test-d.ts
+++ b/packages/weibo-oauth/weibo-oauth.test-d.ts
@@ -1,0 +1,10 @@
+import { expectTypeOf } from "expect-type";
+import { Weibo } from "./weibo-oauth";
+
+expectTypeOf(Weibo).toBeObject();
+
+expectTypeOf(Weibo.requestCredential).toBeFunction();
+expectTypeOf(Weibo.requestCredential).returns.toBeVoid();
+
+expectTypeOf(Weibo.retrieveCredential).parameters.toEqualTypeOf<[string, string]>();
+expectTypeOf(Weibo.retrieveCredential).returns.toBeObject();


### PR DESCRIPTION
## Tier 2 — OAuth providers

Adds `.d.ts` + `.test-d.ts` + `addAssets` for the 7 OAuth provider packages that export a service object via `api.export`.

| Package | Export | Surface |
|---|---|---|
| google-oauth | `Google` | requestCredential, retrieveCredential, signIn, signOut, whitelistedFields |
| facebook-oauth | `Facebook` | + handleAuthFromAccessToken |
| twitter-oauth | `Twitter` | + validParamsAuthenticate, whitelistedFields |
| github-oauth | `Github` | request/retrieveCredential |
| weibo-oauth | `Weibo` | request/retrieveCredential |
| meetup-oauth | `Meetup` | request/retrieveCredential |
| meteor-developer-oauth | `MeteorDeveloperAccounts` | request/retrieveCredential |

### Gates
- `dts-test-coverage`: 171 → **198/198 = 100%**
- `type-coverage`: 99.94%
- `tsc --noEmit`: 0 errors · `fmt:check`: clean

Part of the tier-by-tier rollout tracked in the type-coverage plan. Base: `ts/type-coverage`.