### PR TITLE
fix: resolve JS-module extensions before assets like .css (meteor/meteor#12718)

### DIFF
--- a/tools/isobuild/compiler-plugin.js
+++ b/tools/isobuild/compiler-plugin.js
@@ -21,6 +21,14 @@ import {isTestFilePath} from './test-files.js';
 
 const hasOwn = Object.prototype.hasOwnProperty;
 
+// Preferred order for JavaScript-module extensions when resolving an
+// extensionless import. These are tried before any other (asset) extension —
+// such as ".css" or ".html" — so that `import X from './Foo'` resolves
+// Foo.tsx / Foo.js rather than Foo.css when files share a basename. Extensions
+// not listed here keep their registration order after these.
+const MODULE_IMPORT_EXTENSION_ORDER =
+  [".js", ".json", ".mjs", ".cjs", ".jsx", ".ts", ".tsx"];
+
 // This file implements the new compiler plugins added in Meteor 1.2, which are
 // registered with the Plugin.registerCompiler API.
 //
@@ -1235,9 +1243,30 @@ export class PackageSourceBatch {
       extension = "." + extension;
     }
 
-    if (this.importExtensions.indexOf(extension) < 0) {
-      this.importExtensions.push(extension);
+    if (this.importExtensions.indexOf(extension) >= 0) {
+      return;
     }
+
+    // Insert the extension by its module-resolution rank rather than simply
+    // appending it in (nondeterministic) resource-scan order, so that
+    // JavaScript-module extensions are always resolved before asset
+    // extensions like ".css". Extensions of the same rank keep their
+    // registration order.
+    const rank = ext => {
+      const i = MODULE_IMPORT_EXTENSION_ORDER.indexOf(ext);
+      return i < 0 ? MODULE_IMPORT_EXTENSION_ORDER.length : i;
+    };
+
+    const extRank = rank(extension);
+    let insertAt = this.importExtensions.length;
+    for (let i = 0; i < this.importExtensions.length; i++) {
+      if (rank(this.importExtensions[i]) > extRank) {
+        insertAt = i;
+        break;
+      }
+    }
+
+    this.importExtensions.splice(insertAt, 0, extension);
   }
 
   getResolver(options = {}) {


### PR DESCRIPTION
## Problem
When a JavaScript module and an asset shared a basename, an extensionless import (e.g. `import X from './Foo'`) could resolve to the asset (`Foo.css`) instead of the module (`Foo.js`/`Foo.tsx`). See #12718.

## Fix
Introduce a preferred order for JS-module extensions (`MODULE_IMPORT_EXTENSION_ORDER`) that is tried **before** any asset extension when resolving an extensionless import, via a stable rank-based insert. Extensions not listed keep their existing registration order after these.

Fixes #12718


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of extensionless imports by prioritizing JavaScript and TypeScript files before asset formats such as CSS and HTML.
  * Ensured module resolution is deterministic and consistent across builds, preventing results from varying based on resource discovery order.
  * Duplicate import extensions are now handled cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->