### PR TITLE
Upgrade Cordova iOS to 8.1.1

### DIFF
--- a/npm-packages/cordova-plugin-meteor-webapp/CHANGELOG.md
+++ b/npm-packages/cordova-plugin-meteor-webapp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v2.0.5, 2026-07-28
+
+- Support Cordova iOS 8's fixed `App` project layout in the bridging-header
+  hook.
+- Handle Cordova iOS 8's optional Objective-C imports in the Swift local
+  server.
+
 ## v2.0.0, 2020-10-04
 Use WebViewAssetLoader on Android with newest cordova AndroidX webview usage
 

--- a/npm-packages/cordova-plugin-meteor-webapp/package-lock.json
+++ b/npm-packages/cordova-plugin-meteor-webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-meteor-webapp",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-packages/cordova-plugin-meteor-webapp/package.json
+++ b/npm-packages/cordova-plugin-meteor-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-meteor-webapp",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Cordova plugin that serves a Meteor web app through a local server and implements hot code push",
   "cordova": {
     "id": "cordova-plugin-meteor-webapp",

--- a/npm-packages/cordova-plugin-meteor-webapp/scripts/iosAddBridgingHeader.js
+++ b/npm-packages/cordova-plugin-meteor-webapp/scripts/iosAddBridgingHeader.js
@@ -1,17 +1,16 @@
-module.exports = function(context) {
+module.exports = function(context, CordovaIos) {
   var fs = require('fs');
   var path = require('path');
-  var cordova_util = context.requireCordovaModule('cordova-lib/src/cordova/util.js');
-  var ConfigParser = context.requireCordovaModule('cordova-common').ConfigParser;
-
-  var projectRoot = context.opts.projectRoot;
-
-  var configXml = cordova_util.projectConfig(projectRoot);
-  var config = new ConfigParser(configXml);
-  var projectName = config.name();
+  var createRequire = require('module').createRequire;
+  var projectRequire = createRequire(path.join(
+    context.opts.projectRoot,
+    'package.json'
+  ));
+  CordovaIos = CordovaIos || projectRequire('cordova-ios');
 
   var platformRoot = path.join(context.opts.projectRoot, 'platforms/ios');
-  var projectBridgingHeaderPath = path.join(platformRoot, projectName,
+  var iosProject = new CordovaIos('ios', platformRoot);
+  var projectBridgingHeaderPath = path.join(iosProject.locations.xcodeCordovaProj,
       'Bridging-Header.h');
 
   var pluginId = context.opts.plugin.id;
@@ -25,4 +24,4 @@ module.exports = function(context) {
   if (!regExp.test(data)) {
     fs.appendFileSync(projectBridgingHeaderPath, importDirective + "\n");
   }
-}
+};

--- a/npm-packages/cordova-plugin-meteor-webapp/scripts/iosAddBridgingHeader.test.js
+++ b/npm-packages/cordova-plugin-meteor-webapp/scripts/iosAddBridgingHeader.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+
+const addBridgingHeader = require("./iosAddBridgingHeader");
+
+test("uses the cordova-ios project location for the app bridging header", async (t) => {
+  const projectRoot = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "cordova-ios-hook-test-")
+  );
+  t.after(() => fsp.rm(projectRoot, { recursive: true, force: true }));
+
+  const platformRoot = path.join(projectRoot, "platforms", "ios");
+  const appRoot = path.join(platformRoot, "App");
+  const bridgingHeader = path.join(appRoot, "Bridging-Header.h");
+  await fsp.mkdir(appRoot, { recursive: true });
+  await fsp.writeFile(bridgingHeader, "#import <Cordova/CDV.h>\n", "utf8");
+  const cordovaIosModule = path.join(
+    projectRoot,
+    "node_modules",
+    "cordova-ios",
+    "index.js"
+  );
+  await fsp.mkdir(path.dirname(cordovaIosModule), { recursive: true });
+  await fsp.writeFile(
+    cordovaIosModule,
+    [
+      'const path = require("node:path");',
+      "module.exports = class CordovaIos {",
+      "  constructor(platform, root) {",
+      '    if (platform !== "ios") throw new Error("Expected iOS platform");',
+      '    this.locations = { xcodeCordovaProj: path.join(root, "App") };',
+      "  }",
+      "};",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+
+  const context = {
+    opts: {
+      projectRoot,
+      plugin: { id: "cordova-plugin-meteor-webapp" },
+    },
+    requireCordovaModule(moduleName) {
+      if (moduleName === "cordova-lib/src/cordova/util.js") {
+        return { projectConfig: () => path.join(projectRoot, "config.xml") };
+      }
+      if (moduleName === "cordova-common") {
+        return {
+          ConfigParser: class {
+            name() {
+              return "MeteorSmoke";
+            }
+          },
+        };
+      }
+      throw new Error(`Unexpected module: ${moduleName}`);
+    },
+  };
+
+  addBridgingHeader(context);
+  addBridgingHeader(context);
+
+  const content = fs.readFileSync(bridgingHeader, "utf8");
+  assert.equal(
+    content.match(
+      /#import "cordova-plugin-meteor-webapp-Bridging-Header\.h"/g
+    )?.length,
+    1
+  );
+});

--- a/npm-packages/cordova-plugin-meteor-webapp/src/ios/WebAppLocalServer.swift
+++ b/npm-packages/cordova-plugin-meteor-webapp/src/ios/WebAppLocalServer.swift
@@ -92,7 +92,8 @@ open class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
     // and that is determined based on the appId. Hopefully this will avoid
     // collisions between Meteor apps installed on the same device
     } else if let viewController = self.viewController as? CDVViewController,
-        let port = URLComponents(string: viewController.startPage)?.port {
+        let startPage = viewController.startPage,
+        let port = URLComponents(string: startPage)?.port {
       localServerPort = UInt(port)
     }
 
@@ -277,30 +278,38 @@ open class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
   }
 
   @objc open func onNewVersionReady(_ command: CDVInvokedUrlCommand) {
-    newVersionReadyCallbackId = command.callbackId
+    guard let callbackId = command.callbackId else { return }
+    newVersionReadyCallbackId = callbackId
 
-    let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+    let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
     // This allows us to invoke the callback later
     result?.setKeepCallbackAs(true)
-    commandDelegate?.send(result, callbackId: newVersionReadyCallbackId)
+    if let result = result {
+      commandDelegate?.send(result, callbackId: callbackId)
+    }
   }
 
-  private func notifyNewVersionReady(_ version: String?) {
+  private func notifyNewVersionReady(_ version: String) {
     guard let newVersionReadyCallbackId = newVersionReadyCallbackId else { return }
 
-    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: version)
+    let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: version)
     // This allows us to invoke the callback later
     result?.setKeepCallbackAs(true)
-    commandDelegate?.send(result, callbackId: newVersionReadyCallbackId)
+    if let result = result {
+      commandDelegate?.send(result, callbackId: newVersionReadyCallbackId)
+    }
   }
 
   @objc open func onError(_ command: CDVInvokedUrlCommand) {
-    errorCallbackId = command.callbackId
+    guard let callbackId = command.callbackId else { return }
+    errorCallbackId = callbackId
 
-    let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
+    let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
     // This allows us to invoke the callback later
     result?.setKeepCallbackAs(true)
-    commandDelegate?.send(result, callbackId: errorCallbackId)
+    if let result = result {
+      commandDelegate?.send(result, callbackId: callbackId)
+    }
   }
 
   private func notifyError(_ error: Error) {
@@ -309,10 +318,12 @@ open class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
     guard let errorCallbackId = errorCallbackId else { return }
 
     let errorMessage = String(describing: error)
-    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: errorMessage)
+    let result: CDVPluginResult? = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: errorMessage)
     // This allows us to invoke the callback later
     result?.setKeepCallbackAs(true)
