### PR TITLE
fix(#13121): map Mongo write errors from mutation methods to 409

### DIFF
--- a/packages/allow-deny/allow-deny.js
+++ b/packages/allow-deny/allow-deny.js
@@ -138,7 +138,7 @@ CollectionPrototype._defineMutationMethods = function(options) {
 
       const isInsert = name => name.includes('insert');
 
-      m[methodName] = function (/* ... */) {
+      m[methodName] = async function (/* ... */) {
         // All the methods do their own validation, instead of using check().
         check(arguments, [Match.Any]);
         const args = Array.from(arguments);
@@ -165,7 +165,7 @@ CollectionPrototype._defineMutationMethods = function(options) {
             if (generatedId !== null) {
               args[0]._id = generatedId;
             }
-            return self._collection[method].apply(self._collection, args);
+            return await self._collection[method].apply(self._collection, args);
           }
 
           // This is the server receiving a method call from the client.
@@ -193,7 +193,7 @@ CollectionPrototype._defineMutationMethods = function(options) {
 
             args.unshift(this.userId);
             isInsert(method) && args.push(generatedId);
-            return self[validatedMethodName].apply(self, args);
+            return await self[validatedMethodName].apply(self, args);
           } else if (self._isInsecure()) {
             if (generatedId !== null) args[0]._id = generatedId;
             // In insecure mode we use the server _collection methods, and these sync methods
@@ -217,7 +217,7 @@ CollectionPrototype._defineMutationMethods = function(options) {
             //     invoke it. Bam, broken DDP connection.  Probably should just
             //     take this whole method and write it three times, invoking
             //     helpers for the common code.
-            return self._collection[syncMethodsMapper[method] || method].apply(self._collection, args);
+            return await self._collection[syncMethodsMapper[method] || method].apply(self._collection, args);
           } else {
             // In secure mode, if we haven't called allow or deny, then nothing
             // is permitted.
@@ -230,6 +230,9 @@ CollectionPrototype._defineMutationMethods = function(options) {
             e.name === 'BulkWriteError' ||
             // for newer versions of MongoDB (https://docs.mongodb.com/drivers/node/current/whats-new/#bulkwriteerror---mongobulkwriteerror)
             e.name === 'MongoBulkWriteError' ||
+            // the driver reports single-document server errors, such as an
+            // E11000 duplicate key, as MongoServerError
+            e.name === 'MongoServerError' ||
             e.name === 'MinimongoError'
           ) {
             throw new Meteor.Error(409, e.toString());

--- a/packages/mongo/tests/allow_tests.js
+++ b/packages/mongo/tests/allow_tests.js
@@ -1423,3 +1423,40 @@ function createAllowDenyRulesTest(collections, isAsync = true) {
 testAsyncMulti("collection - async definitions on allow/deny rules", createAllowDenyRulesTest(AllowDenyRulesCollections, true));
 
 testAsyncMulti("collection - sync definitions on allow/deny rules", createAllowDenyRulesTest(AllowDenyRulesCollections, false));
+
+// A duplicate-key (E11000) failure from a mutation method must surface to the
+// client as a 409 Meteor.Error, not a generic 500. The driver reports it as a
+// MongoServerError, so the allow-deny catch block must recognize that name.
+if (Meteor.isServer) {
+  Tinytest.addAsync(
+    'collection - duplicate key from a mutation method is a 409',
+    async function (test) {
+      const name = 'allowDenyDupKey_' + Random.id();
+      const collection = new Mongo.Collection(name);
+      await collection.createIndexAsync({ uniqueField: 1 }, { unique: true });
+      collection.allow({ insert: () => true });
+
+      const conn = DDP.connect(Meteor.absoluteUrl());
+      const insertMethod = '/' + name + '/insertAsync';
+      try {
+        await conn.callAsync(insertMethod, { _id: Random.id(), uniqueField: 'dup' });
+
+        let err;
+        try {
+          await conn.callAsync(insertMethod, { _id: Random.id(), uniqueField: 'dup' });
+        } catch (e) {
+          err = e;
+        }
+        test.isTrue(!!err, 'a duplicate insert should throw');
+        test.equal(
+          err && err.error,
+          409,
+          'a duplicate key should surface as a 409 Meteor.Error'
+        );
+      } finally {
+        conn.disconnect();
+        await collection.rawCollection().drop().catch(() => {});
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Problem
A duplicate-key (`E11000`) or other single-document write error from a collection mutation method (`insert`/`update`/`remove`) surfaced to the client as a generic **500** instead of a **409**. Two issues: the allow-deny `catch` only recognized `BulkWriteError`/`MongoBulkWriteError`, and — more importantly — the mutation method returned the DB promise **without awaiting it**, so the surrounding `try/catch` never observed async rejections at all. See #13121.

## Fix
Make the mutation method `async` and `await` the DB calls so rejections reach the `catch`, and recognize `MongoServerError` (how the driver reports single-document server errors) alongside the existing names, mapping them to a `409` `Meteor.Error`.

Adds a test that a duplicate insert through a mutation method surfaces as `409`.

Fixes #13121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate-record errors from allow/deny-controlled mutations are now returned as a `409` error instead of a generic server error.
  * Async mutation operations now correctly wait for completion and preserve expected error handling.

* **Tests**
  * Added coverage confirming duplicate-key errors are reported correctly when calling asynchronous insert operations over DDP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->