### PR TITLE
backport: DDP session resumption for Meteor 3.4.1 (ddp-server/ddp-client 3.2.1)

### DIFF
--- a/packages/ddp-client/common/connection_stream_handlers.js
+++ b/packages/ddp-client/common/connection_stream_handlers.js
@@ -26,8 +26,10 @@ export class ConnectionStreamHandlers {
     }
 
     if (msg === null || !msg.msg) {
-      if(!msg || !msg.testMessageOnConnect) {
-        if (Object.keys(msg).length === 1 && msg.server_id) return;
+      if (!msg || !msg.testMessageOnConnect) {
+        // msg is null when parseDDP discarded the frame (invalid JSON, or
+        // JSON that is not an object) — guard before inspecting its keys.
+        if (msg && Object.keys(msg).length === 1 && msg.server_id) return;
         Meteor._debug('discarding invalid livedata message', msg);
       }
       return;

--- a/packages/ddp-client/common/connection_stream_handlers.js
+++ b/packages/ddp-client/common/connection_stream_handlers.js
@@ -135,6 +135,10 @@ export class ConnectionStreamHandlers {
     // the necessary RTT to know if we successfully reconnected.
     this._connection._callOnReconnectAndSendAppropriateOutstandingMethods();
     this._resendSubscriptions();
+
+    // Deliver messages that were passed to _sendQueued while disconnected
+    // (e.g. 'unsub' messages); the stream would have dropped them.
+    this._connection._flushMessagesQueuedUntilReconnect();
   }
 
   /**

--- a/packages/ddp-client/common/connection_stream_handlers.js
+++ b/packages/ddp-client/common/connection_stream_handlers.js
@@ -33,6 +33,11 @@ export class ConnectionStreamHandlers {
       return;
     }
 
+    // Track received message count for session resumption (excluding ping/pong)
+    if (!this._connection._ignoredMsgsForSessionOutOfDateCheck.includes(msg.msg)) {
+      this._connection._receivedCount++;
+    }
+
     // Important: This was missing from previous version
     // We need to set the current version before routing the message
     if (msg.msg === 'connected') {
@@ -139,6 +144,7 @@ export class ConnectionStreamHandlers {
     const msg = { msg: 'connect' };
     if (this._connection._lastSessionId) {
       msg.session = this._connection._lastSessionId;
+      msg.receivedCount = this._connection._receivedCount;
     }
     msg.version = this._connection._versionSuggestion || this._connection._supportedDDPVersions[0];
     this._connection._versionSuggestion = msg.version;

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -1091,6 +1091,7 @@ export class Connection {
   }
 
   close() {
+    // _permanent is used by the underlying stream to prevent reconnection attempts
     return this.disconnect({ _permanent: true });
   }
 

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -93,6 +93,10 @@ export class Connection {
     }
 
     self._lastSessionId = null;
+    // how many messages we've received (excluding ping/pong).
+    // when we try to reconnect to the server, it will check this against the number of messages it sent.
+    // if there is a mismatch, our info is out of date and we need a clean session.
+    self._receivedCount = 0;
     self._versionSuggestion = null; // The last proposed DDP version.
     self._version = null; // The DDP version agreed on by client and server.
     self._stores = Object.create(null); // name -> object with methods
@@ -102,6 +106,7 @@ export class Connection {
 
     self._heartbeatInterval = options.heartbeatInterval;
     self._heartbeatTimeout = options.heartbeatTimeout;
+    self._ignoredMsgsForSessionOutOfDateCheck = ['ping', 'pong'];
 
     // Tracks methods which the user has tried to call but which have not yet
     // called their user callback (ie, they are waiting on their result or for all
@@ -1081,11 +1086,12 @@ export class Connection {
    * @locus Client
    */
   disconnect(...args) {
+    this._send({ msg: 'disconnect' });
     return this._stream.disconnect(...args);
   }
 
   close() {
-    return this._stream.disconnect({ _permanent: true });
+    return this.disconnect({ _permanent: true });
   }
 
   ///

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -246,6 +246,11 @@ export class Connection {
       });
     }
 
+    // Messages passed to _sendQueued while the stream was not connected.
+    // The stream drops data sent while disconnected, so these are flushed
+    // once the connection is (re-)established.
+    self._messagesQueuedUntilReconnect = [];
+
     this._streamHandlers = new ConnectionStreamHandlers(this);
 
     const onDisconnect = () => {
@@ -1037,14 +1042,28 @@ export class Connection {
     this._stream.send(DDPCommon.stringifyDDP(obj));
   }
 
-  // Always queues the call before sending the message
-  // Used, for example, on subscription.[id].stop() to make sure a "sub" message is always called before an "unsub" message
+  // Sends the message ordered behind any sends queued by in-flight async
+  // stubs (the second argument to _send routes through the client stub
+  // queue — see queue_stub_helpers.js). If the stream is not connected the
+  // message is held until the connection is (re-)established instead: the
+  // stream drops data sent while disconnected, and e.g. the 'unsub' from
+  // subscription.stop() removes its registry record, so nothing would ever
+  // re-send it.
   // https://github.com/meteor/meteor/issues/13212
-  //
-  // This is part of the actual fix for the rest check:
-  // https://github.com/meteor/meteor/pull/13236
   _sendQueued(obj) {
-    this._send(obj, true);
+    if (this._stream.status().status === 'connected') {
+      this._send(obj, true);
+    } else {
+      this._messagesQueuedUntilReconnect.push(obj);
+    }
+  }
+
+  // Called on stream reset, after subscriptions have been re-sent, so a
+  // queued 'unsub' can never precede its subscription's 'sub'.
+  _flushMessagesQueuedUntilReconnect() {
+    const queued = this._messagesQueuedUntilReconnect;
+    this._messagesQueuedUntilReconnect = [];
+    queued.forEach(obj => this._send(obj, true));
   }
 
   // We detected via DDP-level heartbeats that we've lost the

--- a/packages/ddp-client/common/message_processors.js
+++ b/packages/ddp-client/common/message_processors.js
@@ -43,10 +43,15 @@ export class MessageProcessors {
 
     if (reconnectedToPreviousSession) {
       // Successful reconnection -- pick up where we left off.
+      // Don't reset stores since we're continuing the same session.
+      self._resetStores = false;
       return;
     }
 
     // Server doesn't have our data anymore. Re-sync a new session.
+    // Reset the received count since we're starting a new session.
+    // Set to 1 because the 'connected' message itself counts.
+    self._receivedCount = 1;
 
     // Forget about messages we were buffering for unknown collections. They'll
     // be resent if still relevant.

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data client",
-  version: "3.2.0",
+  version: "3.2.1-patch",
   documentation: null,
 });
 

--- a/packages/ddp-client/package.js
+++ b/packages/ddp-client/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data client",
-  version: "3.2.1-patch",
+  version: "3.2.1-patch.0",
   documentation: null,
 });
 

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -20,14 +20,16 @@ const newConnection = function(stream, options) {
   );
 };
 
