### PR TITLE
[Rspack] Preserve server tla and cover cross-process watcher isolation

### DIFF
--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -724,7 +724,7 @@ try {
       return `${linkBanner}
 // In Blaze, import happens last so HTML files preload first${clientRuntimeBuildId}`;
     }
-    if (config?.isServer && !config?.isNative) {
+    if (config?.isServer && !config?.isNative && !config?.isTest) {
       // Register the rspack bundle as an async dep; meteor#14395.
       // Meteor's Reify Babel plugin automatically detects Top-Level Await
       // and securely wraps this file with `module.wrapAsync(...)` under the hood.

--- a/packages/rspack/lib/build-context.js
+++ b/packages/rspack/lib/build-context.js
@@ -724,7 +724,14 @@ try {
       return `${linkBanner}
 // In Blaze, import happens last so HTML files preload first${clientRuntimeBuildId}`;
     }
-    if (config?.isServer && !config?.isNative && !config?.isTest) {
+    if (config?.isServer && !config?.isNative && config?.isTest) {
+      // Keep the dependency visible to Meteor's linker, but retain the
+      // explicit wait for the Promise exported by a server bundle with TLA.
+      return `${linkBanner}
+import __rspackBundle from './${config?.outputFile || ''}';
+await Promise.resolve(__rspackBundle);`;
+    }
+    if (config?.isServer && !config?.isNative) {
       // Register the rspack bundle as an async dep; meteor#14395.
       // Meteor's Reify Babel plugin automatically detects Top-Level Await
       // and securely wraps this file with `module.wrapAsync(...)` under the hood.

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -246,6 +246,16 @@ export function configureMeteorForRspack() {
       }),
     )}/**`;
   const foldersToIgnore = [
+    // Cross-process isolation: a single app directory can host several Meteor
+    // instances at once (a dev server, a `meteor test` daemon, an E2E run),
+    // each with its own RSPACK_BUILD_CONTEXT (_build, _build-daemon,
+    // _build-local-upstream-3.5.2, ...). Ignore every build context here, then
+    // re-include only our own below; otherwise each instance watches the
+    // others' output writes and treats them as source edits, looping on
+    // spurious "Client modified -- refreshing" rebuilds.
+    '_build/**',
+    '_build-*/**',
+    `!${RSPACK_BUILD_CONTEXT}/**`,
     ...testIgnorePaths,
     otherMainIgnorePath,
     'node_modules/**',

--- a/packages/rspack/lib/config.js
+++ b/packages/rspack/lib/config.js
@@ -253,9 +253,10 @@ export function configureMeteorForRspack() {
     // re-include only our own below; otherwise each instance watches the
     // others' output writes and treats them as source edits, looping on
     // spurious "Client modified -- refreshing" rebuilds.
-    '_build/**',
-    '_build-*/**',
-    `!${RSPACK_BUILD_CONTEXT}/**`,
+    '/_build',
+    '/_build-*',
+    `!/${RSPACK_BUILD_CONTEXT}`,
+    `!/${RSPACK_BUILD_CONTEXT}/**`,
     ...testIgnorePaths,
     otherMainIgnorePath,
     'node_modules/**',

--- a/packages/rspack/rspack_tests.js
+++ b/packages/rspack/rspack_tests.js
@@ -1,3 +1,5 @@
+import { FILE_ROLE } from "./lib/constants";
+import { getBuildFileContent } from "./lib/build-context";
 import {
   RSPACK_EXTENSIONS_TO_IGNORE,
   getRspackFileExtensionsToIgnore,
@@ -60,3 +62,31 @@ Tinytest.add("rspack - file extensions - returns a fresh deterministic list", (t
   test.isFalse(second.includes(".mutated"));
   test.isFalse(RSPACK_EXTENSIONS_TO_IGNORE.includes(".mutated"));
 });
+
+Tinytest.add(
+  "rspack - build-context - test-mode server link uses import, not require+await",
+  function (test) {
+    // When isTest + isServer + isDevelopment + role=run, the server-meteor.js
+    // scaffold must use `import` (not `var __rspackBundle = require()`) so
+    // the Meteor linker does not strip the require line. The local fork uses
+    // this pattern and has been verified with 1,600+ app-spec tests.
+    var content = getBuildFileContent({
+      isTest: true,
+      isTestFullApp: true,
+      isServer: true,
+      isDevelopment: true,
+      role: FILE_ROLE.run,
+      outputFile: "server-rspack.js",
+    });
+
+    test.isTrue(
+      content.includes("import './server-rspack.js'"),
+      "test-mode server link must use import, not require+await"
+    );
+
+    test.isFalse(
+      content.includes("var __rspackBundle = require"),
+      "test-mode server link must not use the require+await pattern (it gets stripped by the linker)"
+    );
+  }
+);

--- a/packages/rspack/rspack_tests.js
+++ b/packages/rspack/rspack_tests.js
@@ -64,12 +64,11 @@ Tinytest.add("rspack - file extensions - returns a fresh deterministic list", (t
 });
 
 Tinytest.add(
-  "rspack - build-context - test-mode server link uses import, not require+await",
+  "rspack - build-context - test-mode server imports and awaits its bundle",
   function (test) {
     // When isTest + isServer + isDevelopment + role=run, the server-meteor.js
-    // scaffold must use `import` (not `var __rspackBundle = require()`) so
-    // the Meteor linker does not strip the require line. The local fork uses
-    // this pattern and has been verified with 1,600+ app-spec tests.
+    // scaffold must keep the dependency visible to Meteor's linker and wait
+    // for the Promise exported by a bundle with TLA.
     var content = getBuildFileContent({
       isTest: true,
       isTestFullApp: true,
@@ -80,13 +79,44 @@ Tinytest.add(
     });
 
     test.isTrue(
-      content.includes("import './server-rspack.js'"),
-      "test-mode server link must use import, not require+await"
+      content.includes(
+        "import __rspackBundle from './server-rspack.js'",
+      ),
+      "test-mode server link must import the Rspack bundle",
     );
 
     test.isFalse(
       content.includes("var __rspackBundle = require"),
-      "test-mode server link must not use the require+await pattern (it gets stripped by the linker)"
+      "test-mode server link must not use the require+await pattern (it gets stripped by the linker)",
     );
-  }
+    test.isTrue(
+      content.includes("await Promise.resolve(__rspackBundle)"),
+      "test-mode server must wait for the async Rspack bundle",
+    );
+  },
+);
+
+Tinytest.add(
+  "rspack - build-context - production server preserves require+await for TLA",
+  function (test) {
+    var content = getBuildFileContent({
+      isTest: false,
+      isServer: true,
+      isProduction: true,
+      role: FILE_ROLE.run,
+      entryFile: "server/main.js",
+      outputFile: "server-rspack.js",
+    });
+
+    test.isTrue(
+      content.includes(
+        "var __rspackBundle = require('./server-rspack.js')",
+      ),
+      "production server must keep registering its Rspack bundle as an async dependency",
+    );
+    test.isTrue(
+      content.includes("await Promise.resolve(__rspackBundle)"),
+      "production server must wait for the async Rspack bundle",
+    );
+  },
 );

--- a/tools/e2e-tests/regressions/concurrent-modes.test.js
+++ b/tools/e2e-tests/regressions/concurrent-modes.test.js
@@ -33,8 +33,36 @@ function getModeEnv(localDir, rspackPort) {
   };
 }
 
+function getSeparateContextEnv(localDir, rspackPort) {
+  return {
+    METEOR_LOCAL_DIR: localDir,
+    RSPACK_DEVSERVER_PORT: String(rspackPort),
+  };
+}
+
 async function readBundle(appDir, relativePath) {
   return fs.readFile(path.join(appDir, relativePath), 'utf8');
+}
+
+async function waitForOutputToSettle(outputLines, {
+  quietMs = 2000,
+  timeout = 30000,
+} = {}) {
+  const startedAt = Date.now();
+  let lastLength = outputLines.length;
+  let lastChangeAt = Date.now();
+
+  while (Date.now() - startedAt < timeout) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    if (outputLines.length !== lastLength) {
+      lastLength = outputLines.length;
+      lastChangeAt = Date.now();
+    } else if (Date.now() - lastChangeAt >= quietMs) {
+      return;
+    }
+  }
+
+  throw new Error('Meteor output did not settle before the watcher probe');
 }
 
 describe('Regressions / Rspack concurrent modes /', () => {
@@ -51,9 +79,16 @@ describe('Regressions / Rspack concurrent modes /', () => {
 
     const packagesPath = path.join(appDir, '.meteor', 'packages');
     const packages = await fs.readFile(packagesPath, 'utf8');
+    const packagesWithoutMongo = packages.replace(
+      /^mongo(?:@[^\s]+)?\s*\n/m,
+      '',
+    );
+    // Keep both Meteor processes on one package solution. If the driver is
+    // transient, run and test repeatedly rewrite .meteor/versions and obscure
+    // the Rspack watcher behavior this suite is meant to exercise.
     await fs.writeFile(
       packagesPath,
-      packages.replace(/^mongo(?:@[^\s]+)?\s*\n/m, ''),
+      `${packagesWithoutMongo.trimEnd()}\nmeteortesting:mocha\n`,
       'utf8',
     );
     basePackageConfig = await fs.readJson(path.join(appDir, 'package.json'));
@@ -123,6 +158,44 @@ describe('Regressions / Rspack concurrent modes /', () => {
     expect(await fs.pathExists(
       path.join(appDir, '_build/app-test/client-rspack.js')
     )).toBe(true);
+  });
+
+  test('ignores Rspack output written by another Meteor process', async () => {
+    const appResult = await runMeteorApp(appDir, APP_PORT, {
+      waitForOutput: '=> App running at',
+      env: getSeparateContextEnv(PRIMARY_LOCAL_DIR, APP_RSPACK_PORT),
+    });
+    appProcess = appResult.meteorProcess;
+
+    const testResult = await runMeteorTests(appDir, TEST_PORT, {
+      waitForOutput: '=> App running at',
+      commandOptions: ['--full-app'],
+      testClient: true,
+      env: getSeparateContextEnv(SECONDARY_LOCAL_DIR, TEST_RSPACK_PORT),
+    });
+    testProcess = testResult.meteorProcess;
+
+    const otherProcessBundle = path.join(
+      appDir,
+      '_build-local-secondary/app-test/client-rspack.js',
+    );
+    expect(await fs.pathExists(otherProcessBundle)).toBe(true);
+
+    // Ignore startup churn, then make one controlled write in the other
+    // process's completed build context. The development process must not
+    // treat this generated output as a source change.
+    await waitForOutputToSettle(appResult.outputLines);
+    const outputStart = appResult.outputLines.length;
+    await fs.appendFile(
+      otherProcessBundle,
+      '\n// cross-process watcher probe\n',
+      'utf8',
+    );
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    expect(appResult.outputLines.slice(outputStart).join('\n')).not.toMatch(
+      /=> (?:Client|Server) modified/,
+    );
   });
 
   test('isolates normal-test and full-app-test module directories', async () => {

--- a/tools/e2e-tests/regressions/concurrent-modes.test.js
+++ b/tools/e2e-tests/regressions/concurrent-modes.test.js
@@ -160,7 +160,7 @@ describe('Regressions / Rspack concurrent modes /', () => {
     )).toBe(true);
   });
 
-  test('ignores Rspack output written by another Meteor process', async () => {
+  test('ignores new output directories in another Rspack context', async () => {
     const appResult = await runMeteorApp(appDir, APP_PORT, {
       waitForOutput: '=> App running at',
       env: getSeparateContextEnv(PRIMARY_LOCAL_DIR, APP_RSPACK_PORT),
@@ -181,14 +181,19 @@ describe('Regressions / Rspack concurrent modes /', () => {
     );
     expect(await fs.pathExists(otherProcessBundle)).toBe(true);
 
-    // Ignore startup churn, then make one controlled write in the other
-    // process's completed build context. The development process must not
-    // treat this generated output as a source change.
+    // Startup metadata and discovery of a new root directory can legitimately
+    // restart the app. Once both processes settle, create a new output
+    // directory inside the other process's context. Without directory-level
+    // isolation, Meteor descends into that context and rebuilds.
     await waitForOutputToSettle(appResult.outputLines);
     const outputStart = appResult.outputLines.length;
-    await fs.appendFile(
-      otherProcessBundle,
-      '\n// cross-process watcher probe\n',
+    const newProcessBundle = path.join(
+      appDir,
+      '_build-local-secondary/watcher-probe/client-rspack.js',
+    );
+    await fs.outputFile(
+      newProcessBundle,
+      '// cross-process watcher probe\n',
       'utf8',
     );
     await new Promise(resolve => setTimeout(resolve, 2000));

--- a/tools/e2e-tests/tla.test.js
+++ b/tools/e2e-tests/tla.test.js
@@ -1,6 +1,8 @@
 import {
   cleanupTempDir,
+  killMeteorProcess,
   killProcessByPort,
+  runMeteorApp,
   runMeteorTests,
   setupMeteorApp,
 } from './helpers';
@@ -10,6 +12,7 @@ const { linkLocalRspack } = require('./scripts/link-rspack');
 describe('Regressions / tla /', () => {
   const port = 3145;
   let tempDir;
+  let meteorProcess;
 
   beforeAll(async () => {
     ({ tempDir } = await setupMeteorApp('tla'));
@@ -25,17 +28,41 @@ describe('Regressions / tla /', () => {
     await killProcessByPort(port);
   });
 
+  afterEach(async () => {
+    await killMeteorProcess(meteorProcess);
+    meteorProcess = null;
+  });
+
+  test('"meteor run" waits for server TLA dependencies', async () => {
+    const result = await runMeteorApp(tempDir, port, {
+      waitForOutput: '[tla] server main loaded: ready',
+      skipWaitOn: true,
+    });
+    meteorProcess = result.meteorProcess;
+
+    const output = result.outputLines.join('\n');
+    const settledIndex = output.indexOf('[tla] async-dep settled');
+    const mainIndex = output.indexOf('[tla] server main loaded: ready');
+
+    expect(settledIndex).toBeGreaterThanOrEqual(0);
+    expect(mainIndex).toBeGreaterThan(settledIndex);
+  });
+
   test('"meteor test --full-app --once" runs tests', async () => {
     const result = await runMeteorTests(tempDir, port, {
       commandOptions: ['--full-app', '--once'],
       checkTestResults: true,
       testClient: false,
     });
+    meteorProcess = result.meteorProcess;
 
     const output = result.outputLines.join('\n');
     expect(output).toContain('[tla] async-dep settled');
     expect(output).toContain('[tla] app test loaded');
     expect(output).toMatch(/\b1 passing\b/);
     expect(output).not.toMatch(/\b0 passing\b/);
+    expect(output).not.toContain(
+      'ReferenceError: __rspackBundle is not defined',
+    );
   });
 });


### PR DESCRIPTION
This PR builds on [#14674](https://github.com/meteor/meteor/pull/14674) and preserves [@hexsprite](https://github.com/hexsprite)'s original commit and cross-process watcher fix, on early testing and fixing for the next Meteor 3.5.2 published beta.

The original linker diagnosis was correct: test-mode server bundles must use `import` because Meteor can strip the `require` binding.

However, the bare import did not await the Promise exported by a server bundle using top-level await. This caused `meteor test --full-app --once` to finish with `0 passing`.

This PR refines the test-mode link to import and await the bundle:

```js
import __rspackBundle from './server-rspack.js';
await Promise.resolve(__rspackBundle);
```

## Tests

Added E2E coverage confirming:

- `meteor run` preserves [TLA support](https://github.com/meteor/meteor/pull/14405)
- `meteor test --full-app --once` reports `1 passing`
- concurrent dev and test processes ignore each other's Rspack output

Rspack Tinytests and both regression E2E suites pass.