### PR TITLE
feat(types): core-runtime packages (tier 1, part 1)

### DIFF
--- a/packages/allow-deny/allow-deny.d.ts
+++ b/packages/allow-deny/allow-deny.d.ts
@@ -1,0 +1,30 @@
+/** A single allow/deny rule set, as passed to `allow()` / `deny()`. */
+interface AllowDenyRules {
+  insert?: (userId: string, doc: Record<string, unknown>) => boolean;
+  update?: (
+    userId: string,
+    doc: Record<string, unknown>,
+    fieldNames: string[],
+    modifier: Record<string, unknown>
+  ) => boolean;
+  remove?: (userId: string, doc: Record<string, unknown>) => boolean;
+  fetch?: string[];
+  transform?: ((doc: Record<string, unknown>) => unknown) | null;
+}
+
+/** The allow/deny methods mixed into every collection's prototype. */
+interface CollectionPrototypeApi {
+  /** Allow client-side writes matching these rules. */
+  allow(rules: AllowDenyRules): boolean;
+  /** Deny client-side writes matching these rules. */
+  deny(rules: AllowDenyRules): boolean;
+  /** Install the insert/update/remove mutation methods for this collection. */
+  _defineMutationMethods(options?: { useExisting?: boolean }): void;
+  /** Whether the collection currently has no allow/deny rules. */
+  _isInsecure(): boolean;
+}
+
+export namespace AllowDeny {
+  /** Prototype object whose members are mixed into `Mongo.Collection`. */
+  var CollectionPrototype: CollectionPrototypeApi;
+}

--- a/packages/allow-deny/allow-deny.test-d.ts
+++ b/packages/allow-deny/allow-deny.test-d.ts
@@ -1,0 +1,9 @@
+import { expectTypeOf } from "expect-type";
+import { AllowDeny } from "./allow-deny";
+
+expectTypeOf(AllowDeny).toBeObject();
+expectTypeOf(AllowDeny.CollectionPrototype).toBeObject();
+expectTypeOf(AllowDeny.CollectionPrototype.allow).returns.toBeBoolean();
+expectTypeOf(AllowDeny.CollectionPrototype.deny).returns.toBeBoolean();
+expectTypeOf(AllowDeny.CollectionPrototype._defineMutationMethods).returns.toBeVoid();
+expectTypeOf(AllowDeny.CollectionPrototype._isInsecure).returns.toBeBoolean();

