### PR TITLE
Add meteor agent skills guide in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Meteor is made possible by our amazing sponsors. Support the project and get you
 
 **Building an application with Meteor?**
 
+* Build with AI coding assistants using [Meteor Agent Skills](https://docs.meteor.com/ai/agent-skills)
 * Deploy on [Galaxy](https://galaxycloud.app)
 * Find packages on [Atmosphere](https://atmospherejs.com/)
 * Discuss on [Forums](https://forums.meteor.com/)

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -27,6 +27,7 @@ export default defineConfig({
         activeMatch: `^/(guide|docs|examples)/`,
         items: [
           { text: "Quick Start", link: "/about/install" },
+          { text: "Agent Skills (Beta)", link: "/ai/agent-skills" },
           { text: "Examples", link: "https://github.com/meteor/examples" },
           {
             text: "Meteor.js 2 Docs",
@@ -201,6 +202,10 @@ export default defineConfig({
                 link: "/about/modern-build-stack/rspack-bundler-integration.md",
               },
             ]
+          },
+          {
+            text: "Agent Skills (Beta)",
+            link: "/ai/agent-skills",
           },
           {
             text: "Cordova",

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -27,7 +27,7 @@ export default defineConfig({
         activeMatch: `^/(guide|docs|examples)/`,
         items: [
           { text: "Quick Start", link: "/about/install" },
-          { text: "Agent Skills (Beta)", link: "/ai/agent-skills" },
+          { text: "Agent Skills", link: "/ai/agent-skills" },
           { text: "Examples", link: "https://github.com/meteor/examples" },
           {
             text: "Meteor.js 2 Docs",
@@ -204,7 +204,7 @@ export default defineConfig({
             ]
           },
           {
-            text: "Agent Skills (Beta)",
+            text: "Agent Skills",
             link: "/ai/agent-skills",
           },
           {

--- a/v3-docs/docs/.vitepress/config.mts
+++ b/v3-docs/docs/.vitepress/config.mts
@@ -24,7 +24,7 @@ export default defineConfig({
     nav: [
       {
         text: "Docs",
-        activeMatch: `^/(guide|docs|examples)/`,
+        activeMatch: `^/(guide|docs|examples|ai)/`,
         items: [
           { text: "Quick Start", link: "/about/install" },
           { text: "Agent Skills", link: "/ai/agent-skills" },

--- a/v3-docs/docs/about/install.md
+++ b/v3-docs/docs/about/install.md
@@ -14,6 +14,16 @@ meteor create
 
 And it will prompt you to choose a project name and frontend framework.
 
+## Build with AI coding assistants {#ai-docs}
+
+Install [Meteor Agent Skills](/ai/agent-skills) to give compatible AI coding assistants Meteor-specific guidance for creating, debugging, testing, migrating, securing, and deploying applications.
+
+For documentation context, Meteor also publishes [`llms.txt`](https://docs.meteor.com/llms.txt) and [`llms-full.txt`](https://docs.meteor.com/llms-full.txt). Use `llms.txt` to discover relevant pages, or download the complete documentation:
+
+```bash
+curl https://docs.meteor.com/llms-full.txt -o meteor-docs.txt
+```
+
 ## Prerequisites {#prereqs}
 
 ### Operating System (OS) {#prereqs-os}
@@ -136,19 +146,6 @@ If you use a node version manager that uses a separate global `node_modules` fol
 To be able to use the `meteor` command from fish it's needed to include `/home/<user>/.meteor` in `$PATH`; to do that just add this line in `/home/<user>/.config/fish/config.fish` file (replace `<user>` with your username):
 
 `set PATH /home/<user>/.meteor $PATH`
-
-## Using AI with Meteor docs {#ai-docs}
-
-Meteor docs ships with [llms.txt](https://llmstxt.org/) file, which helps language models use your website
-
-If you have [LM Studio installed](https://lmstudio.ai/docs/app) or any other LLM tool, you can use the llms.txt file to ask questions about Meteor.
-
-```bash
-curl https://docs.meteor.com/llms-full.txt  -o meteor-docs.txt
-```
-
-Then, you can use the file with your LLM tool of choice. For example, if you have LM Studio installed, you can use their [chat with documents feature](https://lmstudio.ai/docs/app/basics/rag)
-to ask questions about Meteor.
 
 ## Uninstalling Meteor {#uninstall}
 

--- a/v3-docs/docs/about/install.md
+++ b/v3-docs/docs/about/install.md
@@ -16,7 +16,13 @@ And it will prompt you to choose a project name and frontend framework.
 
 ## Build with AI coding assistants {#ai-docs}
 
-Install [Meteor Agent Skills](/ai/agent-skills) to give compatible AI coding assistants Meteor-specific guidance for creating, debugging, testing, migrating, securing, and deploying applications.
+[Meteor Agent Skills](/ai/agent-skills) give compatible AI coding assistants Meteor-specific guidance for creating, debugging, testing, migrating, securing, and deploying applications. Choose and install skills interactively:
+
+```bash
+npx skills add meteor/agent-skills
+```
+
+The Agent Skills guide also covers Codex and Claude Code plugin installation, individual skills, and the complete catalog.
 
 For documentation context, Meteor also publishes [`llms.txt`](https://docs.meteor.com/llms.txt) and [`llms-full.txt`](https://docs.meteor.com/llms-full.txt). Use `llms.txt` to discover relevant pages, or download the complete documentation:
 

--- a/v3-docs/docs/about/install.md
+++ b/v3-docs/docs/about/install.md
@@ -14,22 +14,6 @@ meteor create
 
 And it will prompt you to choose a project name and frontend framework.
 
-## Build with AI coding assistants {#ai-docs}
-
-[Meteor Agent Skills](/ai/agent-skills) give compatible AI coding assistants Meteor-specific guidance for creating, debugging, testing, migrating, securing, and deploying applications. Choose and install skills interactively:
-
-```bash
-npx skills add meteor/agent-skills
-```
-
-The Agent Skills guide also covers Codex and Claude Code plugin installation, individual skills, and the complete catalog.
-
-For documentation context, Meteor also publishes [`llms.txt`](https://docs.meteor.com/llms.txt) and [`llms-full.txt`](https://docs.meteor.com/llms-full.txt). Use `llms.txt` to discover relevant pages, or download the complete documentation:
-
-```bash
-curl https://docs.meteor.com/llms-full.txt -o meteor-docs.txt
-```
-
 ## Prerequisites {#prereqs}
 
 ### Operating System (OS) {#prereqs-os}
@@ -95,6 +79,22 @@ curl https://install.meteor.com/\?release\=2.8 | sh
 ```
 
 > Do not install the npm Meteor Tool in your project's package.json. This library is just an installer.
+
+## Build with AI coding assistants {#ai-docs}
+
+[Meteor Agent Skills](/ai/agent-skills) give compatible AI coding assistants Meteor-specific guidance for creating, debugging, testing, migrating, securing, and deploying applications. Choose and install skills interactively:
+
+```bash
+npx skills add meteor/agent-skills
+```
+
+The Agent Skills guide also covers Codex and Claude Code plugin installation, individual skills, and the complete catalog.
+
+For documentation context, Meteor also publishes [`llms.txt`](https://docs.meteor.com/llms.txt) and [`llms-full.txt`](https://docs.meteor.com/llms-full.txt). Use `llms.txt` to discover relevant pages, or download the complete documentation:
+
+```bash
+curl https://docs.meteor.com/llms-full.txt -o meteor-docs.txt
+```
 
 ## Troubleshooting {#troubleshooting}
 

--- a/v3-docs/docs/ai/agent-skills.md
+++ b/v3-docs/docs/ai/agent-skills.md
@@ -9,12 +9,6 @@ Meteor Agent Skills give compatible AI coding assistants focused guidance for bu
 
 Skills are installed for your coding assistant, not as Atmosphere or npm dependencies in your application. A compatible assistant can match your request to a relevant skill, load its instructions when needed, and follow its Meteor-specific decision flow without adding the entire catalog to every conversation.
 
-:::warning Public beta
-[Meteor Agent Skills v1.0.0-beta.2](https://github.com/meteor/agent-skills/releases/tag/v1.0.0-beta.2) contains 14 Meteor-maintained skills. The tagged release has been verified with Codex, Claude Code, and the open `skills` CLI.
-
-The catalog has not yet been submitted to curated plugin directories. Skill selection and results can vary between clients and models, so review the assistant's changes and validate them in your application.
-:::
-
 ## Quick start
 
 ### Codex
@@ -57,7 +51,7 @@ Install one skill directly:
 npx skills add meteor/agent-skills --skill migrate-to-meteor-3
 ```
 
-Use `--all` to install every skill non-interactively. See the [full catalog and install options](https://github.com/meteor/agent-skills#install) for plugin prerelease pinning and manual ZIP installation.
+Use `--all` to install every skill non-interactively. See the [full catalog and install options](https://github.com/meteor/agent-skills#install) for additional plugin and manual installation options.
 
 ## How skills work
 
@@ -74,9 +68,9 @@ For example:
 - Audit this application for security issues.
 - Validate this production deployment configuration.
 
-## Beta coverage
+## Skill coverage
 
-The beta focuses on Meteor workflows where framework context, version boundaries, and practical decisions are especially important.
+The catalog focuses on Meteor workflows where framework context, version boundaries, and practical decisions are especially important.
 
 | Scope | Skills | What they cover |
 | --- | --- | --- |
@@ -88,7 +82,7 @@ The beta focuses on Meteor workflows where framework context, version boundaries
 | Community packages | `meteor-community-packages` | Selecting and integrating packages from Meteor's documented community catalog while checking versions, ownership, behavior, support boundaries, and upstream repositories. |
 | Debugging and operations | `meteor-debugging`, `meteor-deployment` | Evidence-first diagnosis across builds, runtime, data, tests, browsers, mobile, and production, plus Galaxy, Docker, Kubernetes, settings, and Node version matching. |
 
-The current catalog targets Meteor 3. Most skills support Meteor 3.0 and later. The modern build stack skill starts with Meteor 3.3, and the Rspack migration skill starts with Meteor 3.4. The beta has dedicated UI skills for React and Blaze, but does not yet include dedicated Vue, Svelte, or Solid skills.
+The current catalog targets Meteor 3. Most skills support Meteor 3.0 and later. The modern build stack skill starts with Meteor 3.3, and the Rspack migration skill starts with Meteor 3.4. The catalog has dedicated UI skills for React and Blaze, but does not yet include dedicated Vue, Svelte, or Solid skills.
 
 ## Curated bundles
 
@@ -105,7 +99,7 @@ You can install the complete catalog, one skill, or a curated group of related s
 
 See the [bundle catalog](https://github.com/meteor/agent-skills#bundles) for the exact skill membership and generated install commands.
 
-## Working with the beta
+## Working with Agent Skills
 
 Use the skills on a real task in a separate branch or disposable project. Review the resulting diff, run the checks that apply to the changed area, and keep application secrets out of prompts and reports.
 
@@ -113,7 +107,7 @@ Agent Skills complement the Meteor documentation and your own review. They do no
 
 ## Feedback
 
-Report problems in the [Meteor Agent Skills issue tracker](https://github.com/meteor/agent-skills/issues) or the [public beta forum thread](https://forums.meteor.com/t/introducing-meteor-agent-skills-public-beta-for-ai-coding-assistants/64749). Include:
+Report problems in the [Meteor Agent Skills issue tracker](https://github.com/meteor/agent-skills/issues). Include:
 
 - The prompt or task, with sensitive application details removed.
 - The skill selected, or the skill you expected.
@@ -121,4 +115,4 @@ Report problems in the [Meteor Agent Skills issue tracker](https://github.com/me
 - Your Meteor release and relevant Atmosphere or npm package versions.
 - The result, expected behavior, and a small reproduction or relevant logs when available.
 
-Feedback about missed skill selection, incorrect commands or APIs, inaccurate version boundaries, missing decisions, and installation failures helps determine the next beta updates.
+Feedback about missed skill selection, incorrect commands or APIs, inaccurate version boundaries, missing decisions, and installation failures helps guide future updates.

--- a/v3-docs/docs/ai/agent-skills.md
+++ b/v3-docs/docs/ai/agent-skills.md
@@ -1,0 +1,124 @@
+---
+outline:
+  level: [2, 3]
+---
+
+# Meteor Agent Skills
+
+Meteor Agent Skills give compatible AI coding assistants focused guidance for building, debugging, migrating, testing, securing, and deploying Meteor 3 applications.
+
+Skills are installed for your coding assistant, not as Atmosphere or npm dependencies in your application. A compatible assistant can match your request to a relevant skill, load its instructions when needed, and follow its Meteor-specific decision flow without adding the entire catalog to every conversation.
+
+:::warning Public beta
+[Meteor Agent Skills v1.0.0-beta.2](https://github.com/meteor/agent-skills/releases/tag/v1.0.0-beta.2) contains 14 Meteor-maintained skills. The tagged release has been verified with Codex, Claude Code, and the open `skills` CLI.
+
+The catalog has not yet been submitted to curated plugin directories. Skill selection and results can vary between clients and models, so review the assistant's changes and validate them in your application.
+:::
+
+## Quick start
+
+### Codex
+
+Install the complete catalog as the Meteor plugin:
+
+```bash
+codex plugin marketplace add meteor/agent-skills
+codex plugin add meteor@meteor
+```
+
+### Claude Code
+
+Install the same catalog as a Claude Code plugin:
+
+```bash
+claude plugin marketplace add meteor/agent-skills
+claude plugin install meteor@meteor
+```
+
+### Other compatible assistants
+
+The open `skills` CLI can install the catalog into Claude Code, Cursor, Codex, Copilot, Gemini CLI, OpenCode, and other compatible assistants.
+
+List the available skills:
+
+```bash
+npx skills add meteor/agent-skills --list
+```
+
+Select skills interactively:
+
+```bash
+npx skills add meteor/agent-skills
+```
+
+Install one skill directly:
+
+```bash
+npx skills add meteor/agent-skills --skill migrate-to-meteor-3
+```
+
+Use `--all` to install every skill non-interactively. See the [full catalog and install options](https://github.com/meteor/agent-skills#install) for plugin prerelease pinning and manual ZIP installation.
+
+## How skills work
+
+Each skill exposes a short description that tells an assistant when to use it. When a request matches, the assistant loads the full instructions and only the references or helper scripts needed for that task. Neighboring skills also define handoffs, such as moving from broad debugging to the build, data, testing, or deployment guidance after the failing layer is known.
+
+After installation, start a fresh conversation so your assistant discovers the new skills. Ask for the Meteor task naturally. You do not need to name a skill in the prompt.
+
+For example:
+
+- Build a Meteor 3 application from scratch.
+- Migrate this Meteor 2 application to Meteor 3.
+- Review this publication and subscription flow.
+- Diagnose why this Meteor test hangs.
+- Audit this application for security issues.
+- Validate this production deployment configuration.
+
+## Beta coverage
+
+The beta focuses on Meteor workflows where framework context, version boundaries, and practical decisions are especially important.
+
+| Scope | Skills | What they cover |
+| --- | --- | --- |
+| Meteor 3 migration | `migrate-to-meteor-3`, `migrate-to-rspack` | Fibers removal, async API migration, Promise call chains, package triage, and moving Meteor 3.4+ applications to Rspack. |
+| Modern build stack | `meteor-modern-build-stack` | SWC, file watching, Meteor Bundler optimizations, Rspack setup, version pairing, and build diagnostics. |
+| Data and application APIs | `meteor-methods`, `meteor-pubsub`, `meteor-mongo-minimongo` | Methods, validation, latency compensation, publications, subscriptions, Mongo queries, indexes, Minimongo, oplog, and Change Streams. |
+| User interfaces | `meteor-react`, `meteor-blaze` | Reactive data, Suspense, Fast Refresh, Spacebars, Tracker, async rendering, lifecycle behavior, and bundler-specific refresh behavior. |
+| Application foundations | `meteor-accounts`, `meteor-security`, `meteor-testing` | Authentication, OAuth, password flows, authorization, rate limiting, CSP, unit and integration tests, and browser end-to-end testing. |
+| Community packages | `meteor-community-packages` | Selecting and integrating packages from Meteor's documented community catalog while checking versions, ownership, behavior, support boundaries, and upstream repositories. |
+| Debugging and operations | `meteor-debugging`, `meteor-deployment` | Evidence-first diagnosis across builds, runtime, data, tests, browsers, mobile, and production, plus Galaxy, Docker, Kubernetes, settings, and Node version matching. |
+
+The current catalog targets Meteor 3. Most skills support Meteor 3.0 and later. The modern build stack skill starts with Meteor 3.3, and the Rspack migration skill starts with Meteor 3.4. The beta has dedicated UI skills for React and Blaze, but does not yet include dedicated Vue, Svelte, or Solid skills.
+
+## Curated bundles
+
+You can install the complete catalog, one skill, or a curated group of related skills. The repository currently publishes these bundles:
+
+| Bundle | Use it for |
+| --- | --- |
+| `essentials` | Core debugging, build, Methods, pub/sub, Mongo, and security work. |
+| `migration` | Migrating to Meteor 3 or moving an existing Meteor 3 application to Rspack. |
+| `fullstack` | Data, accounts, security, testing, and general full-stack application work. |
+| `ops` | Debugging and production deployment. |
+| `blaze` | Blaze-specific interface work. |
+| `react` | React-specific interface work. |
+
+See the [bundle catalog](https://github.com/meteor/agent-skills#bundles) for the exact skill membership and generated install commands.
+
+## Working with the beta
+
+Use the skills on a real task in a separate branch or disposable project. Review the resulting diff, run the checks that apply to the changed area, and keep application secrets out of prompts and reports.
+
+Agent Skills complement the Meteor documentation and your own review. They do not replace API documentation, application tests, or decisions based on your deployed Meteor and package versions.
+
+## Feedback
+
+Report problems in the [Meteor Agent Skills issue tracker](https://github.com/meteor/agent-skills/issues) or the [public beta forum thread](https://forums.meteor.com/t/introducing-meteor-agent-skills-public-beta-for-ai-coding-assistants/64749). Include:
+
+- The prompt or task, with sensitive application details removed.
+- The skill selected, or the skill you expected.
+- The assistant client and model.
+- Your Meteor release and relevant Atmosphere or npm package versions.
+- The result, expected behavior, and a small reproduction or relevant logs when available.
+
+Feedback about missed skill selection, incorrect commands or APIs, inaccurate version boundaries, missing decisions, and installation failures helps determine the next beta updates.

--- a/v3-docs/docs/ai/agent-skills.md
+++ b/v3-docs/docs/ai/agent-skills.md
@@ -101,8 +101,6 @@ See the [bundle catalog](https://github.com/meteor/agent-skills#bundles) for the
 
 ## Working with Agent Skills
 
-Use the skills on a real task in a separate branch or disposable project. Review the resulting diff, run the checks that apply to the changed area, and keep application secrets out of prompts and reports.
-
 Agent Skills complement the Meteor documentation and your own review. They do not replace API documentation, application tests, or decisions based on your deployed Meteor and package versions.
 
 ## Feedback


### PR DESCRIPTION
Context: https://forums.meteor.com/t/introducing-meteor-agent-skills-public-beta-for-ai-coding-assistants/64749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation for Meteor Agent Skills, a beta catalog of skills for AI coding assistants.
  * Documented installation options, supported workflows, skill handoffs, curated bundles, coverage areas, and feedback guidance.

* **Documentation**
  * Added Agent Skills links to the Developer Resources section, top-level Docs navigation, and Quick Start sidebar.
  * Improved navigation highlighting for pages in the AI documentation section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->