### PR TITLE
fix(#11807): don't abort installer on a direct binary run

### DIFF
--- a/npm-packages/meteor-installer/install.js
+++ b/npm-packages/meteor-installer/install.js
@@ -31,6 +31,7 @@ const {
 } = require('./extract');
 const { engines } = require('./package.json');
 const { uninstall } = require('./uninstall');
+const { isLocalDependencyInstall } = require('./should-install');
 
 const nodeVersion = engines.node;
 const npmVersion = engines.npm;
@@ -45,11 +46,10 @@ if (!semver.satisfies(process.version, nodeVersion)) {
   );
 }
 
-const isInstalledGlobally =
-  process.env.npm_config_global === 'true' ||
-  process.env.npm_lifecycle_event === 'npx';
-
-if (!isInstalledGlobally) {
+// Only abort when meteor is being installed as a local package.json dependency.
+// A global install, npx / `npm exec`, or a direct run of the installed binary
+// (which has no npm_* env vars) are all legitimate ways to run the installer.
+if (isLocalDependencyInstall()) {
   console.error('******************************************');
   console.error(
     'You are not using a global npm context to install, you should never add meteor to your package.json.',

--- a/npm-packages/meteor-installer/should-install.js
+++ b/npm-packages/meteor-installer/should-install.js
@@ -1,0 +1,17 @@
+// Decide whether `meteor install` should abort because it was run as a local
+// npm dependency install — i.e. someone added meteor to their package.json —
+// rather than a global install, an npx / `npm exec` run, or a direct call of the
+// installed `meteor-installer` binary, all of which are legitimate.
+//
+// npm sets npm_lifecycle_event while running a package's lifecycle scripts and
+// npm_config_global='true' for a global install; a direct run of the installed
+// binary has no npm_* variables at all.
+function isLocalDependencyInstall(env = process.env) {
+  const inNpmLifecycle = !!env.npm_lifecycle_event;
+  const isGlobal = env.npm_config_global === 'true';
+  const isNpx =
+    env.npm_lifecycle_event === 'npx' || env.npm_command === 'exec';
+  return inNpmLifecycle && !isGlobal && !isNpx;
+}
+
+module.exports = { isLocalDependencyInstall };

--- a/npm-packages/meteor-installer/should-install.test.js
+++ b/npm-packages/meteor-installer/should-install.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { isLocalDependencyInstall } = require('./should-install');
+
+test('aborts on a local dependency install (npm lifecycle, not global, not npx)', () => {
+  assert.equal(isLocalDependencyInstall({ npm_lifecycle_event: 'install' }), true);
+});
+
+test('proceeds for a global install', () => {
+  assert.equal(
+    isLocalDependencyInstall({ npm_lifecycle_event: 'install', npm_config_global: 'true' }),
+    false
+  );
+});
+
+test('proceeds for npx / npm exec', () => {
+  assert.equal(isLocalDependencyInstall({ npm_lifecycle_event: 'npx' }), false);
+  assert.equal(
+    isLocalDependencyInstall({ npm_lifecycle_event: 'install', npm_command: 'exec' }),
+    false
+  );
+});
+
+test('proceeds for a direct run of the installed binary (no npm env)', () => {
+  assert.equal(isLocalDependencyInstall({}), false);
+});


### PR DESCRIPTION
## Problem
The installer aborted with *"you should never add meteor to your package.json"* whenever it was **not** a global install or npx — including a **direct run of the installed `meteor-installer` binary**, which sets no `npm_*` env vars. See #11807.

## Fix
Only abort for an actual local-dependency install. `isLocalDependencyInstall()` returns `true` only when running inside an npm lifecycle script that is neither global nor npx / `npm exec`. Direct binary runs, global installs and npx all proceed.

Adds unit tests for the four cases.

Fixes #11807


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer behavior when Meteor is installed as a local package dependency.
  * Prevented unintended installation attempts during npx, npm exec, global, or direct command-line usage.
* **Tests**
  * Added coverage for local, global, npx, npm exec, and direct execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->