### PR TITLE
Adapting meteor pkgs for TypeScript 7

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -127,10 +127,12 @@ jobs:
             echo "::warning::NPM_LINK_RSPACK=false on release branch. E2E tests will install @meteorjs/rspack from npm — make sure the latest version is published or tests may fail."
           fi
 
-      - name: Use TypeScript 7 examples for the TypeScript migration
+      - name: Use TypeScript 7 fixtures for the TypeScript migration
         if: github.base_ref == 'typescript-changes-consolidated'
         run: |
           echo "METEOR_EXAMPLES_BRANCH=codex/typescript-7-examples" >> $GITHUB_ENV
+          echo "METEOR_SIMPLETASKS_BRANCH=codex/typescript-7" >> $GITHUB_ENV
+          echo "METEOR_METEOR3_REACT_BRANCH=codex/typescript-7-rspack" >> $GITHUB_ENV
 
       - name: Prepare Meteor
         if: steps.deps-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -127,6 +127,11 @@ jobs:
             echo "::warning::NPM_LINK_RSPACK=false on release branch. E2E tests will install @meteorjs/rspack from npm — make sure the latest version is published or tests may fail."
           fi
 
+      - name: Use TypeScript 7 examples for the TypeScript migration
+        if: github.base_ref == 'typescript-changes-consolidated'
+        run: |
+          echo "METEOR_EXAMPLES_BRANCH=codex/typescript-7-examples" >> $GITHUB_ENV
+
       - name: Prepare Meteor
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: ./meteor --get-ready --allow-superuser

--- a/tools/cli/examples-branch.test.js
+++ b/tools/cli/examples-branch.test.js
@@ -1,0 +1,44 @@
+const mockRequest = jest.fn();
+const mockExists = jest.fn();
+const mockReadFile = jest.fn();
+
+jest.mock('../fs/files', () => ({
+  pathJoin: (...parts) => parts.join('/'),
+  exists: (...args) => mockExists(...args),
+  readFile: (...args) => mockReadFile(...args),
+  writeFile: jest.fn(),
+}));
+jest.mock('../utils/http-helpers.js', () => ({
+  request: (...args) => mockRequest(...args),
+}));
+jest.mock('../console/console.js', () => ({ Console: { warn: jest.fn() } }));
+jest.mock('../packaging/tropohouse.js', () => ({
+  default: { root: '/tmp/meteor' },
+}));
+jest.mock('./git-clone.js', () => ({}));
+
+const originalExamplesBranch = process.env.METEOR_EXAMPLES_BRANCH;
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  if (originalExamplesBranch === undefined) {
+    delete process.env.METEOR_EXAMPLES_BRANCH;
+  } else {
+    process.env.METEOR_EXAMPLES_BRANCH = originalExamplesBranch;
+  }
+});
+
+test('does not use a cached catalog from another examples branch', async () => {
+  process.env.METEOR_EXAMPLES_BRANCH = 'codex/typescript-7-examples';
+  mockRequest.mockRejectedValue(new Error('offline'));
+  mockExists.mockReturnValue(true);
+  mockReadFile.mockReturnValue(JSON.stringify({
+    branch: 'main',
+    examples: [{ slug: 'tic-tac-toe', repositoryUrl: 'https://example.test' }],
+  }));
+
+  const { getExamples } = require('./examples.js');
+
+  await expect(getExamples()).rejects.toThrow('offline');
+});

--- a/tools/cli/examples.js
+++ b/tools/cli/examples.js
@@ -9,7 +9,9 @@ const {
 } = require('./git-clone.js');
 
 const EXAMPLES_REPO = 'https://github.com/meteor/examples';
-const EXAMPLES_BRANCH = 'main';
+// CI can validate an upcoming examples branch without changing the source
+// used by released Meteor versions.
+const EXAMPLES_BRANCH = process.env.METEOR_EXAMPLES_BRANCH || 'main';
 const EXAMPLES_JSON_URL =
   `https://raw.githubusercontent.com/meteor/examples/${EXAMPLES_BRANCH}/examples.json`;
 
