### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "17"


### PR DESCRIPTION
## Summary

Upgrade the active native workflow from `actions/setup-java@v5` to `@v6`.

## Validation

- `git diff --check`
- Verified all active workflow references use setup-java v6 or newer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Java setup used by Android mobile smoke tests to the latest supported action version.
  * No end-user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->