### PR TITLE
fix: make native driver ObjectId round-trip to the client as Mongo.ObjectID (meteor/meteor#12029)

### DIFF
--- a/packages/mongo/mongo_common.js
+++ b/packages/mongo/mongo_common.js
@@ -5,6 +5,25 @@ export const MongoDB = Object.assign(NpmModuleMongodb, {
   ObjectID: NpmModuleMongodb.ObjectId,
 });
 
+// A native driver ObjectId (as returned from rawCollection()/aggregate()) is not
+// an EJSON type, so returning one from a method sends the client an opaque object
+// (`{}` on older bson, `{ buffer: ... }` on newer bson) rather than a usable id.
+// `find()` results are converted to Mongo.ObjectID by replaceMongoAtomWithMeteor
+// below, but arbitrary method return values are not. Teach EJSON to serialize a
+// native ObjectId as the same "oid" type used by Mongo.ObjectID (see the mongo-id
+// package) so it round-trips to a Mongo.ObjectID on the client.
+if (MongoDB.ObjectId &&
+    MongoDB.ObjectId.prototype &&
+    typeof MongoDB.ObjectId.prototype.typeName !== 'function' &&
+    typeof MongoDB.ObjectId.prototype.toHexString === 'function') {
+  MongoDB.ObjectId.prototype.typeName = function () {
+    return 'oid';
+  };
+  MongoDB.ObjectId.prototype.toJSONValue = function () {
+    return this.toHexString();
+  };
+}
+
 // The write methods block until the database has confirmed the write (it may
 // not be replicated or stable on disk, but one server has confirmed it) if no
 // callback is provided. If a callback is provided, then they call the callback

--- a/packages/mongo/tests/collection_tests.js
+++ b/packages/mongo/tests/collection_tests.js
@@ -10,6 +10,25 @@ Tinytest.add(
   }
 );
 
+Tinytest.add(
+  'collection - native ObjectID round-trips through EJSON as a Mongo.ObjectID',
+  function (test) {
+    // A native driver ObjectId (e.g. returned from rawCollection()/aggregate())
+    // should serialize as the shared "oid" EJSON type so it reaches the client
+    // as a usable Mongo.ObjectID rather than an opaque object.
+    if (! Meteor.isServer) {
+      return;
+    }
+    var nativeId = new MongoDB.ObjectId();
+    var hex = nativeId.toHexString();
+    var json = EJSON.toJSONValue(nativeId);
+    test.equal(json, { $type: 'oid', $value: hex });
+    var parsed = EJSON.fromJSONValue(json);
+    test.isTrue(parsed instanceof Mongo.ObjectID);
+    test.equal(parsed.toHexString(), hex);
+  }
+);
+
 Tinytest.add('collection - call new Mongo.Collection multiple times',
   function (test) {
     var collectionName = 'multiple_times_1_' + test.id;


### PR DESCRIPTION
## Problem
A native driver `ObjectId` (as returned from `rawCollection()`/`aggregate()`) is not an EJSON type, so returning one from a method sent the client an opaque object (`{}` or `{ buffer: … }`) instead of a usable id. `find()` results are converted to `Mongo.ObjectID`, but arbitrary method return values are not. See #12029.

## Fix
Teach EJSON to serialize a native `ObjectId` as the same `"oid"` type used by `Mongo.ObjectID` (via `mongo-id`), so it round-trips to a `Mongo.ObjectID` on the client. The patch is server-only and inert for normal find/observe flows (which already convert native → `Mongo.ObjectID` at the cursor boundary); it only affects the raw-driver values it is meant to fix.

Adds a test.

Fixes #12029


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native MongoDB ObjectIds now serialize and deserialize consistently with Meteor Mongo.ObjectIDs.
  * ObjectIds can round-trip through EJSON while preserving usable client-side identifiers.

* **Tests**
  * Added coverage to verify native ObjectId EJSON round-tripping and value preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->