### PR TITLE
ci: read the branch name from env instead of interpolating it into the shell

### DIFF
--- a/.github/workflows/e2e-accounts.yml
+++ b/.github/workflows/e2e-accounts.yml
@@ -70,9 +70,11 @@ jobs:
         run: npm run install:e2e
 
       - name: Set NPM_LINK_RSPACK=false for release branches
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          echo "Current branch: ${{ github.head_ref || github.ref_name }}"
-          if [[ "${{ github.head_ref || github.ref_name }}" == release-* ]]; then
+          echo "Current branch: $BRANCH"
+          if [[ "$BRANCH" == release-* ]]; then
             echo "NPM_LINK_RSPACK=false" >> $GITHUB_ENV
             echo "::warning::NPM_LINK_RSPACK=false on release branch. E2E tests will install @meteorjs/rspack from npm; make sure the latest version is published or tests may fail."
           fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -118,9 +118,11 @@ jobs:
         run: npm run install:e2e
 
       - name: Set NPM_LINK_RSPACK=false for release branches
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          echo "Current branch: ${{ github.head_ref || github.ref_name }}"
-          if [[ "${{ github.head_ref || github.ref_name }}" == release-* ]]; then
+          echo "Current branch: $BRANCH"
+          if [[ "$BRANCH" == release-* ]]; then
             echo "NPM_LINK_RSPACK=false" >> $GITHUB_ENV
             echo "::warning::NPM_LINK_RSPACK=false on release branch. E2E tests will install @meteorjs/rspack from npm — make sure the latest version is published or tests may fail."
           fi


### PR DESCRIPTION
Hi, and thanks for Meteor.

Two e2e workflows put the PR's source branch name straight into the shell:

`.github/workflows/e2e-tests.yml` (and the same three lines in `e2e-accounts.yml`):

```yaml
run: |
  echo "Current branch: ${{ github.head_ref || github.ref_name }}"
  if [[ "${{ github.head_ref || github.ref_name }}" == release-* ]]; then
```

Actions substitutes `${{ ... }}` into the script text before bash runs, so the branch name is treated as script rather than as a string. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` still runs inside double quotes — so a PR opened from a fork with a branch named something like `release-$(id)` would execute that on the runner.

I want to be honest about the size of this: both workflows are `pull_request`, not `pull_request_target`, so a fork PR gets a read-only `GITHUB_TOKEN` and no repository secrets. It is runner-side execution in a throwaway job, not a route to your credentials. I am raising it as hardening rather than as a vulnerability.

The change is the fix from GitHub's own hardening guidance — bind the value to an environment variable so it arrives as data:

```yaml
env:
  BRANCH: ${{ github.head_ref || github.ref_name }}
run: |
  echo "Current branch: $BRANCH"
  if [[ "$BRANCH" == release-* ]]; then
```

Same comparison, same behaviour; the `release-*` glob still matches the way it does today. Three lines touched per file.

I looked at the other `${{ }}` uses in both workflows and left them alone — they are refs, secrets and job outputs rather than free text, so they do not have this problem.

Disclosure: I used AI assistance to help spot this and prepare the change, and I checked both workflows and their triggers myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release-branch detection in end-to-end test workflows.
  - Ensured branch names are evaluated consistently when configuring release-specific test settings.
  - Preserved the existing behavior of disabling the Rspack npm link during release-branch testing and displaying a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->