### PR TITLE
fix(test-helpers): guard failed() callback in makeTestConnection

### DIFF
--- a/packages/test-helpers/connection_server.js
+++ b/packages/test-helpers/connection_server.js
@@ -16,7 +16,7 @@ makeTestConnection = function (test, succeeded, failed) {
     test.isTrue(typeof serverConn.id === 'string', "connection handle id exists and is a string");
     if (serverConns[serverConn.id]) {
       test.fail("onConnection callback called multiple times for same session id");
-      failed();
+      if (failed) failed();
     } else {
       serverConns[serverConn.id] = serverConn;
     }
@@ -28,7 +28,7 @@ makeTestConnection = function (test, succeeded, failed) {
     var serverConn = serverConns[sessionId];
     if (! serverConn) {
       test.fail("No onConnection received server side for connected client");
-      failed();
+      if (failed) failed();
     } else {
       onConnectionHandle.stop();
       succeeded(clientConn, serverConn);
@@ -48,7 +48,7 @@ makeTestConnection = function (test, succeeded, failed) {
     },
     function () {
       test.fail("client side of connection did not receive a session id");
-      failed();
+      if (failed) failed();
     }
   );
 };


### PR DESCRIPTION
## Summary

`makeTestConnection(test, succeeded, failed)` in
`packages/test-helpers/connection_server.js` declares `failed` as an
optional third argument, but three internal failure paths call it
unconditionally. When a caller only passes `(test, succeeded)` — which
roughly half of the call sites across the codebase do — hitting one of
those failure paths throws `TypeError: failed is not a function`.

The worst instance is the `simplePoll` timeout branch: it fires from
inside a `Meteor.setTimeout` callback, outside any try/catch or promise
chain, so the `TypeError` is uncaught and fatal to the server process
under Node's default `uncaughtException` behavior — a latent crash
hiding in shared test infrastructure.

This PR guards all three call sites with `if (failed) failed();`. Since
`test.fail(...)` already runs immediately before each `failed()` call,
the guard is enough to preserve "mark the test as failed" behavior for
callers with no `failed` argument, without double-reporting the failure
or changing behavior for callers that do pass one.

## The crash path

```js
// packages/test-helpers/connection_server.js
simplePoll(
  function () {
    return clientConn._lastSessionId;
  },
  function () {
    onClientSessionId(clientConn._lastSessionId);
  },
  function () {
    test.fail("client side of connection did not receive a session id");
    failed();               // <- throws if the caller omitted `failed`
  }
);
```

`simplePoll`'s timeout branch (`packages/test-helpers/async_multi.js`)
invokes this callback from a `Meteor.setTimeout`, so the resulting
exception is uncaught:

```js
// packages/test-helpers/async_multi.js
if (start + timeout < (new Date()).valueOf()) {
  failed();   // -> connection_server.js's failed(), TypeError if undefined
  ...
}
```

The other two guarded call sites (duplicate `onConnection` for the same
session id, and a missing server-side connection for a session id the
client received) share the identical unconditional-`failed()` pattern
and the identical exposure.

## Call-site inventory

23 direct `makeTestConnection(...)` call sites across `packages/`
(plus the internal `createTestConnectionPromise` wrapper in
`connection_server.js` itself, which passes `reject` — safe), checked
for arity:

| File | Lines | Arity | Safe? |
|---|---|---|---|
| `accounts-base/accounts_tests.js` | 265 | 3 (`test, succeeded, onComplete`) | yes |
| `accounts-password/password_tests.js` | 7 | 3 (`test, succeeded, reject`) | yes |
| `ddp-server/raw_websocket_tests.js` | 28, 45, 124 | 3 (`test, succeeded, onComplete`) | yes |
| `ddp-server/livedata_server_tests.js` | 39, 62, 107, 144, 163, 181, 623 | 3 (`test, succeeded, onComplete`/`reject`) | yes |
| `ddp-server/livedata_server_tests.js` | 254, 269, 284, 337, 397, 411 | **2** (`test, succeeded`) | **no — crash on timeout/failure** |
| `ddp-server/livedata_server_async_tests.js` | 57, 72, 129, 166, 202 | **2** (`test, succeeded`) | **no — crash on timeout/failure** |

11 of 23 call sites (~48%) omit `failed`, all in `ddp-server`'s
publish/subscribe-focused tests. Any one of them hitting a slow or
failed connection under load takes down the test server process
instead of failing the individual test.

## Fix rationale

- Minimal, semantics-preserving: guard the callback invocation
  (`if (failed) failed();`) rather than restructure the function or
  give `failed` a synthesized default implementation.
- `test.fail(...)` already executes unconditionally right before each
  `failed()` call in all three spots, so the "timeout/failure marks the
  test failed rather than crashing or silently passing" requirement is
  already satisfied by the existing code — the guard just stops the
  crash from masking that already-reported failure.
- No behavior change for the 12 call sites that do pass `failed`.
- No existing tests modified; the three-line guard is confined to
  `packages/test-helpers/connection_server.js`.

## How this was found

Found during a parallel test-suite run of `ddp-server` (see meteor/meteor
discussion #12162) — running suites concurrently made the timing-sensitive
timeout path fire, surfacing the previously-latent crash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling so failure callbacks are invoked only when they are provided, preventing errors during duplicate-session, missing-connection, and polling-timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->