@@ -98,7 +100,7 @@ async function getExamples({ refresh = false } = {}) {
 
     // Network failed, fall back to cache if available
     const cached = readCache();
-    if (cached && cached.examples) {
+    if (cached && cached.branch === EXAMPLES_BRANCH && cached.examples) {
       return cached.examples;
     }
 

--- a/tools/e2e-tests/apps/accounts/.meteor/packages
+++ b/tools/e2e-tests/apps/accounts/.meteor/packages
@@ -3,7 +3,7 @@ mongo                   # The database Meteor supports right now
 ecmascript              # Enable ECMAScript2015+ syntax in app code
 static-html             # Define static page content in .html files
 tracker                 # Reactive programming primitives
-react-meteor-data       # useTracker, used by the React mount in the harness
+react-meteor-data@4.1.0-beta.1 # useTracker, used by the React mount in the harness
 
 standard-minifier-css   # CSS minifier run for production mode
 standard-minifier-js    # JS minifier run for production mode

--- a/tools/e2e-tests/apps/accounts/.meteor/versions
+++ b/tools/e2e-tests/apps/accounts/.meteor/versions
@@ -84,7 +84,7 @@ static-html@1.5.0
 static-html-tools@1.0.0
 tracker@1.3.4
 twitter-oauth@1.3.4
-typescript@5.10.0
+typescript@7.0.2
 url@1.3.6-beta350.11
 webapp@2.2.0-beta350.11
 webapp-hashing@1.1.2

--- a/tools/e2e-tests/apps/coffeescript/.meteor/packages
+++ b/tools/e2e-tests/apps/coffeescript/.meteor/packages
@@ -19,5 +19,5 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 coffeescript            # Enable CoffeeScript syntax in .coffee files

--- a/tools/e2e-tests/apps/coffeescript/.meteor/versions
+++ b/tools/e2e-tests/apps/coffeescript/.meteor/versions
@@ -50,7 +50,7 @@ ordered-dict@1.2.0
 promise@1.0.0
 random@1.2.2
 react-fast-refresh@0.2.9
-react-meteor-data@4.0.0
+react-meteor-data@4.1.0-beta.1
 reactive-var@1.0.13
 reload@1.3.2
 retry@1.1.1
@@ -62,7 +62,7 @@ standard-minifier-js@3.1.1-rc331.2
 static-html@1.4.0
 static-html-tools@1.0.0
 tracker@1.3.4
-typescript@5.6.5-rc331.2
+typescript@7.0.2
 webapp@2.0.7
 webapp-hashing@1.1.2
 zodern:types@1.0.13

--- a/tools/e2e-tests/apps/full-blaze/.meteor/packages
+++ b/tools/e2e-tests/apps/full-blaze/.meteor/packages
@@ -20,4 +20,4 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 typescript              # Enable TypeScript syntax in .ts and .tsx modules
 shell-server            # Server-side component of the `meteor shell` command
 less
-ostrio:flow-router-extra # FlowRouter is a very simple router for Meteor
+ostrio:flow-router-extra@3.16.0-beta.0 # FlowRouter is a very simple router for Meteor

--- a/tools/e2e-tests/apps/full-blaze/.meteor/versions
+++ b/tools/e2e-tests/apps/full-blaze/.meteor/versions
@@ -57,7 +57,7 @@ mongo-id@1.0.9
 npm-mongo@6.10.2
 observe-sequence@2.0.0
 ordered-dict@1.2.0
-ostrio:flow-router-extra@3.12.0
+ostrio:flow-router-extra@3.16.0-beta.0
 promise@1.0.0
 random@1.2.2
 react-fast-refresh@0.2.9
@@ -77,7 +77,7 @@ templating-compiler@2.0.0
 templating-runtime@2.0.1
 templating-tools@2.0.0
 tracker@1.3.4
-typescript@5.6.4
+typescript@7.0.2
 underscore@1.6.4
 webapp@2.0.7
 webapp-hashing@1.1.2

--- a/tools/e2e-tests/apps/full-blaze/package.json
+++ b/tools/e2e-tests/apps/full-blaze/package.json
@@ -16,7 +16,8 @@
     "mainModule": {
       "client": "client/main.js",
       "server": "server/main.js"
-    }
+    },
+    "testModule": "tests/main.js"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/tools/e2e-tests/apps/monorepo/app/.meteor/packages
+++ b/tools/e2e-tests/apps/monorepo/app/.meteor/packages
@@ -19,4 +19,4 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data

--- a/tools/e2e-tests/apps/react-router/.meteor/packages
+++ b/tools/e2e-tests/apps/react-router/.meteor/packages
@@ -19,6 +19,6 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 default-package
 custom-package

--- a/tools/e2e-tests/apps/react-router/.meteor/versions
+++ b/tools/e2e-tests/apps/react-router/.meteor/versions
@@ -50,7 +50,7 @@ ordered-dict@1.2.0
 promise@1.0.0
 random@1.2.2
 react-fast-refresh@0.2.9
-react-meteor-data@4.0.0
+react-meteor-data@4.1.0-beta.1
 reactive-var@1.0.13
 reload@1.3.2
 retry@1.1.1
@@ -62,7 +62,7 @@ standard-minifier-js@3.1.1-rc331.2
 static-html@1.4.0
 static-html-tools@1.0.0
 tracker@1.3.4
-typescript@5.6.5-rc331.2
+typescript@7.0.2
 webapp@2.0.7
 webapp-hashing@1.1.2
 zodern:types@1.0.13

--- a/tools/e2e-tests/apps/react/.meteor/packages
+++ b/tools/e2e-tests/apps/react/.meteor/packages
@@ -19,4 +19,4 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data

--- a/tools/e2e-tests/apps/react/.meteor/versions
+++ b/tools/e2e-tests/apps/react/.meteor/versions
@@ -50,7 +50,7 @@ ordered-dict@1.2.0
 promise@1.0.0
 random@1.2.2
 react-fast-refresh@0.2.9
-react-meteor-data@4.0.0
+react-meteor-data@4.1.0-beta.1
 reactive-var@1.0.13
 reload@1.3.2
 retry@1.1.1
@@ -62,7 +62,7 @@ standard-minifier-js@3.1.1-rc331.2
 static-html@1.4.0
 static-html-tools@1.0.0
 tracker@1.3.4
-typescript@5.6.5-rc331.2
+typescript@7.0.2
 webapp@2.0.7
 webapp-hashing@1.1.2
 zodern:types@1.0.13

--- a/tools/e2e-tests/apps/server-only/.meteor/packages
+++ b/tools/e2e-tests/apps/server-only/.meteor/packages
@@ -15,6 +15,6 @@ standard-minifier-css@1.10.0   # CSS minifier run for production mode
 standard-minifier-js@3.2.0    # JS minifier run for production mode
 es5-shim@4.8.1                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.17.0              # Enable ECMAScript2015+ syntax in app code
-typescript@5.9.3              # Enable TypeScript syntax in .ts and .tsx modules
+typescript@7.0.2              # Enable TypeScript syntax in .ts and .tsx modules
 shell-server@0.7.0            # Server-side component of the `meteor shell` command
 rspack

--- a/tools/e2e-tests/apps/server-only/.meteor/versions
+++ b/tools/e2e-tests/apps/server-only/.meteor/versions
@@ -61,6 +61,6 @@ static-html@1.5.0
 static-html-tools@1.0.0
 tools-core@1.0.0
 tracker@1.3.4
-typescript@5.9.3
+typescript@7.0.2
 webapp@2.1.0
 webapp-hashing@1.1.2

--- a/tools/e2e-tests/apps/typescript/.meteor/packages
+++ b/tools/e2e-tests/apps/typescript/.meteor/packages
@@ -19,5 +19,5 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 fourseven:scss@5.0.0-rc.1 # Enable SCSS syntax in .scss using Meteor
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 zodern:types            # Pull in type declarations from other Meteor packages

--- a/tools/e2e-tests/apps/typescript/.meteor/versions
+++ b/tools/e2e-tests/apps/typescript/.meteor/versions
@@ -50,7 +50,7 @@ ordered-dict@1.2.0
 promise@1.0.0
 random@1.2.2
 react-fast-refresh@0.2.9
-react-meteor-data@4.0.0
+react-meteor-data@4.1.0-beta.1
 reactive-var@1.0.13
 reload@1.3.2
 retry@1.1.1
@@ -62,7 +62,7 @@ standard-minifier-js@3.1.1
 static-html@1.4.0
 static-html-tools@1.0.0
 tracker@1.3.4
-typescript@5.6.5
+typescript@7.0.2
 webapp@2.0.7
 webapp-hashing@1.1.2
 zodern:types@1.0.13

--- a/tools/e2e-tests/example.test.js
+++ b/tools/e2e-tests/example.test.js
@@ -7,6 +7,16 @@ import { runMeteorCommand, cleanupTempDir } from './helpers';
 const METEOR_EXAMPLES_BRANCH = process.env.METEOR_EXAMPLES_BRANCH || 'main';
 const METEOR_EXAMPLES_TREE_URL =
   `https://github.com/meteor/examples/tree/${encodeURIComponent(METEOR_EXAMPLES_BRANCH)}`;
+const SIMPLETASKS_REPOSITORY_URL = 'https://github.com/fredmaiaarantes/simpletasks';
+const METEOR_SIMPLETASKS_BRANCH = process.env.METEOR_SIMPLETASKS_BRANCH;
+const SIMPLETASKS_SOURCE_URL = METEOR_SIMPLETASKS_BRANCH
+  ? `${SIMPLETASKS_REPOSITORY_URL}/tree/${encodeURIComponent(METEOR_SIMPLETASKS_BRANCH)}`
+  : SIMPLETASKS_REPOSITORY_URL;
+const METEOR3_REACT_REPOSITORY_URL = 'https://github.com/meteor/meteor3-react';
+const METEOR_METEOR3_REACT_BRANCH =
+  process.env.METEOR_METEOR3_REACT_BRANCH || '3.4-rspack';
+const METEOR3_REACT_TREE_URL =
+  `${METEOR3_REACT_REPOSITORY_URL}/tree/${encodeURIComponent(METEOR_METEOR3_REACT_BRANCH)}`;
 
 function tempApp(prefix) {
   const suffix = Math.random().toString(36).substring(2, 10);
@@ -53,14 +63,18 @@ describe('Examples /', () => {
     }
   });
 
-  it('meteor create infers --from for an external URL', async () => {
+  it('meteor create uses the configured Simpletasks branch', async () => {
     const { appName, tempDir } = tempApp('from');
     try {
       await runMeteorCommand(
-        'create', [appName, 'https://github.com/fredmaiaarantes/simpletasks'], os.tmpdir(),
+        'create', [appName, SIMPLETASKS_SOURCE_URL], os.tmpdir(),
         { checkExitCode: true }
       );
       expect(fs.existsSync(path.join(tempDir, '.meteor'))).toBe(true);
+      if (METEOR_SIMPLETASKS_BRANCH) {
+        expect(fs.readFileSync(path.join(tempDir, '.meteor', 'versions'), 'utf8'))
+          .toContain('typescript@7.0.2');
+      }
     } finally {
       await cleanupTempDir(tempDir);
     }
@@ -106,12 +120,16 @@ describe('Examples /', () => {
     try {
       await runMeteorCommand(
         'create', [
-          '--from', 'https://github.com/meteor/meteor3-react/tree/3.4-rspack',
+          '--from', METEOR3_REACT_TREE_URL,
           appName
         ], os.tmpdir(),
         { checkExitCode: true }
       );
       expect(fs.existsSync(path.join(tempDir, '.meteor'))).toBe(true);
+      if (process.env.METEOR_METEOR3_REACT_BRANCH) {
+        expect(fs.readFileSync(path.join(tempDir, '.meteor', 'versions'), 'utf8'))
+          .toContain('typescript@7.0.2');
+      }
     } finally {
       await cleanupTempDir(tempDir);
     }
@@ -140,12 +158,16 @@ describe('Examples /', () => {
       await runMeteorCommand(
         'create', [
           '--from', 'https://github.com/meteor/meteor3-react/tree/3.4-rspack',
-          '--from-branch', '3.4-rspack',
+          '--from-branch', METEOR_METEOR3_REACT_BRANCH,
           appName
         ], os.tmpdir(),
         { checkExitCode: true }
       );
       expect(fs.existsSync(path.join(tempDir, '.meteor'))).toBe(true);
+      if (process.env.METEOR_METEOR3_REACT_BRANCH) {
+        expect(fs.readFileSync(path.join(tempDir, '.meteor', 'versions'), 'utf8'))
+          .toContain('typescript@7.0.2');
+      }
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/tools/e2e-tests/example.test.js
+++ b/tools/e2e-tests/example.test.js
@@ -4,6 +4,10 @@ import os from 'os';
 
 import { runMeteorCommand, cleanupTempDir } from './helpers';
 
+const METEOR_EXAMPLES_BRANCH = process.env.METEOR_EXAMPLES_BRANCH || 'main';
+const METEOR_EXAMPLES_TREE_URL =
+  `https://github.com/meteor/examples/tree/${encodeURIComponent(METEOR_EXAMPLES_BRANCH)}`;
+
 function tempApp(prefix) {
   const suffix = Math.random().toString(36).substring(2, 10);
   const appName = `meteortest-${prefix}-${suffix}`;
@@ -32,6 +36,23 @@ describe('Examples /', () => {
     }
   });
 
+  it('meteor create --example uses METEOR_EXAMPLES_BRANCH for internal examples', async () => {
+    const { appName, tempDir } = tempApp('example-branch');
+    try {
+      await runMeteorCommand(
+        'create', ['--example', 'tic-tac-toe', appName], os.tmpdir(),
+        {
+          checkExitCode: true,
+          env: { METEOR_EXAMPLES_BRANCH: 'codex/typescript-7-examples' },
+        }
+      );
+      expect(fs.readFileSync(path.join(tempDir, '.meteor', 'packages'), 'utf8'))
+        .toContain('typescript@7.0.2');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   it('meteor create infers --from for an external URL', async () => {
     const { appName, tempDir } = tempApp('from');
     try {
@@ -51,7 +72,7 @@ describe('Examples /', () => {
       await runMeteorCommand(
         'create', [
           '--from', 'https://github.com/meteor/examples',
-          '--from-branch', 'main',
+          '--from-branch', METEOR_EXAMPLES_BRANCH,
           '--from-dir', 'parties',
           appName
         ], os.tmpdir(),
@@ -101,7 +122,7 @@ describe('Examples /', () => {
     try {
       await runMeteorCommand(
         'create', [
-          '--from', 'https://github.com/meteor/examples/tree/main/parties',
+          '--from', `${METEOR_EXAMPLES_TREE_URL}/parties`,
           appName
         ], os.tmpdir(),
         { checkExitCode: true }

--- a/tools/e2e-tests/full-blaze.test.js
+++ b/tools/e2e-tests/full-blaze.test.js
@@ -10,7 +10,7 @@ describe('Full Blaze App Bundling /', () => {
     filePaths: { 
       client: 'client/main.js', 
       server: 'server/main.js',
-      test: 'imports/api/links/methods.tests.js'
+      test: 'tests/main.js'
     },
     customAssertions: {
       afterRun: async ({ result }) => {

--- a/tools/static-assets/skel-angular/.meteor/packages
+++ b/tools/static-assets/skel-angular/.meteor/packages
@@ -19,7 +19,7 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 zodern:types            # Pull in type declarations from other Meteor packages
 
 rspack                  # Integrate Rspack into Meteor for client and server app bundling

--- a/tools/static-assets/skel-babel/.meteor/packages
+++ b/tools/static-assets/skel-babel/.meteor/packages
@@ -19,6 +19,6 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 
 rspack                  # Integrate Rspack into Meteor for client and server app bundling

--- a/tools/static-assets/skel-chakra-ui/.meteor/packages
+++ b/tools/static-assets/skel-chakra-ui/.meteor/packages
@@ -19,6 +19,6 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 
 rspack                  # Integrate Rspack into Meteor for client and server app bundling

--- a/tools/static-assets/skel-coffeescript/.meteor/packages
+++ b/tools/static-assets/skel-coffeescript/.meteor/packages
@@ -19,7 +19,7 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 coffeescript            # CoffeeScript support
 
 rspack                  # Integrate Rspack into Meteor for client and server app bundling

--- a/tools/static-assets/skel-full/.meteor/packages
+++ b/tools/static-assets/skel-full/.meteor/packages
@@ -20,7 +20,7 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 typescript              # Enable TypeScript syntax in .ts and .tsx modules
 shell-server            # Server-side component of the `meteor shell` command
 
-ostrio:flow-router-extra # FlowRouter is a very simple router for Meteor
+ostrio:flow-router-extra@3.16.0-beta.0 # FlowRouter is a very simple router for Meteor
 
 meteortesting:mocha               # A package for writing and running your meteor app and package tests with mocha
 communitypackages:publication-collector@2.0.0-rc.1  # Test a Meteor publication by collecting its output

--- a/tools/static-assets/skel-react/.meteor/packages
+++ b/tools/static-assets/skel-react/.meteor/packages
@@ -19,6 +19,6 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 
 rspack                  # Integrate Rspack into Meteor for client and server app bundling

--- a/tools/static-assets/skel-tailwind/.meteor/packages
+++ b/tools/static-assets/skel-tailwind/.meteor/packages
@@ -19,6 +19,6 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 
 rspack                  # Integrate Rspack into Meteor for client and server app bundling

--- a/tools/static-assets/skel-typescript-tailwind/.meteor/packages
+++ b/tools/static-assets/skel-typescript-tailwind/.meteor/packages
@@ -19,7 +19,7 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 
 rspack                  # Integrate Rspack into Meteor for client and server app bundling
 

--- a/tools/static-assets/skel-typescript/.meteor/packages
+++ b/tools/static-assets/skel-typescript/.meteor/packages
@@ -19,7 +19,7 @@ hot-module-replacement  # Update client in development without reloading the pag
 
 ~prototype~
 static-html             # Define static page content in .html files
-react-meteor-data       # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1 # React higher-order component for reactively tracking Meteor data
 zodern:types            # Pull in type declarations from other Meteor packages
 
 rspack                  # Integrate Rspack into Meteor for client and server app bundling

--- a/tools/tests/apps/ecmascript-regression/.meteor/packages
+++ b/tools/tests/apps/ecmascript-regression/.meteor/packages
@@ -13,12 +13,12 @@ standard-minifier-css@1.9.3-alpha300.11    # CSS minifier run for production mod
 standard-minifier-js@3.0.0-alpha300.10    # JS minifier run for production mode
 es5-shim@4.8.0               # ECMAScript 5 compatibility for older browsers
 ecmascript@0.16.8-alpha300.11             # Enable ECMAScript2015+ syntax in app code
-typescript@7.0.2!       # Enable TypeScript syntax in .ts and .tsx modules ("!" overrides react-meteor-data's typescript@<=6 constraint)
+typescript@7.0.2        # Enable TypeScript syntax in .ts and .tsx modules
 shell-server@0.6.0-alpha300.11           # Server-side component of the `meteor shell` command
 hot-module-replacement@0.5.4-alpha300.11  # Update client in development without reloading the page
 
 autopublish@1.0.7           # Publish all data to the clients (for prototyping)
 insecure@1.0.7               # Allow all DB writes from clients (for prototyping)
 static-html@1.3.3-alpha300.11            # Define static page content in .html files
-react-meteor-data@4.1.0-beta.0   # React higher-order component for reactively tracking Meteor data
+react-meteor-data@4.1.0-beta.1   # React higher-order component for reactively tracking Meteor data
 meteortesting:mocha@3.0.0

--- a/tools/tests/apps/ecmascript-regression/.meteor/versions
+++ b/tools/tests/apps/ecmascript-regression/.meteor/versions
@@ -58,7 +58,7 @@ ordered-dict@1.1.0
 promise@0.12.0
 random@1.2.1
 react-fast-refresh@0.1.1
-react-meteor-data@4.1.0-beta.0
+react-meteor-data@4.1.0-beta.1
 reactive-var@1.0.12
 reload@1.3.1
 retry@1.1.0


### PR DESCRIPTION
## Summary

This PR prepares Meteor applications, generated skeletons, and E2E coverage for the TypeScript 7 migration.

- pins React E2E fixtures and generated skeletons to `react-meteor-data@4.1.0-beta.1`, which is compatible with TS7
- updates the affected fixtures and locks to `typescript@7.0.2`
- removes the obsolete forced TypeScript 7 override in the ECMAScript regression app
- adds opt-in branch overrides for internal and external Examples E2E sources, so CI for PRs targeting `typescript-changes-consolidated` uses the TS7 branches while released Meteor versions retain their existing sources
- supports branch names containing `/` when cloning an internal example from a GitHub tree URL
- prevents the examples catalog cache from being reused across different example refs

## Context

This is part of the consolidated TypeScript 7 migration:

- TypeScript 7 compiler update: #14670
- TS7-compatible `react-meteor-data` beta: [meteor/react-packages#497](https://github.com/meteor/react-packages/pull/497)
- TS7-compatible `react-meteor-accounts` beta: [meteor/react-packages#498](https://github.com/meteor/react-packages/pull/498)
- Staged TS7 examples: [meteor/examples#49](https://github.com/meteor/examples/pull/49)
- Staged Simpletasks migration: [fredmaiaarantes/simpletasks#24](https://github.com/fredmaiaarantes/simpletasks/pull/24)
- Staged Meteor Rspack example migration: [meteor/meteor3-react#3](https://github.com/meteor/meteor3-react/pull/3)

The external app branches are consumed only by CI for the TypeScript migration. They can be merged into their own repositories later, without exposing TypeScript 7 constraints to users of released Meteor versions before then.

## Validation

- formatting and linting pass
- unit coverage verifies that an offline cache from `main` is not used for a different examples branch
- the TS7 `meteor create --example` flow and the internal `--from` example paths pass end-to-end
- the external `simpletasks` and `meteor3-react` source branches pass their respective `meteor create --from` flows
- full local `Examples` E2E result: 10 passed, 0 failed