### PR TITLE
[Rspack] Fix cache dependency scanner for typescript configs

### DIFF
--- a/dev/modern-tools/rspack/E2E_COVERAGE.md
+++ b/dev/modern-tools/rspack/E2E_COVERAGE.md
@@ -115,6 +115,7 @@ TypeScript with SCSS, type checking, `.ts` rspack config, and `.ts` SWC config.
 | `.meteor/local/types` directory generated | Run |
 | Separate client/server test files | Test |
 | CI: removes TsCheckerRspackPlugin (resource limits) | Init |
+| Persistent cache dependency scanner parses TypeScript configs without errors | All |
 | HMR works in dev, disabled in prod | Run, Prod |
 
 ### babel
@@ -296,7 +297,7 @@ Several apps import specific npm packages to verify that Meteor + Rspack handles
 | Package | Reason |
 |---------|--------|
 | `node:module` (`createRequire`) | Node.js built-in in a `.ts` config file — tests CJS interop via `createRequire(import.meta.url)` in an ESM context |
-| `@swc/core` | Type-only import (`import type { Config }`) — provides typings for `swc.config.ts`, stripped at compile time |
+| `@swc/core`, `@rspack/core` | Type-only import (`import type { Config }`, `import type { Configuration }`) — provides typings for configs, verifies the cache dependency scanner correctly parses TS syntax |
 
 ---
 

--- a/npm-packages/meteor-rspack/lib/localDependenciesHelpers.js
+++ b/npm-packages/meteor-rspack/lib/localDependenciesHelpers.js
@@ -20,7 +20,7 @@ function extractLocalDependencies(configFilePath) {
 
     // Parse the file into an AST
     const ast = swc.parseSync(content, {
-      syntax: 'ecmascript',
+      syntax: /\.[mc]?tsx?$/.test(configFilePath) ? 'typescript' : 'ecmascript',
       dynamicImport: true,
       target: 'es2020',
     });
@@ -30,10 +30,10 @@ function extractLocalDependencies(configFilePath) {
       let modulePath = null;
 
       // Handle require() calls: require('./plugin')
-      if (node.type === 'CallExpression' && 
-          node.callee.type === 'Identifier' && 
-          node.callee.value === 'require' &&
-          node.arguments.length > 0) {
+      if (node.type === 'CallExpression' &&
+        node.callee.type === 'Identifier' &&
+        node.callee.value === 'require' &&
+        node.arguments.length > 0) {
         const arg = node.arguments[0];
         if (arg.expression?.type === 'StringLiteral') {
           modulePath = arg.expression.value;
@@ -42,8 +42,8 @@ function extractLocalDependencies(configFilePath) {
 
       // Handle dynamic import() calls: import('./plugin')
       if (node.type === 'CallExpression' &&
-          node.callee.type === 'Import' &&
-          node.arguments.length > 0) {
+        node.callee.type === 'Import' &&
+        node.arguments.length > 0) {
         const arg = node.arguments[0];
         if (arg.expression?.type === 'StringLiteral') {
           modulePath = arg.expression.value;
@@ -163,7 +163,7 @@ function resolveLocalModule(modulePath, configDir, projectDir) {
     const resolvedReal = fs.realpathSync(resolvedPath);
     const projectReal = fs.realpathSync(projectDir);
 
-    const isWithinProject = 
+    const isWithinProject =
       resolvedReal === projectReal ||
       resolvedReal.startsWith(projectReal + path.sep);
     const hasNodeModulesSegment = resolvedReal.split(path.sep).includes('node_modules');

--- a/tools/e2e-tests/apps/typescript/rspack.config.ts
+++ b/tools/e2e-tests/apps/typescript/rspack.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@meteorjs/rspack';
 import { createRequire } from 'node:module';
 import { TsCheckerRspackPlugin } from 'ts-checker-rspack-plugin';
+import type { Configuration } from '@rspack/core';
 
 const require = createRequire(import.meta.url);
 
@@ -14,6 +15,9 @@ const require = createRequire(import.meta.url);
  *
  * Use these flags to adjust your build settings based on environment.
  */
+// Satisfy TS noUnusedLocals without affecting the return type of defineConfig
+export type _Config = Configuration;
+
 export default defineConfig(Meteor => {
   return {
     ...Meteor.enablePortableBuild(),

--- a/tools/e2e-tests/typescript.test.js
+++ b/tools/e2e-tests/typescript.test.js
@@ -42,6 +42,11 @@ describe('TypeScript App Bundling /', () => {
         });
         await waitForTypeScriptEnvs(result.outputLines, { isTsxEnabled: true });
         await waitForTypeScriptErrorFree(result.outputLines);
+        await waitForMeteorOutput(
+          result.outputLines,
+          /.*\[Rspack Cache\] Failed to parse config dependencies.*/,
+          { negate: true }
+        );
         await assertFileExist(tempDir, ".meteor/local/types");
         // Portable build: Meteor.isDevelopment and Meteor.isProduction must not be defined
         await waitForMeteorOutput(
@@ -65,6 +70,11 @@ describe('TypeScript App Bundling /', () => {
           'white-space': 'break-spaces',
         });
         await waitForTypeScriptEnvs(result.outputLines, { isTsxEnabled: true });
+        await waitForMeteorOutput(
+          result.outputLines,
+          /.*\[Rspack Cache\] Failed to parse config dependencies.*/,
+          { negate: true }
+        );
         // Portable build: Meteor.isDevelopment and Meteor.isProduction must not be defined
         await waitForMeteorOutput(
           result.outputLines,
@@ -89,6 +99,11 @@ describe('TypeScript App Bundling /', () => {
       },
       afterBuild: async ({ result }) => {
         await waitForTypeScriptEnvs(result.outputLines, { isTsxEnabled: true });
+        await waitForMeteorOutput(
+          result.outputLines,
+          /.*\[Rspack Cache\] Failed to parse config dependencies.*/,
+          { negate: true }
+        );
         // Portable build: Meteor.isDevelopment and Meteor.isProduction must not be defined
         await waitForMeteorOutput(
           result.outputLines,


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/issues/14644

This PR resolves an issue in `@meteorjs/rspack` where the persistent cache dependency scanner failed to parse TypeScript configuration files (e.g., `rspack.config.ts`), returning empty dependency lists and throwing parser warnings on every build start.

The root cause was that `swc.parseSync` strictly used the `ecmascript` syntax mode, causing it to fail on TypeScript-specific tokens like `import type`. 

The fix updates `localDependenciesHelpers.js` to dynamically choose the `typescript` parser syntax based on the file extension (e.g., `.ts`, `.tsx`), restoring full parser capability for `rspack.config.ts`. 

## Validation

- Verified that `swc` now correctly builds the AST for TypeScript configuration files containing `import type`.
- Augmented `tools/e2e-tests/typescript.test.js` to intentionally add `import type` syntax into the test app's `rspack.config.ts`.
- Validated via E2E test assertions that the `[Rspack Cache] Failed to parse config dependencies:` warning is strictly absent from both client and server build logs across all startup and production build sequences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of TypeScript configuration files when detecting local dependencies.
  * Prevented cache dependency parsing errors for TypeScript-based applications.
  * Added support for multiple TypeScript configuration extensions, including `.ts`, `.tsx`, `.mts`, and `.cts`.

* **Tests**
  * Expanded end-to-end checks across development, production, and build workflows to verify clean output without cache parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->