-const makeConnectMessage = function(session) {
+const makeConnectMessage = function(session, receivedCount) {
   const msg = {
     msg: 'connect',
     version: DDPCommon.SUPPORTED_DDP_VERSIONS[0],
-    support: DDPCommon.SUPPORTED_DDP_VERSIONS
+    support: DDPCommon.SUPPORTED_DDP_VERSIONS,
   };
 
   if (session) msg.session = session;
+  if (receivedCount) msg.receivedCount = receivedCount;
+
   return msg;
 };
 
@@ -869,7 +871,7 @@ Tinytest.addAsync('livedata stub - reconnect', async function(test, onComplete) 
   // sub. The wait method still is blocked.
   await stream.reset();
 
-  testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+  testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
   testGotMessage(test, stream, methodMessage);
   testGotMessage(test, stream, subMessage);
 
@@ -990,7 +992,7 @@ if (Meteor.isClient) {
     await stream.reset();
 
     // verify that a reconnect message was sent.
-    testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+    testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
     // Make sure that the stream triggers connection.
     await stream.receive({ msg: 'connected', session: SESSION_ID + 1 });
 
@@ -1114,7 +1116,7 @@ if (Meteor.isClient) {
       // in. Reconnect quiescence happens as soon as 'connected' is received because
       // there are no pending methods or subs in need of revival.
       await stream.reset();
-      testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+      testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
       // Still holding out hope for session resumption, so nothing updated yet.
       test.equal(coll.find().count(), 1);
       test.equal(await coll.findOneAsync(stubWrittenId), {
@@ -1209,7 +1211,7 @@ if (Meteor.isClient) {
       // but slowMethod gets called via onReconnect. Reconnect quiescence is now
       // blocking on slowMethod.
       await stream.reset();
-      testGotMessage(test, stream, makeConnectMessage(SESSION_ID + 1));
+      testGotMessage(test, stream, makeConnectMessage(SESSION_ID + 1, conn._receivedCount));
       const slowMethodId = testGotMessage(test, stream, {
         msg: 'method',
         method: 'slowMethod',
@@ -1330,7 +1332,7 @@ Tinytest.addAsync('livedata stub - reconnect method which only got data', async 
   // Reset stream. Method gets resent (with same ID), and blocks reconnect
   // quiescence.
   await stream.reset();
-  testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+  testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
   testGotMessage(test, stream, {
     msg: 'method',
     method: 'doLittle',
@@ -1807,7 +1809,7 @@ addReconnectTests(
     // reconnect
     stream.sent = [];
     await stream.reset();
-    testGotMessage(test, stream, makeConnectMessage(conn._lastSessionId));
+    testGotMessage(test, stream, makeConnectMessage(conn._lastSessionId, conn._receivedCount));
 
     // Test that we sent what we expect to send, and we're blocked on
     // what we expect to be blocked. The subsequent logic to correctly
@@ -2033,7 +2035,7 @@ addReconnectTests(
     // reconnect
     stream.sent = [];
     await stream.reset();
-    testGotMessage(test, stream, makeConnectMessage(conn._lastSessionId));
+    testGotMessage(test, stream, makeConnectMessage(conn._lastSessionId, conn._receivedCount));
 
     // Test that we sent what we expect to send, and we're blocked on
     // what we expect to be blocked. The subsequent logic to correctly
@@ -2084,7 +2086,7 @@ addReconnectTests(
     // initial connect
     stream.sent = [];
     await stream.reset();
-    testGotMessage(test, stream, makeConnectMessage(conn._lastSessionId));
+    testGotMessage(test, stream, makeConnectMessage(conn._lastSessionId, conn._receivedCount));
 
     // Test that we sent just the login message.
     const loginId = testGotMessage(test, stream, {
@@ -2152,7 +2154,7 @@ addReconnectTests('livedata stub - reconnect double wait method', async function
   // Reset stream. halfwayMethod does NOT get resent, but reconnectMethod does!
   // Reconnect quiescence happens when reconnectMethod is done.
   await stream.reset();
-  testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+  testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
   const reconnectId = testGotMessage(test, stream, {
     msg: 'method',
     method: 'reconnectMethod',
@@ -2257,7 +2259,7 @@ Tinytest.addAsync('livedata stub - subscribe errors', async function(test) {
   // stream reset: reconnect!
   await stream.reset();
   // We send a connect.
-  testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+  testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
   // We should NOT re-sub to the sub, because we processed the error.
   test.length(stream.sent, 0);
   test.isFalse(onReadyFired);
@@ -2376,7 +2378,7 @@ if (Meteor.isClient) {
 
       // Initiate reconnect.
       await stream.reset();
-      testGotMessage(test, stream, makeConnectMessage(SESSION_ID));
+      testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
       testGotMessage(test, stream, subMessage);
       await stream.receive({ msg: 'connected', session: SESSION_ID + 1 });
 
@@ -2559,8 +2561,137 @@ if (Meteor.isClient) {
   );
 }
 
+// ============================================================================
+// DDP Session Resumption Tests (Client-side)
+// ============================================================================
+
+Tinytest.addAsync('livedata connection - receivedCount tracking', async function(test) {
+  const stream = new StubStream();
+  const conn = newConnection(stream);
+
+  // Initially receivedCount should be 0
+  test.equal(conn._receivedCount, 0);
+
+  await startAndConnect(test, stream);
+
+  // After receiving 'connected', receivedCount should be 1
+  // (the 'connected' message itself is counted)
+  test.equal(conn._receivedCount, 1);
+
+  // Receive some data messages
+  await stream.receive({ msg: 'added', collection: 'test', id: '1', fields: { a: 1 } });
+  test.equal(conn._receivedCount, 2);
+
+  await stream.receive({ msg: 'added', collection: 'test', id: '2', fields: { b: 2 } });
+  test.equal(conn._receivedCount, 3);
+
+  // Ping/pong should NOT increment receivedCount
+  await stream.receive({ msg: 'ping', id: 'ping1' });
+  test.equal(conn._receivedCount, 3, "ping should not increment receivedCount");
+
+  await stream.receive({ msg: 'pong', id: 'pong1' });
+  test.equal(conn._receivedCount, 3, "pong should not increment receivedCount");
+
+  // More data messages should continue incrementing
+  await stream.receive({ msg: 'changed', collection: 'test', id: '1', fields: { a: 2 } });
+  test.equal(conn._receivedCount, 4);
+});
+
+Tinytest.addAsync('livedata connection - receivedCount sent on reconnect', async function(test) {
+  const stream = new StubStream();
+  const conn = newConnection(stream);
+
+  await startAndConnect(test, stream);
+
+  // Receive some messages to build up receivedCount
+  await stream.receive({ msg: 'added', collection: 'test', id: '1', fields: {} });
+  await stream.receive({ msg: 'added', collection: 'test', id: '2', fields: {} });
+  await stream.receive({ msg: 'ready', subs: ['sub1'] });
+
+  const expectedReceivedCount = conn._receivedCount;
+  test.equal(expectedReceivedCount, 4); // connected + 3 messages
+
+  // Simulate disconnect and reconnect
+  await stream.reset();
+
+  // The connect message should include the receivedCount
+  const connectMsg = JSON.parse(stream.sent.shift());
+  test.equal(connectMsg.msg, 'connect');
+  test.equal(connectMsg.session, SESSION_ID);
+  test.equal(connectMsg.receivedCount, expectedReceivedCount,
+    "Connect message should include receivedCount for session resumption");
+});
+
+Tinytest.addAsync('livedata connection - receivedCount reset on new session', async function(test) {
+  const stream = new StubStream();
+  const conn = newConnection(stream);
+
+  await startAndConnect(test, stream);
+
+  // Build up some receivedCount
+  await stream.receive({ msg: 'added', collection: 'test', id: '1', fields: {} });
+  await stream.receive({ msg: 'added', collection: 'test', id: '2', fields: {} });
+  test.equal(conn._receivedCount, 3);
+
+  // Simulate reconnect
+  await stream.reset();
+  stream.sent.shift(); // consume connect message
+
+  // Server responds with a DIFFERENT session (new session, not resumed)
+  const newSessionId = SESSION_ID + '_new';
+  await stream.receive({ msg: 'connected', session: newSessionId });
+
+  // receivedCount should be reset to 1 (counting the new connected message)
+  test.equal(conn._receivedCount, 1,
+    "receivedCount should be reset to 1 when getting a new session");
+  test.equal(conn._lastSessionId, newSessionId);
+});
+
+Tinytest.addAsync('livedata connection - receivedCount preserved on session resume', async function(test) {
+  const stream = new StubStream();
+  const conn = newConnection(stream);
+
+  await startAndConnect(test, stream);
+
+  // Build up some receivedCount
+  await stream.receive({ msg: 'added', collection: 'test', id: '1', fields: {} });
+  await stream.receive({ msg: 'added', collection: 'test', id: '2', fields: {} });
+  const countBeforeDisconnect = conn._receivedCount;
+  test.equal(countBeforeDisconnect, 3);
+
+  // Simulate reconnect
+  await stream.reset();
+  stream.sent.shift(); // consume connect message
+
+  // Server responds with the SAME session (resumed)
+  await stream.receive({ msg: 'connected', session: SESSION_ID });
+
+  // receivedCount should continue from where it was (plus the connected message)
+  test.equal(conn._receivedCount, countBeforeDisconnect + 1,
+    "receivedCount should continue incrementing on session resume");
+  test.equal(conn._lastSessionId, SESSION_ID);
+});
+
+Tinytest.addAsync('livedata connection - disconnect sends disconnect message', async function(test) {
+  const stream = new StubStream();
+  const conn = newConnection(stream);
+
+  await startAndConnect(test, stream);
+
+  // Clear any pending messages
+  stream.sent.length = 0;
+
+  // Call disconnect
+  conn.disconnect();
+
+  // Should have sent a disconnect message
+  test.isTrue(stream.sent.length > 0, "Should have sent at least one message");
+  const disconnectMsg = JSON.parse(stream.sent.shift());
+  test.equal(disconnectMsg.msg, 'disconnect',
+    "disconnect() should send a disconnect message to the server");
+});
+
 // XXX also test:
-// - reconnect, with session resume.
 // - restart on update flag
 // - on_update event
 // - reloading when the app changes, including session migration

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2691,6 +2691,34 @@ Tinytest.addAsync('livedata connection - disconnect sends disconnect message', a
     "disconnect() should send a disconnect message to the server");
 });
 
+Tinytest.addAsync(
+  'livedata connection - malformed frames are discarded without crashing',
+  async function (test) {
+    const stream = new StubStream();
+    const conn = newConnection(stream);
+
+    await startAndConnect(test, stream);
+
+    // parseDDP returns null both for invalid JSON and for valid JSON that
+    // is not an object. Neither may throw out of the message handler.
+    await stream.receive('this is not json');
+    await stream.receive('"a bare string"');
+    await stream.receive('42');
+
+    // The connection still processes real messages afterwards.
+    let callbackFired = false;
+    conn.call('stillAlive', function () {
+      callbackFired = true;
+    });
+    const message = testGotMessage(test, stream, {
+      msg: 'method', method: 'stillAlive', params: [], id: '*'
+    });
+    await stream.receive({ msg: 'result', id: message.id, result: 'ok' });
+    await stream.receive({ msg: 'updated', methods: [message.id] });
+    test.isTrue(callbackFired);
+  }
+);
+
 // XXX also test:
 // - restart on update flag
 // - on_update event

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2723,3 +2723,33 @@ Tinytest.addAsync(
 // - restart on update flag
 // - on_update event
 // - reloading when the app changes, including session migration
+
+Tinytest.addAsync(
+  'livedata connection - unsub while disconnected is delivered after reconnect',
+  async function (test) {
+    const stream = new StubStream();
+    const conn = newConnection(stream);
+
+    await startAndConnect(test, stream);
+
+    const sub = conn.subscribe('queued-unsub-test');
+    const subMessage = testGotMessage(test, stream, {
+      msg: 'sub', id: '*', name: 'queued-unsub-test', params: []
+    });
+
+    // Stop the subscription while the stream is not connected. The stream
+    // drops data sent in this state, and the registry record is removed, so
+    // nothing would ever re-send the unsub — it must be queued.
+    stream.setStatus('waiting');
+    sub.stop();
+    test.length(stream.sent, 0);
+
+    // On reconnect the queued unsub goes out, after the connect message
+    // (and after any still-registered subscriptions would be re-sent).
+    stream.setStatus('connected');
+    await stream.reset();
+    testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
+    testGotMessage(test, stream, { msg: 'unsub', id: subMessage.id });
+    test.length(stream.sent, 0);
+  }
+);

--- a/packages/ddp-client/test/stub_stream.js
+++ b/packages/ddp-client/test/stub_stream.js
@@ -27,6 +27,10 @@ Object.assign(StubStream.prototype, {
     // no-op
   },
 
+  disconnect: function() {
+    // no-op - for testing Connection.disconnect()
+  },
+
   _lostConnection: function() {
     // no-op
   },

--- a/packages/ddp-client/test/stub_stream.js
+++ b/packages/ddp-client/test/stub_stream.js
@@ -20,7 +20,12 @@ Object.assign(StubStream.prototype, {
   },
 
   status: function() {
-    return { status: 'connected', fake: true };
+    return { status: this._status || 'connected', fake: true };
+  },
+
+  // Test helper: simulate a stream status (e.g. 'waiting' while offline).
+  setStatus: function(status) {
+    this._status = status;
   },
 
   reconnect: function() {

--- a/packages/ddp-server/crossbar.js
+++ b/packages/ddp-server/crossbar.js
@@ -59,8 +59,14 @@ Object.assign(DDPServer._Crossbar.prototype, {
         self.factPackage, self.factName, 1);
     }
 
+    var stopped = false;
     return {
       stop: function () {
+        // Idempotent: a second stop() used to decrement the count (and the
+        // server fact) again — silently dropping the collection's remaining
+        // listeners when the count hit zero, then throwing on later stops.
+        if (stopped) return;
+        stopped = true;
         if (self.factName && Package['facts-base']) {
           Package['facts-base'].Facts.incrementServerFact(
             self.factPackage, self.factName, -1);

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -81,11 +81,16 @@ var Session = function (server, version, socket, options) {
   var self = this;
   self.id = Random.id();
 
+  // how many messages we've actually sent (not queued to send) excluding ping/pong
+  // we'll use this to detect mismatch of data on reconnect.
+  self.sentCount = 0;
+
   self.server = server;
   self.version = version;
 
   self.initialized = false;
   self.socket = socket;
+  self.options = options;
 
   // Set to null when the session is destroyed. Multiple places below
   // use this to determine if the session is alive or not.
@@ -134,6 +139,8 @@ var Session = function (server, version, socket, options) {
   self.connectionHandle = {
     id: self.id,
     close: function () {
+      // Server-initiated close should not be resumable
+      self._expectingDisconnect = true;
       self.close();
     },
     onClose: function (fn) {
@@ -174,6 +181,8 @@ var Session = function (server, version, socket, options) {
   Package['facts-base'] && Package['facts-base'].Facts.incrementServerFact(
     "livedata", "sessions", 1);
 };
+
+const ignoredMsgsForSessionOutOfDateCheck = ['ping', 'pong'];
 
 Object.assign(Session.prototype, {
   sendReady: function (subscriptionIds) {
@@ -269,77 +278,101 @@ Object.assign(Session.prototype, {
   },
 
   startUniversalSubs: function () {
-    var self = this;
+    const self = this;
     // Make a shallow copy of the set of universal handlers and start them. If
     // additional universal publishers start while we're running them (due to
     // yielding), they will run separately as part of Server.publish.
-    var handlers = [...self.server.universal_publish_handlers];
-    handlers.forEach(function (handler) {
+    for (const handler of [...self.server.universal_publish_handlers]) {
       self._startSubscription(handler);
-    });
+    }
   },
 
   // Destroy this session and unregister it at the server.
   close: function () {
-    var self = this;
+    const self = this;
 
     // Destroy this session, even if it's not registered at the
     // server. Stop all processing and tear everything down. If a socket
     // was attached, close it.
 
-    // Already destroyed.
-    if (! self.inQueue)
+    // Already closing or closed - prevent multiple close() calls
+    if (self._isClosing) {
       return;
+    }
+    self._isClosing = true;
 
-    // Drop the merge box data immediately.
-    self.inQueue = null;
-    self.collectionViews = new Map();
-
-    if (self.heartbeat) {
-      self.heartbeat.stop();
-      self.heartbeat = null;
+    if (self._removeTimeoutHandle) {
+      Meteor.clearTimeout(self._removeTimeoutHandle);
+      self._removeTimeoutHandle = null;
     }
 
     if (self.socket) {
       self.socket.close();
       self.socket._meteorSession = null;
+      self.socket = null;
     }
 
-    Package['facts-base'] && Package['facts-base'].Facts.incrementServerFact(
-      "livedata", "sessions", -1);
+    // Stop heartbeat immediately - we don't need it during the grace period
+    // since we have no socket to send pings on anyway.
+    if (self.heartbeat) {
+      self.heartbeat.stop();
+      self.heartbeat = null;
+    }
 
-    Meteor.defer(function () {
-      // Stop callbacks can yield, so we defer this on close.
-      // sub._isDeactivated() detects that we set inQueue to null and
-      // treats it as semi-deactivated (it will ignore incoming callbacks, etc).
-      self._deactivateAllSubscriptions();
+    self.server._removeSession(self, () => {
+      Package['facts-base'] && Package['facts-base'].Facts.incrementServerFact(
+        "livedata", "sessions", -1);
 
-      // Defer calling the close callbacks, so that the caller closing
-      // the session isn't waiting for all the callbacks to complete.
-      self._closeCallbacks.forEach(function (callback) {
-        callback();
+      self.inQueue = null;
+      self.collectionViews = new Map();
+
+      if (self.heartbeat) {
+        self.heartbeat.stop();
+        self.heartbeat = null;
+      }
+
+      Meteor.defer(function () {
+        // stop callbacks can yield, so we defer this on close.
+        // sub._isDeactivated() detects that we set inQueue to null and
+        // treats it as semi-deactivated (it will ignore incoming callbacks, etc).
+        self._deactivateAllSubscriptions();
+
+        // Defer calling the close callbacks, so that the caller closing
+        // the session isn't waiting for all the callbacks to complete.
+        self._closeCallbacks.forEach(callback => {
+          callback();
+        });
       });
     });
-
-    // Unregister the session.
-    self.server._removeSession(self);
   },
 
   // Send a message (doing nothing if no socket is connected right now).
   // It should be a JSON object (it will be stringified).
   send: function (msg) {
     const self = this;
+    const isIgnoredMsg = ignoredMsgsForSessionOutOfDateCheck.includes(msg.msg);
+    if (self.messageQueue && !isIgnoredMsg) {
+      self.messageQueue.push(msg);
+      if (self.messageQueue.length > self.options.maxMessageQueueLength) {
+        Meteor.clearTimeout(self._removeTimeoutHandle);
+        self._pendingRemoveFunction();
+      }
+      return;
+    }
     if (self.socket) {
       if (Meteor._printSentDDP)
         Meteor._debug("Sent DDP", DDPCommon.stringifyDDP(msg));
+      if (!isIgnoredMsg) {
+        self.sentCount++;
+      }
       self.socket.send(DDPCommon.stringifyDDP(msg));
     }
   },
 
   // Send a connection error.
   sendError: function (reason, offendingMessage) {
-    var self = this;
-    var msg = {msg: 'error', reason: reason};
+    const self = this;
+    const msg = {msg: 'error', reason: reason};
     if (offendingMessage)
       msg.offendingMessage = offendingMessage;
     self.send(msg);
@@ -379,7 +412,7 @@ Object.assign(Session.prototype, {
     // the client is still alive.
     if (self.heartbeat) {
       self.heartbeat.messageReceived();
-    };
+    }
 
     if (self.version !== 'pre1' && msg_in.msg === 'ping') {
       if (self._respondToPings)
@@ -389,6 +422,13 @@ Object.assign(Session.prototype, {
     if (self.version !== 'pre1' && msg_in.msg === 'pong') {
       // Since everything is a pong, there is nothing to do
       return;
+    }
+
+    if (msg_in.msg === 'disconnect') {
+      if (msg_in.msg in self.protocol_handlers) {
+        // we want to pre-empt the queue - a disconnect is imminent.
+        return self.protocol_handlers[msg_in.msg].call(self, msg_in, () => {});
+      }
     }
 
     self.inQueue.push(msg_in);
@@ -444,6 +484,9 @@ Object.assign(Session.prototype, {
   },
 
   protocol_handlers: {
+    disconnect: function(msg) {
+      this._expectingDisconnect = true;
+    },
     sub: async function (msg, unblock) {
       var self = this;
 
@@ -1261,6 +1304,19 @@ Server = function (options = {}) {
     // For testing, allow responding to pings to be disabled.
     respondToPings: true,
     defaultPublicationStrategy: publicationStrategies.SERVER_MERGE,
+    /**
+     * @summary How many messages should we queue during a non-graceful disconnect before we kill the session (to insure against memory leaks).
+     * @type {Number}
+     * @locus Server
+     */
+    maxMessageQueueLength: 100,
+    /**
+     * @summary How long we should maintain a session for after a non-graceful disconnect before killing it
+     *          sessions that reconnect within this time will be resumed with minimal performance impact.
+     * @type {Number}
+     * @locus Server
+     */
+    disconnectGracePeriod: 15000,
     ...options,
   };
 
@@ -1433,13 +1489,63 @@ Object.assign(Server.prototype, {
     // Yay, version matches! Create a new session.
     // Note: Troposphere depends on the ability to mutate
     // Meteor.server.options.heartbeatTimeout! This is a hack, but it's life.
-    socket._meteorSession = new Session(self, version, socket, self.options);
-    self.sessions.set(socket._meteorSession.id, socket._meteorSession);
-    self.onConnectionHook.each(function (callback) {
-      if (socket._meteorSession)
-        callback(socket._meteorSession.connectionHandle);
-      return true;
-    });
+    const existingSession = self.sessions.get(msg.session);
+
+    // we've found a session with:
+    // the right ID
+    // a matching sent/received count
+    // was disconnected and hasn't been reconnected to yet.
+    if (existingSession && existingSession.sentCount === msg.receivedCount && existingSession._removeTimeoutHandle) {
+      Meteor.clearTimeout(existingSession._removeTimeoutHandle);
+      delete existingSession._removeTimeoutHandle;
+      delete existingSession._pendingRemoveFunction;
+      existingSession._isClosing = false; // Reset so session can be closed again later
+      socket._meteorSession = existingSession;
+      const messageQueue = existingSession.messageQueue;
+      delete existingSession.messageQueue;
+      existingSession.socket = socket;
+
+      // Restart heartbeat for the resumed session
+      if (existingSession.version !== 'pre1' && self.options.heartbeatInterval !== 0) {
+        socket.setWebsocketTimeout(0);
+        existingSession.heartbeat = new DDPCommon.Heartbeat({
+          heartbeatInterval: self.options.heartbeatInterval,
+          heartbeatTimeout: self.options.heartbeatTimeout,
+          onTimeout: function () {
+            existingSession.close();
+          },
+          sendPing: function () {
+            existingSession.send({msg: 'ping'});
+          }
+        });
+        existingSession.heartbeat.start();
+      }
+
+      // Send connected message so client can restart heartbeat and confirm resumption
+      existingSession.send({ msg: 'connected', session: existingSession.id });
+      if (messageQueue) {
+        Meteor.defer(() => {
+          messageQueue.forEach(msg => existingSession.send(msg));
+        });
+      }
+      // Note: onConnectionHook is NOT called on session resume - the connection
+      // is considered to be the same logical connection as before.
+    }
+    else {
+      // immediately remove the old session since we're out of date.
+      if (existingSession && existingSession._pendingRemoveFunction) {
+        Meteor.clearTimeout(existingSession._removeTimeoutHandle);
+        existingSession._pendingRemoveFunction();
+      }
+      socket._meteorSession = new Session(self, version, socket, self.options);
+      self.sessions.set(socket._meteorSession.id, socket._meteorSession);
+
+      self.onConnectionHook.each(function (callback) {
+        if (socket._meteorSession)
+          callback(socket._meteorSession.connectionHandle);
+        return true;
+      });
+    }
   },
   /**
    * Register a publish handler function.
@@ -1529,9 +1635,31 @@ Object.assign(Server.prototype, {
     }
   },
 
-  _removeSession: function (session) {
+  _removeSession: function (session, callback = () => {}) {
     var self = this;
-    self.sessions.delete(session.id);
+    const sessionRemoveFunction = () => {
+      // Guard against being called multiple times (e.g., from both overflow and timeout)
+      if (!self.sessions.has(session.id)) {
+        return;
+      }
+      // Clear timeout handle if it exists to prevent double execution
+      if (session._removeTimeoutHandle) {
+        Meteor.clearTimeout(session._removeTimeoutHandle);
+        session._removeTimeoutHandle = null;
+      }
+      session._pendingRemoveFunction = null;
+      self.sessions.delete(session.id);
+      callback();
+    };
+    if (session._expectingDisconnect) {
+      return sessionRemoveFunction();
+    }
+    session.messageQueue = [];
+    session._pendingRemoveFunction = sessionRemoveFunction;
+    if (session._removeTimeoutHandle) {
+      Meteor.clearTimeout(session._removeTimeoutHandle);
+    }
+    session._removeTimeoutHandle = Meteor.setTimeout(sessionRemoveFunction, self.options.disconnectGracePeriod);
   },
 
   /**

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -287,6 +287,14 @@ Object.assign(Session.prototype, {
     }
   },
 
+  // Stop heartbeat if running
+  _stopHeartbeat: function () {
+    if (this.heartbeat) {
+      this.heartbeat.stop();
+      this.heartbeat = null;
+    }
+  },
+
   // Destroy this session and unregister it at the server.
   close: function () {
     const self = this;
@@ -314,10 +322,7 @@ Object.assign(Session.prototype, {
 
     // Stop heartbeat immediately - we don't need it during the grace period
     // since we have no socket to send pings on anyway.
-    if (self.heartbeat) {
-      self.heartbeat.stop();
-      self.heartbeat = null;
-    }
+    self._stopHeartbeat();
 
     self.server._removeSession(self, () => {
       Package['facts-base'] && Package['facts-base'].Facts.incrementServerFact(
@@ -326,10 +331,7 @@ Object.assign(Session.prototype, {
       self.inQueue = null;
       self.collectionViews = new Map();
 
-      if (self.heartbeat) {
-        self.heartbeat.stop();
-        self.heartbeat = null;
-      }
+      self._stopHeartbeat();
 
       Meteor.defer(function () {
         // stop callbacks can yield, so we defer this on close.
@@ -425,10 +427,8 @@ Object.assign(Session.prototype, {
     }
 
     if (msg_in.msg === 'disconnect') {
-      if (msg_in.msg in self.protocol_handlers) {
-        // we want to pre-empt the queue - a disconnect is imminent.
-        return self.protocol_handlers[msg_in.msg].call(self, msg_in, () => {});
-      }
+      // Pre-empt the queue - a disconnect is imminent.
+      return self.protocol_handlers.disconnect.call(self, msg_in, () => {});
     }
 
     self.inQueue.push(msg_in);
@@ -1305,7 +1305,7 @@ Server = function (options = {}) {
     respondToPings: true,
     defaultPublicationStrategy: publicationStrategies.SERVER_MERGE,
     /**
-     * @summary How many messages should we queue during a non-graceful disconnect before we kill the session (to insure against memory leaks).
+     * @summary How many messages should we queue during a non-graceful disconnect before we destroy the session, to help prevent memory leaks.
      * @type {Number}
      * @locus Server
      */
@@ -1486,7 +1486,7 @@ Object.assign(Server.prototype, {
       return;
     }
 
-    // Yay, version matches! Create a new session.
+    // Yay, version matches! Resume existing session if possible, otherwise create a new one.
     // Note: Troposphere depends on the ability to mutate
     // Meteor.server.options.heartbeatTimeout! This is a hack, but it's life.
     const existingSession = self.sessions.get(msg.session);
@@ -1497,12 +1497,12 @@ Object.assign(Server.prototype, {
     // was disconnected and hasn't been reconnected to yet.
     if (existingSession && existingSession.sentCount === msg.receivedCount && existingSession._removeTimeoutHandle) {
       Meteor.clearTimeout(existingSession._removeTimeoutHandle);
-      delete existingSession._removeTimeoutHandle;
-      delete existingSession._pendingRemoveFunction;
+      existingSession._removeTimeoutHandle = undefined;
+      existingSession._pendingRemoveFunction = undefined;
       existingSession._isClosing = false; // Reset so session can be closed again later
       socket._meteorSession = existingSession;
       const messageQueue = existingSession.messageQueue;
-      delete existingSession.messageQueue;
+      existingSession.messageQueue = undefined;
       existingSession.socket = socket;
 
       // Restart heartbeat for the resumed session

--- a/packages/ddp-server/livedata_server.js
+++ b/packages/ddp-server/livedata_server.js
@@ -141,6 +141,13 @@ var Session = function (server, version, socket, options) {
     close: function () {
       // Server-initiated close should not be resumable
       self._expectingDisconnect = true;
+      if (self._isClosing && self._pendingRemoveFunction) {
+        // close() already ran and the session is sitting in its resumption
+        // grace period; terminate it now instead of silently doing nothing.
+        Meteor.clearTimeout(self._removeTimeoutHandle);
+        self._pendingRemoveFunction();
+        return;
+      }
       self.close();
     },
     onClose: function (fn) {
@@ -1495,11 +1502,13 @@ Object.assign(Server.prototype, {
     // the right ID
     // a matching sent/received count
     // was disconnected and hasn't been reconnected to yet.
-    if (existingSession && existingSession.sentCount === msg.receivedCount && existingSession._removeTimeoutHandle) {
+    if (existingSession && existingSession.sentCount === msg.receivedCount &&
+        existingSession._removeTimeoutHandle && !existingSession._expectingDisconnect) {
       Meteor.clearTimeout(existingSession._removeTimeoutHandle);
       existingSession._removeTimeoutHandle = undefined;
       existingSession._pendingRemoveFunction = undefined;
       existingSession._isClosing = false; // Reset so session can be closed again later
+      existingSession._expectingDisconnect = undefined;
       socket._meteorSession = existingSession;
       const messageQueue = existingSession.messageQueue;
       existingSession.messageQueue = undefined;
@@ -1523,10 +1532,12 @@ Object.assign(Server.prototype, {
 
       // Send connected message so client can restart heartbeat and confirm resumption
       existingSession.send({ msg: 'connected', session: existingSession.id });
+      // Flush the messages buffered during the grace period synchronously,
+      // before anything else (e.g. a live observe callback) can send on the
+      // reattached socket — deferring the flush would let newer messages
+      // jump ahead of older buffered ones and break DDP's ordering.
       if (messageQueue) {
-        Meteor.defer(() => {
-          messageQueue.forEach(msg => existingSession.send(msg));
-        });
+        messageQueue.forEach(msg => existingSession.send(msg));
       }
       // Note: onConnectionHook is NOT called on session resume - the connection
       // is considered to be the same logical connection as before.
@@ -1648,6 +1659,11 @@ Object.assign(Server.prototype, {
         session._removeTimeoutHandle = null;
       }
       session._pendingRemoveFunction = null;
+      // Stop buffering: with the queue gone, send() falls through to the
+      // (null) socket and becomes a no-op. Leaving the queue in place would
+      // buffer into a removed session until overflow invoked the
+      // now-nulled _pendingRemoveFunction and threw.
+      session.messageQueue = null;
       self.sessions.delete(session.id);
       callback();
     };

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -878,8 +878,12 @@ Tinytest.addAsync(
       // Reconnect
       clientConn.reconnect();
 
-      // Wait for reconnection with timeout
+      // Wait for reconnection with timeout. The stream reports 'connected' at
+      // socket open, one RTT before the DDP 'connected' message updates
+      // _lastSessionId — wait for the handshake to land, like the
+      // count-mismatch test below does.
       await pollUntil(() => clientConn.status().connected);
+      await sleep(WITHIN_GRACE_PERIOD_MS);
 
       // Should have a NEW session (not resumed, because we gracefully disconnected)
       test.notEqual(

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -1,3 +1,38 @@
+// Helper to temporarily set disconnectGracePeriod for DDP resumption tests
+// This ensures test isolation - other tests run with the default grace period
+const DEFAULT_GRACE_PERIOD = Meteor.server.options.disconnectGracePeriod;
+const TEST_GRACE_PERIOD = 5000; // Short grace period for fast tests (ms)
+// Derived timing constants to avoid hardcoding throughout tests
+const WITHIN_GRACE_PERIOD_MS = Math.floor(TEST_GRACE_PERIOD / 4); // Well within grace period
+const AFTER_GRACE_PERIOD_MS = Math.ceil(TEST_GRACE_PERIOD * 1.5); // After grace period expires
+const POLL_TIMEOUT_MS = TEST_GRACE_PERIOD * 2; // Max time to wait for async operations before failing
+
+async function withTestGracePeriod(fn) {
+  const previous = Meteor.server.options.disconnectGracePeriod;
+  Meteor.server.options.disconnectGracePeriod = TEST_GRACE_PERIOD;
+  try {
+    await fn();
+  } finally {
+    Meteor.server.options.disconnectGracePeriod = previous ?? DEFAULT_GRACE_PERIOD;
+  }
+}
+
+// Helper to poll for a condition with timeout to prevent hanging tests
+function pollUntil(conditionFn, timeoutMs = POLL_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+    const interval = setInterval(() => {
+      if (conditionFn()) {
+        clearInterval(interval);
+        resolve();
+      } else if (Date.now() - startTime > timeoutMs) {
+        clearInterval(interval);
+        reject(new Error(`Timed out after ${timeoutMs}ms waiting for condition`));
+      }
+    }, 10);
+  });
+}
+
 Tinytest.addAsync(
   "livedata server - connectionHandle.onClose()",
   function (test, onComplete) {
@@ -594,6 +629,346 @@ function getTestConnections(test) {
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+// ============================================================================
+// DDP Session Resumption Tests
+// ============================================================================
+
+// Test that unexpected disconnects allow session resumption within grace period
+Tinytest.addAsync(
+  "livedata server - DDP resumption: unexpected disconnect preserves session",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const { clientConn, serverConn } = await getTestConnections(test);
+      const originalSessionId = serverConn.id;
+
+      // Verify the session exists
+      test.isTrue(Meteor.server.sessions.has(originalSessionId));
+
+      // Simulate unexpected disconnect by forcing the stream to close
+      // without sending a disconnect message
+      clientConn._stream._lostConnection();
+
+      // Wait a bit but less than the grace period
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+
+      // Session should still exist during grace period
+      test.isTrue(
+        Meteor.server.sessions.has(originalSessionId),
+        "Session should be preserved during grace period"
+      );
+
+      // Wait for grace period to expire
+      await sleep(AFTER_GRACE_PERIOD_MS);
+
+      // Session should be removed after grace period
+      test.isFalse(
+        Meteor.server.sessions.has(originalSessionId),
+        "Session should be removed after grace period expires"
+      );
+    });
+  }
+);
+
+// Test that graceful disconnects (client sends disconnect message) remove session immediately
+Tinytest.addAsync(
+  "livedata server - DDP resumption: graceful disconnect removes session immediately",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const { clientConn, serverConn } = await getTestConnections(test);
+      const originalSessionId = serverConn.id;
+
+      // Verify the session exists
+      test.isTrue(Meteor.server.sessions.has(originalSessionId));
+
+      // Graceful disconnect - this sends the disconnect message
+      clientConn.disconnect();
+
+      // Wait a moment for the disconnect to process
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+
+      // Session should be removed immediately (not waiting for grace period)
+      test.isFalse(
+        Meteor.server.sessions.has(originalSessionId),
+        "Session should be removed immediately after graceful disconnect"
+      );
+    });
+  }
+);
+
+// Test that server-initiated close removes session immediately (not resumable)
+Tinytest.addAsync(
+  "livedata server - DDP resumption: server-initiated close removes session immediately",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const { clientConn, serverConn } = await getTestConnections(test);
+      const originalSessionId = serverConn.id;
+
+      // Verify the session exists
+      test.isTrue(Meteor.server.sessions.has(originalSessionId));
+
+      // Server-initiated close via connectionHandle.close()
+      serverConn.close();
+
+      // Wait a moment for the close to process
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+
+      // Session should be removed immediately (server kicks should not be resumable)
+      test.isFalse(
+        Meteor.server.sessions.has(originalSessionId),
+        "Session should be removed immediately after server-initiated close"
+      );
+    });
+  }
+);
+
+// Test that onConnection hook is NOT called on session resume
+Tinytest.addAsync(
+  "livedata server - DDP resumption: onConnection not called on resume",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      let onConnectionCallCount = 0;
+      let lastConnectionId = null;
+
+      const handle = Meteor.onConnection(function (conn) {
+        onConnectionCallCount++;
+        lastConnectionId = conn.id;
+      });
+
+      // Create initial connection
+      const clientConn = DDP.connect(Meteor.absoluteUrl(), { retry: false });
+
+      // Wait for connection with timeout
+      await pollUntil(() => clientConn._lastSessionId);
+
+      const originalSessionId = clientConn._lastSessionId;
+      test.equal(onConnectionCallCount, 1, "onConnection should be called once on initial connect");
+      test.equal(lastConnectionId, originalSessionId);
+
+      // Get the server session and verify it exists
+      const serverSession = Meteor.server.sessions.get(originalSessionId);
+      test.isTrue(serverSession, "Server session should exist");
+
+      // Simulate unexpected disconnect
+      clientConn._stream._lostConnection();
+
+      // Wait a bit (less than grace period)
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+
+      // Session should still exist
+      test.isTrue(
+        Meteor.server.sessions.has(originalSessionId),
+        "Session should still exist during grace period"
+      );
+
+      // Reconnect - this should resume the session
+      clientConn._stream.reconnect();
+
+      // Wait for reconnection with timeout
+      await pollUntil(() => clientConn.status().connected);
+
+      // Give it a moment to process
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+
+      // IMPORTANT: Assert that session was actually resumed (same session ID)
+      // If this fails, the test is not actually testing resumption
+      test.equal(
+        clientConn._lastSessionId,
+        originalSessionId,
+        "Session should be resumed with same session ID"
+      );
+
+      // onConnection should NOT have been called again for a resumed session
+      test.equal(
+        onConnectionCallCount,
+        1,
+        "onConnection should not be called again on session resume"
+      );
+
+      handle.stop();
+      clientConn.disconnect();
+    });
+  }
+);
+
+// Test that server-initiated close prevents session resumption
+Tinytest.addAsync(
+  "livedata server - DDP resumption: server close prevents resumption",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      let onConnectionCallCount = 0;
+
+      const handle = Meteor.onConnection(function (conn) {
+        onConnectionCallCount++;
+      });
+
+      // Create initial connection
+      const clientConn = DDP.connect(Meteor.absoluteUrl(), { retry: true });
+
+      // Wait for connection with timeout
+      await pollUntil(() => clientConn._lastSessionId);
+
+      const originalSessionId = clientConn._lastSessionId;
+      test.equal(onConnectionCallCount, 1, "onConnection should be called once on initial connect");
+
+      // Get the server session
+      const serverSession = Meteor.server.sessions.get(originalSessionId);
+      test.isTrue(serverSession, "Server session should exist");
+
+      // Server-initiated close (kick the client)
+      serverSession.connectionHandle.close();
+
+      // Wait for client to reconnect with new session (retry is enabled)
+      await pollUntil(() =>
+        clientConn.status().connected && clientConn._lastSessionId !== originalSessionId
+      );
+
+      // Should have a NEW session (not resumed)
+      test.notEqual(
+        clientConn._lastSessionId,
+        originalSessionId,
+        "Should have a new session ID after server-initiated close"
+      );
+
+      // onConnection should have been called again (new session, not resumed)
+      test.equal(
+        onConnectionCallCount,
+        2,
+        "onConnection should be called again after server-initiated close"
+      );
+
+      handle.stop();
+      clientConn.disconnect();
+    });
+  }
+);
+
+// Test that graceful client disconnect prevents session resumption
+Tinytest.addAsync(
+  "livedata server - DDP resumption: graceful disconnect prevents resumption",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      let onConnectionCallCount = 0;
+
+      const handle = Meteor.onConnection(function (conn) {
+        onConnectionCallCount++;
+      });
+
+      // Create initial connection with retry enabled
+      const clientConn = DDP.connect(Meteor.absoluteUrl(), { retry: true });
+
+      // Wait for connection with timeout
+      await pollUntil(() => clientConn._lastSessionId);
+
+      const originalSessionId = clientConn._lastSessionId;
+      test.equal(onConnectionCallCount, 1, "onConnection should be called once on initial connect");
+
+      // Graceful disconnect (sends disconnect message)
+      clientConn.disconnect();
+
+      // Wait for session to be removed
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+
+      // Session should be removed immediately
+      test.isFalse(
+        Meteor.server.sessions.has(originalSessionId),
+        "Session should be removed after graceful disconnect"
+      );
+
+      // Reconnect
+      clientConn.reconnect();
+
+      // Wait for reconnection with timeout
+      await pollUntil(() => clientConn.status().connected);
+
+      // Should have a NEW session (not resumed, because we gracefully disconnected)
+      test.notEqual(
+        clientConn._lastSessionId,
+        originalSessionId,
+        "Should have a new session ID after graceful disconnect and reconnect"
+      );
+
+      // onConnection should have been called again
+      test.equal(
+        onConnectionCallCount,
+        2,
+        "onConnection should be called again after graceful disconnect"
+      );
+
+      handle.stop();
+      clientConn.disconnect();
+    });
+  }
+);
+
+// Test that receivedCount mismatch causes new session (not resume)
+Tinytest.addAsync(
+  "livedata server - DDP resumption: count mismatch creates new session",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      let onConnectionCallCount = 0;
+
+      const handle = Meteor.onConnection(function (conn) {
+        onConnectionCallCount++;
+      });
+
+      // Create initial connection
+      const clientConn = DDP.connect(Meteor.absoluteUrl(), { retry: false });
+
+      // Wait for connection with timeout
+      await pollUntil(() => clientConn._lastSessionId);
+
+      const originalSessionId = clientConn._lastSessionId;
+      test.equal(onConnectionCallCount, 1, "onConnection should be called once on initial connect");
+
+      // Get the server session
+      const serverSession = Meteor.server.sessions.get(originalSessionId);
+      test.isTrue(serverSession, "Server session should exist");
+
+      // Artificially increment sentCount to create a mismatch
+      // This simulates messages sent by server that client didn't receive
+      serverSession.sentCount += 5;
+
+      // Simulate unexpected disconnect
+      clientConn._stream._lostConnection();
+
+      // Wait a bit (less than grace period)
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+
+      // Session should still exist during grace period
+      test.isTrue(
+        Meteor.server.sessions.has(originalSessionId),
+        "Session should still exist during grace period"
+      );
+
+      // Reconnect - this should NOT resume due to count mismatch
+      clientConn._stream.reconnect();
+
+      // Wait for reconnection with timeout
+      await pollUntil(() => clientConn.status().connected);
+
+      // Give it a moment to process
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+
+      // Should have a NEW session (counts didn't match)
+      test.notEqual(
+        clientConn._lastSessionId,
+        originalSessionId,
+        "Should have a new session ID when counts mismatch"
+      );
+
+      // onConnection should have been called again (new session)
+      test.equal(
+        onConnectionCallCount,
+        2,
+        "onConnection should be called again when counts mismatch"
+      );
+
+      handle.stop();
+      clientConn.disconnect();
+    });
+  }
+);
 
 // ============================================================================
 // Async onStop cleanup tests (memory leak fix)

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -701,7 +701,7 @@ Tinytest.addAsync(
   "livedata server - DDP resumption: server-initiated close removes session immediately",
   async function (test) {
     await withTestGracePeriod(async () => {
-      const { clientConn, serverConn } = await getTestConnections(test);
+      const { serverConn } = await getTestConnections(test);
       const originalSessionId = serverConn.id;
 
       // Verify the session exists

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -1148,3 +1148,32 @@ Tinytest.addAsync(
     delete asyncCleanupTracker[trackerId];
   }
 );
+// A crossbar listen handle's stop() must be idempotent. A second stop()
+// used to decrement the listener count again, silently deleting the
+// collection's remaining listeners once it hit zero (and throwing on any
+// later stop). Observer teardown races make double-stop plausible.
+Tinytest.addAsync(
+  "livedata server - crossbar listen handle stop is idempotent",
+  async function (test) {
+    const crossbar = new DDPServer._Crossbar({});
+    let fired = 0;
+    const handleA = crossbar.listen(
+      { collection: 'crossbar-idempotent-stop' },
+      function () {}
+    );
+    const handleB = crossbar.listen(
+      { collection: 'crossbar-idempotent-stop' },
+      function () {
+        fired++;
+      }
+    );
+
+    handleA.stop();
+    handleA.stop(); // no-op, must not disturb other listeners
+
+    await crossbar.fire({ collection: 'crossbar-idempotent-stop', id: 'x' });
+    test.equal(fired, 1);
+
+    handleB.stop(); // must not throw
+  }
+);

--- a/packages/ddp-server/livedata_server_tests.js
+++ b/packages/ddp-server/livedata_server_tests.js
@@ -970,6 +970,110 @@ Tinytest.addAsync(
   }
 );
 
+// Test that send() on a removed session is a safe no-op
+Tinytest.addAsync(
+  "livedata server - DDP resumption: send after session removal is a no-op",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const { clientConn, serverConn } = await getTestConnections(test);
+      const session = Meteor.server.sessions.get(serverConn.id);
+
+      // Unexpected disconnect: session enters its grace period and buffers.
+      clientConn._stream._lostConnection();
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+      test.isTrue(
+        Array.isArray(session.messageQueue),
+        "session should buffer messages during the grace period"
+      );
+
+      // Let the grace period expire — the session is removed.
+      await sleep(AFTER_GRACE_PERIOD_MS);
+      test.isFalse(Meteor.server.sessions.has(serverConn.id));
+
+      // The buffer must be gone, and a late send (e.g. a deferred
+      // write-fence callback) must not buffer toward an overflow that
+      // would invoke the nulled _pendingRemoveFunction and throw.
+      test.isNull(session.messageQueue);
+      session.send({ msg: 'added', collection: 'x', id: '1', fields: {} });
+      test.isNull(session.messageQueue);
+    });
+  }
+);
+
+// Test that a server-initiated close during the grace period removes the
+// session immediately instead of silently doing nothing
+Tinytest.addAsync(
+  "livedata server - DDP resumption: connection close during grace period removes session",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const { clientConn, serverConn } = await getTestConnections(test);
+      const sessionId = serverConn.id;
+      const session = Meteor.server.sessions.get(sessionId);
+
+      // Unexpected disconnect: session enters its grace period.
+      clientConn._stream._lostConnection();
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+      test.isTrue(
+        Meteor.server.sessions.has(sessionId),
+        "session should be in its grace period"
+      );
+
+      // Server explicitly closes the connection: the session must not
+      // remain resumable.
+      session.connectionHandle.close();
+      test.isFalse(
+        Meteor.server.sessions.has(sessionId),
+        "server-initiated close should remove the session immediately"
+      );
+    });
+  }
+);
+
+// Test that messages buffered during the grace period are delivered on
+// resume, and that the resumed session gets a fresh grace period later
+Tinytest.addAsync(
+  "livedata server - DDP resumption: grace-period messages delivered on resume",
+  async function (test) {
+    await withTestGracePeriod(async () => {
+      const clientConn = DDP.connect(Meteor.absoluteUrl(), { retry: false });
+      await pollUntil(() => clientConn._lastSessionId);
+      const sessionId = clientConn._lastSessionId;
+      const session = Meteor.server.sessions.get(sessionId);
+
+      // Record raw messages arriving on the client stream.
+      const received = [];
+      clientConn._stream.on('message', raw => received.push(raw));
+
+      // Unexpected disconnect, then buffer a message during the grace period.
+      clientConn._stream._lostConnection();
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+      session.send({
+        msg: 'added', collection: 'resume-order', id: 'q1', fields: {}
+      });
+      test.isTrue(Array.isArray(session.messageQueue));
+
+      // Resume.
+      clientConn._stream.reconnect();
+      await pollUntil(() => clientConn.status().connected);
+      await sleep(WITHIN_GRACE_PERIOD_MS);
+      test.equal(clientConn._lastSessionId, sessionId,
+        "session should have been resumed");
+
+      // The buffered message reached the client...
+      test.isTrue(
+        received.some(raw => raw.indexOf('"q1"') !== -1),
+        "message buffered during the grace period should be delivered on resume"
+      );
+      // ...the queue is detached...
+      test.isUndefined(session.messageQueue);
+      // ...and no stale flag denies the session its next grace period.
+      test.isFalse(!!session._expectingDisconnect);
+
+      clientConn.disconnect();
+    });
+  }
+);
+
 // ============================================================================
 // Async onStop cleanup tests (memory leak fix)
 // ============================================================================

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '3.2.0',
+  version: '3.2.1-patch',
   documentation: null,
 });
 

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '3.2.1-patch',
+  version: '3.2.1-patch.0',
   documentation: null,
 });
 

--- a/packages/ddp/package.js
+++ b/packages/ddp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data framework",
-  version: '1.4.2',
+  version: '1.4.3-patch.0',
 });
 
 Package.onUse(function (api) {

--- a/packages/meteor-tool/package.js
+++ b/packages/meteor-tool/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "The Meteor command-line tool",
-  version: '3.4.1',
+  version: '3.4.1-patch.0',
 });
 
 Package.includeTool();

--- a/scripts/admin/meteor-release-experimental.json
+++ b/scripts/admin/meteor-release-experimental.json
@@ -1,6 +1,6 @@
 {
   "track": "METEOR",
-  "version": "3.4.1-rc.1",
+  "version": "3.4.1-patch.0",
   "recommended": false,
   "official": false,
   "description": "Meteor experimental release"

--- a/v3-docs/docs/api/meteor.md
+++ b/v3-docs/docs/api/meteor.md
@@ -995,16 +995,17 @@ contains the following fields:
   security risk for this transport. For details and alternatives, see
   the [SockJS documentation](https://github.com/sockjs/sockjs-node#authorisation).
 
-> Currently when a client reconnects to the server (such as after
-> temporarily losing its Internet connection), it will get a new
-> connection each time. The `onConnection` callbacks will be called
-> again, and the new connection will have a new connection `id`.
+> In previous versions of Meteor, when a client reconnects to the server (such as after temporarily losing its Internet connection), it will get a new connection each time. The `onConnection` callbacks will be called again, and the new connection will have a new connection `id`.
 
-> In the future, when client reconnection is fully implemented,
-> reconnecting from the client will reconnect to the same connection on
-> the server: the `onConnection` callback won't be called for that
-> connection again, and the connection will still have the same
-> connection `id`.
+> With the new client reconnection feature ([DDP resumption](https://github.com/meteor/meteor/pull/13378)) introduced in Meteor version 3.4, the client will attempt to automatically resume the previous connection to the server without calling the `onConnection` callback again and the connection will still keep the previous connection `id`. This functionality is controlled by the following new server options:
+
+### Meteor.server.options.disconnectGracePeriod
+
+Defines how long (in milliseconds) we should maintain a session for after a non-graceful disconnect before destroying it. Sessions that reconnect within this time will be resumed with minimal performance impact. Defaults to `15000`.
+
+### Meteor.server.options.maxMessageQueueLength
+
+Determines how many messages we should queue during a non-graceful disconnect before we destroy the session, to insure against memory leaks. Defaults to `100`.
 
 <ApiBox name="DDP.connect"  hasCustomExample/>
 

--- a/v3-docs/docs/api/meteor.md
+++ b/v3-docs/docs/api/meteor.md
@@ -995,9 +995,11 @@ contains the following fields:
   security risk for this transport. For details and alternatives, see
   the [SockJS documentation](https://github.com/sockjs/sockjs-node#authorisation).
 
-> In previous versions of Meteor, when a client reconnects to the server (such as after temporarily losing its Internet connection), it will get a new connection each time. The `onConnection` callbacks will be called again, and the new connection will have a new connection `id`.
+## Reconnection
 
-> With the new client reconnection feature ([DDP resumption](https://github.com/meteor/meteor/pull/13378)) introduced in Meteor version 3.4, the client will attempt to automatically resume the previous connection to the server without calling the `onConnection` callback again and the connection will still keep the previous connection `id`. This functionality is controlled by the following new server options:
+Meteor 3.5+ supports [DDP session resumption](https://github.com/meteor/meteor/pull/14051), allowing clients to automatically resume their previous connection after a temporary network disconnect. When a client reconnects within the grace period, the `onConnection` callback is not called again and the connection retains its original `id`.
+
+This behavior is controlled by the following server options:
 
 ### Meteor.server.options.disconnectGracePeriod
 
@@ -1005,7 +1007,7 @@ Defines how long (in milliseconds) we should maintain a session for after a non-
 
 ### Meteor.server.options.maxMessageQueueLength
 
-Determines how many messages we should queue during a non-graceful disconnect before we destroy the session, to insure against memory leaks. Defaults to `100`.
+Determines how many messages we should queue during a non-graceful disconnect before we destroy the session, to help prevent memory leaks. Defaults to `100`.
 
 <ApiBox name="DDP.connect"  hasCustomExample/>
 


### PR DESCRIPTION
## Why

Meteor 3.5 shipped DDP session resumption ([PR #14051](https://github.com/meteor/meteor/pull/14051)), but it requires **both** packages: a 3.2.0 client never sends `receivedCount`, so it gets zero benefit from a resuming server. Apps pinned on Meteor 3.4.1 — for example behind proxies or load balancers that terminate long-lived WebSocket connections — pay a full session teardown on every reconnect: re-login, every publish re-run, full mergebox rebuild, all documents re-sent, simultaneously across all clients.

This branch backports resumption onto the released 3.4.1 code so it can be published as **ddp-server@3.2.1-patch + ddp-client@3.2.1-patch**, installable on unchanged Meteor 3.4.1 for apps that can't move to 3.5.x yet.

## What's included (in order)

| Commit here | Upstream | What |
|---|---|---|
| 30f3459c85 | 00ff9c17b5 (PR #14051) | The session-resumption feature |
| 795e120c03 | 4984d3bf1e (PR #14051) | Review-feedback follow-up (required for the fixes below to apply) |
| 9a6c238c12 | fa7457c0ff (PR #14528, 3.5.1) | Harden resumption edge cases |
| 1729c1b327 | 953918033a (PR #14528, 3.5.1) | Regression tests for the above |
| fcd444f363 | ec3dedd94d (PR #14530, 3.5.1) | Discard malformed DDP frames (protects receivedCount accounting) |
| 8dca5dc5b9 | 2ef12d9c56 (PR #14542, 3.5.1) | Queue messages sent while disconnected (fixes ghost subscriptions on resume) |
| 93452dd94d | 15cdabdef8 (PR #14536, 3.5.1) | Idempotent crossbar listen-handle stop (safety net for resumption teardown races) |
| 74b8503c12 | — | Version bumps 3.2.0 → 3.2.1-patch |
| 9151013c63 | — | Deflake the graceful-disconnect test (same race exists on devel; separate fix incoming there) |

The third commit of upstream PR #14051 (c5b725020b, flaky-test fix) cherry-picked empty — its content is already in 3.4.1.

**Conflict resolutions** (all in test files, both end-of-file test-append collisions): the picks of PR #14530 and PR #14542 carried tests belonging to fixes *not* in this backport (PR #14526's batch-size test, PR #14544's stop-callback test, PR #14538's connection-tracking test) — those tests were dropped since they'd fail without their code changes; everything else is verbatim upstream.

**Deliberately not included** (pre-existing 3.4.1 bugs, not resumption regressions — reviewers can opt in): PR #14544, #14538, #14526, #14532, #14534. Also skipped: PR #14546 (targets 3.5's pluggable client transports, N/A here).

## Verification

- Full Tinytest suites for both packages run on the **installed Meteor 3.4.1 tool** with only these two packages local (`METEOR_PACKAGE_DIRS`) and every other dependency from the stock 3.4.1 catalog — the exact mix an app on 3.4.1 would run: **190 passed, 0 failed** (`meteor test-packages ddp-server ddp-client --driver-package test-in-console`).
- One earlier failure was root-caused to a race in the test itself (asserting `_lastSessionId` one RTT before the DDP handshake lands; the stream reports 'connected' at socket open). Fixed here by mirroring the sibling test's settle-wait; the same fix is being PRed to devel.
- `node --check` passes on every changed file; the async-onStop memory-leak fix that *is* ddp-server 3.2.0 was verified to survive the merge intact.

## Publish status

**Published**: `ddp-server@3.2.1-patch` and `ddp-client@3.2.1-patch` are live on the package server (visible via `meteor show <pkg> --show-all`; prerelease versions are hidden from the default listing).

## Consuming the published packages

**Heads-up, verified empirically:** a direct pin of the published `-patch` versions does **not** resolve on release METEOR@3.4.1. In a fresh 3.4.1 app, `ddp-client@=3.2.1-patch!` + `ddp-server@=3.2.1-patch!` fail with `No version of ddp-client satisfies all constraints`. Root cause: the constraint solver's "analyze allowed versions" pre-filter (`packages/constraint-solver/solver.js`, ~line 114) applies the release manifest's `~3.2.0` constraint before the `!` override analysis marks other constraints as weak minimums, and a semver `~` range excludes prerelease versions — so `3.2.1-patch` is pruned from the candidate set before the override can apply. (Filed as a separate solver fix for devel; that fix won't help apps on already-released tools.)

Two working consumption paths:

1. **Custom release (keeps these exact package versions):** publish a release `METEOR@3.4.1-patch` whose manifest is identical to `METEOR@3.4.1` (same `meteor-tool@3.4.1`) except `ddp-server`/`ddp-client` set to `3.2.1-patch`, via `meteor publish-release <manifest>.json`. Release-manifest constraints are `~version`, and `~3.2.1-patch` **does** admit `3.2.1-patch` (a range that names a prerelease admits that prerelease) — this is exactly how official beta releases ship prerelease packages. Apps then run `meteor update --release 3.4.1-patch` with no package pins needed.
2. **Wrap-number republish:** publish the same content as `3.2.1_1` (Meteor's suffix for out-of-band republishes, not a prerelease — it satisfies `~3.2.0` natively). Verified resolving in a 3.4.1 app with `ddp-client@=3.2.1_1!` / `ddp-server@=3.2.1_1!` pins.

Operational notes either way: `Meteor.server.options.disconnectGracePeriod = 30000` (default 15 s) is the tuning knob; `Meteor.disconnect()` is a *graceful* disconnect and intentionally does not resume; multi-instance deployments need sticky sessions for resumption to hit the process holding the session.

## Semver note

This ships a new DDP message ('disconnect'), new client close behavior, and two new server options in a patch-level bump — minor-shaped change, but 3.3.0 is taken by the 3.5 builds. The `-patch` prerelease suffix marks these builds as out-of-band and keeps the plain 3.2.1 number free for a potential official release; the trade-off is the consumption constraint described above (custom release or wrap-number republish). Flagging for reviewer judgment.