-    commandDelegate?.send(result, callbackId: errorCallbackId)
+    if let result = result {
+      commandDelegate?.send(result, callbackId: errorCallbackId)
+    }
   }
 
   // MARK: - Managing Versions

--- a/tools/cordova/index.js
+++ b/tools/cordova/index.js
@@ -25,7 +25,7 @@ export const CORDOVA_DEV_BUNDLE_VERSIONS = {
 
 export const CORDOVA_PLATFORM_VERSIONS = {
   'android': CORDOVA_ANDROID_VERSION,
-  'ios': '7.1.1',
+  'ios': '8.1.1',
 };
 
 export const SWIFT_VERSION = 5;


### PR DESCRIPTION
<!-- OSS-935 -->

Context: https://github.com/meteor/meteor/pull/14487

This PR upgrades Cordova iOS to 8.1.1. It is intentionally separate from PR [https://github.com/meteor/meteor/pull/14487](https://github.com/meteor/meteor/pull/14487) because upgrading iOS requires publishing the long-unreleased `cordova-plugin-meteor-webapp` package, making it a riskier change for a patch release. Unlike Android, Apple does not currently require this upgrade for App Store submissions.

I will likely target this for Meteor 3.6 instead. Although the Maestro E2E tests pass, I think it's better to let it go through a longer beta cycle to get more community testing, in case there are scenarios not yet covered by the current test suite.

https://github.com/user-attachments/assets/f70b250f-70f7-495c-8082-b524c9f3c7e2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility with Cordova iOS 8.1.1 projects, including their updated app layout and optional imports.

- **Bug Fixes**
  - Improved iOS startup handling when a start page or port is unavailable.
  - Prevented invalid update and error callbacks from being sent to the app.
  - Ensured the iOS bridging-header import is added only once.

- **Chores**
  - Updated the Cordova iOS platform version to 8.1.1.
  - Released `cordova-plugin-meteor-webapp` version 2.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->