### PR TITLE
docs: fix stale DDP session-resumption and heartbeat comments

### DIFF
--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -1294,8 +1294,9 @@ Object.assign(Subscription.prototype, {
 Server = function (options = {}) {
   var self = this;
 
-  // The default heartbeat interval is 30 seconds on the server and 35
-  // seconds on the client.  Since the client doesn't need to send a
+  // The server's default heartbeat interval (below) is deliberately
+  // shorter than the client's default (see ddp-client's
+  // livedata_connection.js).  Since the client doesn't need to send a
   // ping as long as it is receiving pings, this means that pings
   // normally go from the server to the client.
   //

--- a/v3-docs/docs/api/meteor.md
+++ b/v3-docs/docs/api/meteor.md
@@ -1050,7 +1050,7 @@ Determines how many messages we should queue during a non-graceful disconnect be
 ### Resume Behavior and Edge Cases
 
 When a session correctly resumes, clients pick up exactly where they left off:
-- **Subscriptions:** Active subscriptions automatically resume without needing to be re-published and clients do not re-send subscription requests.
+- **Subscriptions:** Clients optimistically re-send their subscription requests on every reconnect, before knowing whether the resume succeeded. On a resumed session the server ignores these duplicates — active subscriptions stay live, publish handlers are not re-run, and the client keeps its local data instead of resetting its stores.
 - **Method Calls:** Any in-flight method calls that were unacknowledged during the disconnection will be replayed.
 - **Queue Overflow:** If the number of messages emitted while a client is disconnected exceeds `maxMessageQueueLength`, the session is discarded. When the client reconnects, it initiates a fresh session.
 - **Hot Code Push:** HCP is treated as a manual, graceful disconnect. Session resumption is gracefully skipped so clients receive entirely fresh state for the new code.


### PR DESCRIPTION
## What

Two documentation accuracy fixes:

1. **`v3-docs/docs/api/meteor.md` (Resume Behavior and Edge Cases):** the Subscriptions bullet claimed that on a DDP session resume "clients do not re-send subscription requests". This contradicts the client: `onReset()` in `packages/ddp-client/common/connection_stream_handlers.js` always re-sends the connect message, outstanding methods, and every `sub` message on reconnect, before the resume outcome is known (the code comment says it "blasts out" everything). On a resumed session the server ignores the duplicate subs because subs are idempotent (`livedata_server.js` `sub` handler), so publish handlers are not re-run and the client skips its store reset. The bullet now describes that actual flow.

2. **`packages/ddp-server/livedata_server.js`:** the comment above the Server options claimed default heartbeats of "30 seconds on the server and 35 seconds on the client"; the real defaults are 15000 ms interval/timeout on the server (directly below the comment) and 17500/15000 ms on the client (`livedata_connection.js`). Reworded to state the invariant that matters — the server interval is deliberately shorter than the client's, so pings normally flow server→client — instead of hardcoding numbers that can drift again.

## Notes

- Checked the surrounding `disconnectGracePeriod` / `maxMessageQueueLength` prose in `meteor.md` and `v3-docs/docs/performance/ddp-transport.md` for consistency: those match the code defaults (15000 ms / 100) and needed no changes.
- Docs/comments only — no behavior change, so no changelog entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation on session resumption behavior, clarifying how clients handle reconnections and preserve subscriptions and local data without rerunning publication handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
