### PR TITLE
Add documentation for modern tools: Rspack, SWC, Profiler, and contributors' guide for integration maintenance

### DIFF
--- a/dev/modern-tools/README.md
+++ b/dev/modern-tools/README.md
@@ -72,16 +72,6 @@ Rspack is our Rust-based Webpack-compatible bundler integration. The `rspack` At
 - 📊 **Check E2E Coverage:** [`rspack/E2E_COVERAGE.md`](rspack/E2E_COVERAGE.md)
 - 🧠 **Benchmark Memory:** [`rspack/MEMORY_BENCHMARK.md`](rspack/MEMORY_BENCHMARK.md)
 
-### Quick Start: Memory Benchmarking
-
-To run the Rspack memory benchmark locally and analyze retention across `meteor-tool` and child processes:
-
-```bash
-# Run the baseline memory benchmark against a local app
-APP_PATH=/path/to/your-app \
-TOUCH_FILE=server/main.js \
-node scripts/build-stack-memory-bench.js
-```
 
 ---
 

--- a/dev/modern-tools/README.md
+++ b/dev/modern-tools/README.md
@@ -1,89 +1,92 @@
-# Modern Tools
+# Modern Tools Maintainer Guide
 
-Meteor's modern tooling has three integrated areas: the SWC transpiler/minifier, the Rspack bundler integration, and the profiler. This directory documents how those pieces wire into the build system, where they live in the codebase, and the maintenance tasks contributors most often touch.
+Meteor's modern tooling ecosystem revolves around three core pillars: 
+1. **SWC** (Transpiler/Minifier)
+2. **Rspack** (Bundler Integration)
+3. **Profiler** (Performance Tooling)
 
-End-user documentation lives in [`v3-docs/docs/about/modern-build-stack/`](../../v3-docs/docs/about/modern-build-stack/). These notes are the maintainer-facing counterpart.
+This directory provides the architectural overview and maintenance guides for these components. If you are looking for user-facing documentation, please refer to the [Modern Build Stack User Guide](../../v3-docs/docs/about/modern-build-stack/).
 
