### PR TITLE
[rspack] Discover tests under private parent paths

### DIFF
--- a/dev/modern-tools/rspack/E2E_COVERAGE.md
+++ b/dev/modern-tools/rspack/E2E_COVERAGE.md
@@ -254,6 +254,7 @@ Minimal top-level await fixture.
 |----------------|-------|
 | `meteor test --full-app --once` waits for macrotask top-level await before running server app tests | Test once |
 | Exit-code-zero `0 passing` regression is rejected by explicit `1 passing` assertion | Test once |
+| Absolute project paths containing a `private` segment still discover eager tests ([#14688](https://github.com/meteor/meteor/issues/14688)) | Test once |
 
 ---
 

--- a/npm-packages/meteor-rspack/lib/ignore.js
+++ b/npm-packages/meteor-rspack/lib/ignore.js
@@ -85,14 +85,24 @@ function createIgnoreGlobConfig(entries = []) {
 /**
  * Creates a regex pattern to match the specified glob patterns.
  * Converts glob patterns with * and ** into regex equivalents.
- * 
+ *
  * @param {string[]} globPatterns - Array of glob patterns from createIgnoreGlobConfig
+ * @param {string} [rootPath] - Absolute root that matched paths must belong to
  * @returns {RegExp} - Regex pattern to match the specified patterns
  */
-function createIgnoreRegex(globPatterns) {
+function createIgnoreRegex(globPatterns, rootPath) {
   if (!Array.isArray(globPatterns) || globPatterns.length === 0) {
     throw new Error('globPatterns must be a non-empty array');
   }
+
+  // Rspack applies context exclusions to absolute module paths. Anchor rooted
+  // patterns here so matching starts inside the app, not in a parent folder.
+  const pathPrefix = rootPath
+    ? `^${rootPath
+        .replace(/\\/g, '/')
+        .replace(/\/+$/, '')
+        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=/|$)`
+    : '(?:^|/)';
 
   // Process each glob pattern and convert to regex
   const regexPatterns = globPatterns.map(pattern => {
@@ -115,9 +125,7 @@ function createIgnoreRegex(globPatterns) {
     // Convert the ** placeholder to its regex equivalent (any number of characters including /)
     regexPattern = regexPattern.replace(new RegExp(DOUBLE_ASTERISK_PLACEHOLDER, 'g'), '.*');
 
-    // For absolute paths, we don't want to force the pattern to match from the beginning
-    // but we still want to ensure it matches to the end of the path segment
-    regexPattern = '(?:^|/)' + regexPattern;
+    regexPattern = pathPrefix + regexPattern;
 
     return regexPattern;
   }).filter(pattern => pattern !== null);

--- a/npm-packages/meteor-rspack/lib/test.js
+++ b/npm-packages/meteor-rspack/lib/test.js
@@ -44,7 +44,8 @@ const generateEagerTestFile = ({
 
   // Create regex from ignore entries
   const excludeFoldersRegex = createIgnoreRegex(
-    createIgnoreGlobConfig(ignoreEntries)
+    createIgnoreGlobConfig(ignoreEntries),
+    projectDir,
   );
   // Create regex from meteor ignore entries
   const excludeMeteorIgnoreRegex = inMeteorIgnoreEntries.length > 0

--- a/tools/e2e-tests/helpers.js
+++ b/tools/e2e-tests/helpers.js
@@ -83,14 +83,23 @@ export async function clearBuildArtifacts(appDir) {
  * @param {Object} options - Additional options
  * @param {boolean} options.isMonorepo - Whether the app is a monorepo
  * @param {boolean} options.preserveFixtureSymlinks - Whether to preserve symlinks when copying the fixture
+ * @param {string[]} options.tempDirSegments - Path segments to insert below the system temp directory
  * @returns {string} - Path to the temporary directory containing the app
  */
 export async function setupMeteorApp(appName, options = {}) {
-  const { isMonorepo = false, preserveFixtureSymlinks = false } = options;
+  const {
+    isMonorepo = false,
+    preserveFixtureSymlinks = false,
+    tempDirSegments = [],
+  } = options;
 
   // Create a unique temporary directory
   const randomSuffix = Math.random().toString(36).substring(2, 10);
-  const tempDir = path.join(os.tmpdir(), `meteortest-${appName}-${randomSuffix}`);
+  const tempDir = path.join(
+    os.tmpdir(),
+    ...tempDirSegments,
+    `meteortest-${appName}-${randomSuffix}`,
+  );
 
   // Source app directory
   const sourceAppDir = path.join(__dirname, 'apps', appName);

--- a/tools/e2e-tests/tla.test.js
+++ b/tools/e2e-tests/tla.test.js
@@ -15,7 +15,10 @@ describe('Regressions / tla /', () => {
   let meteorProcess;
 
   beforeAll(async () => {
-    ({ tempDir } = await setupMeteorApp('tla'));
+    ({ tempDir } = await setupMeteorApp('tla', {
+      tempDirSegments: ['private'],
+    }));
+    expect(tempDir.split(/[\\/]/)).toContain('private');
     await linkLocalRspack(tempDir);
   });
 
@@ -48,7 +51,7 @@ describe('Regressions / tla /', () => {
     expect(mainIndex).toBeGreaterThan(settledIndex);
   });
 
-  test('"meteor test --full-app --once" runs tests', async () => {
+  test('"meteor test --full-app --once" runs tests below a private path segment', async () => {
     const result = await runMeteorTests(tempDir, port, {
       commandOptions: ['--full-app', '--once'],
       checkTestResults: true,


### PR DESCRIPTION
Context: https://github.com/meteor/meteor/issues/14688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed eager test discovery for projects located under paths containing a `private` directory segment.
  * Ensured test file exclusions are correctly scoped to the project directory, preventing unrelated paths from being ignored.

* **Tests**
  * Added end-to-end coverage for full-app testing when the project resides below a `private` path segment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->