### PR TITLE
Test coverage for runner restart kills app ignoring sigterm

### DIFF
--- a/tools/tests/run.js
+++ b/tools/tests/run.js
@@ -442,6 +442,59 @@ selftest.define("run and SIGKILL parent process", ["yet-unsolved-windows-failure
   await run.stop();
 });
 
+// Regression test for #13490. An app can override Node's default SIGTERM
+// behavior, but the development runner must still stop it during a restart.
+selftest.define("run restart kills app ignoring SIGTERM", ["yet-unsolved-windows-failure"], async function () {
+  var s = new Sandbox({ fakeMongo: true });
+  await s.init();
+
+  await s.createApp("myapp", "app-prints-pid");
+  s.cd("myapp");
+
+  const appSource = `
+    Meteor.startup(function () {
+      console.log("My pid is " + process.pid);
+      process.on("SIGTERM", function () {
+        console.log("Ignoring SIGTERM in " + process.pid);
+      });
+    });
+  `;
+  s.write("print.js", appSource);
+
+  const run = s.run();
+  await run.tellMongo(MONGO_LISTENING);
+  run.waitSecs(30);
+
+  const firstMatch = await run.match(/My pid is (\d+)/);
+  const firstPid = Number(firstMatch[1]);
+  await run.match("App running at");
+
+  s.write("print.js", appSource + "\n// trigger restart\n");
+  await run.match("Server modified -- restarting");
+  await run.match("Ignoring SIGTERM in " + firstPid);
+
+  const secondMatch = await run.match(/My pid is (\d+)/);
+  const secondPid = Number(secondMatch[1]);
+  selftest.expectTrue(secondPid !== firstPid);
+  await run.match("Meteor server restarted");
+
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(firstPid, 0);
+    } catch (error) {
+      if (error.code === "ESRCH") {
+        await run.stop();
+        return;
+      }
+      throw error;
+    }
+    await utils.sleepMs(100);
+  }
+
+  selftest.fail("Old app process " + firstPid + " is still running");
+});
+
 selftest.define("'meteor run --port' accepts/rejects proper values", async function () {
   var s = new Sandbox();
   await s.init();


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/pull/14516 and https://github.com/meteor/meteor/issues/13490

This PR adds test coverage for the improvement introduced in [#14516](https://github.com/meteor/meteor/pull/14516), ensuring that Meteor force-kills an application process that ignores SIGTERM during a development restart and does not leave the previous process running.

Meteor self-tests are well suited to tool-level changes like this one. E2E tests are better reserved for broader workflows across complete application setups. Here, a self-test is sufficient and signal faster because it runs the Meteor tool against a sandboxed app, triggers a real restart, and verifies that the old process is terminated. This protects the behavior from future regressions.

<img width="728" height="181" alt="image" src="https://github.com/user-attachments/assets/45a4af41-3c58-4ddb-9079-44d693d1c9e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression test ensuring app restarts terminate the previous process even when it ignores termination requests.
  * Verifies that a new process starts successfully and the original process exits within five seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->