### PR TITLE
Fix Windows Mongo troubleshooting link

### DIFF
--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -995,7 +995,7 @@ Object.assign(MRp, {
       message +=
         '\n\n' +
         'Check how to troubleshoot here ' +
-        'https://docs.meteor.com/windows.html#cant-start-mongo-server';
+        'https://v2-docs.meteor.com/windows.html#cant-start-mongo-server';
     }
 
     if (explanation && explanation.symbol === 'EXIT_NET_ERROR') {


### PR DESCRIPTION
## Summary

I updated the Windows Mongo startup failure message to use the archived troubleshooting page. The existing docs.meteor.com URL returns 404, while the archived page is available.

## Verification

- Parsed tools/runners/run-mongo.js in Node module mode
- Confirmed the old URL returns HTTP 404 and the replacement returns HTTP 200
- Ran git diff --check

## Limitations

I did not run the full Meteor self-test suite because this is a literal URL-only change. I also could not run the repository-pinned formatter or linter because npm/npx is unavailable on the validation host.

Fixes #14571.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Windows MongoDB startup troubleshooting link to point to the latest version 2 documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->