### PR TITLE
Add maxRetries option to Meteor.apply

### DIFF
--- a/packages/ddp-client/common/connection_stream_handlers.js
+++ b/packages/ddp-client/common/connection_stream_handlers.js
@@ -163,20 +163,24 @@ export class ConnectionStreamHandlers {
     const currentMethodBlock = blocks[0].methods;
     blocks[0].methods = currentMethodBlock.filter(
       methodInvoker => {
-        // Methods with 'noRetry' option set are not allowed to re-send after
-        // recovering dropped connection.
-        if (methodInvoker.sentMessage && methodInvoker.noRetry) {
-          methodInvoker.receiveResult(
-            new Meteor.Error(
-              'invocation-failed',
-              'Method invocation might have failed due to dropped connection. ' +
-              'Failing because `noRetry` option was passed to Meteor.apply.'
-            )
-          );
+        // Methods which were never sent are always kept. A sent method is
+        // about to be re-sent, which consumes one retry: methods with the
+        // 'noRetry' option never re-send, and methods with 'maxRetries'
+        // re-send at most that many times.
+        if (!methodInvoker.sentMessage || methodInvoker.consumeRetry()) {
+          return true;
         }
 
-        // Only keep a method if it wasn't sent or it's allowed to retry.
-        return !(methodInvoker.sentMessage && methodInvoker.noRetry);
+        methodInvoker.receiveResult(
+          new Meteor.Error(
+            'invocation-failed',
+            'Method invocation might have failed due to dropped connection. ' +
+            (methodInvoker.noRetry
+              ? 'Failing because `noRetry` option was passed to Meteor.apply.'
+              : 'Failing because the `maxRetries` limit was reached.')
+          )
+        );
+        return false;
       }
     );
 

--- a/packages/ddp-client/common/livedata_connection.js
+++ b/packages/ddp-client/common/livedata_connection.js
@@ -620,6 +620,7 @@ export class Connection {
    * @param {Boolean} options.wait (Client only) If true, don't send this method until all previous method calls have completed, and don't send any subsequent method calls until this one is completed.
    * @param {Function} options.onResultReceived (Client only) This callback is invoked with the error or result of the method (just like `asyncCallback`) as soon as the error or result is available. The local cache may not yet reflect the writes performed by the method.
    * @param {Boolean} options.noRetry (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
+   * @param {Number} options.maxRetries (Client only) If set, the maximum number of times this method may be re-sent on reconnect. Once exceeded, the method fails with an error with the code 'invocation-failed', like `noRetry` (`maxRetries: 0` is equivalent to `noRetry`). If unset, the method is re-sent on every reconnect.
    * @param {Boolean} options.throwStubExceptions (Client only) If true, exceptions thrown by method stubs will be thrown instead of logged, and the method will not be invoked on the server.
    * @param {Boolean} options.returnStubValue (Client only) If true then in cases where we would have otherwise discarded the stub's return value and returned undefined, instead we go ahead and return it. Specifically, this is any time other than when (a) we are already inside a stub or (b) we are in Node and no callback was provided. Currently we require this flag to be explicitly passed to reduce the likelihood that stub return values will be confused with server return values; we may improve this in future.
    * @param {Function} [asyncCallback] Optional callback; same semantics as in [`Meteor.call`](#meteor_call).
@@ -663,6 +664,7 @@ export class Connection {
    * @param {Boolean} options.wait (Client only) If true, don't send this method until all previous method calls have completed, and don't send any subsequent method calls until this one is completed.
    * @param {Function} options.onResultReceived (Client only) This callback is invoked with the error or result of the method (just like `asyncCallback`) as soon as the error or result is available. The local cache may not yet reflect the writes performed by the method.
    * @param {Boolean} options.noRetry (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
+   * @param {Number} options.maxRetries (Client only) If set, the maximum number of times this method may be re-sent on reconnect. Once exceeded, the method fails with an error with the code 'invocation-failed', like `noRetry` (`maxRetries: 0` is equivalent to `noRetry`). If unset, the method is re-sent on every reconnect.
    * @param {Boolean} options.throwStubExceptions (Client only) If true, exceptions thrown by method stubs will be thrown instead of logged, and the method will not be invoked on the server.
    * @param {Boolean} options.returnStubValue (Client only) If true then in cases where we would have otherwise discarded the stub's return value and returned undefined, instead we go ahead and return it. Specifically, this is any time other than when (a) we are already inside a stub or (b) we are in Node and no callback was provided. Currently we require this flag to be explicitly passed to reduce the likelihood that stub return values will be confused with server return values; we may improve this in future.
    * @param {Boolean} options.returnServerResultPromise (Client only) If true, the promise returned by applyAsync will resolve to the server's return value, rather than the stub's return value. This is useful when you want to ensure that the server's return value is used, even if the stub returns a promise. The same behavior as `callAsync`.
@@ -862,7 +864,8 @@ export class Connection {
       onResultReceived: options.onResultReceived,
       wait: !!options.wait,
       message: message,
-      noRetry: !!options.noRetry
+      noRetry: !!options.noRetry,
+      maxRetries: options.maxRetries
     });
 
     let result;

--- a/packages/ddp-client/common/method_invoker.js
+++ b/packages/ddp-client/common/method_invoker.js
@@ -15,6 +15,8 @@ export class MethodInvoker {
     this._onResultReceived = options.onResultReceived || (() => {});
     this._wait = options.wait;
     this.noRetry = options.noRetry;
+    this._maxRetries = options.maxRetries != null ? options.maxRetries : null;
+    this._retryCount = 0;
     this._methodResult = null;
     this._dataVisible = false;
 
@@ -42,6 +44,17 @@ export class MethodInvoker {
 
     // Actually send the message.
     this._connection._send(this._message);
+  }
+  // Called when a dropped connection has been recovered and this method,
+  // which had already been sent, is about to be re-sent. Consumes one retry
+  // from the maxRetries budget. Returns false if the method may not be
+  // re-sent: either noRetry was set, or the method has already been re-sent
+  // maxRetries times. An unset maxRetries allows unlimited re-sends.
+  consumeRetry() {
+    if (this.noRetry) return false;
+    if (this._maxRetries === null) return true;
+    this._retryCount++;
+    return this._retryCount <= this._maxRetries;
   }
   // Invoke the callback, if we have both a result and know that all data has
   // been written to the local cache.

--- a/packages/ddp-client/test/livedata_connection_tests.js
+++ b/packages/ddp-client/test/livedata_connection_tests.js
@@ -2647,6 +2647,121 @@ if (Meteor.isClient) {
 
 }
 
+if (Meteor.isClient) {
+  Tinytest.addAsync(
+    'livedata connection - maxRetries stops re-sending after the limit',
+    async function (test) {
+      const stream = new StubStream();
+      const conn = newConnection(stream);
+
+      await startAndConnect(test, stream);
+
+      let callbackError = null;
+      let callbackFired = false;
+      conn.apply('limitedMethod', [], { maxRetries: 2 }, function (error) {
+        callbackFired = true;
+        callbackError = error;
+      });
+      const message = testGotMessage(test, stream, {
+        msg: 'method', method: 'limitedMethod', params: [], id: '*'
+      });
+
+      // Reconnects 1 and 2: the method is re-sent each time.
+      let session = SESSION_ID;
+      for (let retry = 1; retry <= 2; retry++) {
+        await stream.reset();
+        testGotMessage(test, stream, makeConnectMessage(session, conn._receivedCount));
+        testGotMessage(test, stream, {
+          msg: 'method', method: 'limitedMethod', params: [], id: message.id
+        });
+        test.length(stream.sent, 0);
+        test.isFalse(callbackFired);
+
+        // Answer with a new session id so stores reset (no resumption).
+        session = 'session-' + retry;
+        await stream.receive({ msg: 'connected', session: session });
+      }
+
+      // Reconnect 3: retry budget exhausted — fails instead of re-sending.
+      await stream.reset();
+      testGotMessage(test, stream, makeConnectMessage(session, conn._receivedCount));
+      test.length(stream.sent, 0);
+      await stream.receive({ msg: 'connected', session: 'session-final' });
+
+      test.isTrue(callbackFired);
+      test.instanceOf(callbackError, Meteor.Error);
+      test.equal(callbackError.error, 'invocation-failed');
+      test.equal(Object.keys(conn._methodInvokers).length, 0);
+      test.equal(conn._outstandingMethodBlocks.length, 0);
+    }
+  );
+
+  Tinytest.addAsync(
+    'livedata connection - maxRetries 0 never re-sends, like noRetry',
+    async function (test) {
+      const stream = new StubStream();
+      const conn = newConnection(stream);
+
+      await startAndConnect(test, stream);
+
+      let callbackError = null;
+      let callbackFired = false;
+      conn.apply('oneShotMethod', [], { maxRetries: 0 }, function (error) {
+        callbackFired = true;
+        callbackError = error;
+      });
+      testGotMessage(test, stream, {
+        msg: 'method', method: 'oneShotMethod', params: [], id: '*'
+      });
+
+      // First reconnect: the method may not be re-sent.
+      await stream.reset();
+      testGotMessage(test, stream, makeConnectMessage(SESSION_ID, conn._receivedCount));
+      test.length(stream.sent, 0);
+      await stream.receive({ msg: 'connected', session: 'session-1' });
+
+      test.isTrue(callbackFired);
+      test.instanceOf(callbackError, Meteor.Error);
+      test.equal(callbackError.error, 'invocation-failed');
+      test.equal(Object.keys(conn._methodInvokers).length, 0);
+    }
+  );
+
+  Tinytest.addAsync(
+    'livedata connection - methods without maxRetries re-send on every reconnect',
+    async function (test) {
+      const stream = new StubStream();
+      const conn = newConnection(stream);
+
+      await startAndConnect(test, stream);
+
+      let callbackFired = false;
+      conn.call('unlimitedMethod', function () {
+        callbackFired = true;
+      });
+      const message = testGotMessage(test, stream, {
+        msg: 'method', method: 'unlimitedMethod', params: [], id: '*'
+      });
+
+      let session = SESSION_ID;
+      for (let i = 1; i <= 5; i++) {
+        await stream.reset();
+        testGotMessage(test, stream, makeConnectMessage(session, conn._receivedCount));
+        testGotMessage(test, stream, {
+          msg: 'method', method: 'unlimitedMethod', params: [], id: message.id
+        });
+        test.isFalse(callbackFired);
+
+        session = 'session-' + i;
+        await stream.receive({ msg: 'connected', session: session });
+      }
+
+      test.isFalse(callbackFired);
+      test.equal(Object.keys(conn._methodInvokers).length, 1);
+    }
+  );
+}
+
 // ============================================================================
 // DDP Session Resumption Tests (Client-side)
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds a `maxRetries` option to `Meteor.apply` / `applyAsync`: the maximum number of times an already-sent method may be re-sent when a dropped connection is recovered. Once exceeded, the method fails with the same `invocation-failed` error that `noRetry` produces (`maxRetries: 0` is equivalent to `noRetry`). Unset preserves Meteor's default retry-forever behavior.

## Why

Between `noRetry` (fail on the first reconnect) and the default (re-send forever), there is no way to say "this method is worth retrying a few times, but must not outlive N reconnects." Unbounded re-send is a liability for non-idempotent methods on flapping connections; `maxRetries` bounds it.

## Design notes

- Implemented on the existing `MethodInvoker` — no scheduling changes. `MethodInvoker.consumeRetry()` owns the budget; the existing `noRetry` filter in `_handleOutstandingMethodsOnReset` is its single call site, so `noRetry` and `maxRetries` share one code path and one failure shape.
- Fails with `invocation-failed` (not `disconnected`) so error handling written for `noRetry` applies unchanged. `disconnected` remains the signal for "connection permanently down" (see #14193); `invocation-failed` means "connection recovered, but this call gave up."

## Tests

- `maxRetries: 2` — re-sent on reconnects 1 and 2 (same method id), fails with `invocation-failed` on the 3rd; `_methodInvokers` and `_outstandingMethodBlocks` fully cleaned up
- `maxRetries: 0` — never re-sent, fails on the first reconnect (same behavior and error code as `noRetry`)
- unset — re-sent on every reconnect (5 cycles), callback never fires

Verification: `ddp-client` suite run with the implementation reverted fails exactly on the two limit tests (the third new test pins the unchanged default and passes either way); with it applied, the whole suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for limiting method retries after reconnects with `maxRetries` in `Meteor.apply` and `Meteor.applyAsync`.
  * Methods now report an invocation failure when retry limits are reached or retries are disabled.
  * Methods without a retry limit continue retrying as before.

* **Bug Fixes**
  * Retry settings are now consistently enforced during connection resets and reconnects.

* **Tests**
  * Added coverage for limited, disabled, and unlimited retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->