### PR TITLE
Improve Rspack CLI path resolution with proper fallback for edge cases

### DIFF
--- a/packages/rspack/lib/processes.js
+++ b/packages/rspack/lib/processes.js
@@ -215,12 +215,20 @@ export function getRspackCliPath() {
   const appDir = getMeteorAppDir();
 
   try {
-    // Dynamically resolve the exact bin path defined by the package
+    // Dynamically resolve the exact bin path defined by the package.
+    // Meteor's module system ignores the `paths` option and resolves unknown
+    // top-level ids to themselves, so only an absolute path that exists on
+    // disk can be trusted here.
     const pkgPath = require.resolve('@rspack/cli/package.json', { paths: [appDir] });
-    const pkg = require(pkgPath);
-    const bin = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.rspack;
-    if (bin) {
-      return path.join(path.dirname(pkgPath), bin);
+    if (path.isAbsolute(pkgPath)) {
+      const pkg = require(pkgPath);
+      const bin = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.rspack;
+      if (bin) {
+        const binPath = path.join(path.dirname(pkgPath), bin);
+        if (fs.existsSync(binPath)) {
+          return binPath;
+        }
+      }
     }
   } catch (err) {
     // Fall through to hardcoded fallback if package.json isn't exported

--- a/packages/rspack/lib/processes.js
+++ b/packages/rspack/lib/processes.js
@@ -245,7 +245,18 @@ export function getRspackCliPath() {
     );
   }
 
-  for (const candidatePath of candidatePaths) {
+  // Walk up from the app directory so hoisted installs are still found when the
+  // parent holding node_modules carries no monorepo marker. Nearest ancestor
+  // wins, and the loop stops at the filesystem root.
+  let currentDir = path.dirname(appDir);
+  while (currentDir !== path.dirname(currentDir)) {
+    candidatePaths.push(
+      path.join(currentDir, 'node_modules', '@rspack', 'cli', 'bin', 'rspack.js'),
+    );
+    currentDir = path.dirname(currentDir);
+  }
+
+  for (const candidatePath of new Set(candidatePaths)) {
     if (fs.existsSync(candidatePath)) {
       return candidatePath;
     }


### PR DESCRIPTION
This PR is a fix within Windows environment on having spaced paths (not neccesarly spaced app names) and monorepos. When testing this scenario, it was failing so the fix on this PR improve by covering more cases.

<img width="1686" height="660" alt="image" src="https://github.com/user-attachments/assets/1d885bbb-dedf-450f-adcf-03b22f313d6d" />

After this tweak is fixed:

<img width="2398" height="555" alt="image" src="https://github.com/user-attachments/assets/e4843c58-7ed6-4fe6-b335-a43aa7330b80" />

The problem with Windows is how fragile its any fix on this since we don't have enough E2E coverage for regressions specifically on this OS.

