### PR TITLE
fix(oauth): unique login popup names, and survive a cross-origin opener

### DIFF
--- a/packages/oauth/end_of_popup_response.js
+++ b/packages/oauth/end_of_popup_response.js
@@ -16,11 +16,25 @@
       window.location.hash = credentialString;
     }
 
-    if (window.opener && window.opener.Package &&
-          window.opener.Package.oauth) {
-      window.opener.Package.oauth.OAuth._handleCredentialSecret(
-        credentialToken, credentialSecret);
-    } else {
+    var handledByOpener = false;
+
+    try {
+      if (window.opener && window.opener.Package &&
+            window.opener.Package.oauth) {
+        window.opener.Package.oauth.OAuth._handleCredentialSecret(
+          credentialToken, credentialSecret);
+        handledByOpener = true;
+      }
+    } catch (err) {
+      // Reading `Package` off the opener throws a SecurityError when the
+      // opener is on a different origin, which happens when the login service
+      // sends this popup to a host other than the one that opened it. Without
+      // this catch the error aborts the script, so we never reach the
+      // localStorage fallback below or window.close(), and the popup hangs
+      // open forever while the login silently never completes. See #12418.
+    }
+
+    if (! handledByOpener) {
       try {
         localStorage[config.storagePrefix + credentialToken] = credentialSecret;
       } catch (err) {

--- a/packages/oauth/oauth_browser.js
+++ b/packages/oauth/oauth_browser.js
@@ -38,6 +38,21 @@ OAuth.showPopup = (url, callback, dimensions) => {
   }, 100);
 };
 
+// Login popups must never share a window name. `window.open` re-targets an
+// existing window when the name matches, so a constant name (this used to be
+// 'Login') breaks nested OAuth flows: when the login service is itself a
+// Meteor app — e.g. logging into Meteor developer accounts, which then logs in
+// via GitHub — the service's own `window.open(url, 'Login', ...)` matches the
+// popup we already opened and navigates THAT window to the inner provider
+// instead of opening a new one. Both login attempts then fail with no error.
+// The counter keeps names unique within this document; the timestamp and
+// random suffix keep them unique across documents, since the app and the login
+// service each run their own copy of this code. See issue #12418.
+let popupSequence = 0;
+
+const uniqueLoginWindowName = () =>
+  `Login_${Date.now()}_${Math.floor(Math.random() * 1e9)}_${++popupSequence}`;
+
 const openCenteredPopup = function(url, width, height) {
   const screenX = typeof window.screenX !== 'undefined'
         ? window.screenX : window.screenLeft;
@@ -56,8 +71,7 @@ const openCenteredPopup = function(url, width, height) {
   const features = (`width=${width},height=${height}` +
                   `,left=${left},top=${top},scrollbars=yes`);
 
-
-  const newwindow = window.open(url, 'Login', features);
+  const newwindow = window.open(url, uniqueLoginWindowName(), features);
 
   if (!newwindow || newwindow.closed) {
     // blocked by a popup blocker maybe?

--- a/packages/oauth/oauth_browser_tests.js
+++ b/packages/oauth/oauth_browser_tests.js
@@ -1,0 +1,50 @@
+// Regression tests for issue #12418.
+//
+// Login popups must not share a window name. `window.open` re-targets an
+// existing window whose name matches, so a constant name breaks OAuth flows
+// where the login service is itself a Meteor app opening its own login popup.
+
+Tinytest.add('oauth - each login popup gets a unique window name', test => {
+  const names = [];
+  const popups = [];
+  const originalOpen = window.open;
+
+  window.open = (url, name) => {
+    names.push(name);
+    const popup = { closed: false, focus() {} };
+    popups.push(popup);
+    return popup;
+  };
+
+  try {
+    OAuth.showPopup('about:blank', () => {});
+    OAuth.showPopup('about:blank', () => {});
+  } finally {
+    window.open = originalOpen;
+    // Let showPopup's `popup.closed` polling finish so it clears its interval.
+    popups.forEach(popup => { popup.closed = true; });
+  }
+
+  test.equal(names.length, 2);
+
+  names.forEach(name => {
+    test.isTrue(
+      typeof name === 'string' && name.length > 0,
+      'popup must be opened with a window name'
+    );
+    // A constant name is what broke nested flows; reserved targets would let
+    // the popup replace the app's own window.
+    test.notEqual(name, 'Login');
+    test.notEqual(name, '_blank');
+    test.notEqual(name, '_self');
+    test.notEqual(name, '_parent');
+    test.notEqual(name, '_top');
+  });
+
+  test.notEqual(
+    names[0],
+    names[1],
+    'two login popups must not share a window name, otherwise the second ' +
+      'window.open re-targets the first popup instead of opening a new one'
+  );
+});

--- a/packages/oauth/package.js
+++ b/packages/oauth/package.js
@@ -43,9 +43,11 @@ Npm.depends({
 Package.onTest(api => {
   api.use('tinytest');
   api.use('random');
+  api.use('ecmascript');
   api.use('service-configuration', 'server');
-  api.use('oauth', 'server');
+  api.use('oauth', ['client', 'server']);
   api.addFiles("oauth_tests.js", 'server');
+  api.addFiles("oauth_browser_tests.js", 'web.browser');
 });
 
 Cordova.depends({


### PR DESCRIPTION
## Problem

Logging into a Meteor app with **Meteor developer accounts → GitHub** silently fails: the popup closes (or hangs), no error is shown, and the user is not logged in. Email/password on the same dialog works.

Refs #12418 (reproduction: https://github.com/zodern/repro-meteor-developer-account-github)

## Two defects, both in `packages/oauth`

### 1. Every login popup was named `Login`

```js
const newwindow = window.open(url, 'Login', features);
```

`window.open` re-targets an **existing** browsing context whose name matches, and the lookup includes the calling window itself. That's fine until the login service is *itself* a Meteor app using this package — which Meteor developer accounts is:

1. The app opens a popup named `Login` → the accounts dialog.
2. The user picks "Sign in with GitHub". The dialog runs its own `Meteor.loginWithGithub`, calling `window.open(githubUrl, 'Login', …)`.
3. That window is *already* named `Login`, so the browser re-targets **it** instead of opening a nested popup.
4. It navigates itself to GitHub and closes. The app's `credentialToken` never receives its secret, and the login method fails with no user-visible error.

Fixed by giving each popup a unique name. A per-document counter guarantees uniqueness within a document; the timestamp and random suffix keep names distinct across documents, since the app and the login service each run their own copy of this code.

### 2. A cross-origin opener aborted the popup script

```js
if (window.opener && window.opener.Package && window.opener.Package.oauth) {
```

Reading a named property off a **cross-origin** opener throws a `SecurityError`. Nothing caught it, so the script aborted before the `localStorage` fallback (unreachable in the `else` branch) *and* before `window.close()`. The popup was left open forever with no error.

Captured against the live service:

```
SecurityError: Failed to read a named property 'Package' from 'Window':
Blocked a frame with origin "https://accounts.meteor.com" from accessing a cross-origin frame.
```

This triggers whenever the login service sends the popup to a host other than the one that opened it. Now the access is guarded, so the popup always reaches `window.close()` and the flow either completes or fails visibly instead of hanging.

## Testing

**New regression test** (`oauth_browser_tests.js`, client) stubs `window.open` and asserts two consecutive popups get different, non-constant, non-reserved names. It fails against the old code (both come back `Login`) and passes with the fix.

Full `oauth` suite via `test-in-console`: `passed/expected/failed/total 10 / 0 / 0 / 10`, including the new client test.

**Manual verification** against the real accounts server, driven through Chrome DevTools Protocol:

- Stock build reproduces the reported symptom — popup name `"Login"`, no nested window, `No matching login attempt found`, not logged in.
- Patched build opens a genuine nested GitHub window with a unique name and an intact opener chain.
- With defect 2 also fixed, the callback popup closes itself and the dialog resumes to the app's `_oauth/meteor-developer` callback.

## Scope — what this does *not* fix

These changes are necessary but **not sufficient** to make meteor.com's GitHub login work end to end today. That flow additionally breaks because the login dialog is served from `www.meteor.com` while its OAuth callbacks land on `accounts.meteor.com` — a different origin. That is a deployment-side issue on the accounts service and cannot be fixed from this repository; it needs the two to share an origin.

Apps can work around it today by pointing the client at the same origin the callbacks use:

```js
MeteorDeveloperAccounts._config({ developerAccountsServer: 'https://accounts.meteor.com' });
```

Also worth a separate look (not addressed here): both popup/redirect templates hide their config blob with an inline `style="display:none"`. Under a strict CSP (`accounts.meteor.com` sends `style-src 'self'`) that style is blocked, so the `credentialSecret` renders in plain text and "Login completed" is shown even when the script has already failed.
