### PR TITLE
perf(selftest): reuse prepared application templates

### DIFF
--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -29,6 +29,9 @@ env:
   METEOR_MODERN: true
   CXX: g++-12
   METEOR_ALLOW_SUPERUSER: 1
+  # Temporary, stable-reason diagnostics for prepared-app cache eligibility.
+  # Remove after the current CI investigation identifies the runner condition.
+  METEOR_SELFTEST_PREPARED_APP_CACHE_DIAGNOSTICS: 1
 
 
 jobs:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -29,9 +29,6 @@ env:
   METEOR_MODERN: true
   CXX: g++-12
   METEOR_ALLOW_SUPERUSER: 1
-  # Temporary, stable-reason diagnostics for prepared-app cache eligibility.
-  # Remove after the current CI investigation identifies the runner condition.
-  METEOR_SELFTEST_PREPARED_APP_CACHE_DIAGNOSTICS: 1
 
 
 jobs:

--- a/tools/tests/prepared-app-cache.js
+++ b/tools/tests/prepared-app-cache.js
@@ -51,6 +51,21 @@ selftest.define('prepared-app-cache roundtrip', async function () {
   if (savedNodeEnv === undefined) process.env.NODE_ENV = 'development';
   try {
     await withTempCacheRoot(async (cacheRoot) => {
+      const failedWarmSandbox = new Sandbox();
+      await failedWarmSandbox.init();
+      let failedWarmDidThrow = false;
+      try {
+        await getPreparedAppCacheEntry({
+          template: 'standard-app',
+          execPath: files.pathJoin(failedWarmSandbox.root, 'missing-meteor'),
+          env: failedWarmSandbox._makeEnv(),
+        });
+      } catch {
+        failedWarmDidThrow = true;
+      }
+      selftest.expectTrue(failedWarmDidThrow);
+      await selftest.expectEqual(files.readdirNoDots(cacheRoot).length, 0);
+
       const firstSandbox = new Sandbox();
       await firstSandbox.init();
       await firstSandbox.createApp('app1', 'standard-app');
@@ -86,6 +101,27 @@ selftest.define('prepared-app-cache roundtrip', async function () {
         env: cacheEnv,
       });
       selftest.expectTrue(Boolean(activeCacheEntry));
+
+      const sourceProbePath = files.pathJoin(
+        files.getCurrentToolsDir(),
+        `prepared-app-cache-source-probe-${process.pid}.txt`,
+      );
+      files.writeFile(sourceProbePath, 'source fingerprint probe', 'utf8');
+      let sourceProbeDidThrow = false;
+      try {
+        await getPreparedAppCacheEntry({
+          template: 'standard-app',
+          execPath: files.pathJoin(secondSandbox.root, 'missing-meteor'),
+          env: cacheEnv,
+        });
+      } catch {
+        sourceProbeDidThrow = true;
+      } finally {
+        files.unlink(sourceProbePath);
+      }
+      selftest.expectTrue(sourceProbeDidThrow);
+      await selftest.expectEqual(files.readdirNoDots(cacheRoot).length, 1);
+
       const activeMetadata = JSON.parse(files.readFile(
         files.pathJoin(activeCacheEntry.root, activeCacheEntry.cacheKey, METADATA_FILE),
         'utf8',

--- a/tools/tests/prepared-app-cache.js
+++ b/tools/tests/prepared-app-cache.js
@@ -95,7 +95,7 @@ selftest.define('prepared-app-cache roundtrip', async function () {
       secondSandbox.execPath = files.pathJoin(secondSandbox.root, 'missing-meteor');
       await secondSandbox.createApp('app2', 'standard-app');
       const cacheEnv = secondSandbox._makeEnv();
-      const activeCacheEntry = await getPreparedAppCacheEntry({
+      let activeCacheEntry = await getPreparedAppCacheEntry({
         template: 'standard-app',
         execPath: secondSandbox.execPath,
         env: cacheEnv,
@@ -121,6 +121,15 @@ selftest.define('prepared-app-cache roundtrip', async function () {
       }
       selftest.expectTrue(sourceProbeDidThrow);
       await selftest.expectEqual(files.readdirNoDots(cacheRoot).length, 1);
+
+      files.writeFile(activeCacheEntry.metadataPath, 'corrupt metadata', 'utf8');
+      activeCacheEntry = await getPreparedAppCacheEntry({
+        template: 'standard-app',
+        execPath: firstSandbox.execPath,
+        env: cacheEnv,
+      });
+      selftest.expectTrue(Boolean(activeCacheEntry));
+      selftest.expectTrue(files.exists(activeCacheEntry.readyPath));
 
       const activeMetadata = JSON.parse(files.readFile(
         files.pathJoin(activeCacheEntry.root, activeCacheEntry.cacheKey, METADATA_FILE),

--- a/tools/tests/prepared-app-cache.js
+++ b/tools/tests/prepared-app-cache.js
@@ -5,10 +5,15 @@
 const selftest = require('../tool-testing/selftest.js');
 const Sandbox = selftest.Sandbox;
 const files = require('../fs/files');
+const {
+  applyPreparedAppCacheEntry,
+  getPreparedAppCacheEntry,
+} = require('../tool-testing/prepared-app-cache.js');
 
 const CACHE_DIR_ENV = 'METEOR_SELFTEST_PREPARED_APP_CACHE_DIR';
 const READY_MARKER = '.meteor-selftest-cache-ready';
 const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
+const SNAPSHOT_DIRECTORY = 'app';
 
 async function withTempCacheRoot(fn) {
   const cacheRoot = files.mkdtemp('prepared-app-cache-test');
@@ -43,6 +48,10 @@ selftest.define('prepared-app-cache roundtrip', async function () {
     const metadata = JSON.parse(files.readFile(metadataPath, 'utf8'));
     await selftest.expectEqual(metadata.version, 1);
     await selftest.expectEqual(metadata.cacheKey, entries[0]);
+    await selftest.expectEqual(
+      metadata.producerToolsDir,
+      files.realpath(files.getCurrentToolsDir()),
+    );
     selftest.expectTrue(typeof metadata.sentinelPath === 'string');
 
     const beforeMarkerStat = files.statOrNull(markerPath);
@@ -55,22 +64,29 @@ selftest.define('prepared-app-cache roundtrip', async function () {
     const afterMarkerStat = files.statOrNull(markerPath);
     await selftest.expectEqual(afterMarkerStat?.mtimeMs, beforeMarkerStat?.mtimeMs);
 
-    // A sandbox-specific environment can affect preparation, so it must take
-    // the uncached path rather than reuse the standard snapshot.
-    const customEnvSandbox = new Sandbox();
-    await customEnvSandbox.init();
-    customEnvSandbox.set('METEOR_SELFTEST_CACHE_REGRESSION', '1');
-    customEnvSandbox.execPath = files.pathJoin(
-      customEnvSandbox.root,
+    // A process-level override can affect preparation, so it must not reuse
+    // the standard snapshot created without that override.
+    const savedModern = process.env.METEOR_MODERN;
+    process.env.METEOR_MODERN = 'legacy';
+    const modernOverrideSandbox = new Sandbox();
+    await modernOverrideSandbox.init();
+    modernOverrideSandbox.execPath = files.pathJoin(
+      modernOverrideSandbox.root,
       'missing-meteor',
     );
-    let customEnvCreateDidThrow = false;
+    let modernOverrideDidThrow = false;
     try {
-      await customEnvSandbox.createApp('app3', 'modern');
+      await modernOverrideSandbox.createApp('app3', 'modern');
     } catch {
-      customEnvCreateDidThrow = true;
+      modernOverrideDidThrow = true;
+    } finally {
+      if (savedModern === undefined) {
+        delete process.env.METEOR_MODERN;
+      } else {
+        process.env.METEOR_MODERN = savedModern;
+      }
     }
-    selftest.expectTrue(customEnvCreateDidThrow);
+    selftest.expectTrue(modernOverrideDidThrow);
 
     const app2Dir = files.pathJoin(secondSandbox.cwd, 'app2');
     const localDir = files.pathJoin(app2Dir, '.meteor', 'local');
@@ -88,6 +104,69 @@ selftest.define('prepared-app-cache roundtrip', async function () {
         const contents = files.readFile(buildInfoPath, 'utf8');
         selftest.expectFalse(contents.includes(metadata.sentinelPath));
       }
+    }
+
+    const snapshotDir = files.pathJoin(cacheEntryDir, SNAPSHOT_DIRECTORY);
+    const staleFile = files.pathJoin(
+      snapshotDir,
+      '.meteor',
+      'local',
+      'prepared-app-cache-stale.json',
+    );
+    files.writeFile(staleFile, metadata.sentinelPath, 'utf8');
+    const staleDestRoot = files.mkdtemp('prepared-app-cache-stale-dest');
+    const staleDest = files.pathJoin(staleDestRoot, 'app');
+    let staleResult;
+    try {
+      staleResult = await applyPreparedAppCacheEntry({
+        cacheEntry: { root: cacheRoot, cacheKey: entries[0] },
+        destAppDir: staleDest,
+        destRoot: staleDestRoot,
+      });
+    } catch {
+      staleResult = 'threw';
+    }
+    await selftest.expectEqual(staleResult, false);
+    selftest.expectFalse(files.exists(staleDest));
+    await files.rm_recursive(staleDestRoot);
+    files.unlink(staleFile);
+
+    const unsafeTarget = files.pathJoin(cacheEntryDir, 'unsafe-target');
+    const unsafeLink = files.pathJoin(snapshotDir, 'unsafe-link');
+    files.writeFile(unsafeTarget, 'cache data must not contain symlinks', 'utf8');
+    files.symlink('../unsafe-target', unsafeLink);
+    const symlinkDestRoot = files.mkdtemp('prepared-app-cache-symlink-dest');
+    const symlinkDest = files.pathJoin(symlinkDestRoot, 'app');
+    const symlinkResult = await applyPreparedAppCacheEntry({
+      cacheEntry: { root: cacheRoot, cacheKey: entries[0] },
+      destAppDir: symlinkDest,
+      destRoot: symlinkDestRoot,
+    });
+    await selftest.expectEqual(symlinkResult, false);
+    selftest.expectFalse(files.exists(symlinkDest));
+    await files.rm_recursive(symlinkDestRoot);
+  });
+});
+
+selftest.define('prepared-app-cache rejects unsafe cache roots', async function () {
+  await withTempCacheRoot(async (cacheRoot) => {
+    files.chmod(cacheRoot, 0o777);
+    try {
+      const missingMeteor = files.pathJoin(cacheRoot, 'missing-meteor');
+      let result;
+      let didThrow = false;
+      try {
+        result = await getPreparedAppCacheEntry({
+          template: 'modern',
+          execPath: missingMeteor,
+        });
+      } catch {
+        didThrow = true;
+      }
+      selftest.expectFalse(didThrow);
+      await selftest.expectEqual(result, null);
+    } finally {
+      files.chmod(cacheRoot, 0o700);
     }
   });
 });

--- a/tools/tests/prepared-app-cache.js
+++ b/tools/tests/prepared-app-cache.js
@@ -31,121 +31,181 @@ async function withTempCacheRoot(fn) {
   }
 }
 
+function snapshotHasNoSymlinks(root) {
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    const stat = files.lstat(current);
+    if (stat.isSymbolicLink()) return false;
+    if (stat.isDirectory()) {
+      for (const entry of files.readdir(current)) {
+        pending.push(files.pathJoin(current, entry));
+      }
+    }
+  }
+  return true;
+}
+
 selftest.define('prepared-app-cache roundtrip', async function () {
-  await withTempCacheRoot(async (cacheRoot) => {
-    const firstSandbox = new Sandbox();
-    await firstSandbox.init();
-    await firstSandbox.createApp('app1', 'modern');
+  const savedNodeEnv = process.env.NODE_ENV;
+  if (savedNodeEnv === undefined) process.env.NODE_ENV = 'development';
+  try {
+    await withTempCacheRoot(async (cacheRoot) => {
+      const firstSandbox = new Sandbox();
+      await firstSandbox.init();
+      await firstSandbox.createApp('app1', 'standard-app');
+      const entries = files.readdirNoDots(cacheRoot);
+      await selftest.expectEqual(entries.length, 1);
+      const cacheEntryDir = files.pathJoin(cacheRoot, entries[0]);
+      const markerPath = files.pathJoin(cacheEntryDir, READY_MARKER);
+      const metadataPath = files.pathJoin(cacheEntryDir, METADATA_FILE);
+      selftest.expectTrue(files.exists(markerPath));
+      selftest.expectTrue(files.exists(metadataPath));
 
-    const entries = files.readdirNoDots(cacheRoot);
-    await selftest.expectEqual(entries.length, 1);
-    const cacheEntryDir = files.pathJoin(cacheRoot, entries[0]);
-    const markerPath = files.pathJoin(cacheEntryDir, READY_MARKER);
-    const metadataPath = files.pathJoin(cacheEntryDir, METADATA_FILE);
-    selftest.expectTrue(files.exists(markerPath));
-    selftest.expectTrue(files.exists(metadataPath));
+      const metadata = JSON.parse(files.readFile(metadataPath, 'utf8'));
+      await selftest.expectEqual(metadata.version, 3);
+      await selftest.expectEqual(metadata.cacheKey, entries[0]);
+      await selftest.expectEqual(
+        metadata.producerToolsDir,
+        files.realpath(files.getCurrentToolsDir()),
+      );
+      selftest.expectTrue(typeof metadata.environmentFingerprint === 'string');
+      selftest.expectTrue(typeof metadata.sentinelPath === 'string');
 
-    const metadata = JSON.parse(files.readFile(metadataPath, 'utf8'));
-    await selftest.expectEqual(metadata.version, 1);
-    await selftest.expectEqual(metadata.cacheKey, entries[0]);
-    await selftest.expectEqual(
-      metadata.producerToolsDir,
-      files.realpath(files.getCurrentToolsDir()),
-    );
-    selftest.expectTrue(typeof metadata.sentinelPath === 'string');
+      const snapshotDir = files.pathJoin(cacheEntryDir, SNAPSHOT_DIRECTORY);
+      selftest.expectTrue(snapshotHasNoSymlinks(snapshotDir));
 
-    const beforeMarkerStat = files.statOrNull(markerPath);
-
-    const secondSandbox = new Sandbox();
-    await secondSandbox.init();
-    secondSandbox.execPath = files.pathJoin(secondSandbox.root, 'missing-meteor');
-    await secondSandbox.createApp('app2', 'modern');
-
-    const afterMarkerStat = files.statOrNull(markerPath);
-    await selftest.expectEqual(afterMarkerStat?.mtimeMs, beforeMarkerStat?.mtimeMs);
-
-    // A process-level override can affect preparation, so it must not reuse
-    // the standard snapshot created without that override.
-    const savedModern = process.env.METEOR_MODERN;
-    process.env.METEOR_MODERN = 'legacy';
-    const modernOverrideSandbox = new Sandbox();
-    await modernOverrideSandbox.init();
-    modernOverrideSandbox.execPath = files.pathJoin(
-      modernOverrideSandbox.root,
-      'missing-meteor',
-    );
-    let modernOverrideDidThrow = false;
-    try {
-      await modernOverrideSandbox.createApp('app3', 'modern');
-    } catch {
-      modernOverrideDidThrow = true;
-    } finally {
-      if (savedModern === undefined) {
-        delete process.env.METEOR_MODERN;
-      } else {
-        process.env.METEOR_MODERN = savedModern;
-      }
-    }
-    selftest.expectTrue(modernOverrideDidThrow);
-
-    const app2Dir = files.pathJoin(secondSandbox.cwd, 'app2');
-    const localDir = files.pathJoin(app2Dir, '.meteor', 'local');
-    selftest.expectTrue(files.exists(localDir));
-    selftest.expectFalse(files.exists(files.pathJoin(app2Dir, READY_MARKER)));
-    selftest.expectFalse(files.exists(files.pathJoin(app2Dir, METADATA_FILE)));
-
-    const isopacksDir = files.pathJoin(localDir, 'isopacks');
-    if (files.exists(isopacksDir)) {
-      for (const pkg of files.readdirNoDots(isopacksDir)) {
-        const buildInfoPath = files.pathJoin(
-          isopacksDir, pkg, 'isopack-buildinfo.json',
-        );
-        if (!files.exists(buildInfoPath)) continue;
-        const contents = files.readFile(buildInfoPath, 'utf8');
-        selftest.expectFalse(contents.includes(metadata.sentinelPath));
-      }
-    }
-
-    const snapshotDir = files.pathJoin(cacheEntryDir, SNAPSHOT_DIRECTORY);
-    const staleFile = files.pathJoin(
-      snapshotDir,
-      '.meteor',
-      'local',
-      'prepared-app-cache-stale.json',
-    );
-    files.writeFile(staleFile, metadata.sentinelPath, 'utf8');
-    const staleDestRoot = files.mkdtemp('prepared-app-cache-stale-dest');
-    const staleDest = files.pathJoin(staleDestRoot, 'app');
-    let staleResult;
-    try {
-      staleResult = await applyPreparedAppCacheEntry({
-        cacheEntry: { root: cacheRoot, cacheKey: entries[0] },
-        destAppDir: staleDest,
-        destRoot: staleDestRoot,
+      const secondSandbox = new Sandbox();
+      await secondSandbox.init();
+      secondSandbox.execPath = files.pathJoin(secondSandbox.root, 'missing-meteor');
+      await secondSandbox.createApp('app2', 'standard-app');
+      const cacheEnv = secondSandbox._makeEnv();
+      const activeCacheEntry = await getPreparedAppCacheEntry({
+        template: 'standard-app',
+        execPath: secondSandbox.execPath,
+        env: cacheEnv,
       });
-    } catch {
-      staleResult = 'threw';
-    }
-    await selftest.expectEqual(staleResult, false);
-    selftest.expectFalse(files.exists(staleDest));
-    await files.rm_recursive(staleDestRoot);
-    files.unlink(staleFile);
+      selftest.expectTrue(Boolean(activeCacheEntry));
+      const activeMetadata = JSON.parse(files.readFile(
+        files.pathJoin(activeCacheEntry.root, activeCacheEntry.cacheKey, METADATA_FILE),
+        'utf8',
+      ));
+      const activeSnapshotDir = files.pathJoin(
+        activeCacheEntry.root,
+        activeCacheEntry.cacheKey,
+        SNAPSHOT_DIRECTORY,
+      );
 
-    const unsafeTarget = files.pathJoin(cacheEntryDir, 'unsafe-target');
-    const unsafeLink = files.pathJoin(snapshotDir, 'unsafe-link');
-    files.writeFile(unsafeTarget, 'cache data must not contain symlinks', 'utf8');
-    files.symlink('../unsafe-target', unsafeLink);
-    const symlinkDestRoot = files.mkdtemp('prepared-app-cache-symlink-dest');
-    const symlinkDest = files.pathJoin(symlinkDestRoot, 'app');
-    const symlinkResult = await applyPreparedAppCacheEntry({
-      cacheEntry: { root: cacheRoot, cacheKey: entries[0] },
-      destAppDir: symlinkDest,
-      destRoot: symlinkDestRoot,
+      // A process-level override can affect preparation. It must create a
+      // separate cache partition, which a later sandbox can then reuse.
+      const savedModern = process.env.METEOR_MODERN;
+      process.env.METEOR_MODERN = savedModern === 'true' ? 'false' : 'true';
+      const modernOverrideSandbox = new Sandbox();
+      await modernOverrideSandbox.init();
+      try {
+        const entriesBeforeModernOverride = files.readdirNoDots(cacheRoot).length;
+        await modernOverrideSandbox.createApp('app4', 'standard-app');
+        const entriesWithModernOverride = files.readdirNoDots(cacheRoot);
+        selftest.expectTrue(entriesWithModernOverride.length > entriesBeforeModernOverride);
+
+        const modernReuseSandbox = new Sandbox();
+        await modernReuseSandbox.init();
+        modernReuseSandbox.execPath = files.pathJoin(
+          modernReuseSandbox.root,
+          'missing-meteor',
+        );
+        await modernReuseSandbox.createApp('app5', 'standard-app');
+      } finally {
+        if (savedModern === undefined) {
+          delete process.env.METEOR_MODERN;
+        } else {
+          process.env.METEOR_MODERN = savedModern;
+        }
+      }
+
+      const app2Dir = files.pathJoin(secondSandbox.cwd, 'app2');
+      const localDir = files.pathJoin(app2Dir, '.meteor', 'local');
+      selftest.expectTrue(files.exists(localDir));
+      selftest.expectFalse(files.exists(files.pathJoin(app2Dir, READY_MARKER)));
+      selftest.expectFalse(files.exists(files.pathJoin(app2Dir, METADATA_FILE)));
+
+      const isopacksDir = files.pathJoin(localDir, 'isopacks');
+      if (files.exists(isopacksDir)) {
+        for (const pkg of files.readdirNoDots(isopacksDir)) {
+          const buildInfoPath = files.pathJoin(
+            isopacksDir, pkg, 'isopack-buildinfo.json',
+          );
+          if (!files.exists(buildInfoPath)) continue;
+          const contents = files.readFile(buildInfoPath, 'utf8');
+          selftest.expectFalse(contents.includes(activeMetadata.sentinelPath));
+        }
+      }
+
+      const staleFile = files.pathJoin(
+        activeSnapshotDir,
+        '.meteor',
+        'local',
+        'prepared-app-cache-stale.json',
+      );
+      files.writeFile(staleFile, activeMetadata.sentinelPath, 'utf8');
+      const staleDestRoot = files.mkdtemp('prepared-app-cache-stale-dest');
+      const staleDest = files.pathJoin(staleDestRoot, 'app');
+      let staleResult;
+      try {
+        staleResult = await applyPreparedAppCacheEntry({
+          cacheEntry: activeCacheEntry,
+          destAppDir: staleDest,
+          destRoot: staleDestRoot,
+          env: cacheEnv,
+        });
+      } catch {
+        staleResult = 'threw';
+      }
+      await selftest.expectEqual(staleResult, false);
+      selftest.expectFalse(files.exists(staleDest));
+      await files.rm_recursive(staleDestRoot);
+      files.unlink(staleFile);
+
+      const outsideDestRoot = files.mkdtemp('prepared-app-cache-outside-dest');
+      const symlinkedDestRoot = files.mkdtemp('prepared-app-cache-symlinked-dest');
+      const symlinkedDest = files.pathJoin(symlinkedDestRoot, 'link', 'app');
+      files.symlink(outsideDestRoot, files.pathJoin(symlinkedDestRoot, 'link'));
+      const symlinkedDestResult = await applyPreparedAppCacheEntry({
+        cacheEntry: activeCacheEntry,
+        destAppDir: symlinkedDest,
+        destRoot: symlinkedDestRoot,
+        env: cacheEnv,
+      });
+      await selftest.expectEqual(symlinkedDestResult, false);
+      selftest.expectFalse(files.exists(files.pathJoin(outsideDestRoot, 'app')));
+      await files.rm_recursive(symlinkedDestRoot);
+      await files.rm_recursive(outsideDestRoot);
+
+      const unsafeTarget = files.pathJoin(
+        activeCacheEntry.root, activeCacheEntry.cacheKey, 'unsafe-target',
+      );
+      const unsafeLink = files.pathJoin(activeSnapshotDir, 'unsafe-link');
+      files.writeFile(unsafeTarget, 'cache data must not contain symlinks', 'utf8');
+      files.symlink('../unsafe-target', unsafeLink);
+      const symlinkDestRoot = files.mkdtemp('prepared-app-cache-symlink-dest');
+      const symlinkDest = files.pathJoin(symlinkDestRoot, 'app');
+      const symlinkResult = await applyPreparedAppCacheEntry({
+        cacheEntry: activeCacheEntry,
+        destAppDir: symlinkDest,
+        destRoot: symlinkDestRoot,
+        env: cacheEnv,
+      });
+      await selftest.expectEqual(symlinkResult, false);
+      selftest.expectFalse(files.exists(symlinkDest));
+      await files.rm_recursive(symlinkDestRoot);
     });
-    await selftest.expectEqual(symlinkResult, false);
-    selftest.expectFalse(files.exists(symlinkDest));
-    await files.rm_recursive(symlinkDestRoot);
-  });
+  } finally {
+    if (savedNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = savedNodeEnv;
+    }
+  }
 });
 
 selftest.define('prepared-app-cache rejects unsafe cache roots', async function () {
@@ -157,7 +217,7 @@ selftest.define('prepared-app-cache rejects unsafe cache roots', async function 
       let didThrow = false;
       try {
         result = await getPreparedAppCacheEntry({
-          template: 'modern',
+          template: 'standard-app',
           execPath: missingMeteor,
         });
       } catch {
@@ -168,5 +228,16 @@ selftest.define('prepared-app-cache rejects unsafe cache roots', async function 
     } finally {
       files.chmod(cacheRoot, 0o700);
     }
+  });
+});
+
+selftest.define('prepared-app-cache bypasses local file dependency templates', async function () {
+  await withTempCacheRoot(async (cacheRoot) => {
+    const result = await getPreparedAppCacheEntry({
+      template: 'modern',
+      execPath: files.pathJoin(cacheRoot, 'missing-meteor'),
+    });
+    await selftest.expectEqual(result, null);
+    await selftest.expectEqual(files.readdirNoDots(cacheRoot).length, 0);
   });
 });

--- a/tools/tests/prepared-app-cache.js
+++ b/tools/tests/prepared-app-cache.js
@@ -3,6 +3,7 @@
 // copying the valid snapshot warmed by the first sandbox.
 
 const selftest = require('../tool-testing/selftest.js');
+const fs = require('fs');
 const Sandbox = selftest.Sandbox;
 const files = require('../fs/files');
 const {
@@ -121,6 +122,29 @@ selftest.define('prepared-app-cache roundtrip', async function () {
       }
       selftest.expectTrue(sourceProbeDidThrow);
       await selftest.expectEqual(files.readdirNoDots(cacheRoot).length, 1);
+
+      files.unlink(activeCacheEntry.readyPath);
+      const expiredLease = new Date(Date.now() - 60 * 60 * 1000);
+      fs.utimesSync(
+        files.convertToOSPath(activeCacheEntry.cacheDir),
+        expiredLease,
+        expiredLease,
+      );
+      let incompleteEntry;
+      let incompleteDidThrow = false;
+      try {
+        incompleteEntry = await getPreparedAppCacheEntry({
+          template: 'standard-app',
+          execPath: files.pathJoin(secondSandbox.root, 'missing-meteor'),
+          env: cacheEnv,
+        });
+      } catch {
+        incompleteDidThrow = true;
+      }
+      selftest.expectFalse(incompleteDidThrow);
+      await selftest.expectEqual(incompleteEntry, null);
+      selftest.expectTrue(files.exists(activeCacheEntry.cacheDir));
+      files.writeFile(activeCacheEntry.readyPath, '', 'utf8');
 
       files.writeFile(activeCacheEntry.metadataPath, 'corrupt metadata', 'utf8');
       activeCacheEntry = await getPreparedAppCacheEntry({

--- a/tools/tests/prepared-app-cache.js
+++ b/tools/tests/prepared-app-cache.js
@@ -1,0 +1,93 @@
+// Regression coverage for the prepared-app snapshot used by Sandbox#createApp.
+// The second sandbox has no executable tool path: it can succeed only by
+// copying the valid snapshot warmed by the first sandbox.
+
+const selftest = require('../tool-testing/selftest.js');
+const Sandbox = selftest.Sandbox;
+const files = require('../fs/files');
+
+const CACHE_DIR_ENV = 'METEOR_SELFTEST_PREPARED_APP_CACHE_DIR';
+const READY_MARKER = '.meteor-selftest-cache-ready';
+const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
+
+async function withTempCacheRoot(fn) {
+  const cacheRoot = files.mkdtemp('prepared-app-cache-test');
+  const saved = process.env[CACHE_DIR_ENV];
+  process.env[CACHE_DIR_ENV] = files.convertToOSPath(cacheRoot);
+  try {
+    return await fn(cacheRoot);
+  } finally {
+    if (saved === undefined) {
+      delete process.env[CACHE_DIR_ENV];
+    } else {
+      process.env[CACHE_DIR_ENV] = saved;
+    }
+    await files.rm_recursive(cacheRoot).catch(() => {});
+  }
+}
+
+selftest.define('prepared-app-cache roundtrip', async function () {
+  await withTempCacheRoot(async (cacheRoot) => {
+    const firstSandbox = new Sandbox();
+    await firstSandbox.init();
+    await firstSandbox.createApp('app1', 'modern');
+
+    const entries = files.readdirNoDots(cacheRoot);
+    await selftest.expectEqual(entries.length, 1);
+    const cacheEntryDir = files.pathJoin(cacheRoot, entries[0]);
+    const markerPath = files.pathJoin(cacheEntryDir, READY_MARKER);
+    const metadataPath = files.pathJoin(cacheEntryDir, METADATA_FILE);
+    selftest.expectTrue(files.exists(markerPath));
+    selftest.expectTrue(files.exists(metadataPath));
+
+    const metadata = JSON.parse(files.readFile(metadataPath, 'utf8'));
+    await selftest.expectEqual(metadata.version, 1);
+    await selftest.expectEqual(metadata.cacheKey, entries[0]);
+    selftest.expectTrue(typeof metadata.sentinelPath === 'string');
+
+    const beforeMarkerStat = files.statOrNull(markerPath);
+
+    const secondSandbox = new Sandbox();
+    await secondSandbox.init();
+    secondSandbox.execPath = files.pathJoin(secondSandbox.root, 'missing-meteor');
+    await secondSandbox.createApp('app2', 'modern');
+
+    const afterMarkerStat = files.statOrNull(markerPath);
+    await selftest.expectEqual(afterMarkerStat?.mtimeMs, beforeMarkerStat?.mtimeMs);
+
+    // A sandbox-specific environment can affect preparation, so it must take
+    // the uncached path rather than reuse the standard snapshot.
+    const customEnvSandbox = new Sandbox();
+    await customEnvSandbox.init();
+    customEnvSandbox.set('METEOR_SELFTEST_CACHE_REGRESSION', '1');
+    customEnvSandbox.execPath = files.pathJoin(
+      customEnvSandbox.root,
+      'missing-meteor',
+    );
+    let customEnvCreateDidThrow = false;
+    try {
+      await customEnvSandbox.createApp('app3', 'modern');
+    } catch {
+      customEnvCreateDidThrow = true;
+    }
+    selftest.expectTrue(customEnvCreateDidThrow);
+
+    const app2Dir = files.pathJoin(secondSandbox.cwd, 'app2');
+    const localDir = files.pathJoin(app2Dir, '.meteor', 'local');
+    selftest.expectTrue(files.exists(localDir));
+    selftest.expectFalse(files.exists(files.pathJoin(app2Dir, READY_MARKER)));
+    selftest.expectFalse(files.exists(files.pathJoin(app2Dir, METADATA_FILE)));
+
+    const isopacksDir = files.pathJoin(localDir, 'isopacks');
+    if (files.exists(isopacksDir)) {
+      for (const pkg of files.readdirNoDots(isopacksDir)) {
+        const buildInfoPath = files.pathJoin(
+          isopacksDir, pkg, 'isopack-buildinfo.json',
+        );
+        if (!files.exists(buildInfoPath)) continue;
+        const contents = files.readFile(buildInfoPath, 'utf8');
+        selftest.expectFalse(contents.includes(metadata.sentinelPath));
+      }
+    }
+  });
+});

--- a/tools/tool-testing/prepared-app-cache.js
+++ b/tools/tool-testing/prepared-app-cache.js
@@ -16,7 +16,6 @@ const execFileAsync = promisify(execFile);
 const CACHE_DIRECTORY_NAME = 'meteor-selftest-prepared-app-cache';
 const CACHE_DIR_ENV = 'METEOR_SELFTEST_PREPARED_APP_CACHE_DIR';
 const DISABLE_ENV = 'METEOR_DISABLE_PREPARED_APP_CACHE';
-const DIAGNOSTIC_ENV = 'METEOR_SELFTEST_PREPARED_APP_CACHE_DIAGNOSTICS';
 const READY_MARKER = '.meteor-selftest-cache-ready';
 const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
 const SNAPSHOT_DIRECTORY = 'app';
@@ -51,20 +50,6 @@ const PREPARE_ENV_NAMES = new Set([
 ]);
 
 export const isDisabled = () => Boolean(process.env[DISABLE_ENV]);
-
-// This opt-in is used only while investigating cache eligibility on an
-// unfamiliar runner. Keep diagnostic output to stable reason labels, never
-// paths or environment values.
-function unavailable(reason) {
-  diagnostic(reason);
-  return null;
-}
-
-function diagnostic(reason) {
-  if (process.env[DIAGNOSTIC_ENV] === '1') {
-    console.error(`prepared-app-cache: unavailable (${reason})`);
-  }
-}
 
 // Preparation is affected by these deterministic inputs. `NPM_CONFIG_*`
 // options cover npm install/rebuild behavior. Harness output such as
@@ -344,32 +329,33 @@ function materializeSnapshot(sourceRoot, destinationRoot, allowedRoots) {
 // within bounded memory.
 async function computeSourceFingerprint(toolsDir) {
   const hash = createHash('sha256');
+  // The Actions checkout action records safe.directory in its own temporary
+  // HOME. The self-test runs in the container with a different HOME, so trust
+  // only this canonical checkout for the read-only fingerprint commands.
+  const safeGitArgs = [
+    '-c',
+    `safe.directory=${files.convertToOSPath(toolsDir)}`,
+  ];
   try {
-    const { stdout: head } = await execFileAsync('git', ['rev-parse', 'HEAD'], {
+    const { stdout: head } = await execFileAsync('git', [
+      ...safeGitArgs,
+      'rev-parse',
+      'HEAD',
+    ], {
       cwd: files.convertToOSPath(toolsDir),
     });
     hash.update(`HEAD:${head.trim()}\n`);
-  } catch {
-    diagnostic('source-head');
-    return null;
-  }
 
-  try {
     const { stdout: diff } = await execFileAsync(
       'git',
-      ['diff', '--binary', '--no-ext-diff', '--no-renames', 'HEAD'],
+      [...safeGitArgs, 'diff', '--binary', '--no-ext-diff', '--no-renames', 'HEAD'],
       { cwd: files.convertToOSPath(toolsDir), maxBuffer: SOURCE_FINGERPRINT_MAX_BYTES },
     );
     hash.update(diff);
-  } catch {
-    diagnostic('source-diff');
-    return null;
-  }
 
-  try {
     const { stdout: untracked } = await execFileAsync(
       'git',
-      ['ls-files', '--others', '--exclude-standard', '-z'],
+      [...safeGitArgs, 'ls-files', '--others', '--exclude-standard', '-z'],
       { cwd: files.convertToOSPath(toolsDir), maxBuffer: SOURCE_FINGERPRINT_MAX_BYTES },
     );
     for (const relativePath of untracked.split('\0')) {
@@ -378,14 +364,12 @@ async function computeSourceFingerprint(toolsDir) {
       const stat = lstatOrNull(absolutePath);
       if (!isContainedPath(toolsDir, absolutePath) || !stat?.isFile() ||
           stat.isSymbolicLink() || stat.size > SOURCE_FINGERPRINT_MAX_BYTES) {
-        diagnostic('source-untracked-entry');
         return null;
       }
       hash.update(`${relativePath}\0`);
       hash.update(files.readFile(absolutePath));
     }
   } catch {
-    diagnostic('source-untracked');
     return null;
   }
   return hash.digest('hex').slice(0, 16);
@@ -779,28 +763,28 @@ async function warmCacheEntry({
 export async function getPreparedAppCacheEntry({
   template, releaseName = null, upgradersToAppend = [], execPath, env = {},
 }) {
-  if (isDisabled()) return unavailable('disabled');
-  if (!files.inCheckout()) return unavailable('not-checkout');
+  if (isDisabled()) return null;
+  if (!files.inCheckout()) return null;
   if (typeof template !== 'string' ||
       !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(template)) {
-    return unavailable('invalid-template');
+    return null;
   }
   const environmentFingerprint = computeEnvironmentFingerprint(env);
-  if (!environmentFingerprint) return unavailable('environment');
+  if (!environmentFingerprint) return null;
 
   const toolsDir = files.realpath(files.getCurrentToolsDir());
   const templatesDir = files.pathJoin(toolsDir, 'tools', 'tests', 'apps');
   const templatePath = files.pathResolve(templatesDir, template);
   if (!isContainedPath(templatesDir, templatePath) || !isDirectory(templatePath)) {
-    return unavailable('template');
+    return null;
   }
-  if (!templateAllowsCache(templatePath)) return unavailable('template-policy');
+  if (!templateAllowsCache(templatePath)) return null;
 
   const sourceFingerprint = await computeSourceFingerprint(toolsDir);
-  if (!sourceFingerprint) return unavailable('source-fingerprint');
+  if (!sourceFingerprint) return null;
 
   const root = makeCacheRoot();
-  if (!root) return unavailable('cache-root');
+  if (!root) return null;
   const cacheKey = createHash('sha256').update(JSON.stringify({
     version: CACHE_FORMAT_VERSION,
     source: sourceFingerprint,

--- a/tools/tool-testing/prepared-app-cache.js
+++ b/tools/tool-testing/prepared-app-cache.js
@@ -21,6 +21,7 @@ const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
 const SNAPSHOT_DIRECTORY = 'app';
 const CACHE_FORMAT_VERSION = 3;
 const PREPARE_TIMEOUT_MS = 15 * 60 * 1000;
+const SOURCE_FINGERPRINT_MAX_BYTES = 16 * 1024 * 1024;
 const STAGING_NAME_RE = /^\.staging-[0-9]+-[a-f0-9]{32}$/;
 const CACHE_KEY_RE = /^[a-f0-9]{24}$/;
 const SKIP_GUARD_EXTENSIONS = new Set(['.wt', '.wiredtiger', '.bson']);
@@ -321,6 +322,10 @@ function materializeSnapshot(sourceRoot, destinationRoot, allowedRoots) {
   copyEntry(canonicalSourceRoot, destinationRoot);
 }
 
+// Preparation invokes the checkout launcher and can consume repository-root
+// inputs, so dirty tracked and untracked state is scoped to the whole checkout.
+// Refuse caching rather than use a coarse fingerprint when it cannot be read
+// within bounded memory.
 async function computeSourceFingerprint(toolsDir) {
   const hash = createHash('sha256');
   try {
@@ -331,29 +336,29 @@ async function computeSourceFingerprint(toolsDir) {
 
     const { stdout: diff } = await execFileAsync(
       'git',
-      ['diff', '--binary', '--no-ext-diff', '--no-renames', 'HEAD', '--', 'tools', 'packages'],
-      { cwd: files.convertToOSPath(toolsDir), maxBuffer: 16 * 1024 * 1024 },
+      ['diff', '--binary', '--no-ext-diff', '--no-renames', 'HEAD'],
+      { cwd: files.convertToOSPath(toolsDir), maxBuffer: SOURCE_FINGERPRINT_MAX_BYTES },
     );
     hash.update(diff);
 
     const { stdout: untracked } = await execFileAsync(
       'git',
-      ['ls-files', '--others', '--exclude-standard', '-z', '--', 'tools', 'packages'],
-      { cwd: files.convertToOSPath(toolsDir), maxBuffer: 16 * 1024 * 1024 },
+      ['ls-files', '--others', '--exclude-standard', '-z'],
+      { cwd: files.convertToOSPath(toolsDir), maxBuffer: SOURCE_FINGERPRINT_MAX_BYTES },
     );
     for (const relativePath of untracked.split('\0')) {
       if (!relativePath) continue;
       const absolutePath = files.pathResolve(toolsDir, relativePath);
-      if (!isContainedPath(toolsDir, absolutePath) || !isRegularFile(absolutePath)) {
-        hash.update(`UNSAFE:${relativePath}\n`);
-        continue;
+      const stat = lstatOrNull(absolutePath);
+      if (!isContainedPath(toolsDir, absolutePath) || !stat?.isFile() ||
+          stat.isSymbolicLink() || stat.size > SOURCE_FINGERPRINT_MAX_BYTES) {
+        return null;
       }
       hash.update(`${relativePath}\0`);
       hash.update(files.readFile(absolutePath));
     }
   } catch {
-    const stat = files.statOrNull(toolsDir);
-    hash.update(`MTIME:${stat?.mtimeMs ?? 0}\n`);
+    return null;
   }
   return hash.digest('hex').slice(0, 16);
 }
@@ -576,6 +581,13 @@ async function removeStagingDirectory(root, stagingDir) {
   }
 }
 
+async function removeClaimedCacheDirectory(root, cacheDir) {
+  if (!isDirectChild(root, cacheDir, CACHE_KEY_RE)) return;
+  const stat = lstatOrNull(cacheDir);
+  if (!stat?.isDirectory() || stat.isSymbolicLink()) return;
+  await files.rm_recursive(cacheDir);
+}
+
 async function runPrepareApp({ execPath, cwd, env }) {
   await execFileAsync(files.convertToOSPath(execPath), ['--prepare-app'], {
     cwd: files.convertToOSPath(cwd),
@@ -603,9 +615,10 @@ async function warmCacheEntry({
     );
   }
 
-  const preparationStagingDir = createStagingDirectory(root);
+  let preparationStagingDir = null;
   let snapshotStagingDir = null;
   try {
+    preparationStagingDir = createStagingDirectory(root);
     await files.cp_r(templatePath, preparationStagingDir, {
       ignore: [/^local$/],
       preserveSymlinks: true,
@@ -650,14 +663,21 @@ async function warmCacheEntry({
       environmentFingerprint,
     })}\n`);
     await files.writeFileAtomically(paths.readyPath, '');
-    return validatedCacheEntry(
+    const entry = validatedCacheEntry(
       root, cacheKey, producerToolsDir, environmentFingerprint,
     );
+    if (!entry) {
+      await removeClaimedCacheDirectory(root, paths.cacheDir);
+    }
+    return entry;
   } catch (error) {
-    await removeStagingDirectory(root, preparationStagingDir).catch(() => {});
+    if (preparationStagingDir) {
+      await removeStagingDirectory(root, preparationStagingDir).catch(() => {});
+    }
     if (snapshotStagingDir) {
       await removeStagingDirectory(root, snapshotStagingDir).catch(() => {});
     }
+    await removeClaimedCacheDirectory(root, paths.cacheDir).catch(() => {});
     throw error;
   }
 }
@@ -680,11 +700,14 @@ export async function getPreparedAppCacheEntry({
   }
   if (!templateAllowsCache(templatePath)) return null;
 
+  const sourceFingerprint = await computeSourceFingerprint(toolsDir);
+  if (!sourceFingerprint) return null;
+
   const root = makeCacheRoot();
   if (!root) return null;
   const cacheKey = createHash('sha256').update(JSON.stringify({
     version: CACHE_FORMAT_VERSION,
-    source: await computeSourceFingerprint(toolsDir),
+    source: sourceFingerprint,
     checkout: toolsDir,
     environment: environmentFingerprint,
     template: computeTemplateFingerprint(templatePath),

--- a/tools/tool-testing/prepared-app-cache.js
+++ b/tools/tool-testing/prepared-app-cache.js
@@ -19,13 +19,67 @@ const DISABLE_ENV = 'METEOR_DISABLE_PREPARED_APP_CACHE';
 const READY_MARKER = '.meteor-selftest-cache-ready';
 const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
 const SNAPSHOT_DIRECTORY = 'app';
-const CACHE_FORMAT_VERSION = 1;
+const CACHE_FORMAT_VERSION = 3;
 const PREPARE_TIMEOUT_MS = 15 * 60 * 1000;
 const STAGING_NAME_RE = /^\.staging-[0-9]+-[a-f0-9]{32}$/;
 const CACHE_KEY_RE = /^[a-f0-9]{24}$/;
 const SKIP_GUARD_EXTENSIONS = new Set(['.wt', '.wiredtiger', '.bson']);
+const PREPARE_ENV_NAMES = new Set([
+  'BABEL_ENV',
+  'METEOR_DEBUG_BUILD',
+  'METEOR_DISABLE_OPTIMISTIC_CACHING',
+  'METEOR_FORCE_EXCLUDE_ARCHS',
+  'METEOR_FORCE_INCLUDE_ARCHS',
+  'METEOR_LOCAL_DIR',
+  'METEOR_MODERN',
+  'METEOR_NPM_REBUILD_FLAGS',
+  'METEOR_NO_RELEASE_CHECK',
+  'METEOR_OFFLINE_CATALOG',
+  'METEOR_PACKAGE_DIRS',
+  'METEOR_PACKAGE_SERVER_URL',
+  'METEOR_PROFILE',
+  'METEOR_REIFY_CACHE_DIR',
+  'METEOR_SKIP_NPM_REBUILD',
+  'METEOR_TOOL_ENABLE_REIFY_RUNTIME_CACHE',
+  'NODE_ENV',
+  'NODE_OPTIONS',
+  'SELF_TEST_TOOL_NODE_FLAGS',
+  'TOOL_NODE_FLAGS',
+]);
 
 export const isDisabled = () => Boolean(process.env[DISABLE_ENV]);
+
+// Preparation is affected by these deterministic inputs. `NPM_CONFIG_*`
+// options cover npm install/rebuild behavior. Harness output such as
+// TEST_METADATA and the sandbox-specific METEOR_SESSION_FILE are deliberately
+// excluded. Keep values out of metadata and logs: this digest is only a cache
+// partition key.
+function computeEnvironmentFingerprint(env) {
+  if (!env || typeof env !== 'object') return null;
+  const effective = new Map();
+  for (const [name, value] of Object.entries(process.env)) {
+    if ((PREPARE_ENV_NAMES.has(name) ||
+         name.toUpperCase().startsWith('NPM_CONFIG_')) && value !== undefined) {
+      effective.set(name, String(value));
+    }
+  }
+  for (const [name, value] of Object.entries(env)) {
+    if (!PREPARE_ENV_NAMES.has(name) &&
+        !name.toUpperCase().startsWith('NPM_CONFIG_')) continue;
+    if (value === undefined) {
+      effective.delete(name);
+    } else {
+      effective.set(name, String(value));
+    }
+  }
+
+  const hash = createHash('sha256');
+  for (const [name, value] of [...effective.entries()].sort(([a], [b]) =>
+    a.localeCompare(b))) {
+    hash.update(`${name.length}:${name}${value.length}:${value}\0`);
+  }
+  return hash.digest('hex').slice(0, 24);
+}
 
 function lstatOrNull(path) {
   try {
@@ -46,6 +100,14 @@ function isDirectory(path) {
 function isRegularFile(path) {
   const stat = lstatOrNull(path);
   return Boolean(stat?.isFile() && !stat.isSymbolicLink());
+}
+
+function isPrivateDirectory(path) {
+  const stat = lstatOrNull(path);
+  if (!stat?.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) {
+    return false;
+  }
+  return typeof process.getuid !== 'function' || stat.uid === process.getuid();
 }
 
 function isContainedPath(parent, child) {
@@ -69,6 +131,18 @@ function resolveAbsolutePath(value) {
   return files.pathResolve(standardPath);
 }
 
+function userCacheNamespace() {
+  let identity = 'unknown';
+  try {
+    identity = os.userInfo().username || identity;
+  } catch {
+    if (typeof process.getuid === 'function') {
+      identity = String(process.getuid());
+    }
+  }
+  return `user-${createHash('sha256').update(identity).digest('hex').slice(0, 24)}`;
+}
+
 // Descend from a canonical temporary directory one component at a time. This
 // prevents the optional test hook from creating a cache through a symlink that
 // points outside the temporary-directory boundary.
@@ -78,7 +152,7 @@ function makeCacheRoot() {
   );
   const configuredRoot = process.env[CACHE_DIR_ENV]
     ? resolveAbsolutePath(process.env[CACHE_DIR_ENV])
-    : files.pathJoin(tempRoot, CACHE_DIRECTORY_NAME);
+    : files.pathJoin(tempRoot, CACHE_DIRECTORY_NAME, userCacheNamespace());
 
   if (!configuredRoot || !isContainedPath(tempRoot, configuredRoot)) {
     return null;
@@ -97,7 +171,7 @@ function makeCacheRoot() {
     const next = files.pathJoin(current, part);
     const stat = lstatOrNull(next);
     if (stat) {
-      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      if (!isPrivateDirectory(next)) {
         return null;
       }
     } else {
@@ -106,7 +180,7 @@ function makeCacheRoot() {
       } catch (error) {
         if (error?.code !== 'EEXIST') throw error;
       }
-      if (!isDirectory(next)) {
+      if (!isPrivateDirectory(next)) {
         return null;
       }
     }
@@ -114,7 +188,9 @@ function makeCacheRoot() {
   }
 
   const realRoot = files.realpath(current);
-  return isContainedPath(tempRoot, realRoot) ? realRoot : null;
+  return isContainedPath(tempRoot, realRoot) && isPrivateDirectory(realRoot)
+    ? realRoot
+    : null;
 }
 
 function safelyWalk(root, visit, shouldSkip = () => false) {
@@ -140,6 +216,111 @@ function safelyWalk(root, visit, shouldSkip = () => false) {
   }
 }
 
+function snapshotIsSafe(snapshotDir) {
+  const pending = [''];
+  while (pending.length > 0) {
+    const relativePath = pending.pop();
+    const absolutePath = relativePath
+      ? files.pathJoin(snapshotDir, relativePath)
+      : snapshotDir;
+    const stat = lstatOrNull(absolutePath);
+    if (!stat || stat.isSymbolicLink()) return false;
+    if (stat.isDirectory()) {
+      for (const entry of files.readdir(absolutePath)) {
+        pending.push(relativePath
+          ? files.pathJoin(relativePath, entry)
+          : entry);
+      }
+    } else if (!stat.isFile()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// `npm install` commonly creates .bin symlinks. Cache snapshots deliberately
+// forbid symlinks, so materialize only links that resolve inside the private
+// preparation directory or the producer checkout. This prevents a snapshot
+// from capturing arbitrary files reached through a link, and
+// `activeDirectories` rejects link cycles.
+function materializeSnapshot(sourceRoot, destinationRoot, allowedRoots) {
+  const canonicalSourceRoot = files.realpath(sourceRoot);
+  if (!isDirectory(canonicalSourceRoot)) {
+    throw new Error('prepared-app-cache source snapshot is not a directory');
+  }
+  const canonicalAllowedRoots = allowedRoots.map(root => files.realpath(root));
+  const isAllowedSourcePath = sourcePath =>
+    canonicalAllowedRoots.some(root => isContainedPath(root, sourcePath));
+
+  const activeDirectories = new Set();
+  const copyEntry = (sourcePath, destinationPath) => {
+    let resolvedSource = sourcePath;
+    let stat = lstatOrNull(sourcePath);
+    if (!stat) {
+      throw new Error('prepared-app-cache source snapshot entry disappeared');
+    }
+    if (stat.isSymbolicLink()) {
+      const linkTarget = files.readlink(sourcePath);
+      const unresolvedTarget = files.pathResolve(
+        files.pathDirname(sourcePath),
+        linkTarget,
+      );
+      if (!isAllowedSourcePath(unresolvedTarget)) {
+        throw new Error(
+          `prepared-app-cache source snapshot link escapes allowed roots: ${
+            sourcePath} -> ${linkTarget}`,
+        );
+      }
+      try {
+        resolvedSource = files.realpath(sourcePath);
+      } catch (error) {
+        throw new Error(
+          `prepared-app-cache source snapshot has a broken link: ${
+            linkTarget} (${error?.code || 'unknown'})`,
+        );
+      }
+      if (!isAllowedSourcePath(resolvedSource)) {
+        throw new Error(
+          `prepared-app-cache source snapshot link escapes allowed roots: ${
+            sourcePath} -> ${resolvedSource}`,
+        );
+      }
+      stat = lstatOrNull(resolvedSource);
+      if (!stat || stat.isSymbolicLink()) {
+        throw new Error('prepared-app-cache source snapshot link is invalid');
+      }
+    }
+
+    if (stat.isDirectory()) {
+      const canonicalDirectory = files.realpath(resolvedSource);
+      if (!isAllowedSourcePath(canonicalDirectory) ||
+          activeDirectories.has(canonicalDirectory)) {
+        throw new Error('prepared-app-cache source snapshot has a directory cycle');
+      }
+      activeDirectories.add(canonicalDirectory);
+      try {
+        files.mkdir_p(destinationPath, 0o700);
+        for (const entry of files.readdir(resolvedSource)) {
+          copyEntry(
+            files.pathJoin(resolvedSource, entry),
+            files.pathJoin(destinationPath, entry),
+          );
+        }
+      } finally {
+        activeDirectories.delete(canonicalDirectory);
+      }
+      return;
+    }
+
+    if (!stat.isFile()) {
+      throw new Error('prepared-app-cache source snapshot has an unsupported entry');
+    }
+    files.copyFile(resolvedSource, destinationPath);
+  };
+
+  copyEntry(canonicalSourceRoot, destinationRoot);
+}
+
 async function computeSourceFingerprint(toolsDir) {
   const hash = createHash('sha256');
   try {
@@ -148,18 +329,27 @@ async function computeSourceFingerprint(toolsDir) {
     });
     hash.update(`HEAD:${head.trim()}\n`);
 
-    const { stdout: status } = await execFileAsync(
+    const { stdout: diff } = await execFileAsync(
       'git',
-      ['status', '--porcelain', '--', 'tools', 'packages'],
+      ['diff', '--binary', '--no-ext-diff', '--no-renames', 'HEAD', '--', 'tools', 'packages'],
       { cwd: files.convertToOSPath(toolsDir), maxBuffer: 16 * 1024 * 1024 },
     );
-    for (const line of status.split('\n')) {
-      if (!line) continue;
-      const relativePath = line.slice(3).replace(/^"(.*)"$/, '$1');
+    hash.update(diff);
+
+    const { stdout: untracked } = await execFileAsync(
+      'git',
+      ['ls-files', '--others', '--exclude-standard', '-z', '--', 'tools', 'packages'],
+      { cwd: files.convertToOSPath(toolsDir), maxBuffer: 16 * 1024 * 1024 },
+    );
+    for (const relativePath of untracked.split('\0')) {
+      if (!relativePath) continue;
       const absolutePath = files.pathResolve(toolsDir, relativePath);
-      if (!isContainedPath(toolsDir, absolutePath)) continue;
-      const stat = files.statOrNull(absolutePath);
-      hash.update(`${relativePath}:${stat?.size ?? 'missing'}:${stat?.mtimeMs ?? ''}\n`);
+      if (!isContainedPath(toolsDir, absolutePath) || !isRegularFile(absolutePath)) {
+        hash.update(`UNSAFE:${relativePath}\n`);
+        continue;
+      }
+      hash.update(`${relativePath}\0`);
+      hash.update(files.readFile(absolutePath));
     }
   } catch {
     const stat = files.statOrNull(toolsDir);
@@ -176,6 +366,29 @@ function computeTemplateFingerprint(templatePath) {
     hash.update('\n');
   }, relativePath => relativePath === '.meteor/local');
   return hash.digest('hex').slice(0, 16);
+}
+
+// A local file dependency is represented by npm as a symlink. Some tests
+// intentionally create its target after createApp (for example modern's
+// config-package), so a snapshot without symlinks cannot preserve its meaning.
+// Bypass the cache for every local file dependency rather than weaken that
+// snapshot boundary.
+function templateAllowsCache(templatePath) {
+  const manifestPath = files.pathJoin(templatePath, 'package.json');
+  if (!isRegularFile(manifestPath)) return true;
+  let manifest;
+  try {
+    manifest = JSON.parse(files.readFile(manifestPath, 'utf8'));
+  } catch {
+    return false;
+  }
+  return ![
+    manifest.dependencies,
+    manifest.devDependencies,
+    manifest.optionalDependencies,
+  ].some(dependencies => dependencies && typeof dependencies === 'object' &&
+    Object.values(dependencies).some(specifier =>
+      typeof specifier === 'string' && specifier.startsWith('file:')));
 }
 
 function swapPathPrefix(value, fromPrefix, toPrefix) {
@@ -208,7 +421,7 @@ function rewriteStrings(value, fromPrefix, toPrefix) {
   return value;
 }
 
-function rewriteJsonFile(path, fromPrefix, toPrefix) {
+function rewriteJsonFile(path, pathRewrites) {
   if (!isRegularFile(path)) return;
   let json;
   try {
@@ -216,10 +429,13 @@ function rewriteJsonFile(path, fromPrefix, toPrefix) {
   } catch {
     return;
   }
-  files.writeFile(path, `${JSON.stringify(rewriteStrings(json, fromPrefix, toPrefix))}\n`, 'utf8');
+  for (const { fromPrefix, toPrefix } of pathRewrites) {
+    json = rewriteStrings(json, fromPrefix, toPrefix);
+  }
+  files.writeFile(path, `${JSON.stringify(json)}\n`, 'utf8');
 }
 
-function rewriteCachedPaths(destinationAppDir, sentinelPath) {
+function rewriteCachedPaths(destinationAppDir, pathRewrites) {
   const localDir = files.pathJoin(destinationAppDir, '.meteor', 'local');
   if (!isDirectory(localDir)) return;
 
@@ -230,8 +446,7 @@ function rewriteCachedPaths(destinationAppDir, sentinelPath) {
       if (!isDirectory(packageDir)) continue;
       rewriteJsonFile(
         files.pathJoin(packageDir, 'isopack-buildinfo.json'),
-        sentinelPath,
-        destinationAppDir,
+        pathRewrites,
       );
     }
   }
@@ -245,8 +460,7 @@ function rewriteCachedPaths(destinationAppDir, sentinelPath) {
         if (entry.endsWith('.json')) {
           rewriteJsonFile(
             files.pathJoin(pluginLocalDir, entry),
-            sentinelPath,
-            destinationAppDir,
+            pathRewrites,
           );
         }
       }
@@ -260,7 +474,8 @@ function rewriteCachedPaths(destinationAppDir, sentinelPath) {
       return;
     }
     try {
-      if (files.readFile(absolutePath, 'utf8').includes(sentinelPath)) {
+      if (pathRewrites.some(({ fromPrefix }) =>
+        files.readFile(absolutePath, 'utf8').includes(fromPrefix))) {
         offenders.push(relativePath);
       }
     } catch {
@@ -286,11 +501,13 @@ function cacheEntryPaths(root, cacheKey) {
   };
 }
 
-function validatedCacheEntry(root, cacheKey) {
+function validatedCacheEntry(
+  root, cacheKey, expectedToolsDir, expectedEnvironmentFingerprint,
+) {
   const paths = cacheEntryPaths(root, cacheKey);
   if (!paths || !isDirectory(paths.cacheDir) ||
       !isRegularFile(paths.readyPath) || !isRegularFile(paths.metadataPath) ||
-      !isDirectory(paths.snapshotDir)) {
+      !isDirectory(paths.snapshotDir) || !snapshotIsSafe(paths.snapshotDir)) {
     return null;
   }
 
@@ -304,6 +521,8 @@ function validatedCacheEntry(root, cacheKey) {
       metadata.version !== CACHE_FORMAT_VERSION ||
       metadata.cacheKey !== cacheKey ||
       metadata.snapshotDirectory !== SNAPSHOT_DIRECTORY ||
+      typeof metadata.producerToolsDir !== 'string' ||
+      typeof metadata.environmentFingerprint !== 'string' ||
       typeof metadata.sentinelPath !== 'string') {
     return null;
   }
@@ -312,7 +531,21 @@ function validatedCacheEntry(root, cacheKey) {
   if (!sentinelPath || !isDirectChild(root, sentinelPath, STAGING_NAME_RE)) {
     return null;
   }
-  return { ...paths, root, cacheKey, sentinelPath };
+  const producerToolsDir = resolveAbsolutePath(metadata.producerToolsDir);
+  if (!producerToolsDir ||
+      (expectedToolsDir && producerToolsDir !== expectedToolsDir) ||
+      (expectedEnvironmentFingerprint &&
+       metadata.environmentFingerprint !== expectedEnvironmentFingerprint)) {
+    return null;
+  }
+  return {
+    ...paths,
+    root,
+    cacheKey,
+    sentinelPath,
+    producerToolsDir,
+    environmentFingerprint: metadata.environmentFingerprint,
+  };
 }
 
 function createStagingDirectory(root) {
@@ -357,6 +590,7 @@ async function runPrepareApp({ execPath, cwd, env }) {
 
 async function warmCacheEntry({
   root, cacheKey, templatePath, releaseName, upgradersToAppend, execPath, env,
+  producerToolsDir, environmentFingerprint,
 }) {
   const paths = cacheEntryPaths(root, cacheKey);
   if (!paths) return null;
@@ -364,45 +598,66 @@ async function warmCacheEntry({
     files.mkdir(paths.cacheDir, 0o700);
   } catch (error) {
     if (error?.code !== 'EEXIST') throw error;
-    return validatedCacheEntry(root, cacheKey);
+    return validatedCacheEntry(
+      root, cacheKey, producerToolsDir, environmentFingerprint,
+    );
   }
 
-  const stagingDir = createStagingDirectory(root);
+  const preparationStagingDir = createStagingDirectory(root);
+  let snapshotStagingDir = null;
   try {
-    await files.cp_r(templatePath, stagingDir, {
+    await files.cp_r(templatePath, preparationStagingDir, {
       ignore: [/^local$/],
       preserveSymlinks: true,
     });
 
     if (releaseName) {
       files.writeFile(
-        files.pathJoin(stagingDir, '.meteor', 'release'),
+        files.pathJoin(preparationStagingDir, '.meteor', 'release'),
         releaseName,
         'utf8',
       );
     }
 
-    const upgradersFile = new FinishedUpgraders({ projectDir: stagingDir });
+    const upgradersFile = new FinishedUpgraders({ projectDir: preparationStagingDir });
     if (upgradersFile.readUpgraders().length === 0 && upgradersToAppend.length) {
       upgradersFile.appendUpgraders(upgradersToAppend);
     }
-    await defaultNpmDeps.install(stagingDir);
-    await runPrepareApp({ execPath, cwd: stagingDir, env });
+    await defaultNpmDeps.install(preparationStagingDir);
+    await runPrepareApp({ execPath, cwd: preparationStagingDir, env });
+
+    snapshotStagingDir = createStagingDirectory(root);
+    materializeSnapshot(preparationStagingDir, snapshotStagingDir, [
+      preparationStagingDir,
+      producerToolsDir,
+    ]);
+    if (!snapshotIsSafe(snapshotStagingDir)) {
+      throw new Error('prepared-app-cache materialized an unsafe snapshot');
+    }
 
     // The cache key directory is claimed before warming, while the complete
     // snapshot stays invisible in an unrelated staging directory. Promotion
     // is one rename, and the ready marker is written only after it succeeds.
-    await files.rename(stagingDir, paths.snapshotDir);
+    await removeStagingDirectory(root, preparationStagingDir);
+    await files.rename(snapshotStagingDir, paths.snapshotDir);
+    snapshotStagingDir = null;
     await files.writeFileAtomically(paths.metadataPath, `${JSON.stringify({
       version: CACHE_FORMAT_VERSION,
       cacheKey,
       snapshotDirectory: SNAPSHOT_DIRECTORY,
-      sentinelPath: stagingDir,
+      sentinelPath: preparationStagingDir,
+      producerToolsDir,
+      environmentFingerprint,
     })}\n`);
     await files.writeFileAtomically(paths.readyPath, '');
-    return validatedCacheEntry(root, cacheKey);
+    return validatedCacheEntry(
+      root, cacheKey, producerToolsDir, environmentFingerprint,
+    );
   } catch (error) {
-    await removeStagingDirectory(root, stagingDir).catch(() => {});
+    await removeStagingDirectory(root, preparationStagingDir).catch(() => {});
+    if (snapshotStagingDir) {
+      await removeStagingDirectory(root, snapshotStagingDir).catch(() => {});
+    }
     throw error;
   }
 }
@@ -414,25 +669,31 @@ export async function getPreparedAppCacheEntry({
       typeof template !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(template)) {
     return null;
   }
+  const environmentFingerprint = computeEnvironmentFingerprint(env);
+  if (!environmentFingerprint) return null;
 
-  const toolsDir = files.getCurrentToolsDir();
+  const toolsDir = files.realpath(files.getCurrentToolsDir());
   const templatesDir = files.pathJoin(toolsDir, 'tools', 'tests', 'apps');
   const templatePath = files.pathResolve(templatesDir, template);
   if (!isContainedPath(templatesDir, templatePath) || !isDirectory(templatePath)) {
     return null;
   }
+  if (!templateAllowsCache(templatePath)) return null;
 
   const root = makeCacheRoot();
   if (!root) return null;
   const cacheKey = createHash('sha256').update(JSON.stringify({
     version: CACHE_FORMAT_VERSION,
     source: await computeSourceFingerprint(toolsDir),
+    checkout: toolsDir,
+    environment: environmentFingerprint,
     template: computeTemplateFingerprint(templatePath),
     templateName: template,
     releaseName: releaseName || null,
   })).digest('hex').slice(0, 24);
-
-  return validatedCacheEntry(root, cacheKey) || await warmCacheEntry({
+  return validatedCacheEntry(
+    root, cacheKey, toolsDir, environmentFingerprint,
+  ) || await warmCacheEntry({
     root,
     cacheKey,
     templatePath,
@@ -440,17 +701,101 @@ export async function getPreparedAppCacheEntry({
     upgradersToAppend,
     execPath,
     env,
+    producerToolsDir: toolsDir,
+    environmentFingerprint,
   });
 }
 
-export async function applyPreparedAppCacheEntry({ cacheEntry, destAppDir }) {
-  if (!cacheEntry || !resolveAbsolutePath(destAppDir)) return false;
-  const verifiedEntry = validatedCacheEntry(cacheEntry.root, cacheEntry.cacheKey);
-  if (!verifiedEntry) return false;
+async function removePartialDestination(destRoot, destAppDir) {
+  const root = resolveAbsolutePath(destRoot);
+  const destination = resolveAbsolutePath(destAppDir);
+  if (!root || !destination || root === destination ||
+      !isContainedPath(root, destination)) {
+    return;
+  }
+  const stat = lstatOrNull(destination);
+  if (!stat) return;
+  if (stat.isDirectory() && !stat.isSymbolicLink()) {
+    await files.rm_recursive(destination);
+  } else {
+    files.unlink(destination);
+  }
+}
 
-  await files.cp_r(verifiedEntry.snapshotDir, destAppDir, {
-    preserveSymlinks: true,
-  });
-  rewriteCachedPaths(destAppDir, verifiedEntry.sentinelPath);
-  return true;
+function resolveSafeDestination(destRoot, destAppDir) {
+  const root = resolveAbsolutePath(destRoot);
+  const destination = resolveAbsolutePath(destAppDir);
+  if (!root || !destination || root === destination ||
+      !isContainedPath(root, destination) || !isDirectory(root)) {
+    return null;
+  }
+
+  const destinationParent = files.pathDirname(destination);
+  if (!isDirectory(destinationParent) || lstatOrNull(destination)) {
+    return null;
+  }
+  const canonicalRoot = files.realpath(root);
+  const canonicalParent = files.realpath(destinationParent);
+  const canonicalDestination = files.pathJoin(
+    canonicalParent,
+    files.pathBasename(destination),
+  );
+  if (canonicalRoot === canonicalDestination ||
+      !isContainedPath(canonicalRoot, canonicalParent) ||
+      !isContainedPath(canonicalRoot, canonicalDestination)) {
+    return null;
+  }
+  return { root: canonicalRoot, destination: canonicalDestination };
+}
+
+export async function applyPreparedAppCacheEntry({
+  cacheEntry, destAppDir, destRoot, env = {},
+}) {
+  const expectedCacheRoot = makeCacheRoot();
+  const cacheRoot = cacheEntry && typeof cacheEntry.root === 'string'
+    ? resolveAbsolutePath(cacheEntry.root)
+    : null;
+  const safeDestination = resolveSafeDestination(destRoot, destAppDir);
+  if (!cacheEntry || typeof cacheEntry.root !== 'string' ||
+      typeof cacheEntry.cacheKey !== 'string' || !cacheRoot ||
+      cacheRoot !== expectedCacheRoot || !safeDestination) {
+    return false;
+  }
+  const { root, destination } = safeDestination;
+
+  let copyStarted = false;
+  try {
+    const consumerToolsDir = files.realpath(files.getCurrentToolsDir());
+    const environmentFingerprint = computeEnvironmentFingerprint(env);
+    if (!environmentFingerprint) return false;
+    const verifiedEntry = validatedCacheEntry(
+      cacheEntry.root,
+      cacheEntry.cacheKey,
+      consumerToolsDir,
+      environmentFingerprint,
+    );
+    if (!verifiedEntry) return false;
+
+    copyStarted = true;
+    await files.cp_r(verifiedEntry.snapshotDir, destination, {
+      preserveSymlinks: true,
+    });
+    const pathRewrites = [{
+      fromPrefix: verifiedEntry.sentinelPath,
+      toPrefix: destination,
+    }];
+    if (verifiedEntry.producerToolsDir !== consumerToolsDir) {
+      pathRewrites.push({
+        fromPrefix: verifiedEntry.producerToolsDir,
+        toPrefix: consumerToolsDir,
+      });
+    }
+    rewriteCachedPaths(destination, pathRewrites);
+    return true;
+  } catch {
+    if (copyStarted) {
+      await removePartialDestination(root, destination).catch(() => {});
+    }
+    return false;
+  }
 }

--- a/tools/tool-testing/prepared-app-cache.js
+++ b/tools/tool-testing/prepared-app-cache.js
@@ -21,9 +21,11 @@ const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
 const SNAPSHOT_DIRECTORY = 'app';
 const CACHE_FORMAT_VERSION = 3;
 const PREPARE_TIMEOUT_MS = 15 * 60 * 1000;
+const STALE_ENTRY_LEASE_MS = PREPARE_TIMEOUT_MS + 5 * 60 * 1000;
 const SOURCE_FINGERPRINT_MAX_BYTES = 16 * 1024 * 1024;
 const STAGING_NAME_RE = /^\.staging-[0-9]+-[a-f0-9]{32}$/;
 const CACHE_KEY_RE = /^[a-f0-9]{24}$/;
+const QUARANTINE_NAME_RE = /^\.quarantine-[a-f0-9]{24}-[0-9]+-[a-f0-9]{32}$/;
 const SKIP_GUARD_EXTENSIONS = new Set(['.wt', '.wiredtiger', '.bson']);
 const PREPARE_ENV_NAMES = new Set([
   'BABEL_ENV',
@@ -588,6 +590,59 @@ async function removeClaimedCacheDirectory(root, cacheDir) {
   await files.rm_recursive(cacheDir);
 }
 
+function staleEntryCanBeReclaimed(paths) {
+  const cacheStat = lstatOrNull(paths.cacheDir);
+  if (!cacheStat?.isDirectory() || cacheStat.isSymbolicLink()) return false;
+
+  // A ready marker is written last, so a regular marker on an entry that
+  // failed validation cannot belong to an active warmer. An incomplete claim
+  // has no marker and is left alone until it exceeds the preparation lease.
+  const readyStat = lstatOrNull(paths.readyPath);
+  if (readyStat?.isFile() && !readyStat.isSymbolicLink()) return true;
+  return !readyStat && Date.now() - cacheStat.mtimeMs > STALE_ENTRY_LEASE_MS;
+}
+
+function makeQuarantinePath(root, cacheKey) {
+  const quarantineName = `.quarantine-${cacheKey}-${process.pid}-${
+    randomBytes(16).toString('hex')}`;
+  const quarantinePath = files.pathJoin(root, quarantineName);
+  return isDirectChild(root, quarantinePath, QUARANTINE_NAME_RE)
+    ? quarantinePath
+    : null;
+}
+
+async function removeQuarantineDirectory(root, quarantinePath) {
+  if (!isDirectChild(root, quarantinePath, QUARANTINE_NAME_RE)) return false;
+  const stat = lstatOrNull(quarantinePath);
+  if (!stat?.isDirectory() || stat.isSymbolicLink()) return false;
+  await files.rm_recursive(quarantinePath);
+  return true;
+}
+
+async function reclaimStaleCacheEntry(root, paths, cacheKey) {
+  if (!staleEntryCanBeReclaimed(paths)) return false;
+
+  // Rename first so no racing caller can mistake the old entry for its own,
+  // then delete only the controlled direct-child quarantine directory.
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const quarantinePath = makeQuarantinePath(root, cacheKey);
+    if (!quarantinePath || lstatOrNull(quarantinePath)) continue;
+    try {
+      await files.rename(paths.cacheDir, quarantinePath);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return false;
+      if (error?.code === 'EEXIST' || error?.code === 'ENOTEMPTY') continue;
+      return false;
+    }
+    try {
+      return await removeQuarantineDirectory(root, quarantinePath);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 async function runPrepareApp({ execPath, cwd, env }) {
   await execFileAsync(files.convertToOSPath(execPath), ['--prepare-app'], {
     cwd: files.convertToOSPath(cwd),
@@ -603,16 +658,31 @@ async function runPrepareApp({ execPath, cwd, env }) {
 async function warmCacheEntry({
   root, cacheKey, templatePath, releaseName, upgradersToAppend, execPath, env,
   producerToolsDir, environmentFingerprint,
-}) {
+}, allowReclaim = true) {
   const paths = cacheEntryPaths(root, cacheKey);
   if (!paths) return null;
   try {
     files.mkdir(paths.cacheDir, 0o700);
   } catch (error) {
     if (error?.code !== 'EEXIST') throw error;
-    return validatedCacheEntry(
+    const entry = validatedCacheEntry(
       root, cacheKey, producerToolsDir, environmentFingerprint,
     );
+    if (entry || !allowReclaim ||
+        !await reclaimStaleCacheEntry(root, paths, cacheKey)) {
+      return entry;
+    }
+    return warmCacheEntry({
+      root,
+      cacheKey,
+      templatePath,
+      releaseName,
+      upgradersToAppend,
+      execPath,
+      env,
+      producerToolsDir,
+      environmentFingerprint,
+    }, false);
   }
 
   let preparationStagingDir = null;

--- a/tools/tool-testing/prepared-app-cache.js
+++ b/tools/tool-testing/prepared-app-cache.js
@@ -56,10 +56,14 @@ export const isDisabled = () => Boolean(process.env[DISABLE_ENV]);
 // unfamiliar runner. Keep diagnostic output to stable reason labels, never
 // paths or environment values.
 function unavailable(reason) {
+  diagnostic(reason);
+  return null;
+}
+
+function diagnostic(reason) {
   if (process.env[DIAGNOSTIC_ENV] === '1') {
     console.error(`prepared-app-cache: unavailable (${reason})`);
   }
-  return null;
 }
 
 // Preparation is affected by these deterministic inputs. `NPM_CONFIG_*`
@@ -345,14 +349,24 @@ async function computeSourceFingerprint(toolsDir) {
       cwd: files.convertToOSPath(toolsDir),
     });
     hash.update(`HEAD:${head.trim()}\n`);
+  } catch {
+    diagnostic('source-head');
+    return null;
+  }
 
+  try {
     const { stdout: diff } = await execFileAsync(
       'git',
       ['diff', '--binary', '--no-ext-diff', '--no-renames', 'HEAD'],
       { cwd: files.convertToOSPath(toolsDir), maxBuffer: SOURCE_FINGERPRINT_MAX_BYTES },
     );
     hash.update(diff);
+  } catch {
+    diagnostic('source-diff');
+    return null;
+  }
 
+  try {
     const { stdout: untracked } = await execFileAsync(
       'git',
       ['ls-files', '--others', '--exclude-standard', '-z'],
@@ -364,12 +378,14 @@ async function computeSourceFingerprint(toolsDir) {
       const stat = lstatOrNull(absolutePath);
       if (!isContainedPath(toolsDir, absolutePath) || !stat?.isFile() ||
           stat.isSymbolicLink() || stat.size > SOURCE_FINGERPRINT_MAX_BYTES) {
+        diagnostic('source-untracked-entry');
         return null;
       }
       hash.update(`${relativePath}\0`);
       hash.update(files.readFile(absolutePath));
     }
   } catch {
+    diagnostic('source-untracked');
     return null;
   }
   return hash.digest('hex').slice(0, 16);

--- a/tools/tool-testing/prepared-app-cache.js
+++ b/tools/tool-testing/prepared-app-cache.js
@@ -21,7 +21,6 @@ const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
 const SNAPSHOT_DIRECTORY = 'app';
 const CACHE_FORMAT_VERSION = 3;
 const PREPARE_TIMEOUT_MS = 15 * 60 * 1000;
-const STALE_ENTRY_LEASE_MS = PREPARE_TIMEOUT_MS + 5 * 60 * 1000;
 const SOURCE_FINGERPRINT_MAX_BYTES = 16 * 1024 * 1024;
 const STAGING_NAME_RE = /^\.staging-[0-9]+-[a-f0-9]{32}$/;
 const CACHE_KEY_RE = /^[a-f0-9]{24}$/;
@@ -590,16 +589,14 @@ async function removeClaimedCacheDirectory(root, cacheDir) {
   await files.rm_recursive(cacheDir);
 }
 
-function staleEntryCanBeReclaimed(paths) {
+function invalidReadyEntryCanBeReclaimed(paths) {
   const cacheStat = lstatOrNull(paths.cacheDir);
   if (!cacheStat?.isDirectory() || cacheStat.isSymbolicLink()) return false;
 
-  // A ready marker is written last, so a regular marker on an entry that
-  // failed validation cannot belong to an active warmer. An incomplete claim
-  // has no marker and is left alone until it exceeds the preparation lease.
-  const readyStat = lstatOrNull(paths.readyPath);
-  if (readyStat?.isFile() && !readyStat.isSymbolicLink()) return true;
-  return !readyStat && Date.now() - cacheStat.mtimeMs > STALE_ENTRY_LEASE_MS;
+  // A regular ready marker is written last. If the entry then failed
+  // validation, it cannot belong to an active warmer. Never reclaim an
+  // unready claim automatically: preparation may still be running.
+  return isRegularFile(paths.readyPath);
 }
 
 function makeQuarantinePath(root, cacheKey) {
@@ -619,8 +616,8 @@ async function removeQuarantineDirectory(root, quarantinePath) {
   return true;
 }
 
-async function reclaimStaleCacheEntry(root, paths, cacheKey) {
-  if (!staleEntryCanBeReclaimed(paths)) return false;
+async function reclaimInvalidReadyEntry(root, paths, cacheKey) {
+  if (!invalidReadyEntryCanBeReclaimed(paths)) return false;
 
   // Rename first so no racing caller can mistake the old entry for its own,
   // then delete only the controlled direct-child quarantine directory.
@@ -669,7 +666,7 @@ async function warmCacheEntry({
       root, cacheKey, producerToolsDir, environmentFingerprint,
     );
     if (entry || !allowReclaim ||
-        !await reclaimStaleCacheEntry(root, paths, cacheKey)) {
+        !await reclaimInvalidReadyEntry(root, paths, cacheKey)) {
       return entry;
     }
     return warmCacheEntry({

--- a/tools/tool-testing/prepared-app-cache.js
+++ b/tools/tool-testing/prepared-app-cache.js
@@ -16,6 +16,7 @@ const execFileAsync = promisify(execFile);
 const CACHE_DIRECTORY_NAME = 'meteor-selftest-prepared-app-cache';
 const CACHE_DIR_ENV = 'METEOR_SELFTEST_PREPARED_APP_CACHE_DIR';
 const DISABLE_ENV = 'METEOR_DISABLE_PREPARED_APP_CACHE';
+const DIAGNOSTIC_ENV = 'METEOR_SELFTEST_PREPARED_APP_CACHE_DIAGNOSTICS';
 const READY_MARKER = '.meteor-selftest-cache-ready';
 const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
 const SNAPSHOT_DIRECTORY = 'app';
@@ -50,6 +51,16 @@ const PREPARE_ENV_NAMES = new Set([
 ]);
 
 export const isDisabled = () => Boolean(process.env[DISABLE_ENV]);
+
+// This opt-in is used only while investigating cache eligibility on an
+// unfamiliar runner. Keep diagnostic output to stable reason labels, never
+// paths or environment values.
+function unavailable(reason) {
+  if (process.env[DIAGNOSTIC_ENV] === '1') {
+    console.error(`prepared-app-cache: unavailable (${reason})`);
+  }
+  return null;
+}
 
 // Preparation is affected by these deterministic inputs. `NPM_CONFIG_*`
 // options cover npm install/rebuild behavior. Harness output such as
@@ -752,26 +763,28 @@ async function warmCacheEntry({
 export async function getPreparedAppCacheEntry({
   template, releaseName = null, upgradersToAppend = [], execPath, env = {},
 }) {
-  if (isDisabled() || !files.inCheckout() ||
-      typeof template !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(template)) {
-    return null;
+  if (isDisabled()) return unavailable('disabled');
+  if (!files.inCheckout()) return unavailable('not-checkout');
+  if (typeof template !== 'string' ||
+      !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(template)) {
+    return unavailable('invalid-template');
   }
   const environmentFingerprint = computeEnvironmentFingerprint(env);
-  if (!environmentFingerprint) return null;
+  if (!environmentFingerprint) return unavailable('environment');
 
   const toolsDir = files.realpath(files.getCurrentToolsDir());
   const templatesDir = files.pathJoin(toolsDir, 'tools', 'tests', 'apps');
   const templatePath = files.pathResolve(templatesDir, template);
   if (!isContainedPath(templatesDir, templatePath) || !isDirectory(templatePath)) {
-    return null;
+    return unavailable('template');
   }
-  if (!templateAllowsCache(templatePath)) return null;
+  if (!templateAllowsCache(templatePath)) return unavailable('template-policy');
 
   const sourceFingerprint = await computeSourceFingerprint(toolsDir);
-  if (!sourceFingerprint) return null;
+  if (!sourceFingerprint) return unavailable('source-fingerprint');
 
   const root = makeCacheRoot();
-  if (!root) return null;
+  if (!root) return unavailable('cache-root');
   const cacheKey = createHash('sha256').update(JSON.stringify({
     version: CACHE_FORMAT_VERSION,
     source: sourceFingerprint,

--- a/tools/tool-testing/prepared-app-cache.js
+++ b/tools/tool-testing/prepared-app-cache.js
@@ -1,0 +1,456 @@
+// A process-local cache for the result of `meteor --prepare-app` in tool
+// self-tests. The cache belongs below the operating system's temporary
+// directory and is intentionally not persisted or restored by CI.
+
+import { createHash, randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import os from 'node:os';
+
+import * as files from '../fs/files';
+import { FinishedUpgraders } from '../project-context.js';
+import * as defaultNpmDeps from '../cli/default-npm-deps.js';
+
+const execFileAsync = promisify(execFile);
+
+const CACHE_DIRECTORY_NAME = 'meteor-selftest-prepared-app-cache';
+const CACHE_DIR_ENV = 'METEOR_SELFTEST_PREPARED_APP_CACHE_DIR';
+const DISABLE_ENV = 'METEOR_DISABLE_PREPARED_APP_CACHE';
+const READY_MARKER = '.meteor-selftest-cache-ready';
+const METADATA_FILE = '.meteor-selftest-cache-metadata.json';
+const SNAPSHOT_DIRECTORY = 'app';
+const CACHE_FORMAT_VERSION = 1;
+const PREPARE_TIMEOUT_MS = 15 * 60 * 1000;
+const STAGING_NAME_RE = /^\.staging-[0-9]+-[a-f0-9]{32}$/;
+const CACHE_KEY_RE = /^[a-f0-9]{24}$/;
+const SKIP_GUARD_EXTENSIONS = new Set(['.wt', '.wiredtiger', '.bson']);
+
+export const isDisabled = () => Boolean(process.env[DISABLE_ENV]);
+
+function lstatOrNull(path) {
+  try {
+    return files.lstat(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function isDirectory(path) {
+  const stat = lstatOrNull(path);
+  return Boolean(stat?.isDirectory() && !stat.isSymbolicLink());
+}
+
+function isRegularFile(path) {
+  const stat = lstatOrNull(path);
+  return Boolean(stat?.isFile() && !stat.isSymbolicLink());
+}
+
+function isContainedPath(parent, child) {
+  return files.containsPath(parent, child);
+}
+
+function isDirectChild(parent, child, namePattern) {
+  return isContainedPath(parent, child) &&
+    files.pathDirname(child) === parent &&
+    namePattern.test(files.pathBasename(child));
+}
+
+function resolveAbsolutePath(value) {
+  if (typeof value !== 'string' || value.includes('\0')) {
+    return null;
+  }
+  const standardPath = files.convertToStandardPath(value);
+  if (!files.pathIsAbsolute(standardPath)) {
+    return null;
+  }
+  return files.pathResolve(standardPath);
+}
+
+// Descend from a canonical temporary directory one component at a time. This
+// prevents the optional test hook from creating a cache through a symlink that
+// points outside the temporary-directory boundary.
+function makeCacheRoot() {
+  const tempRoot = files.realpath(
+    files.pathResolve(files.convertToStandardPath(os.tmpdir())),
+  );
+  const configuredRoot = process.env[CACHE_DIR_ENV]
+    ? resolveAbsolutePath(process.env[CACHE_DIR_ENV])
+    : files.pathJoin(tempRoot, CACHE_DIRECTORY_NAME);
+
+  if (!configuredRoot || !isContainedPath(tempRoot, configuredRoot)) {
+    return null;
+  }
+
+  const relativeRoot = files.pathRelative(tempRoot, configuredRoot);
+  const parts = relativeRoot ? relativeRoot.split('/') : [];
+  if (parts.length === 0) {
+    return null;
+  }
+  let current = tempRoot;
+  for (const part of parts) {
+    if (!part || part === '.' || part === '..') {
+      return null;
+    }
+    const next = files.pathJoin(current, part);
+    const stat = lstatOrNull(next);
+    if (stat) {
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        return null;
+      }
+    } else {
+      try {
+        files.mkdir(next, 0o700);
+      } catch (error) {
+        if (error?.code !== 'EEXIST') throw error;
+      }
+      if (!isDirectory(next)) {
+        return null;
+      }
+    }
+    current = next;
+  }
+
+  const realRoot = files.realpath(current);
+  return isContainedPath(tempRoot, realRoot) ? realRoot : null;
+}
+
+function safelyWalk(root, visit, shouldSkip = () => false) {
+  const pending = [''];
+  while (pending.length > 0) {
+    const relativePath = pending.pop();
+    const absolutePath = relativePath
+      ? files.pathJoin(root, relativePath)
+      : root;
+    const stat = lstatOrNull(absolutePath);
+    if (!stat || stat.isSymbolicLink() || shouldSkip(relativePath, stat)) {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      for (const entry of files.readdir(absolutePath)) {
+        pending.push(relativePath
+          ? files.pathJoin(relativePath, entry)
+          : entry);
+      }
+    } else if (stat.isFile()) {
+      visit(relativePath, absolutePath, stat);
+    }
+  }
+}
+
+async function computeSourceFingerprint(toolsDir) {
+  const hash = createHash('sha256');
+  try {
+    const { stdout: head } = await execFileAsync('git', ['rev-parse', 'HEAD'], {
+      cwd: files.convertToOSPath(toolsDir),
+    });
+    hash.update(`HEAD:${head.trim()}\n`);
+
+    const { stdout: status } = await execFileAsync(
+      'git',
+      ['status', '--porcelain', '--', 'tools', 'packages'],
+      { cwd: files.convertToOSPath(toolsDir), maxBuffer: 16 * 1024 * 1024 },
+    );
+    for (const line of status.split('\n')) {
+      if (!line) continue;
+      const relativePath = line.slice(3).replace(/^"(.*)"$/, '$1');
+      const absolutePath = files.pathResolve(toolsDir, relativePath);
+      if (!isContainedPath(toolsDir, absolutePath)) continue;
+      const stat = files.statOrNull(absolutePath);
+      hash.update(`${relativePath}:${stat?.size ?? 'missing'}:${stat?.mtimeMs ?? ''}\n`);
+    }
+  } catch {
+    const stat = files.statOrNull(toolsDir);
+    hash.update(`MTIME:${stat?.mtimeMs ?? 0}\n`);
+  }
+  return hash.digest('hex').slice(0, 16);
+}
+
+function computeTemplateFingerprint(templatePath) {
+  const hash = createHash('sha256');
+  safelyWalk(templatePath, (relativePath, absolutePath, stat) => {
+    hash.update(`${relativePath}:${stat.size}:${stat.mtimeMs}:`);
+    hash.update(files.readFile(absolutePath));
+    hash.update('\n');
+  }, relativePath => relativePath === '.meteor/local');
+  return hash.digest('hex').slice(0, 16);
+}
+
+function swapPathPrefix(value, fromPrefix, toPrefix) {
+  if (typeof value !== 'string') return value;
+  if (value === fromPrefix) return toPrefix;
+  return value.startsWith(`${fromPrefix}/`)
+    ? `${toPrefix}${value.slice(fromPrefix.length)}`
+    : value;
+}
+
+function rewriteStrings(value, fromPrefix, toPrefix) {
+  if (typeof value === 'string') {
+    return swapPathPrefix(value, fromPrefix, toPrefix);
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => rewriteStrings(item, fromPrefix, toPrefix));
+  }
+  if (value && typeof value === 'object') {
+    const result = Object.create(null);
+    for (const [key, item] of Object.entries(value)) {
+      Object.defineProperty(result, swapPathPrefix(key, fromPrefix, toPrefix), {
+        value: rewriteStrings(item, fromPrefix, toPrefix),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return result;
+  }
+  return value;
+}
+
+function rewriteJsonFile(path, fromPrefix, toPrefix) {
+  if (!isRegularFile(path)) return;
+  let json;
+  try {
+    json = JSON.parse(files.readFile(path, 'utf8'));
+  } catch {
+    return;
+  }
+  files.writeFile(path, `${JSON.stringify(rewriteStrings(json, fromPrefix, toPrefix))}\n`, 'utf8');
+}
+
+function rewriteCachedPaths(destinationAppDir, sentinelPath) {
+  const localDir = files.pathJoin(destinationAppDir, '.meteor', 'local');
+  if (!isDirectory(localDir)) return;
+
+  const isopacksDir = files.pathJoin(localDir, 'isopacks');
+  if (isDirectory(isopacksDir)) {
+    for (const packageName of files.readdirNoDots(isopacksDir)) {
+      const packageDir = files.pathJoin(isopacksDir, packageName);
+      if (!isDirectory(packageDir)) continue;
+      rewriteJsonFile(
+        files.pathJoin(packageDir, 'isopack-buildinfo.json'),
+        sentinelPath,
+        destinationAppDir,
+      );
+    }
+  }
+
+  const pluginCacheDir = files.pathJoin(localDir, 'plugin-cache');
+  if (isDirectory(pluginCacheDir)) {
+    for (const pluginName of files.readdirNoDots(pluginCacheDir)) {
+      const pluginLocalDir = files.pathJoin(pluginCacheDir, pluginName, 'local');
+      if (!isDirectory(pluginLocalDir)) continue;
+      for (const entry of files.readdirNoDots(pluginLocalDir)) {
+        if (entry.endsWith('.json')) {
+          rewriteJsonFile(
+            files.pathJoin(pluginLocalDir, entry),
+            sentinelPath,
+            destinationAppDir,
+          );
+        }
+      }
+    }
+  }
+
+  const offenders = [];
+  safelyWalk(localDir, (relativePath, absolutePath, stat) => {
+    const extension = files.pathExtname(relativePath).toLowerCase();
+    if (SKIP_GUARD_EXTENSIONS.has(extension) || stat.size === 0 || stat.size > 8 * 1024 * 1024) {
+      return;
+    }
+    try {
+      if (files.readFile(absolutePath, 'utf8').includes(sentinelPath)) {
+        offenders.push(relativePath);
+      }
+    } catch {
+      // Binary data and unreadable files cannot safely be interpreted as text.
+    }
+  });
+  if (offenders.length > 0) {
+    throw new Error(
+      `prepared-app-cache left stale source paths in ${offenders.slice(0, 10).join(', ')}`,
+    );
+  }
+}
+
+function cacheEntryPaths(root, cacheKey) {
+  if (!CACHE_KEY_RE.test(cacheKey)) return null;
+  const cacheDir = files.pathJoin(root, cacheKey);
+  if (!isDirectChild(root, cacheDir, CACHE_KEY_RE)) return null;
+  return {
+    cacheDir,
+    metadataPath: files.pathJoin(cacheDir, METADATA_FILE),
+    readyPath: files.pathJoin(cacheDir, READY_MARKER),
+    snapshotDir: files.pathJoin(cacheDir, SNAPSHOT_DIRECTORY),
+  };
+}
+
+function validatedCacheEntry(root, cacheKey) {
+  const paths = cacheEntryPaths(root, cacheKey);
+  if (!paths || !isDirectory(paths.cacheDir) ||
+      !isRegularFile(paths.readyPath) || !isRegularFile(paths.metadataPath) ||
+      !isDirectory(paths.snapshotDir)) {
+    return null;
+  }
+
+  let metadata;
+  try {
+    metadata = JSON.parse(files.readFile(paths.metadataPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  if (!metadata || typeof metadata !== 'object' ||
+      metadata.version !== CACHE_FORMAT_VERSION ||
+      metadata.cacheKey !== cacheKey ||
+      metadata.snapshotDirectory !== SNAPSHOT_DIRECTORY ||
+      typeof metadata.sentinelPath !== 'string') {
+    return null;
+  }
+
+  const sentinelPath = resolveAbsolutePath(metadata.sentinelPath);
+  if (!sentinelPath || !isDirectChild(root, sentinelPath, STAGING_NAME_RE)) {
+    return null;
+  }
+  return { ...paths, root, cacheKey, sentinelPath };
+}
+
+function createStagingDirectory(root) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const stagingName = `.staging-${process.pid}-${randomBytes(16).toString('hex')}`;
+    const stagingDir = files.pathJoin(root, stagingName);
+    if (!isDirectChild(root, stagingDir, STAGING_NAME_RE)) {
+      throw new Error('prepared-app-cache generated an invalid staging path');
+    }
+    try {
+      files.mkdir(stagingDir, 0o700);
+      return stagingDir;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+    }
+  }
+  throw new Error('prepared-app-cache could not allocate a staging directory');
+}
+
+async function removeStagingDirectory(root, stagingDir) {
+  if (!isDirectChild(root, stagingDir, STAGING_NAME_RE)) return;
+  const stat = lstatOrNull(stagingDir);
+  if (!stat) return;
+  if (stat.isDirectory() && !stat.isSymbolicLink()) {
+    await files.rm_recursive(stagingDir);
+  } else {
+    files.unlink(stagingDir);
+  }
+}
+
+async function runPrepareApp({ execPath, cwd, env }) {
+  await execFileAsync(files.convertToOSPath(execPath), ['--prepare-app'], {
+    cwd: files.convertToOSPath(cwd),
+    env: { ...process.env, ...env },
+    timeout: PREPARE_TIMEOUT_MS,
+    maxBuffer: 32 * 1024 * 1024,
+    // `meteor.bat` requires a shell on Windows; both the executable and the
+    // sole argument are fixed by the self-test harness, not by test input.
+    ...(process.platform === 'win32' ? { shell: true } : {}),
+  });
+}
+
+async function warmCacheEntry({
+  root, cacheKey, templatePath, releaseName, upgradersToAppend, execPath, env,
+}) {
+  const paths = cacheEntryPaths(root, cacheKey);
+  if (!paths) return null;
+  try {
+    files.mkdir(paths.cacheDir, 0o700);
+  } catch (error) {
+    if (error?.code !== 'EEXIST') throw error;
+    return validatedCacheEntry(root, cacheKey);
+  }
+
+  const stagingDir = createStagingDirectory(root);
+  try {
+    await files.cp_r(templatePath, stagingDir, {
+      ignore: [/^local$/],
+      preserveSymlinks: true,
+    });
+
+    if (releaseName) {
+      files.writeFile(
+        files.pathJoin(stagingDir, '.meteor', 'release'),
+        releaseName,
+        'utf8',
+      );
+    }
+
+    const upgradersFile = new FinishedUpgraders({ projectDir: stagingDir });
+    if (upgradersFile.readUpgraders().length === 0 && upgradersToAppend.length) {
+      upgradersFile.appendUpgraders(upgradersToAppend);
+    }
+    await defaultNpmDeps.install(stagingDir);
+    await runPrepareApp({ execPath, cwd: stagingDir, env });
+
+    // The cache key directory is claimed before warming, while the complete
+    // snapshot stays invisible in an unrelated staging directory. Promotion
+    // is one rename, and the ready marker is written only after it succeeds.
+    await files.rename(stagingDir, paths.snapshotDir);
+    await files.writeFileAtomically(paths.metadataPath, `${JSON.stringify({
+      version: CACHE_FORMAT_VERSION,
+      cacheKey,
+      snapshotDirectory: SNAPSHOT_DIRECTORY,
+      sentinelPath: stagingDir,
+    })}\n`);
+    await files.writeFileAtomically(paths.readyPath, '');
+    return validatedCacheEntry(root, cacheKey);
+  } catch (error) {
+    await removeStagingDirectory(root, stagingDir).catch(() => {});
+    throw error;
+  }
+}
+
+export async function getPreparedAppCacheEntry({
+  template, releaseName = null, upgradersToAppend = [], execPath, env = {},
+}) {
+  if (isDisabled() || !files.inCheckout() ||
+      typeof template !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(template)) {
+    return null;
+  }
+
+  const toolsDir = files.getCurrentToolsDir();
+  const templatesDir = files.pathJoin(toolsDir, 'tools', 'tests', 'apps');
+  const templatePath = files.pathResolve(templatesDir, template);
+  if (!isContainedPath(templatesDir, templatePath) || !isDirectory(templatePath)) {
+    return null;
+  }
+
+  const root = makeCacheRoot();
+  if (!root) return null;
+  const cacheKey = createHash('sha256').update(JSON.stringify({
+    version: CACHE_FORMAT_VERSION,
+    source: await computeSourceFingerprint(toolsDir),
+    template: computeTemplateFingerprint(templatePath),
+    templateName: template,
+    releaseName: releaseName || null,
+  })).digest('hex').slice(0, 24);
+
+  return validatedCacheEntry(root, cacheKey) || await warmCacheEntry({
+    root,
+    cacheKey,
+    templatePath,
+    releaseName,
+    upgradersToAppend,
+    execPath,
+    env,
+  });
+}
+
+export async function applyPreparedAppCacheEntry({ cacheEntry, destAppDir }) {
+  if (!cacheEntry || !resolveAbsolutePath(destAppDir)) return false;
+  const verifiedEntry = validatedCacheEntry(cacheEntry.root, cacheEntry.cacheKey);
+  if (!verifiedEntry) return false;
+
+  await files.cp_r(verifiedEntry.snapshotDir, destAppDir, {
+    preserveSymlinks: true,
+  });
+  rewriteCachedPaths(destAppDir, verifiedEntry.sentinelPath);
+  return true;
+}

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -59,6 +59,10 @@ import { randomToken } from '../utils/utils.js';
 import { Tropohouse } from '../packaging/tropohouse.js';
 import { PackageMap } from '../packaging/package-map.js';
 import { capture, enterJob } from '../utils/buildmessage.js';
+import {
+  getPreparedAppCacheEntry,
+  applyPreparedAppCacheEntry,
+} from './prepared-app-cache.js';
 
 const hasOwn = Object.prototype.hasOwnProperty;
 
@@ -185,6 +189,31 @@ export default class Sandbox {
   async createApp(to, template, options) {
     options = options || {};
     const absoluteTo = files.pathJoin(this.cwd, to);
+
+    // Only a normal checkout sandbox with no caller-specific release,
+    // prepare-app opt-out, or custom environment can share a prepared snapshot.
+    // Unsupported shapes use the original path below without changing their
+    // behavior.
+    const usePreparedCache =
+      !this.warehouse && !options.release && !options.dontPrepareApp &&
+      Object.keys(this.env).length === 0 &&
+      files.containsPath(this.root, absoluteTo);
+    if (usePreparedCache) {
+      const cacheEntry = await getPreparedAppCacheEntry({
+        template,
+        releaseName: releaseCurrent.isProperRelease() ? releaseCurrent.name : null,
+        upgradersToAppend: allUpgraders(),
+        execPath: this.execPath,
+        env: this._makeEnv(),
+      });
+      if (cacheEntry && await applyPreparedAppCacheEntry({
+        cacheEntry,
+        destAppDir: absoluteTo,
+      })) {
+        return;
+      }
+    }
+
     const absoluteFrom = files.pathJoin(
       files.convertToStandardPath(__dirname),
       '..', 'tests', 'apps', template

--- a/tools/tool-testing/sandbox.js
+++ b/tools/tool-testing/sandbox.js
@@ -192,23 +192,33 @@ export default class Sandbox {
 
     // Only a normal checkout sandbox with no caller-specific release,
     // prepare-app opt-out, or custom environment can share a prepared snapshot.
-    // Unsupported shapes use the original path below without changing their
-    // behavior.
+    // Process-level environment is partitioned by the cache key; caller-provided
+    // sandbox environment remains an unsupported shape.
     const usePreparedCache =
       !this.warehouse && !options.release && !options.dontPrepareApp &&
       Object.keys(this.env).length === 0 &&
+      absoluteTo !== this.cwd &&
       files.containsPath(this.root, absoluteTo);
     if (usePreparedCache) {
-      const cacheEntry = await getPreparedAppCacheEntry({
-        template,
-        releaseName: releaseCurrent.isProperRelease() ? releaseCurrent.name : null,
-        upgradersToAppend: allUpgraders(),
-        execPath: this.execPath,
-        env: this._makeEnv(),
-      });
+      let cacheEntry = null;
+      const prepareEnv = this._makeEnv();
+      try {
+        cacheEntry = await getPreparedAppCacheEntry({
+          template,
+          releaseName: releaseCurrent.isProperRelease() ? releaseCurrent.name : null,
+          upgradersToAppend: allUpgraders(),
+          execPath: this.execPath,
+          env: prepareEnv,
+        });
+      } catch {
+        // A corrupt or inaccessible local cache must not block the baseline
+        // self-test setup path.
+      }
       if (cacheEntry && await applyPreparedAppCacheEntry({
         cacheEntry,
         destAppDir: absoluteTo,
+        destRoot: this.root,
+        env: prepareEnv,
       })) {
         return;
       }


### PR DESCRIPTION
## Summary

- Reuses a validated, local prepared-app snapshot for eligible repeated `Sandbox#createApp` calls in a self-test process.
- Rewrites generated absolute paths on copy and falls back to the existing preparation path for any unsupported, corrupt, or incomplete cache entry.
- Partitions entries by checkout, source state, template, release, and preparation-affecting environment without storing environment values.

## Measured CI impact — 6 GitHub Actions samples

Compared the fixed base SHA `5cafdbc20f5afe5ec82430700d046f7f6ce2b2fe` with this PR's fixed SHA `80886312edbfa381454ba3e61471030aadc4d91a`. Each value is the successful workflow critical path: earliest job `startedAt` to latest job `completedAt`. Runs were serialized; timings include the real GitHub-hosted runner, cache, setup, and test tail.

| Sample | Base | This PR | Delta |
| --- | --- | --- | --- |
| 1 | [38m50s](https://github.com/meteor/meteor/actions/runs/32286339367/attempts/1) | [32m47s](https://github.com/meteor/meteor/actions/runs/32291416429/attempts/1) | **6m03s faster** |
| 2 | [29m04s](https://github.com/meteor/meteor/actions/runs/32531012962/attempts/1) | [40m07s](https://github.com/meteor/meteor/actions/runs/32291416429/attempts/2) | 11m03s slower |
| 3 | [29m12s](https://github.com/meteor/meteor/actions/runs/32535927179/attempts/1) | [30m37s](https://github.com/meteor/meteor/actions/runs/32291416429/attempts/3) | 1m25s slower |
| 4 | [29m11s](https://github.com/meteor/meteor/actions/runs/32539575210/attempts/1) | [32m15s](https://github.com/meteor/meteor/actions/runs/32291416429/attempts/4) | 3m04s slower |
| 5 | [30m03s](https://github.com/meteor/meteor/actions/runs/32542928852/attempts/1) | [33m19s](https://github.com/meteor/meteor/actions/runs/32291416429/attempts/5) | 3m16s slower |
| 6 | [27m20s](https://github.com/meteor/meteor/actions/runs/32546014865/attempts/1) | [33m45s](https://github.com/meteor/meteor/actions/runs/32291416429/attempts/6) | 6m25s slower |

Median critical path: **29m11.5s → 33m03s**, a **3m51.5s increase (13.2%)**. This PR was faster in only 1 of 6 successful paired samples.

Therefore, this six-run end-to-end benchmark does **not** demonstrate a CI-time reduction. The previous one-run result is retained above as sample 1 but is not representative of the full sample. The implementation may still reduce repeated app preparation within a process, but it should not be credited with a workflow-level CI gain on this evidence.

The cache is process-local under the OS temporary directory: this PR adds no workflow cache, runner, or action changes. Templates with NPM `file:` dependencies fall back to the established path because their symlink semantics cannot be represented safely in a snapshot.

## Validation

- Six successful Test Tools measurements: 14/14 jobs each
- `./meteor self-test --retries 0 --headless --file ^prepared-app-cache$` (3/3, 229.8s)
- `npm run fmt:check`, `npm run lint`, `git diff --check`

## Credits

Adapted from [#14388](https://github.com/meteor/meteor/pull/14388) by [@mvogttech](https://github.com/mvogttech) (Michael Pfeiffer).