-- [**Build plugins for modern tool integration**](#build-plugins-for-modern-tool-integration): how external tools plug into the Meteor build via `Package.registerBuildPlugin` and `Plugin.registerCompiler`.
-- [**`tools-core` helpers package**](#tools-core-helpers-package): shared utilities (npm, processes, logging, git, Meteor config) that every modern integration builds on.
-- [**SWC case**](#swc-case): pointer to the SWC-specific maintainer notes.
-- [**Rspack case**](#rspack-case): pointer to the Rspack-specific maintainer notes.
-- [**Profiler case**](#profiler-case): pointer to the profiler maintainer notes.
+## Table of Contents
 
-## Build plugins for modern tool integration
+- [Integration Architecture](#integration-architecture)
+- [The `tools-core` Helpers Package](#the-tools-core-helpers-package)
+- [SWC Transpiler Integration](#swc-transpiler-integration)
+- [Rspack Bundler Integration](#rspack-bundler-integration)
+- [Profiler Tooling](#profiler-tooling)
 
-Each modern tool plugs into the bundler lifecycle through a Meteor build plugin declared in a package's `package.js`. There are two integration points:
+---
 
-- `Package.registerBuildPlugin({ name, sources, use })`. Registers a plugin that runs in the Meteor tool's plugin context. The Rspack package uses this form to spawn the Rspack processes and configure Meteor before the bundler runs. See `packages/rspack/package.js`.
-- `Plugin.registerCompiler({ extensions, filenames }, factory)`. Registers a compiler that processes specific source files during the build. The TypeScript package uses this form to register `compile-typescript`; the Babel compiler is invoked through the same mechanism by `caching-compiler`. See `packages/typescript/plugin.js` and `packages/babel-compiler/babel-compiler.js`.
+## Integration Architecture
 
-Package-level tooling integrations keep the per-tool wiring inside the Atmosphere package that owns the dependency. Adding the package (for example `meteor add rspack`) brings the integration in; removing the package takes it out. The tool itself does not hard-code references to SWC, Rspack, or any other external tool.
+External tools plug into Meteor's bundler lifecycle through build plugins declared in their respective `package.js` files. We use two primary integration points:
 
-## `tools-core` helpers package
+1. **`Package.registerBuildPlugin`**
+   Use this to spawn external processes or configure Meteor before the bundler runs.
+   *Example:* Rspack uses this to initialize its dev server and build context.
+   ```javascript
+   Package.registerBuildPlugin({ name, sources, use });
+   ```
 
-`packages/tools-core` is the helpers package that modern integrations build on top of. It exposes shared utilities for npm, processes, logging, git, and Meteor-specific configuration, so each integration does not have to reinvent them. It is `devOnly`, used at build-plugin time as well as from the server entry.
+2. **`Plugin.registerCompiler`**
+   Use this to process specific source files during the build process.
+   *Example:* TypeScript and Babel integrations use this to compile their respective files.
+   ```javascript
+   Plugin.registerCompiler({ extensions, filenames }, factory);
+   ```
 
-Source: `packages/tools-core/lib/*.js`. The package is documented in `packages/tools-core/README.md`. Each helper module is summarized below.
+> **Design Principle:** Tooling integrations are scoped to their Atmosphere packages. Running `meteor add rspack` wires in the tool; removing it cleans it up completely. The core Meteor tool maintains zero hard-coded references to these external utilities.
 
-### `lib/log.js`, colored progress logging
+---
 
-Adds `logProgress`, `logSuccess`, `logInfo`, `logError`, and `logRaw` helpers that wrap `console.log` with ANSI colors and a minimum line length. Respects `METEOR_DISABLE_COLORS`. Use these from any plugin that prints lifecycle messages so output stays consistent between SWC, Rspack, and future integrations. `getRunLog()` returns the `Plugin.runLogInstance` when available, for plugins that need to feed structured messages back into the Meteor run UI.
+## The `tools-core` Helpers Package
 
-### `lib/npm.js`, npm/yarn dependency management
+The `packages/tools-core` package provides shared, `devOnly` utilities for npm management, process handling, logging, and configuration. Every modern integration builds on top of it to avoid reinventing the wheel.
 
-The npm module is the workhorse for any plugin that needs to inspect or install npm dependencies on the user's behalf. Highlights:
+For complete documentation, see [`packages/tools-core/README.md`](../../packages/tools-core/README.md).
 
-- `getNodeBinaryPath('npm' | 'npx' | 'node' | 'yarn')` and `getNodeBinEnv()` resolve binaries from Meteor's `dev_bundle`. Use them when spawning a child process that must use the same Node version Meteor is running on.
-- `checkNpmDependencyExists`, `checkNpmDependencyVersion`, `checkNpmBinaryExists` read the project's `package.json` and `node_modules` to validate what is installed. The Rspack plugin uses these to decide whether `@rspack/core`, `@meteorjs/rspack`, and friends need to be added.
-- `installNpmDependency(deps, { dev, exact, yarn })` installs missing dependencies, falling back to `meteor npm install` when the dev bundle npm cannot be located.
-- `getNpmCommand`, `getNpxCommand`, `getYarnCommand` return the `{ command, args, prefix }` triple a plugin should pass to `spawnProcess`.
-- `isYarnProject`, `isMonorepo`, `getMonorepoPath` answer common layout questions.
+### Core Modules Overview
 
-Caveat: these helpers parse `package.json` directly rather than invoking `npm ls`. That is intentional (it is much faster), but it means that the version reported is the declared range, not the installed lockfile version, unless `checkNodeModules: true` is passed.
+- **`lib/log.js` (Logging):** Provides colorful, consistent lifecycle logging (`logProgress`, `logSuccess`, etc.) that respects `METEOR_DISABLE_COLORS`.
+- **`lib/npm.js` (Dependencies):** Handles npm/yarn validation and installation. Use helpers like `installNpmDependency` and `getNodeBinaryPath` to interact with project dependencies reliably.
+- **`lib/process.js` (Processes):** Exposes `spawnProcess` to manage child processes with robust defaults (color preservation, graceful termination, and port coordination).
+- **`lib/meteor.js` (Introspection):** Reads user configurations and detects project characteristics (e.g., `isMeteorAppTest`, `isMeteorBlazeProject`). It manages entry points dynamically via `setMeteorAppEntrypoints`.
+- **`lib/global-state.js` (State):** Manages state across incremental rebuilds using `Package.meteor.global.persistentState`.
+- **`lib/git.js` & `lib/ignore.js` (File System):** Automates `.gitignore` updates and manages complex file watcher exclusion rules.
 
-### `lib/process.js`, process and port helpers
+---
 
-`spawnProcess(command, args, options)` wraps `child_process.spawn` with sensible defaults: `FORCE_COLOR=1`, decoded `onStdout`/`onStderr` callbacks, `onExit`/`onError` hooks, Windows `shell: true`, and a detached-mode escape hatch. Use it instead of calling `spawn` directly so streaming output stays color-preserving and detachment works the same way across plugins. `stopProcess` adds a graceful `SIGTERM` then `SIGKILL` fallback. `isProcessRunning`, `isPortAvailable`, and `waitForPort` round out the lifecycle utilities; Rspack uses `waitForPort` to coordinate the dev server with the Meteor server.
+## SWC Transpiler Integration
 
-### `lib/meteor.js`, Meteor app introspection
+SWC serves as Meteor's modern transpiler and minifier. The core bundler utilizes `@meteorjs/swc-core` for packages, while app-level code is handled via Rspack's `swc-loader`.
 
-The largest module. Helpers are grouped by purpose:
+- 📚 **Read the Maintainer Guide:** [`swc/README.md`](swc/README.md)
 
-| Group | Functions | When to use |
-|-------|-----------|-------------|
-| App configuration | `getMeteorAppDir`, `getMeteorAppPackageJson`, `getMeteorAppConfig`, `getMeteorAppConfigModern`, `isMeteorAppConfigModernVerbose`, `hasMeteorAppConfigAutoInstallDeps`, `getMeteorAppPort` | Reading the user's `meteor.*` config from `package.json` (or `Plugin.getMeteorConfig()`, which `getMeteorAppConfig` prefers). |
-| Entry points | `getMeteorAppEntrypoints`, `getMeteorInitialAppEntrypoints`, `setMeteorAppEntrypoints`, `setMeteorAppIgnore`, `setMeteorAppCustomScriptUrl`, `isMeteorAppTestModule` | Resolving or overriding client/server/test entry modules. `setMeteorAppEntrypoints` writes `METEOR_CONFIG_*` env vars and calls `global.reinitializeMeteorConfig?.()` so child processes pick up the change. `getMeteorInitialAppEntrypoints` also resolves the matching client HTML file. |
-| Command/mode detection | `isMeteorAppRun`, `isMeteorAppBuild`, `isMeteorAppUpdate`, `isMeteorAppTest`, `isMeteorAppTestFullApp`, `isMeteorAppTestWatch`, `isMeteorAppNative` (+ `Android`/`Ios`), `isMeteorAppDevelopment`, `isMeteorAppProduction`, `isMeteorAppDebug`, `isMeteorAppProfile`, `isMeteorPackagesTest` | Branching plugin behavior on the current CLI subcommand and run mode. |
-| Project detection | `isMeteorBlazeProject`, `isMeteorBlazeHotProject`, `isMeteorCoffeescriptProject`, `isMeteorLessProject`, `isMeteorScssProject`, `isMeteorTypescriptProject`, `isMeteorBundleVisualizerProject` | Detecting which optional packages the app uses, to enable or disable loaders and framework-specific wiring. |
-| File system | `getMeteorAppFilesAndFolders`, `getMeteorAppPackages`, `getMeteorEnvPackageDirs`, `getMeteorToolsRequire` | Scanning the app tree, listing loaded packages, or requiring modules relative to the running `meteor` tool binary. |
-| Process environment | `inheritMeteorToolNodeFlags` | Spreading `TOOL_NODE_FLAGS` into `NODE_OPTIONS` for spawned children. Controlled by `TOOL_NODE_FLAGS_INHERIT`. |
+---
 
-Most of these depend on `Plugin` and `Package.meteor.global` being available, so they only return meaningful values inside a build-plugin context or the running tool.
+## Rspack Bundler Integration
 
-### `lib/global-state.js`, state across file changes
+Rspack is our Rust-based Webpack-compatible bundler integration. The `rspack` Atmosphere package hooks into the lifecycle, while `@meteorjs/rspack` provides the default configuration framework.
 
-`getGlobalState`, `setGlobalState`, `removeGlobalState`, `clearGlobalState` read and write keys on `Package.meteor.global.persistentState`. This state survives across incremental rebuilds, which is the only place a build plugin can keep process handles, "already installed" flags, and similar one-shot markers. The Rspack plugin keys are listed in `packages/rspack/lib/constants.js#GLOBAL_STATE_KEYS`.
+- 📚 **Read the Maintainer Guide:** [`rspack/README.md`](rspack/README.md)
+- 📊 **Check E2E Coverage:** [`rspack/E2E_COVERAGE.md`](rspack/E2E_COVERAGE.md)
+- 🧠 **Benchmark Memory:** [`rspack/MEMORY_BENCHMARK.md`](rspack/MEMORY_BENCHMARK.md)
 
-### `lib/git.js`, `.gitignore` maintenance
+### Quick Start: Memory Benchmarking
 
-`isGitRepository`, `gitignoreExists`, `ensureGitignoreExists`, `getMissingGitignoreEntries`, `addGitignoreEntries`. The Rspack plugin uses these to add entries like the custom build context directory to `.gitignore` automatically.
+To run the Rspack memory benchmark locally and analyze retention across `meteor-tool` and child processes:
 
-### `lib/string.js`, small string utilities
+```bash
+# Run the baseline memory benchmark against a local app
+APP_PATH=/path/to/your-app \
+TOUCH_FILE=server/main.js \
+node scripts/build-stack-memory-bench.js
+```
 
-`capitalizeFirstLetter`, `shuffleString`, `joinWithAnd` (for human-readable lists in log lines).
+---
 
-### `lib/ignore.js`, gitignore-style negation patterns
+## Profiler Tooling
 
-`buildUnignorePatterns(paths, options)` produces the `!` patterns required to keep specific files and folders visible to the watcher when a broader ignore rule would otherwise hide them. The defaults emit ancestor directories so paths like `assets/public/icon.png` are restored level by level.
+The profiler instruments the Meteor build tool to track performance bottlenecks, which is exposed to users via the `meteor profile` command.
 
-## SWC case
-
-SWC is the modern transpiler and minifier. The Meteor bundler ships `@meteorjs/swc-core` and uses it from `babel-compiler` and `standard-minifier-js`, while application code goes through SWC via the Rspack `swc-loader` in the bundler integration. See [`swc/README.md`](swc/README.md) for the full picture, including how the bundler's `@swc/core` relates to `@meteorjs/swc-core`.
-
-## Rspack case
-
-Rspack is the modern bundler integration. The `rspack` Atmosphere package wires Rspack into the Meteor lifecycle, and `@meteorjs/rspack` provides the default configuration. See [`rspack/README.md`](rspack/README.md) for the integration map, E2E testing strategy, and common maintenance tasks.
-
-## Profiler case
-
-The profiler tooling instruments the Meteor tool (via `METEOR_PROFILE`) and exposes `meteor profile` to run a benchmark suite against the current project. See [`profiler/README.md`](profiler/README.md) for the maintenance flow.
+- 📚 **Read the Maintainer Guide:** [`profiler/README.md`](profiler/README.md)

--- a/dev/modern-tools/README.md
+++ b/dev/modern-tools/README.md
@@ -1,0 +1,89 @@
+# Modern Tools
+
+Meteor's modern tooling has three integrated areas: the SWC transpiler/minifier, the Rspack bundler integration, and the profiler. This directory documents how those pieces wire into the build system, where they live in the codebase, and the maintenance tasks contributors most often touch.
+
+End-user documentation lives in [`v3-docs/docs/about/modern-build-stack/`](../../v3-docs/docs/about/modern-build-stack/). These notes are the maintainer-facing counterpart.
+
+- [**Build plugins for modern tool integration**](#build-plugins-for-modern-tool-integration): how external tools plug into the Meteor build via `Package.registerBuildPlugin` and `Plugin.registerCompiler`.
+- [**`tools-core` helpers package**](#tools-core-helpers-package): shared utilities (npm, processes, logging, git, Meteor config) that every modern integration builds on.
+- [**SWC case**](#swc-case): pointer to the SWC-specific maintainer notes.
+- [**Rspack case**](#rspack-case): pointer to the Rspack-specific maintainer notes.
+- [**Profiler case**](#profiler-case): pointer to the profiler maintainer notes.
+
+## Build plugins for modern tool integration
+
+Each modern tool plugs into the bundler lifecycle through a Meteor build plugin declared in a package's `package.js`. There are two integration points:
+
+- `Package.registerBuildPlugin({ name, sources, use })`. Registers a plugin that runs in the Meteor tool's plugin context. The Rspack package uses this form to spawn the Rspack processes and configure Meteor before the bundler runs. See `packages/rspack/package.js`.
+- `Plugin.registerCompiler({ extensions, filenames }, factory)`. Registers a compiler that processes specific source files during the build. The TypeScript package uses this form to register `compile-typescript`; the Babel compiler is invoked through the same mechanism by `caching-compiler`. See `packages/typescript/plugin.js` and `packages/babel-compiler/babel-compiler.js`.
+
+Package-level tooling integrations keep the per-tool wiring inside the Atmosphere package that owns the dependency. Adding the package (for example `meteor add rspack`) brings the integration in; removing the package takes it out. The tool itself does not hard-code references to SWC, Rspack, or any other external tool.
+
+## `tools-core` helpers package
+
+`packages/tools-core` is the helpers package that modern integrations build on top of. It exposes shared utilities for npm, processes, logging, git, and Meteor-specific configuration, so each integration does not have to reinvent them. It is `devOnly`, used at build-plugin time as well as from the server entry.
+
+Source: `packages/tools-core/lib/*.js`. The package is documented in `packages/tools-core/README.md`. Each helper module is summarized below.
+
+### `lib/log.js`, colored progress logging
+
+Adds `logProgress`, `logSuccess`, `logInfo`, `logError`, and `logRaw` helpers that wrap `console.log` with ANSI colors and a minimum line length. Respects `METEOR_DISABLE_COLORS`. Use these from any plugin that prints lifecycle messages so output stays consistent between SWC, Rspack, and future integrations. `getRunLog()` returns the `Plugin.runLogInstance` when available, for plugins that need to feed structured messages back into the Meteor run UI.
+
+### `lib/npm.js`, npm/yarn dependency management
+
+The npm module is the workhorse for any plugin that needs to inspect or install npm dependencies on the user's behalf. Highlights:
+
+- `getNodeBinaryPath('npm' | 'npx' | 'node' | 'yarn')` and `getNodeBinEnv()` resolve binaries from Meteor's `dev_bundle`. Use them when spawning a child process that must use the same Node version Meteor is running on.
+- `checkNpmDependencyExists`, `checkNpmDependencyVersion`, `checkNpmBinaryExists` read the project's `package.json` and `node_modules` to validate what is installed. The Rspack plugin uses these to decide whether `@rspack/core`, `@meteorjs/rspack`, and friends need to be added.
+- `installNpmDependency(deps, { dev, exact, yarn })` installs missing dependencies, falling back to `meteor npm install` when the dev bundle npm cannot be located.
+- `getNpmCommand`, `getNpxCommand`, `getYarnCommand` return the `{ command, args, prefix }` triple a plugin should pass to `spawnProcess`.
+- `isYarnProject`, `isMonorepo`, `getMonorepoPath` answer common layout questions.
+
+Caveat: these helpers parse `package.json` directly rather than invoking `npm ls`. That is intentional (it is much faster), but it means that the version reported is the declared range, not the installed lockfile version, unless `checkNodeModules: true` is passed.
+
+### `lib/process.js`, process and port helpers
+
+`spawnProcess(command, args, options)` wraps `child_process.spawn` with sensible defaults: `FORCE_COLOR=1`, decoded `onStdout`/`onStderr` callbacks, `onExit`/`onError` hooks, Windows `shell: true`, and a detached-mode escape hatch. Use it instead of calling `spawn` directly so streaming output stays color-preserving and detachment works the same way across plugins. `stopProcess` adds a graceful `SIGTERM` then `SIGKILL` fallback. `isProcessRunning`, `isPortAvailable`, and `waitForPort` round out the lifecycle utilities; Rspack uses `waitForPort` to coordinate the dev server with the Meteor server.
+
+### `lib/meteor.js`, Meteor app introspection
+
+The largest module. Helpers are grouped by purpose:
+
+| Group | Functions | When to use |
+|-------|-----------|-------------|
+| App configuration | `getMeteorAppDir`, `getMeteorAppPackageJson`, `getMeteorAppConfig`, `getMeteorAppConfigModern`, `isMeteorAppConfigModernVerbose`, `hasMeteorAppConfigAutoInstallDeps`, `getMeteorAppPort` | Reading the user's `meteor.*` config from `package.json` (or `Plugin.getMeteorConfig()`, which `getMeteorAppConfig` prefers). |
+| Entry points | `getMeteorAppEntrypoints`, `getMeteorInitialAppEntrypoints`, `setMeteorAppEntrypoints`, `setMeteorAppIgnore`, `setMeteorAppCustomScriptUrl`, `isMeteorAppTestModule` | Resolving or overriding client/server/test entry modules. `setMeteorAppEntrypoints` writes `METEOR_CONFIG_*` env vars and calls `global.reinitializeMeteorConfig?.()` so child processes pick up the change. `getMeteorInitialAppEntrypoints` also resolves the matching client HTML file. |
+| Command/mode detection | `isMeteorAppRun`, `isMeteorAppBuild`, `isMeteorAppUpdate`, `isMeteorAppTest`, `isMeteorAppTestFullApp`, `isMeteorAppTestWatch`, `isMeteorAppNative` (+ `Android`/`Ios`), `isMeteorAppDevelopment`, `isMeteorAppProduction`, `isMeteorAppDebug`, `isMeteorAppProfile`, `isMeteorPackagesTest` | Branching plugin behavior on the current CLI subcommand and run mode. |
+| Project detection | `isMeteorBlazeProject`, `isMeteorBlazeHotProject`, `isMeteorCoffeescriptProject`, `isMeteorLessProject`, `isMeteorScssProject`, `isMeteorTypescriptProject`, `isMeteorBundleVisualizerProject` | Detecting which optional packages the app uses, to enable or disable loaders and framework-specific wiring. |
+| File system | `getMeteorAppFilesAndFolders`, `getMeteorAppPackages`, `getMeteorEnvPackageDirs`, `getMeteorToolsRequire` | Scanning the app tree, listing loaded packages, or requiring modules relative to the running `meteor` tool binary. |
+| Process environment | `inheritMeteorToolNodeFlags` | Spreading `TOOL_NODE_FLAGS` into `NODE_OPTIONS` for spawned children. Controlled by `TOOL_NODE_FLAGS_INHERIT`. |
+
+Most of these depend on `Plugin` and `Package.meteor.global` being available, so they only return meaningful values inside a build-plugin context or the running tool.
+
+### `lib/global-state.js`, state across file changes
+
+`getGlobalState`, `setGlobalState`, `removeGlobalState`, `clearGlobalState` read and write keys on `Package.meteor.global.persistentState`. This state survives across incremental rebuilds, which is the only place a build plugin can keep process handles, "already installed" flags, and similar one-shot markers. The Rspack plugin keys are listed in `packages/rspack/lib/constants.js#GLOBAL_STATE_KEYS`.
+
+### `lib/git.js`, `.gitignore` maintenance
+
+`isGitRepository`, `gitignoreExists`, `ensureGitignoreExists`, `getMissingGitignoreEntries`, `addGitignoreEntries`. The Rspack plugin uses these to add entries like the custom build context directory to `.gitignore` automatically.
+
+### `lib/string.js`, small string utilities
+
+`capitalizeFirstLetter`, `shuffleString`, `joinWithAnd` (for human-readable lists in log lines).
+
+### `lib/ignore.js`, gitignore-style negation patterns
+
+`buildUnignorePatterns(paths, options)` produces the `!` patterns required to keep specific files and folders visible to the watcher when a broader ignore rule would otherwise hide them. The defaults emit ancestor directories so paths like `assets/public/icon.png` are restored level by level.
+
+## SWC case
+
+SWC is the modern transpiler and minifier. The Meteor bundler ships `@meteorjs/swc-core` and uses it from `babel-compiler` and `standard-minifier-js`, while application code goes through SWC via the Rspack `swc-loader` in the bundler integration. See [`swc/README.md`](swc/README.md) for the full picture, including how the bundler's `@swc/core` relates to `@meteorjs/swc-core`.
+
+## Rspack case
+
+Rspack is the modern bundler integration. The `rspack` Atmosphere package wires Rspack into the Meteor lifecycle, and `@meteorjs/rspack` provides the default configuration. See [`rspack/README.md`](rspack/README.md) for the integration map, E2E testing strategy, and common maintenance tasks.
+
+## Profiler case
+
+The profiler tooling instruments the Meteor tool (via `METEOR_PROFILE`) and exposes `meteor profile` to run a benchmark suite against the current project. See [`profiler/README.md`](profiler/README.md) for the maintenance flow.

--- a/dev/modern-tools/profiler/README.md
+++ b/dev/modern-tools/profiler/README.md
@@ -18,57 +18,56 @@ Use `METEOR_PROFILE` to find out *where* time is being spent; use `meteor profil
 
 ## Common maintenance tasks
 
-### Update the `meteor profile` script
+This section covers updating the `meteor profile` script and validating changes locally.
 
-The CLI lives in `tools/cli/commands.js`. Two functions matter:
+### Updating the `meteor profile` Script
 
-- `setupBenchmarkSuite(profilingPath)` at the top of the `meteor profile` flow. It clones the `meteor/performance` repository (sparse, `scripts/` only) into `<app>/node_modules/.cache/meteor/performance/scripts`. The clone uses a pinned branch:
+The CLI implementation lives in `tools/cli/commands.js`. Updates are typically needed when the upstream `meteor/performance` repository ships a new tag or changes its monitoring script API.
 
-  ```js
-  const repoUrl = "https://github.com/meteor/performance";
-  const branch  = "v3.4.0";
-  ```
+**Steps to update:**
 
-  Bump that `branch` constant when a new tag of the performance repo ships. Both the tar-based and the plain-`git clone` fallbacks use the same constant, so updating it once is enough.
+**1. Update the Pinned Performance Branch**
+Locate `setupBenchmarkSuite` in `tools/cli/commands.js`. Change the `branch` constant to match the newly tagged release.
 
-- `doBenchmarkCommand(options)` invokes `scripts/monitor-bundler.sh <projectDir> <timestamp> <meteor-options>` with `METEOR_BUNDLE_SIZE`, `METEOR_BUNDLE_SIZE_ONLY`, and `METEOR_BUNDLE_BUILD` env vars derived from the `--size`, `--size-only`, and `--build` CLI flags. If the performance repo renames its script or its env contract, mirror the change here.
+```javascript
+// tools/cli/commands.js
+const repoUrl = "https://github.com/meteor/performance";
+const branch  = "v3.5.0"; // Bump this branch tag
+```
 
-The `meteor profile` command itself is registered just below, at `main.registerCommand({ name: 'profile', ... }, doBenchmarkCommand)`. Options are merged from `buildCommands.options` and `runCommandOptions.options`, so most `meteor run` and `meteor build` flags pass through transparently.
+**2. Synchronize CLI Arguments (If Needed)**
+If new flags were added upstream (e.g., `--client-size`), locate `doBenchmarkCommand` and map the new flag into the `meteorSizeEnvs` environment variables.
 
-#### When the script needs updating
+### Validating Profiler Changes
 
-- The pinned branch in `meteor/performance` has a new tag with metric changes worth picking up.
-- A new sub-flag is added (for example, a separate `--client-size`). Add it to the `options:` block and forward it through `meteorSizeEnvs` / `meteorOptions`.
-- A breaking change in the underlying `monitor-bundler.sh` contract requires a new env var or argument.
+The profiler is not covered by automated E2E tests, so manual verification is required.
 
-#### Validating that the profiler still works after changes
+**Steps to validate:**
 
-The profiler is not exercised by self-test or E2E; validate manually:
+```bash
+# 1. Prepare a sandbox environment (e.g., an E2E test fixture)
+cd tools/e2e-tests/apps/react
 
-1. Pick a test app. Any of `tools/e2e-tests/apps/*` or a fresh `meteor create` works.
-2. Run a fresh sandbox so the benchmark cache is cloned from scratch:
+# 2. Clear the old performance script cache to force a fresh clone
+rm -rf node_modules/.cache/meteor/performance
 
-   ```bash
-   rm -rf node_modules/.cache/meteor/performance
-   meteor profile
-   ```
+# 3. Verify the default profile run
+meteor profile
 
-   The output should include "Meteor profiling suite cloned to: ...", followed by the monitor running through the build.
-3. Run with each flag and confirm the expected metric prints:
+# 4. Verify specific benchmarking flags
+meteor profile --build
+meteor profile --size
+meteor profile --size-only
 
-   ```bash
-   meteor profile --build
-   meteor profile --size
-   meteor profile --size-only
-   ```
+# 5. Verify timeouts (ensure it propagates successfully)
+METEOR_IDLE_TIMEOUT=120 meteor profile
+```
 
-4. Try a long build with `METEOR_IDLE_TIMEOUT=120` to confirm the timeout option still propagates.
-5. If the change touched the clone path, delete the cache directory and run again to confirm both the tar path and the `git clone` fallback still produce a usable `scripts/` directory. (Force the fallback by temporarily renaming `tar` on `PATH`.)
+*Note:* If you modified the cloning logic in `setupBenchmarkSuite`, temporarily rename your system's `tar` binary to verify that the plain `git clone` fallback logic also works seamlessly.
 
-#### Debugging notes
+### Debugging Notes
 
-- The profiler is unsupported on Windows; `doBenchmarkCommand` throws early. WSL is the workaround.
-- The clone fails fast if `git --version` is below 2.25. The script uses `git sparse-checkout` which requires that minimum.
-- The cache directory is per-app (`<projectDir>/node_modules/.cache/meteor/performance`). If the suite scripts ever drift between projects, that is where to clean up.
-- The performance repo's branch is pinned by tag (`v3.4.0` at time of writing). Avoid pointing at `main`, since unreviewed changes in the benchmark suite will silently affect every contributor's results.
-- For deeper investigations, combine `meteor profile` with `METEOR_PROFILE=1 meteor run` (run separately): the first gives the end-to-end metric, the second points at the hot spots inside the tool.
+- **Unsupported Systems:** The profiler throws early on Windows natively. Use WSL as a workaround.
+- **Git Requirements:** The script requires `git >= 2.25` to utilize `sparse-checkout`.
+- **Target Branching:** Always pin the `branch` constant to a specific tag (e.g., `v3.4.0`), never `main`, to prevent unreviewed upstream changes from bleeding into all contributor environments.
+- **Deep Profiling:** Combine `meteor profile` with `METEOR_PROFILE=1 meteor run` to get both the end-to-end benchmark timing and a deep trace of where time is spent inside the tool itself.

--- a/dev/modern-tools/profiler/README.md
+++ b/dev/modern-tools/profiler/README.md
@@ -1,0 +1,74 @@
+# Profiler
+
+Two profilers live in the Meteor codebase: the built-in `METEOR_PROFILE` instrumentation that prints where time is spent inside the tool, and the `meteor profile` CLI that runs a controlled benchmark suite against an app. This document covers the maintenance flow for both.
+
+End-user docs for `meteor profile` live at [`v3-docs/docs/cli/index.md#meteorprofile`](../../../v3-docs/docs/cli/index.md). The Meteor tool's internal profiler is documented in [`tools/PERFORMANCE.md`](../../../tools/PERFORMANCE.md).
+
+- [**What the profiler is for**](#what-the-profiler-is-for): `METEOR_PROFILE` vs `meteor profile`, when to use each.
+- [**Common maintenance tasks**](#common-maintenance-tasks): updating the `meteor profile` script and validating changes.
+
+## What the profiler is for
+
+There are two complementary profilers in the codebase:
+
+- **`METEOR_PROFILE`**, the built-in tool profiler. Setting `METEOR_PROFILE=<threshold-ms>` makes any `meteor` command print a top-down profile of all annotated calls that exceed the threshold. Annotations come from `Profile.time(...)` / `Profile.run(...)` blocks scattered through `tools/`. Useful when investigating where time is going inside the tool itself (constraint solving, package load, bundler, watcher).
+- **`meteor profile`**, the benchmark CLI. Wraps `meteor run` (or `meteor build` with `--build`) with the [`meteor/performance`](https://github.com/meteor/performance) suite and reports build time and/or bundle size metrics over a controlled set of runs. Useful when comparing two branches, two Meteor versions, or before-and-after of a perf change.
+
+Use `METEOR_PROFILE` to find out *where* time is being spent; use `meteor profile` to get a stable, repeatable measurement of *how much* time or bytes a change costs or saves.
+
+## Common maintenance tasks
+
+### Update the `meteor profile` script
+
+The CLI lives in `tools/cli/commands.js`. Two functions matter:
+
+- `setupBenchmarkSuite(profilingPath)` at the top of the `meteor profile` flow. It clones the `meteor/performance` repository (sparse, `scripts/` only) into `<app>/node_modules/.cache/meteor/performance/scripts`. The clone uses a pinned branch:
+
+  ```js
+  const repoUrl = "https://github.com/meteor/performance";
+  const branch  = "v3.4.0";
+  ```
+
+  Bump that `branch` constant when a new tag of the performance repo ships. Both the tar-based and the plain-`git clone` fallbacks use the same constant, so updating it once is enough.
+
+- `doBenchmarkCommand(options)` invokes `scripts/monitor-bundler.sh <projectDir> <timestamp> <meteor-options>` with `METEOR_BUNDLE_SIZE`, `METEOR_BUNDLE_SIZE_ONLY`, and `METEOR_BUNDLE_BUILD` env vars derived from the `--size`, `--size-only`, and `--build` CLI flags. If the performance repo renames its script or its env contract, mirror the change here.
+
+The `meteor profile` command itself is registered just below, at `main.registerCommand({ name: 'profile', ... }, doBenchmarkCommand)`. Options are merged from `buildCommands.options` and `runCommandOptions.options`, so most `meteor run` and `meteor build` flags pass through transparently.
+
+#### When the script needs updating
+
+- The pinned branch in `meteor/performance` has a new tag with metric changes worth picking up.
+- A new sub-flag is added (for example, a separate `--client-size`). Add it to the `options:` block and forward it through `meteorSizeEnvs` / `meteorOptions`.
+- A breaking change in the underlying `monitor-bundler.sh` contract requires a new env var or argument.
+
+#### Validating that the profiler still works after changes
+
+The profiler is not exercised by self-test or E2E; validate manually:
+
+1. Pick a test app. Any of `tools/e2e-tests/apps/*` or a fresh `meteor create` works.
+2. Run a fresh sandbox so the benchmark cache is cloned from scratch:
+
+   ```bash
+   rm -rf node_modules/.cache/meteor/performance
+   meteor profile
+   ```
+
+   The output should include "Meteor profiling suite cloned to: ...", followed by the monitor running through the build.
+3. Run with each flag and confirm the expected metric prints:
+
+   ```bash
+   meteor profile --build
+   meteor profile --size
+   meteor profile --size-only
+   ```
+
+4. Try a long build with `METEOR_IDLE_TIMEOUT=120` to confirm the timeout option still propagates.
+5. If the change touched the clone path, delete the cache directory and run again to confirm both the tar path and the `git clone` fallback still produce a usable `scripts/` directory. (Force the fallback by temporarily renaming `tar` on `PATH`.)
+
+#### Debugging notes
+
+- The profiler is unsupported on Windows; `doBenchmarkCommand` throws early. WSL is the workaround.
+- The clone fails fast if `git --version` is below 2.25. The script uses `git sparse-checkout` which requires that minimum.
+- The cache directory is per-app (`<projectDir>/node_modules/.cache/meteor/performance`). If the suite scripts ever drift between projects, that is where to clean up.
+- The performance repo's branch is pinned by tag (`v3.4.0` at time of writing). Avoid pointing at `main`, since unreviewed changes in the benchmark suite will silently affect every contributor's results.
+- For deeper investigations, combine `meteor profile` with `METEOR_PROFILE=1 meteor run` (run separately): the first gives the end-to-end metric, the second points at the hot spots inside the tool.

--- a/dev/modern-tools/profiler/README.md
+++ b/dev/modern-tools/profiler/README.md
@@ -5,7 +5,10 @@ Two profilers live in the Meteor codebase: the built-in `METEOR_PROFILE` instrum
 End-user docs for `meteor profile` live at [`v3-docs/docs/cli/index.md#meteorprofile`](../../../v3-docs/docs/cli/index.md). The Meteor tool's internal profiler is documented in [`tools/PERFORMANCE.md`](../../../tools/PERFORMANCE.md).
 
 - [**What the profiler is for**](#what-the-profiler-is-for): `METEOR_PROFILE` vs `meteor profile`, when to use each.
-- [**Common maintenance tasks**](#common-maintenance-tasks): updating the `meteor profile` script and validating changes.
+- [**Common maintenance tasks**](#common-maintenance-tasks)
+  - [Updating the `meteor profile` Script](#updating-the-meteor-profile-script)
+  - [Validating Profiler Changes](#validating-profiler-changes)
+  - [Debugging Notes](#debugging-notes)
 
 ## What the profiler is for
 

--- a/dev/modern-tools/rspack/README.md
+++ b/dev/modern-tools/rspack/README.md
@@ -1,0 +1,152 @@
+# Rspack
+
+Rspack is the Rust-based, Webpack-compatible bundler that handles app source compilation, HMR, and asset emission for Meteor apps that opt in via `meteor add rspack`. Meteor itself still owns package compilation, the dev server lifecycle, and the runtime program manifest; this document covers the integration layer between the two.
+
+End-user documentation is at [`v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md`](../../../v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md). The E2E coverage matrix is at [`E2E_COVERAGE.md`](E2E_COVERAGE.md).
+
+- [**Why Rspack**](#why-rspack): goals of the Rspack integration.
+- [**Rspack integration and modules**](#rspack-integration-and-modules): the Atmosphere package and the npm package, file-by-file responsibilities, and how Rspack fits next to Meteor's own bundler.
+- [**E2E testing**](#e2e-testing): strategy, how to add a new test app, what to verify.
+- [**Common maintenance tasks**](#common-maintenance-tasks): linking `@meteorjs/rspack` locally and upgrading Rspack.
+
+## Why Rspack
+
+Rspack replaces parts of Meteor's bundler for client and server code. The goals of the integration are:
+
+- Get faster cold and incremental builds without giving up Webpack ecosystem compatibility (loaders, plugins, HMR semantics).
+- Support modern app code patterns (full ESM with `exports` fields, tree shaking, dynamic import, persistent FS cache) on the same code path Meteor uses for SSR and packages.
+- Keep Meteor packages, atmosphere conventions, and the dev server flow working unchanged from the app's perspective: `meteor add rspack` is the only required step.
+
+## Rspack integration and modules
+
+The integration is split across two packages.
+
+### `packages/rspack` (Atmosphere package)
+
+This is the build-plugin side. `package.js` registers a build plugin and declares the runtime package:
+
+```js
+Package.registerBuildPlugin({
+  name: 'rspack',
+  sources: ['lib/constants.js', 'lib/dependencies.js',
+            'lib/build-context.js', 'lib/processes.js',
+            'lib/config.js', 'rspack_plugin.js'],
+  use: ['modules@0.8.2', 'ecmascript', 'tools-core'],
+});
+
+Package.onUse(function (api) {
+  api.use('ecmascript', ['client', 'server']);
+  api.use(['tools-core', 'webapp']);
+  api.mainModule('rspack_server.js', 'server');
+});
+```
+
+`lib/` contains:
+
+| File | Responsibility |
+|------|----------------|
+| `constants.js` | Default versions of `@rspack/core`, `@meteorjs/rspack`, `swc-loader`, etc. Build context directory names (`_build`, `build-assets`, `build-chunks`, `.rsdoctor`). `GLOBAL_STATE_KEYS` used to track installation/compile state across rebuilds. |
+| `dependencies.js` | Auto-install flow for `@rspack/core`, `@meteorjs/rspack`, React HMR, Rsdoctor. Uses `tools-core`'s npm helpers. |
+| `build-context.js` | Creates and cleans the build context, asset, and chunk directories. Manages the default `rspack.config.js`. |
+| `config.js` | Sets Meteor entry points and env from the resolved app config. |
+| `processes.js` | Spawns the Rspack dev server and server-side watch process, computes ports, picks the right config file (`.cjs`/`.mjs`/`.ts`/...), handles cleanup. |
+| `compilation.js` | First-compile barrier; coordinates the Meteor server start with Rspack's first emit. |
+
+`rspack_plugin.js` is the orchestrator that runs inside the plugin sandbox: it checks installation, ensures the build context exists, configures Meteor, starts the Rspack processes (or runs a one-shot build), and waits for first compilation.
+
+`rspack_server.js` is the runtime side that runs inside the user's app (see `mainModule` in `package.js`). It uses `webapp` to compose Meteor with the Rspack dev server (proxy middleware in development, static serving in production).
+
+### `npm-packages/meteor-rspack` (the `@meteorjs/rspack` npm package)
+
+This is the configuration side. Users install it through the Atmosphere package's auto-install flow, and it provides the default Rspack configuration plus a `defineConfig(factory)` helper. Key files:
+
+| Path | Responsibility |
+|------|----------------|
+| `index.js`, `index.d.ts` | Public API: `defineConfig`, `HtmlRspackPlugin`. |
+| `rspack.config.js` | The big default Rspack config (client + server, SWC loader, plugins, externals, HMR, persistent cache). |
+| `lib/meteorRspackConfigFactory.js` | Factory that builds the `Meteor.*` helpers (`compileWithMeteor`, `compileWithRspack`, `extendSwcConfig`, `replaceSwcConfig`, `disablePlugins`, `enablePortableBuild`, `persistDevFiles`, `splitVendorChunk`, `setCache`, `extendConfig`). |
+| `lib/meteorRspackHelpers.js`, `lib/meteorRspackConfigHelpers.js` | Detection helpers (React/Blaze/TS/etc.), Meteor define plugin values, output and externals wiring. |
+| `lib/swc.js` | Resolves `.swcrc` / `swc.config.js` / `swc.config.ts` using `@swc/core` for TS configs; see also [`../swc/README.md`](../swc/README.md). |
+| `lib/localDependenciesHelpers.js` | Parses the user's `rspack.config.js` with `@swc/core` to discover local plugin files and add them to the FS cache's `buildDependencies`. |
+| `lib/mergeRulesSplitOverlap.js`, `lib/ignore.js` | Safe-merge logic for module rules and ignore-loader rules. |
+| `plugins/` | Custom Rspack plugins (HTML generation, asset externals, server output, require externals). |
+| `scripts/bump-version.js`, `scripts/publish-beta.sh` | Version bumper and beta publish script (see [`README.md`](../../../npm-packages/meteor-rspack/README.md) in the package). |
+
+### How it interacts with Meteor
+
+The bundler does *not* replace Meteor's bundler wholesale. Instead:
+
+- Meteor still owns package compilation, the boilerplate generator, the dev server lifecycle, and the runtime program manifest.
+- Rspack owns app source compilation (client and server), HMR, asset emission, and the chunk graph for user code.
+- The two are stitched together at three points: the `webapp` middleware (dev: proxy to the Rspack dev server; prod: serve emitted files), the asset externals plugin (so Meteor packages remain external to Rspack), and the entry point env vars (`METEOR_CONFIG_CLIENT` / `METEOR_CONFIG_SERVER` / ...) set by the build plugin via `tools-core`'s `setMeteorAppEntrypoints`.
+
+When debugging an integration issue, it is usually one of: a missing externals binding, a stale build context directory, an entrypoint env var that did not reach the bundler, or a config helper that returned a fragment Rspack does not merge correctly. The places to start are `packages/rspack/lib/build-context.js` (directory state), `packages/rspack/lib/processes.js` (process and port wiring), `npm-packages/meteor-rspack/rspack.config.js` (defaults), and `npm-packages/meteor-rspack/lib/meteorRspackConfigFactory.js` (helpers).
+
+## E2E testing
+
+The Rspack integration is exercised by the Jest + Playwright suite in `tools/e2e-tests/`. Each app fixture under `tools/e2e-tests/apps/<name>/` has a matching `<name>.test.js` that runs init/dev/prod/test/build/reset phases against a real Meteor + Rspack project. The full matrix lives in [`E2E_COVERAGE.md`](E2E_COVERAGE.md); maintain that file via the [`e2e-coverage`](../../../.github/skills/e2e-coverage/SKILL.md) skill when adding or modifying apps.
+
+### Strategy
+
+- **Real projects, not mocks.** Each test copies an app fixture, installs deps, adds the `rspack` package, and runs the Meteor CLI. This catches integration bugs that unit tests miss (HMR wiring, externals, asset paths, Windows quirks).
+- **Same lifecycle for every fixture.** Init, dev run, prod run, test (watch and once), build, reset. The shared `helpers.js` and `test-helpers.js` enforce a consistent set of assertions: build artifacts exist, the page renders, `__rspack__` script is present, HMR is on in dev and off in prod.
+- **Skeletons are covered too.** `skeleton.test.js` walks every `meteor create --<skeleton>` template through the same phases on dedicated ports.
+
+### Creating a new E2E test app
+
+1. Copy an existing app under `tools/e2e-tests/apps/` as the starting point (`apps/react` is a good baseline for a generic case).
+2. Add an `<name>.test.js` next to the existing ones; reuse the helpers in `test-helpers.js` to drive lifecycle phases.
+3. Update `jest.config.js` if the new file is not picked up by the default `testMatch`.
+4. Install deps once with `npm run install:e2e` (run from repo root).
+5. Run the new file alone: `npm run test:e2e -- --testPathPattern <name>`. That is also the fastest way to debug a single regression.
+6. Update [`E2E_COVERAGE.md`](E2E_COVERAGE.md) per the e2e-coverage skill so the matrix stays accurate.
+
+### What to verify when touching Rspack
+
+- Dev run: build artifacts exist under the build context dir, the client loads in the browser, HMR triggers on a source edit.
+- Prod run: same assertions with `--production`; HMR must be off.
+- Test mode: `meteor test` runs the mocha driver, watches rebuilds, and `meteor test --once` exits with the expected code.
+- Build: `meteor build` produces a valid bundle tree (`main.js`, `programs/server`, `web.browser`, `web.browser.legacy`) and any static assets the app expects.
+- Reset: `meteor reset` clears the build context, asset/chunk directories, and `.meteor/local` subdirs.
+
+## Common maintenance tasks
+
+### Link `@meteorjs/rspack` to a local app
+
+When iterating on the npm package (default config, helpers, plugins), linking it into a sandbox app is the fastest feedback loop. The `tools/e2e-tests/apps/*` fixtures and the standard skeletons under `tools/static-assets/skel-*` are good targets.
+
+Steps:
+
+```bash
+# In the meteor-rspack package
+cd npm-packages/meteor-rspack
+npm link
+
+# In the target app
+cd /path/to/target-app
+meteor add rspack          # if not already added
+meteor npm link @meteorjs/rspack
+meteor run
+```
+
+Notes:
+
+- The Rspack Atmosphere package's auto-install flow may try to install a newer version of `@meteorjs/rspack`. Set `meteor.autoInstallDeps` to `false` in the app's `package.json` to make the link stick.
+- Local plugin files referenced from the app's `rspack.config.js` are parsed via `lib/localDependenciesHelpers.js` and added to the persistent cache's `buildDependencies`. If a change to a local plugin is not reflected after a rebuild, run `meteor reset`.
+
+### Upgrade Rspack to verify compatibility
+
+This covers bumping `@rspack/core`, `@rspack/plugin-react-refresh`, `swc-loader`, and `@rsdoctor/rspack-plugin`. The default versions are declared in `packages/rspack/lib/constants.js` (`DEFAULT_RSPACK_VERSION` and friends) and as `peerDependencies` / `devDependencies` in `npm-packages/meteor-rspack/package.json`.
+
+Expected process:
+
+1. Bump versions in `packages/rspack/lib/constants.js` and `npm-packages/meteor-rspack/package.json` together. Keep `peerDependencies` ranges as broad as the new minimum allows.
+2. Run `npm install` inside `npm-packages/meteor-rspack/` to refresh `package-lock.json`.
+3. Run the full E2E suite: `npm run test:e2e` from the repo root. At minimum confirm `react`, `react-router`, `typescript`, `blaze`, `monorepo`, and the skeletons pass.
+4. Check Rspack's release notes for breaking changes in:
+   - Module resolution (especially around `exports` conditions, ESM, `node:` protocol).
+   - Persistent FS cache layout, since user apps may carry stale caches across the bump.
+   - HMR client wiring (the `__rspack__` script tag, dev server URL).
+   - SWC loader options if SWC was bumped at the same time; see [`../swc/README.md`](../swc/README.md).
+5. If a regression appears, the safest rollback is to revert the constants and the `package.json` bumps and rerun the failing E2E target with `npm run test:e2e -- --testPathPattern <name>` to confirm. Apps can opt out of the new version with `meteor reset` followed by manually pinning `@meteorjs/rspack` and `@rspack/core` in `package.json` until a fix lands.
+6. When ready to ship, follow the [`version-bump`](../../../.github/skills/version-bump/SKILL.md) skill for the Atmosphere package and use `npm run bump` / `npm run publish:beta` in `npm-packages/meteor-rspack/` for the npm side.

--- a/dev/modern-tools/rspack/README.md
+++ b/dev/modern-tools/rspack/README.md
@@ -2,12 +2,12 @@
 
 Rspack is the Rust-based, Webpack-compatible bundler that handles app source compilation, HMR, and asset emission for Meteor apps that opt in via `meteor add rspack`. Meteor itself still owns package compilation, the dev server lifecycle, and the runtime program manifest; this document covers the integration layer between the two.
 
-End-user documentation is at [`v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md`](../../../v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md). The E2E coverage matrix is at [`E2E_COVERAGE.md`](E2E_COVERAGE.md).
+End-user documentation is at [`v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md`](../../../v3-docs/docs/about/modern-build-stack/rspack-bundler-integration.md). The E2E coverage matrix is at [`E2E_COVERAGE.md`](E2E_COVERAGE.md). The memory benchmark guide is at [`MEMORY_BENCHMARK.md`](MEMORY_BENCHMARK.md).
 
 - [**Why Rspack**](#why-rspack): goals of the Rspack integration.
 - [**Rspack integration and modules**](#rspack-integration-and-modules): the Atmosphere package and the npm package, file-by-file responsibilities, and how Rspack fits next to Meteor's own bundler.
 - [**E2E testing**](#e2e-testing): strategy, how to add a new test app, what to verify.
-- [**Common maintenance tasks**](#common-maintenance-tasks): linking `@meteorjs/rspack` locally and upgrading Rspack.
+- [**Common maintenance tasks**](#common-maintenance-tasks): linking `@meteorjs/rspack` locally, upgrading Rspack, and benchmarking rebuild memory.
 
 ## Why Rspack
 
@@ -111,42 +111,88 @@ The Rspack integration is exercised by the Jest + Playwright suite in `tools/e2e
 
 ## Common maintenance tasks
 
-### Link `@meteorjs/rspack` to a local app
+This section covers the typical workflows for iterating on the Rspack integration, upgrading its core dependencies, and publishing changes.
 
-When iterating on the npm package (default config, helpers, plugins), linking it into a sandbox app is the fastest feedback loop. The `tools/e2e-tests/apps/*` fixtures and the standard skeletons under `tools/static-assets/skel-*` are good targets.
+### Iterating on `@meteorjs/rspack` (NPM Package)
 
-Steps:
+The `@meteorjs/rspack` npm package (`npm-packages/meteor-rspack/`) provides the default Rspack configuration. When making changes here, you need to link it to a local app to verify your modifications. The easiest targets are the E2E test fixtures (`tools/e2e-tests/apps/*`) or standard skeletons.
+
+**Steps to test local changes:**
 
 ```bash
-# In the meteor-rspack package
+# 1. Build and link the local NPM package
 cd npm-packages/meteor-rspack
 npm link
 
-# In the target app
+# 2. Go to your target app and link the package
 cd /path/to/target-app
 meteor add rspack          # if not already added
 meteor npm link @meteorjs/rspack
 meteor run
 ```
 
-Notes:
+*Note:* The Atmosphere package's auto-install flow may try to install a newer version of `@meteorjs/rspack` from the registry. To make your local link stick, set `"meteor": { "autoInstallDeps": false }` in the app's `package.json`.
 
-- The Rspack Atmosphere package's auto-install flow may try to install a newer version of `@meteorjs/rspack`. Set `meteor.autoInstallDeps` to `false` in the app's `package.json` to make the link stick.
-- Local plugin files referenced from the app's `rspack.config.js` are parsed via `lib/localDependenciesHelpers.js` and added to the persistent cache's `buildDependencies`. If a change to a local plugin is not reflected after a rebuild, run `meteor reset`.
+After verifying changes manually, always run the E2E suite to ensure broader compatibility is intact before committing:
+```bash
+npm run test:e2e
+```
 
-### Upgrade Rspack to verify compatibility
+### Upgrading Rspack Core Dependencies
 
-This covers bumping `@rspack/core`, `@rspack/plugin-react-refresh`, `swc-loader`, and `@rsdoctor/rspack-plugin`. The default versions are declared in `packages/rspack/lib/constants.js` (`DEFAULT_RSPACK_VERSION` and friends) and as `peerDependencies` / `devDependencies` in `npm-packages/meteor-rspack/package.json`.
+When a new version of Rspack is released, you must bump the core dependencies: `@rspack/core`, `@rspack/plugin-react-refresh`, `swc-loader`, and `@rsdoctor/rspack-plugin`.
 
-Expected process:
+**1. Update the Constants (Atmosphere Package)**
+Modify the default versions in `packages/rspack/lib/constants.js`. For example, change `DEFAULT_RSPACK_VERSION` to the new target version:
+```javascript
+// packages/rspack/lib/constants.js
+const DEFAULT_RSPACK_VERSION = '1.0.0-beta.1'; 
+```
 
-1. Bump versions in `packages/rspack/lib/constants.js` and `npm-packages/meteor-rspack/package.json` together. Keep `peerDependencies` ranges as broad as the new minimum allows.
-2. Run `npm install` inside `npm-packages/meteor-rspack/` to refresh `package-lock.json`.
-3. Run the full E2E suite: `npm run test:e2e` from the repo root. At minimum confirm `react`, `react-router`, `typescript`, `blaze`, `monorepo`, and the skeletons pass.
-4. Check Rspack's release notes for breaking changes in:
-   - Module resolution (especially around `exports` conditions, ESM, `node:` protocol).
-   - Persistent FS cache layout, since user apps may carry stale caches across the bump.
-   - HMR client wiring (the `__rspack__` script tag, dev server URL).
-   - SWC loader options if SWC was bumped at the same time; see [`../swc/README.md`](../swc/README.md).
-5. If a regression appears, the safest rollback is to revert the constants and the `package.json` bumps and rerun the failing E2E target with `npm run test:e2e -- --testPathPattern <name>` to confirm. Apps can opt out of the new version with `meteor reset` followed by manually pinning `@meteorjs/rspack` and `@rspack/core` in `package.json` until a fix lands.
-6. When ready to ship, follow the [`version-bump`](../../../.github/skills/version-bump/SKILL.md) skill for the Atmosphere package and use `npm run bump` / `npm run publish:beta` in `npm-packages/meteor-rspack/` for the npm side.
+**2. Update the Package Configuration (NPM Package)**
+Bump the versions in the `peerDependencies` and `devDependencies` inside `npm-packages/meteor-rspack/package.json`. Keep `peerDependencies` ranges as broad as the new minimum allows.
+```bash
+# Refresh the lockfile after bumping package.json
+cd npm-packages/meteor-rspack
+npm install
+```
+
+**3. Verify Compatibility**
+Run the full E2E suite from the repository root:
+```bash
+npm run test:e2e
+```
+*Look out for breaking changes in Rspack's release notes around:*
+- Module resolution (especially `exports` conditions, ESM, `node:` protocol).
+- Persistent FS cache layouts, as user apps may carry stale caches.
+- HMR client wiring (the `__rspack__` script tag, dev server URL).
+- SWC loader options (see [`../swc/README.md`](../swc/README.md)).
+
+### Publishing the Packages
+
+Whenever there are modifications in `npm-packages/meteor-rspack` or `packages/rspack`, you must publish the new versions. The NPM package is always published *first*, followed by the Atmosphere package bump.
+
+**For a Beta Release:**
+```bash
+# 1. Publish the NPM package as a beta
+cd npm-packages/meteor-rspack
+npm run publish:beta
+
+# 2. Bump the Atmosphere package version (e.g., to 1.0.0-beta.1)
+# See the version-bump skill for detailed instructions.
+```
+
+**For an Official Release:**
+```bash
+# 1. Bump the NPM package version and publish
+cd npm-packages/meteor-rspack
+npm run bump
+npm publish
+
+# 2. Bump the Atmosphere package version (e.g., to 1.0.0)
+# See the version-bump skill for detailed instructions.
+```
+
+### Benchmark rebuild memory
+
+For investigating rebuild memory issues or analyzing process-tree memory retention (`meteor-tool`, app server, Rspack/TypeScript child processes), see [`MEMORY_BENCHMARK.md`](MEMORY_BENCHMARK.md) for instructions on running `scripts/build-stack-memory-bench.js` and capturing heap snapshots.

--- a/dev/modern-tools/rspack/README.md
+++ b/dev/modern-tools/rspack/README.md
@@ -7,7 +7,11 @@ End-user documentation is at [`v3-docs/docs/about/modern-build-stack/rspack-bund
 - [**Why Rspack**](#why-rspack): goals of the Rspack integration.
 - [**Rspack integration and modules**](#rspack-integration-and-modules): the Atmosphere package and the npm package, file-by-file responsibilities, and how Rspack fits next to Meteor's own bundler.
 - [**E2E testing**](#e2e-testing): strategy, how to add a new test app, what to verify.
-- [**Common maintenance tasks**](#common-maintenance-tasks): linking `@meteorjs/rspack` locally, upgrading Rspack, and benchmarking rebuild memory.
+- [**Common maintenance tasks**](#common-maintenance-tasks)
+  - [Iterating on `@meteorjs/rspack` (NPM Package)](#iterating-on-meteorjsrspack-npm-package)
+  - [Upgrading Rspack Core Dependencies](#upgrading-rspack-core-dependencies)
+  - [Publishing the Packages](#publishing-the-packages)
+  - [Benchmark rebuild memory](#benchmark-rebuild-memory)
 
 ## Why Rspack
 
@@ -135,6 +139,8 @@ meteor run
 
 After verifying changes manually, always run the E2E suite to ensure broader compatibility is intact before committing:
 ```bash
+# Tip: If the test suite complains about missing dependencies,
+# run `npm run install:e2e` from the repo root first.
 npm run test:e2e
 ```
 
@@ -160,6 +166,7 @@ npm install
 **3. Verify Compatibility**
 Run the full E2E suite from the repository root:
 ```bash
+# Tip: Run `npm run install:e2e` first if encountering missing dependency errors
 npm run test:e2e
 ```
 *Look out for breaking changes in Rspack's release notes around:*
@@ -174,8 +181,9 @@ Whenever there are modifications in `npm-packages/meteor-rspack` or `packages/rs
 
 **For a Beta Release:**
 ```bash
-# 1. Publish the NPM package as a beta
+# 1. Bump the NPM package version and publish as beta
 cd npm-packages/meteor-rspack
+npm run bump -- patch --beta   # use patch, minor, or major depending on the change
 npm run publish:beta
 
 # 2. Bump the Atmosphere package version (e.g., to 1.0.0-beta.1)
@@ -186,7 +194,7 @@ npm run publish:beta
 ```bash
 # 1. Bump the NPM package version and publish
 cd npm-packages/meteor-rspack
-npm run bump
+npm run bump -- patch          # use patch, minor, or major depending on the change
 npm publish
 
 # 2. Bump the Atmosphere package version (e.g., to 1.0.0)

--- a/dev/modern-tools/swc/README.md
+++ b/dev/modern-tools/swc/README.md
@@ -1,0 +1,110 @@
+# SWC
+
+SWC is the Rust-based transpiler and minifier on Meteor's modern build path. It compiles app code through `packages/babel-compiler`, minifies production bundles in `packages/standard-minifier-js`, and powers the Rspack `swc-loader` for application source.
+
+The end-user view is documented in [`v3-docs/docs/about/modern-build-stack/meteor-bundler-optimizations.md`](../../../v3-docs/docs/about/modern-build-stack/meteor-bundler-optimizations.md). This document is the maintainer-facing counterpart, covering where the integration lives and the tasks needed when bumping or debugging it.
+
+- [**Why SWC**](#why-swc): goals of the SWC integration.
+- [**SWC integration and modules**](#swc-integration-and-modules): packages involved, `@swc/core` vs `@meteorjs/swc-core`, debugging notes.
+- [**Test coverage**](#test-coverage): legacy self-test vs modern E2E, when to run which.
+- [**Common maintenance tasks**](#common-maintenance-tasks): bumping the SWC dependencies safely.
+
+## Why SWC
+
+SWC replaces the Babel transpilation step on the modern path. The goals of the integration are:
+
+- Move transpilation off of Babel and onto a Rust-based parser/codegen for substantially faster cold builds and rebuilds.
+- Keep Meteor-specific behavior intact (reify modules, nested imports, top-level await, modern vs legacy browser targets) without forcing users to maintain a Babel config.
+- Reuse the same SWC backend for both the transpiler (compile step) and the minifier (production builds), so the bundler does not need to ship two JavaScript engines.
+
+## SWC integration and modules
+
+There are three places SWC is wired into the codebase:
+
+1. **`packages/babel-compiler`**, the transpiler entry point.
+   - Depends on `@meteorjs/swc-core` (see `package.js`).
+   - `babel-compiler.js` requires `@meteorjs/swc-core` and exposes `compileWithSwc(source, swcOptions, { features })`. The output is post-processed by `@meteorjs/reify` so module compilation, nested imports, top-level await, and modern/legacy targets match Babel's behavior.
+   - `initializeMeteorAppSwcrc` resolves the user's SWC config, in this order: `.swcrc`, `swc.config.js`, `swc.config.ts`. Dynamic (`.js` / `.ts`) configs are read, transpiled to CJS (using SWC itself), then evaluated. The resolved config is cached against the file's mtime plus a content hash.
+   - `BabelCompiler` exports a `SwcCompiler` variant used when modern mode is enabled (`Meteor.modern: true` or `METEOR_MODERN=`). When SWC cannot handle a file, the compiler falls back to Babel and logs `[Transpiler] Used SWC` / `Used Babel` lines under verbose mode.
+
+2. **`packages/standard-minifier-js`**, the minifier entry point.
+   - Depends on `@meteorjs/swc-core`.
+   - `plugin/minify-js.js` lazily requires `@meteorjs/swc-core` and uses it as the minifier for the modern build target.
+
+3. **`npm-packages/meteor-rspack`**, the bundler-side integration.
+   - The bundler uses Rspack's `swc-loader`, which depends on a peer-installed `@swc/core` (see `peerDependencies` in `package.json`).
+   - `lib/swc.js` reads the same `.swcrc` / `swc.config.js` / `swc.config.ts` family for the loader, and `lib/localDependenciesHelpers.js` parses the user's `rspack.config.js` with `@swc/core` to discover local plugin files that should invalidate the persistent cache.
+
+### `@swc/core` vs `@meteorjs/swc-core`
+
+There are two different SWC packages in play, and the difference matters when bumping versions:
+
+- **`@meteorjs/swc-core`** is a Meteor-controlled wrapper that vendors `@swc/core` and its native binaries. It is the dependency declared in `babel-compiler/package.js` and `standard-minifier-js/package.js`. Vendoring lets Meteor ship the right native binary for every supported platform without depending on each user's npm install hitting the optional-dependency platform-pick logic. It also pins the SWC API the Meteor tool is built against.
+- **`@swc/core`** is the upstream package. It is a peer dependency of `@meteorjs/rspack`, because `swc-loader` resolves it from the user's project. The user's app installs it as part of the Rspack integration (the `rspack` Atmosphere package's auto-install flow handles this).
+- The bundler integration also requires `@swc/core` directly in `meteor-rspack/lib/swc.js` and `lib/localDependenciesHelpers.js` to parse user configs. That `@swc/core` resolves through the app's `node_modules`, so the version is controlled by what the Rspack integration installs at the project level, not by what `@meteorjs/swc-core` ships.
+
+In short: the tool-side compile/minify path uses `@meteorjs/swc-core`, and the bundler-side loader path uses `@swc/core`. Both should advance together so the user's app and the tool agree on syntax support.
+
+### Debugging notes
+
+- Set `METEOR_PROFILE=1` and look for `SWC.compile` / `Babel.compile` entries in the report to confirm which path each file took.
+- Set `meteor.modern.verbose` to `true` in `package.json` (or `meteor.modern.transpiler.verbose`) to log `[Transpiler] Used SWC ...` / `[Transpiler] Used Babel ...` lines per file, distinguishing `(app)`, `(package)`, and `(node_modules)` contexts.
+- A `.swcrc` is parsed as JSON. `swc.config.js` and `swc.config.ts` are evaluated in a vm sandbox; any change to the resolver should be exercised against both the static `.swcrc` and the dynamic config paths.
+- When config changes are not taking effect, check the mtime+hash cache in `initializeMeteorAppSwcrc`. The config is re-read only when the mtime changes (and, for dynamic configs, when the hash of the resolved object changes).
+
+## Test coverage
+
+Two complementary suites cover SWC:
+
+- **Legacy self-test coverage**, run via `meteor self-test`. The relevant files are `tools/tests/modern.js` (covers transpiler on/off and `.swcrc` / `swc.config.js` paths) and `tools/tests/compiler-plugins.js` (covers the `SwcCompiler` registered through `Plugin.registerCompiler`). These tests assert profile output (`/SWC\.compile/`, `/Babel\.compile/`) and verbose log lines like `[Transpiler] Used SWC.*(app)`. They catch regressions in how files are routed between SWC and Babel, how custom configs are picked up, and how legacy targets behave when modern mode is off.
+- **Modern E2E coverage**, run via the Jest + Playwright suite under `tools/e2e-tests/`. The `typescript` app exercises a real `swc.config.ts` (including a type-only `import type { Config } from '@swc/core'`), `Meteor.extendSwcConfig` path aliases, and the Rspack `swc-loader` end-to-end. These tests catch regressions in the bundler's SWC path rather than the tool's transpiler path. See [`../rspack/E2E_COVERAGE.md`](../rspack/E2E_COVERAGE.md) for the full matrix.
+
+When to run which:
+
+- Touching `packages/babel-compiler`, `packages/standard-minifier-js`, or anything in the tool that calls `@meteorjs/swc-core`: run the self-tests in `tools/tests/modern.js` and `compiler-plugins.js`.
+- Touching `npm-packages/meteor-rspack/lib/swc.js`, the bundler-side config parsing, or any helper from `@meteorjs/rspack` related to SWC: run the Rspack E2E suite, at minimum the `typescript` app.
+- Changing the SWC version (either `@meteorjs/swc-core` or `@swc/core`): run both, since the two paths share user-facing config files.
+
+## Common maintenance tasks
+
+### Bump `@meteorjs/swc-core` (wrapper publish + Meteor core rollout)
+
+Publishing a new `@meteorjs/swc-core` and consuming it from `meteor/meteor` is one task with two stages. Do not split them: the wrapper must hit npm before the core repo can pull the new version, and the bundler-side `@swc/core` range in `meteor-rspack` must move in the same change so the tool path (`@meteorjs/swc-core`) and the bundler path (`@swc/core` via `swc-loader`) agree on syntax support.
+
+Before starting, read the relevant commit history once:
+
+- `meteor-package-install-swc`: last few release commits (e.g. `4dc9ae27`, `f9b089c9`, `02bd3b41`) show the canonical diff shape.
+- `meteor/meteor`: `git log -- packages/babel-compiler/package.js packages/standard-minifier-js/package.js npm-packages/meteor-rspack/package.json` explains why the wrapper exists and how the peer dependency is structured.
+
+#### Stage 1: publish a new wrapper version from `meteor-package-install-swc`
+
+Repo: [`meteor/meteor-package-install-swc`](https://github.com/meteor/meteor-package-install-swc). Thin wrapper, four meaningful files:
+
+- `package.json`: published name (`@meteorjs/swc-core`), version, `postinstall` runs `install.js`.
+- `install.js`: writes inline `package.json` into `./.swc/` pinning `@swc/core` to a version, then `npm install` inside that folder so npm picks the right platform-specific optional dependency.
+- `index.js`: re-exports `./.swc/node_modules/@swc/core/index.js`.
+- `package-lock.json`: lockfile for the publisher's own dev install.
+
+Wrapper version equals wrapped `@swc/core` version (e.g. `@meteorjs/swc-core@1.15.3` pins `@swc/core@1.15.3`). Commits before `4dc9ae27` used a different scheme; current rule is to keep them equal.
+
+Steps (requires publish rights on the `@meteorjs` npm scope):
+
+1. `git pull` the repo. Change pinned `@swc/core` version in the inline `dependencies` block in `install.js`.
+2. Set `version` in `package.json` to the same SWC version.
+3. `npm install` at repo root to regenerate `package-lock.json`. Commit `install.js` + `package.json` + `package-lock.json` together (see `4dc9ae27` for the canonical diff).
+4. Local sanity check: `rm -rf .swc node_modules && npm install` should fetch the new `@swc/core` and create `./.swc/node_modules/@swc/core/index.js`. `node -e "require('./index.js')"` must load without throwing.
+5. Commit (`bump @swc/core version to <version>`), push, then `npm publish --access public` from the repo root. `--access public` is required because the package is under the scoped `@meteorjs` org.
+6. Verify with `npm view @meteorjs/swc-core version`.
+
+#### Stage 2: roll the new wrapper into `meteor/meteor`
+
+Direct consumers of `@meteorjs/swc-core`: `packages/babel-compiler` (top-level `Npm.depends`) and `packages/standard-minifier-js` (plugin `Npm.depends`). Direct consumer of `@swc/core`: `npm-packages/meteor-rspack`. No other call sites today (verify with `grep -rn '@meteorjs/swc-core' packages npm-packages` and `grep -rn '"@swc/core"' packages npm-packages`).
+
+Steps:
+
+1. Update `@meteorjs/swc-core` to the new wrapper version in `packages/babel-compiler/package.js` and `packages/standard-minifier-js/package.js`.
+2. Refresh `npm-shrinkwrap.json` in both locations. Either run `meteor npm install` inside `packages/babel-compiler/.npm/package/` and `packages/standard-minifier-js/.npm/plugin/minifyStdJS/`, or let Meteor regenerate them on a clean local build. Commit whichever files actually changed.
+3. Update the `@swc/core` range in `npm-packages/meteor-rspack/package.json` (`peerDependencies` and `devDependencies`). Minimum must not be older than the wrapper's pinned SWC version. Run `npm install` inside `npm-packages/meteor-rspack/` to refresh its `package-lock.json`.
+4. If any new SWC option is being threaded through, update `compileWithSwc` and the `.swcrc` / `swc.config.{js,ts}` resolver in `packages/babel-compiler/babel-compiler.js`, the loader defaults in `npm-packages/meteor-rspack/lib/meteorRspackConfigFactory.js` and `meteorRspackHelpers.js`, and the config parser in `npm-packages/meteor-rspack/lib/swc.js`.
+5. Run the test suites listed in [Test coverage](#test-coverage). Required: `meteor self-test --file modern.js`, `meteor self-test --file compiler-plugins.js`, and the Rspack E2E `typescript` app under `tools/e2e-tests/`.
+6. Bump Atmosphere package versions per the [`version-bump`](../../../.github/skills/version-bump/SKILL.md) skill. `babel-compiler` and `standard-minifier-js` change because they consume the new wrapper; downstream packages are re-released automatically by the version-bump tool.

--- a/dev/modern-tools/swc/README.md
+++ b/dev/modern-tools/swc/README.md
@@ -7,7 +7,9 @@ The end-user view is documented in [`v3-docs/docs/about/modern-build-stack/meteo
 - [**Why SWC**](#why-swc): goals of the SWC integration.
 - [**SWC integration and modules**](#swc-integration-and-modules): packages involved, `@swc/core` vs `@meteorjs/swc-core`, debugging notes.
 - [**Test coverage**](#test-coverage): legacy self-test vs modern E2E, when to run which.
-- [**Common maintenance tasks**](#common-maintenance-tasks): bumping the SWC dependencies safely.
+- [**Common maintenance tasks**](#common-maintenance-tasks)
+  - [Stage 1: Publish the New Wrapper (`@meteorjs/swc-core`)](#stage-1-publish-the-new-wrapper-meteorjsswc-core)
+  - [Stage 2: Roll the Wrapper into Meteor Core](#stage-2-roll-the-wrapper-into-meteor-core)
 
 ## Why SWC
 
@@ -132,6 +134,8 @@ Run the self-tests and the E2E suite to ensure transpilation and bundling paths 
 ```bash
 meteor self-test --file modern.js
 meteor self-test --file compiler-plugins.js
+
+# Tip: Run `npm run install:e2e` first if the E2E suite fails to start
 npm run test:e2e
 ```
 

--- a/dev/modern-tools/swc/README.md
+++ b/dev/modern-tools/swc/README.md
@@ -67,44 +67,73 @@ When to run which:
 
 ## Common maintenance tasks
 
-### Bump `@meteorjs/swc-core` (wrapper publish + Meteor core rollout)
+This section covers the typical workflows for bumping the SWC dependencies safely. 
+Publishing a new `@meteorjs/swc-core` wrapper and rolling it into Meteor core are two stages of a single task. Do not split them; both must advance together so the tool path and the bundler path agree on syntax support.
 
-Publishing a new `@meteorjs/swc-core` and consuming it from `meteor/meteor` is one task with two stages. Do not split them: the wrapper must hit npm before the core repo can pull the new version, and the bundler-side `@swc/core` range in `meteor-rspack` must move in the same change so the tool path (`@meteorjs/swc-core`) and the bundler path (`@swc/core` via `swc-loader`) agree on syntax support.
+### Stage 1: Publish the New Wrapper (`@meteorjs/swc-core`)
 
-Before starting, read the relevant commit history once:
+The wrapper package lives in the [`meteor/meteor-package-install-swc`](https://github.com/meteor/meteor-package-install-swc) repository.
 
-- `meteor-package-install-swc`: last few release commits (e.g. `4dc9ae27`, `f9b089c9`, `02bd3b41`) show the canonical diff shape.
-- `meteor/meteor`: `git log -- packages/babel-compiler/package.js packages/standard-minifier-js/package.js npm-packages/meteor-rspack/package.json` explains why the wrapper exists and how the peer dependency is structured.
+**Steps to publish:**
 
-#### Stage 1: publish a new wrapper version from `meteor-package-install-swc`
+```bash
+# 1. Clone or pull the latest wrapper repository
+git clone https://github.com/meteor/meteor-package-install-swc
+cd meteor-package-install-swc
 
-Repo: [`meteor/meteor-package-install-swc`](https://github.com/meteor/meteor-package-install-swc). Thin wrapper, four meaningful files:
+# 2. Update the wrapper configuration
+# - Open `install.js` and update the `@swc/core` version in the inline `dependencies` block.
+# - Open `package.json` and set `"version"` to match the new SWC version exactly.
 
-- `package.json`: published name (`@meteorjs/swc-core`), version, `postinstall` runs `install.js`.
-- `install.js`: writes inline `package.json` into `./.swc/` pinning `@swc/core` to a version, then `npm install` inside that folder so npm picks the right platform-specific optional dependency.
-- `index.js`: re-exports `./.swc/node_modules/@swc/core/index.js`.
-- `package-lock.json`: lockfile for the publisher's own dev install.
+# 3. Regenerate the lockfile and verify
+npm install
+rm -rf .swc node_modules
+npm install
+node -e "require('./index.js')" # Must load without throwing
 
-Wrapper version equals wrapped `@swc/core` version (e.g. `@meteorjs/swc-core@1.15.3` pins `@swc/core@1.15.3`). Commits before `4dc9ae27` used a different scheme; current rule is to keep them equal.
+# 4. Commit and Publish (requires @meteorjs npm org publish rights)
+git commit -am "bump @swc/core version to <version>"
+npm publish --access public
 
-Steps (requires publish rights on the `@meteorjs` npm scope):
+# 5. Verify the publish succeeded
+npm view @meteorjs/swc-core version
+```
 
-1. `git pull` the repo. Change pinned `@swc/core` version in the inline `dependencies` block in `install.js`.
-2. Set `version` in `package.json` to the same SWC version.
-3. `npm install` at repo root to regenerate `package-lock.json`. Commit `install.js` + `package.json` + `package-lock.json` together (see `4dc9ae27` for the canonical diff).
-4. Local sanity check: `rm -rf .swc node_modules && npm install` should fetch the new `@swc/core` and create `./.swc/node_modules/@swc/core/index.js`. `node -e "require('./index.js')"` must load without throwing.
-5. Commit (`bump @swc/core version to <version>`), push, then `npm publish --access public` from the repo root. `--access public` is required because the package is under the scoped `@meteorjs` org.
-6. Verify with `npm view @meteorjs/swc-core version`.
+### Stage 2: Roll the Wrapper into Meteor Core
 
-#### Stage 2: roll the new wrapper into `meteor/meteor`
+Once the wrapper is live on npm, update the `meteor/meteor` codebase to consume it.
 
-Direct consumers of `@meteorjs/swc-core`: `packages/babel-compiler` (top-level `Npm.depends`) and `packages/standard-minifier-js` (plugin `Npm.depends`). Direct consumer of `@swc/core`: `npm-packages/meteor-rspack`. No other call sites today (verify with `grep -rn '@meteorjs/swc-core' packages npm-packages` and `grep -rn '"@swc/core"' packages npm-packages`).
+**Steps to update Meteor core:**
 
-Steps:
+**1. Update the Core Packages**
+Update the `@meteorjs/swc-core` version string in these files:
+- `packages/babel-compiler/package.js` (top-level `Npm.depends`)
+- `packages/standard-minifier-js/package.js` (plugin `Npm.depends`)
 
-1. Update `@meteorjs/swc-core` to the new wrapper version in `packages/babel-compiler/package.js` and `packages/standard-minifier-js/package.js`.
-2. Refresh `npm-shrinkwrap.json` in both locations. Either run `meteor npm install` inside `packages/babel-compiler/.npm/package/` and `packages/standard-minifier-js/.npm/plugin/minifyStdJS/`, or let Meteor regenerate them on a clean local build. Commit whichever files actually changed.
-3. Update the `@swc/core` range in `npm-packages/meteor-rspack/package.json` (`peerDependencies` and `devDependencies`). Minimum must not be older than the wrapper's pinned SWC version. Run `npm install` inside `npm-packages/meteor-rspack/` to refresh its `package-lock.json`.
-4. If any new SWC option is being threaded through, update `compileWithSwc` and the `.swcrc` / `swc.config.{js,ts}` resolver in `packages/babel-compiler/babel-compiler.js`, the loader defaults in `npm-packages/meteor-rspack/lib/meteorRspackConfigFactory.js` and `meteorRspackHelpers.js`, and the config parser in `npm-packages/meteor-rspack/lib/swc.js`.
-5. Run the test suites listed in [Test coverage](#test-coverage). Required: `meteor self-test --file modern.js`, `meteor self-test --file compiler-plugins.js`, and the Rspack E2E `typescript` app under `tools/e2e-tests/`.
-6. Bump Atmosphere package versions per the [`version-bump`](../../../.github/skills/version-bump/SKILL.md) skill. `babel-compiler` and `standard-minifier-js` change because they consume the new wrapper; downstream packages are re-released automatically by the version-bump tool.
+**2. Update the Bundler Integration (NPM Package)**
+Bump the `@swc/core` peer dependency range in `npm-packages/meteor-rspack/package.json`.
+
+```bash
+# Refresh the lockfiles
+cd packages/babel-compiler/.npm/package && meteor npm install
+cd ../../../../packages/standard-minifier-js/.npm/plugin/minifyStdJS && meteor npm install
+cd ../../../../../npm-packages/meteor-rspack && npm install
+```
+
+**3. Update Option Resolvers (If SWC API Changed)**
+If new SWC options are required, update:
+- `compileWithSwc` and the resolver in `packages/babel-compiler/babel-compiler.js`
+- Loader defaults in `npm-packages/meteor-rspack/lib/meteorRspackConfigFactory.js` (and `meteorRspackHelpers.js`)
+- Config parser in `npm-packages/meteor-rspack/lib/swc.js`
+
+**4. Verify Compatibility via Tests**
+Run the self-tests and the E2E suite to ensure transpilation and bundling paths are intact:
+
+```bash
+meteor self-test --file modern.js
+meteor self-test --file compiler-plugins.js
+npm run test:e2e
+```
+
+**5. Bump Atmosphere Package Versions**
+Use the [`version-bump`](../../../.github/skills/version-bump/SKILL.md) skill to bump `babel-compiler` and `standard-minifier-js`. Downstream packages will re-release automatically.

--- a/dev/modern-tools/swc/README.md
+++ b/dev/modern-tools/swc/README.md
@@ -8,8 +8,7 @@ The end-user view is documented in [`v3-docs/docs/about/modern-build-stack/meteo
 - [**SWC integration and modules**](#swc-integration-and-modules): packages involved, `@swc/core` vs `@meteorjs/swc-core`, debugging notes.
 - [**Test coverage**](#test-coverage): legacy self-test vs modern E2E, when to run which.
 - [**Common maintenance tasks**](#common-maintenance-tasks)
-  - [Stage 1: Publish the New Wrapper (`@meteorjs/swc-core`)](#stage-1-publish-the-new-wrapper-meteorjsswc-core)
-  - [Stage 2: Roll the Wrapper into Meteor Core](#stage-2-roll-the-wrapper-into-meteor-core)
+  - [Bumping the SWC Dependencies](#bumping-the-swc-dependencies)
 
 ## Why SWC
 
@@ -72,7 +71,9 @@ When to run which:
 This section covers the typical workflows for bumping the SWC dependencies safely. 
 Publishing a new `@meteorjs/swc-core` wrapper and rolling it into Meteor core are two stages of a single task. Do not split them; both must advance together so the tool path and the bundler path agree on syntax support.
 
-### Stage 1: Publish the New Wrapper (`@meteorjs/swc-core`)
+### Bumping the SWC Dependencies
+
+#### Stage 1: Publish the New Wrapper (`@meteorjs/swc-core`)
 
 The wrapper package lives in the [`meteor/meteor-package-install-swc`](https://github.com/meteor/meteor-package-install-swc) repository.
 
@@ -101,7 +102,7 @@ npm publish --access public
 npm view @meteorjs/swc-core version
 ```
 
-### Stage 2: Roll the Wrapper into Meteor Core
+#### Stage 2: Roll the Wrapper into Meteor Core
 
 Once the wrapper is live on npm, update the `meteor/meteor` codebase to consume it.
 


### PR DESCRIPTION
This PR introduces a structured set of maintainer guides under `dev/modern-tools/` for Meteor's modern build stack components: **Rspack**, **SWC**, and the **Profiler**.

## Why this is needed

Historically, tribal knowledge surrounding how external tools hook into Meteor's core (via `Package.registerBuildPlugin` and `Plugin.registerCompiler`) has made it difficult for new contributors to jump in. Complex workflows, like bumping the SWC wrapper safely, or iterating on the `@meteorjs/rspack` NPM package alongside the Atmosphere package, were undocumented, leading to a high barrier to entry and occasional publishing errors.

By providing clear, direct, and actionable steps with copy-pasteable bash snippets, this documentation ensures that **any contributor** can easily pick up, debug, and safely maintain these integrations.

## What's included

- **Architectural Overview (`dev/modern-tools/README.md`)**: A high-level map explaining how tools integrate without polluting the core codebase, and an overview of the shared `tools-core` package.
- **Rspack Maintainer Guide**: Covers the relationship between the NPM configuration and the Atmosphere integration, E2E testing strategies, memory benchmarking workflows, and exact publishing steps for beta and official releases.
- **SWC Maintainer Guide**: Documents the split between `@swc/core` and `@meteorjs/swc-core`, and details the exact two-stage workflow required to publish the wrapper and roll it into Meteor core.
- **Profiler Guide**: Instructions for bumping the underlying `meteor/performance` benchmark suite and verifying CLI flags locally.

## Future Vision

This PR sets a standard for all future maintainer documentation. As we continue to iterate on the Meteor modern tools integration and introduce new technologies (such as **CapacitorJS** and other emerging tools), we will expand this directory using this exact same structured, command-driven format. This ongoing effort will drastically improve the developer experience for anyone contributing to the Meteor ecosystem.
