### PR TITLE
fix(npm-mongo): redact credentials from MONGO_URL warning and drop forced TLS in startup pre-check

### DIFF
--- a/packages/npm-mongo/package.js
+++ b/packages/npm-mongo/package.js
@@ -14,6 +14,12 @@ Npm.depends({
 Package.onUse(function (api) {
   api.addFiles("wrapper.js", "server");
   api.export(["NpmModuleMongodb", "NpmModuleMongodbVersion"], "server");
+  api.export("NpmMongoTest", "server", { testOnly: true });
   api.addAssets("index.d.ts", "server");
   api.addAssets("package-types.json", "server");
+});
+
+Package.onTest(function (api) {
+  api.use(["npm-mongo", "tinytest"], "server");
+  api.addFiles("wrapper-tests.js", "server");
 });

--- a/packages/npm-mongo/wrapper-tests.js
+++ b/packages/npm-mongo/wrapper-tests.js
@@ -1,0 +1,24 @@
+Tinytest.add('npm-mongo - redacts credentials in invalid MongoDB URLs', function (test) {
+  const cases = [
+    {
+      url: 'mongodb://user:pa@ss@host/database',
+      redactedUrl: 'mongodb://***:***@host/database',
+    },
+    {
+      url: 'mongodb://user:pa%40ss@host/database',
+      redactedUrl: 'mongodb://***:***@host/database',
+    },
+    {
+      url: 'mongodb+srv://user:password@cluster.example/database',
+      redactedUrl: 'mongodb+srv://***:***@cluster.example/database',
+    },
+    {
+      url: 'mongodb://host/database',
+      redactedUrl: 'mongodb://host/database',
+    },
+  ];
+
+  cases.forEach(({ url, redactedUrl }) => {
+    test.equal(NpmMongoTest.redactMongoUrl(url), redactedUrl);
+  });
+});

--- a/packages/npm-mongo/wrapper.js
+++ b/packages/npm-mongo/wrapper.js
@@ -18,14 +18,22 @@ function connect(client) {
 
 if (process.env.MONGO_URL && (/^mongodb(\+srv)?:\/\//.test(process.env.MONGO_URL))) {
   try {
-    connect(new MongoClient(process.env.MONGO_URL, {
-      tls: true,
-      tlsAllowInvalidCertificates: true,
-    })).then(client => {
+    // No TLS overrides here: the connection string carries its own TLS
+    // semantics (mongodb+srv implies TLS), and forcing tls with
+    // tlsAllowInvalidCertificates would both break plaintext deployments
+    // and skip certificate validation.
+    connect(new MongoClient(process.env.MONGO_URL)).then(client => {
       if (client) client.close();
     });
   } catch (e) {
-    console.warn('Invalid MongoDB connection string in MONGO_URL:', process.env.MONGO_URL);
+    // The URL may embed credentials (user:password@), so never log it raw.
+    // Redacts everything up to the first "@" — over-redacting a credential-less
+    // URL is fine here, leaking a password is not.
+    const redactedUrl = process.env.MONGO_URL.replace(
+      /(mongodb(?:\+srv)?:\/\/)[^@]+@/,
+      '$1***:***@'
+    );
+    console.warn('Invalid MongoDB connection string in MONGO_URL:', redactedUrl);
   }
 }
 

--- a/packages/npm-mongo/wrapper.js
+++ b/packages/npm-mongo/wrapper.js
@@ -16,6 +16,13 @@ function connect(client) {
   })
 }
 
+function redactMongoUrl(mongoUrl) {
+  return mongoUrl.replace(
+    /(mongodb(?:\+srv)?:\/\/)[\s\S]*@/,
+    '$1***:***@'
+  );
+}
+
 if (process.env.MONGO_URL && (/^mongodb(\+srv)?:\/\//.test(process.env.MONGO_URL))) {
   try {
     // No TLS overrides here: the connection string carries its own TLS
@@ -27,15 +34,14 @@ if (process.env.MONGO_URL && (/^mongodb(\+srv)?:\/\//.test(process.env.MONGO_URL
     });
   } catch (e) {
     // The URL may embed credentials (user:password@), so never log it raw.
-    // Redacts everything up to the first "@" — over-redacting a credential-less
+    // Redacts everything up to the final "@" — over-redacting a credential-less
     // URL is fine here, leaking a password is not.
-    const redactedUrl = process.env.MONGO_URL.replace(
-      /(mongodb(?:\+srv)?:\/\/)[^@]+@/,
-      '$1***:***@'
-    );
+    const redactedUrl = redactMongoUrl(process.env.MONGO_URL);
     console.warn('Invalid MongoDB connection string in MONGO_URL:', redactedUrl);
   }
 }
+
+NpmMongoTest = { redactMongoUrl };
 
 const useLegacyMongo = !!Package['npm-mongo-legacy']
 const oldNoDeprecationValue = process.noDeprecation;


### PR DESCRIPTION
Fixes #14400

Since Meteor 3.3.1, the legacy-MongoDB startup pre-check in `packages/npm-mongo/wrapper.js` logged the **raw** `MONGO_URL` — credentials included — whenever the throwaway `MongoClient` constructor threw (e.g. a `mongodb+srv://` URL with a port number). It also hardcoded `tls: true, tlsAllowInvalidCertificates: true` on that probe client.

## Changes

- The "Invalid MongoDB connection string" warning now redacts everything up to the first `@` (`mongodb+srv://***:***@host/db`), so credentials never reach stderr or log aggregation systems. Redaction is deliberately greedy: over-redacting a credential-less invalid URL is fine, leaking a password is not.
- The pre-check no longer forces `tls: true, tlsAllowInvalidCertificates: true`. The connection string carries its own TLS semantics (`mongodb+srv` implies TLS, explicit `tls`/`ssl` parameters are honored), so the probe stops failing against plaintext deployments and no longer disables certificate validation.

The pre-check itself is kept — it is what detects legacy MongoDB (≤ 3.6) and points users at `npm-mongo-legacy`; without the forced TLS options it now works for plaintext deployments too.

## Verification

Repro: https://github.com/italojs/meteor-issue-repros/tree/issue-14400 (stock 3.5.1 minimal app, zero code changes)

```bash
MONGO_URL='mongodb+srv://admin:S3cr3tPass@localhost:27017/proddb' meteor run 2>&1 | grep 'Invalid MongoDB'
```

- Before (3.5.1): `Invalid MongoDB connection string in MONGO_URL: mongodb+srv://admin:S3cr3tPass@localhost:27017/proddb`
- After (this fix): `Invalid MongoDB connection string in MONGO_URL: mongodb+srv://***:***@localhost:27017/proddb` — zero occurrences of the password anywhere in the log.

Redaction checked against credential shapes including passwords with `/`, `:` and percent-encoding, user-only credentials, and credential-less URLs (left untouched). `packages/npm-mongo` is the only place in the repo that logged `MONGO_URL`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved TLS settings provided in MongoDB connection strings.
  * Improved error messages for invalid connection URLs by masking embedded credentials.
  * Added support for safely redacting credentials in standard and SRV MongoDB URLs, including encoded characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->