### PR TITLE
fix(mongo): normalize both operands in compareOperationTimes (#14600)

### DIFF
--- a/packages/mongo/mongo_common.js
+++ b/packages/mongo/mongo_common.js
@@ -197,7 +197,11 @@ export function replaceNames(filter, thing) {
  * @returns {number} Comparison result: negative if `opTime1` < `opTime2`, zero if equal, positive if `opTime1` > `opTime2`.
  */
 export function compareOperationTimes(opTime1, opTime2) {
-  return (new MongoDB.Timestamp(opTime1)).compare(opTime2);
+  // Wrap BOTH operands: MongoDB.Timestamp#compare mishandles a plain
+  // {t,i} object (it never reads .t/.i), silently returning a wrong
+  // result. The documented contract accepts {t,i} for either operand, so
+  // normalize both before comparing.
+  return (new MongoDB.Timestamp(opTime1)).compare(new MongoDB.Timestamp(opTime2));
 }
 
 /**


### PR DESCRIPTION
Fixes the `test-packages (changeStreams,polling)` CI job on `release-3.5.1`,
failing deterministically since 2026-07-22 on:

```
changestream- _waitUntilCaughtUp still waits for its own connection (#14600) : FAIL
  expected "still-waiting", actual "resolved"
```

## Root cause

`compareOperationTimes(a, b)` in `packages/mongo/mongo_common.js` wrapped only
its first operand in a `Timestamp`:

```js
new MongoDB.Timestamp(a).compare(b);   // only `a` wrapped
```

`MongoDB.Timestamp#compare` never reads `.t`/`.i` off a plain object, so a
`{ t, i }` second operand mis-compares (returns `1` instead of `-1` for a future
ts). The function's own JSDoc documents `{t,i}` as an accepted form for
`opTime2`, so the implementation was violating its contract.

The `#14600` fence test asserts `_waitUntilCaughtUp(ownFence)` still blocks on a
target ts one hour in the future, built as a plain `{ t, i }` object. The
change-stream driver's caught-up-floor seed makes `_lastProcessedOperationTime`
non-null, so `_waitUntilCaughtUp` now runs this comparison — and the mis-compare
released a wait that must still block.

**Production is unaffected:** real fence target timestamps are always BSON
`Timestamp`s (`session.operationTime`), and all callers pass real Timestamps.
Only the test uses the documented `{t,i}` object form.

## What this changes

One line — wrap **both** operands in `MongoDB.Timestamp` before comparing.
Real-vs-real comparisons are byte-identical before/after, so there is no
production behavior change.

## Verification

Ran the mongo package tests under `METEOR_REACTIVITY_ORDER=changeStreams` on
`release-3.5.1` (dev_bundle Mongo 7 single-node replica set):

- **Before:** `... still waits for its own connection (#14600) : FAIL` — 1
  change-stream failure.
- **After:** `... still waits for its own connection (#14600) : OK` — 0
  change-stream failures; sibling `#14600`/`#14452` fence tests still green.