### PR TITLE
fix(#12404): reuse existing collection during HMR re-declaration

### DIFF
--- a/packages/hot-module-replacement/client.js
+++ b/packages/hot-module-replacement/client.js
@@ -473,11 +473,16 @@ function applyChangeset(options) {
   });
 
   try {
+    // Signal that changed modules are being re-evaluated, so packages (e.g.
+    // mongo) can reuse existing resources instead of failing on re-declaration.
+    Meteor._hmrApplying = true;
     toRerun.forEach(function (moduleId) {
       require(moduleId);
     });
   } catch (error) {
     console.error('HMR: Error while applying changes:', error);
+  } finally {
+    Meteor._hmrApplying = false;
   }
 
   var updateCount = changedFiles.length + addedFiles.length;

--- a/packages/mongo/collection/collection.js
+++ b/packages/mongo/collection/collection.js
@@ -40,6 +40,16 @@ The default id generation technique is `'STRING'`.
 Mongo.Collection = function Collection(name, options) {
   name = validateCollectionName(name);
 
+  // While an HMR update re-runs a module, reuse an already-registered
+  // collection instead of throwing on the duplicate name, so it (and its live
+  // subscriptions and observers) survives the reload. The existing instance is
+  // returned as-is: options changed in the edited declaration take effect only
+  // after a full reload. _hmrApplying is set only by the hot-module-replacement
+  // client while it re-runs changed modules.
+  if (Meteor._hmrApplying && name && Mongo._collections.has(name)) {
+    return Mongo._collections.get(name);
+  }
+
   options = normalizeOptions(options);
 
   this._makeNewID = ID_GENERATORS[options.idGeneration]?.(name);

--- a/packages/mongo/tests/collection_tests.js
+++ b/packages/mongo/tests/collection_tests.js
@@ -24,6 +24,34 @@ Tinytest.add('collection - call new Mongo.Collection multiple times',
   }
 );
 
+Tinytest.add('collection - reuses existing instance during HMR re-declaration',
+  function (test) {
+    var collectionName = 'hmr_redeclare_' + test.id;
+    var original = new Mongo.Collection(collectionName);
+
+    // With _hmrApplying set (as during an HMR re-run), re-declaring the same
+    // name returns the existing instance instead of throwing.
+    Meteor._hmrApplying = true;
+    try {
+      var reran = new Mongo.Collection(collectionName);
+      test.isTrue(
+        reran === original,
+        'HMR re-declaration should reuse the existing collection instance'
+      );
+    } finally {
+      Meteor._hmrApplying = false;
+    }
+
+    // Outside of HMR, re-declaring the same name still throws as before.
+    test.throws(
+      function () {
+        new Mongo.Collection(collectionName);
+      },
+      /There is already a collection named/
+    );
+  }
+);
+
 Tinytest.add('collection - call new Mongo.Collection multiple times with _suppressSameNameError=true',
   function (test) {
     var collectionName = 'multiple_times_2_' + test.id;


### PR DESCRIPTION
## Problem
During an HMR update, re-running an edited module re-declared its `Mongo.Collection`, throwing *"There is already a collection named …"* and breaking hot reload for any module that declares a collection. See #12404.

## Fix
The `hot-module-replacement` client sets `Meteor._hmrApplying` while it re-runs changed modules; `Mongo.Collection` then **reuses the already-registered instance** (keeping its live subscriptions and observers) instead of throwing. Outside HMR, a duplicate name still throws as before. Options changed in the edited declaration take effect after a full reload.

Adds a test.

Fixes #12404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hot module replacement so Mongo collections are reused during code updates.
  * Existing subscriptions and observers now continue working after eligible module reloads.

* **Bug Fixes**
  * Prevented duplicate collection registration during hot reloads.
  * Preserved existing duplicate-name errors outside hot module replacement.

* **Tests**
  * Added coverage validating collection reuse during hot reloads and standard duplicate-name behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->