### PR TITLE
fix(#14151): await user lookup in Accounts._reportLoginFailure

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -601,7 +601,7 @@ export class AccountsServer extends AccountsCommon {
     };
 
     if (result.userId) {
-      attempt.user = this.users.findOneAsync(result.userId, {fields: this._options.defaultFieldSelector});
+      attempt.user = await this.users.findOneAsync(result.userId, {fields: this._options.defaultFieldSelector});
     }
 
     await this._validateLogin(methodInvocation.connection, attempt);

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -461,6 +461,40 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
+  'accounts - _reportLoginFailure resolves attempt.user before failure callbacks',
+  async test => {
+    const username = Random.id();
+    const userId = await Accounts.insertUserDoc({}, { username });
+
+    let seenUser;
+    const onLoginFailureStopper =
+      Accounts.onLoginFailure(attempt => { seenUser = attempt.user; });
+
+    try {
+      // _reportLoginFailure passes the looked-up user to onLoginFailure. It must
+      // be the resolved document, not an unresolved Promise (a Promise reaches
+      // the callbacks as an empty object, so every user property reads as
+      // undefined).
+      await Accounts._reportLoginFailure(
+        { connection: {} },
+        'test-report-login-failure',
+        [{}],
+        { type: 'test', error: new Meteor.Error(403, 'nope'), userId }
+      );
+
+      test.equal(
+        seenUser && seenUser._id,
+        userId,
+        'attempt.user is the resolved user document, not an unresolved Promise'
+      );
+    } finally {
+      onLoginFailureStopper.stop();
+      await Meteor.users.removeAsync(userId);
+    }
+  }
+);
+
+Tinytest.addAsync(
   'accounts - Meteor.user() obeys options.defaultFieldSelector',
   async test => {
     const ignoreFieldName = "bigArray";


### PR DESCRIPTION
## Problem
`Accounts._reportLoginFailure` assigned `attempt.user` the **unresolved Promise** returned by `findOneAsync`, so `_validateLogin` and every `onLoginFailure` callback received a Promise instead of the user document — every user field read as `undefined`. See #14151.

## Fix
`await` the user lookup so `attempt.user` is the resolved document.

Adds a test asserting the failure callback sees the resolved user.

Fixes #14151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed-login handling so login-failure callbacks receive the correct user information.
  * Prevented unresolved data from being passed during login validation and failure processing.

* **Tests**
  * Added coverage to verify that failed-login events include the expected user record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->