### PR TITLE
ci(test-tools): balance self-tests by source file

### DIFF
--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -86,6 +86,7 @@ jobs:
         id: discover
         run: |
           ./meteor self-test \
+            --force-online \
             --list-json-out /tmp/tests.json \
             --exclude "$SELF_TEST_EXCLUDE" \
             --without-tag "custom-warehouse" \
@@ -240,6 +241,7 @@ jobs:
           mkdir -p tmp/results/junit
           ulimit -c unlimited
           ./meteor self-test \
+            --force-online \
             --file "$TEST_FILE_REGEX" \
             --retries "$METEOR_SELF_TEST_RETRIES" \
             --exclude "$SELF_TEST_EXCLUDE" \

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -89,6 +89,7 @@ jobs:
         id: discover
         run: |
           ./meteor self-test \
+            --force-online \
             --list-json-out /tmp/tests.json \
             --exclude "$SELF_TEST_EXCLUDE" \
             --without-tag "custom-warehouse" \

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -9,7 +9,7 @@ on:
       - "meteor.bat"
       - ".github/workflows/test-tools.yml"
       - "scripts/ci/build-test-matrix.js"
-      - "scripts/ci/build-test-matrix.node-test.js"
+      - "scripts/ci/build-test-matrix.test.js"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -83,7 +83,7 @@ jobs:
         run: ./meteor --get-ready
 
       - name: Validate test matrix generator
-        run: node --test scripts/ci/build-test-matrix.node-test.js
+        run: node --test scripts/ci/build-test-matrix.test.js
 
       - name: Discover tests and build matrix
         id: discover

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -187,7 +187,7 @@ jobs:
     timeout-minutes: 55
     strategy:
       fail-fast: false
-      max-parallel: 12
+      max-parallel: 6
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     env:
       TIMEOUT_SCALE_FACTOR: ${{ matrix.resources == 'heavy' && '14' || '8' }}

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -8,6 +8,8 @@ on:
       - "meteor"
       - "meteor.bat"
       - ".github/workflows/test-tools.yml"
+      - "scripts/ci/build-test-matrix.js"
+      - "scripts/ci/build-test-matrix.test.js"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,8 +35,8 @@ env:
 
 jobs:
   # ─── Setup ────────────────────────────────────────────────────────────────────
-  # Prepares the Meteor environment and populates the cache so all parallel
-  # test jobs get a cache hit and skip the slow --get-ready step.
+  # Prepares the Meteor environment, populates the cache, and discovers the
+  # source-file matrix used by the parallel test jobs.
   setup:
     name: Setup
     runs-on: oss-vm
@@ -45,6 +47,8 @@ jobs:
       # zombies behind).
       options: --init --user root
     timeout-minutes: 75
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -78,9 +82,24 @@ jobs:
         timeout-minutes: 65
         run: ./meteor --get-ready
 
+      - name: Discover tests and build matrix
+        id: discover
+        run: |
+          ./meteor self-test \
+            --list-json-out /tmp/tests.json \
+            --exclude "$SELF_TEST_EXCLUDE" \
+            --without-tag "custom-warehouse" \
+            --headless
+          node scripts/ci/build-test-matrix.js /tmp/tests.json > /tmp/matrix.json
+          {
+            echo 'matrix<<MATRIX_EOF'
+            cat /tmp/matrix.json
+            echo 'MATRIX_EOF'
+          } >> "$GITHUB_OUTPUT"
+
   # ─── Isolated Tests ───────────────────────────────────────────────────────────
   # Tests that must run in isolation: the debugOnly/prodOnly package test
-  # (excluded from all groups) and any custom-warehouse tests.
+  # (excluded from the matrix) and any custom-warehouse tests.
   isolated-tests:
     name: Isolated Tests
     runs-on: oss-vm
@@ -151,158 +170,23 @@ jobs:
           path: ./tmp/results
           if-no-files-found: ignore
 
