### PR TITLE
ci: run job containers with --init so orphaned processes get reaped

### DIFF
--- a/.github/workflows/e2e-accounts.yml
+++ b/.github/workflows/e2e-accounts.yml
@@ -31,7 +31,10 @@ jobs:
     timeout-minutes: 60
     container:
       image: node:22-bookworm
-      options: --cpus 6 --memory 16g --security-opt seccomp=unconfined
+      # --init runs tini as PID 1 so orphaned processes get reaped. Without it
+      # the container's PID 1 is `tail -f /dev/null`, which never calls wait(),
+      # leaving every orphan (chrome, mongod, sh, ...) as a permanent zombie.
+      options: --init --cpus 6 --memory 16g --security-opt seccomp=unconfined
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,11 @@ jobs:
     timeout-minutes: 60
     container:
       image: node:22-bookworm
+      # --init runs tini as PID 1 so orphaned processes get reaped. Without it
+      # the container's PID 1 is `tail -f /dev/null`, which never calls wait(),
+      # leaving every orphan (chrome, mongod, sh, ...) as a permanent zombie.
       options: >-
+        --init
         --cpus 6
         --memory 16g
         --security-opt seccomp=unconfined

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -40,7 +40,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     timeout-minutes: 75
     steps:
       - name: Checkout repository
@@ -83,7 +86,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 45
     steps:
@@ -151,7 +157,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
     needs: setup
     timeout-minutes: 55
     env:
@@ -217,7 +226,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -283,7 +295,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -355,7 +370,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -420,7 +438,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -485,7 +506,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
     needs: setup
     timeout-minutes: 55
     env:
@@ -551,7 +575,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -616,7 +643,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -681,7 +711,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -746,7 +779,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -811,7 +847,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 55
     env:
@@ -876,7 +915,10 @@ jobs:
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      options: --user root
+      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
+      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
+      # zombies behind).
+      options: --init --user root
     needs: setup
     timeout-minutes: 40
     env:


### PR DESCRIPTION
## Problem

Job containers start with `tail -f /dev/null` as PID 1:

```
CONTAINER      IMAGE              COMMAND
2dc7cbb56fcd   node:22-bookworm   "tail -f /dev/null"
```

Inside a container, PID 1 inherits every orphaned process. A real init reaps them; `tail` never calls `wait()`, so **every orphan stays a zombie for the container's lifetime**.

Measured on `oss-vm-01`:

```
155 zombies total
  54 sh          53 chrome-headless     19 npm
  15 rspack-node 15 MainThread          13 mongod

152 of them <- ppid 734006 (tail -f /dev/null), inside container 2dc7cbb56fcd
```

Confirmed the containers have no init: `docker inspect -f '{{.HostConfig.Init}}'` → `<nil>` on all of them.

## Fix

`--init` makes Docker run **tini** as PID 1, with the real command as its child. tini reaps orphans and forwards signals (so containers also stop cleanly instead of waiting for SIGKILL).

Applied to **all 16 container jobs** (`e2e-accounts`, `e2e-tests`, `test-tools`) — verified none were missed by parsing every workflow.

## Scope / what this does *not* fix

This is a **process-hygiene fix**, not a test fix. It does **not** address the `Test Packages` 90-minute hangs — I verified those are caused by an uncaught promise rejection in the `observeChangesAsync` error test, which is unrelated to zombies (zombies show up as `[mongod] <defunct>` with no args, so `findMongoPids`' regex never matches them). That one is being handled separately.

## Verification

- `actionlint` clean (pre-existing shellcheck infos in `run:` blocks are untouched)
- All workflow YAML parses
- Every `container:` job asserted to carry `--init`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated test environments by ensuring background processes are cleaned up correctly.
  * Reduced the risk of lingering or zombie processes during end-to-end and tool-based test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->