### PR TITLE
fix(watcher): skip immutable package warehouse files

### DIFF
--- a/tools/fs/safe-watcher.test.js
+++ b/tools/fs/safe-watcher.test.js
@@ -1,0 +1,73 @@
+const path = require("node:path").posix;
+
+const mockUnsubscribe = jest.fn(async () => {});
+const mockSubscribe = jest.fn(async () => ({ unsubscribe: mockUnsubscribe }));
+const mockWatchFile = jest.fn();
+const mockUnwatchFile = jest.fn();
+
+jest.mock(
+  "@parcel/watcher",
+  () => ({
+    __esModule: true,
+    default: { subscribe: mockSubscribe },
+  }),
+  { virtual: true },
+);
+
+jest.mock("./safe-watcher-legacy", () => ({
+  watch: jest.fn(),
+  addWatchRoot: jest.fn(),
+  closeAllWatchers: jest.fn(),
+}));
+
+jest.mock("../tool-env/profile", () => ({
+  Profile: (_name, fn) => fn,
+}));
+
+jest.mock("../tool-env/meteor-config", () => ({
+  getMeteorConfig: () => ({ modern: { watcher: true } }),
+}));
+
+jest.mock("./files", () => ({
+  statOrNull: (filePath) => ({
+    isDirectory: () => !filePath.endsWith(".js"),
+  }),
+  lstat: () => ({ isSymbolicLink: () => false }),
+  toPosixPath: (filePath) => filePath,
+  convertToOSPath: (filePath) => filePath,
+  pathRelative: path.relative,
+  watchFile: mockWatchFile,
+  unwatchFile: mockUnwatchFile,
+  pathResolve: path.resolve,
+  pathDirname: path.dirname,
+  pathJoin: path.join,
+  getHomeDir: () => "/home/tester",
+  getCurrentToolsDir: () => "/checkout",
+  inCheckout: () => false,
+}));
+
+delete process.env.METEOR_WAREHOUSE_DIR;
+
+const safeWatcher = require("./safe-watcher.ts");
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+afterAll(async () => {
+  await safeWatcher.closeAllWatchers();
+});
+
+test("does not create native subscriptions for immutable warehouse packages", async () => {
+  const appCallback = jest.fn();
+  safeWatcher.watch("/home/tester/.meteor/packages/ddp-client/3.3.0/os/client.js", jest.fn());
+  safeWatcher.watch("/app/imports/main.js", appCallback);
+
+  await flushPromises();
+
+  expect(mockSubscribe).toHaveBeenCalledTimes(1);
+  expect(mockSubscribe.mock.calls[0][0]).toBe("/app/imports");
+  expect(mockWatchFile).not.toHaveBeenCalled();
+
+  const parcelCallback = mockSubscribe.mock.calls[0][1];
+  parcelCallback(null, [{ path: "/app/imports/main.js", type: "update" }]);
+  expect(appCallback).toHaveBeenCalledWith("change");
+});

--- a/tools/fs/safe-watcher.ts
+++ b/tools/fs/safe-watcher.ts
@@ -3,7 +3,21 @@ import ParcelWatcher from "@parcel/watcher";
 import { watch as watchLegacy, addWatchRoot as addWatchRootLegacy, closeAllWatchers as closeAllWatchersLegacy } from './safe-watcher-legacy';
 
 import { Profile } from "../tool-env/profile";
-import { statOrNull, lstat, toPosixPath, convertToOSPath, pathRelative, watchFile, unwatchFile, pathResolve, pathDirname } from "./files";
+import {
+  statOrNull,
+  lstat,
+  toPosixPath,
+  convertToOSPath,
+  pathRelative,
+  watchFile,
+  unwatchFile,
+  pathResolve,
+  pathDirname,
+  pathJoin,
+  getHomeDir,
+  getCurrentToolsDir,
+  inCheckout
+} from "./files";
 import { getMeteorConfig } from "../tool-env/meteor-config";
 
 const constants = require("constants");
