### PR TITLE
Fix Windows Mongo troubleshooting link

### DIFF
--- a/tools/runners/run-mongo.js
+++ b/tools/runners/run-mongo.js
@@ -995,7 +995,7 @@ Object.assign(MRp, {
       message +=
         '\n\n' +
         'Check how to troubleshoot here ' +
-        'https://docs.meteor.com/windows.html#cant-start-mongo-server';
+        'https://v2-docs.meteor.com/windows.html#cant-start-mongo-server';
     }
 
     if (explanation && explanation.symbol === 'EXIT_NET_ERROR') {


### PR DESCRIPTION
The Windows mongo-failed-to-start message pointed at docs.meteor.com/windows.html#cant-start-mongo-server, which 404s. Switched it to the v2 docs URL that returns 200.

Fixes #14571.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Windows MongoDB startup troubleshooting link to the current documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->