### PR TITLE
fix(#12952): recover from EACCES in Builder#write over a read-only target

### DIFF
--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -334,9 +334,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
           // Since builder is not updating in place, and
           // this build is only used if every file is successfully written,
           // it is not important to write atomically.
-          files.writeFile(absPath, getData(), {
-            mode
-          });
+          await this._writeFileWithReadOnlyFallback(absPath, getData(), { mode });
       }
       }
 
@@ -345,6 +343,23 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     this.usedAsFile[relPath] = true;
 
     return relPath;
+  }
+
+  // Write a file, falling back to an atomic rewrite when the target already
+  // exists and is read-only. Writing over such a file (e.g. one reached through
+  // a symlink into a prior build) fails with EACCES/EPERM; the atomic temp-file
+  // + rename path can replace it, since rename only needs write access to the
+  // parent directory.
+  async _writeFileWithReadOnlyFallback(absPath, content, options) {
+    try {
+      files.writeFile(absPath, content, options);
+    } catch (e) {
+      if (e.code === 'EACCES' || e.code === 'EPERM') {
+        await atomicallyRewriteFile(absPath, content, options);
+      } else {
+        throw e;
+      }
+    }
   }
 
   async copyTranspiledModules(relativePaths, {
@@ -800,18 +815,16 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
           if (this.previousWrittenHashes[thisRelTo] !== hash) {
             const content = optimisticReadFile(thisAbsFrom);
 
-            files.writeFile(
+            // We call writeFile (rather than files.copyFile) so we can read the
+            // source with optimisticReadFile instead of a stream. The mode logic
+            // is borrowed from files.copyFile: create the file readable and
+            // writable by everyone, and executable by everyone if the original
+            // is executable by owner (modified by umask); we don't copy the mode
+            // directly because this is also used by 'meteor create', copying
+            // from the read-only tools tree into a writable app.
+            await this._writeFileWithReadOnlyFallback(
                 files.pathResolve(this.buildPath, thisRelTo),
-                // The reason we call files.writeFile here instead of
-                // files.copyFile is so that we can read the file using
-                // optimisticReadFile instead of files.createReadStream.
                 content,
-                // Logic borrowed from files.copyFile: "Create the file as
-                // readable and writable by everyone, and executable by everyone
-                // if the original file is executably by owner. (This mode will be
-                // modified by umask.) We don't copy the mode *directly* because
-                // this function is used by 'meteor create' which is copying from
-                // the read-only tools tree into a writable app."
                 { mode: (fileStatus.mode & 0o100) ? 0o777 : 0o666 },
             );
           }

--- a/tools/tests/builder-readonly-tests.js
+++ b/tools/tests/builder-readonly-tests.js
@@ -1,0 +1,35 @@
+import Builder from '../isobuild/builder.js';
+
+var selftest = require('../tool-testing/selftest.js');
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+
+// A build product may resolve, through a symlink, onto a file a previous build
+// left read-only. Writing over it directly fails with EACCES/EPERM; Builder#write
+// must fall back to an atomic rewrite and still land the new contents.
+if (process.platform !== 'win32') {
+  selftest.define('builder - write recovers from a read-only symlinked target', async function () {
+    var root = fs.mkdtempSync(path.join(os.tmpdir(), 'builder-ro-'));
+    try {
+      var outputPath = path.join(root, 'out');
+      var realDir = path.join(root, 'readonly');
+      fs.mkdirSync(realDir);
+      fs.writeFileSync(path.join(realDir, 'app.js'), 'OLD', { mode: 0o444 });
+
+      var b = new Builder({ outputPath: outputPath });
+      await b.init();
+      // Route a build-output subpath through a symlink into the read-only tree.
+      fs.symlinkSync(realDir, path.join(b.buildPath, 'sub'), 'dir');
+
+      await b.write('sub/app.js', { data: Buffer.from('NEW') });
+
+      await selftest.expectEqual(
+        fs.readFileSync(path.join(realDir, 'app.js'), 'utf8'),
+        'NEW'
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
## Problem
Writing a build product over a file a previous build left **read-only** (e.g. one reached through a symlink into a prior build) failed with `EACCES`/`EPERM` and aborted the build. See #12952.

## Fix
`Builder#write` falls back to an atomic temp-file + rename when the direct write hits `EACCES`/`EPERM`. `rename` needs only write access to the parent directory, so it can replace the read-only target.

Adds a selftest.

Fixes #12952


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability when overwriting read-only files or files accessed through symlinks.
  * Build output files can now be updated successfully in more previously failing scenarios.

* **Tests**
  * Added coverage for updating read-only build files through symlinked output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->