### PR TITLE
fix: do not create ~/.bash_profile in the installer, shadowing ~/.profile (meteor/meteor#12172)

### DIFF
--- a/npm-packages/meteor-installer/install.js
+++ b/npm-packages/meteor-installer/install.js
@@ -327,7 +327,17 @@ async function setupExecPath() {
     await appendPathToFile('.zshrc');
   } else {
     await appendPathToFile('.bashrc');
-    await appendPathToFile('.bash_profile');
+    // A bash login shell reads the first of ~/.bash_profile, ~/.bash_login,
+    // ~/.profile. Only append to a bash-specific login file if one already
+    // exists; otherwise append to ~/.profile. Creating ~/.bash_profile when it
+    // is absent would make bash stop sourcing the user's existing ~/.profile.
+    if (fs.existsSync(`${rootPath}/.bash_profile`)) {
+      await appendPathToFile('.bash_profile');
+    } else if (fs.existsSync(`${rootPath}/.bash_login`)) {
+      await appendPathToFile('.bash_login');
+    } else {
+      await appendPathToFile('.profile');
+    }
   }
 }
 async function fixOwnership() {


### PR DESCRIPTION
## Problem
The installer appended the `PATH` export to `~/.bash_profile`, **creating it if absent**. A bash login shell reads only the first of `~/.bash_profile`, `~/.bash_login`, `~/.profile`, so creating `~/.bash_profile` makes bash silently stop sourcing the user's existing `~/.profile`. See #12172.

## Fix
Only append to a bash-specific login file (`~/.bash_profile`/`~/.bash_login`) if one already exists; otherwise append to `~/.profile`. This never shadows an existing `~/.profile`.

Fixes #12172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PATH configuration for Bash login shells.
  * Updates are now saved to the appropriate existing shell profile, with a fallback for systems without a Bash-specific profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->