### PR TITLE
perf(isobuild): batch npm preparation for --get-ready

### DIFF
--- a/scripts/windows/ci/test.ps1
+++ b/scripts/windows/ci/test.ps1
@@ -6,6 +6,7 @@ $tests = @(
   '^autoupdate'
   '^dynamic import.*development'
   'client refresh for application code'
+  '^npm - prefetch runs speculative work on Windows$'
 ) -Join '|'
 
 Write-Host "Running: $tests" -ForegroundColor Yellow

--- a/tools/cli/dev-bundle-helpers.js
+++ b/tools/cli/dev-bundle-helpers.js
@@ -1,5 +1,5 @@
 import { pathJoin, getDevBundle, statOrNull } from '../fs/files';
-import { installNpmModule } from '../isobuild/meteor-npm.js';
+import { batchInstallNpmModules } from '../isobuild/meteor-npm.js';
 
 export async function ensureDependencies(deps) {
   const devBundleLib = pathJoin(getDevBundle(), 'lib');
@@ -18,8 +18,5 @@ export async function ensureDependencies(deps) {
     }
   });
 
-  // Install each of the requested modules.
-  for (const dep of Object.keys(needToInstall)) {
-    await installNpmModule(dep, needToInstall[dep], devBundleLib);
-  }
+  await batchInstallNpmModules(needToInstall, devBundleLib);
 }

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -66,7 +66,9 @@ export class IsopackCache {
       files.mkdir_p(self.cacheDir);
     }
 
