### PR TITLE
Bump bundled qs to 6.16.0 in meteor-node-stubs to address GHSA-4mjr-xmp4-gh2g and GHSA-x5fp-wj9c-mxmx

### DIFF
--- a/npm-packages/meteor-node-stubs/package-lock.json
+++ b/npm-packages/meteor-node-stubs/package-lock.json
@@ -1473,13 +1473,14 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1669,15 +1670,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1689,14 +1690,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Summary

`meteor-node-stubs` bundles a vulnerable copy of `qs` (`6.15.2`) via `url@0.11.4` (`bundledDependencies`). This bumps the bundled `qs` to **6.16.0**, the patched version for two advisories published on 2026-09-02.

Closes #14707.

## Details

- **[GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g)** (CVE-2026-82417, moderate, CVSS 6.3) — DoS via attacker-controlled `isBuffer`: `qs.stringify()` calls `utils.isBuffer()` without checking that `constructor.isBuffer` is callable, so an object parsed with `plainObjects: true` / `allowPrototypes: true` can make it throw an uncaught `TypeError`.
  - Affected: `qs >= 2.2.5 < 6.16.0`
  - Patched: `qs 6.16.0`
- **[GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx)** (CVE-2026-82562, moderate, CVSS 6.3) — array-limit bypass via bracket-key comma parsing: with `comma: true`, `a[]=1,2,3,4` skips the `arrayLimit` / `throwOnLimitExceeded` checks, allowing unbounded allocation from a single parameter.
  - Affected: `qs >= 6.14.2 <= 6.15.3`
  - Patched: `qs 6.16.0`
- `url@0.11.4` declares `qs@^6.12.3`, so `6.16.0` satisfies the existing range — no breaking change.
- Because `qs` is bundled in the published tarball (via `url`), consumers cannot patch it with npm `overrides`; it has to be fixed here.

Same class of fix as #14485 / #14074 / #14137.

## Change

Lockfile-only bump of the bundled `qs` (`6.15.2` → `6.16.0`) in `npm-packages/meteor-node-stubs/package-lock.json`, produced with `npm update qs --package-lock-only`. It also pulls in `side-channel@1.1.1` and `side-channel-list@1.0.1`. `qs@6.16.0` adds `es-define-property` as a direct dependency; it was already bundled as a transitive dependency, so the set of bundled packages is unchanged.

As in #14485, the `meteor-node-stubs` version bump and the skeleton `package.json` updates are left to the release process.
