### PR TITLE
fix: read file resources from their real offset (meteor/meteor#11918)

### DIFF
--- a/tools/fs/files.ts
+++ b/tools/fs/files.ts
@@ -1440,7 +1440,7 @@ export function readBufferWithLengthAndOffset(
   if (length > 0) {
     const fd = open(filename, "r");
     try {
-      const count = read(fd, data, { position: 0, length, offset });
+      const count = read(fd, data, { offset: 0, length, position: offset });
       if (count !== length) {
         throw new Error("couldn't read entire resource");
       }

--- a/tools/tests/files-read-offset-tests.js
+++ b/tools/tests/files-read-offset-tests.js
@@ -1,0 +1,22 @@
+import { readBufferWithLengthAndOffset } from '../fs/files';
+
+var selftest = require('../tool-testing/selftest.js');
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+
+// readBufferWithLengthAndOffset must read `length` bytes starting at `offset`
+// within the file (isopack resources are concatenated into one file, each at a
+// byte offset). A non-zero offset must not overflow the buffer or read from the
+// wrong position.
+selftest.define('files - readBufferWithLengthAndOffset reads from a non-zero offset', async function () {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'files-offset-'));
+  try {
+    const file = path.join(dir, 'concat.bin');
+    fs.writeFileSync(file, 'AAAABBBB');
+    await selftest.expectEqual(readBufferWithLengthAndOffset(file, 4, 0).toString(), 'AAAA');
+    await selftest.expectEqual(readBufferWithLengthAndOffset(file, 4, 4).toString(), 'BBBB');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem
`readBufferWithLengthAndOffset` (`tools/fs/files.ts`) passed the file **offset** as the *buffer* offset and read from file **position 0**, so any non-zero offset read the wrong bytes and overflowed the destination buffer (`RangeError: "length" is out of range`). Isopack resources are concatenated into a single file and read back at per-resource byte offsets, so this broke reading any resource past the first.

## Fix
Read `length` bytes starting at file `position: offset` into `offset: 0` of the buffer.

Adds a selftest covering a non-zero-offset read (`AAAABBBB` → offset 4 yields `BBBB`).

Fixes #11918


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file reading with non-zero offsets so the requested bytes are read from the intended position.

* **Tests**
  * Added coverage confirming reads return the expected data at both zero and non-zero offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->