-    await self._prefetchNpmDependencies();
+    await Profile.time('IsopackCache prefetch npm dependencies', async () => {
+      await self._prefetchNpmDependencies();
+    });
 
     var onStack = {};
     if (rootPackageNames) {
@@ -96,6 +98,7 @@ export class IsopackCache {
     }
 
     const tasks = Array.from(byDir.values());
+    if (tasks.length === 0) return;
     const concurrency = Math.max(1, Math.min(os.cpus().length, 8, tasks.length));
     let cursor = 0;
     await Promise.all(Array.from({ length: concurrency }, async () => {

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -31,15 +31,15 @@ export async function prefetchNpmDependencies(packageMap, updateDependencies,
     Math.min(maxConcurrency, os.cpus().length, 8, tasks.length),
   );
   let cursor = 0;
-  await Promise.all(Array.from({ length: concurrency }, async () => {
-    while (cursor < tasks.length) {
-      const { name, dir, deps } = tasks[cursor++];
-      await buildmessage.capture({ title: `prefetch ${name}` }, async () => {
+  await buildmessage.capture({ title: 'prefetch npm dependencies' }, async () => {
+    await Promise.all(Array.from({ length: concurrency }, async () => {
+      while (cursor < tasks.length) {
+        const { name, dir, deps } = tasks[cursor++];
         try { await updateDependencies(name, dir, deps, true); }
         catch (error) {}
-      });
-    }
-  }));
+      }
+    }));
+  });
 }
 
 export class IsopackCache {

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -34,8 +34,10 @@ export async function prefetchNpmDependencies(packageMap, updateDependencies,
   await Promise.all(Array.from({ length: concurrency }, async () => {
     while (cursor < tasks.length) {
       const { name, dir, deps } = tasks[cursor++];
-      try { await updateDependencies(name, dir, deps, true); }
-      catch (error) { console.error(`[prefetch] ${name} failed:`, error); }
+      await buildmessage.capture({ title: `prefetch ${name}` }, async () => {
+        try { await updateDependencies(name, dir, deps, true); }
+        catch (error) {}
+      });
     }
   }));
 }
@@ -95,9 +97,11 @@ export class IsopackCache {
       files.mkdir_p(self.cacheDir);
     }
 
-    await Profile.time('IsopackCache prefetch npm dependencies', async () => {
-      await self._prefetchNpmDependencies();
-    });
+    if (!rootPackageNames) {
+      await Profile.time('IsopackCache prefetch npm dependencies', async () => {
+        await self._prefetchNpmDependencies();
+      });
+    }
 
     var onStack = {};
     if (rootPackageNames) {

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -26,7 +26,10 @@ export async function prefetchNpmDependencies(packageMap, updateDependencies,
   }
   const tasks = Array.from(byDir.values());
   if (!tasks.length) return;
-  const concurrency = Math.max(1, Math.min(maxConcurrency, 8, tasks.length));
+  const concurrency = Math.max(
+    1,
+    Math.min(maxConcurrency, os.cpus().length, 8, tasks.length),
+  );
   let cursor = 0;
   await Promise.all(Array.from({ length: concurrency }, async () => {
     while (cursor < tasks.length) {

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var os = require('os');
 
 var buildmessage = require('../utils/buildmessage.js');
 var compiler = require('./compiler.js');
@@ -6,6 +7,7 @@ var files = require('../fs/files');
 var isopackModule = require('./isopack.js');
 var watch = require('../fs/watch');
 var colonConverter = require('../utils/colon-converter.js');
+var meteorNpm = require('./meteor-npm.js');
 var Profile = require('../tool-env/profile').Profile;
 import { requestGarbageCollection } from "../utils/gc.js";
 
@@ -64,6 +66,8 @@ export class IsopackCache {
       files.mkdir_p(self.cacheDir);
     }
 
+    await self._prefetchNpmDependencies();
+
     var onStack = {};
     if (rootPackageNames) {
       for (const name of rootPackageNames) {
@@ -75,6 +79,35 @@ export class IsopackCache {
         await requestGarbageCollection();
       });
     }
+  }
+
+  async _prefetchNpmDependencies() {
+    const byDir = new Map();
+    const enqueue = (name, dir, deps) => {
+      if (! dir || _.isEmpty(deps) || byDir.has(dir)) return;
+      byDir.set(dir, { name, dir, deps });
+    };
+
+    for (const [, info] of Object.entries(this._packageMap._map)) {
+      if (info.kind !== 'local' || ! info.packageSource) continue;
+      const source = info.packageSource;
+      enqueue(source.name, source.npmCacheDirectory, source.npmDependencies);
+      enqueue(source.name, source.npmDevCacheDirectory, source.npmDevDependencies);
+    }
+
+    const tasks = Array.from(byDir.values());
+    const concurrency = Math.max(1, Math.min(os.cpus().length, 8, tasks.length));
+    let cursor = 0;
+    await Promise.all(Array.from({ length: concurrency }, async () => {
+      while (cursor < tasks.length) {
+        const { name, dir, deps } = tasks[cursor++];
+        try {
+          await meteorNpm.updateDependencies(name, dir, deps, true);
+        } catch (error) {
+          console.error(`[prefetch] ${name} failed:`, (error && error.stack) || error);
+        }
+      }
+    }));
   }
 
   async wipeCachedPackages(packages) {

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -12,7 +12,13 @@ var Profile = require('../tool-env/profile').Profile;
 import { requestGarbageCollection } from "../utils/gc.js";
 
 export async function prefetchNpmDependencies(packageMap, updateDependencies,
-  { maxConcurrency = 8, cpuCount = os.cpus().length } = {}) {
+  {
+    maxConcurrency = 8,
+    cpuCount = os.cpus().length,
+    platform = process.platform,
+  } = {}) {
+  if (platform === 'win32') return;
+
   const byDir = new Map();
   const enqueue = (name, dir, deps) => {
     if (!dir || _.isEmpty(deps) || byDir.has(dir)) return;

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -15,10 +15,7 @@ export async function prefetchNpmDependencies(packageMap, updateDependencies,
   {
     maxConcurrency = 8,
     cpuCount = os.cpus().length,
-    platform = process.platform,
   } = {}) {
-  if (platform === 'win32') return;
-
   const byDir = new Map();
   const enqueue = (name, dir, deps) => {
     if (!dir || _.isEmpty(deps) || byDir.has(dir)) return;

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -11,6 +11,32 @@ var meteorNpm = require('./meteor-npm.js');
 var Profile = require('../tool-env/profile').Profile;
 import { requestGarbageCollection } from "../utils/gc.js";
 
+export async function prefetchNpmDependencies(packageMap, updateDependencies,
+  { maxConcurrency = 8 } = {}) {
+  const byDir = new Map();
+  const enqueue = (name, dir, deps) => {
+    if (!dir || _.isEmpty(deps) || byDir.has(dir)) return;
+    byDir.set(dir, { name, dir, deps });
+  };
+  for (const [, info] of Object.entries(packageMap._map)) {
+    if (info.kind !== 'local' || !info.packageSource) continue;
+    const source = info.packageSource;
+    enqueue(source.name, source.npmCacheDirectory, source.npmDependencies);
+    enqueue(source.name, source.npmDevCacheDirectory, source.npmDevDependencies);
+  }
+  const tasks = Array.from(byDir.values());
+  if (!tasks.length) return;
+  const concurrency = Math.max(1, Math.min(maxConcurrency, 8, tasks.length));
+  let cursor = 0;
+  await Promise.all(Array.from({ length: concurrency }, async () => {
+    while (cursor < tasks.length) {
+      const { name, dir, deps } = tasks[cursor++];
+      try { await updateDependencies(name, dir, deps, true); }
+      catch (error) { console.error(`[prefetch] ${name} failed:`, error); }
+    }
+  }));
+}
+
 export class IsopackCache {
   constructor(options) {
     var self = this;
@@ -84,33 +110,7 @@ export class IsopackCache {
   }
 
   async _prefetchNpmDependencies() {
-    const byDir = new Map();
-    const enqueue = (name, dir, deps) => {
-      if (! dir || _.isEmpty(deps) || byDir.has(dir)) return;
-      byDir.set(dir, { name, dir, deps });
-    };
-
-    for (const [, info] of Object.entries(this._packageMap._map)) {
-      if (info.kind !== 'local' || ! info.packageSource) continue;
-      const source = info.packageSource;
-      enqueue(source.name, source.npmCacheDirectory, source.npmDependencies);
-      enqueue(source.name, source.npmDevCacheDirectory, source.npmDevDependencies);
-    }
-
-    const tasks = Array.from(byDir.values());
-    if (tasks.length === 0) return;
-    const concurrency = Math.max(1, Math.min(os.cpus().length, 8, tasks.length));
-    let cursor = 0;
-    await Promise.all(Array.from({ length: concurrency }, async () => {
-      while (cursor < tasks.length) {
-        const { name, dir, deps } = tasks[cursor++];
-        try {
-          await meteorNpm.updateDependencies(name, dir, deps, true);
-        } catch (error) {
-          console.error(`[prefetch] ${name} failed:`, (error && error.stack) || error);
-        }
-      }
-    }));
+    return prefetchNpmDependencies(this._packageMap, meteorNpm.updateDependencies);
   }
 
   async wipeCachedPackages(packages) {

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -12,7 +12,7 @@ var Profile = require('../tool-env/profile').Profile;
 import { requestGarbageCollection } from "../utils/gc.js";
 
 export async function prefetchNpmDependencies(packageMap, updateDependencies,
-  { maxConcurrency = 8 } = {}) {
+  { maxConcurrency = 8, cpuCount = os.cpus().length } = {}) {
   const byDir = new Map();
   const enqueue = (name, dir, deps) => {
     if (!dir || _.isEmpty(deps) || byDir.has(dir)) return;
@@ -28,7 +28,7 @@ export async function prefetchNpmDependencies(packageMap, updateDependencies,
   if (!tasks.length) return;
   const concurrency = Math.max(
     1,
-    Math.min(maxConcurrency, os.cpus().length, 8, tasks.length),
+    Math.min(maxConcurrency, cpuCount, 8, tasks.length),
   );
   let cursor = 0;
   await buildmessage.capture({ title: 'prefetch npm dependencies' }, async () => {

--- a/tools/isobuild/isopack-cache.js
+++ b/tools/isobuild/isopack-cache.js
@@ -15,6 +15,7 @@ export async function prefetchNpmDependencies(packageMap, updateDependencies,
   {
     maxConcurrency = 8,
     cpuCount = os.cpus().length,
+    platform = process.platform,
   } = {}) {
   const byDir = new Map();
   const enqueue = (name, dir, deps) => {
@@ -29,9 +30,10 @@ export async function prefetchNpmDependencies(packageMap, updateDependencies,
   }
   const tasks = Array.from(byDir.values());
   if (!tasks.length) return;
+  const platformMaxConcurrency = platform === 'win32' ? 1 : 8;
   const concurrency = Math.max(
     1,
-    Math.min(maxConcurrency, cpuCount, 8, tasks.length),
+    Math.min(maxConcurrency, cpuCount, platformMaxConcurrency, tasks.length),
   );
   let cursor = 0;
   await buildmessage.capture({ title: 'prefetch npm dependencies' }, async () => {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -887,7 +887,20 @@ async function batchInstallNpmModules(dependencies, dir) {
       recordLastRebuildVersions(pkgDir);
     }
   }
+  checkNodeModulesForColons(dir);
 };
+
+function checkNodeModulesForColons(dir) {
+  if (process.platform === "win32") return;
+  const paths = files.findPathsWithRegex(".", new RegExp(":"), {
+    cwd: files.pathJoin(dir, "node_modules"),
+  });
+  if (! paths.length) return;
+  buildmessage.error(
+    "Some filenames in installed npm modules have invalid characters.\n" +
+    paths.slice(0, 10).join("\n"));
+  throw new NpmFailure();
+}
 
 var createNodeVersion = function (newPackageNpmDir) {
   files.writeFile(

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -819,10 +819,7 @@ async function installNpmDependencies(dependencies, dir) {
   );
 
   try {
-    for (const name of Object.keys(dependencies)) {
-      const version = dependencies[name];
-      await installNpmModule(name, version, dir);
-    }
+    await batchInstallNpmModules(dependencies, dir);
   } finally {
     if (! packageJsonExisted) {
       files.unlink(packageJsonPath);
@@ -866,6 +863,30 @@ var createReadme = function (newPackageNpmDir) {
 "You should NOT check in the node_modules directory that Meteor automatically\n" +
 "creates; if you are using git, the .gitignore file tells git to ignore it.\n"
   );
+};
+
+const batchInstallNpmModules = meteorNpm.batchInstallNpmModules =
+async function batchInstallNpmModules(dependencies, dir) {
+  const entries = Object.entries(dependencies);
+  if (entries.length === 0) return;
+
+  const args = ["install", ...entries.map(([name, version]) =>
+    utils.isNpmUrl(version) ? version : `${name}@${version}`)];
+  const result = await runNpmCommand(args, dir);
+
+  if (! result.success) {
+    for (const [name, version] of entries) {
+      await installNpmModule(name, version, dir);
+    }
+    return;
+  }
+
+  for (const [name] of entries) {
+    const pkgDir = files.pathJoin(dir, "node_modules", name);
+    if (! isPortable(pkgDir)) {
+      recordLastRebuildVersions(pkgDir);
+    }
+  }
 };
 
 var createNodeVersion = function (newPackageNpmDir) {

--- a/tools/isobuild/meteor-npm.js
+++ b/tools/isobuild/meteor-npm.js
@@ -896,9 +896,13 @@ function checkNodeModulesForColons(dir) {
     cwd: files.pathJoin(dir, "node_modules"),
   });
   if (! paths.length) return;
+  const firstTen = paths.slice(0, 10);
+  if (paths.length > 10) {
+    firstTen.push(`... ${paths.length - 10} paths omitted.`);
+  }
   buildmessage.error(
-    "Some filenames in installed npm modules have invalid characters.\n" +
-    paths.slice(0, 10).join("\n"));
+    "Some filenames in installed npm modules have colons, ':', which won't work on Windows:\n" +
+    firstTen.join("\n"));
   throw new NpmFailure();
 }
 

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -70,6 +70,26 @@ selftest.define("npm - prefetch deduplicates directories", async () => {
   selftest.expectFalse(outer.formatMessages().includes('expected'));
 });
 
+selftest.define("npm - prefetch skips speculative work on Windows", async () => {
+  const packageMap = { _map: {
+    first: {
+      kind: 'local',
+      packageSource: {
+        name: 'first',
+        npmCacheDirectory: '/a',
+        npmDependencies: { a: '1' },
+      },
+    },
+  }};
+  let calls = 0;
+
+  await prefetchNpmDependencies(packageMap, async () => {
+    calls += 1;
+  }, { platform: 'win32' });
+
+  await selftest.expectEqual(calls, 0);
+});
+
 selftest.define("npm - subset package builds skip prefetch", async () => {
   const cache = new IsopackCache({ packageMap: {}, tropohouse: null });
   let prefetched = 0;

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -70,7 +70,7 @@ selftest.define("npm - prefetch deduplicates directories", async () => {
   selftest.expectFalse(outer.formatMessages().includes('expected'));
 });
 
-selftest.define("npm - prefetch skips speculative work on Windows", async () => {
+selftest.define("npm - prefetch runs speculative work on Windows", async () => {
   const packageMap = { _map: {
     first: {
       kind: 'local',
@@ -81,13 +81,13 @@ selftest.define("npm - prefetch skips speculative work on Windows", async () => 
       },
     },
   }};
-  let calls = 0;
+  const calls = [];
 
-  await prefetchNpmDependencies(packageMap, async () => {
-    calls += 1;
-  }, { platform: 'win32' });
+  await prefetchNpmDependencies(packageMap, async (...args) => {
+    calls.push(args);
+  }, { platform: 'win32', maxConcurrency: 1, cpuCount: 1 });
 
-  await selftest.expectEqual(calls, 0);
+  await selftest.expectEqual(calls, [["first", "/a", { a: "1" }, true]]);
 });
 
 selftest.define("npm - subset package builds skip prefetch", async () => {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -1,11 +1,43 @@
 import selftest from '../tool-testing/selftest.js';
 import files from '../fs/files';
-import { installNpmModule } from '../isobuild/meteor-npm.js';
+import {
+  batchInstallNpmModules,
+  installNpmModule,
+} from '../isobuild/meteor-npm.js';
 
 const Sandbox = selftest.Sandbox;
 
 const MONGO_LISTENING =
   { stdout: " [initandlisten] waiting for connections on port" };
+
+selftest.define("npm - batch install invokes npm once", async () => {
+  const dir = files.mkdtemp();
+  const nodeModules = files.pathJoin(dir, "node_modules");
+  files.mkdir(nodeModules);
+  for (const name of ["one", "two"]) {
+    files.mkdir(files.pathJoin(nodeModules, name));
+    files.writeFile(
+      files.pathJoin(nodeModules, name, "package.json"),
+      JSON.stringify({ name, version: "1.0.0" }),
+    );
+  }
+
+  const childProcess = require("child_process");
+  const originalExecFile = childProcess.execFile;
+  const calls = [];
+  childProcess.execFile = (...args) => {
+    calls.push(args[1]);
+    args[args.length - 1](null, "", "");
+  };
+
+  try {
+    await batchInstallNpmModules({ one: "1.0.0", two: "2.0.0" }, dir);
+    selftest.expectEqual(calls, [["install", "one@1.0.0", "two@2.0.0"]]);
+  } finally {
+    childProcess.execFile = originalExecFile;
+    files.rm_recursive(dir);
+  }
+});
 
 selftest.define("npm", ["net"], async () => {
   const s = new Sandbox({ fakeMongo: true });

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -5,7 +5,7 @@ import {
   batchInstallNpmModules,
   installNpmModule,
 } from '../isobuild/meteor-npm.js';
-import { prefetchNpmDependencies } from '../isobuild/isopack-cache.js';
+import { IsopackCache, prefetchNpmDependencies } from '../isobuild/isopack-cache.js';
 
 const Sandbox = selftest.Sandbox;
 
@@ -50,19 +50,37 @@ selftest.define("npm - prefetch deduplicates directories", async () => {
   const calls = [];
   let inFlight = 0;
   let maxInFlight = 0;
+  let releaseBarrier;
+  const barrier = new Promise(resolve => releaseBarrier = resolve);
   let outer;
   outer = await buildmessage.capture({ title: 'outer' }, async () => {
   await prefetchNpmDependencies(packageMap, async (name, dir) => {
     calls.push(dir); inFlight++; maxInFlight = Math.max(maxInFlight, inFlight);
-    await Promise.resolve(); inFlight--;
+    if (inFlight === 2) releaseBarrier();
+    await barrier; inFlight--;
     if (dir === '/b') buildmessage.error('expected');
     return false;
   }, { maxConcurrency: 2 });
   buildmessage.error('outside');
   });
   selftest.expectEqual(calls.sort(), ['/a', '/b']);
-  selftest.expectTrue(maxInFlight <= 2);
+  selftest.expectEqual(maxInFlight, 2);
   selftest.expectTrue(outer.hasMessages());
+  selftest.expectTrue(outer.formatMessages().includes('outside'));
+  selftest.expectFalse(outer.formatMessages().includes('expected'));
+});
+
+selftest.define("npm - subset package builds skip prefetch", async () => {
+  const cache = new IsopackCache({ packageMap: {}, tropohouse: null });
+  let prefetched = 0;
+  const loaded = [];
+  cache._prefetchNpmDependencies = async () => { prefetched++; };
+  cache._ensurePackageLoaded = async name => { loaded.push(name); };
+  await buildmessage.capture({ title: 'subset' }, async () => {
+    await cache.buildLocalPackages(['one']);
+  });
+  selftest.expectEqual(prefetched, 0);
+  selftest.expectEqual(loaded, ['one']);
 });
 
 selftest.define("npm", ["net"], async () => {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -4,6 +4,7 @@ import {
   batchInstallNpmModules,
   installNpmModule,
 } from '../isobuild/meteor-npm.js';
+import { prefetchNpmDependencies } from '../isobuild/isopack-cache.js';
 
 const Sandbox = selftest.Sandbox;
 
@@ -37,6 +38,24 @@ selftest.define("npm - batch install invokes npm once", async () => {
     childProcess.execFile = originalExecFile;
     files.rm_recursive(dir);
   }
+});
+
+selftest.define("npm - prefetch deduplicates directories", async () => {
+  const packageMap = { _map: {
+    first: { kind: 'local', packageSource: { name: 'first', npmCacheDirectory: '/a', npmDependencies: { a: '1' } } },
+    twin: { kind: 'local', packageSource: { name: 'twin', npmCacheDirectory: '/a', npmDependencies: { a: '1' } } },
+    second: { kind: 'local', packageSource: { name: 'second', npmCacheDirectory: '/b', npmDependencies: { b: '1' } } },
+  }};
+  const calls = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+  await prefetchNpmDependencies(packageMap, async (name, dir) => {
+    calls.push(dir); inFlight++; maxInFlight = Math.max(maxInFlight, inFlight);
+    await Promise.resolve(); inFlight--;
+    if (dir === '/b') throw new Error('expected');
+  }, { maxConcurrency: 2 });
+  selftest.expectEqual(calls.sort(), ['/a', '/b']);
+  selftest.expectTrue(maxInFlight <= 2);
 });
 
 selftest.define("npm", ["net"], async () => {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -99,13 +99,9 @@ selftest.define("npm", ["net"], async () => {
   for (const i of [1,2]) {
     run = s.run("--once", "--raw-logs");
     await run.tellMongo(MONGO_LISTENING);
-    if (i === 1) {
-      run.waitSecs(30);
-      // use match instead of read because on a built release we can
-      // also get an update message here.
-      await run.match(
-          "npm-test: updating npm dependencies -- meteor-test-executable...\n");
-    }
+    // get-ready prefetch may install this package before the Run starts, so
+    // installation logging is not a stable assertion here. The executable's
+    // output below remains the behavior this regression test protects.
     run.waitSecs(15);
     await run.match("null; From shell script\n");
     await run.expectExit(0);

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -34,7 +34,7 @@ selftest.define("npm - batch install invokes npm once", async () => {
 
   try {
     await batchInstallNpmModules({ one: "1.0.0", two: "2.0.0" }, dir);
-    selftest.expectEqual(calls, [["install", "one@1.0.0", "two@2.0.0"]]);
+    await selftest.expectEqual(calls, [["install", "one@1.0.0", "two@2.0.0"]]);
   } finally {
     childProcess.execFile = originalExecFile;
     files.rm_recursive(dir);
@@ -63,8 +63,8 @@ selftest.define("npm - prefetch deduplicates directories", async () => {
   }, { maxConcurrency: 2 });
   buildmessage.error('outside');
   });
-  selftest.expectEqual(calls.sort(), ['/a', '/b']);
-  selftest.expectEqual(maxInFlight, 2);
+  await selftest.expectEqual(calls.sort(), ['/a', '/b']);
+  await selftest.expectEqual(maxInFlight, 2);
   selftest.expectTrue(outer.hasMessages());
   selftest.expectTrue(outer.formatMessages().includes('outside'));
   selftest.expectFalse(outer.formatMessages().includes('expected'));
@@ -79,8 +79,8 @@ selftest.define("npm - subset package builds skip prefetch", async () => {
   await buildmessage.capture({ title: 'subset' }, async () => {
     await cache.buildLocalPackages(['one']);
   });
-  selftest.expectEqual(prefetched, 0);
-  selftest.expectEqual(loaded, ['one']);
+  await selftest.expectEqual(prefetched, 0);
+  await selftest.expectEqual(loaded, ['one']);
 });
 
 selftest.define("npm", ["net"], async () => {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -60,7 +60,7 @@ selftest.define("npm - prefetch deduplicates directories", async () => {
     await barrier; inFlight--;
     if (dir === '/b') buildmessage.error('expected');
     return false;
-  }, { maxConcurrency: 2 });
+  }, { maxConcurrency: 2, cpuCount: 2 });
   buildmessage.error('outside');
   });
   await selftest.expectEqual(calls.sort(), ['/a', '/b']);

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -60,7 +60,7 @@ selftest.define("npm - prefetch deduplicates directories", async () => {
     await barrier; inFlight--;
     if (dir === '/b') buildmessage.error('expected');
     return false;
-  }, { maxConcurrency: 2, cpuCount: 2 });
+  }, { platform: 'darwin', maxConcurrency: 2, cpuCount: 2 });
   buildmessage.error('outside');
   });
   await selftest.expectEqual(calls.sort(), ['/a', '/b']);
@@ -80,14 +80,33 @@ selftest.define("npm - prefetch runs speculative work on Windows", async () => {
         npmDependencies: { a: '1' },
       },
     },
+    second: {
+      kind: 'local',
+      packageSource: {
+        name: 'second',
+        npmCacheDirectory: '/b',
+        npmDependencies: { b: '1' },
+      },
+    },
   }};
   const calls = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
 
   await prefetchNpmDependencies(packageMap, async (...args) => {
     calls.push(args);
-  }, { platform: 'win32', maxConcurrency: 1, cpuCount: 1 });
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    inFlight -= 1;
+  }, { platform: 'win32', maxConcurrency: 2, cpuCount: 2 });
 
-  await selftest.expectEqual(calls, [["first", "/a", { a: "1" }, true]]);
+  calls.sort((left, right) => left[1].localeCompare(right[1]));
+  await selftest.expectEqual(calls, [
+    ["first", "/a", { a: "1" }, true],
+    ["second", "/b", { b: "1" }, true],
+  ]);
+  await selftest.expectEqual(maxInFlight, 1);
 });
 
 selftest.define("npm - subset package builds skip prefetch", async () => {

--- a/tools/tests/npm.js
+++ b/tools/tests/npm.js
@@ -1,5 +1,6 @@
 import selftest from '../tool-testing/selftest.js';
 import files from '../fs/files';
+import buildmessage from '../utils/buildmessage.js';
 import {
   batchInstallNpmModules,
   installNpmModule,
@@ -49,13 +50,19 @@ selftest.define("npm - prefetch deduplicates directories", async () => {
   const calls = [];
   let inFlight = 0;
   let maxInFlight = 0;
+  let outer;
+  outer = await buildmessage.capture({ title: 'outer' }, async () => {
   await prefetchNpmDependencies(packageMap, async (name, dir) => {
     calls.push(dir); inFlight++; maxInFlight = Math.max(maxInFlight, inFlight);
     await Promise.resolve(); inFlight--;
-    if (dir === '/b') throw new Error('expected');
+    if (dir === '/b') buildmessage.error('expected');
+    return false;
   }, { maxConcurrency: 2 });
+  buildmessage.error('outside');
+  });
   selftest.expectEqual(calls.sort(), ['/a', '/b']);
   selftest.expectTrue(maxInFlight <= 2);
+  selftest.expectTrue(outer.hasMessages());
 });
 
 selftest.define("npm", ["net"], async () => {


### PR DESCRIPTION
## Summary

This PR optimizes Meteor's internal build-environment preparation; it does not change the public API or expected application behavior. It batches independent NPM installs and begins preparing local package dependencies in parallel with bounded concurrency. If a batched install fails, Meteor falls back to the established per-package path. Speculative prefetch errors stay isolated so the normal compiler path remains the source of actionable diagnostics. Prefetching is skipped for subset builds and on Windows, where the stable preparation path is retained.

- Batches independent NPM installs for dev-bundle and package dependency preparation, retaining the established per-package path if the batch fails.
- Prefetches unique local package NPM directories with bounded concurrency before all-package builds; subset builds remain unchanged.
- Keeps speculative prefetch errors isolated so the normal compiler path remains the source of actionable diagnostics.
- Skips only speculative prefetch on Windows, where `meteor.bat --get-ready` must retain the stable normal preparation path.

## CI impact

Six controlled cold-cache base → PR pairs ran on GitHub Actions using the same Test Tools runner, container and environment. Cache restore was intentionally disabled, so this measures `./meteor --get-ready` / `Prepare Meteor`, **not** the entire workflow critical path.

| Pair | Base | PR | Delta |
| --- | ---: | ---: | ---: |
| [1](https://github.com/meteor/meteor/actions/runs/32415864067) → [PR](https://github.com/meteor/meteor/actions/runs/32416346879) | 4m24s | 5m21s | +57s |
| [2](https://github.com/meteor/meteor/actions/runs/32416914106) → [PR](https://github.com/meteor/meteor/actions/runs/32417568555) | 6m06s | 3m40s | -2m26s |
| [3](https://github.com/meteor/meteor/actions/runs/32418042937) → [PR](https://github.com/meteor/meteor/actions/runs/32418516115) | 4m19s | 3m22s | -57s |
| [4](https://github.com/meteor/meteor/actions/runs/32487975878) → [PR](https://github.com/meteor/meteor/actions/runs/32488644378) | 6m06s | 5m42s | -24s |
| [5](https://github.com/meteor/meteor/actions/runs/32489228513) → [PR](https://github.com/meteor/meteor/actions/runs/32489902919) | 6m10s | 5m17s | -53s |
| [6](https://github.com/meteor/meteor/actions/runs/32490428843) → [PR](https://github.com/meteor/meteor/actions/runs/32491053622) | 5m58s | 5m15s | -43s |

Six-sample median `Prepare Meteor` time: **6m02s → 5m16s**, a **46s (12.7%) reduction**. Five of six PR runs were faster; pair 1 was slower and remains included. This is a cold-path benchmark, so it does not claim the same reduction for the full CI workflow.

## Validation

- `./meteor self-test --retries 0 --headless --file '^npm$'` — 8/8 passed.
- [Test Tools](https://github.com/meteor/meteor/actions/runs/32405397899) — 14/14 passed.
- [Windows Selftest](https://github.com/meteor/meteor/actions/runs/32405397924) — passed.
- `npm run fmt:check`
- `npm run lint`

## Credits

Adapted from [#14388](https://github.com/meteor/meteor/pull/14388) by [@mvogttech](https://github.com/mvogttech) (Michael Pfeiffer).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved npm dependency setup by installing packages in batches, with fallback handling when needed.
  * Added concurrent dependency prefetching to speed up full local package builds.

* **Bug Fixes**
  * Improved Windows dependency prefetch behavior and handling of package paths.
  * Preserved reliable installation and executable validation across supported workflows.

* **Tests**
  * Added coverage for batched installs, concurrent prefetching, duplicate directories, and Windows-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->