@@ -142,6 +156,17 @@ if (process.env.METEOR_WATCH_PRIORITIZE_CHANGED &&
 // watchLibrary.watch if available.
 const changedPaths = new Set;
 
+function getPackageWarehouseRoot(): string | null {
+  if (process.env.METEOR_WAREHOUSE_DIR) {
+    return pathJoin(toPosixPath(process.env.METEOR_WAREHOUSE_DIR), "packages");
+  }
+
+  const baseDir = inCheckout() ? getCurrentToolsDir() : getHomeDir();
+  return baseDir ? pathJoin(toPosixPath(baseDir), ".meteor", "packages") : null;
+}
+
+const packageWarehouseRoot = getPackageWarehouseRoot();
+
 function shouldIgnorePath(absPath: string): boolean {
   const posixPath = toPosixPath(absPath);
   const parts = posixPath.split('/');
@@ -158,6 +183,17 @@ function shouldIgnorePath(absPath: string): boolean {
 
   if (isWithinCwd && absPath.includes(`${cwd}/.meteor/local`)) {
     return true;
+  }
+
+  // Downloaded package versions are installed atomically and immutable. Watching
+  // their contents creates hundreds of native subscriptions without enabling a
+  // development workflow; package selection changes are watched in the app.
+  if (packageWarehouseRoot) {
+    const relativeToWarehouse = pathRelative(packageWarehouseRoot, posixPath);
+    if (relativeToWarehouse === "" ||
+        (!relativeToWarehouse.startsWith("..") && !relativeToWarehouse.startsWith("/"))) {
+      return true;
+    }
   }
 
   // Check for .meteor: allow the .meteor directory itself,

--- a/tools/unit-tests/jest.config.js
+++ b/tools/unit-tests/jest.config.js
@@ -37,6 +37,13 @@ module.exports = {
       },
       module: { type: "commonjs" },
     }],
+    "^.+\\.ts$": [require.resolve("@swc/jest"), {
+      jsc: {
+        parser: { syntax: "typescript" },
+        target: "es2022",
+      },
+      module: { type: "commonjs" },
+    }],
   },
   transformIgnorePatterns: ["/node_modules/"],
   testTimeout: 10_000,


### PR DESCRIPTION
Fixes #14671.

## Problem

The modern safe-watcher creates one recursive Parcel subscription for every distinct parent directory in a watch set. In a measured package-heavy app, one Meteor test process held 224 Parcel subscriptions: 223 beneath the downloaded package warehouse and one for the app. Rspack used only 13 additional `fs.watch` handles.

Because macOS has a shared empirical ceiling of roughly 450 attached FSEvent streams, a second package-heavy Meteor process can exhaust the pool and receive `Error starting FSEvents stream`. Those failed roots can then miss rebuilds.

## Change

Treat downloaded package warehouse contents as immutable inputs and skip file watchers for them. Meteor installs downloaded package versions atomically; package selection metadata in the app remains watched. Application files and local package source roots continue using the native watcher.

The warehouse root respects:

- `METEOR_WAREHOUSE_DIR` in sandboxes/custom installations;
- the checkout-local `.meteor/packages` cache when running from source; and
- `$HOME/.meteor/packages` for normal installations.

## Tests

The commits preserve the red/green sequence:

1. `0e50024834` adds a public-interface test showing that a warehouse file and an app file create two Parcel subscriptions.
2. `1da081c973` skips the immutable warehouse path, leaving only the app subscription while verifying that app events still dispatch.

Validation:

- `npm run test:unit` — 122 passing
- `npx oxlint@1.57.0 --ignore-path .oxlintignore .` — clean
- `./meteor --help` from the checkout — successful tool bootstrap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file watching to ignore Meteor’s package warehouse and its contents, reducing unnecessary activity.
  - Continued monitoring application files and reporting file changes correctly.

- **Tests**
  - Added coverage verifying warehouse files are excluded while application files trigger change callbacks.
  - Enhanced test support for TypeScript-based tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->