### PR TITLE
Bridge Npm and Assets into the dev-mode Rspack server bundle

### DIFF
--- a/dev/modern-tools/rspack/E2E_COVERAGE.md
+++ b/dev/modern-tools/rspack/E2E_COVERAGE.md
@@ -212,6 +212,7 @@ Server-only app (no client entry point).
 | What is covered | Phase |
 |----------------|-------|
 | Absolute external `METEOR_LOCAL_DIR` outside the app | Run |
+| `Assets` and `Npm` wrapper globals visible to server bundle code | Run |
 | Development server bundle stays outside Meteor's linked `app.js` payload | Run |
 | Delayed server import of a previously unused Meteor package | Run |
 | CommonJS development server bundle under a `type: module` app | Run |
@@ -320,6 +321,7 @@ Where each feature is tested across apps and skeletons.
 | CoffeeScript compilation | coffeescript | coffeescript |
 | Server-only (no client) | server-only | |
 | Server bundle excluded from Meteor linker payload | server-only regression | |
+| `Assets`/`Npm` server globals in the dev bundle | server-only regression | |
 | Delayed server Meteor package import | server-only regression | |
 | Monorepo layout | monorepo | |
 | Full-app test mode | react-router | |

--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -639,6 +639,10 @@ __rspackServerModule.require = function(request) {
 };
 delete __rspackServerRequire.cache[__rspackServerBundlePath];
 __rspackServerRequire.cache[__rspackServerBundlePath] = __rspackServerModule;
+/* Node compiles the bundle outside Meteor's boot wrapper, so the
+ * wrapper-scoped server globals must be bridged through globalThis */
+globalThis.Npm = Npm;
+globalThis.Assets = Assets;
 try {
   __rspackServerModule.load(__rspackServerBundlePath);
 } catch (error) {

--- a/tools/e2e-tests/server-runtime.test.js
+++ b/tools/e2e-tests/server-runtime.test.js
@@ -18,6 +18,7 @@ const ABSOLUTE_LOCAL_PORTS = [3130, 18130];
 const DELAYED_IMPORT_PORTS = [3131, 18131];
 const ES_MODULE_APP_PORTS = [3132, 18132];
 const DEBUGGING_PORTS = [3133, 18133, 9233];
+const ASSETS_GLOBAL_PORTS = [3134, 18134];
 
 async function getInspectorWebSocketUrl(port, timeout = 90000) {
   const deadline = Date.now() + timeout;
@@ -251,6 +252,65 @@ describe('Regressions / Server Runtime /', () => {
         ports: ABSOLUTE_LOCAL_PORTS,
       });
       await fs.remove(meteorLocalDir);
+    }
+  });
+
+  test('exposes the Assets and Npm globals to server bundle code', async () => {
+    let tempDir;
+    let meteorProcess;
+
+    try {
+      tempDir = await prepareServerOnlyApp(ASSETS_GLOBAL_PORTS);
+
+      await fs.outputFile(
+        path.join(tempDir, 'private', 'assets-fixture.txt'),
+        'assets fixture content'
+      );
+      await fs.writeFile(
+        path.join(tempDir, 'server', 'main.js'),
+        `const nodePath = Npm.require('path');
+
+const absolutePath = Assets.absoluteFilePath('assets-fixture.txt');
+
+Assets.getTextAsync('assets-fixture.txt')
+  .then(text => {
+    console.log(
+      \`assets fixture read: \${text} from \${nodePath.basename(absolutePath)}\`
+    );
+  })
+  .catch(error => {
+    console.error(\`assets fixture failed: \${error.message}\`);
+  });
+`
+      );
+
+      const result = await runMeteorCommand(
+        'run',
+        ['--port', String(ASSETS_GLOBAL_PORTS[0])],
+        tempDir,
+        {
+          captureOutput: true,
+          env: {
+            RSPACK_DEVSERVER_PORT: String(ASSETS_GLOBAL_PORTS[1]),
+          },
+        }
+      );
+      meteorProcess = result.meteorProcess;
+
+      const assetsResult = await waitForMeteorOutput(
+        result.outputLines,
+        /assets fixture (?:read|failed)|(?:Assets|Npm) is not defined|Your application is crashing/,
+        { timeout: 90000, meteorProcess }
+      );
+      expect(assetsResult).toContain(
+        'assets fixture read: assets fixture content from assets-fixture.txt'
+      );
+    } finally {
+      await cleanupRegressionApp({
+        tempDir,
+        meteorProcess,
+        ports: ASSETS_GLOBAL_PORTS,
+      });
     }
   });
 


