### PR TITLE
[3.6] Fix bundler crash: npm-rebuild scratch dirs race the node_modules walk

### DIFF
--- a/packages/test-in-console/run.sh
+++ b/packages/test-in-console/run.sh
@@ -8,6 +8,12 @@
 cd $(dirname $0)/../..
 export METEOR_HOME=`pwd`
 
+# Make sure the dev_bundle matches the checked-out BUNDLE_VERSION before
+# probing it for puppeteer: a cached dev_bundle from another branch passes the
+# probe and is then replaced mid-run by the first real meteor invocation,
+# taking its puppeteer install with it.
+./meteor --version >/dev/null 2>&1 || true
+
 # Install puppeteer into dev_bundle only when it is not already available globally
 # (e.g. on oss-vm, where puppeteer@23.6.0 is pre-installed via system npm and
 # NODE_PATH is set to $(npm root -g) by the CI workflow).

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -47,6 +47,12 @@ const ENABLE_IN_PLACE_BUILDER_REPLACEMENT =
   (process.platform !== 'win32') &&
   ! process.env.METEOR_DISABLE_BUILDER_IN_PLACE;
 
+// Scratch directories created inside node_modules by meteorNpm.
+// rebuildIfNonPortable, rm_recursive_deferred and renameDirAlmostAtomically;
+// never legitimate bundle content.
+const TRANSIENT_SCRATCH_REGEX =
+  /^\.(?:temp-[0-9a-z]+(?:\.old-\d+)?|.*-garbage-[0-9a-z]+)$/;
+
 
 // Options:
 //  - outputPath: Required. Path to the directory that will hold the
@@ -559,6 +565,10 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     return this._copyDirectory(Object.assign({}, options, {
       filter: (absPath, isDirectory) => {
         if (isDirectory && absPath === rootCache) return false;
+        if (isDirectory &&
+            TRANSIENT_SCRATCH_REGEX.test(files.pathBasename(absPath))) {
+          return false;
+        }
         return userFilter ? userFilter(absPath, isDirectory) : true;
       },
     }));
@@ -776,8 +786,15 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
           // Symbolic links pointing to relative external paths are less
           // portable than absolute links, so getExternalPath() is
           // preferred if it returns a path.
-          const linkSource = getExternalPath() ||
-              files.readlink(thisAbsFrom);
+          let linkSource;
+          try {
+            linkSource = getExternalPath() ||
+                files.readlink(thisAbsFrom);
+          } catch (e) {
+            // Entry deleted between readdir and readlink; skip it.
+            if (e.code === "ENOENT") continue;
+            throw e;
+          }
 
           const linkTarget =
               files.pathResolve(this.buildPath, thisRelTo);

--- a/tools/isobuild/builder.js
+++ b/tools/isobuild/builder.js
@@ -53,6 +53,21 @@ const ENABLE_IN_PLACE_BUILDER_REPLACEMENT =
 const TRANSIENT_SCRATCH_REGEX =
   /^\.(?:temp-[0-9a-z]+(?:\.old-\d+)?|.*-garbage-[0-9a-z]+)$/;
 
+// Meteor only ever creates those directly inside a node_modules directory
+// (or a node_modules/@scope directory), so the location is part of the
+// check: a package-owned lookalike deeper in the tree (e.g.
+// node_modules/example/.temp-cache) is preserved.
+function isTransientScratchDir(absPath) {
+  if (! TRANSIENT_SCRATCH_REGEX.test(files.pathBasename(absPath))) {
+    return false;
+  }
+  let parent = files.pathDirname(absPath);
+  if (files.pathBasename(parent).startsWith("@")) {
+    parent = files.pathDirname(parent);
+  }
+  return files.pathBasename(parent) === "node_modules";
+}
+
 
 // Options:
 //  - outputPath: Required. Path to the directory that will hold the
@@ -565,10 +580,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
     return this._copyDirectory(Object.assign({}, options, {
       filter: (absPath, isDirectory) => {
         if (isDirectory && absPath === rootCache) return false;
-        if (isDirectory &&
-            TRANSIENT_SCRATCH_REGEX.test(files.pathBasename(absPath))) {
-          return false;
-        }
+        if (isDirectory && isTransientScratchDir(absPath)) return false;
         return userFilter ? userFilter(absPath, isDirectory) : true;
       },
     }));
