### PR TITLE
docs: validate VitePress theme links

### DIFF
--- a/.github/workflows/v3-docs.yml
+++ b/.github/workflows/v3-docs.yml
@@ -1,0 +1,35 @@
+name: V3 Docs
+
+on:
+  push:
+    paths:
+      - 'v3-docs/docs/**'
+      - '.github/workflows/v3-docs.yml'
+  pull_request:
+    paths:
+      - 'v3-docs/docs/**'
+      - '.github/workflows/v3-docs.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: v3-docs/docs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: v3-docs/docs/package-lock.json
+      - run: npm ci
+      - run: npm run test:links
+      - run: npm run docs:build

--- a/.github/workflows/v3-docs.yml
+++ b/.github/workflows/v3-docs.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -32,4 +32,3 @@ jobs:
           cache-dependency-path: v3-docs/docs/package-lock.json
       - run: npm ci
       - run: npm run test:links
-      - run: npm run docs:build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Learn how we use GitHub labels [here](LABELS.md)
 
 ## Documentation
 
-If you'd like to contribute to Meteor's documentation, head over to https://docs.meteor.com/about/contributing.html for guidelines.
+If you'd like to contribute to Meteor's documentation, head over to https://docs.meteor.com/community/contributing.html for guidelines.
 
 ## Blaze
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Learn how we use GitHub labels [here](LABELS.md)
 
 ## Documentation
 
-If you'd like to contribute to Meteor's documentation, head over to https://docs.meteor.com/community/contributing.html for guidelines.
+If you'd like to contribute to Meteor's documentation, head over to https://docs.meteor.com/about/contributing.html for guidelines.
 
 ## Blaze
 

--- a/v3-docs/docs/.vitepress/check-theme-links.mjs
+++ b/v3-docs/docs/.vitepress/check-theme-links.mjs
@@ -37,10 +37,8 @@ export function checkThemeLinks({
   themeConfig,
   pages,
   siteOrigin = "https://docs.meteor.com",
-  ignoredRoutes = [],
 }) {
   const pageRoutes = new Set(pages.map(normalizeRoute));
-  const ignored = new Set(ignoredRoutes.map(normalizeRoute));
   const origin = new URL(siteOrigin).origin;
   const failures = [];
   let checkedLinks = 0;
@@ -67,7 +65,7 @@ export function checkThemeLinks({
       continue;
     }
 
-    if (!pageRoutes.has(route) && !ignored.has(route)) {
+    if (!pageRoutes.has(route)) {
       failures.push(`${location}: ${link} does not match a documentation page`);
     }
   }

--- a/v3-docs/docs/.vitepress/check-theme-links.mjs
+++ b/v3-docs/docs/.vitepress/check-theme-links.mjs
@@ -1,0 +1,76 @@
+function collectLinks(value, location = "themeConfig", links = []) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectLinks(item, `${location}[${index}]`, links));
+    return links;
+  }
+
+  if (!value || typeof value !== "object") {
+    return links;
+  }
+
+  for (const [key, item] of Object.entries(value)) {
+    const itemLocation = `${location}.${key}`;
+
+    if (key === "link" && typeof item === "string") {
+      links.push({ link: item, location: itemLocation });
+    } else {
+      collectLinks(item, itemLocation, links);
+    }
+  }
+
+  return links;
+}
+
+function normalizeRoute(path) {
+  if (/%2f|%5c/i.test(path)) {
+    throw new Error("encoded path separator");
+  }
+
+  return decodeURIComponent(path)
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/\.(?:html|md)$/i, "")
+    .replace(/(?:^|\/)index$/i, "")
+    .replace(/\/$/, "");
+}
+
+export function checkThemeLinks({ themeConfig, pages, siteOrigin = "https://docs.meteor.com" }) {
+  const pageRoutes = new Set(pages.map(normalizeRoute));
+  const origin = new URL(siteOrigin).origin;
+  const failures = [];
+  let checkedLinks = 0;
+
+  for (const { link, location } of collectLinks(themeConfig)) {
+    let url;
+    try {
+      url = new URL(link, origin);
+    } catch {
+      failures.push(`${location}: ${link} is not a valid URL`);
+      continue;
+    }
+
+    if (url.origin !== origin) {
+      continue;
+    }
+
+    checkedLinks += 1;
+    let route;
+    try {
+      route = normalizeRoute(url.pathname);
+    } catch {
+      failures.push(`${location}: ${link} is not a valid URL`);
+      continue;
+    }
+
+    if (!pageRoutes.has(route)) {
+      failures.push(`${location}: ${link} does not match a documentation page`);
+    }
+  }
+
+  if (failures.length) {
+    throw new Error(
+      `Found ${failures.length} broken VitePress theme link(s):\n- ${failures.join("\n- ")}`
+    );
+  }
+
+  console.log(`Validated ${checkedLinks} internal VitePress theme links.`);
+}