--- a/packages/allow-deny/package.js
+++ b/packages/allow-deny/package.js
@@ -21,6 +21,7 @@ Package.onUse(function(api) {
 
   api.addFiles('allow-deny.js');
   api.export('AllowDeny');
+  api.addAssets('allow-deny.d.ts', 'server');
 });
 
 Package.onTest(function(api) {

--- a/packages/autoupdate/autoupdate.d.ts
+++ b/packages/autoupdate/autoupdate.d.ts
@@ -1,0 +1,17 @@
+export namespace Autoupdate {
+  /** This app's id (from `APP_ID`), if set. */
+  var appId: string | undefined;
+
+  /** Target client program version; `null` until computed. */
+  var autoupdateVersion: string | null;
+  /** Version used to hot-refresh CSS without a full reload. */
+  var autoupdateVersionRefreshable: string | null;
+  /** Version served to Cordova clients. */
+  var autoupdateVersionCordova: string | null;
+
+  /**
+   * (Client) Reactive data source: `true` once a newer client version is
+   * available and the app should reload.
+   */
+  function newClientAvailable(): boolean;
+}

--- a/packages/autoupdate/autoupdate.test-d.ts
+++ b/packages/autoupdate/autoupdate.test-d.ts
@@ -1,0 +1,10 @@
+import { expectTypeOf } from "expect-type";
+import { Autoupdate } from "./autoupdate";
+
+expectTypeOf(Autoupdate).toBeObject();
+
+expectTypeOf(Autoupdate.appId).toEqualTypeOf<string | undefined>();
+expectTypeOf(Autoupdate.autoupdateVersion).toEqualTypeOf<string | null>();
+expectTypeOf(Autoupdate.autoupdateVersionRefreshable).toEqualTypeOf<string | null>();
+expectTypeOf(Autoupdate.autoupdateVersionCordova).toEqualTypeOf<string | null>();
+expectTypeOf(Autoupdate.newClientAvailable).returns.toBeBoolean();

--- a/packages/autoupdate/package.js
+++ b/packages/autoupdate/package.js
@@ -15,6 +15,7 @@ Package.onUse(function(api) {
   api.mainModule('autoupdate_server.js', 'server');
   api.mainModule('autoupdate_client.js', 'client');
   api.mainModule('autoupdate_cordova.js', 'web.cordova');
+  api.addAssets('autoupdate.d.ts', 'server');
 
   api.export('Autoupdate');
 });

--- a/packages/binary-heap/binary-heap.d.ts
+++ b/packages/binary-heap/binary-heap.d.ts
@@ -1,0 +1,50 @@
+/** Options accepted by the heap constructors. */
+interface HeapOptions {
+  /** Custom IdMap constructor used to store the id → index mapping. */
+  IdMap?: unknown;
+  /** Initial `{ id, value }` pairs to build the heap from. */
+  initData?: Array<{ id: string; value: unknown }>;
+}
+
+/**
+ * A binary max-heap keyed by id. `V` is the type of the values being compared
+ * by the supplied comparator (defaults to `number`).
+ */
+export class MaxHeap<V = number> {
+  constructor(comparator: (a: V, b: V) => number, options?: HeapOptions);
+
+  /** Value stored for `id`, or `null` if absent. */
+  get(id: string): V | null;
+  /** Insert or update the value for `id`. */
+  set(id: string, value: V): void;
+  /** Remove `id` from the heap. */
+  remove(id: string): void;
+  /** Whether `id` is present. */
+  has(id: string): boolean;
+  /** Whether the heap has no elements. */
+  empty(): boolean;
+  /** Remove every element. */
+  clear(): void;
+  /** Iterate over every `value`/`id` pair. */
+  forEach(iterator: (value: V, id: string) => void): void;
+  /** Number of elements. */
+  size(): number;
+  /** Set `id` to `def` only if it isn't already present; returns the value. */
+  setDefault(id: string, def: V): V;
+  /** A structural copy of the heap. */
+  clone(): MaxHeap<V>;
+  /** Id of the maximum element, or `null` if empty. */
+  maxElementId(): string | null;
+}
+
+/** A binary min-heap: a `MaxHeap` with an inverted comparator. */
+export class MinHeap<V = number> extends MaxHeap<V> {
+  /** Id of the minimum element, or `null` if empty. */
+  minElementId(): string | null;
+}
+
+/** A heap exposing both extremes. */
+export class MinMaxHeap<V = number> extends MaxHeap<V> {
+  /** Id of the minimum element, or `null` if empty. */
+  minElementId(): string | null;
+}

--- a/packages/binary-heap/binary-heap.test-d.ts
+++ b/packages/binary-heap/binary-heap.test-d.ts
@@ -1,0 +1,22 @@
+import { expectTypeOf } from "expect-type";
+import { MaxHeap, MinHeap, MinMaxHeap } from "./binary-heap";
+
+expectTypeOf<MaxHeap<number>>().toBeObject();
+expectTypeOf<MinHeap<number>>().toBeObject();
+expectTypeOf<MinMaxHeap<number>>().toBeObject();
+
+const heap = new MaxHeap<number>((a, b) => a - b);
+expectTypeOf(heap.get).parameters.toEqualTypeOf<[string]>();
+expectTypeOf(heap.get).returns.toEqualTypeOf<number | null>();
+expectTypeOf(heap.set).parameters.toEqualTypeOf<[string, number]>();
+expectTypeOf(heap.has).returns.toBeBoolean();
+expectTypeOf(heap.size).returns.toBeNumber();
+expectTypeOf(heap.clone).returns.toEqualTypeOf<MaxHeap<number>>();
+expectTypeOf(heap.maxElementId).returns.toEqualTypeOf<string | null>();
+
+expectTypeOf(new MinHeap<number>((a, b) => a - b).minElementId).returns.toEqualTypeOf<
+  string | null
+>();
+expectTypeOf(new MinMaxHeap<number>((a, b) => a - b).minElementId).returns.toEqualTypeOf<
+  string | null
+>();

--- a/packages/binary-heap/package.js
+++ b/packages/binary-heap/package.js
@@ -7,6 +7,7 @@ Package.onUse((api) => {
   api.export(["MaxHeap", "MinHeap", "MinMaxHeap"]);
   api.use(["id-map", "ecmascript"]);
   api.mainModule("binary-heap.js");
+  api.addAssets("binary-heap.d.ts", "server");
 });
 
 Package.onTest((api) => {

--- a/packages/facts-base/facts-base.d.ts
+++ b/packages/facts-base/facts-base.d.ts
@@ -1,0 +1,20 @@
+/** Name of the collection facts are published through. */
+export const FACTS_COLLECTION: string;
+/** Name of the publication that streams server facts to clients. */
+export const FACTS_PUBLICATION: string;
+
+export namespace Facts {
+  /**
+   * (Server) Restrict which users receive facts. The filter is called with the
+   * subscribing user's id (or `null`) and returns whether to send facts.
+   */
+  function setUserIdFilter(filter: (userId: string | null) => boolean): void;
+
+  /**
+   * (Server) Increment a named fact for a package and notify subscribers.
+   */
+  function incrementServerFact(pkg: string, fact: string, increment: number): void;
+
+  /** (Server) Reset all recorded server facts to zero. */
+  function resetServerFacts(): void;
+}

--- a/packages/facts-base/facts-base.test-d.ts
+++ b/packages/facts-base/facts-base.test-d.ts
@@ -1,0 +1,11 @@
+import { expectTypeOf } from "expect-type";
+import { Facts, FACTS_COLLECTION, FACTS_PUBLICATION } from "./facts-base";
+
+expectTypeOf(FACTS_COLLECTION).toBeString();
+expectTypeOf(FACTS_PUBLICATION).toBeString();
+
+expectTypeOf(Facts).toBeObject();
+expectTypeOf(Facts.setUserIdFilter).toBeFunction();
+expectTypeOf(Facts.setUserIdFilter).returns.toBeVoid();
+expectTypeOf(Facts.incrementServerFact).parameters.toEqualTypeOf<[string, string, number]>();
+expectTypeOf(Facts.resetServerFacts).returns.toBeVoid();

--- a/packages/facts-base/package.js
+++ b/packages/facts-base/package.js
@@ -17,6 +17,7 @@ Package.onUse(function (api) {
   api.mainModule("facts_base_common.js", "client");
 
   api.export("Facts");
+  api.addAssets("facts-base.d.ts", "server");
 });
 
 Package.onTest(function (api) {

--- a/packages/facts-ui/facts-ui.d.ts
+++ b/packages/facts-ui/facts-ui.d.ts
@@ -1,0 +1,12 @@
+import { Mongo } from "meteor/mongo";
+
+// facts-ui runs on the client and adds `Facts.server`, a live collection of the
+// facts published by facts-base, keyed by package name.
+declare module "meteor/facts-base" {
+  namespace Facts {
+    /** (Client) Reactive collection of server facts, indexed by package. */
+    const server: Mongo.Collection<Record<string, number>>;
+  }
+}
+
+export {};

--- a/packages/facts-ui/facts-ui.test-d.ts
+++ b/packages/facts-ui/facts-ui.test-d.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf } from "expect-type";
+import { Facts } from "meteor/facts-base";
+
+// facts-ui contributes `Facts.server` onto the facts-base namespace.
+expectTypeOf(Facts.server).toBeObject();

--- a/packages/facts-ui/package.js
+++ b/packages/facts-ui/package.js
@@ -12,4 +12,5 @@ Package.onUse(function (api) {
   api.mainModule("facts_ui_client.js", "client");
 
   api.export("Facts", "client");
+  api.addAssets("facts-ui.d.ts", "client");
 });

--- a/packages/force-ssl-common/force-ssl-common.d.ts
+++ b/packages/force-ssl-common/force-ssl-common.d.ts
@@ -1,0 +1,13 @@
+/** The subset of a Node HTTP request these helpers inspect. */
+interface ConnectionRequest {
+  headers?: Record<string, string | string[] | undefined>;
+  connection?: { remoteAddress?: string; [key: string]: unknown };
+  socket?: { remoteAddress?: string; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+/** Whether the request originated from a loopback / local address. */
+export function isLocalConnection(req: ConnectionRequest): boolean;
+
+/** Whether the request reached the server over a secure (TLS) connection. */
+export function isSslConnection(req: ConnectionRequest): boolean;

--- a/packages/force-ssl-common/force-ssl-common.test-d.ts
+++ b/packages/force-ssl-common/force-ssl-common.test-d.ts
@@ -1,0 +1,8 @@
+import { expectTypeOf } from "expect-type";
+import { isLocalConnection, isSslConnection } from "./force-ssl-common";
+
+expectTypeOf(isLocalConnection).toBeFunction();
+expectTypeOf(isLocalConnection).returns.toBeBoolean();
+
+expectTypeOf(isSslConnection).toBeFunction();
+expectTypeOf(isSslConnection).returns.toBeBoolean();

--- a/packages/force-ssl-common/package.js
+++ b/packages/force-ssl-common/package.js
@@ -10,6 +10,7 @@ Npm.depends({
 Package.onUse(function (api) {
   api.use('ecmascript');
   api.mainModule('force_ssl_common.js', 'server');
+  api.addAssets('force-ssl-common.d.ts', 'server');
 });
 
 Package.onTest(function (api) {

--- a/packages/geojson-utils/geojson-utils.d.ts
+++ b/packages/geojson-utils/geojson-utils.d.ts
@@ -1,0 +1,41 @@
+/** A GeoJSON position: `[longitude, latitude]` (with optional altitude). */
+type Position = number[];
+
+/** A GeoJSON geometry object, e.g. a Point, LineString or Polygon. */
+interface Geometry {
+  type: string;
+  coordinates: Position | Position[] | Position[][];
+}
+
+/**
+ * Geometry helpers operating on GeoJSON objects. Ported from the
+ * `geojson-utils` library.
+ */
+export namespace GeoJSON {
+  /** Area of a polygon, in square units of its coordinates. */
+  export function area(polygon: Geometry): number;
+  /** Centroid point of a polygon. */
+  export function centroid(polygon: Geometry): Geometry;
+  /** Point reached by travelling `dist` from `point` on bearing `brng`. */
+  export function destinationPoint(point: Geometry, brng: number, dist: number): Geometry;
+  /** Approximate a circle of `radiusInMeters` around `centerPoint`. */
+  export function drawCircle(radiusInMeters: number, centerPoint: Geometry, steps?: number): Geometry;
+  /** Whether every vertex of `geometry` lies within `radius` of `center`. */
+  export function geometryWithinRadius(geometry: Geometry, center: Geometry, radius: number): boolean;
+  /** Intersection points of two line strings, or `false` if none. */
+  export function lineStringsIntersect(line1: Geometry, line2: Geometry): Geometry[] | false;
+  /** Convert degrees to radians. */
+  export function numberToRadius(degrees: number): number;
+  /** Convert radians to degrees. */
+  export function numberToDegree(radians: number): number;
+  /** Great-circle distance between two points, in kilometres. */
+  export function pointDistance(pt1: Geometry, pt2: Geometry): number;
+  /** Whether `point` lies inside the given bounding box. */
+  export function pointInBoundingBox(point: Geometry, bounds: Geometry): boolean;
+  /** Whether `point` lies inside `polygon`. */
+  export function pointInPolygon(point: Geometry, polygon: Geometry): boolean;
+  /** Centroid of a rectangle geometry. */
+  export function rectangleCentroid(rectangle: Geometry): Geometry;
+  /** Simplify a set of points using the Douglas–Peucker algorithm. */
+  export function simplify(source: Geometry[], kink?: number): Geometry[];
+}

--- a/packages/geojson-utils/geojson-utils.test-d.ts
+++ b/packages/geojson-utils/geojson-utils.test-d.ts
@@ -1,0 +1,20 @@
+import { expectTypeOf } from "expect-type";
+import { GeoJSON } from "./geojson-utils";
+
+expectTypeOf(GeoJSON).toBeObject();
+
+expectTypeOf(GeoJSON.area).returns.toBeNumber();
+expectTypeOf(GeoJSON.centroid).toBeFunction();
+expectTypeOf(GeoJSON.destinationPoint).toBeFunction();
+expectTypeOf(GeoJSON.drawCircle).toBeFunction();
+expectTypeOf(GeoJSON.geometryWithinRadius).returns.toBeBoolean();
+expectTypeOf(GeoJSON.lineStringsIntersect).toBeFunction();
+expectTypeOf(GeoJSON.numberToRadius).parameters.toEqualTypeOf<[number]>();
+expectTypeOf(GeoJSON.numberToRadius).returns.toBeNumber();
+expectTypeOf(GeoJSON.numberToDegree).parameters.toEqualTypeOf<[number]>();
+expectTypeOf(GeoJSON.numberToDegree).returns.toBeNumber();
+expectTypeOf(GeoJSON.pointDistance).returns.toBeNumber();
+expectTypeOf(GeoJSON.pointInBoundingBox).returns.toBeBoolean();
+expectTypeOf(GeoJSON.pointInPolygon).returns.toBeBoolean();
+expectTypeOf(GeoJSON.rectangleCentroid).toBeFunction();
+expectTypeOf(GeoJSON.simplify).toBeFunction();

--- a/packages/geojson-utils/package.js
+++ b/packages/geojson-utils/package.js
@@ -7,6 +7,7 @@ Package.onUse(function (api) {
   api.use('modules');
   api.export('GeoJSON');
   api.mainModule('main.js');
+  api.addAssets('geojson-utils.d.ts', 'server');
 });
 
 Package.onTest(function (api) {

--- a/packages/oauth-encryption/oauth-encryption.d.ts
+++ b/packages/oauth-encryption/oauth-encryption.d.ts
@@ -1,0 +1,26 @@
+export namespace OAuthEncryption {
+  /**
+   * Load the AES-128-GCM key used to seal/open OAuth secrets. Pass `null` to
+   * unload the current key.
+   * @param key Base64-encoded 16-byte key, or `null` to clear it.
+   */
+  export function loadKey(key: string | null): void;
+
+  /** Whether an encryption key is currently loaded. */
+  export function keyIsLoaded(): boolean;
+
+  /**
+   * Encrypt `data`, binding the ciphertext to `userId` as additional
+   * authenticated data. Returns the sealed value.
+   */
+  export function seal(data: unknown, userId: string): string;
+
+  /**
+   * Decrypt a value previously produced by `seal`, verifying it was bound to
+   * `userId`. Returns the original data.
+   */
+  export function open(ciphertext: string, userId: string): unknown;
+
+  /** Whether `value` looks like a value produced by `seal`. */
+  export function isSealed(value: unknown): boolean;
+}

--- a/packages/oauth-encryption/oauth-encryption.test-d.ts
+++ b/packages/oauth-encryption/oauth-encryption.test-d.ts
@@ -1,0 +1,11 @@
+import { expectTypeOf } from "expect-type";
+import { OAuthEncryption } from "./oauth-encryption";
+
+expectTypeOf(OAuthEncryption).toBeObject();
+
+expectTypeOf(OAuthEncryption.loadKey).parameters.toEqualTypeOf<[string | null]>();
+expectTypeOf(OAuthEncryption.keyIsLoaded).returns.toBeBoolean();
+expectTypeOf(OAuthEncryption.seal).parameters.toEqualTypeOf<[unknown, string]>();
+expectTypeOf(OAuthEncryption.seal).returns.toBeString();
+expectTypeOf(OAuthEncryption.open).parameters.toEqualTypeOf<[string, string]>();
+expectTypeOf(OAuthEncryption.isSealed).returns.toBeBoolean();

--- a/packages/oauth-encryption/package.js
+++ b/packages/oauth-encryption/package.js
@@ -9,6 +9,7 @@ Package.onUse(api => {
   api.use("ejson@1.1.3", "server");
   api.mainModule("encrypt.js", "server");
   api.export("OAuthEncryption", "server");
+  api.addAssets("oauth-encryption.d.ts", "server");
 });
 
 Package.onTest(api => {

--- a/packages/oauth1/oauth1.d.ts
+++ b/packages/oauth1/oauth1.d.ts
@@ -1,0 +1,53 @@
+/** Service configuration passed to `OAuth1Binding`. */
+interface OAuth1Config {
+  consumerKey?: string;
+  secret?: string;
+  [key: string]: unknown;
+}
+
+/** The provider endpoints an `OAuth1Binding` talks to. */
+interface OAuth1Urls {
+  requestToken: string;
+  authorize: string;
+  accessToken: string;
+  authenticate?: string;
+}
+
+/** Query parameters returned to the callback after user authorization. */
+interface OAuth1Query {
+  oauth_token: string;
+  oauth_verifier: string;
+  [key: string]: unknown;
+}
+
+type OAuth1Params = Record<string, unknown>;
+type OAuth1Callback = (error: Error | undefined, response?: unknown) => void;
+
+/**
+ * A binding to a single OAuth 1.0(a) service, handling the request-token /
+ * access-token handshake and signed requests.
+ */
+export class OAuth1Binding {
+  constructor(config: OAuth1Config, urls: OAuth1Urls);
+
+  requestToken?: string;
+  requestTokenSecret?: string;
+  accessToken?: string;
+  accessTokenSecret?: string;
+
+  /** Obtain a request token, storing it on the instance. */
+  prepareRequestToken(callbackUrl: string): Promise<void>;
+  /** Exchange the authorized request token for an access token. */
+  prepareAccessToken(query: OAuth1Query, requestTokenSecret?: string): Promise<void>;
+
+  /** Make a signed request with an explicit HTTP method. */
+  callAsync(method: string, url: string, params?: OAuth1Params, callback?: OAuth1Callback): Promise<unknown>;
+  /** Make a signed GET request. */
+  getAsync(url: string, params?: OAuth1Params, callback?: OAuth1Callback): Promise<unknown>;
+  /** Make a signed POST request. */
+  postAsync(url: string, params?: OAuth1Params, callback?: OAuth1Callback): Promise<unknown>;
+  /** @deprecated Use `getAsync`. */
+  get(url: string, params?: OAuth1Params, callback?: OAuth1Callback): unknown;
+  /** @deprecated Use `postAsync`. */
+  post(url: string, params?: OAuth1Params, callback?: OAuth1Callback): unknown;
+}

--- a/packages/oauth1/oauth1.test-d.ts
+++ b/packages/oauth1/oauth1.test-d.ts
@@ -1,0 +1,22 @@
+import { expectTypeOf } from "expect-type";
+import { OAuth1Binding } from "./oauth1";
+
+expectTypeOf(OAuth1Binding).toBeConstructibleWith(
+  { consumerKey: "k", secret: "s" },
+  { requestToken: "r", authorize: "a", accessToken: "t" }
+);
+
+const binding = new OAuth1Binding(
+  { consumerKey: "k", secret: "s" },
+  { requestToken: "r", authorize: "a", accessToken: "t" }
+);
+
+expectTypeOf(binding.requestToken).toEqualTypeOf<string | undefined>();
+expectTypeOf(binding.prepareRequestToken).parameters.toEqualTypeOf<[string]>();
+expectTypeOf(binding.prepareRequestToken).returns.toEqualTypeOf<Promise<void>>();
+expectTypeOf(binding.prepareAccessToken).returns.toEqualTypeOf<Promise<void>>();
+expectTypeOf(binding.callAsync).returns.toEqualTypeOf<Promise<unknown>>();
+expectTypeOf(binding.getAsync).returns.toEqualTypeOf<Promise<unknown>>();
+expectTypeOf(binding.postAsync).returns.toEqualTypeOf<Promise<unknown>>();
+expectTypeOf(binding.get).toBeFunction();
+expectTypeOf(binding.post).toBeFunction();

--- a/packages/oauth1/package.js
+++ b/packages/oauth1/package.js
@@ -14,6 +14,7 @@ Package.onUse(api => {
 
   api.export('OAuth1Binding', 'server');
   api.export('OAuth1Test', 'server', { testOnly: true });
+  api.addAssets('oauth1.d.ts', 'server');
 
   api.addFiles('oauth1_binding.js', 'server');
   api.addFiles('oauth1_server.js', 'server');

--- a/packages/reload/package.js
+++ b/packages/reload/package.js
@@ -7,6 +7,7 @@ Package.onUse(function (api) {
   api.use('ecmascript');
   api.mainModule('reload.js', 'client');
   api.export('Reload', 'client');
+  api.addAssets('reload.d.ts', 'client');
 });
 
 Package.onTest(function (api) {

--- a/packages/reload/reload.d.ts
+++ b/packages/reload/reload.d.ts
@@ -1,0 +1,24 @@
+export namespace Reload {
+  /**
+   * A migration handler. Receives a `retry` callback and returns
+   * `[readyToMigrate, data?]`; returning `false` blocks the reload until
+   * `retry` is called.
+   */
+  type MigrationCallback = (retry: () => void) => [boolean, unknown?];
+
+  /** Register a migration handler, optionally under a named key. */
+  export function _onMigrate(callback: MigrationCallback): void;
+  export function _onMigrate(name: string, callback: MigrationCallback): void;
+
+  /** Data saved by the named migration handler on the previous reload. */
+  export function _migrationData(name: string): unknown;
+
+  /** All migration data saved across handlers. */
+  export function _getData(): Record<string, unknown>;
+
+  /** Attempt to migrate; `tryReload` triggers a page reload when ready. */
+  export function _migrate(tryReload: boolean, options?: { immediateMigration?: boolean }): void;
+
+  /** Reload the client program, running migration handlers first. */
+  export function _reload(options?: { immediateMigration?: boolean }): void;
+}

--- a/packages/reload/reload.test-d.ts
+++ b/packages/reload/reload.test-d.ts
@@ -1,0 +1,11 @@
+import { expectTypeOf } from "expect-type";
+import { Reload } from "./reload";
+
+expectTypeOf(Reload).toBeObject();
+
+expectTypeOf(Reload._onMigrate).toBeFunction();
+expectTypeOf(Reload._migrationData).parameters.toEqualTypeOf<[string]>();
+expectTypeOf(Reload._getData).returns.toEqualTypeOf<Record<string, unknown>>();
+expectTypeOf(Reload._migrate).toBeFunction();
+expectTypeOf(Reload._migrate).returns.toBeVoid();
+expectTypeOf(Reload._reload).returns.toBeVoid();

--- a/packages/shell-server/package.js
+++ b/packages/shell-server/package.js
@@ -10,4 +10,5 @@ Package.onUse(function(api) {
   api.use("ecmascript", "server");
   api.use("babel-compiler", "server");
   api.mainModule("main.js", "server");
+  api.addAssets("shell-server.d.ts", "server");
 });

--- a/packages/shell-server/shell-server.d.ts
+++ b/packages/shell-server/shell-server.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Start listening for `meteor shell` connections on the socket inside
+ * `shellDir` (the app's local shell directory).
+ */
+export function listen(shellDir: string): void;
+
+/**
+ * Stop serving `meteor shell` connections for `shellDir`.
+ */
+export function disable(shellDir: string): void;

--- a/packages/shell-server/shell-server.test-d.ts
+++ b/packages/shell-server/shell-server.test-d.ts
@@ -1,0 +1,8 @@
+import { expectTypeOf } from "expect-type";
+import { listen, disable } from "./shell-server";
+
+expectTypeOf(listen).parameters.toEqualTypeOf<[string]>();
+expectTypeOf(listen).returns.toBeVoid();
+
+expectTypeOf(disable).parameters.toEqualTypeOf<[string]>();
+expectTypeOf(disable).returns.toBeVoid();

--- a/packages/socket-stream-client/package.js
+++ b/packages/socket-stream-client/package.js
@@ -21,6 +21,7 @@ Package.onUse(function (api) {
 
   api.addFiles("server.js", "server");
   api.mainModule("node.js", "server", { lazy: true });
+  api.addAssets("socket-stream-client.d.ts", "server");
 });
 
 Package.onTest(function (api) {

--- a/packages/socket-stream-client/socket-stream-client.d.ts
+++ b/packages/socket-stream-client/socket-stream-client.d.ts
@@ -1,0 +1,42 @@
+/** Options accepted by the `ClientStream` constructor. */
+interface ClientStreamOptions {
+  /** Automatically reconnect on failure (default `true`). */
+  retry?: boolean;
+  /** Custom error constructor thrown on connection failure. */
+  ConnectionError?: unknown;
+  /** Extra headers sent with the connection (server-to-server only). */
+  headers?: Record<string, string>;
+  npmFayeOptions?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** Snapshot of a stream's connection state, as returned by `status()`. */
+interface StreamStatus {
+  status: "connected" | "connecting" | "failed" | "waiting" | "offline";
+  connected: boolean;
+  retryCount: number;
+  retryTime?: number;
+  reason?: string;
+}
+
+/** Events a caller can subscribe to via `on`. */
+type StreamEvent = "message" | "reset" | "disconnect";
+
+/**
+ * A DDP transport stream backed by SockJS/WebSocket in the browser (and a
+ * faye-websocket in Node). Handles connection, reconnection and heartbeats.
+ */
+export class ClientStream {
+  constructor(url: string, options?: ClientStreamOptions);
+
+  /** Send a raw string message over the socket. */
+  send(data: string): void;
+  /** Subscribe to a stream event. */
+  on(name: StreamEvent, callback: (...args: unknown[]) => void): void;
+  /** Force a reconnect, optionally to a new URL. */
+  reconnect(options?: { url?: string; _force?: boolean }): void;
+  /** Close the connection. */
+  disconnect(options?: { _permanent?: boolean; _error?: unknown }): void;
+  /** Current connection status. */
+  status(): StreamStatus;
+}

--- a/packages/socket-stream-client/socket-stream-client.test-d.ts
+++ b/packages/socket-stream-client/socket-stream-client.test-d.ts
@@ -1,0 +1,12 @@
+import { expectTypeOf } from "expect-type";
+import { ClientStream } from "./socket-stream-client";
+
+expectTypeOf<ClientStream>().toBeObject();
+
+const stream = new ClientStream("ws://localhost:3000/websocket");
+expectTypeOf(stream.send).parameters.toEqualTypeOf<[string]>();
+expectTypeOf(stream.send).returns.toBeVoid();
+expectTypeOf(stream.on).toBeFunction();
+expectTypeOf(stream.reconnect).toBeFunction();
+expectTypeOf(stream.disconnect).toBeFunction();
+expectTypeOf(stream.status).returns.toBeObject();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
       "meteor/ddp": ["./packages/ddp/ddp.d.ts"],
       "meteor/ejson": ["./packages/ejson/ejson.d.ts"],
       "meteor/check": ["./packages/check/check.d.ts"],
+      "meteor/facts-base": ["./packages/facts-base/facts-base.d.ts"],
       "meteor/tracker": ["./packages/tracker/tracker.d.ts"],
       "meteor/random": ["./packages/random/random.d.ts"],
       "meteor/accounts-base": ["./packages/accounts-base/accounts-base.d.ts"],


### PR DESCRIPTION
## Tier 1 — core runtime (part 1)

Adds `.d.ts` + `.test-d.ts` + `addAssets` for 11 core-runtime packages with clear, self-contained export surface.

| Package | Export |
|---|---|
| binary-heap | `MaxHeap` / `MinHeap` / `MinMaxHeap` |
| reload | `Reload` |
| autoupdate | `Autoupdate` |
| allow-deny | `AllowDeny` |
| oauth1 | `OAuth1Binding` |
| oauth-encryption | `OAuthEncryption` |
| facts-base | `Facts`, `FACTS_COLLECTION`, `FACTS_PUBLICATION` |
| geojson-utils | `GeoJSON` |
| force-ssl-common | `isLocalConnection`, `isSslConnection` |
| socket-stream-client | `ClientStream` |
| shell-server | `listen`, `disable` |

### Gates
- `dts-test-coverage`: 171 → **211/211 = 100%**
- `type-coverage`: passes (≥99%)
- `tsc --noEmit`: 0 errors · `fmt:check`: clean

### Scoped out of this PR (findings)
- **DDP trio** (`ddp-client`/`ddp-server`/`ddp-common`) — large, mostly internal (`_`-prefixed) surface that overlaps the existing `ddp.d.ts`; deserves a dedicated PR.
- **facts-ui** — augments `facts-base` (`Facts.server`); needs the augmentation + paths treatment, deferred with the augmentation batch.
- **browser-policy / -content / -framing** — need no `.d.ts`: their full surface is already typed centrally in `browser-policy-common.d.ts`.
- **Pure side-effect** (`force-ssl`, `dynamic-import`, `mongo-dev-server`, `inter-process-messaging`, `accounts-passwordless`) — no exported surface to type.

Base: `ts/type-coverage`.