### PR TITLE
Bump meteor-node-stubs to 1.2.30

### DIFF
--- a/npm-packages/meteor-node-stubs/package-lock.json
+++ b/npm-packages/meteor-node-stubs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meteor-node-stubs",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meteor-node-stubs",
-      "version": "1.2.29",
+      "version": "1.2.30",
       "bundleDependencies": [
         "@meteorjs/crypto-browserify",
         "assert",

--- a/npm-packages/meteor-node-stubs/package.json
+++ b/npm-packages/meteor-node-stubs/package.json
@@ -2,7 +2,7 @@
   "name": "meteor-node-stubs",
   "author": "Ben Newman <ben@meteor.com>",
   "description": "Stub implementations of Node built-in modules, a la Browserify",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "main": "index.js",
   "license": "MIT",
   "homepage": "https://github.com/meteor/meteor/blob/devel/npm-packages/meteor-node-stubs/README.md",

--- a/tools/static-assets/skel-angular/package.json
+++ b/tools/static-assets/skel-angular/package.json
@@ -16,7 +16,7 @@
     "@angular/router": "^20.0.0",
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "rxjs": "^7.8.1",
     "zone.js": "^0.15.1"
   },

--- a/tools/static-assets/skel-apollo/package.json
+++ b/tools/static-assets/skel-apollo/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.23.9",
     "@swc/helpers": "^0.5.17",
     "graphql": "^16.8.1",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/static-assets/skel-babel/package.json
+++ b/tools/static-assets/skel-babel/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/static-assets/skel-bare/package.json
+++ b/tools/static-assets/skel-bare/package.json
@@ -6,6 +6,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
-    "meteor-node-stubs": "^1.2.29"
+    "meteor-node-stubs": "^1.2.30"
   }
 }

--- a/tools/static-assets/skel-blaze/package.json
+++ b/tools/static-assets/skel-blaze/package.json
@@ -11,7 +11,7 @@
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
     "jquery": "^3.7.1",
