### PR TITLE
fix: report the missing module (not a missing package) for meteor/<pkg>/<file> (meteor/meteor#12164)

### DIFF
--- a/packages/modules-runtime/errors/cannotFindMeteorPackage.js
+++ b/packages/modules-runtime/errors/cannotFindMeteorPackage.js
@@ -4,7 +4,25 @@
  * @return {Error}
  */
 cannotFindMeteorPackage = function(id) {
-  var packageName = id.split('/', 2)[1];
+  var parts = id.split('/');
+  var packageName = parts[1];
+
+  // When the id points at a sub-module of an installed package
+  // (e.g. "meteor/mongo/x"), the package itself exists but the requested
+  // module does not. Reporting a missing package there is misleading (and
+  // suggesting "meteor add <core-package>" is nonsensical), so report the
+  // missing module instead.
+  if (parts.length > 2 &&
+      typeof Package === 'object' &&
+      Package !== null &&
+      Package[packageName]) {
+    return new Error(
+      'Cannot find module "' + id + '". ' +
+      'The package "' + packageName + '" is installed but does not ' +
+      'provide that module.'
+    );
+  }
+
   return new Error(
     'Cannot find package "' + packageName + '". ' +
     'Try "meteor add ' + packageName + '".'

--- a/packages/modules-runtime/modules-runtime-tests.js
+++ b/packages/modules-runtime/modules-runtime-tests.js
@@ -11,6 +11,15 @@ Tinytest.add('errors - standard', function (test) {
   }, 'Cannot find package "foo". Try "meteor add foo".');
 });
 
+Tinytest.add('errors - missing module in installed package', function (test) {
+  var require = meteorInstall();
+  // The "meteor" package is always installed, so importing a non-existent
+  // module from it should report the missing module, not a missing package.
+  test.throws(() => {
+    require('meteor/meteor/this-module-does-not-exist');
+  }, /Cannot find module "meteor\/meteor\/this-module-does-not-exist"\. The package "meteor" is installed/);
+});
+
 Tinytest.add('errors - node_modules', function (test) {
   var require = meteorInstall();
   test.throws(() => {

--- a/packages/modules-runtime/server.js
+++ b/packages/modules-runtime/server.js
@@ -17,11 +17,7 @@ makeInstallerOptions.fallback = function (id, parentId, error) {
   // the fallback for dependencies installed in node_modules directories.
   if (topLevelIdPattern.test(id)) {
     if (id && id.startsWith('meteor/')) {
-      const [meteorPrefix, packageName] = id.split('/', 2);
-      throw new Error(
-        `Cannot find package "${packageName}". ` +
-        `Try "meteor add ${packageName}".`
-      );
+      throw cannotFindMeteorPackage(id);
     }
     if (typeof Npm === "object" &&
         typeof Npm.require === "function") {


### PR DESCRIPTION
## Problem
Requiring a **sub-module** of an installed package (e.g. `meteor/mongo/does-not-exist`) reported a missing *package* and suggested `meteor add <core-package>`, which is misleading and nonsensical — the package exists, only the requested module does not. See #12164.

## Fix
When the id points at a sub-module of an installed package, report the missing **module** rather than a missing package (and drop the bogus `meteor add` suggestion).

Adds a test.

Fixes #12164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when a requested module is missing from an installed Meteor package.
  * Clarified when a package is missing entirely, including guidance for adding it.
  * Server-side module resolution now consistently reports missing Meteor packages and sub-modules.

* **Tests**
  * Added coverage for requests targeting non-existent modules within installed packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->