### PR TITLE
docs: Fix broken links to contributing information and deprecated package `underscore`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Learn how we use GitHub labels [here](LABELS.md)
 
 ## Documentation
 
-If you'd like to contribute to Meteor's documentation, head over to https://docs.meteor.com/about/contributing.html for guidelines.
+If you'd like to contribute to Meteor's documentation, head over to https://docs.meteor.com/community/contributing.html for guidelines.
 
 ## Blaze
 

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -397,10 +397,6 @@ export default defineConfig({
                 link: "/packages/logging",
               },
               {
-                text: "underscore",
-                link: "/packages/underscore",
-              },
-              {
                 text: "autoupdate",
                 link: "/packages/autoupdate",
               },


### PR DESCRIPTION
Fix #14659 

Fix one broken link and remove another one to an old, deprecated package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contribution guidelines link to its current location.
  * Removed the obsolete Underscore package from the Developer tools navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->