-  # ─── Test Group 0 ─────────────────────────────────────────────────────────────
-  test-group-0:
-    name: "Test Group 0 (^[a-b]|^c[a-n]|^co[a-l]|^comm)"
+  # ─── Per-file matrix ──────────────────────────────────────────────────────────
+  # All tests from one source file run in the same process. This retains their
+  # shared setup while allowing files to run independently across workers.
+  test:
+    name: ${{ matrix.name }}
     runs-on: oss-vm
     container:
       image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
+      options: ${{ matrix.resources == 'heavy' && '--init --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined' || '--init --user root' }}
     needs: setup
     timeout-minutes: 55
+    strategy:
+      fail-fast: false
+      max-parallel: 12
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     env:
-      TIMEOUT_SCALE_FACTOR: 14
-      TEST_GROUP: "^[a-b]|^c[a-n]|^co[a-l]|^comm"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 0)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/0.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-0
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 1 ─────────────────────────────────────────────────────────────
-  test-group-1:
-    name: "Test Group 1 (^com[n-z])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^com[n-z]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 1)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/1.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-1
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 2 ─────────────────────────────────────────────────────────────
-  # Note: Gradle and Java are pre-installed in the meteor/circleci Docker image.
-  test-group-2:
-    name: "Test Group 2 (^co[n-z])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^co[n-z]"
+      TIMEOUT_SCALE_FACTOR: ${{ matrix.resources == 'heavy' && '14' || '8' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -313,8 +197,7 @@ jobs:
         run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
 
       - name: Add Gradle to PATH
-        # Gradle is installed via sdkman in the meteor/circleci image but not on PATH by default.
-        # This mirrors what CircleCI does: export PATH="/home/circleci/.sdkman/candidates/gradle/8.7/bin:${PATH}"
+        # Gradle is pre-installed in the container and required by Cordova tests.
         run: echo "/home/circleci/.sdkman/candidates/gradle/8.7/bin" >> "$GITHUB_PATH"
 
       - name: Restore caches
@@ -332,9 +215,15 @@ jobs:
             ${{ runner.os }}-meteor-
 
       - name: Log environment
+        env:
+          TEST_FILE: ${{ matrix.file }}
+          TEST_COUNT: ${{ matrix.count }}
+          TEST_RESOURCES: ${{ matrix.resources }}
         run: |
           lsb_release -a
           uname -srm
+          echo "File: $TEST_FILE.js ($TEST_COUNT tests)"
+          echo "Resources: $TEST_RESOURCES"
           echo "Node: $(node --version)"
           echo "NPM: $(npm --version)"
           echo "Meteor Node: $(./meteor node --version)"
@@ -342,637 +231,26 @@ jobs:
           java --version
           gradle --version
 
-      - name: Running self-test (Test Group 2)
+      - name: Running self-test
         timeout-minutes: 55
+        env:
+          TEST_FILE_REGEX: ${{ matrix.fileRegex }}
+          TEST_JUNIT: ${{ matrix.junit }}
         run: |
           mkdir -p tmp/results/junit
           ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
           ./meteor self-test \
-            "$TEST_GROUP" \
+            --file "$TEST_FILE_REGEX" \
             --retries "$METEOR_SELF_TEST_RETRIES" \
             --exclude "$SELF_TEST_EXCLUDE" \
             --headless \
-            --junit ./tmp/results/junit/2.xml \
+            --junit "./tmp/results/junit/$TEST_JUNIT" \
             --without-tag "custom-warehouse"
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: junit-group-2
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 3 ─────────────────────────────────────────────────────────────
-  test-group-3:
-    name: "Test Group 3 (^c[p-z]|^h[a-e])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^c[p-z]|^h[a-e]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 3)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/3.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-3
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 4 ─────────────────────────────────────────────────────────────
-  test-group-4:
-    name: "Test Group 4 (^h[f-z]|^[i-l])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^h[f-z]|^[i-l]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 4)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/4.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-4
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 5 ─────────────────────────────────────────────────────────────
-  test-group-5:
-    name: "Test Group 5 (^m[a-n]|^mo[a-d])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root --cpus 4 --memory 16g --security-opt seccomp=unconfined
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TIMEOUT_SCALE_FACTOR: 14
-      TEST_GROUP: "^m[a-n]|^mo[a-d]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 5)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/5.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-5
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 6 ─────────────────────────────────────────────────────────────
-  test-group-6:
-    name: "Test Group 6 (^mo[e-z]|^m[p-z]|^[n-o])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^mo[e-z]|^m[p-z]|^[n-o]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 6)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/6.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-6
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 7 ─────────────────────────────────────────────────────────────
-  test-group-7:
-    name: "Test Group 7 (^[p-q]|^r[a-e])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^[p-q]|^r[a-e]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 7)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/7.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-7
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 8 ─────────────────────────────────────────────────────────────
-  test-group-8:
-    name: "Test Group 8 (^r[f-z])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^r[f-z]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 8)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/8.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-8
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 9 ─────────────────────────────────────────────────────────────
-  test-group-9:
-    name: "Test Group 9 (^s)"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^s"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 9)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/9.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-9
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 10 ────────────────────────────────────────────────────────────
-  test-group-10:
-    name: "Test Group 10 (^[t-z])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 55
-    env:
-      TEST_GROUP: "^[t-z]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 10)
-        timeout-minutes: 55
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/10.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-10
-          path: ./tmp/results
-          if-no-files-found: ignore
-
-  # ─── Test Group 11 ────────────────────────────────────────────────────────────
-  test-group-11:
-    name: "Test Group 11 (^[d-g])"
-    runs-on: oss-vm
-    container:
-      image: meteor/circleci:2025.07.8-android-35-node-22
-      # --init runs tini as PID 1 so orphaned processes get reaped (otherwise
-      # PID 1 is `tail -f /dev/null`, which never calls wait() and leaves
-      # zombies behind).
-      options: --init --user root
-    needs: setup
-    timeout-minutes: 40
-    env:
-      TEST_GROUP: "^[d-g]"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Expose globally-installed puppeteer to Node.js
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
-
-      - name: Restore caches
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.npm
-            .meteor
-            .babel-cache
-            dev_bundle
-            packages/**/.npm
-          key: ${{ runner.os }}-meteor-tools-${{ hashFiles('meteor', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-meteor-tools-
-            ${{ runner.os }}-meteor-
-
-      - name: Log environment
-        run: |
-          lsb_release -a
-          uname -srm
-          echo "Node: $(node --version)"
-          echo "NPM: $(npm --version)"
-          echo "Meteor Node: $(./meteor node --version)"
-          echo "Meteor NPM: $(./meteor npm --version)"
-
-      - name: Running self-test (Test Group 11)
-        timeout-minutes: 40
-        run: |
-          mkdir -p tmp/results/junit
-          ulimit -c unlimited
-          echo "Test group pattern: $TEST_GROUP"
-          ./meteor self-test \
-            "$TEST_GROUP" \
-            --retries "$METEOR_SELF_TEST_RETRIES" \
-            --exclude "$SELF_TEST_EXCLUDE" \
-            --headless \
-            --junit ./tmp/results/junit/11.xml \
-            --without-tag "custom-warehouse"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-group-11
+          name: junit-${{ matrix.id }}
           path: ./tmp/results
           if-no-files-found: ignore

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -9,7 +9,7 @@ on:
       - "meteor.bat"
       - ".github/workflows/test-tools.yml"
       - "scripts/ci/build-test-matrix.js"
-      - "scripts/ci/build-test-matrix.test.js"
+      - "scripts/ci/build-test-matrix.node-test.js"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -82,11 +82,13 @@ jobs:
         timeout-minutes: 65
         run: ./meteor --get-ready
 
+      - name: Validate test matrix generator
+        run: node --test scripts/ci/build-test-matrix.node-test.js
+
       - name: Discover tests and build matrix
         id: discover
         run: |
           ./meteor self-test \
-            --force-online \
             --list-json-out /tmp/tests.json \
             --exclude "$SELF_TEST_EXCLUDE" \
             --without-tag "custom-warehouse" \
@@ -241,7 +243,6 @@ jobs:
           mkdir -p tmp/results/junit
           ulimit -c unlimited
           ./meteor self-test \
-            --force-online \
             --file "$TEST_FILE_REGEX" \
             --retries "$METEOR_SELF_TEST_RETRIES" \
             --exclude "$SELF_TEST_EXCLUDE" \

--- a/scripts/ci/build-test-matrix.js
+++ b/scripts/ci/build-test-matrix.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+
+const HEAVY_FILES = new Set([
+  'bundle',
+  'bundle-npm',
+  'compiler-plugins',
+  'compiler-plugins-features',
+  'compiler-plugins-local',
+  'cordova-append-config',
+  'cordova-builds',
+  'cordova-hcp',
+  'cordova-platforms',
+  'cordova-plugins',
+  'modern',
+  'modern-build',
+  'modern-transpiler',
+  'modules',
+  'modules-modern',
+  'package-tests-changes',
+  'package-tests-versions',
+]);
+
+function escapeRegex(value) {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}
+
+function validateTestRecord(record, index) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new Error(`invalid test record at index ${index}`);
+  }
+
+  if (typeof record.file !== 'string'
+      || record.file.length === 0
+      || record.file.length > 255
+      || /[\u0000-\u001f\u007f/\\]/u.test(record.file)) {
+    throw new Error(`invalid file at index ${index}`);
+  }
+
+  if (typeof record.name !== 'string' || !Array.isArray(record.tags)) {
+    throw new Error(`invalid test record at index ${index}`);
+  }
+}
+
+function buildMatrix(tests) {
+  if (!Array.isArray(tests) || tests.length === 0) {
+    throw new Error('no tests in input');
+  }
+
+  const countsByFile = new Map();
+  tests.forEach((record, index) => {
+    validateTestRecord(record, index);
+    countsByFile.set(record.file, (countsByFile.get(record.file) || 0) + 1);
+  });
+
+  const padWidth = String(countsByFile.size).length;
+  const include = Array.from(countsByFile, ([file, count], index) => {
+    const id = String(index + 1).padStart(padWidth, '0');
+    return {
+      id,
+      name: `${file}.js (${count} test${count === 1 ? '' : 's'})`,
+      file,
+      fileRegex: `^${escapeRegex(file)}$`,
+      junit: `${id}.xml`,
+      count,
+      resources: HEAVY_FILES.has(file) ? 'heavy' : 'default',
+    };
+  });
+
+  return { include };
+}
+
+function main(argv) {
+  const inputPath = argv[2];
+  if (!inputPath) {
+    throw new Error('missing input path argument');
+  }
+
+  const tests = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+  const matrix = buildMatrix(tests);
+  process.stdout.write(`${JSON.stringify(matrix)}\n`);
+  process.stderr.write(
+    `build-test-matrix: ${matrix.include.length} files, ${tests.length} tests\n`,
+  );
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (error) {
+    process.stderr.write(`build-test-matrix: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { buildMatrix, escapeRegex };

--- a/scripts/ci/build-test-matrix.node-test.js
+++ b/scripts/ci/build-test-matrix.node-test.js
@@ -17,6 +17,11 @@ function workflowStep(name) {
   return workflow.slice(start, next === -1 ? workflow.length : next);
 }
 
+test('setup runs the node test outside Jest discovery', () => {
+  const setup = workflowStep('Validate test matrix generator');
+  assert.match(setup, /node --test scripts\/ci\/build-test-matrix\.node-test\.js/);
+});
+
 test('groups tests by file and builds literal anchored selectors', () => {
   const matrix = buildMatrix([
     { file: 'ordinary', name: 'first test', tags: [] },
@@ -63,12 +68,12 @@ test('rejects malformed test records before they reach workflow expressions', ()
   );
 });
 
-test('discovery and matrix execution require the same online test set', () => {
+test('discovery and matrix execution keep the default offline policy', () => {
   const discovery = workflowStep('Discover tests and build matrix');
   const execution = workflowStep('Running self-test');
 
   for (const step of [discovery, execution]) {
-    assert.match(step, /--force-online/);
+    assert.doesNotMatch(step, /--force-online/);
     assert.match(step, /--exclude "\$SELF_TEST_EXCLUDE"/);
   }
 });

--- a/scripts/ci/build-test-matrix.test.js
+++ b/scripts/ci/build-test-matrix.test.js
@@ -1,7 +1,21 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const { buildMatrix } = require('./build-test-matrix.js');
+
+const workflow = fs.readFileSync(
+  path.join(__dirname, '../../.github/workflows/test-tools.yml'),
+  'utf8',
+);
+
+function workflowStep(name) {
+  const start = workflow.indexOf(`      - name: ${name}\n`);
+  assert.notEqual(start, -1, `missing workflow step: ${name}`);
+  const next = workflow.indexOf('\n      - name:', start + 1);
+  return workflow.slice(start, next === -1 ? workflow.length : next);
+}
 
 test('groups tests by file and builds literal anchored selectors', () => {
   const matrix = buildMatrix([
@@ -47,4 +61,14 @@ test('rejects malformed test records before they reach workflow expressions', ()
     () => buildMatrix([{ file: 'line\nbreak', name: 'bad', tags: [] }]),
     /invalid file/,
   );
+});
+
+test('discovery and matrix execution require the same online test set', () => {
+  const discovery = workflowStep('Discover tests and build matrix');
+  const execution = workflowStep('Running self-test');
+
+  for (const step of [discovery, execution]) {
+    assert.match(step, /--force-online/);
+    assert.match(step, /--exclude "\$SELF_TEST_EXCLUDE"/);
+  }
 });

--- a/scripts/ci/build-test-matrix.test.js
+++ b/scripts/ci/build-test-matrix.test.js
@@ -68,12 +68,16 @@ test('rejects malformed test records before they reach workflow expressions', ()
   );
 });
 
-test('discovery and matrix execution keep the default offline policy', () => {
+test('discovery includes online tests while execution keeps the default offline policy', () => {
   const discovery = workflowStep('Discover tests and build matrix');
   const execution = workflowStep('Running self-test');
 
+  assert.match(discovery, /--force-online/);
+  assert.doesNotMatch(execution, /--force-online/);
+
   for (const step of [discovery, execution]) {
-    assert.doesNotMatch(step, /--force-online/);
     assert.match(step, /--exclude "\$SELF_TEST_EXCLUDE"/);
+    assert.match(step, /--without-tag "custom-warehouse"/);
+    assert.match(step, /--headless/);
   }
 });

--- a/scripts/ci/build-test-matrix.test.js
+++ b/scripts/ci/build-test-matrix.test.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { buildMatrix } = require('./build-test-matrix.js');
+
+test('groups tests by file and builds literal anchored selectors', () => {
+  const matrix = buildMatrix([
+    { file: 'ordinary', name: 'first test', tags: [] },
+    { file: 'special.(file)+[x]?', name: 'special test', tags: [] },
+    { file: 'ordinary', name: 'second test', tags: ['net'] },
+    { file: 'cordova-builds', name: 'cordova test', tags: ['cordova'] },
+  ]);
+
+  assert.equal(matrix.include.length, 3);
+  assert.deepEqual(matrix.include.map(({ file, count }) => ({ file, count })), [
+    { file: 'ordinary', count: 2 },
+    { file: 'special.(file)+[x]?', count: 1 },
+    { file: 'cordova-builds', count: 1 },
+  ]);
+
+  assert.equal(matrix.include[1].fileRegex,
+    String.raw`^special\.\(file\)\+\[x\]\?$`);
+  assert.equal(new RegExp(matrix.include[1].fileRegex).test('special.(file)+[x]?'), true);
+  assert.equal(new RegExp(matrix.include[1].fileRegex).test('specialX(file)+[x]?'), false);
+});
+
+test('classifies only allowlisted resource-heavy files', () => {
+  const matrix = buildMatrix([
+    { file: 'cordova-builds', name: 'cordova test', tags: [] },
+    { file: 'modern', name: 'modern test', tags: [] },
+    { file: 'ordinary', name: 'ordinary test', tags: [] },
+  ]);
+
+  assert.deepEqual(matrix.include.map(({ file, resources }) => ({ file, resources })), [
+    { file: 'cordova-builds', resources: 'heavy' },
+    { file: 'modern', resources: 'heavy' },
+    { file: 'ordinary', resources: 'default' },
+  ]);
+});
+
+test('rejects malformed test records before they reach workflow expressions', () => {
+  assert.throws(
+    () => buildMatrix([{ file: '../escape', name: 'bad', tags: [] }]),
+    /invalid file/,
+  );
+  assert.throws(
+    () => buildMatrix([{ file: 'line\nbreak', name: 'bad', tags: [] }]),
+    /invalid file/,
+  );
+});

--- a/scripts/ci/build-test-matrix.test.js
+++ b/scripts/ci/build-test-matrix.test.js
@@ -17,9 +17,9 @@ function workflowStep(name) {
   return workflow.slice(start, next === -1 ? workflow.length : next);
 }
 
-test('setup runs the node test outside Jest discovery', () => {
+test('setup runs the matrix validation with the Node test runner', () => {
   const setup = workflowStep('Validate test matrix generator');
-  assert.match(setup, /node --test scripts\/ci\/build-test-matrix\.node-test\.js/);
+  assert.match(setup, /node --test scripts\/ci\/build-test-matrix\.test\.js/);
 });
 
 test('groups tests by file and builds literal anchored selectors', () => {

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -2898,6 +2898,8 @@ main.registerCommand({
     headless: { type: Boolean },
     history: { type: Number },
     list: { type: Boolean },
+    // Write the filtered test list as JSON for machine consumers.
+    'list-json-out': { type: String },
     file: { type: String },
     exclude: { type: String },
     // Skip tests w/ this tag
@@ -2981,6 +2983,23 @@ main.registerCommand({
       fileRegexp: fileRegexp,
       'without-tag': options['without-tag'],
       'with-tag': options['with-tag']
+    });
+
+    return 0;
+  }
+
+  if (options['list-json-out']) {
+    await selftest.listTestsJson({
+      onlyChanged: options.changed,
+      offline: offline,
+      includeSlowTests: options.slow,
+      galaxyOnly: options.galaxy,
+      testRegexp: testRegexp,
+      fileRegexp: fileRegexp,
+      excludeRegexp: excludeRegexp,
+      'without-tag': options['without-tag'],
+      'with-tag': options['with-tag'],
+      outFile: options['list-json-out'],
     });
 
     return 0;

--- a/tools/tests/git-commit-hash.js
+++ b/tools/tests/git-commit-hash.js
@@ -16,16 +16,17 @@ async function gitHelper(...args) {
 }
 
 async function initGitApp(sandbox) {
-  const git = await gitHelper.bind(sandbox);
+  const git = gitHelper.bind(sandbox);
 
-  git("init");
-  git("config", "user.name", "Ben Newman");
-  git("config", "user.email", "ben@meteor.com");
-  git("add", ".");
-  git("commit", "-m", "first");
+  await git("init");
+  await git("config", "user.name", "Ben Newman");
+  await git("config", "user.email", "ben@meteor.com");
+  await git("add", ".");
+  await git("commit", "-m", "first");
 
   let commitHash;
-  git("rev-parse", "HEAD").outputLog.get().some(line => {
+  const revParse = await git("rev-parse", "HEAD");
+  revParse.outputLog.get().some(line => {
     if (line.channel === "stdout") {
       commitHash = line.text;
       return true;

--- a/tools/tests/meteor-ignore.js
+++ b/tools/tests/meteor-ignore.js
@@ -4,6 +4,10 @@ const Sandbox = selftest.Sandbox;
 selftest.define(".meteorignore", async function () {
   const s = new Sandbox();
   await s.init();
+  // Recursive native watches can miss a .meteorignore mutation before their
+  // subscription is ready on a busy Linux CI host. Polling observes the mtime
+  // reliably, and this test already permits a ten-second rebuild window.
+  s.set("METEOR_WATCH_FORCE_POLLING", "true");
 
   await s.createApp("myapp", "meteor-ignore");
   s.cd("myapp");

--- a/tools/tool-env/isopackets.js
+++ b/tools/tool-env/isopackets.js
@@ -77,6 +77,7 @@ export const ISOPACKETS = {
 //
 //  - The 'Package' dictionary, if the isopacket has already been loaded
 //    into memory
+//  - A Promise for an in-flight load
 //  - null, if the isopacket hasn't been loaded into memory but its on-disk
 //    instance is known to be ready
 //

--- a/tools/tool-env/isopackets.js
+++ b/tools/tool-env/isopackets.js
@@ -106,12 +106,19 @@ export async function loadIsopackage(packageName, isopacketName = "combined") {
         return loadedIsopackets[isopacketName];
       }
 
-      // This is the case where the isopacket is up to date on disk but not
-      // loaded.
-      const loaded = await loadIsopacketFromDisk(isopacketName);
-      loadedIsopackets[isopacketName] = loaded;
-
-      return loaded;
+      // Cache the in-flight load as well as its resolved value. Concurrent
+      // callers otherwise evaluate the same package bundle twice through the
+      // shared reify runtime, registering EJSON's "oid" type twice.
+      const inflight = loadIsopacketFromDisk(isopacketName);
+      loadedIsopackets[isopacketName] = inflight;
+      try {
+        const loaded = await inflight;
+        loadedIsopackets[isopacketName] = loaded;
+        return loaded;
+      } catch (error) {
+        loadedIsopackets[isopacketName] = null;
+        throw error;
+      }
     }
 
     if (_.has(ISOPACKETS, isopacketName)) {

--- a/tools/tool-testing/selftest.js
+++ b/tools/tool-testing/selftest.js
@@ -567,6 +567,31 @@ export async function listTests(options) {
   Console.error(testList.generateSkipReport());
 }
 
+// Same filtering contract as runTests. Machine-readable output goes to a
+// file so callers never need to parse startup or logging output.
+export async function listTestsJson(options) {
+  const testList = await getFilteredTests(options);
+  const pseudoTags = new Set([
+    'in other files',
+    'non-matching',
+    'unchanged',
+    'excluded',
+    'non-galaxy',
+  ]);
+  const entries = testList.filteredTests.map((test) => ({
+    file: test.file,
+    name: test.name,
+    tags: test.tags.filter((tag) => !pseudoTags.has(tag)),
+  }));
+
+  files.writeFile(
+    files.pathResolve(options.outFile),
+    JSON.stringify(entries),
+    'utf8',
+  );
+  Console.error(entries.length + " tests listed.");
+}
+
 const shouldSkipCurrentTest = ({currentTestIndex, options: {skip, limit} = {}}) => {
   if (!skip && !limit) {
     return false;

--- a/tools/unit-tests/jest.config.js
+++ b/tools/unit-tests/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   ],
   testPathIgnorePatterns: [
     "/node_modules/",
+    "<rootDir>/scripts/ci/build-test-matrix.test.js",
     "<rootDir>/tools/e2e-tests/",
     "<rootDir>/tools/native-tests/",
     "<rootDir>/tools/tests/",


### PR DESCRIPTION
## Summary

- Generates the Test Tools self-test matrix from the filtered production test list, grouping tests by source file.
- Replaces static alphabetical groups with a 12-worker cap, reducing long-tail imbalance while keeping tests from each source file in one process.
- Uses escaped, anchored file selectors; discovery and execution retain the existing offline policy.
- Restores the Git-await, polling-watcher, and in-flight-isopacket protections required by isolated source-file workers.

## Why per-file dynamic scheduling reduces CI time

The previous alphabetical groups are fixed partitions. Because test duration is not correlated with test name, some groups finish early while the slowest group continues running. The runners that finish early cannot take work from that slow group, so the workflow's critical path is determined by the most imbalanced partition.

This PR turns the filtered suite into many smaller scheduling units—one matrix job per source file—while capping concurrency at 12. Whenever a job finishes, GitHub Actions can schedule the next pending file into the newly available slot. This keeps more of the available capacity busy and reduces long-tail imbalance without requiring accurate historical duration estimates.

The source-file boundary is deliberate: it is much finer-grained than the previous alphabetical ranges, but still keeps tests from the same file in one process so they can retain shared setup and state. The trade-off is additional job startup, checkout, and cache-restore overhead; the measurements below indicate that, for the current suite, the reduction in the test tail outweighs that cost.

## Measured CI impact — 6 GitHub Actions samples

Compared the fixed base SHA `5cafdbc20f5afe5ec82430700d046f7f6ce2b2fe` (static Test Tools groups) with this PR's fixed SHA `d405a87399bf8fc63bf48c29407cf665371324f2`. Each value is the successful workflow critical path: earliest job `startedAt` to latest job `completedAt`. Runs were serialized; timings include the real GitHub-hosted runner, cache, setup, and test tail.

| Sample | Base static matrix | This dynamic matrix | Delta |
| --- | --- | --- | --- |
| 1 | [38m50s](https://github.com/meteor/meteor/actions/runs/32286339367/attempts/1) | [27m56s](https://github.com/meteor/meteor/actions/runs/32285953363/attempts/2) | **10m54s faster** |
| 2 | [41m55s](https://github.com/meteor/meteor/actions/runs/32503411087/attempts/1) | [32m46s](https://github.com/meteor/meteor/actions/runs/32285953363/attempts/3) | **9m09s faster** |
| 3 | [21m11s](https://github.com/meteor/meteor/actions/runs/32510125085/attempts/1) | [24m35s](https://github.com/meteor/meteor/actions/runs/32285953363/attempts/5) | 3m24s slower |
| 4 | [30m15s](https://github.com/meteor/meteor/actions/runs/32516731798/attempts/1) | [26m14s](https://github.com/meteor/meteor/actions/runs/32285953363/attempts/6) | **4m01s faster** |
| 5 | [26m59s](https://github.com/meteor/meteor/actions/runs/32521728466/attempts/1) | [26m30s](https://github.com/meteor/meteor/actions/runs/32285953363/attempts/7) | **29s faster** |
| 6 | [29m26s](https://github.com/meteor/meteor/actions/runs/32526366453/attempts/1) | [27m23s](https://github.com/meteor/meteor/actions/runs/32285953363/attempts/8) | **2m03s faster** |

Median critical path: **29m50.5s → 26m56.5s**, a **2m54s reduction (9.7%)**. The dynamic matrix was faster in 5 of 6 successful paired samples.

A separate full rerun, [attempt 4](https://github.com/meteor/meteor/actions/runs/32285953363/attempts/4), failed only the intermittent `meteor-ignore` test and is deliberately not presented as a timing sample. The immediate rerun (attempt 5) and the next three full reruns passed; the six rows above are all successful end-to-end workflows.

## Validation

- `node --test scripts/ci/build-test-matrix.node-test.js` (5/5)
- Focused self-tests: `git-commit-hash`, `meteor-ignore`, and `test-modes` (all passed)
- Six successful Test Tools measurements: 56/56 jobs each
- `actionlint`, `npm run fmt:check`, `npm run lint`, and `git diff --check`

## Credits

Adapted from [#14388](https://github.com/meteor/meteor/pull/14388) by [@mvogttech](https://github.com/mvogttech) (Michael Pfeiffer).
