### PR TITLE
perf(isobuild): reuse cached Git npm dependencies

### DIFF
--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -708,6 +708,7 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
   } else if (canReuseNpmShrinkwrap(
     npmTree,
     minShrinkwrapTree,
+    resolvedShrinkwrapTree,
   )) {
     // If the top-level npm dependencies are already encompassed by the
     // npm-shrinkwrap.json file, then reuse that file.
@@ -805,15 +806,54 @@ export function declaredSpecMatchesInstalledVersion(declared, installed) {
   }
 }
 
+function gitRepositoryIdentity(spec) {
+  try {
+    const url = new URL(spec);
+    if (! ["git+https:", "git+ssh:"].includes(url.protocol) ||
+        ! url.hostname) {
+      return null;
+    }
+
+    let pathname = url.pathname;
+    while (pathname.endsWith("/")) {
+      pathname = pathname.slice(0, -1);
+    }
+    if (pathname.endsWith(".git")) {
+      pathname = pathname.slice(0, -4);
+    }
+    if (! pathname || pathname === "/") {
+      return null;
+    }
+
+    return `${url.hostname.toLowerCase()}:${url.port}:${pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
 function declaredDependenciesMatchResolvedTree(
   declaredTree,
+  installedTree,
   resolvedTree,
 ) {
-  return isSubtreeOf(
-    declaredTree,
-    resolvedTree,
-    declaredSpecMatchesInstalledVersion,
-  );
+  if (declaredTree === installedTree) {
+    return true;
+  }
+
+  if (_.isObject(declaredTree)) {
+    return _.isObject(installedTree) && _.isObject(resolvedTree) &&
+      _.every(declaredTree, (value, key) =>
+        declaredDependenciesMatchResolvedTree(
+          value,
+          installedTree[key],
+          resolvedTree[key],
+        ));
+  }
+
+  const declaredRepository = gitRepositoryIdentity(declaredTree);
+  return declaredSpecMatchesInstalledVersion(declaredTree, installedTree) &&
+    declaredRepository !== null &&
+    declaredRepository === gitRepositoryIdentity(resolvedTree);
 }
 
 export function npmDependencyCacheIsCurrent(
@@ -823,12 +863,24 @@ export function npmDependencyCacheIsCurrent(
   resolvedInstalledTree = minInstalledTree,
   resolvedShrinkwrapTree = minShrinkwrapTree,
 ) {
-  return declaredDependenciesMatchResolvedTree(npmTree, minInstalledTree) &&
+  return declaredDependenciesMatchResolvedTree(
+    npmTree,
+    minInstalledTree,
+    resolvedInstalledTree,
+  ) &&
     isSubtreeOf(resolvedShrinkwrapTree, resolvedInstalledTree);
 }
 
-export function canReuseNpmShrinkwrap(npmTree, minShrinkwrapTree) {
-  return declaredDependenciesMatchResolvedTree(npmTree, minShrinkwrapTree);
+export function canReuseNpmShrinkwrap(
+  npmTree,
+  minShrinkwrapTree,
+  resolvedShrinkwrapTree = minShrinkwrapTree,
+) {
+  return declaredDependenciesMatchResolvedTree(
+    npmTree,
+    minShrinkwrapTree,
+    resolvedShrinkwrapTree,
+  );
 }
 
 function isSubtreeOf(subsetTree, supersetTree, predicate) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -679,7 +679,11 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
   const minShrinkwrapTree =
     minimizeDependencyTree(shrinkwrappedDependenciesTree);
 
-  if (isSubtreeOf(npmTree, minInstalledTree) &&
+  if (isSubtreeOf(
+        npmTree,
+        minInstalledTree,
+        declaredSpecMatchesInstalledVersion,
+      ) &&
       isSubtreeOf(minShrinkwrapTree, minInstalledTree)) {
     return;
   }
@@ -696,7 +700,11 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
     // If there are no npmDependencies, make sure nothing is installed.
     preservedShrinkwrap = { dependencies: {} };
 
-  } else if (isSubtreeOf(npmTree, minShrinkwrapTree)) {
+  } else if (isSubtreeOf(
+    npmTree,
+    minShrinkwrapTree,
+    declaredSpecMatchesInstalledVersion,
+  )) {
     // If the top-level npm dependencies are already encompassed by the
     // npm-shrinkwrap.json file, then reuse that file.
     preservedShrinkwrap = shrinkwrappedDependenciesTree;
@@ -772,6 +780,18 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
   await completeNpmDirectory(packageName, newPackageNpmDir, packageNpmDir,
                        npmDependencies);
 };
+
+export function declaredSpecMatchesInstalledVersion(declared, installed) {
+  if (typeof declared !== "string" || typeof installed !== "string") {
+    return false;
+  }
+
+  if (! declared.startsWith("git+https://") || ! parse(installed)) {
+    return false;
+  }
+
+  return declared.endsWith(`#v${installed}`);
+}
 
 function isSubtreeOf(subsetTree, supersetTree, predicate) {
   if (subsetTree === supersetTree) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -679,12 +679,11 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
   const minShrinkwrapTree =
     minimizeDependencyTree(shrinkwrappedDependenciesTree);
 
-  if (isSubtreeOf(
+  if (npmDependencyCacheIsCurrent(
         npmTree,
         minInstalledTree,
-        declaredSpecMatchesInstalledVersion,
-      ) &&
-      isSubtreeOf(minShrinkwrapTree, minInstalledTree)) {
+        minShrinkwrapTree,
+      )) {
     return;
   }
 
@@ -700,10 +699,9 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
     // If there are no npmDependencies, make sure nothing is installed.
     preservedShrinkwrap = { dependencies: {} };
 
-  } else if (isSubtreeOf(
+  } else if (canReuseNpmShrinkwrap(
     npmTree,
     minShrinkwrapTree,
-    declaredSpecMatchesInstalledVersion,
   )) {
     // If the top-level npm dependencies are already encompassed by the
     // npm-shrinkwrap.json file, then reuse that file.
@@ -786,11 +784,43 @@ export function declaredSpecMatchesInstalledVersion(declared, installed) {
     return false;
   }
 
-  if (! declared.startsWith("git+https://") || ! parse(installed)) {
+  const parsedInstalledVersion = parse(installed);
+  if (! parsedInstalledVersion || parsedInstalledVersion.version !== installed) {
     return false;
   }
 
-  return declared.endsWith(`#v${installed}`);
+  try {
+    const url = new URL(declared);
+    return url.protocol === "git+https:" &&
+      Boolean(url.hostname) &&
+      url.hash === `#v${installed}`;
+  } catch {
+    return false;
+  }
+}
+
+function declaredDependenciesMatchResolvedTree(
+  declaredTree,
+  resolvedTree,
+) {
+  return isSubtreeOf(
+    declaredTree,
+    resolvedTree,
+    declaredSpecMatchesInstalledVersion,
+  );
+}
+
+export function npmDependencyCacheIsCurrent(
+  npmTree,
+  minInstalledTree,
+  minShrinkwrapTree,
+) {
+  return declaredDependenciesMatchResolvedTree(npmTree, minInstalledTree) &&
+    isSubtreeOf(minShrinkwrapTree, minInstalledTree);
+}
+
+export function canReuseNpmShrinkwrap(npmTree, minShrinkwrapTree) {
+  return declaredDependenciesMatchResolvedTree(npmTree, minShrinkwrapTree);
 }
 
 function isSubtreeOf(subsetTree, supersetTree, predicate) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -1401,11 +1401,32 @@ function minimizeDependencyTree(tree, preferPackageVersion = false) {
 }
 
 function isUrlFromRegistry(url) {
-  if (url.match(/^https?:\/\/registry.npmjs.org\//)) {
-    return true;
+  const configuredRegistry = process.env.NPM_CONFIG_REGISTRY;
+  if (configuredRegistry) {
+    return registryContainsUrl(configuredRegistry, url);
   }
-  const NCR = process.env.NPM_CONFIG_REGISTRY;
-  return NCR && url.startsWith(NCR);
+
+  return registryContainsUrl("https://registry.npmjs.org/", url) ||
+    registryContainsUrl("http://registry.npmjs.org/", url);
+}
+
+function registryContainsUrl(registry, url) {
+  try {
+    const registryUrl = new URL(registry);
+    const resolvedUrl = new URL(url);
+    if (! ["http:", "https:"].includes(registryUrl.protocol) ||
+        ! ["http:", "https:"].includes(resolvedUrl.protocol) ||
+        registryUrl.origin !== resolvedUrl.origin) {
+      return false;
+    }
+
+    const registryPath = registryUrl.pathname.replace(/\/+$/, "");
+    return ! registryPath ||
+      resolvedUrl.pathname === registryPath ||
+      resolvedUrl.pathname.startsWith(`${registryPath}/`);
+  } catch {
+    return false;
+  }
 }
 
 var logUpdateDependencies = function (packageName, npmDependencies) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -678,11 +678,17 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
   }
   const minShrinkwrapTree =
     minimizeDependencyTree(shrinkwrappedDependenciesTree);
+  const resolvedInstalledTree =
+    minimizeDependencyTree(installedDependenciesTree, true);
+  const resolvedShrinkwrapTree =
+    minimizeDependencyTree(shrinkwrappedDependenciesTree, true);
 
   if (npmDependencyCacheIsCurrent(
         npmTree,
         minInstalledTree,
         minShrinkwrapTree,
+        resolvedInstalledTree,
+        resolvedShrinkwrapTree,
       )) {
     return;
   }
@@ -814,9 +820,11 @@ export function npmDependencyCacheIsCurrent(
   npmTree,
   minInstalledTree,
   minShrinkwrapTree,
+  resolvedInstalledTree = minInstalledTree,
+  resolvedShrinkwrapTree = minShrinkwrapTree,
 ) {
   return declaredDependenciesMatchResolvedTree(npmTree, minInstalledTree) &&
-    isSubtreeOf(minShrinkwrapTree, minInstalledTree);
+    isSubtreeOf(resolvedShrinkwrapTree, resolvedInstalledTree);
 }
 
 export function canReuseNpmShrinkwrap(npmTree, minShrinkwrapTree) {
@@ -1291,10 +1299,13 @@ function shrinkwrap(dir) {
 // Reduces a dependency tree (as read from a just-made npm-shrinkwrap.json or
 // from npm ls --json) to just the versions we want. Returns an object that does
 // not share state with its input
-function minimizeDependencyTree(tree) {
+function minimizeDependencyTree(tree, preferResolved = false) {
   function minimizeModule(module) {
-    // Prefer the installed semver over a resolved Git URL with a commit hash.
+    // Prefer the installed semver for declared dependency comparisons, but
+    // preserve resolved URLs when comparing installed and shrinkwrapped trees.
     var version =
+      (preferResolved && module.resolved &&
+        ! isUrlFromRegistry(module.resolved) && module.resolved) ||
       module.version ||
       (module.resolved && ! isUrlFromRegistry(module.resolved) && module.resolved) ||
       (utils.isNpmUrl(module.from) && module.from);

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -1293,14 +1293,11 @@ function shrinkwrap(dir) {
 // not share state with its input
 function minimizeDependencyTree(tree) {
   function minimizeModule(module) {
-    var version;
-    if (module.resolved && ! isUrlFromRegistry(module.resolved)) {
-      version = module.resolved;
-    } else if (utils.isNpmUrl(module.from)) {
-      version = module.from;
-    } else {
-      version = module.version;
-    }
+    // Prefer the installed semver over a resolved Git URL with a commit hash.
+    var version =
+      module.version ||
+      (module.resolved && ! isUrlFromRegistry(module.resolved) && module.resolved) ||
+      (utils.isNpmUrl(module.from) && module.from);
     var minimized = {version: version};
 
     if (module.dependencies) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -34,6 +34,7 @@ var meteorNpm = exports;
 // change this will recreate the npm-shrinkwrap.json file
 // and install all dependencies from scratch
 const LOCK_FILE_VERSION = 4;
+const METEOR_NPM_DEPENDENCIES = "meteorNpmDependencies";
 
 // Expose the version of npm in use from the dev bundle.
 meteorNpm.npmVersion = "10.1.0";
@@ -661,10 +662,14 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
   var shrinkwrappedDependenciesTree =
     getShrinkwrappedDependenciesTree(packageNpmDir);
 
-  const npmTree = { dependencies: {} };
-  _.each(npmDependencies, (version, name) => {
-    npmTree.dependencies[name] = { version };
-  });
+  const npmTree = dependencyTreeFromDependencies(npmDependencies);
+  const cachedNpmDependencies =
+    shrinkwrappedDependenciesTree[METEOR_NPM_DEPENDENCIES];
+  const cachedNpmTree = cachedNpmDependencies &&
+    ! Array.isArray(cachedNpmDependencies) &&
+    typeof cachedNpmDependencies === "object"
+      ? dependencyTreeFromDependencies(cachedNpmDependencies)
+      : null;
 
   let minInstalledTree;
   try {
@@ -678,17 +683,17 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
   }
   const minShrinkwrapTree =
     minimizeDependencyTree(shrinkwrappedDependenciesTree);
-  const resolvedInstalledTree =
+  const installedVersionTree =
     minimizeDependencyTree(installedDependenciesTree, true);
-  const resolvedShrinkwrapTree =
+  const shrinkwrapVersionTree =
     minimizeDependencyTree(shrinkwrappedDependenciesTree, true);
 
   if (npmDependencyCacheIsCurrent(
         npmTree,
         minInstalledTree,
         minShrinkwrapTree,
-        resolvedInstalledTree,
-        resolvedShrinkwrapTree,
+        installedVersionTree,
+        cachedNpmTree,
       )) {
     return;
   }
@@ -708,7 +713,8 @@ var updateExistingNpmDirectory = async function (packageName, newPackageNpmDir,
   } else if (canReuseNpmShrinkwrap(
     npmTree,
     minShrinkwrapTree,
-    resolvedShrinkwrapTree,
+    shrinkwrapVersionTree,
+    cachedNpmTree,
   )) {
     // If the top-level npm dependencies are already encompassed by the
     // npm-shrinkwrap.json file, then reuse that file.
@@ -831,56 +837,72 @@ function gitRepositoryIdentity(spec) {
   }
 }
 
-function declaredDependenciesMatchResolvedTree(
+function declaredDependenciesMatchVersionAndSourceTrees(
   declaredTree,
-  installedTree,
-  resolvedTree,
+  versionTree,
+  sourceTree,
 ) {
-  if (declaredTree === installedTree) {
+  if (declaredTree === sourceTree) {
     return true;
   }
 
   if (_.isObject(declaredTree)) {
-    return _.isObject(installedTree) && _.isObject(resolvedTree) &&
+    return _.isObject(versionTree) && _.isObject(sourceTree) &&
       _.every(declaredTree, (value, key) =>
-        declaredDependenciesMatchResolvedTree(
+        declaredDependenciesMatchVersionAndSourceTrees(
           value,
-          installedTree[key],
-          resolvedTree[key],
+          versionTree[key],
+          sourceTree[key],
         ));
   }
 
   const declaredRepository = gitRepositoryIdentity(declaredTree);
-  return declaredSpecMatchesInstalledVersion(declaredTree, installedTree) &&
+  return declaredSpecMatchesInstalledVersion(declaredTree, versionTree) &&
     declaredRepository !== null &&
-    declaredRepository === gitRepositoryIdentity(resolvedTree);
+    declaredRepository === gitRepositoryIdentity(sourceTree);
 }
 
 export function npmDependencyCacheIsCurrent(
   npmTree,
   minInstalledTree,
   minShrinkwrapTree,
-  resolvedInstalledTree = minInstalledTree,
-  resolvedShrinkwrapTree = minShrinkwrapTree,
+  installedVersionTree = minInstalledTree,
+  cachedNpmTree = null,
 ) {
-  return declaredDependenciesMatchResolvedTree(
-    npmTree,
-    minInstalledTree,
-    resolvedInstalledTree,
-  ) &&
-    isSubtreeOf(resolvedShrinkwrapTree, resolvedInstalledTree);
+  const declaredDependenciesAreCurrent =
+    isSubtreeOf(npmTree, minInstalledTree) ||
+    (_.isEqual(npmTree, cachedNpmTree) &&
+      declaredDependenciesMatchVersionAndSourceTrees(
+        npmTree,
+        installedVersionTree,
+        minInstalledTree,
+      ));
+
+  return declaredDependenciesAreCurrent &&
+    isSubtreeOf(minShrinkwrapTree, minInstalledTree);
 }
 
 export function canReuseNpmShrinkwrap(
   npmTree,
   minShrinkwrapTree,
-  resolvedShrinkwrapTree = minShrinkwrapTree,
+  shrinkwrapVersionTree = minShrinkwrapTree,
+  cachedNpmTree = null,
 ) {
-  return declaredDependenciesMatchResolvedTree(
-    npmTree,
-    minShrinkwrapTree,
-    resolvedShrinkwrapTree,
-  );
+  return isSubtreeOf(npmTree, minShrinkwrapTree) ||
+    (_.isEqual(npmTree, cachedNpmTree) &&
+      declaredDependenciesMatchVersionAndSourceTrees(
+        npmTree,
+        shrinkwrapVersionTree,
+        minShrinkwrapTree,
+      ));
+}
+
+function dependencyTreeFromDependencies(dependencies) {
+  const tree = { dependencies: {} };
+  _.each(dependencies, (version, name) => {
+    tree.dependencies[name] = { version };
+  });
+  return tree;
 }
 
 function isSubtreeOf(subsetTree, supersetTree, predicate) {
@@ -948,7 +970,7 @@ async function completeNpmDirectory(
   npmDependencies,
 ) {
   // Create a shrinkwrap file.
-  shrinkwrap(newPackageNpmDir);
+  shrinkwrap(newPackageNpmDir, npmDependencies);
 
   // And stow a copy of npm-shrinkwrap too.
   files.copyFile(
@@ -1329,8 +1351,9 @@ var installFromShrinkwrap = async function (dir) {
 };
 
 // `npm shrinkwrap`
-function shrinkwrap(dir) {
+function shrinkwrap(dir, npmDependencies) {
   const tree = getInstalledDependenciesTree(dir);
+  tree[METEOR_NPM_DEPENDENCIES] = npmDependencies;
 
   files.writeFile(
     files.pathJoin(dir, "npm-shrinkwrap.json"),
@@ -1351,16 +1374,14 @@ function shrinkwrap(dir) {
 // Reduces a dependency tree (as read from a just-made npm-shrinkwrap.json or
 // from npm ls --json) to just the versions we want. Returns an object that does
 // not share state with its input
-function minimizeDependencyTree(tree, preferResolved = false) {
+function minimizeDependencyTree(tree, preferPackageVersion = false) {
   function minimizeModule(module) {
-    // Prefer the installed semver for declared dependency comparisons, but
-    // preserve resolved URLs when comparing installed and shrinkwrapped trees.
-    var version =
-      (preferResolved && module.resolved &&
-        ! isUrlFromRegistry(module.resolved) && module.resolved) ||
-      module.version ||
-      (module.resolved && ! isUrlFromRegistry(module.resolved) && module.resolved) ||
-      (utils.isNpmUrl(module.from) && module.from);
+    const resolved = module.resolved &&
+      ! isUrlFromRegistry(module.resolved) && module.resolved;
+    const from = utils.isNpmUrl(module.from) && module.from;
+    var version = preferPackageVersion
+      ? module.version || resolved || from
+      : resolved || from || module.version;
     var minimized = {version: version};
 
     if (module.dependencies) {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -6,6 +6,7 @@ import {
   installNpmModule,
   npmDependencyCacheIsCurrent,
 } from '../isobuild/meteor-npm.js';
+import * as meteorNpm from '../isobuild/meteor-npm.js';
 
 const Sandbox = selftest.Sandbox;
 
@@ -80,6 +81,58 @@ selftest.define("npm - git dependency cache decisions", () => {
     malformedDeclaredTree,
     resolvedTree,
   ));
+});
+
+selftest.define("npm - git dependency cache uses installed version", async () => {
+  const packageNpmDir = files.mkdtemp();
+  const nodeModulesDir = files.pathJoin(packageNpmDir, "node_modules");
+  const declaredVersion =
+    "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0";
+
+  files.mkdir(nodeModulesDir);
+  files.writeFile(
+    files.pathJoin(nodeModulesDir, ".node_version"),
+    `${process.version.replace(/\.(\d+)$/, ".*")}\n`,
+  );
+  files.writeFile(
+    files.pathJoin(nodeModulesDir, ".package-lock.json"),
+    JSON.stringify({
+      packages: {
+        "node_modules/uWebSockets.js": {
+          version: "20.66.0",
+          resolved:
+            "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#0123456789abcdef",
+        },
+      },
+    }),
+  );
+  files.writeFile(
+    files.pathJoin(packageNpmDir, "npm-shrinkwrap.json"),
+    JSON.stringify({
+      lockfileVersion: 4,
+      dependencies: {
+        "uWebSockets.js": { version: "20.66.0" },
+      },
+    }),
+  );
+
+  const childProcess = require("child_process");
+  const originalExecFile = childProcess.execFile;
+  childProcess.execFile = (...args) => {
+    args[args.length - 1](new Error("npm install should not run"), "", "");
+  };
+
+  try {
+    selftest.expectTrue(await meteorNpm.updateDependencies(
+      "test-package",
+      packageNpmDir,
+      { "uWebSockets.js": declaredVersion },
+      true,
+    ));
+  } finally {
+    childProcess.execFile = originalExecFile;
+    files.rm_recursive(packageNpmDir);
+  }
 });
 
 selftest.define("npm", ["net"], async () => {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -130,7 +130,7 @@ async function updateGitDependencyCache(shrinkwrapResolved) {
   files.mkdir(nodeModulesDir);
   files.writeFile(
     files.pathJoin(nodeModulesDir, ".node_version"),
-    `${process.version.replace(/\.(\d+)$/, ".*")}\n`,
+    `${process.version.slice(0, process.version.lastIndexOf(".") + 1)}*\n`,
   );
   files.writeFile(
     files.pathJoin(nodeModulesDir, ".package-lock.json"),

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -43,6 +43,28 @@ selftest.define("npm - git dependency cache decisions", () => {
       },
     },
   };
+  const differentRepositoryTree = {
+    dependencies: {
+      "uWebSockets.js": {
+        version:
+          "git+https://github.com/uNetworking/different-uWebSockets.js.git#v20.66.0",
+      },
+    },
+  };
+  const pathlessRepositoryTree = {
+    dependencies: {
+      "uWebSockets.js": {
+        version: "git+https://github.com#v20.66.0",
+      },
+    },
+  };
+  const pathlessResolvedSourceTree = {
+    dependencies: {
+      "uWebSockets.js": {
+        version: "git+ssh://git@github.com#0123456789abcdef",
+      },
+    },
+  };
 
   selftest.expectTrue(declaredSpecMatchesInstalledVersion(
     "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0",
@@ -87,9 +109,34 @@ selftest.define("npm - git dependency cache decisions", () => {
     sameSourceTree,
     differentSourceTree,
   ));
+  selftest.expectFalse(npmDependencyCacheIsCurrent(
+    differentRepositoryTree,
+    resolvedTree,
+    resolvedTree,
+    sameSourceTree,
+    sameSourceTree,
+  ));
+  selftest.expectFalse(npmDependencyCacheIsCurrent(
+    pathlessRepositoryTree,
+    resolvedTree,
+    resolvedTree,
+    pathlessResolvedSourceTree,
+    pathlessResolvedSourceTree,
+  ));
   selftest.expectTrue(canReuseNpmShrinkwrap(
     declaredTree,
     resolvedTree,
+    sameSourceTree,
+  ));
+  selftest.expectFalse(canReuseNpmShrinkwrap(
+    differentRepositoryTree,
+    resolvedTree,
+    sameSourceTree,
+  ));
+  selftest.expectFalse(canReuseNpmShrinkwrap(
+    pathlessRepositoryTree,
+    resolvedTree,
+    pathlessResolvedSourceTree,
   ));
   const malformedDeclaredTree = {
     dependencies: {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -1,11 +1,33 @@
 import selftest from '../tool-testing/selftest.js';
 import files from '../fs/files';
-import { installNpmModule } from '../isobuild/meteor-npm.js';
+import {
+  declaredSpecMatchesInstalledVersion,
+  installNpmModule,
+} from '../isobuild/meteor-npm.js';
 
 const Sandbox = selftest.Sandbox;
 
 const MONGO_LISTENING =
   { stdout: " [initandlisten] waiting for connections on port" };
+
+selftest.define("npm - git dependency cache version matching", () => {
+  selftest.expectTrue(declaredSpecMatchesInstalledVersion(
+    "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0",
+    "20.66.0",
+  ));
+  selftest.expectFalse(declaredSpecMatchesInstalledVersion(
+    "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0",
+    "20.66.1",
+  ));
+  selftest.expectFalse(declaredSpecMatchesInstalledVersion(
+    "git+https://github.com/uNetworking/uWebSockets.js.git#main",
+    "20.66.0",
+  ));
+  selftest.expectFalse(declaredSpecMatchesInstalledVersion(
+    "https://github.com/uNetworking/uWebSockets.js/archive/v20.66.0.tar.gz",
+    "20.66.0",
+  ));
+});
 
 selftest.define("npm", ["net"], async () => {
   const s = new Sandbox({ fakeMongo: true });

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -270,6 +270,95 @@ selftest.define("npm - dependency cache detects Git to registry changes", async 
   });
 });
 
+selftest.define("npm - dependency cache detects registry source changes", async () => {
+  const publicResolved =
+    "https://registry.npmjs.org/uWebSockets.js/-/uWebSockets.js-20.66.0.tgz";
+  const customResolved =
+    "https://registry-a.example/npm/uWebSockets.js-20.66.0.tgz";
+  const cachedDependencies = { "uWebSockets.js": "20.66.0" };
+
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: "20.66.0",
+    installedResolved: publicResolved,
+    shrinkwrapResolved: publicResolved,
+    cachedDependencies,
+    registry: "https://registry-b.example/npm/",
+  }), {
+    updated: false,
+    npmCalls: [["install", "uWebSockets.js@20.66.0"]],
+  });
+
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: "20.66.0",
+    installedResolved: customResolved,
+    shrinkwrapResolved: customResolved,
+    cachedDependencies,
+    registry: "https://registry-b.example/npm/",
+  }), {
+    updated: false,
+    npmCalls: [["install", "uWebSockets.js@20.66.0"]],
+  });
+
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: "20.66.0",
+    installedResolved: customResolved,
+    shrinkwrapResolved: customResolved,
+    cachedDependencies,
+    registry: "https://registry-a.example/npm",
+  }), {
+    updated: true,
+    npmCalls: [],
+  });
+
+  const prefixCollisionResolved =
+    "https://registry-a.example/npm-old/uWebSockets.js-20.66.0.tgz";
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: "20.66.0",
+    installedResolved: prefixCollisionResolved,
+    shrinkwrapResolved: prefixCollisionResolved,
+    cachedDependencies,
+    registry: "https://registry-a.example/npm/",
+  }), {
+    updated: false,
+    npmCalls: [["install", "uWebSockets.js@20.66.0"]],
+  });
+
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: "20.66.0",
+    installedResolved: publicResolved,
+    shrinkwrapResolved: publicResolved,
+    cachedDependencies,
+    registry: null,
+  }), {
+    updated: true,
+    npmCalls: [],
+  });
+
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: "20.66.0",
+    installedResolved: customResolved,
+    shrinkwrapResolved: customResolved,
+    cachedDependencies,
+    registry: "https://registry-a.example/",
+  }), {
+    updated: true,
+    npmCalls: [],
+  });
+
+  for (const registry of ["not a URL", "file:///tmp/npm-registry/"]) {
+    await selftest.expectEqual(await updateDependencyCache({
+      declaredVersion: "20.66.0",
+      installedResolved: publicResolved,
+      shrinkwrapResolved: publicResolved,
+      cachedDependencies,
+      registry,
+    }), {
+      updated: false,
+      npmCalls: [["install", "uWebSockets.js@20.66.0"]],
+    });
+  }
+});
+
 selftest.define("npm - dependency cache preserves HTTPS tarballs", async () => {
   const tarball =
     "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.66.0.tar.gz";
@@ -326,6 +415,7 @@ async function updateDependencyCache({
   installedResolved,
   shrinkwrapResolved,
   cachedDependencies,
+  registry,
 }) {
   const packageNpmDir = files.mkdtemp();
   const nodeModulesDir = files.pathJoin(packageNpmDir, "node_modules");
@@ -365,6 +455,8 @@ async function updateDependencyCache({
 
   const childProcess = require("child_process");
   const originalExecFile = childProcess.execFile;
+  const previousRegistry = process.env.NPM_CONFIG_REGISTRY;
+  const overridesRegistry = registry !== undefined;
   const npmCalls = [];
   childProcess.execFile = (...args) => {
     const commandArgs = args[1];
@@ -374,6 +466,14 @@ async function updateDependencyCache({
   };
 
   try {
+    if (overridesRegistry) {
+      if (registry === null) {
+        delete process.env.NPM_CONFIG_REGISTRY;
+      } else {
+        process.env.NPM_CONFIG_REGISTRY = registry;
+      }
+    }
+
     let updated;
     await buildmessage.capture({ title: "npm cache test" }, async () => {
       updated = await meteorNpm.updateDependencies(
@@ -386,6 +486,13 @@ async function updateDependencyCache({
     return { updated, npmCalls };
   } finally {
     childProcess.execFile = originalExecFile;
+    if (overridesRegistry) {
+      if (previousRegistry === undefined) {
+        delete process.env.NPM_CONFIG_REGISTRY;
+      } else {
+        process.env.NPM_CONFIG_REGISTRY = previousRegistry;
+      }
+    }
     files.rm_recursive(packageNpmDir);
   }
 }

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -14,6 +14,13 @@ const Sandbox = selftest.Sandbox;
 const MONGO_LISTENING =
   { stdout: " [initandlisten] waiting for connections on port" };
 
+const GIT_DECLARED_VERSION =
+  "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0";
+const GIT_INSTALLED_RESOLVED =
+  "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#0123456789abcdef";
+const GIT_DIFFERENT_RESOLVED =
+  "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#fedcba9876543210";
+
 selftest.define("npm - git dependency cache decisions", () => {
   const declaredTree = {
     dependencies: {
@@ -65,6 +72,40 @@ selftest.define("npm - git dependency cache decisions", () => {
       },
     },
   };
+  const mixedDeclaredTree = {
+    dependencies: {
+      ...declaredTree.dependencies,
+      tarball: {
+        version: "https://example.com/tarball-v1.0.0.tgz",
+      },
+    },
+  };
+  const mixedVersionTree = {
+    dependencies: {
+      ...resolvedTree.dependencies,
+      tarball: { version: "1.0.0" },
+    },
+  };
+  const mixedSourceTree = {
+    dependencies: {
+      ...sameSourceTree.dependencies,
+      tarball: {
+        version: "https://example.com/tarball-v1.0.0.tgz",
+      },
+    },
+  };
+  const registryDeclaredTree = {
+    dependencies: {
+      registryPackage: { version: "1.0.0" },
+    },
+  };
+  const oldRegistrySourceTree = {
+    dependencies: {
+      registryPackage: {
+        version: "https://registry-a.example/registry-package-1.0.0.tgz",
+      },
+    },
+  };
 
   selftest.expectTrue(declaredSpecMatchesInstalledVersion(
     "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0",
@@ -97,46 +138,75 @@ selftest.define("npm - git dependency cache decisions", () => {
 
   selftest.expectTrue(npmDependencyCacheIsCurrent(
     declaredTree,
-    resolvedTree,
-    resolvedTree,
     sameSourceTree,
     sameSourceTree,
+    resolvedTree,
+    declaredTree,
   ));
   selftest.expectFalse(npmDependencyCacheIsCurrent(
     declaredTree,
-    resolvedTree,
-    resolvedTree,
     sameSourceTree,
     differentSourceTree,
+    resolvedTree,
+    declaredTree,
   ));
   selftest.expectFalse(npmDependencyCacheIsCurrent(
     differentRepositoryTree,
-    resolvedTree,
-    resolvedTree,
     sameSourceTree,
     sameSourceTree,
+    resolvedTree,
+    differentRepositoryTree,
   ));
   selftest.expectFalse(npmDependencyCacheIsCurrent(
     pathlessRepositoryTree,
-    resolvedTree,
-    resolvedTree,
     pathlessResolvedSourceTree,
     pathlessResolvedSourceTree,
+    resolvedTree,
+    pathlessRepositoryTree,
   ));
   selftest.expectTrue(canReuseNpmShrinkwrap(
     declaredTree,
-    resolvedTree,
     sameSourceTree,
+    resolvedTree,
+    declaredTree,
   ));
   selftest.expectFalse(canReuseNpmShrinkwrap(
     differentRepositoryTree,
-    resolvedTree,
     sameSourceTree,
+    resolvedTree,
+    differentRepositoryTree,
   ));
   selftest.expectFalse(canReuseNpmShrinkwrap(
     pathlessRepositoryTree,
-    resolvedTree,
     pathlessResolvedSourceTree,
+    resolvedTree,
+    pathlessRepositoryTree,
+  ));
+  selftest.expectTrue(npmDependencyCacheIsCurrent(
+    mixedDeclaredTree,
+    mixedSourceTree,
+    mixedSourceTree,
+    mixedVersionTree,
+    mixedDeclaredTree,
+  ));
+  selftest.expectTrue(canReuseNpmShrinkwrap(
+    mixedDeclaredTree,
+    mixedSourceTree,
+    mixedVersionTree,
+    mixedDeclaredTree,
+  ));
+  selftest.expectFalse(npmDependencyCacheIsCurrent(
+    registryDeclaredTree,
+    oldRegistrySourceTree,
+    oldRegistrySourceTree,
+    registryDeclaredTree,
+    registryDeclaredTree,
+  ));
+  selftest.expectFalse(canReuseNpmShrinkwrap(
+    registryDeclaredTree,
+    oldRegistrySourceTree,
+    registryDeclaredTree,
+    registryDeclaredTree,
   ));
   const malformedDeclaredTree = {
     dependencies: {
@@ -147,32 +217,118 @@ selftest.define("npm - git dependency cache decisions", () => {
   };
   selftest.expectFalse(npmDependencyCacheIsCurrent(
     malformedDeclaredTree,
+    sameSourceTree,
+    sameSourceTree,
     resolvedTree,
-    resolvedTree,
+    malformedDeclaredTree,
   ));
   selftest.expectFalse(canReuseNpmShrinkwrap(
     malformedDeclaredTree,
+    sameSourceTree,
     resolvedTree,
+    malformedDeclaredTree,
   ));
 });
 
 selftest.define("npm - git dependency cache uses installed version", async () => {
-  const installedResolved =
-    "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#0123456789abcdef";
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: GIT_DECLARED_VERSION,
+    installedResolved: GIT_INSTALLED_RESOLVED,
+    shrinkwrapResolved: GIT_INSTALLED_RESOLVED,
+    cachedDependencies: {
+      "uWebSockets.js": GIT_DECLARED_VERSION,
+    },
+  }), {
+    updated: true,
+    npmCalls: [],
+  });
 
-  selftest.expectTrue(await updateGitDependencyCache(installedResolved));
-  selftest.expectFalse(await updateGitDependencyCache(
-    "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#fedcba9876543210",
-  ));
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: GIT_DECLARED_VERSION,
+    installedResolved: GIT_INSTALLED_RESOLVED,
+    shrinkwrapResolved: GIT_DIFFERENT_RESOLVED,
+    cachedDependencies: {
+      "uWebSockets.js": GIT_DECLARED_VERSION,
+    },
+  }), {
+    updated: false,
+    npmCalls: [["install"]],
+  });
 });
 
-async function updateGitDependencyCache(shrinkwrapResolved) {
+selftest.define("npm - dependency cache detects Git to registry changes", async () => {
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: "20.66.0",
+    installedResolved: GIT_INSTALLED_RESOLVED,
+    shrinkwrapResolved: GIT_INSTALLED_RESOLVED,
+    cachedDependencies: {
+      "uWebSockets.js": GIT_DECLARED_VERSION,
+    },
+  }), {
+    updated: false,
+    npmCalls: [["install", "uWebSockets.js@20.66.0"]],
+  });
+});
+
+selftest.define("npm - dependency cache preserves HTTPS tarballs", async () => {
+  const tarball =
+    "https://github.com/uNetworking/uWebSockets.js/archive/refs/tags/v20.66.0.tar.gz";
+
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: tarball,
+    installedResolved: tarball,
+    shrinkwrapResolved: tarball,
+  }), {
+    updated: true,
+    npmCalls: [],
+  });
+});
+
+selftest.define("npm - dependency cache preserves Git SSH commits", async () => {
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: GIT_INSTALLED_RESOLVED,
+    installedResolved: GIT_INSTALLED_RESOLVED,
+    shrinkwrapResolved: GIT_INSTALLED_RESOLVED,
+  }), {
+    updated: true,
+    npmCalls: [],
+  });
+});
+
+selftest.define("npm - Git tag cache requires matching provenance", async () => {
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: GIT_DECLARED_VERSION,
+    installedResolved: GIT_INSTALLED_RESOLVED,
+    shrinkwrapResolved: GIT_INSTALLED_RESOLVED,
+    cachedDependencies: {
+      "uWebSockets.js":
+        "git+https://github.com/uNetworking/uWebSockets.js.git#0123456789abcdef",
+    },
+  }), {
+    updated: false,
+    npmCalls: [["install", GIT_DECLARED_VERSION]],
+  });
+});
+
+selftest.define("npm - legacy Git tag cache refreshes once", async () => {
+  await selftest.expectEqual(await updateDependencyCache({
+    declaredVersion: GIT_DECLARED_VERSION,
+    installedResolved: GIT_INSTALLED_RESOLVED,
+    shrinkwrapResolved: GIT_INSTALLED_RESOLVED,
+  }), {
+    updated: false,
+    npmCalls: [["install", GIT_DECLARED_VERSION]],
+  });
+});
+
+async function updateDependencyCache({
+  declaredVersion,
+  installedResolved,
+  shrinkwrapResolved,
+  cachedDependencies,
+}) {
   const packageNpmDir = files.mkdtemp();
   const nodeModulesDir = files.pathJoin(packageNpmDir, "node_modules");
-  const declaredVersion =
-    "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0";
-  const installedResolved =
-    "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#0123456789abcdef";
 
   files.mkdir(nodeModulesDir);
   files.writeFile(
@@ -190,22 +346,30 @@ async function updateGitDependencyCache(shrinkwrapResolved) {
       },
     }),
   );
+  const shrinkwrap = {
+    lockfileVersion: 4,
+    dependencies: {
+      "uWebSockets.js": {
+        version: "20.66.0",
+        resolved: shrinkwrapResolved,
+      },
+    },
+  };
+  if (cachedDependencies) {
+    shrinkwrap.meteorNpmDependencies = cachedDependencies;
+  }
   files.writeFile(
     files.pathJoin(packageNpmDir, "npm-shrinkwrap.json"),
-    JSON.stringify({
-      lockfileVersion: 4,
-      dependencies: {
-        "uWebSockets.js": {
-          version: "20.66.0",
-          resolved: shrinkwrapResolved,
-        },
-      },
-    }),
+    JSON.stringify(shrinkwrap),
   );
 
   const childProcess = require("child_process");
   const originalExecFile = childProcess.execFile;
+  const npmCalls = [];
   childProcess.execFile = (...args) => {
+    const commandArgs = args[1];
+    const installIndex = commandArgs.indexOf("install");
+    npmCalls.push(commandArgs.slice(installIndex));
     args[args.length - 1](new Error("npm install should not run"), "", "");
   };
 
@@ -219,7 +383,7 @@ async function updateGitDependencyCache(shrinkwrapResolved) {
         true,
       );
     });
-    return updated;
+    return { updated, npmCalls };
   } finally {
     childProcess.execFile = originalExecFile;
     files.rm_recursive(packageNpmDir);
@@ -253,6 +417,13 @@ selftest.define("npm", ["net"], async () => {
     await run.match("null; From shell script\n");
     await run.expectExit(0);
   }
+
+  const shrinkwrap = JSON.parse(s.read(
+    "packages/npm-test/.npm/package/npm-shrinkwrap.json",
+  ));
+  await selftest.expectEqual(shrinkwrap.meteorNpmDependencies, {
+    "meteor-test-executable": "0.0.3",
+  });
 });
 
 async function testThatNpmInstallThrows(name, version, regexMatcher) {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -1,8 +1,10 @@
 import selftest from '../tool-testing/selftest.js';
 import files from '../fs/files';
 import {
+  canReuseNpmShrinkwrap,
   declaredSpecMatchesInstalledVersion,
   installNpmModule,
+  npmDependencyCacheIsCurrent,
 } from '../isobuild/meteor-npm.js';
 
 const Sandbox = selftest.Sandbox;
@@ -10,7 +12,20 @@ const Sandbox = selftest.Sandbox;
 const MONGO_LISTENING =
   { stdout: " [initandlisten] waiting for connections on port" };
 
-selftest.define("npm - git dependency cache version matching", () => {
+selftest.define("npm - git dependency cache decisions", () => {
+  const declaredTree = {
+    dependencies: {
+      "uWebSockets.js": {
+        version: "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0",
+      },
+    },
+  };
+  const resolvedTree = {
+    dependencies: {
+      "uWebSockets.js": { version: "20.66.0" },
+    },
+  };
+
   selftest.expectTrue(declaredSpecMatchesInstalledVersion(
     "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0",
     "20.66.0",
@@ -26,6 +41,44 @@ selftest.define("npm - git dependency cache version matching", () => {
   selftest.expectFalse(declaredSpecMatchesInstalledVersion(
     "https://github.com/uNetworking/uWebSockets.js/archive/v20.66.0.tar.gz",
     "20.66.0",
+  ));
+  selftest.expectFalse(declaredSpecMatchesInstalledVersion(
+    "git+https://github.com/uNetworking/uWebSockets.js.git#main#v20.66.0",
+    "20.66.0",
+  ));
+  selftest.expectFalse(declaredSpecMatchesInstalledVersion(
+    "git+https://github.com/uNetworking/uWebSockets.js.git#vv20.66.0",
+    "v20.66.0",
+  ));
+  selftest.expectFalse(declaredSpecMatchesInstalledVersion(
+    "git+https://#v20.66.0",
+    "20.66.0",
+  ));
+
+  selftest.expectTrue(npmDependencyCacheIsCurrent(
+    declaredTree,
+    resolvedTree,
+    resolvedTree,
+  ));
+  selftest.expectTrue(canReuseNpmShrinkwrap(
+    declaredTree,
+    resolvedTree,
+  ));
+  const malformedDeclaredTree = {
+    dependencies: {
+      "uWebSockets.js": {
+        version: "git+https://github.com/uNetworking/uWebSockets.js.git#main#v20.66.0",
+      },
+    },
+  };
+  selftest.expectFalse(npmDependencyCacheIsCurrent(
+    malformedDeclaredTree,
+    resolvedTree,
+    resolvedTree,
+  ));
+  selftest.expectFalse(canReuseNpmShrinkwrap(
+    malformedDeclaredTree,
+    resolvedTree,
   ));
 });
 

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -1,5 +1,6 @@
 import selftest from '../tool-testing/selftest.js';
 import files from '../fs/files';
+import buildmessage from '../utils/buildmessage.js';
 import {
   canReuseNpmShrinkwrap,
   declaredSpecMatchesInstalledVersion,
@@ -24,6 +25,22 @@ selftest.define("npm - git dependency cache decisions", () => {
   const resolvedTree = {
     dependencies: {
       "uWebSockets.js": { version: "20.66.0" },
+    },
+  };
+  const sameSourceTree = {
+    dependencies: {
+      "uWebSockets.js": {
+        version:
+          "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#0123456789abcdef",
+      },
+    },
+  };
+  const differentSourceTree = {
+    dependencies: {
+      "uWebSockets.js": {
+        version:
+          "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#fedcba9876543210",
+      },
     },
   };
 
@@ -60,6 +77,15 @@ selftest.define("npm - git dependency cache decisions", () => {
     declaredTree,
     resolvedTree,
     resolvedTree,
+    sameSourceTree,
+    sameSourceTree,
+  ));
+  selftest.expectFalse(npmDependencyCacheIsCurrent(
+    declaredTree,
+    resolvedTree,
+    resolvedTree,
+    sameSourceTree,
+    differentSourceTree,
   ));
   selftest.expectTrue(canReuseNpmShrinkwrap(
     declaredTree,
@@ -84,10 +110,22 @@ selftest.define("npm - git dependency cache decisions", () => {
 });
 
 selftest.define("npm - git dependency cache uses installed version", async () => {
+  const installedResolved =
+    "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#0123456789abcdef";
+
+  selftest.expectTrue(await updateGitDependencyCache(installedResolved));
+  selftest.expectFalse(await updateGitDependencyCache(
+    "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#fedcba9876543210",
+  ));
+});
+
+async function updateGitDependencyCache(shrinkwrapResolved) {
   const packageNpmDir = files.mkdtemp();
   const nodeModulesDir = files.pathJoin(packageNpmDir, "node_modules");
   const declaredVersion =
     "git+https://github.com/uNetworking/uWebSockets.js.git#v20.66.0";
+  const installedResolved =
+    "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#0123456789abcdef";
 
   files.mkdir(nodeModulesDir);
   files.writeFile(
@@ -100,8 +138,7 @@ selftest.define("npm - git dependency cache uses installed version", async () =>
       packages: {
         "node_modules/uWebSockets.js": {
           version: "20.66.0",
-          resolved:
-            "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#0123456789abcdef",
+          resolved: installedResolved,
         },
       },
     }),
@@ -111,7 +148,10 @@ selftest.define("npm - git dependency cache uses installed version", async () =>
     JSON.stringify({
       lockfileVersion: 4,
       dependencies: {
-        "uWebSockets.js": { version: "20.66.0" },
+        "uWebSockets.js": {
+          version: "20.66.0",
+          resolved: shrinkwrapResolved,
+        },
       },
     }),
   );
@@ -123,17 +163,21 @@ selftest.define("npm - git dependency cache uses installed version", async () =>
   };
 
   try {
-    selftest.expectTrue(await meteorNpm.updateDependencies(
-      "test-package",
-      packageNpmDir,
-      { "uWebSockets.js": declaredVersion },
-      true,
-    ));
+    let updated;
+    await buildmessage.capture({ title: "npm cache test" }, async () => {
+      updated = await meteorNpm.updateDependencies(
+        "test-package",
+        packageNpmDir,
+        { "uWebSockets.js": declaredVersion },
+        true,
+      );
+    });
+    return updated;
   } finally {
     childProcess.execFile = originalExecFile;
     files.rm_recursive(packageNpmDir);
   }
-});
+}
 
 selftest.define("npm", ["net"], async () => {
   const s = new Sandbox({ fakeMongo: true });


### PR DESCRIPTION
## Summary

Allows the existing package `.npm` cache to satisfy an exact `git+https://…#v<semver>` `Npm.depends` declaration, including `uWebSockets.js`.

The cache short-circuit still requires the shrinkwrap and installed dependency trees to agree on the resolved Git source/commit, so a matching semver alone cannot preserve stale content.

## CI impact

The measured target is Test Tools **Group 6** (`^mo[e-z]|^m[p-z]|^[n-o]`), which includes the npm tests for Git-based package dependencies. The table records successful GitHub Actions jobs only. Samples 1–3 are the original Test Tools attempts; samples 4–6 are fresh controlled base → PR pairs using the same runner, container, command, retries and warm cache policy (cache hit on both sides).

| Sample | devel base | This PR | Delta |
| --- | ---: | ---: | ---: |
| 1 | [4m08s](https://github.com/meteor/meteor/actions/runs/32286339367/attempts/2) | [1m47s](https://github.com/meteor/meteor/actions/runs/32267485625/attempts/3) | -2m21s |
| 2 | [2m40s](https://github.com/meteor/meteor/actions/runs/32286339367/attempts/3) | [1m46s](https://github.com/meteor/meteor/actions/runs/32267485625/attempts/4) | -54s |
| 3 | [3m05s](https://github.com/meteor/meteor/actions/runs/32286339367/attempts/4) | [1m45s](https://github.com/meteor/meteor/actions/runs/32267485625/attempts/5) | -1m20s |
| 4 | [3m18s](https://github.com/meteor/meteor/actions/runs/32487227060) | [3m31s](https://github.com/meteor/meteor/actions/runs/32487227060) | +13s |
| 5 | [3m37s](https://github.com/meteor/meteor/actions/runs/32487868619) | [3m22s](https://github.com/meteor/meteor/actions/runs/32487868619) | -15s |
| 6 | [3m29s](https://github.com/meteor/meteor/actions/runs/32488514488) | [2m18s](https://github.com/meteor/meteor/actions/runs/32488514488) | -1m11s |

Pooled six-sample median job time: **3m23.5s → 2m02.5s**, a **1m21s (39.8%) reduction**. The three fresh controlled pairs show normal runner variance (including one slower PR job), which is retained above. This does **not** claim a workflow-wide critical-path reduction: unrelated parallel test groups and runner variation dominate that path.

To verify a value, open its link and inspect `Running self-test (Test Group 6)`; for samples 4–6 both jobs are in the same run.

## Validation

- `./meteor self-test --retries 0 --headless --file ^npm$` (6/6)
- `npm run fmt:check`
- `npm run lint`
- `git diff --check origin/devel...HEAD`

## Credits

Adapted from [#14388](https://github.com/meteor/meteor/pull/14388) by [@mvogttech](https://github.com/mvogttech) (Michael Pfeiffer).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of npm dependencies sourced from Git repositories.
  * Reuses compatible cached dependency installations when resolved sources match.
  * Preserves npm shrinkwrap information when it remains valid.
  * Prevents unnecessary npm installations when cached Git-based dependencies are up to date.

* **Tests**
  * Added coverage for matching and mismatched Git dependency sources, resolved versions, and malformed dependency data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->