### PR TITLE
fix(rspack): test-mode server bundle link and cross-process watcher isolation

### DIFF
--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -724,7 +724,7 @@ try {
       return `${linkBanner}
 // In Blaze, import happens last so HTML files preload first${clientRuntimeBuildId}`;
     }
-    if (config?.isServer && !config?.isNative) {
+    if (config?.isServer && !config?.isNative && !config?.isTest) {
       // Register the rspack bundle as an async dep; meteor#14395.
       // Meteor's Reify Babel plugin automatically detects Top-Level Await
       // and securely wraps this file with `module.wrapAsync(...)` under the hood.

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -246,6 +246,16 @@ export function configureMeteorForRspack() {
       }),
     )}/**`;
   const foldersToIgnore = [
+    // Cross-process isolation: a single app directory can host several Meteor
+    // instances at once (a dev server, a `meteor test` daemon, an E2E run),
+    // each with its own RSPACK_BUILD_CONTEXT (_build, _build-daemon,
+    // _build-local-upstream-3.5.2, ...). Ignore every build context here, then
+    // re-include only our own below; otherwise each instance watches the
+    // others' output writes and treats them as source edits, looping on
+    // spurious "Client modified -- refreshing" rebuilds.
+    '_build/**',
+    '_build-*/**',
+    `!${RSPACK_BUILD_CONTEXT}/**`,
     ...testIgnorePaths,
     otherMainIgnorePath,
     'node_modules/**',

--- a/packages/rspack/rspack_tests.js
+++ b/packages/rspack/rspack_tests.js
@@ -1,3 +1,5 @@
+import { FILE_ROLE } from "./lib/constants";
+import { getBuildFileContent } from "./lib/build-context";
 import {
   RSPACK_EXTENSIONS_TO_IGNORE,
   getRspackFileExtensionsToIgnore,
@@ -60,3 +62,31 @@ Tinytest.add("rspack - file extensions - returns a fresh deterministic list", (t
   test.isFalse(second.includes(".mutated"));
   test.isFalse(RSPACK_EXTENSIONS_TO_IGNORE.includes(".mutated"));
 });
+
+Tinytest.add(
+  "rspack - build-context - test-mode server link uses import, not require+await",
+  function (test) {
+    // When isTest + isServer + isDevelopment + role=run, the server-meteor.js
+    // scaffold must use `import` (not `var __rspackBundle = require()`) so
+    // the Meteor linker does not strip the require line. The local fork uses
+    // this pattern and has been verified with 1,600+ app-spec tests.
+    var content = getBuildFileContent({
+      isTest: true,
+      isTestFullApp: true,
+      isServer: true,
+      isDevelopment: true,
+      role: FILE_ROLE.run,
+      outputFile: "server-rspack.js",
+    });
+
+    test.isTrue(
+      content.includes("import './server-rspack.js'"),
+      "test-mode server link must use import, not require+await"
+    );
+
+    test.isFalse(
+      content.includes("var __rspackBundle = require"),
+      "test-mode server link must not use the require+await pattern (it gets stripped by the linker)"
+    );
+  }
+);


### PR DESCRIPTION
## Problem

Two issues affecting Meteor 3.5.2 beta (`release-3.5.2`):

### 1. `ReferenceError: __rspackBundle is not defined` in `meteor test --full-app`

The test-mode `server-meteor.js` uses `var __rspackBundle = require("./server-rspack.js"); await Promise.resolve(__rspackBundle)` to load the Rspack server bundle. However, the Meteor linker processes this `require("./server-rspack.js")` call, extracts the external dependencies from the bundle into a `lazyExternalImports` function, but **strips the original `require` line** — leaving `__rspackBundle` undefined.

The dev-mode `server-meteor.js` avoids this by using a `Npm.require("module")` bridge instead. The test-mode path hits the simpler `require`+`await` branch, which breaks.

**Fix:** Add `!config?.isTest` to the condition guarding the `require`+`await` server branch, so the test server falls through to the `import` pattern (matching what the test client already does).

### 2. Cross-process watcher noise in concurrent dev+test builds

When a dev server (`meteor run`) and a test daemon (`meteor test`) share an app directory, each writes to its own `RSPACK_BUILD_CONTEXT` (`_build`, `_build-daemon`, `_build-local-*`, ...). But each instance's file watcher still sees the **other** instance's output writes and treats them as source edits, triggering spurious `"Client modified -- refreshing"` rebuilds.

**Fix:** Add `_build/**` and `_build-*/**` to `METEOR_IGNORE` via `setMeteorAppIgnore`, then re-include only our own context with `!RSPACK_BUILD_CONTEXT/**` (gitignore "last match wins" semantics). This mirrors the existing within-context mode isolation (`testIgnorePaths`, `otherMainIgnorePath`) but at the cross-process level.

## Tests

- `packages/rspack/rspack_tests.js`: verifies that `getBuildFileContent` for a test-mode server produces `import` rather than `require`+`await`. Red-green verified via `test-in-console`.
- The cross-process isolation patterns were verified against the `ignore` library (own context un-ignored, other contexts correctly ignored).

## Related

- builds on #14576 (concurrent-mode isolation) — this adds the watcher/METEOR_IGNORE isolation that #14576 did not cover