### PR TITLE
FEATURE: `meteor deploy` now ships with an interactive site wizard

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -2033,21 +2033,33 @@ async function deployCommand(options, { rawOptions }) {
     return 1;
   }
 
-  if (! site && ! options['build-only']) {
-    // Deleting is destructive, so we never offer a guess: naming the site is
-    // always the user's job, interactive terminal or not.
-    if (options.delete) {
-      Console.error("Error: site is required to delete.");
-      return 1;
-    }
+  // Deleting is destructive, so we never offer a guess: naming the site is
+  // always the user's job, interactive terminal or not. Checked before the
+  // build-only carve-out below so `--delete --build-only` can't slip past it.
+  if (options.delete && ! site) {
+    Console.error("Error: site is required to delete.");
+    return 1;
+  }
 
-    if (! Console.isInteractive() || ! process.stdin.isTTY) {
+  // "First time" for the registration message at the end of the deploy means
+  // "was not logged in when the command started" -- capture it before any
+  // interactive login below muddies the water.
+  const wasLoggedIn = auth.isLoggedIn();
+
+  if (! site && ! options['build-only']) {
+    // Self-tests drive these prompts through pipes, where stdin has no TTY;
+    // METEOR_FORCE_INTERACTIVE lets the harness opt in to the prompts anyway
+    // (same spirit as METEOR_PRETTY_OUTPUT / METEOR_HEADLESS in console.js).
+    const stdinIsInteractive = process.stdin.isTTY ||
+      (process.env.METEOR_FORCE_INTERACTIVE &&
+        process.env.METEOR_FORCE_INTERACTIVE !== '0');
+    if (! Console.isInteractive() || ! stdinIsInteractive) {
       Console.error("Error deploying application: site is required.");
       return 1;
     }
 
     let sites = [];
-    let loggedIn = auth.isLoggedIn();
+    let loggedIn = wasLoggedIn;
     if (! loggedIn && ! options["deploy-token"]) {
       Console.info(
         "You must be logged in to deploy, just enter your email address.");
@@ -2060,15 +2072,14 @@ async function deployCommand(options, { rawOptions }) {
     }
 
     if (loggedIn) {
-      try {
-        sites = await deploy.getSitesList();
-      } catch (err) {
-        // Couldn't reach Galaxy: fall through and just ask for a site name.
-      }
+      // Returns null when Galaxy can't be reached (deployRpc reports errors
+      // as values, it doesn't throw); we fall through to the free-text prompt.
+      sites = await deploy.getSitesList();
     }
 
     // Inquirer paints its own prompts, so the progress display has to stand
-    // down until we're done asking.
+    // down until we're done asking. (main.js enables it for every command, so
+    // unconditionally re-enabling in the finally restores the prior state.)
     Console.enableProgressDisplay(false);
     try {
       const prompt = inquirer.createPromptModule();
@@ -2097,23 +2108,15 @@ async function deployCommand(options, { rawOptions }) {
             type: "input",
             name: "site",
             message: "Enter the site name (e.g. myapp.meteorapp.com):",
+            validate(input) {
+              return input.trim() ? true : "Please enter a site name.";
+            }
           }
         ]);
         site = answers.site.trim();
       }
-    } catch (err) {
-      // A closed pipe or Ctrl-C during the prompt is a plain exit, not a crash.
-      if (err && (err.isTtyError || err.name === 'ExitPromptError')) {
-        return 1;
-      }
-      throw err;
     } finally {
       Console.enableProgressDisplay(true);
-    }
-
-    if (! site) {
-      Console.error("Error: site name is required.");
-      return 1;
     }
   }
 
