### PR TITLE
fix(#12340): rewrite in-place build files that vanished from disk

### DIFF
--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -244,7 +244,8 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
   usePreviousWrite(relPath, hash, sanitize) {
     relPath = this._normalizeFilePath(relPath, sanitize);
 
-    if (this.previousWrittenHashes[relPath] === hash) {
+    if (this.previousWrittenHashes[relPath] === hash &&
+        this._previousWriteStillOnDisk(relPath)) {
       this._ensureDirectory(files.pathDirname(relPath));
       this.writtenHashes[relPath] = hash;
       this.usedAsFile[relPath] = true;
@@ -252,6 +253,22 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     }
 
     return false;
+  }
+
+  // An in-place rebuild may only skip recreating a file (or symlink) when it
+  // still exists on disk, so anything removed out of band (e.g. an OS purging
+  // the temp bundle dir) is recreated. Only consulted after a cache match, so
+  // fresh builds pay no extra stat. Uses files.exists rather than the optimistic
+  // stat cache: that cache persists across rebuilds and would report a purged
+  // file as present, whereas files.exists is scoped to the current build.
+  _previousWriteStillOnDisk(relPath) {
+    try {
+      return files.exists(files.pathJoin(this.buildPath, relPath));
+    } catch (e) {
+      // files.exists maps ENOENT to false; any other stat error (e.g. EACCES)
+      // is not evidence the file is gone, so keep the previous skip behavior.
+      return true;
+    }
   }
 
   _normalizeFilePath(relPath, sanitize) {
@@ -318,7 +335,9 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       hash = hash || sha1(getData());
 
       // Write is called multiple times for assets when they have multiple urls for the same file
-      if (this.previousWrittenHashes[relPath] !== hash && this.writtenHashes[relPath] !== hash) {
+      if (this.writtenHashes[relPath] !== hash &&
+          (this.previousWrittenHashes[relPath] !== hash ||
+            ! this._previousWriteStillOnDisk(relPath))) {
 
         // Builder is used to create build products, which should be read-only;
         // users shouldn't be manually editing automatically generated files and
@@ -670,7 +689,8 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
       if (symlink && ! (relTo in this.usedAsFile)) {
         this._ensureDirectory(files.pathDirname(relTo));
         const absTo = files.pathResolve(this.buildPath, relTo);
-        if (this.previousCreatedSymlinks[absFrom] !== relTo) {
+        if (this.previousCreatedSymlinks[absFrom] !== relTo ||
+            ! this._previousWriteStillOnDisk(relTo)) {
           await symlinkWithOverwrite(absFrom, absTo);
         }
         this.usedAsFile[relTo] = false;
@@ -797,7 +817,8 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
         if (fileStatus && fileStatus.isFile()) {
           const hash = optimisticHashOrNull(thisAbsFrom);
 
-          if (this.previousWrittenHashes[thisRelTo] !== hash) {
+          if (this.previousWrittenHashes[thisRelTo] !== hash ||
+              ! this._previousWriteStillOnDisk(thisRelTo)) {
             const content = optimisticReadFile(thisAbsFrom);
 
             files.writeFile(

--- a/tools/tests/builder-inplace-tests.js
+++ b/tools/tests/builder-inplace-tests.js
@@ -1,0 +1,43 @@
+import Builder from '../isobuild/builder.js';
+
+var selftest = require('../tool-testing/selftest.js');
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+
+// An in-place rebuild reuses the previous build's written-hash cache. If a file
+// was removed from the output directory out of band, a matching cached hash must
+// not let the rebuild skip it — the file has to be rewritten.
+if (process.platform !== 'win32') {
+  selftest.define('builder - in-place rebuild rewrites a file removed from disk', async function () {
+    var root = fs.mkdtempSync(path.join(os.tmpdir(), 'builder-inplace-'));
+    try {
+      var outputPath = path.join(root, 'bundle');
+      var data = Buffer.from('build product');
+
+      // First build writes the file and finalizes it into outputPath.
+      var first = new Builder({ outputPath: outputPath });
+      await first.init();
+      await first.write('programs/web/app.js', { data: data });
+      await first.complete();
+
+      // Second build reuses the first in place (buildPath === outputPath).
+      var second = new Builder({
+        outputPath: outputPath,
+        previousBuilder: first,
+        forceInPlaceBuild: true,
+      });
+      await second.init();
+      await selftest.expectEqual(second.buildPath, outputPath);
+
+      var target = path.join(outputPath, 'programs/web/app.js');
+      fs.unlinkSync(target);
+
+      // Same path and content/hash as before; must be rewritten, not skipped.
+      await second.write('programs/web/app.js', { data: data });
+      await selftest.expectTrue(fs.existsSync(target));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
## Problem
An in-place rebuild reuses the previous build's written-hash cache. If an output file was removed out of band (e.g. the OS purging the temp bundle dir), a matching cached hash let the rebuild **skip recreating it**, so the file went silently missing from the bundle. See #12340.

## Fix
Gate every cache-hit skip on the file still existing on disk (`_previousWriteStillOnDisk`), using build-scoped `files.exists` rather than the persistent optimistic stat cache. It is consulted only after a cache match, so fresh and non-in-place builds pay no extra `stat`.

Adds a selftest.

Fixes #12340


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-place rebuilds to detect when previously generated files or symbolic links have been removed.
  * Ensured missing files are recreated instead of incorrectly skipped based on cached build data.
* **Tests**
  * Added coverage verifying that deleted output files are restored during subsequent in-place builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->