@@ -576,6 +588,7 @@ Previous builder: ${previousBuilder.outputPath}, this builder: ${outputPath}`
 
   _ensureAllNonPackageDirectories(absFromDir, relToDir, skipPath) {
     if (skipPath && absFromDir === skipPath) return;
+    if (isTransientScratchDir(absFromDir)) return;
 
     const dirStat = optimisticStatOrNull(absFromDir);
     if (! (dirStat && dirStat.isDirectory())) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -384,9 +384,9 @@ Profile("meteorNpm.rebuildIfNonPortable", async function (nodeModulesDir) {
   const rebuildResult = await runNpmCommand(getRebuildArgs(), tempDir);
   if (! rebuildResult.success) {
     buildmessage.error(rebuildResult.error);
-    // Not deferred: tempDir is inside nodeModulesDir, which the bundler
-    // may walk as soon as we return.
-    await files.rm_recursive(tempDir);
+    // Awaited so the bundler never walks nodeModulesDir while tempDir is
+    // half-deleted, but async so the event loop is not blocked meanwhile.
+    await files.rm_recursive_async(tempDir);
     return false;
   }
 
@@ -422,9 +422,9 @@ Profile("meteorNpm.rebuildIfNonPortable", async function (nodeModulesDir) {
     await files.renameDirAlmostAtomically(tempPkgDirs[pkgPath], pkgPath);
   }
 
-  // Not deferred: tempDir is inside nodeModulesDir, which the bundler may
-  // walk as soon as we return.
-  await files.rm_recursive(tempDir);
+  // Awaited so the bundler never walks nodeModulesDir while tempDir is
+  // half-deleted, but async so the event loop is not blocked meanwhile.
+  await files.rm_recursive_async(tempDir);
 
   return true;
 });

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -384,7 +384,9 @@ Profile("meteorNpm.rebuildIfNonPortable", async function (nodeModulesDir) {
   const rebuildResult = await runNpmCommand(getRebuildArgs(), tempDir);
   if (! rebuildResult.success) {
     buildmessage.error(rebuildResult.error);
-    await files.rm_recursive_deferred(tempDir);
+    // Not deferred: tempDir is inside nodeModulesDir, which the bundler
+    // may walk as soon as we return.
+    await files.rm_recursive(tempDir);
     return false;
   }
 
@@ -420,7 +422,9 @@ Profile("meteorNpm.rebuildIfNonPortable", async function (nodeModulesDir) {
     await files.renameDirAlmostAtomically(tempPkgDirs[pkgPath], pkgPath);
   }
 
-  await files.rm_recursive_deferred(tempDir);
+  // Not deferred: tempDir is inside nodeModulesDir, which the bundler may
+  // walk as soon as we return.
+  await files.rm_recursive(tempDir);
 
   return true;
 });

--- a/tools/tests/builder-scratch-dirs.js
+++ b/tools/tests/builder-scratch-dirs.js
@@ -1,0 +1,69 @@
+const selftest = require('../tool-testing/selftest.js');
+const files = require('../fs/files');
+const Builder = require('../isobuild/builder.js').default;
+
+// Regression test for the npm-rebuild scratch-dir race: transient
+// directories that meteorNpm.rebuildIfNonPortable / rm_recursive_deferred /
+// renameDirAlmostAtomically leave directly inside a node_modules directory
+// must never be copied into bundles, while package-owned directories with
+// similar names deeper in the tree must be preserved.
+async function buildAndCheck(symlink) {
+  const sourceRoot = files.mkdtemp('builder-scratch-source');
+  const nm = files.pathJoin(sourceRoot, 'node_modules');
+
+  // Meteor-owned scratch dirs, directly under node_modules and under a
+  // node_modules/@scope directory.
+  files.mkdir_p(files.pathJoin(nm, '.temp-abc123.old-42', 'node_modules'));
+  files.writeFile(
+    files.pathJoin(nm, '.temp-abc123.old-42', 'node_modules', 'junk.txt'),
+    'junk\n');
+  files.mkdir_p(files.pathJoin(nm, '@scope', '.pkg-garbage-xyz789'));
+  files.writeFile(
+    files.pathJoin(nm, '@scope', '.pkg-garbage-xyz789', 'junk.txt'),
+    'junk\n');
+
+  // Package-owned lookalike deeper in the tree.
+  files.mkdir_p(files.pathJoin(nm, 'example', '.temp-cache'));
+  files.writeFile(
+    files.pathJoin(nm, 'example', 'package.json'),
+    '{"name":"example","version":"1.0.0"}\n');
+  files.writeFile(
+    files.pathJoin(nm, 'example', '.temp-cache', 'keep.txt'),
+    'keep\n');
+
+  const outputPath = files.pathJoin(
+    files.mkdtemp('builder-scratch-out'), 'bundle');
+  const builder = new Builder({ outputPath });
+  await builder.init();
+  await builder.copyNodeModulesDirectory({
+    from: nm,
+    to: 'node_modules',
+    symlink,
+  });
+  await builder.complete();
+
+  const outNm = files.pathJoin(outputPath, 'node_modules');
+  await selftest.expectEqual(
+    files.exists(files.pathJoin(outNm, 'example', '.temp-cache', 'keep.txt')),
+    true);
+  await selftest.expectEqual(
+    files.exists(files.pathJoin(outNm, '.temp-abc123.old-42')),
+    false);
+  await selftest.expectEqual(
+    files.exists(files.pathJoin(outNm, '@scope', '.pkg-garbage-xyz789')),
+    false);
+}
+
+selftest.define(
+  'builder - scratch dirs excluded from node_modules copies',
+  async () => {
+    await buildAndCheck(false);
+  });
+
+selftest.define(
+  'builder - scratch dirs excluded from symlinked node_modules copies',
+  async () => {
+    // The symlink variant also exercises the _ensureAllNonPackageDirectories
+    // pre-pass, which must skip scratch dirs too.
+    await buildAndCheck(true);
+  });


### PR DESCRIPTION
## Problem

Test-in-console workflows were flaky: whenever two CI jobs ran at the same time, one of them died with "meteor exited before becoming ready", and a solo rerun passed. The dying job always showed this crash:

```
Error: ENOENT: no such file or directory, readlink
'.../node_modules/.temp-1jd62f6lqcfl.old-189249/node_modules/.bin/resolve'
    at walk (/tools/isobuild/builder.js:780:21)
