### PR TITLE
Document that Meteor.user() may be undefined

### DIFF
--- a/docs/source/api/accounts.md
+++ b/docs/source/api/accounts.md
@@ -48,6 +48,10 @@ client). By default the server publishes `username`, `emails`, and
 `profile` (writable by user). See [`Meteor.users`](#meteor_users) for more on
 the fields used in user documents.
 
+On the client, `Meteor.user()` returns `null` when no user is logged in.
+It can also return `undefined` when a user id is set but the matching
+document is not yet in Minimongo, for example during login or logout.
+
 On the server, this will fetch the record from the database. To improve the
 latency of a method that uses the user document multiple times, save the
 returned record to a variable instead of re-calling `Meteor.user()`.

--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -164,7 +164,7 @@ export class AccountsCommon {
   }
 
   /**
-   * @summary Get the current user record, or `null` if no user is logged in. A reactive data source. In the server this fuction returns a promise.
+   * @summary Get the current user record, or `null` if no user is logged in. On the client this can also be `undefined` while a user id is set but the user document is not yet in Minimongo. A reactive data source. In the server this fuction returns a promise.
    * @locus Anywhere
    * @param {Object} [options]
    * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
@@ -189,7 +189,7 @@ export class AccountsCommon {
   }
 
   /**
-   * @summary Get the current user record, or `null` if no user is logged in.
+   * @summary Get the current user record, or `null` if no user is logged in. May also be `undefined` when a user id is set but the user document cannot be found yet.
    * @locus Anywhere
    * @param {Object} [options]
    * @param {MongoFieldSpecifier} options.fields Dictionary of fields to return or exclude.
@@ -434,7 +434,7 @@ export class AccountsCommon {
 Meteor.userId = () => Accounts.userId();
 
 /**
- * @summary Get the current user record, or `null` if no user is logged in. A reactive data source.
+ * @summary Get the current user record, or `null` if no user is logged in. On the client this can also be `undefined` while a user id is set but the user document is not yet in Minimongo. A reactive data source.
  * @locus Anywhere
  * @importFromPackage meteor
  * @param {Object} [options]
@@ -443,7 +443,7 @@ Meteor.userId = () => Accounts.userId();
 Meteor.user = options => Accounts.user(options);
 
 /**
- * @summary Get the current user record, or `null` if no user is logged in. A reactive data source.
+ * @summary Get the current user record, or `null` if no user is logged in. May also be `undefined` when a user id is set but the user document cannot be found yet. A reactive data source.
  * @locus Anywhere
  * @importFromPackage meteor
  * @param {Object} [options]


### PR DESCRIPTION
`Meteor.user()` is documented as `User | null`, but on the client `findOne` returns `undefined` when a user id is set and the document is not in Minimongo yet.

Updated the Accounts / Meteor.user docs and JSDoc to mention that case.

Fixes #11820


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that client-side `Meteor.user()` and `Meteor.userAsync()` may return `undefined` when a user ID exists but the corresponding user record is not yet available.
  - Documented that these methods return `null` when no user is logged in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->