### PR TITLE
fix: do not fail the build when minify bundle-size stats cannot be parsed (meteor/meteor#13245)

### DIFF
--- a/packages/standard-minifier-js/plugin/stats.js
+++ b/packages/standard-minifier-js/plugin/stats.js
@@ -24,6 +24,7 @@ const meteorInstallRegExp = new RegExp([
 export function extractModuleSizesTree(source) {
   const match = meteorInstallRegExp.exec(source);
   if (match) {
+    let ast;
     try {
       ast = acorn.parse(source, {
         ecmaVersion: 'latest',
@@ -35,11 +36,19 @@ export function extractModuleSizesTree(source) {
         checkPrivateFields: false
       });
     }
-    catch(e){
-      console.log(`Error while parsing with acorn. Falling back to babel minifier. ${e}`);
-      ast = Babel.parse(source);
+    catch(acornError){
+      // The module-size tree only feeds optional bundle stats
+      // (bundle-visualizer). If neither parser can handle the minified source,
+      // skip the tree instead of aborting the whole production build.
+      try {
+        console.log(`Error while parsing with acorn. Falling back to babel. ${acornError}`);
+        ast = Babel.parse(source);
+      } catch (babelError) {
+        console.log(`Error while parsing bundle for module sizes; skipping stats. ${babelError}`);
+        return;
+      }
     }
-    
+
     let meteorInstallName = "meteorInstall";
     // The minifier may have renamed meteorInstall to something shorter.
     match.some((name, i) => (i > 0 && (meteorInstallName = name)));


### PR DESCRIPTION
## Problem
When the minifier could not parse a bundle to compute its size stats (e.g. Babel failed on an edge-case input), the whole build failed — even though the size stats are informational only. See #13245.

## Fix
Treat unpar-seable bundle-size stats as non-fatal: return `undefined` on parse failure (the caller already handles a falsy tree with a size-only path) instead of throwing. Also scopes a previously implicit-global `ast` with `let`.

Fixes #13245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when analyzing bundle output with syntax that cannot be parsed.
  * Prevented module-size statistics generation from failing the overall process when parsing is unsuccessful.
  * Added diagnostic logging for parsing failures to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->