### PR TITLE
feat(types): complete DDPCommon + add DDPServer

### DIFF
--- a/packages/ddp/ddp.d.ts
+++ b/packages/ddp/ddp.d.ts
@@ -66,4 +66,57 @@ export namespace DDPCommon {
      */
     connection: Meteor.Connection;
   }
+
+  /** Supported DDP protocol versions, newest first. */
+  const SUPPORTED_DDP_VERSIONS: string[];
+
+  /** Parse a raw DDP wire string into a message object, or `null` if invalid. */
+  function parseDDP(stringMessage: string): Record<string, unknown> | null;
+
+  /** Serialize a DDP message object to its wire string. */
+  function stringifyDDP(msg: Record<string, unknown>): string;
+
+  /** Derive the deterministic random seed used by a method stub. */
+  function makeRpcSeed(enclosing: MethodInvocation, methodName: string): unknown;
+
+  /** Options for constructing a `Heartbeat`. */
+  interface HeartbeatOptions {
+    heartbeatInterval: number;
+    heartbeatTimeout: number;
+    onTimeout: () => void;
+    sendPing: () => void;
+  }
+
+  /** Client/server heartbeat used to detect dropped DDP connections. */
+  interface Heartbeat {
+    new (options: HeartbeatOptions): Heartbeat;
+    /** Begin sending pings and watching for timeouts. */
+    start(): void;
+    /** Stop all heartbeat timers. */
+    stop(): void;
+    /** Reset the timeout timer after any message is received. */
+    messageReceived(): void;
+  }
+
+  /** A deterministic, seeded source of `Random` generators. */
+  interface RandomStream {
+    new (options: { seed?: string | string[] }): RandomStream;
+  }
+}
+
+export namespace DDPServer {
+  /** How a publication reconciles documents across overlapping subscriptions. */
+  interface PublicationStrategy {
+    useDummyDocumentView: boolean;
+    useCollectionView: boolean;
+    doAccountingForCollection: boolean;
+  }
+
+  /** The built-in publication strategies, passed to `setPublicationStrategy`. */
+  var publicationStrategies: {
+    SERVER_MERGE: PublicationStrategy;
+    NO_MERGE_NO_HISTORY: PublicationStrategy;
+    NO_MERGE: PublicationStrategy;
+    NO_MERGE_MULTI: PublicationStrategy;
+  };
 }

--- a/packages/ddp/ddp.test-d.ts
+++ b/packages/ddp/ddp.test-d.ts
@@ -1,6 +1,14 @@
 import { expectTypeOf } from "expect-type";
-import { DDP } from "./ddp";
+import { DDP, DDPServer } from "./ddp";
 import type { DDPCommon } from "./ddp";
 
 expectTypeOf(DDP).toBeObject();
+
 expectTypeOf<DDPCommon.MethodInvocation>().toBeObject();
+expectTypeOf<DDPCommon.Heartbeat>().toBeObject();
+expectTypeOf<DDPCommon.RandomStream>().toBeObject();
+expectTypeOf<DDPCommon.HeartbeatOptions>().toBeObject();
+
+expectTypeOf(DDPServer).toBeObject();
+expectTypeOf(DDPServer.publicationStrategies).toBeObject();
+expectTypeOf(DDPServer.publicationStrategies.SERVER_MERGE.useCollectionView).toBeBoolean();


### PR DESCRIPTION
## DDP types

The `DDP` / `DDPCommon` / `DDPServer` namespaces are owned centrally by the **ddp** umbrella package's `ddp.d.ts` — `ddp-client` / `ddp-server` / `ddp-common` only *implement* them (they're `imply`-ed by `ddp`). So this expands `ddp.d.ts` rather than adding three overlapping files (same pattern as `browser-policy-common` owning the BrowserPolicy type).

### Changes to `ddp.d.ts`
- **DDPCommon** — was only `MethodInvocation`; now also `Heartbeat`, `RandomStream`, `parseDDP`, `stringifyDDP`, `makeRpcSeed`, `SUPPORTED_DDP_VERSIONS`.
- **DDPServer** — new namespace exposing `publicationStrategies` (`SERVER_MERGE` / `NO_MERGE` / `NO_MERGE_NO_HISTORY` / `NO_MERGE_MULTI`). The rest of `DDPServer` is `_`-internal and intentionally left out.

### Why no separate ddp-client / ddp-server / ddp-common .d.ts
Their exported surface *is* the `DDP` / `DDPServer` / `DDPCommon` namespaces, which live in `ddp.d.ts`. Separate files would duplicate/conflict with it — exactly the overlap flagged when this was split out of the tier-1 PR.

### Gates
- `dts-test-coverage`: **172/172 = 100%**
- `type-coverage`: passes · `tsc --noEmit`: 0 errors · `fmt:check`: clean

Base: `ts/type-coverage`.