@@ -2201,7 +2204,9 @@ async function deployCommand(options, { rawOptions }) {
       // If the user was already logged in at the beginning of the
       // deploy, then they've already been prompted to set a password
       // at least once before, so we use a slightly different message.
-      firstTime: !loggedIn
+      // (wasLoggedIn, not loggedIn: the interactive site prompt may have
+      // logged them in between the start of the command and here.)
+      firstTime: ! wasLoggedIn
     });
   }
 

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -2022,11 +2022,7 @@ main.registerCommand({
 });
 
 async function deployCommand(options, { rawOptions }) {
-  const site = options.args[0];
-
-  if (options.delete) {
-    return await deploy.deleteApp(site);
-  }
+  let site = options.args[0];
 
   if (options.password) {
     Console.error(
@@ -2035,6 +2031,94 @@ async function deployCommand(options, { rawOptions }) {
         "that only you (and people you designate) can access them. See the " +
         Console.command("'meteor authorized'") + " command.");
     return 1;
+  }
+
+  if (! site && ! options['build-only']) {
+    // Deleting is destructive, so we never offer a guess: naming the site is
+    // always the user's job, interactive terminal or not.
+    if (options.delete) {
+      Console.error("Error: site is required to delete.");
+      return 1;
+    }
+
+    if (! Console.isInteractive() || ! process.stdin.isTTY) {
+      Console.error("Error deploying application: site is required.");
+      return 1;
+    }
+
+    let sites = [];
+    let loggedIn = auth.isLoggedIn();
+    if (! loggedIn && ! options["deploy-token"]) {
+      Console.info(
+        "You must be logged in to deploy, just enter your email address.");
+      Console.info();
+      const isRegistered = await auth.registerOrLogIn();
+      if (! isRegistered) {
+        return 1;
+      }
+      loggedIn = true;
+    }
+
+    if (loggedIn) {
+      try {
+        sites = await deploy.getSitesList();
+      } catch (err) {
+        // Couldn't reach Galaxy: fall through and just ask for a site name.
+      }
+    }
+
+    // Inquirer paints its own prompts, so the progress display has to stand
+    // down until we're done asking.
+    Console.enableProgressDisplay(false);
+    try {
+      const prompt = inquirer.createPromptModule();
+
+      if (sites && sites.length > 0) {
+        const answers = await prompt([
+          {
+            type: "list",
+            name: "site",
+            message: "Which site do you want to deploy to?",
+            choices: [
+              // A null value falls through to the free-text prompt below,
+              // and can't collide with a real hostname.
+              { name: "+ Deploy to a new site...", value: null },
+              new inquirer.Separator(),
+              ...sites
+            ]
+          }
+        ]);
+        site = answers.site;
+      }
+
+      if (! site) {
+        const answers = await prompt([
+          {
+            type: "input",
+            name: "site",
+            message: "Enter the site name (e.g. myapp.meteorapp.com):",
+          }
+        ]);
+        site = answers.site.trim();
+      }
+    } catch (err) {
+      // A closed pipe or Ctrl-C during the prompt is a plain exit, not a crash.
+      if (err && (err.isTtyError || err.name === 'ExitPromptError')) {
+        return 1;
+      }
+      throw err;
+    } finally {
+      Console.enableProgressDisplay(true);
+    }
+
+    if (! site) {
+      Console.error("Error: site name is required.");
+      return 1;
+    }
+  }
+
+  if (options.delete) {
+    return await deploy.deleteApp(site);
   }
 
   const loggedIn = auth.isLoggedIn();

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -520,9 +520,14 @@ The --db flag also removes the local database.
 
 >>> deploy
 Deploy this project to Galaxy, Meteor's hosting service.
-Usage: meteor deploy <site> [--settings settings.json] [--debug] [--delete]
+Usage: meteor deploy [site] [--settings settings.json] [--debug] [--delete]
 
 Deploys the project in your current directory to Meteor's servers.
+
+If you don't specify a site name, and are running in an interactive terminal,
+Meteor will prompt you to select from your existing deployed sites or
+enter a new one. If you run with `--delete` (or `-D`) without a site name,
+Meteor will error out, requiring you to specify the site to delete.
 
 You can deploy to any available name under 'meteorapp.com'
 without any additional configuration, for example,

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -914,6 +914,26 @@ export async function listSites() {
   return 0;
 };
 
+export async function getSitesList() {
+  var result = await deployRpc({
+    method: "GET",
+    operation: "authorized-apps",
+    promptIfAuthFails: false,
+    expectPayload: ["sites"]
+  });
+
+  if (result.errorMessage) {
+    return null;
+  }
+
+  if (! result.payload ||
+      ! result.payload.sites ||
+      ! result.payload.sites.length) {
+    return [];
+  }
+  return result.payload.sites.sort();
+};
+
 // Given a hostname, add "http://" or "https://" as
 // appropriate. (localhost gets http; anything else is always https.)
 function addScheme(hostOrURL) {

--- a/tools/meteor-services/deploy.js
+++ b/tools/meteor-services/deploy.js
@@ -914,11 +914,13 @@ export async function listSites() {
   return 0;
 };
 
+// Like listSites, but returns the sites as a sorted array instead of
+// printing them: null if the RPC failed (deployRpc reports errors as
+// values rather than throwing), [] if the account has no sites.
 export async function getSitesList() {
   var result = await deployRpc({
     method: "GET",
     operation: "authorized-apps",
-    promptIfAuthFails: false,
     expectPayload: ["sites"]
   });
 

--- a/tools/tests/deploy_interactive_test.js
+++ b/tools/tests/deploy_interactive_test.js
@@ -2,7 +2,7 @@ var selftest = require('../tool-testing/selftest.js');
 var Sandbox = selftest.Sandbox;
 var testUtils = require('../tool-testing/test-utils.js');
 
-selftest.define('deploy interactive prompt test', ['net'], async function () {
+selftest.define('deploy interactive site prompt', ['net'], async function () {
   var s = new Sandbox();
   await s.init();
 
@@ -10,24 +10,35 @@ selftest.define('deploy interactive prompt test', ['net'], async function () {
   await s.createApp(appName, 'standard-app');
   s.cd(appName);
 
-  // Run deploy without site argument – it will trigger login and site prompts.
-  var loginRun = s.run('login');
-  await loginRun.matchErr('Email:');
-  loginRun.write('test@test.com\n');
-  await loginRun.matchErr('Password:');
-  loginRun.write('testtest\n');
-  await loginRun.expectExit(0);
+  await testUtils.login(s, 'test', 'testtest');
+
+  // Non-interactive runs must keep the old error: the harness spawns
+  // commands with piped stdio (no TTY), so a plain run hits the guard.
   var run = s.run('deploy');
-
-  // Wait for site selection prompt.
-  await run.match(/Which site do you want to deploy to\?/);
-  // Choose the default "new site" option.
-  await run.write('\n');
-  await run.match(/Enter the site name/);
-  // Type a site name.
-  run.write('mynewsite.meteorapp.com\n');
-
-  // Ensure the site name appears only once and the command exits (expected failure without a token).
-  await run.match('mynewsite.meteorapp.com');
+  run.waitSecs(30);
+  await run.matchErr('site is required');
   await run.expectExit(1);
+
+  // Now opt in to the prompts despite the missing TTY.
+  s.set('METEOR_FORCE_INTERACTIVE', 't');
+
+  run = s.run('deploy');
+  run.waitSecs(30);
+
+  // The shared test account may or may not own deployed sites, so either the
+  // site picker or the free-text prompt can come first.
+  await run.match(/Which site do you want to deploy to\?|Enter the site name/);
+
+  // An Enter keypress converges both paths onto the free-text prompt: in the
+  // picker it selects the default "+ Deploy to a new site..." choice, and at
+  // the free-text prompt the empty answer fails validation and re-prompts.
+  run.write('\n');
+  await run.match(/Enter the site name|Please enter a site name/);
+
+  run.write('mynewsite.meteorapp.com\n');
+  // Inquirer echoes the accepted answer; that's the wizard's job done.
+  // Everything past this point is the pre-existing deploy path, so stop the
+  // run rather than waiting out a full build-and-deploy attempt.
+  await run.match('mynewsite.meteorapp.com');
+  await run.stop();
 });

--- a/tools/tests/deploy_interactive_test.js
+++ b/tools/tests/deploy_interactive_test.js
@@ -1,0 +1,33 @@
+var selftest = require('../tool-testing/selftest.js');
+var Sandbox = selftest.Sandbox;
+var testUtils = require('../tool-testing/test-utils.js');
+
+selftest.define('deploy interactive prompt test', ['net'], async function () {
+  var s = new Sandbox();
+  await s.init();
+
+  var appName = testUtils.randomAppName();
+  await s.createApp(appName, 'standard-app');
+  s.cd(appName);
+
+  // Run deploy without site argument – it will trigger login and site prompts.
+  var loginRun = s.run('login');
+  await loginRun.matchErr('Email:');
+  loginRun.write('test@test.com\n');
+  await loginRun.matchErr('Password:');
+  loginRun.write('testtest\n');
+  await loginRun.expectExit(0);
+  var run = s.run('deploy');
+
+  // Wait for site selection prompt.
+  await run.match(/Which site do you want to deploy to\?/);
+  // Choose the default "new site" option.
+  await run.write('\n');
+  await run.match(/Enter the site name/);
+  // Type a site name.
+  run.write('mynewsite.meteorapp.com\n');
+
+  // Ensure the site name appears only once and the command exits (expected failure without a token).
+  await run.match('mynewsite.meteorapp.com');
+  await run.expectExit(1);
+});

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -740,9 +740,11 @@ Displays your currently logged-in username.
 meteor whoami
 ```
 
-## meteor deploy _site_ {#meteordeploy}
+## meteor deploy [site] {#meteordeploy}
 
 Deploys the project in your current directory to [Galaxy](https://www.meteor.com/galaxy).
+
+If `site` is not provided and you are running in an interactive terminal, Meteor will prompt you to select from your existing deployed sites or enter a new one. Deleting is never prompted for: running `--delete` (or `-D`) without a site name is an error, so you always name the site you intend to remove.
 
 ### Basic Deployment
 


### PR DESCRIPTION
## `meteor deploy` now walks you through it

Deploying used to require you to remember the exact hostname you shipped to last time:

```bash
meteor deploy myapp.meteorapp.com
```

Forget it, and you got an error instead of help. Now the site name is optional — run `meteor deploy` on its own and Meteor asks:

```
? Which site do you want to deploy to? (Use arrow keys)
  + Deploy to a new site...
  ──────────────
❯ myapp.meteorapp.com
  staging-myapp.meteorapp.com
```

Pick a site and it deploys. Pick **+ Deploy to a new site...** and it asks for the hostname. If you aren't logged in yet, the login flow runs first, then the picker — one continuous path from `meteor deploy` to a running app.

This matches how `meteor create` already behaves when you invoke it bare.

### Behavior

| Invocation | What happens |
| --- | --- |
| `meteor deploy` (TTY) | Site picker, seeded from your authorized apps |
| `meteor deploy` (TTY, no sites on account) | Straight to the hostname prompt |
| `meteor deploy` (TTY, not logged in) | Login first, then the picker |
| `meteor deploy` (CI / piped stdin) | Same error and exit code as before — **no change** |
| `meteor deploy <site>` | Unchanged |
| `meteor deploy --build-only` | Unchanged, no site needed |
| `meteor deploy --delete` (no site) | Errors out — see below |

Two deliberate choices:

- **Non-interactive runs are untouched.** The prompt is gated on `Console.isInteractive() && process.stdin.isTTY`, so nothing in CI can hang waiting on stdin. Existing scripts behave exactly as they did.
- **`--delete` never prompts.** Choosing which app to destroy from an arrow-key list is one fat-finger away from deleting production. Deleting still requires you to name the site.

Behavior notes surfaced in review:

- **`--password` is now rejected before `--delete` runs**: `meteor deploy <site> -D --password x` used to delete the site while silently ignoring `--password`; it now errors. Deliberate — an unsupported flag next to a destructive one shouldn't be ignored.
- **`meteor deploy --delete --build-only` (no site) now errors** instead of crashing with a `TypeError` in `canonicalizeSite` (the delete guard runs before the build-only carve-out).
- Ctrl-C at a prompt behaves like the tool's other Inquirer prompts (e.g. bare `meteor create`) — no special handling.
- An empty answer at the site-name prompt re-prompts (Inquirer `validate`) instead of erroring out.
- `METEOR_FORCE_INTERACTIVE` (same spirit as `METEOR_HEADLESS` / `METEOR_PRETTY_OUTPUT`) lets the self-test harness opt in to the prompts despite piped stdio; not intended for general use.

### Implementation

- **`tools/meteor-services/deploy.js`** — new `getSitesList()`. Same `authorized-apps` RPC that backs `meteor list-sites`, but returns a sorted array rather than printing. Returns `null` on error and `[]` when the account has no sites, so the caller can degrade to the free-text prompt.
- **`tools/cli/commands.js`** — the prompting in `deployCommand`. The progress spinner is suspended around the prompt (restored in a `finally`) so it doesn't fight Inquirer for the cursor. The "new site" choice uses a `null` value, which can't collide with a real hostname.
- If the Galaxy lookup fails, `getSitesList()` returns `null` (`deployRpc` reports errors as values, it doesn't throw) and we fall through to the hostname prompt — a network blip shouldn't block a deploy where you already know the name.
- A user who registers through the wizard still gets the first-time registration message after a successful deploy (logged-in state is captured before the interactive flow).

### Docs

`tools/cli/help.txt` and `v3-docs/docs/cli/index.md` both updated to `meteor deploy [site]`, including the `--delete` caveat.

### Test

`tools/tests/deploy_interactive_test.js` (tagged `net`) creates an app, logs in as the shared `test` user, then: (1) verifies a bare `meteor deploy` under piped stdio still errors with `site is required`, exit 1 — the no-regression case for CI/scripts; (2) sets `METEOR_FORCE_INTERACTIVE` and drives the wizard. Since the shared account's site list is unknown, the test accepts either prompt first and converges both paths with a single Enter keypress (selects "+ Deploy to a new site..." in the picker; fails validation at the free-text prompt), then enters a hostname and stops the run once the wizard hands off to the pre-existing deploy path.

```bash
./meteor self-test deploy interactive
```

### Note

No changelog entry: files under `v3-docs/docs/generators/changelog/versions` are per-release and generated from PRs merged to `release-<VERSION>` branches; there's no next-version file on `devel` yet. This PR should be picked up when that file is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - `meteor deploy` now prompts for an existing site or a new site name when none is provided in an interactive terminal.
  - Site selection supports authenticated workflows and displays available deployed sites.

- **Bug Fixes**
  - Deletion now requires an explicitly specified site.
  - Site names are validated before deployment or deletion.

- **Documentation**
  - Updated CLI help and documentation to describe optional site names and interactive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
