### PR TITLE
test(types): enable namespace-member coverage + cover ddp (pilot)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/sockjs-client": "^1.5.4",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
-        "check-type-test-coverage": "^1.2.0",
+        "check-type-test-coverage": "^1.3.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.2",
         "eslint-config-vazco": "^7.4.0",
@@ -2180,9 +2180,9 @@
       }
     },
     "node_modules/check-type-test-coverage": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/check-type-test-coverage/-/check-type-test-coverage-1.2.0.tgz",
-      "integrity": "sha512-RFln0ATCeAgnAogu0CaIJbXVX2FF1NF7ngzMPnGIoA/Hs6AItgSLP8TQl9PnYlt3sgBFEl+dgYzkwOodcaD0rw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/check-type-test-coverage/-/check-type-test-coverage-1.3.0.tgz",
+      "integrity": "sha512-J/B3m7oHsB0JMV2weZTiaWxvsVKeNY+oknSxZcXuoy6BcbOLkru8kwkhh998POcIk+Ewi8jYnqTAtOq3bRz/6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/sockjs-client": "^1.5.4",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "check-type-test-coverage": "^1.2.0",
+    "check-type-test-coverage": "^1.3.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.2",
     "eslint-config-vazco": "^7.4.0",
@@ -61,7 +61,7 @@
     "types:compile": "npx tsc --noEmit",
     "types:coverage": "npm run types:compile && type-coverage --at-least 99",
     "types:coverage:table": "npm run types:compile && node -e \"require('typescript-coverage-report/dist/lib/getCoverage').default().then(d=>{process.stdout.write(require('typescript-coverage-report/dist/lib/reporters/text').generate(d,80)+'\\n');process.exit(d.percentage>=80?0:1)})\"",
-    "types:dts-test-coverage": "check-type-test-coverage ./packages --augmentation --ignore '**/non-core/blaze/**' --tsconfig ./tsconfig.json --min 100"
+    "types:dts-test-coverage": "check-type-test-coverage ./packages --augmentation --ignore '**/non-core/blaze/**' --tsconfig ./tsconfig.json --namespace-members --min 56"
   },
   "jshintConfig": {
     "esversion": 11

--- a/packages/ddp/ddp.test-d.ts
+++ b/packages/ddp/ddp.test-d.ts
@@ -1,14 +1,27 @@
 import { expectTypeOf } from "expect-type";
-import { DDP, DDPServer } from "./ddp";
-import type { DDPCommon } from "./ddp";
+import { DDP, DDPServer, DDPCommon } from "./ddp";
 
+// --- DDP ---
 expectTypeOf(DDP).toBeObject();
+expectTypeOf<DDP.DDPStatic>().toBeObject();
+expectTypeOf<DDP.DDPStatus>().toBeObject();
+expectTypeOf<DDP.Status>().toEqualTypeOf<
+  "connected" | "connecting" | "failed" | "waiting" | "offline"
+>();
+expectTypeOf(DDP.connect).toBeFunction();
 
+// --- DDPCommon ---
 expectTypeOf<DDPCommon.MethodInvocation>().toBeObject();
+expectTypeOf<DDPCommon.MethodInvocationOptions>().toBeObject();
 expectTypeOf<DDPCommon.Heartbeat>().toBeObject();
-expectTypeOf<DDPCommon.RandomStream>().toBeObject();
 expectTypeOf<DDPCommon.HeartbeatOptions>().toBeObject();
+expectTypeOf<DDPCommon.RandomStream>().toBeObject();
+expectTypeOf(DDPCommon.SUPPORTED_DDP_VERSIONS).toEqualTypeOf<string[]>();
+expectTypeOf(DDPCommon.parseDDP).toBeFunction();
+expectTypeOf(DDPCommon.stringifyDDP).toBeFunction();
+expectTypeOf(DDPCommon.makeRpcSeed).toBeFunction();
 
+// --- DDPServer ---
 expectTypeOf(DDPServer).toBeObject();
+expectTypeOf<DDPServer.PublicationStrategy>().toBeObject();
 expectTypeOf(DDPServer.publicationStrategies).toBeObject();
-expectTypeOf(DDPServer.publicationStrategies.SERVER_MERGE.useCollectionView).toBeBoolean();


### PR DESCRIPTION
## Close the coverage blind-spot (Finding #2 from the audit)

The dts-test-coverage gate was only counting **top-level exports** and members that carried an explicit `export`. But in a `.d.ts`, a member declared inside an exported `namespace` is **accessible API whether or not it says `export`** — so functions like `DDP.connect` were real API the gate never required a test for. A namespace could hide any number of functions behind one counted declaration and still read "100%".

This turns on `check-type-test-coverage@1.3.0`'s new `--namespace-members` (counts those members, skipping `_`-prefixed internals).

### Honest re-baseline
What read as **100%** was really **~55%** of the surface (300/549). This is not a regression — it's the gate finally measuring what it should.

- `--min` is set to the **current floor (56)** and **ratchets up** per package.
- Pilot: **`ddp.d.ts` fully covered** (18/18 with the flag) — `DDP.connect`, `DDP.Status`, `DDPStatic`, `DDPCommon.parseDDP` / `stringifyDDP` / `makeRpcSeed` / `SUPPORTED_DDP_VERSIONS`, `DDPServer.PublicationStrategy`, …

### Rollout
Follow-up PRs cover namespace members per package (biggest: `meteor.d.ts` 83, `accounts-base` 58, `roles` 41, `webapp` 32, `mongo` 22), bumping `--min` each time until back to 100%.

### Gates
- `dts-test-coverage`: 310/549 = **56%** (≥ --min 56, EXIT 0)
- `type-coverage`: passes · `tsc --noEmit`: 0 errors · `fmt:check`: clean

### Companion tool fix
`check-type-test-coverage@1.3.0` also fixes a rounding bug found in the audit: the gate compared the *rounded* percent, so 240/241 (99.58%) rounded to 100% and passed `--min 100`. It now gates on the exact ratio.

Base: `ts/type-coverage`.