```

## Why this targets `release-3.5.2`

#14645 (in this release line) made the deferred background deletion truly asynchronous, which is what opened the race window — on devel the background deletion still blocks the event loop, so the window is nearly closed there. Landing the fix here ships it with the release that carries the regression; it flows to devel/3.6 with the usual merge-back.

## What actually happens

Each CI job restores an npm cache built on another machine, so `meteor` has to rebuild the binary deps. That rebuild creates `.temp-*` scratch directories **inside** the package's `node_modules` and deletes them **in the background, without awaiting**.

With two jobs hammering the same runner's disk, that background deletion lags. Moments later the same meteor process starts bundling, walks that same `node_modules`, steps into its own half-deleted `.temp-*` directory — and crashes when an entry disappears mid-walk. That's the flakiness: the crash needs the IO contention of a second job to show up, which is why running both together killed one and a rerun alone passed.

## This can happen outside CI too

The two ingredients — a rebuild that creates `.temp-*` dirs, and IO slow enough for the cleanup to lag — are not CI-specific:

- Upgrading Meteor to a release with a newer dev_bundle Node → full binary rebuild on next run.
- Moving a project between machines or architectures (Intel → Apple Silicon, macOS → Linux).
- Devcontainers with a bind-mounted project built on the host: guaranteed rebuild on the slowest IO there is.
- Cloud IDEs restoring prebuilt workspaces.

And the race is between two operations of the **same meteor process**, so isolating CI jobs would only make it rarer, never impossible. It has to be fixed in the tool.

## Fix

- `meteor-npm.js`: await the scratch-directory deletion instead of deferring it.
- `builder.js`: skip entries that vanish mid-walk (ENOENT on `readlink`), matching the existing `readdir` handling.
- `builder.js`: never copy Meteor's own scratch directories (`.temp-*`, `*-garbage-*`) into bundles.

## Verification

- Planted a half-deleted `.temp-*` directory (same shape as the CI crash) inside babel-compiler's `node_modules` and built an app with the checkout tool: no crash, and the scratch dir stays out of the bundle.
- The `test-ddp-transport` matrix — where the crash occurred — passed 5+ consecutive rounds with both jobs running concurrently.

Other issues found while validating this (accounts token race, external-network test, Windows cache poisoning, CI host contention) were split into separate PRs — analyses in the comment thread below.