--- a/v3-docs/docs/.vitepress/check-theme-links.mjs
+++ b/v3-docs/docs/.vitepress/check-theme-links.mjs
@@ -33,8 +33,14 @@ function normalizeRoute(path) {
     .replace(/\/$/, "");
 }
 
-export function checkThemeLinks({ themeConfig, pages, siteOrigin = "https://docs.meteor.com" }) {
+export function checkThemeLinks({
+  themeConfig,
+  pages,
+  siteOrigin = "https://docs.meteor.com",
+  ignoredRoutes = [],
+}) {
   const pageRoutes = new Set(pages.map(normalizeRoute));
+  const ignored = new Set(ignoredRoutes.map(normalizeRoute));
   const origin = new URL(siteOrigin).origin;
   const failures = [];
   let checkedLinks = 0;
@@ -61,7 +67,7 @@ export function checkThemeLinks({ themeConfig, pages, siteOrigin = "https://docs
       continue;
     }
 
-    if (!pageRoutes.has(route)) {
+    if (!pageRoutes.has(route) && !ignored.has(route)) {
       failures.push(`${location}: ${link} does not match a documentation page`);
     }
   }

--- a/v3-docs/docs/.vitepress/check-theme-links.test.mjs
+++ b/v3-docs/docs/.vitepress/check-theme-links.test.mjs
@@ -50,3 +50,13 @@ test("rejects encoded path separators", () => {
     /\/about%2Finstall is not a valid URL/
   );
 });
+
+test("allows explicitly ignored existing routes", () => {
+  checkThemeLinks({
+    themeConfig: {
+      sidebar: [{ text: "Underscore", link: "/packages/underscore" }],
+    },
+    pages: ["index.md"],
+    ignoredRoutes: ["/packages/underscore"],
+  });
+});

--- a/v3-docs/docs/.vitepress/check-theme-links.test.mjs
+++ b/v3-docs/docs/.vitepress/check-theme-links.test.mjs
@@ -50,13 +50,3 @@ test("rejects encoded path separators", () => {
     /\/about%2Finstall is not a valid URL/
   );
 });
-
-test("allows explicitly ignored existing routes", () => {
-  checkThemeLinks({
-    themeConfig: {
-      sidebar: [{ text: "Underscore", link: "/packages/underscore" }],
-    },
-    pages: ["index.md"],
-    ignoredRoutes: ["/packages/underscore"],
-  });
-});

--- a/v3-docs/docs/.vitepress/check-theme-links.test.mjs
+++ b/v3-docs/docs/.vitepress/check-theme-links.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { checkThemeLinks } from "./check-theme-links.mjs";
+
+test("rejects missing links in nested theme configuration", () => {
+  assert.throws(
+    () => checkThemeLinks({
+      themeConfig: {
+        sidebar: [{ text: "Underscore", link: "/packages/underscore" }],
+      },
+      pages: ["index.md", "packages/meteor.md"],
+    }),
+    /themeConfig\.sidebar\[0\]\.link: \/packages\/underscore does not match a documentation page/
+  );
+});
+
+test("accepts supported internal route formats", () => {
+  checkThemeLinks({
+    themeConfig: {
+      nav: [
+        { text: "Home", link: "/" },
+        { text: "API", link: "/api/" },
+        { text: "Install", link: "/about/install.html#requirements" },
+        { text: "Absolute", link: "https://docs.meteor.com/about/install" },
+        { text: "External", link: "https://example.com/missing" },
+        { text: "Protocol-relative", link: "//example.com/missing" },
+      ],
+    },
+    pages: ["index.md", "api/index.md", "about/install.md"],
+  });
+});
+
+test("reports invalid internal URLs", () => {
+  assert.throws(
+    () => checkThemeLinks({
+      themeConfig: { nav: [{ text: "Invalid", link: "/%" }] },
+      pages: ["index.md"],
+    }),
+    /\/% is not a valid URL/
+  );
+});
+
+test("rejects encoded path separators", () => {
+  assert.throws(
+    () => checkThemeLinks({
+      themeConfig: { nav: [{ text: "Ambiguous", link: "/about%2Finstall" }] },
+      pages: ["about/install.md"],
+    }),
+    /\/about%2Finstall is not a valid URL/
+  );
+});

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -24,6 +24,8 @@ export default defineConfig({
     checkThemeLinks({
       themeConfig: siteConfig.site.themeConfig,
       pages: siteConfig.pages,
+      // Remove after https://github.com/meteor/meteor/pull/14660 lands.
+      ignoredRoutes: ["/packages/underscore"],
     });
   },
   themeConfig: {
@@ -402,6 +404,10 @@ export default defineConfig({
               {
                 text: "logging",
                 link: "/packages/logging",
+              },
+              {
+                text: "underscore",
+                link: "/packages/underscore",
               },
               {
                 text: "autoupdate",

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -24,8 +24,6 @@ export default defineConfig({
     checkThemeLinks({
       themeConfig: siteConfig.site.themeConfig,
       pages: siteConfig.pages,
-      // Remove after https://github.com/meteor/meteor/pull/14660 lands.
-      ignoredRoutes: ["/packages/underscore"],
     });
   },
   themeConfig: {

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitepress";
 import metadata from "../generators/meteor-versions/metadata.generated";
 import llmstxt from "vitepress-plugin-llms";
+import { checkThemeLinks } from "./check-theme-links.mjs";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -19,6 +20,12 @@ export default defineConfig({
     hostname: "https://v3-docs.meteor.com",
   },
   ignoreDeadLinks: [/^http:\/\/localhost/],
+  buildEnd(siteConfig) {
+    checkThemeLinks({
+      themeConfig: siteConfig.site.themeConfig,
+      pages: siteConfig.pages,
+    });
+  },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
@@ -395,10 +402,6 @@ export default defineConfig({
               {
                 text: "logging",
                 link: "/packages/logging",
-              },
-              {
-                text: "underscore",
-                link: "/packages/underscore",
               },
               {
                 text: "autoupdate",

--- a/v3-docs/docs/netlify.toml
+++ b/v3-docs/docs/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = ".vitepress/dist"
+  command = "npm run test:links && npm run docs:build"

--- a/v3-docs/docs/package.json
+++ b/v3-docs/docs/package.json
@@ -5,7 +5,8 @@
     "docs:dev": "npm run codegen && vitepress dev",
     "docs:build": "npm run codegen && vitepress build",
     "docs:preview": "vitepress preview",
-    "deploy:preview": "npm run docs:build && npm run docs:preview"
+    "deploy:preview": "npm run docs:build && npm run docs:preview",
+    "test:links": "node --test .vitepress/check-theme-links.test.mjs"
   },
   "devDependencies": {
     "canonical-json": "^0.0.4",


### PR DESCRIPTION
## Summary

- validate internal links from VitePress theme configuration against the resolved page list during every docs build
- add dependency-free Node tests for nested theme links and route normalization
- run the unit tests in a path-filtered GitHub Actions workflow
- run the tests before the existing Netlify documentation build

VitePress already checks links parsed from Markdown, but theme navigation and sidebar links bypass that validation. The new `buildEnd` check fills that page-level gap without adding a link-checking dependency or making network requests.

Anchor and external URL validation are intentionally out of scope because the current generated API documentation contains an existing backlog of stale fragments.

## Verification

- `npm run test:links`
- `npm run docs:build` (validated 139 internal VitePress theme links)
- `actionlint -shellcheck= -pyflakes=`
- `git diff --check`

Follow-up to #14659.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for internal V3 documentation links, including nested sidebar links and supported route formats.
  * Documentation builds now report invalid or unmatched links.

* **Tests**
  * Added coverage for valid, malformed, external, encoded, and ignored links.

* **Chores**
  * Added automated checks for documentation changes, including link testing and build verification.
  * Updated documentation publishing to run link checks before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->