### PR TITLE
release: trigger Slack release notifications after tarballs land

### DIFF
--- a/scripts/make-release-tarballs.sh
+++ b/scripts/make-release-tarballs.sh
@@ -29,3 +29,36 @@ git clean -df
   aws s3 cp --acl public-read osx/meteor-bootstrap-os.osx.arm64.tar.gz s3://com.meteor.static/packages-bootstrap/"$VERSION"/ &&
   aws s3 mb s3://com.meteor.static/packages-bootstrap/"$VERSION"/ &&
   aws s3 ls s3://com.meteor.static/packages-bootstrap/"$VERSION"
+
+# --- Trigger release notifications ---------------------------------------
+# Once every platform tarball is live on S3 the release is actually
+# installable, so trigger the Release Notifications workflow on the
+# release-bot repo. We verify S3 directly (rather than trusting the exit
+# status of the chain above) because that chain can report success even
+# when an intermediate `aws s3` step short-circuited.
+echo "Verifying bootstrap tarballs on S3..."
+ALL_TARBALLS_LIVE=true
+for PLATFORM in os.windows.x86_64 os.linux.x86_64 os.linux.aarch64 os.osx.x86_64 os.osx.arm64; do
+  HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+    "https://static.meteor.com/packages-bootstrap/${VERSION}/meteor-bootstrap-${PLATFORM}.tar.gz")
+  echo "  ${PLATFORM} -> ${HTTP_CODE}"
+  [ "$HTTP_CODE" = "200" ] || ALL_TARBALLS_LIVE=false
+done
+
+if [ "$ALL_TARBALLS_LIVE" != true ]; then
+  echo "Not all bootstrap tarballs are live; skipping release notifications."
+  exit 0
+fi
+
+if [ -z "${RELEASE_BOT_DISPATCH_TOKEN:-}" ]; then
+  echo "RELEASE_BOT_DISPATCH_TOKEN is not set; cannot trigger release notifications." >&2
+  exit 0
+fi
+
+echo "All bootstrap tarballs are live; triggering release notifications for ${BRANCH_NAME}."
+curl -sf -X POST \
+  -H "Authorization: Bearer ${RELEASE_BOT_DISPATCH_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/meteor-private/meteor-release-bot/actions/workflows/release-notifications.yml/dispatches" \
+  -d "$(printf '{"ref":"main","inputs":{"branch_name":"%s"}}' "$BRANCH_NAME")"


### PR DESCRIPTION
## What

Extends `scripts/make-release-tarballs.sh` so that, after the bootstrap tarballs are built and uploaded, it verifies all five platform tarballs are live on S3 and then dispatches the **Release Notifications** workflow on `meteor-private/meteor-release-bot`.

That workflow posts two Slack messages to the platform channel:
- the new-version announcement (update/create commands + changelog), and
- a heads-up when the bundled Node.js version changed vs. the previous release.

## Why

The announcement should only fire once the release is actually installable — i.e. after the bootstrap tarballs land (the only thing fresh installs download). Triggering from the end of the tarball script makes the notifications fully automatic, with no extra manual dispatch, and at exactly the right moment in the release.

It verifies S3 directly (five HTTP 200 checks) instead of trusting the exit status of the `&&` chain above, which can report success even when an intermediate `aws s3` step short-circuited.

## Requires

`RELEASE_BOT_DISPATCH_TOKEN` in the release agent environment — a token with `actions:write` on `meteor-private/meteor-release-bot`. When it is unset, or when any tarball is missing, the script logs and skips the trigger (no failure).

## Notes

- The companion PR (`meteor-release-bot#20`) adds the `release-notifications.yml` workflow this dispatches.
- Targets `devel`; for it to take effect on an in-flight release line it also needs to be present on the release branch the tarball job resets to (`git reset --hard origin/$BRANCH_NAME`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release notifications are now sent only after all platform tarballs are confirmed available.
  * Notifications are skipped when release verification fails or required authorization is unavailable.
  * Successful verification triggers release notifications for the appropriate release branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->