### PR DESCRIPTION
## Summary

Since #14464, any Rspack-bundled app whose server code references `Assets` crashes at boot in development:

```
ReferenceError: Assets is not defined
```

Production builds and test mode were unaffected.

## Mechanism

1. Meteor's server boot evaluates every linked server file inside `(function (Npm, Assets) { ... })` and calls it with the per-file `Npm`/`Assets` objects (`tools/static-assets/server/boot.js`). Those names are function parameters, not globals; that wrapper is the only place app server code gets them from.
2. Before #14464, the generated `main-dev/server-meteor.js` pulled the server bundle in with a plain `import './server-rspack.cjs'`, so the linker inlined the bundle into the app program and it executed inside that wrapper.
3. #14464 replaced the import with a raw Node `Module.load()` shim so Meteor no longer links the bundle in development. The shim forwards `meteor/*` requires to Meteor's module system, but Node compiles the bundle under its own module wrapper (`exports`, `require`, `module`, `__filename`, `__dirname`). The boot wrapper's parameters are out of scope there, and the first `Assets` or `Npm` reference in bundled app code throws.
4. The shim only runs for development server builds (the `isDevelopment && isServer && !isTest && !isNative` branch in `packages/rspack/lib/build-context.js`), which is why production and test mode still work.

## Fix

Two lines in the shim template: assign the wrapper parameters to `globalThis` before `.load()`. The generated shim file is itself linked by Meteor (that's why its own `Npm['require']` call works), so both objects are in scope at the assignment site, and they're the app program's instances: `Assets` sees `private/` and `Npm.require` resolves against the app's `node_modules`.

The globals become visible process-wide afterwards, but every linked file (packages and classic app code) receives these names as wrapper parameters that shadow the global, so nothing else observes the change. The only `typeof Npm` feature-detection in the tree (`packages/modules-runtime/server.js`) closes over its own wrapper parameter and is likewise unaffected.

These two names are also the complete set: everything else the old linked scope offered app code already reaches the Node-loaded bundle. For the app program the linker deliberately emits its package imports as global assignments (`getHeader` passes `omitVar: true` under `/* Imports for global scope */` in `tools/isobuild/linker.js`), so `Meteor`, `Mongo`, and friends are real server globals, and the boot wrapper's remaining extras (`specialArgPaths`) apply only to two package program files the shim never diverts. `Npm` and `Assets` are the only names Meteor delivers to app code by function parameter instead of via the global object.

I considered injecting the names into the module's scope instead of using `globalThis`, but Node gives a `Module.load()`-ed file only the five standard wrapper parameters; adding more would mean reimplementing `Module._compile` with a custom wrapper. The global matches how the bundled code lexically resolves these names anyway.

## Regression test

New case in `tools/e2e-tests/server-runtime.test.js`: a `server-only` app with a file in `private/` whose server main calls `Npm.require('path')`, `Assets.absoluteFilePath()`, and `Assets.getTextAsync()`, asserting the dev server boots and logs the asset's content. Without the fix it fails with `ReferenceError: Npm is not defined`; with it, it passes.

Also verified against a real modern app ([jolly-roger](https://github.com/deathandmayhem/jolly-roger), which calls `Assets.absoluteFilePath()` at server module scope): it crashes at `75e14e380c` and boots at its parent, and with this bridge it boots and serves correct `private/` content.

One unrelated observation from the same commit, noted while bisecting: the dev-server shutdown path leaves `rspack-node` watcher processes running after SIGINT (observed on macOS). Not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server-side bundled code can now access the `Assets` and `Npm` globals as expected in development/server execution.
  * Improved reliability when reading application assets and loading server-side modules within server bundles.
* **Tests**
  * Added end-to-end regression coverage that verifies `Assets`/`Npm` global visibility for server bundle code, including new scenarios and fixtures to confirm correct asset access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->