### PR TITLE
fix: scope change-stream fence timestamps to their connection (#14600)

### DIFF
--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -6,7 +6,7 @@ import { DDPServer } from 'meteor/ddp-server';
 import { DiffSequence } from 'meteor/diff-sequence';
 import { listenAll } from './mongo_driver';
 import { replaceTypes, replaceMongoAtomWithMeteor, replaceMeteorAtomWithMongo } from './mongo_common';
-import { compareOperationTimes } from './mongo_common';
+import { compareOperationTimes, fenceWriteTsKey } from './mongo_common';
 
 const SUPPORTED_OPERATIONS = ['insert', 'update', 'replace', 'delete'];
 
@@ -480,10 +480,22 @@ export class ChangeStreamObserveDriver {
     // server's clock advances with replication heartbeats, but our stream
     // only sees events emitted on this collection, so the wait would never
     // resolve under the previous (no-timeout) regime.
+    //
+    // The lookup is scoped to our own connection as well as our collection.
+    // The crossbar notifies every driver listening on a collection *name*, so
+    // an app with a second MongoConnection (e.g. a RemoteCollectionDriver onto
+    // another cluster) that happens to use the same name lands us here on a
+    // fence carrying only that other connection's write. Its clusterTime comes
+    // from a different cluster and our stream will never emit an event at or
+    // past it, so matching on name alone parks this wait forever and hangs the
+    // method that issued the write (meteor/meteor#14600).
     const fence = fenceOverride || DDPServer._getCurrentFence();
     const { collectionName } = this._cursorDescription;
     const { _csTargetTsByCollection } = fence || {};
-    const targetTs = _csTargetTsByCollection && collectionName ? _csTargetTsByCollection[collectionName] : undefined;
+    const connectionId = this._mongoHandle?._csConnectionId;
+    const targetTs = _csTargetTsByCollection && collectionName && connectionId
+      ? _csTargetTsByCollection[fenceWriteTsKey(connectionId, collectionName)]
+      : undefined;
 
     if (!targetTs) {
       return;

--- a/packages/mongo/changestream_observe_driver.js
+++ b/packages/mongo/changestream_observe_driver.js
@@ -468,8 +468,8 @@ export class ChangeStreamObserveDriver {
     if (this._stopped) return;
 
     // The fence's write path stamps the exact clusterTime of each write on
-    // fence._csTargetTsByCollection[collectionName] (see
-    // mongo_connection._annotateFenceWithWriteTs). Wait specifically for
+    // fence._csTargetTsByCollection[fenceWriteTsKey(connectionId, collectionName)]
+    // (see mongo_connection._annotateFenceWithWriteTs). Wait specifically for
     // that ts. The fence must be passed explicitly because fence.fire()
     // runs outside the AsyncLocalStorage context where _getCurrentFence()
     // would find it.

--- a/packages/mongo/mongo_common.js
+++ b/packages/mongo/mongo_common.js
@@ -199,3 +199,27 @@ export function replaceNames(filter, thing) {
 export function compareOperationTimes(opTime1, opTime2) {
   return (new MongoDB.Timestamp(opTime1)).compare(opTime2);
 }
+
+/**
+ * Key under which a write's clusterTime is recorded on the DDP write fence.
+ *
+ * Scoped to the *connection* as well as the collection: an app can hold more
+ * than one MongoConnection (a second `MongoInternals.RemoteCollectionDriver`
+ * pointed at another cluster is the common case) and those connections
+ * routinely share collection names. Both the crossbar listener and the fence
+ * annotation are otherwise keyed by collection name alone, so a write on
+ * connection B would park a change-stream driver watching connection A on a
+ * clusterTime from a cluster that driver's stream can never observe — the wait
+ * never resolves and the method that issued the write hangs forever
+ * (meteor/meteor#14600). clusterTimes are only comparable within one cluster,
+ * so they must never be matched across connections.
+ *
+ * @param {string} connectionId - `MongoConnection#_csConnectionId` of the connection the write went to.
+ * @param {string} collectionName - Name of the collection written.
+ * @returns {string} Composite key for `fence._csTargetTsByCollection`.
+ */
+export function fenceWriteTsKey(connectionId, collectionName) {
+  // NUL cannot appear in a Mongo collection name, so it is a safe
+  // separator: no (connection, collection) pair can collide with another.
+  return `${connectionId}\u0000${collectionName}`;
+}

--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -6,7 +6,7 @@ import { AsynchronousCursor } from './asynchronous_cursor';
 import { Cursor } from './cursor';
 import { CursorDescription } from './cursor_description';
 import { DocFetcher } from './doc_fetcher';
-import { MongoDB, compareOperationTimes, replaceMeteorAtomWithMongo, replaceTypes, transformResult } from './mongo_common';
+import { MongoDB, compareOperationTimes, fenceWriteTsKey, replaceMeteorAtomWithMongo, replaceTypes, transformResult } from './mongo_common';
 import { ObserveHandle } from './observe_handle';
 import { ObserveMultiplexer } from './observe_multiplex';
 import { OplogObserveDriver } from './oplog_observe_driver';
@@ -20,6 +20,11 @@ const ASSETS_FOLDER = 'assets';
 const APP_FOLDER = 'app';
 
 const oplogCollectionWarnings = [];
+
+// Distinguishes MongoConnection instances from each other so a write fence can
+// record which connection a write went to (see fenceWriteTsKey). A process-local
+// counter is enough: the ids never leave the process.
+let nextCsConnectionId = 1;
 const availableDrivers = ['changeStreams', 'oplog', 'polling']
 const DEFAULT_REACTIVITY_ORDER = process.env.METEOR_REACTIVITY_ORDER ? process.env.METEOR_REACTIVITY_ORDER.split(',') : availableDrivers;
 
@@ -38,6 +43,10 @@ export const MongoConnection = function (url, options) {
   self._observeMultiplexers = {};
   self._sharedChangeStreams = {};
   self._onFailoverHook = new Hook;
+  // Identifies this connection when annotating a write fence with the
+  // clusterTime of a write, so drivers on other connections that happen to
+  // watch a same-named collection don't pick it up (meteor/meteor#14600).
+  self._csConnectionId = `mc${nextCsConnectionId++}`;
 
   const userOptions = {
     ...(Mongo._connectionOptions || {}),
@@ -195,12 +204,17 @@ MongoConnection.prototype._maybeBeginWrite = function () {
 // creating a card also writes to activities), so picking a single "max ts"
 // for the whole fence would stall drivers whose collection never sees
 // that specific ts. We therefore keep the max ts per collection.
-function _annotateFenceWithWriteTs(fence, collectionName, writeTs) {
-  if (!fence || !writeTs || !collectionName) return;
+//
+// It is also per-connection: see fenceWriteTsKey. A single fence can span
+// writes to several MongoConnections, and clusterTimes from different clusters
+// are not comparable, so the connection has to be part of the key.
+function _annotateFenceWithWriteTs(fence, connection, collectionName, writeTs) {
+  if (!fence || !writeTs || !collectionName || !connection) return;
   const map = fence._csTargetTsByCollection = fence._csTargetTsByCollection || {};
-  const prev = map[collectionName];
+  const key = fenceWriteTsKey(connection._csConnectionId, collectionName);
+  const prev = map[key];
   if (!prev || compareOperationTimes(writeTs, prev) > 0) {
-    map[collectionName] = writeTs;
+    map[key] = writeTs;
   }
 }
 
@@ -236,7 +250,7 @@ MongoConnection.prototype.insertAsync = async function (collection_name, documen
       session,
     }
   ).then(async ({insertedId}) => {
-    _annotateFenceWithWriteTs(DDPServer._getCurrentFence(), collection_name, session.operationTime);
+    _annotateFenceWithWriteTs(DDPServer._getCurrentFence(), self, collection_name, session.operationTime);
     await session.endSession();
     await refresh();
     await write.committed();
@@ -293,7 +307,7 @@ MongoConnection.prototype.removeAsync = async function (collection_name, selecto
       // stream event, so a ChangeStreamObserveDriver waiting on this ts
       // would block forever waiting for an event Mongo will never emit.
       if (deletedCount > 0) {
-        _annotateFenceWithWriteTs(DDPServer._getCurrentFence(), collection_name, session.operationTime);
+        _annotateFenceWithWriteTs(DDPServer._getCurrentFence(), self, collection_name, session.operationTime);
       }
       await session.endSession();
       await refresh();
@@ -456,7 +470,7 @@ MongoConnection.prototype.updateAsync = async function (collection_name, selecto
         // observers wait for the exact ts and a no-op upsert produces no
         // event, so the wait would never resolve.
         if (result && result.numberAffected) {
-          _annotateFenceWithWriteTs(DDPServer._getCurrentFence(), collection_name, session.operationTime);
+          _annotateFenceWithWriteTs(DDPServer._getCurrentFence(), self, collection_name, session.operationTime);
         }
         await session.endSession();
         await refresh();
@@ -494,7 +508,7 @@ MongoConnection.prototype.updateAsync = async function (collection_name, selecto
         // forever. modifiedCount excludes matched-but-unchanged docs (which
         // also produce no event), and upsertedCount catches inserts.
         if (result && (result.modifiedCount > 0 || result.upsertedCount > 0)) {
-          _annotateFenceWithWriteTs(DDPServer._getCurrentFence(), collection_name, session.operationTime);
+          _annotateFenceWithWriteTs(DDPServer._getCurrentFence(), self, collection_name, session.operationTime);
         }
         await session.endSession();
         var meteorResult = transformResult({result});

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -2407,6 +2407,13 @@ const isBsonTimestamp = (ts) =>
   ts != null && typeof ts === 'object'
   && typeof ts.t === 'number' && typeof ts.i === 'number';
 
+// Write timestamps are recorded on the fence per (connection, collection) —
+// see fenceWriteTsKey in mongo_common.js. Tests that read or fabricate the
+// annotation map have to build the same composite key.
+const defaultMongo = () => MongoInternals.defaultRemoteCollectionDriver().mongo;
+const fenceKey = (collectionName, connection) =>
+  `${(connection || defaultMongo())._csConnectionId}\u0000${collectionName}`;
+
 Tinytest.addAsync(
   'changestream - insertAsync annotates fence with per-collection ts',
   async function (test) {
@@ -2417,8 +2424,8 @@ Tinytest.addAsync(
       snapshot = f._csTargetTsByCollection && { ...f._csTargetTsByCollection };
     });
     test.isTrue(snapshot !== null, 'fence should have been annotated during the fn');
-    test.isTrue(snapshot[c._name] !== undefined, 'map should contain the collection name key');
-    test.isTrue(isBsonTimestamp(snapshot[c._name]), 'annotation value should be a BSON Timestamp');
+    test.isTrue(snapshot[fenceKey(c._name)] !== undefined, 'map should contain the (connection, collection) key');
+    test.isTrue(isBsonTimestamp(snapshot[fenceKey(c._name)]), 'annotation value should be a BSON Timestamp');
     test.isTrue(fence.fired, 'fence should have fired');
   }
 );
@@ -2434,7 +2441,7 @@ Tinytest.addAsync(
       snapshot = f._csTargetTsByCollection && { ...f._csTargetTsByCollection };
     });
     test.isTrue(snapshot !== null);
-    test.isTrue(isBsonTimestamp(snapshot[c._name]), 'update should annotate with a Timestamp');
+    test.isTrue(isBsonTimestamp(snapshot[fenceKey(c._name)]), 'update should annotate with a Timestamp');
   }
 );
 
@@ -2449,7 +2456,7 @@ Tinytest.addAsync(
       snapshot = f._csTargetTsByCollection && { ...f._csTargetTsByCollection };
     });
     test.isTrue(snapshot !== null);
-    test.isTrue(isBsonTimestamp(snapshot[c._name]), 'remove should annotate with a Timestamp');
+    test.isTrue(isBsonTimestamp(snapshot[fenceKey(c._name)]), 'remove should annotate with a Timestamp');
   }
 );
 
@@ -2465,8 +2472,8 @@ Tinytest.addAsync(
       snapshot = f._csTargetTsByCollection && { ...f._csTargetTsByCollection };
     });
     test.isTrue(snapshot !== null);
-    test.isTrue(isBsonTimestamp(snapshot[a._name]), 'collection A should be annotated');
-    test.isTrue(isBsonTimestamp(snapshot[b._name]), 'collection B should be annotated');
+    test.isTrue(isBsonTimestamp(snapshot[fenceKey(a._name)]), 'collection A should be annotated');
+    test.isTrue(isBsonTimestamp(snapshot[fenceKey(b._name)]), 'collection B should be annotated');
     test.notEqual(a._name, b._name, 'sanity: distinct collection names');
   }
 );
@@ -2484,9 +2491,9 @@ Tinytest.addAsync(
     const snapshotTs = (ts) => (ts == null ? null : { t: ts.t, i: ts.i });
     await withFence(async (f) => {
       await c.insertAsync({ n: 1 });
-      tsFirst = snapshotTs(f._csTargetTsByCollection[c._name]);
+      tsFirst = snapshotTs(f._csTargetTsByCollection[fenceKey(c._name)]);
       await c.insertAsync({ n: 2 });
-      tsFinal = snapshotTs(f._csTargetTsByCollection[c._name]);
+      tsFinal = snapshotTs(f._csTargetTsByCollection[fenceKey(c._name)]);
     });
     test.isTrue(isBsonTimestamp(tsFirst) && isBsonTimestamp(tsFinal));
     const firstLessOrEqual = tsFirst.t < tsFinal.t
@@ -2532,7 +2539,7 @@ Tinytest.addAsync(
     // _waitUntilCaughtUp should hit the 'already-caught-up' early exit
     // and not enqueue a resolver.
     const pastTs = driver._lastProcessedOperationTime;
-    const fakeFence = { _csTargetTsByCollection: { [c._name]: pastTs } };
+    const fakeFence = { _csTargetTsByCollection: { [fenceKey(c._name)]: pastTs } };
 
     const t0 = Date.now();
     await driver._waitUntilCaughtUp(fakeFence);
@@ -2576,7 +2583,7 @@ Tinytest.addAsync(
 
     const farFutureTs = { t: Math.floor(Date.now() / 1000) + 3600, i: 1 };
     const strayFence = {
-      _csTargetTsByCollection: { ['not_' + c._name]: farFutureTs },
+      _csTargetTsByCollection: { [fenceKey('not_' + c._name)]: farFutureTs },
     };
 
     const t0 = Date.now();
@@ -2588,6 +2595,137 @@ Tinytest.addAsync(
       `annotation for another collection should be ignored; elapsed=${elapsed}ms`
     );
     handle.stop();
+  }
+);
+
+Tinytest.addAsync(
+  'changestream- _waitUntilCaughtUp ignores annotation from another connection (#14600)',
+  async function (test) {
+    // Regression for meteor/meteor#14600. An app can hold more than one
+    // MongoConnection — a second MongoInternals.RemoteCollectionDriver onto a
+    // different cluster is the common case — and those connections routinely
+    // use the same collection names. The crossbar notifies every driver
+    // listening on a collection *name*, so a write on the other connection
+    // lands this driver in _waitUntilCaughtUp with a fence that only carries
+    // that connection's timestamp. Its clusterTime comes from a cluster this
+    // driver's stream never observes, so keying on the name alone parked the
+    // wait forever and hung the method that issued the write.
+    const c = makeCollection();
+    const handle = await c.find({}).observeChanges({ added: function () { } });
+    test.isTrue(isChangeStreamDriver(handle));
+    const driver = handle._multiplexer._observeDriver;
+
+    // Same collection name, but recorded against a connection that is not ours.
+    const farFutureTs = { t: Math.floor(Date.now() / 1000) + 3600, i: 1 };
+    const otherConnection = { _csConnectionId: 'mc_other_connection' };
+    const foreignFence = {
+      _csTargetTsByCollection: {
+        [fenceKey(c._name, otherConnection)]: farFutureTs,
+      },
+    };
+
+    // Race the wait: before the fix this never resolves, and awaiting it
+    // directly would hang the whole suite instead of failing.
+    const t0 = Date.now();
+    const raced = await Promise.race([
+      driver._waitUntilCaughtUp(foreignFence).then(() => 'resolved'),
+      new Promise(r => setTimeout(() => r('timed-out'), 2000)),
+    ]);
+    const elapsed = Date.now() - t0;
+
+    test.equal(
+      raced, 'resolved',
+      'a foreign connection\'s annotation must not park this driver\'s wait'
+    );
+    test.isTrue(
+      elapsed < 250,
+      `foreign-connection annotation should be ignored; elapsed=${elapsed}ms`
+    );
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
+  'changestream- _waitUntilCaughtUp still waits for its own connection (#14600)',
+  async function (test) {
+    // Guards the other side of the #14600 fix: scoping the lookup by
+    // connection must not turn every wait into a no-op. An annotation recorded
+    // against *our* connection for *our* collection still has to park the wait
+    // until the stream reaches it — releasing early is what #14452 was about
+    // (the fence fires before the change is applied and the client sees
+    // `updated` with no preceding `added`/`changed`/`removed`).
+    const c = makeCollection();
+    const handle = await c.find({}).observeChanges({ added: function () { } });
+    test.isTrue(isChangeStreamDriver(handle));
+    const driver = handle._multiplexer._observeDriver;
+
+    const farFutureTs = { t: Math.floor(Date.now() / 1000) + 3600, i: 1 };
+    const ownFence = {
+      _csTargetTsByCollection: { [fenceKey(c._name)]: farFutureTs },
+    };
+
+    const raced = await Promise.race([
+      driver._waitUntilCaughtUp(ownFence).then(() => 'resolved'),
+      new Promise(r => setTimeout(() => r('still-waiting'), 500)),
+    ]);
+
+    test.equal(
+      raced, 'still-waiting',
+      'a ts for our own connection and collection must still block the wait'
+    );
+
+    // stop() drains the parked resolver so the pending wait above doesn't
+    // outlive the test (see the #14452 test below).
+    handle.stop();
+  }
+);
+
+Tinytest.addAsync(
+  'changestream- a second connection annotates its own fence key (#14600)',
+  async function (test) {
+    // End-to-end counterpart of the two tests above, with a real second
+    // MongoConnection rather than a hand-built fence: writing the same
+    // collection name through each connection must produce two distinct
+    // entries, so neither driver can pick up the other's clusterTime.
+    const collectionName = 'changestream_test_' + Random.id();
+    const primary = defaultMongo();
+    const secondary = new MongoInternals.RemoteCollectionDriver(
+      process.env.MONGO_URL
+    );
+
+    test.notEqual(
+      primary._csConnectionId, secondary.mongo._csConnectionId,
+      'each MongoConnection should get its own id'
+    );
+
+    const primaryCollection = new Mongo.Collection(collectionName);
+    const secondaryCollection = new Mongo.Collection(collectionName, {
+      _driver: secondary,
+      _suppressSameNameError: true,
+    });
+
+    let snapshot = null;
+    await withFence(async (f) => {
+      await primaryCollection.insertAsync({ via: 'primary' });
+      await secondaryCollection.insertAsync({ via: 'secondary' });
+      snapshot = f._csTargetTsByCollection && { ...f._csTargetTsByCollection };
+    });
+
+    test.isTrue(snapshot !== null, 'fence should have been annotated');
+    test.isTrue(
+      isBsonTimestamp(snapshot[fenceKey(collectionName, primary)]),
+      'the primary connection should have its own entry'
+    );
+    test.isTrue(
+      isBsonTimestamp(snapshot[fenceKey(collectionName, secondary.mongo)]),
+      'the secondary connection should have a separate entry'
+    );
+    test.equal(
+      Object.keys(snapshot).length, 2,
+      'same collection name on two connections should not share one entry'
+    );
+
+    await secondary.mongo.close();
   }
 );
 
@@ -2617,7 +2755,7 @@ Tinytest.addAsync(
 
     const Timestamp = driver._lastProcessedOperationTime.constructor;
     const farFutureTs = new Timestamp({ t: Math.floor(Date.now() / 1000) + 3600, i: 1 });
-    const fakeFence = { _csTargetTsByCollection: { [c._name]: farFutureTs } };
+    const fakeFence = { _csTargetTsByCollection: { [fenceKey(c._name)]: farFutureTs } };
 
     // Park the waiter. Do NOT await — it must not resolve until stop().
     let resolved = false;


### PR DESCRIPTION
Fixes #14600.

## Problem

An app can have two Mongo connections — its own, plus a second `RemoteCollectionDriver` onto another cluster — with the same collection name on both.

Writes record their clusterTime on the DDP write fence so a change-stream observer waits for that event before the fence fires. The annotation was keyed by **collection name alone**:

```js
fence._csTargetTsByCollection[collectionName] = writeTs;
```

So a write to `foo` on connection B stored **B's** clusterTime under `'foo'`, and the observer watching **A's** `foo` read that same key and waited for a timestamp from a cluster it doesn't watch. That event never arrives.

The wait is deliberately unbounded (releasing early is what #14452 was about), so it parks forever: `change stream catching up took too long` every 10s, and the method never returns.

Introduced in #14362. Not reachable in 3.4.1, where these observers used oplog instead — that driver pulled its target from its own connection rather than reading a name-keyed annotation.

## Fix

Key the annotation by `(connection, collection)` on both ends. `MongoConnection` gets a `_csConnectionId`; `fenceWriteTsKey()` builds the key for the write and for the lookup.

A write is now only awaited by observers watching the connection it went to. ClusterTimes are only comparable within one cluster, so matching them across connections was never sound.

Waits within one connection are unchanged and still block until the stream catches up, so #14452 stays fixed — there's a test pinning that.

## `TEST_FETCH_FIRST` is not a workaround

Easy to misread the reporter's flag as a fix. It's a fence-lifetime toggle, not a Mongo one.

The repro's handler never awaits its work (`'syncdb': function() { syncAppB(); }`), so the fence arms at the first suspension point:

- **`false`** — that's `removeAsync`, and `_maybeBeginWrite()` runs before it. Fence stays open, observer enlists, wait wedges.
- **`true`** — that's `countAsync`, a pure read that never touches the fence. The fence fires and retires before `removeAsync` runs, so no observer ever enlists.

The count just moves the sync outside the fence. **Any app that correctly `await`s its sync inside the method hangs either way.** It's also why the log only ever names `foo` and never `bar` — `removeAsync` never resolves, so the second `importCollection` is never reached.

## Verification

Against the reporter's repro (https://github.com/jakubliszkowski/meteor35BugMongoStream), run locally against this checkout:

- **before** — hangs at `remove`, never reaches `fetch`/`insert`, warning repeats (`waitedMs` 10010 → 50010, `warnCount` 1 → 5)
- **after** — `remove → fetch → insert → done` on both collections, 0 warnings

`TINYTEST_FILTER=changestream METEOR_REACTIVITY_ORDER=changeStreams ./packages/test-in-console/run.sh mongo` → **86/86 pass**.

Three new tests: the regression itself (a foreign connection's annotation must be ignored), the counter-guard (our own connection must still block — without it, a fix that made every lookup miss would silently re-open #14452), and an end-to-end with a real second `MongoConnection`. Existing annotation tests were migrated to the composite key.

## Trade-off

Two connections to the *same* cluster sharing a collection name no longer wait on each other. That wait was satisfiable before, so a client could in principle see `updated` slightly before `changed` — but the alternative is a permanent hang in the cross-cluster case, and the observer is still enlisted on the fence and still flushes through the multiplexer, so ordering holds whenever the event has already arrived.

Keying by cluster would be tighter, but there's no cheap reliable source for cluster identity — `db.databaseName` isn't one, since both databases here are named `meteor`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed change-stream synchronization when multiple MongoDB connections use the same collection name.
  * Prevented waits from hanging by ensuring write timestamps are matched to the correct connection.
  * Improved reliability for insert, update, remove, and multi-connection write operations.

* **Tests**
  * Added regression coverage for connection-specific change-stream fences and synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->