### PR TITLE
ci(test-in-console): fail fast when the suite stalls, naming the test in flight

### DIFF
--- a/packages/test-in-console/puppeteer_runner.js
+++ b/packages/test-in-console/puppeteer_runner.js
@@ -10,6 +10,15 @@ try {
 
 let testNumber = 0;
 
+// The suite is driven entirely by console output from the page: if the app
+// server dies (e.g. an uncaught exception), `isDone` never flips and the poll
+// loop below would otherwise spin until the CI job's own timeout — burning a
+// runner for over an hour and reporting nothing useful. Bail out after a
+// stretch of total silence instead, naming the test that was in flight.
+const STALL_TIMEOUT_MS = Number(process.env.TEST_STALL_TIMEOUT_MIN || 10) * 60 * 1000;
+
+let lastOutputAt = Date.now();
+
 async function runNextUrl(browser) {
   const page = await browser.newPage();
 
@@ -18,7 +27,7 @@ async function runNextUrl(browser) {
   // });
 
   page.on("console", async (msg) => {
-    // if the test is running for too long without any output to the console (10 minutes)
+    lastOutputAt = Date.now();
     const text = msg.text();
     if (text.includes("Permissions policy violation")) {
       return;
@@ -77,11 +86,53 @@ async function runNextUrl(browser) {
         process.exit(0);
       }
     } else {
+      const idleMs = Date.now() - lastOutputAt;
+      if (idleMs > STALL_TIMEOUT_MS) {
+        await reportStall(page, idleMs);
+        await browser.close().catch(() => {});
+        process.exit(1);
+      }
       setTimeout(poll, 1000);
     }
   }
 
+  // Start the clock here, not at module load: everything before this point
+  // (build, app boot, page load) legitimately produces no page output.
+  lastOutputAt = Date.now();
+
   await poll();
+}
+
+/**
+ * Print why the run is being abandoned, naming whatever test was still in
+ * flight. Reading it is best-effort: if the app server is what died, these
+ * evaluations will fail too, and that in itself is worth reporting.
+ *
+ * @param page
+ * @param idleMs how long the page has produced no output
+ */
+async function reportStall(page, idleMs) {
+  const idle =
+    idleMs < 60000 ? `${Math.round(idleMs / 1000)}s` : `${Math.round(idleMs / 60000)}min`;
+  console.log(`\nNo test output for ${idle} — treating the run as stalled.`);
+
+  try {
+    const clientTest = await page.evaluate(() => __Tinytest._getCurrentRunningTestOnClient());
+    console.log(`Client test in flight: ${clientTest || "(none)"}`);
+  } catch (e) {
+    console.log(`Could not read the client test: ${e.message}`);
+  }
+
+  try {
+    const serverTest = await page.evaluate(
+      async () => await __Tinytest._getCurrentRunningTestOnServer(),
+    );
+    console.log(`Server test in flight: ${serverTest || "(none)"}`);
+  } catch (e) {
+    console.log(`Could not read the server test (the app server may have died): ${e.message}`);
+  }
+
+  console.log("Raise TEST_STALL_TIMEOUT_MIN if a legitimately slow test needs longer.");
 }
 
 /**

--- a/packages/test-in-console/puppeteer_runner.js
+++ b/packages/test-in-console/puppeteer_runner.js
@@ -50,11 +50,13 @@ async function runNextUrl(browser) {
   // });
 
   page.on("console", async (msg) => {
-    lastOutputAt = Date.now();
     const text = msg.text();
     if (text.includes("Permissions policy violation")) {
+      // Ignored warnings must not count as activity, or a page that spams them
+      // would reset the stall clock forever and defeat the timeout.
       return;
     }
+    lastOutputAt = Date.now();
     if (text) console.log(text);
     else {
       testNumber++;
@@ -97,6 +99,7 @@ async function runNextUrl(browser) {
       const failCount = await getFailCount(page);
       console.log(`Tests complete with ${failCount} failures`);
       console.log(`Tests complete with ${await getPassCount(page)} passes`);
+      clearInterval(stallInterval);
       if (failCount > 0) {
         const failed = await getFailed(page);
         failed.map((f) => console.log(`${f.name} failed: ${f.info}`));
@@ -109,18 +112,6 @@ async function runNextUrl(browser) {
         process.exit(0);
       }
     } else {
-      const idleMs = Date.now() - lastOutputAt;
-      if (idleMs > STALL_TIMEOUT_MS) {
-        // reportStall is best-effort; the browser cleanup and non-zero exit must
-        // happen regardless of whether the diagnostics resolve, hang, or throw.
-        try {
-          await reportStall(page, idleMs);
-        } finally {
-          await browser.close().catch(() => {});
-          process.exit(1);
-        }
-        return;
-      }
       setTimeout(poll, 1000);
     }
   }
@@ -128,6 +119,31 @@ async function runNextUrl(browser) {
   // Start the clock here, not at module load: everything before this point
   // (build, app boot, page load) legitimately produces no page output.
   lastOutputAt = Date.now();
+
+  // Stall detection runs on its own timer, independent of `poll`. If the client
+  // event loop is blocked (e.g. an infinite loop in a test), `poll`'s
+  // `await isDone(page)` hangs too — so a check living inside `poll` would never
+  // fire. A standalone interval keeps ticking regardless of what the page does.
+  let handlingStall = false;
+  const stallInterval = setInterval(async () => {
+    if (handlingStall) return;
+    const idleMs = Date.now() - lastOutputAt;
+    if (idleMs <= STALL_TIMEOUT_MS) return;
+    handlingStall = true;
+    clearInterval(stallInterval);
+    // reportStall is best-effort; the browser cleanup and non-zero exit must
+    // happen regardless of whether the diagnostics resolve, hang, or throw.
+    try {
+      await reportStall(page, idleMs);
+    } finally {
+      // Cap the shutdown too: a dead app server can wedge browser.close(), and
+      // the exit must not depend on it.
+      await withTimeout(browser.close(), STALL_DIAGNOSTIC_TIMEOUT_MS, "browser shutdown").catch(
+        () => {},
+      );
+      process.exit(1);
+    }
+  }, 1000);
 
   await poll();
 }

--- a/packages/test-in-console/puppeteer_runner.js
+++ b/packages/test-in-console/puppeteer_runner.js
@@ -17,7 +17,30 @@ let testNumber = 0;
 // stretch of total silence instead, naming the test that was in flight.
 const STALL_TIMEOUT_MS = Number(process.env.TEST_STALL_TIMEOUT_MIN || 10) * 60 * 1000;
 
+// The stall diagnostics query the app through DDP (`Meteor.callAsync`), which is
+// exactly what may never settle when the app server has died — the situation the
+// stall timeout exists to escape. Cap each diagnostic so a hung call can't wedge
+// the handler and re-strand the runner.
+const STALL_DIAGNOSTIC_TIMEOUT_MS = 5000;
+
 let lastOutputAt = Date.now();
+
+/**
+ * Race a promise against a timeout so a hung diagnostic call can't block the
+ * stall handler forever. Rejects with a labelled error if `ms` elapses first.
+ *
+ * @param promise
+ * @param ms
+ * @param label
+ * @return {Promise<*>}
+ */
+function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
 
 async function runNextUrl(browser) {
   const page = await browser.newPage();
@@ -88,9 +111,15 @@ async function runNextUrl(browser) {
     } else {
       const idleMs = Date.now() - lastOutputAt;
       if (idleMs > STALL_TIMEOUT_MS) {
-        await reportStall(page, idleMs);
-        await browser.close().catch(() => {});
-        process.exit(1);
+        // reportStall is best-effort; the browser cleanup and non-zero exit must
+        // happen regardless of whether the diagnostics resolve, hang, or throw.
+        try {
+          await reportStall(page, idleMs);
+        } finally {
+          await browser.close().catch(() => {});
+          process.exit(1);
+        }
+        return;
       }
       setTimeout(poll, 1000);
     }
@@ -117,15 +146,21 @@ async function reportStall(page, idleMs) {
   console.log(`\nNo test output for ${idle} — treating the run as stalled.`);
 
   try {
-    const clientTest = await page.evaluate(() => __Tinytest._getCurrentRunningTestOnClient());
+    const clientTest = await withTimeout(
+      page.evaluate(() => __Tinytest._getCurrentRunningTestOnClient()),
+      STALL_DIAGNOSTIC_TIMEOUT_MS,
+      "client test lookup",
+    );
     console.log(`Client test in flight: ${clientTest || "(none)"}`);
   } catch (e) {
     console.log(`Could not read the client test: ${e.message}`);
   }
 
   try {
-    const serverTest = await page.evaluate(
-      async () => await __Tinytest._getCurrentRunningTestOnServer(),
+    const serverTest = await withTimeout(
+      page.evaluate(async () => await __Tinytest._getCurrentRunningTestOnServer()),
+      STALL_DIAGNOSTIC_TIMEOUT_MS,
+      "server test lookup",
     );
     console.log(`Server test in flight: ${serverTest || "(none)"}`);
   } catch (e) {


### PR DESCRIPTION
## Problem

`puppeteer_runner.js` waits for the suite like this:

```js
async function poll() {
  if (await isDone(page)) { /* report + exit */ }
  else { setTimeout(poll, 1000); }   // ← no upper bound
}
```

If the app server dies mid-run (e.g. an uncaught promise rejection), `isDone()` never flips and this loop spins **forever**. The job then runs until GitHub's own `timeout-minutes: 90` and is reported as `cancelled` — with no indication of where it wedged, while holding a self-hosted runner the entire time.

Seen on CI: both `test-packages` jobs went silent at `14:26:57` right after an uncaught exception, then sat idle for **83 minutes** before being cancelled. Two runners tied up, and the failure named nothing.

There was even a leftover comment stating the intent (*"if the test is running for too long without any output to the console (10 minutes)"*) — but nothing implemented it.

## Change

Abort after `TEST_STALL_TIMEOUT_MIN` (default **10**) minutes with no page output, printing the client/server test still in flight:

```
No test output for 10min — treating the run as stalled.
Client test in flight: (none)
Server test in flight: mongo-livedata - observeChangesAsync callback errors should not crash the process
Raise TEST_STALL_TIMEOUT_MIN if a legitimately slow test needs longer.
```

The clock starts when polling begins, so builds, app boot and page load don't count against it. Reading the in-flight test is best-effort — if the app server is what died, that failure gets reported too, which is itself informative.

## Verification

Both directions, locally:

| Scenario | Result |
|---|---|
| `TEST_STALL_TIMEOUT_MIN=0.1` (6s) | Fires, names the in-flight test (`mongo-livedata - connection failure throws`), exits 1 ✅ |
| Default (10 min), full mongo suite | **387 tests, 0 false stalls**, suite progresses normally ✅ |

## Scope

This does **not** fix the underlying uncaught-rejection race in the `observeChangesAsync` error test. I could not reproduce that locally — it passes here on both the default and `changeStreams,polling` drivers, with the error correctly caught and logged — so I'm not guessing at a patch to core async code.

What it does: turn a silent 90-minute runner-hog into a fast, labelled failure. The next occurrence will name the offending test directly, which is what's needed to fix the race properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Puppeteer test runs from hanging when console output stops for an extended period; they now stop promptly instead of waiting for CI timeouts.
  * Stall reports now include the idle duration and best-effort diagnostics about the currently running test (with time-limited diagnostics to avoid additional delays).
  * Excluded initial page loading from stall detection to avoid false failures during app startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->