### PR TITLE
fix: fall back to polling for positional ($) projections instead of crashing Change Streams (meteor/meteor#12688)

### DIFF
--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -1104,6 +1104,27 @@ MongoConnection.prototype._observeChanges = async function (
             reasons.push('Cursor with skip/limit not supported by Change Streams');
           }
 
+          // If a fields projection is given, it must be one minimongo can
+          // compile client-side. A positional ('$') projection cannot be, so
+          // report Change Streams as unavailable rather than letting the driver
+          // constructor throw (which crashes the whole subscription). Selection
+          // then falls through to polling, which projects server-side in
+          // MongoDB. Mirrors OplogObserveDriver.cursorSupported.
+          const csFields = csOptions.projection || csOptions.fields;
+          if (csFields) {
+            try {
+              LocalCollection._checkSupportedProjection(csFields);
+            } catch (e) {
+              if (e.name === 'MinimongoError') {
+                reasons.push(
+                  `Projection not supported for Change Streams: ${e.message}`
+                );
+              } else {
+                throw e;
+              }
+            }
+          }
+
           if (reasons.length) {
             return {
               available: false,

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -83,6 +83,38 @@ Tinytest.addAsync(
   }
 );
 
+Tinytest.addAsync(
+  'changestream - positional ($) projection falls back instead of crashing',
+  async function (test) {
+    const c = makeCollection();
+    await c.insertAsync({
+      _id: 'doc1',
+      myArray: [{ foo: 1, val: 'a' }, { foo: 2, val: 'b' }],
+    });
+
+    // A positional ('$') projection cannot be compiled by minimongo, so Change
+    // Streams must report itself unavailable and selection must fall through to
+    // a driver that projects server-side (polling) rather than throwing and
+    // crashing the whole observe/subscription.
+    let handle;
+    try {
+      handle = await c
+        .find({ 'myArray.foo': 1 }, { fields: { 'myArray.$': 1 } })
+        .observeChanges({ added: function () {} });
+    } catch (e) {
+      test.fail('observeChanges threw for a $ projection: ' + e.message);
+      return;
+    }
+
+    test.isFalse(
+      handle._multiplexer._observeDriver._usesChangeStreams === true,
+      'a $ (positional) projection must not use the Change Streams driver'
+    );
+
+    handle.stop();
+  }
+);
+
 // if not using ChangeStreams, skip the rest of the tests
 if (!IS_CHANGESTREAM) {
   console.log('Skipping ChangeStream tests because ChangeStreams are not the active reactivity driver.');


### PR DESCRIPTION
## Problem
A cursor with a positional (`$`) fields projection cannot be compiled client-side by minimongo. Under the Change Streams reactivity driver this threw during driver construction and **crashed the whole observe/subscription** instead of degrading gracefully. See #12688.

## Fix
Before selecting Change Streams, check the projection with `LocalCollection._checkSupportedProjection`; on a `MinimongoError` (e.g. a `$` projection) report Change Streams as unavailable so selection falls through to polling, which projects server-side in MongoDB. Mirrors `OplogObserveDriver.cursorSupported`.

Adds a test.

Fixes #12688


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where unsupported positional projections could cause `observeChanges` to fail.
  * Change Streams now safely fall back to polling when a projection isn’t supported, while preserving supported projection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->