### PR TITLE
Surface the full npm error output in the Windows dev bundle build

### DIFF
--- a/scripts/generate-dev-bundle.ps1
+++ b/scripts/generate-dev-bundle.ps1
@@ -263,6 +263,29 @@ Function Add-Mongo {
   cd "$previousCwd"
 }
 
+# Runs a native command printing its full output (stdout + stderr) to the
+# host and returns its exit code. Under the GitHub Actions PowerShell wrapper
+# ($ErrorActionPreference = 'Stop'), the first stderr line of a native command
+# becomes a terminating NativeCommandError: the script dies mid-command and
+# the rest of the output (the actual error detail) is lost. Routing the merged
+# stream through Write-Host avoids the conversion and keeps everything in the
+# CI log; failures are decided by exit code instead.
+Function Invoke-NativeCommandLoud {
+  Param (
+    [Parameter(Mandatory=$True, Position=0)]
+    [string]$Executable,
+    [Parameter(Position=1)]
+    [string[]]$Arguments = @()
+  )
+
+  $previousEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  & $Executable @Arguments 2>&1 | ForEach-Object { Write-Host "$_" }
+  $ErrorActionPreference = $previousEap
+
+  return $LASTEXITCODE
+}
+
 Function Add-NpmModulesFromJsBundleFile {
   Param (
     [Parameter(Mandatory=$True, Position=0)]
@@ -290,16 +313,16 @@ Function Add-NpmModulesFromJsBundleFile {
     Out-File -FilePath $(Join-Path $Destination 'package.json') -Encoding ascii
 
   # No bin-links because historically, they weren't used anyway.
-  & "$($Commands.npm)" install
-  if ($LASTEXITCODE -ne 0) {
-    throw "Couldn't install npm packages."
+  $npmExit = Invoke-NativeCommandLoud "$($Commands.npm)" @('install')
+  if ($npmExit -ne 0) {
+    throw "Couldn't install npm packages (npm exited with code $npmExit)."
   }
 
   # As of npm@5, this just renames `package-lock.json` to `npm-shrinkwrap.json`.
   if ($Shrinkwrap -eq $True) {
-    & "$($Commands.npm)" shrinkwrap
-    if ($LASTEXITCODE -ne 0) {
-      throw "Couldn't make shrinkwrap."
+    $npmExit = Invoke-NativeCommandLoud "$($Commands.npm)" @('shrinkwrap')
+    if ($npmExit -ne 0) {
+      throw "Couldn't make shrinkwrap (npm exited with code $npmExit)."
     }
   }
 


### PR DESCRIPTION
## Problem
Under the GitHub Actions PowerShell wrapper (`$ErrorActionPreference = 'Stop'`), the first stderr line of `npm install` in `generate-dev-bundle.ps1` becomes a terminating `NativeCommandError`: the script dies mid-command, the existing exit-code check never runs, and the CI log keeps a single useless line (`npm error code 1`) while the real error stays only on the runner.

Seen on the `dev-bundle-26.1.0.0` (Node 26.7.0) Windows build — the tool-package install failure was undiagnosable from the CI log ([run](https://github.com/meteor-private/meteor-release-bot/actions/runs/31621347462/job/94196834663)).

## Fix
Route `npm install` / `npm shrinkwrap` through a small helper that prints the merged stdout+stderr via `Write-Host` (no error-record conversion, full output lands in the CI log) and fails by exit code, keeping the existing `throw` behavior.

Same class of fix as meteor-private/meteor-release-bot#22 (publish script).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development bundle generation by displaying output from package installation and shrinkwrap commands.
  * Failures now report the originating command’s exit code for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->