### PR TITLE
docs: document WebApp.addHtmlAttributeHook

### DIFF
--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -214,9 +214,6 @@ WebApp.categorizeRequest = function(req) {
   return categorized;
 };
 
-// HTML attribute hooks: functions to be called to determine any attributes to
-// be added to the '<html>' tag. Each function is passed a 'request' object (see
-// #BrowserIdentification) and should return null or object.
 var htmlAttributeHooks = [];
 var getHtmlAttributes = function(request) {
   var combinedAttributes = {};
@@ -229,6 +226,17 @@ var getHtmlAttributes = function(request) {
   });
   return combinedAttributes;
 };
+
+/**
+ * @summary Registers a callback that runs whenever Meteor generates app HTML.
+ * Attributes returned by all registered callbacks are merged onto the
+ * `<html>` element. If callbacks return the same attribute, the callback
+ * registered last takes precedence.
+ * @locus Server
+ * @param {Function} hook A callback that receives information about the request
+ * for app HTML and returns an object of HTML attribute names and values, or
+ * `null` to add no attributes for that request.
+ */
 WebApp.addHtmlAttributeHook = function(hook) {
   htmlAttributeHooks.push(hook);
 };

--- a/v3-docs/docs/packages/webapp.md
+++ b/v3-docs/docs/packages/webapp.md
@@ -25,6 +25,35 @@ WebApp.handlers.use("/hello", (req, res, next) => {
 <ApiBox name="WebApp.handlers"/>
 <ApiBox name="expressHandlersCallback(req, res, next)" hasCustomExample/>
 
+### Customizing the `<html>` Element
+
+Use `WebApp.addHtmlAttributeHook` on the server to add attributes to the
+`<html>` element. The hook runs whenever Meteor generates app HTML and receives
+information about the request, so attributes can be static or request-specific.
+
+For example, this sets the document language for every request:
+
+```js
+// server/main.js
+import { WebApp } from "meteor/webapp";
+
+WebApp.addHtmlAttributeHook(() => ({ lang: "en" }));
+```
+
+Return `null` when no attributes should be added for a request. If multiple
+hooks return the same attribute, the hook registered last takes precedence.
+The request object contains:
+
+- `browser`: the browser `name` and `major`, `minor`, and `patch` versions
+- `modern`: whether the browser supports Meteor's modern JavaScript bundle
+- `path`: the request path
+- `arch`: the selected client architecture
+- `url`: parsed URL data, including a `query` object
+- `headers`: the request headers
+- `cookies`: the parsed request cookies
+
+<ApiBox name="WebApp.addHtmlAttributeHook" hasCustomExample/>
+
 ### Serving a Static Landing Page
 
 One of the really cool things you can do with WebApp is serve static HTML for a landing page where TTFB (time to first byte) is of utmost importance.
@@ -151,11 +180,9 @@ When using React SSR with packages like `server-render`, you may want to complet
 
 ```js
 // server/main.js
-import { WebApp } from 'meteor/webapp';
+import { WebAppInternals } from "meteor/webapp";
 
-WebApp.addHtmlAttributeHook(() => ({
-  disableBoilerplateResponse: true
-}));
+WebAppInternals.disableBoilerplateResponse();
 ```
 
 **Benefits:**
@@ -178,11 +205,9 @@ Example with server-render:
 ```js
 import { onPageLoad } from 'meteor/server-render';
 import { renderToString } from 'react-dom/server';
-import { WebApp } from 'meteor/webapp';
+import { WebAppInternals } from 'meteor/webapp';
 
-WebApp.addHtmlAttributeHook(() => ({
-  disableBoilerplateResponse: true
-}));
+WebAppInternals.disableBoilerplateResponse();
 
 onPageLoad(sink => {
   const html = renderToString(<App />);


### PR DESCRIPTION
## Summary

- add generated API documentation for `WebApp.addHtmlAttributeHook`
- document its request object, return contract, merge behavior, and a `lang` example
- correct the React SSR examples to call `WebAppInternals.disableBoilerplateResponse()` instead of emitting a `disableBoilerplateResponse` HTML attribute

Forum context: https://forums.meteor.com/t/where-is-the-documentation-for-webapp-addhtmlattributehook/64729

## Testing

- `npm run docs:build` from `v3-docs/docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for customizing `<html>` attributes during server-side rendering.
  * Documented callback behavior, request metadata, attribute precedence, and return requirements.
  * Updated React server-rendering examples to use the recommended boilerplate-response configuration method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->