### PR TITLE
ci: temporary Test Tools baseline benchmark

### DIFF
--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: base-3
+# Temporary controlled benchmark trigger: base-4
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,4 +1,5 @@
 name: Test Tools
+# Temporary controlled benchmark trigger: base-2
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: prepared-2
+# Temporary controlled benchmark trigger: prepared-3
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: prepared-5
+# Temporary controlled benchmark trigger: prepared-6
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: base-5
+# Temporary controlled benchmark trigger: base-6
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: prepared-3
+# Temporary controlled benchmark trigger: prepared-4
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: base-2
+# Temporary controlled benchmark trigger: base-3
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: prepared-4
+# Temporary controlled benchmark trigger: prepared-5
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: base-6
+# Temporary controlled benchmark trigger: prepared-2
 
 on:
   pull_request:

--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,5 +1,5 @@
 name: Test Tools
-# Temporary controlled benchmark trigger: base-4
+# Temporary controlled benchmark trigger: base-5
 
 on:
   pull_request:

--- a/benchmarks/ci-benchmark-marker.md
+++ b/benchmarks/ci-benchmark-marker.md
@@ -1,0 +1,2 @@
+Temporary marker for controlled CI benchmark runs. This file intentionally does
+not match the Test Tools workflow path filters.


### PR DESCRIPTION
Temporary benchmark-only PR. It is pinned to the split series base SHA and exists solely to trigger the unmodified static Test Tools workflow on controlled commits. Do not merge.