-    "meteor-node-stubs": "^1.2.29"
+    "meteor-node-stubs": "^1.2.30"
   },
   "devDependencies": {
     "@meteorjs/rspack": "^2.2.0-beta.1",

--- a/tools/static-assets/skel-chakra-ui/package.json
+++ b/tools/static-assets/skel-chakra-ui/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "^11.9.3",
     "@react-icons/all-files": "^4.1.0",
     "framer-motion": "^6.4.2",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/static-assets/skel-coffeescript/package.json
+++ b/tools/static-assets/skel-coffeescript/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/static-assets/skel-full/package.json
+++ b/tools/static-assets/skel-full/package.json
@@ -9,7 +9,7 @@
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
     "jquery": "^3.7.1",
-    "meteor-node-stubs": "^1.2.29"
+    "meteor-node-stubs": "^1.2.30"
   },
   "devDependencies": {
     "@meteorjs/rspack": "^2.2.0-beta.1",

--- a/tools/static-assets/skel-legacy/package.json
+++ b/tools/static-assets/skel-legacy/package.json
@@ -11,7 +11,7 @@
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
     "jquery": "^3.7.1",
-    "meteor-node-stubs": "^1.2.29"
+    "meteor-node-stubs": "^1.2.30"
   },
   "meteor": {
     "mainModule": {

--- a/tools/static-assets/skel-minimal/package.json
+++ b/tools/static-assets/skel-minimal/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29"
+    "meteor-node-stubs": "^1.2.30"
   },
   "meteor": {
     "mainModule": {

--- a/tools/static-assets/skel-react/package.json
+++ b/tools/static-assets/skel-react/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/static-assets/skel-solid/package.json
+++ b/tools/static-assets/skel-solid/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.9",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/tools/static-assets/skel-svelte/package.json
+++ b/tools/static-assets/skel-svelte/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29"
+    "meteor-node-stubs": "^1.2.30"
   },
   "devDependencies": {
     "@meteorjs/rspack": "^2.2.0-beta.1",

--- a/tools/static-assets/skel-tailwind/package.json
+++ b/tools/static-assets/skel-tailwind/package.json
@@ -11,7 +11,7 @@
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
     "autoprefixer": "^10.4.4",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/tools/static-assets/skel-typescript-tailwind/package.json
+++ b/tools/static-assets/skel-typescript-tailwind/package.json
@@ -12,7 +12,7 @@
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
     "autoprefixer": "^10.4.4",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/static-assets/skel-typescript/package.json
+++ b/tools/static-assets/skel-typescript/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/tools/static-assets/skel-vue/package.json
+++ b/tools/static-assets/skel-vue/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@swc/helpers": "^0.5.17",
-    "meteor-node-stubs": "^1.2.29",
+    "meteor-node-stubs": "^1.2.30",
     "vue": "^3.3.9",
     "vue-meteor-tracker": "^3.0.0-beta.7",
     "vue-router": "^4.2.5"

--- a/v3-docs/docs/generators/changelog/versions/3.5.2.md
+++ b/v3-docs/docs/generators/changelog/versions/3.5.2.md
@@ -1,4 +1,4 @@
-## v3.5.2-rc.0, 2026-08-28
+## v3.5.2-rc.0, 2026-09-03
 
 ### Highlights
 
@@ -11,6 +11,7 @@
 - Add a shared `tools-core` dependency manager and let Rspack install required npm dependencies automatically, with actionable instructions when automatic installation is disabled, [PR#14492](https://github.com/meteor/meteor/pull/14492).
 - Upgrade to Cordova CLI 13 and `cordova-android@15.1.0`, update Android native testing, and preserve local Cordova plugin paths containing encoded or reserved characters, [PR#14487](https://github.com/meteor/meteor/pull/14487).
 - Update `meteor-node-stubs` to 1.2.29 with bundled `qs@6.15.2` to address [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26), [PR#14485](https://github.com/meteor/meteor/pull/14485), issue [#14484](https://github.com/meteor/meteor/issues/14484).
+- Update `meteor-node-stubs` to 1.2.30 with bundled `qs@6.16.0` to address [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) and [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx), [PR#14708](https://github.com/meteor/meteor/pull/14708), issue [#14707](https://github.com/meteor/meteor/issues/14707).
 - Expose the HttpOnly cookie endpoints only when `useHttpOnlyCookies` is enabled and reject oversized request bodies, [PR#14657](https://github.com/meteor/meteor/pull/14657), issue [#14654](https://github.com/meteor/meteor/issues/14654).
 - Prevent change stream observers from replaying events already covered by a causal primary snapshot, avoiding intermittent login disconnects, [PR#14697](https://github.com/meteor/meteor/pull/14697), issue [#14695](https://github.com/meteor/meteor/issues/14695).
 - Redact credentials from invalid `MONGO_URL` warnings and respect the connection string's TLS settings during the startup compatibility check, [PR#14658](https://github.com/meteor/meteor/pull/14658), issue [#14400](https://github.com/meteor/meteor/issues/14400).
@@ -64,7 +65,7 @@ Package tests that need jQuery must declare it explicitly or run with `--extra-p
 #### Bumped NPM Packages
 
 - @meteorjs/rspack@2.2.0-beta.1
-- meteor-node-stubs@1.2.29
+- meteor-node-stubs@1.2.30
 
 #### Special thanks to
 


### PR DESCRIPTION
## Summary

- bump meteor-node-stubs package and lockfile metadata to 1.2.30
- update all 17 project skeletons to require meteor-node-stubs ^1.2.30
- document the qs 6.16.0 security update in the Meteor 3.5.2 changelog

meteor-node-stubs@1.2.30 is already published on npm and includes the bundled qs@6.16.0 fix from #14708.

Closes #14707.

## Verification

- parsed and asserted all updated package JSON files
- confirmed all 17 skeleton references use ^1.2.30
- confirmed the lockfile retains qs@6.16.0
- npm pack --dry-run --ignore-scripts: 1,396 files and 106 bundled dependencies, including qs
- npm audit --omit=dev: 0 vulnerabilities
- npm run fmt:check
- npm run lint
- git diff --check