### PR TITLE
Document that Meteor apps need a main function

### DIFF
--- a/docs/source/api/core.md
+++ b/docs/source/api/core.md
@@ -47,8 +47,8 @@ if (Meteor.isServer) {
 
 Every Meteor server process also needs a `main` function. The `webapp`
 package supplies one that starts the HTTP server. Apps that omit `webapp`
-must export their own `main`, or startup exits with
-`Program has no main() function.`
+must provide their own `main` as a package export or on the global object,
+or startup exits with `Program has no main() function.`
 
 {% apibox "Meteor.wrapAsync" %}
 

--- a/docs/source/api/core.md
+++ b/docs/source/api/core.md
@@ -45,6 +45,11 @@ if (Meteor.isServer) {
 }
 ```
 
+Every Meteor server process also needs a `main` function. The `webapp`
+package supplies one that starts the HTTP server. Apps that omit `webapp`
+must export their own `main`, or startup exits with
+`Program has no main() function.`
+
 {% apibox "Meteor.wrapAsync" %}
 
 {% apibox "Meteor.defer" %}

--- a/docs/source/packages/webapp.md
+++ b/docs/source/packages/webapp.md
@@ -11,9 +11,10 @@ tool that still used the Meteor package system and DDP.
 
 Every Meteor server process must provide a `main` function. `webapp`
 defines that function and starts the HTTP server. Apps that do not use
-`webapp` need to export their own `main` (as a package export or a global),
+`webapp` need to provide their own `main` (as a package export or a global),
 or the process exits with `Program has no main() function.` Returning the
-string `'DAEMON'` from `main` keeps the process alive after `main` returns.
+string `'DAEMON'` from `main` prevents the bootstrap from exiting the
+process after `main` returns.
 
 This package also allows you to add handlers for HTTP requests.
 This lets other services access your app's data through an HTTP API, allowing

--- a/docs/source/packages/webapp.md
+++ b/docs/source/packages/webapp.md
@@ -9,6 +9,12 @@ automatically added when you run `meteor create`. You can easily build a
 Meteor app without it - for example if you wanted to make a command-line
 tool that still used the Meteor package system and DDP.
 
+Every Meteor server process must provide a `main` function. `webapp`
+defines that function and starts the HTTP server. Apps that do not use
+`webapp` need to export their own `main` (as a package export or a global),
+or the process exits with `Program has no main() function.` Returning the
+string `'DAEMON'` from `main` keeps the process alive after `main` returns.
+
 This package also allows you to add handlers for HTTP requests.
 This lets other services access your app's data through an HTTP API, allowing
 it to easily interoperate with tools and frameworks that don't yet support DDP.


### PR DESCRIPTION
Every server process needs a `main` function. `webapp` provides one. Apps that omit `webapp` have to export their own or they exit with `Program has no main() function.`

Fixes #12320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that every Meteor server process requires a `main` function.
  * Documented that the `webapp` package provides this function and starts the HTTP server.
  * Explained how applications without `webapp` can provide a custom `main` function.
  * Documented the startup error shown when no `main` function is available.
  * Clarified that returning `'DAEMON'` prevents the startup process from exiting after `main` returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->