### PR TITLE
fix(#12323): suppress browserslist "caniuse-lite is outdated" warning

### DIFF
--- a/tools/node-process-warnings.js
+++ b/tools/node-process-warnings.js
@@ -1,3 +1,10 @@
+// Suppress browserslist's "caniuse-lite is outdated" warning. browserslist
+// prints it with console.warn (not process.emitWarning, so the override below
+// does not catch it) and skips it only when this env var is set. Preserve an
+// explicit user value.
+process.env.BROWSERSLIST_IGNORE_OLD_DATA =
+  process.env.BROWSERSLIST_IGNORE_OLD_DATA || '1';
+
 const originalEmitWarning = process.emitWarning;
 
 process.emitWarning = function (message) {

--- a/tools/node-process-warnings.test.js
+++ b/tools/node-process-warnings.test.js
@@ -1,0 +1,48 @@
+// Unit tests for tools/node-process-warnings.js. The module runs its side
+// effects (the BROWSERSLIST env var and the process.emitWarning override) at
+// require time, so each test controls process state and re-requires it fresh.
+
+describe('node-process-warnings', () => {
+  let savedEmit;
+  let savedEnv;
+
+  beforeEach(() => {
+    savedEmit = process.emitWarning;
+    savedEnv = process.env.BROWSERSLIST_IGNORE_OLD_DATA;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.emitWarning = savedEmit;
+    if (savedEnv === undefined) {
+      delete process.env.BROWSERSLIST_IGNORE_OLD_DATA;
+    } else {
+      process.env.BROWSERSLIST_IGNORE_OLD_DATA = savedEnv;
+    }
+  });
+
+  test('sets BROWSERSLIST_IGNORE_OLD_DATA when unset', () => {
+    delete process.env.BROWSERSLIST_IGNORE_OLD_DATA;
+    require('./node-process-warnings.js');
+    expect(process.env.BROWSERSLIST_IGNORE_OLD_DATA).toBe('1');
+  });
+
+  test('preserves an explicit BROWSERSLIST_IGNORE_OLD_DATA value', () => {
+    process.env.BROWSERSLIST_IGNORE_OLD_DATA = '0';
+    require('./node-process-warnings.js');
+    expect(process.env.BROWSERSLIST_IGNORE_OLD_DATA).toBe('0');
+  });
+
+  test('suppresses punycode warnings but passes others through', () => {
+    const seen = [];
+    // The module captures the current process.emitWarning as the delegate, so
+    // install a spy before requiring it.
+    process.emitWarning = (message) => { seen.push(message); };
+    require('./node-process-warnings.js');
+
+    process.emitWarning('The `punycode` module is deprecated.');
+    process.emitWarning('some unrelated deprecation');
+
+    expect(seen).toEqual(['some unrelated deprecation']);
+  });
+});


### PR DESCRIPTION
## Problem
Builds surfaced a noisy `Browserslist: caniuse-lite is outdated` warning originating from the bundled browserslist data — nothing an app author can act on. See #12323.

## Fix
Default `BROWSERSLIST_IGNORE_OLD_DATA=1` (unless the user already set it) so the outdated-data warning is suppressed, without otherwise changing browserslist behavior.

Adds a unit test.

Fixes #12323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy runtime warnings related to outdated browser data and `punycode`.
  * Preserved other runtime warnings so important notices continue to appear.
  * Respected existing configuration values when browser data warning suppression is already set.

* **Tests**
  * Added coverage to verify warning suppression and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->