### PR TITLE
ci: probe upstream services at the start of every PR run

### DIFF
--- a/.github/workflows/upstream-services.yml
+++ b/.github/workflows/upstream-services.yml
@@ -1,0 +1,23 @@
+name: Upstream Services
+
+# Probes the external services the other workflows download from (npm
+# registry and audit, Meteor dev bundle, Atmosphere, GitHub, Docker apt repo)
+# and reports them in the job summary. When this check is red, failures in
+# the other checks of the same run are most likely external: see
+# scripts/ci/check-upstream-services.sh.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  probe:
+    name: Upstream services
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Probe upstream services
+        run: bash scripts/ci/check-upstream-services.sh

--- a/.github/workflows/upstream-services.yml
+++ b/.github/workflows/upstream-services.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# The job only reads the checkout and talks to public endpoints.
+permissions:
+  contents: read
+
 jobs:
   probe:
     name: Upstream services
@@ -18,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Probe upstream services
         run: bash scripts/ci/check-upstream-services.sh

--- a/scripts/ci/check-upstream-services.sh
+++ b/scripts/ci/check-upstream-services.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Probes the external services CI downloads from and reports them in the job
+# summary, so a run that goes red for an external reason says so up front
+# instead of looking like a broken branch. Exits 1 when a critical service is
+# down; slowness is a warning, except for npm audit, which every npm install
+# waits for.
+#
+# Usage: scripts/ci/check-upstream-services.sh   (curl only; no Meteor needed)
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BUNDLE_VERSION="$(sed -n 's/^BUNDLE_VERSION=//p' "$ROOT/meteor" | head -1)"
+# Same tarball name the ./meteor script downloads (PLATFORM="${UNAME}_${ARCH}").
+DEV_BUNDLE_URL="https://d3sqy0vbqsdhku.cloudfront.net/dev_bundle_$(uname -s)_$(uname -m)_${BUNDLE_VERSION}.tar.gz"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+SLOW_MS=5000
+failures=0
+rows=""
+
+# probe <critical|optional> <name> <method> <url> [json body] [timeout s] [slow-is-failure]
+probe() {
+  local level="$1" name="$2" method="$3" url="$4" body="${5:-}" timeout="${6:-20}" slow_fails="${7:-no}"
+  local out code secs ms status detail
+  # HEAD goes through -I: with -X HEAD curl waits for a body that never comes.
+  if [ "$method" = "HEAD" ]; then
+    out="$(curl -sS -o /dev/null -m "$timeout" -I -w '%{http_code} %{time_total}' "$url" 2>/dev/null)" || true
+  elif [ -n "$body" ]; then
+    out="$(curl -sS -o /dev/null -m "$timeout" -X "$method" -H 'content-type: application/json' -d "$body" -w '%{http_code} %{time_total}' "$url" 2>/dev/null)" || true
+  else
+    out="$(curl -sS -o /dev/null -m "$timeout" -X "$method" -w '%{http_code} %{time_total}' "$url" 2>/dev/null)" || true
+  fi
+  code="${out%% *}"; secs="${out##* }"
+  ms="$(awk -v s="${secs:-0}" 'BEGIN { printf "%d", s * 1000 }')"
+
+  if [ -z "$code" ] || [ "$code" = "000" ]; then
+    status="down"; detail="no response within ${timeout}s"
+  elif [ "$code" -ge 500 ]; then
+    status="down"; detail="HTTP $code"
+  elif [ "$code" -ge 400 ]; then
+    status="down"; detail="HTTP $code (probe URL may be stale)"
+  elif [ "$ms" -gt "$SLOW_MS" ]; then
+    status="slow"; detail="HTTP $code in ${ms} ms"
+  else
+    status="ok"; detail="HTTP $code in ${ms} ms"
+  fi
+
+  case "$status" in
+    ok) icon="✅" ;;
+    slow)
+      if [ "$slow_fails" = "yes" ] && [ "$level" = "critical" ]; then
+        icon="❌"; failures=$((failures + 1))
+        echo "::error title=$name::slow ($detail) - every npm install waits for this"
+      else
+        icon="⚠️"; echo "::warning title=$name::$detail"
+      fi ;;
+    down)
+      if [ "$level" = "critical" ]; then
+        icon="❌"; failures=$((failures + 1)); echo "::error title=$name::$detail"
+      else
+        icon="⚠️"; echo "::warning title=$name::$detail (not blocking)"
+      fi ;;
+  esac
+
+  printf '%s %-34s %-6s %s\n' "$icon" "$name" "$method" "$detail"
+  rows="$rows| $icon | $name | \`$method $url\` | $detail |
+"
+}
+
+echo "Probing upstream services (BUNDLE_VERSION=$BUNDLE_VERSION)"
+
+probe critical "npm registry: ping"        GET  https://registry.npmjs.org/-/ping
+probe critical "npm registry: packument"   GET  https://registry.npmjs.org/lodash
+probe critical "npm registry: tarball"     HEAD https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz
+probe critical "npm audit (advisories)"    POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk '{"lodash":["4.17.21"]}' 20 yes
+probe critical "Meteor dev bundle (CloudFront)" HEAD "$DEV_BUNDLE_URL"
+probe critical "Atmosphere (packages.meteor.com)" GET https://packages.meteor.com/sockjs/info
+probe critical "GitHub (git dependencies)" HEAD https://github.com/unetworking/uWebSockets.js
+probe critical "GitHub raw (examples.json)" GET https://raw.githubusercontent.com/meteor/examples/main/examples.json
+probe critical "Docker apt repo (E2E runners)" HEAD https://download.docker.com/linux/debian/dists/bookworm/Release
+
+{
+  echo "### Upstream services"
+  echo
+  echo "| | Service | Probe | Result |"
+  echo "|---|---|---|---|"
+  printf '%s' "$rows"
+  echo
+  if [ "$failures" -gt 0 ]; then
+    echo "**$failures critical service(s) unavailable.** Failures in the other checks of this run are probably external; retrigger once the table is green."
+  else
+    echo "All critical services reachable when this run started."
+  fi
+} >> "$SUMMARY"
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures critical service(s) unavailable"
+  exit 1
+fi
+echo "All critical services reachable"


### PR DESCRIPTION
_Problem encountered while developing an application. This pull request was written and opened by Claude Code, after review by the author._

## Summary

Adds an `Upstream services` check that probes the external services the other workflows download from and reports them in the job summary. When it is red, failures in the other checks of the same run are most likely external.

Context: on 2026-09-03/04 npm's audit backend stopped answering while status.npmjs.org stayed green (npm/cli#9950), the Actions cache had been evicted, and every cold E2E job on #14473 spent its 60 minutes in "Prepare Meteor" waiting for audit round-trips. It looked like a broken branch first, then like Atmosphere (#14710). This check would have named the culprit in the first 20 seconds of the run.

## What it probes

| Service | Probe |
|---|---|
| npm registry | ping, packument, tarball |
| npm audit | `POST /-/npm/v1/security/advisories/bulk`; red when down or slower than 5 s, since every `npm install` waits for it |
| Meteor dev bundle | the CloudFront tarball for the branch's `BUNDLE_VERSION`, same name `./meteor` downloads |
| Atmosphere | `GET packages.meteor.com/sockjs/info` |
| GitHub | repository reachability (git dependencies such as uWebSockets.js) and `raw.githubusercontent.com` (`examples.json`) |
| Docker apt repo | the Release file the E2E runners install the Docker CLI from |

One job on `ubuntu-latest`, curl only, a few seconds when everything answers and at most 20 s per hanging probe. Red only for critical services; slowness is a warning, except for npm audit. The job summary carries the table with response times. It does not gate the other workflows: they keep running, the check just explains their failures.

## Verified

- Run locally during the npm incident: the audit probe goes red (no response within 20 s) while everything else is green, which matches what the E2E runs experienced.
- Run with a healthy audit endpoint: all green, audit answering in 1.6 s.
- Failure path with a bogus URL: `::error` annotation, exit 1, summary table still written.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated monitoring for external services required during continuous integration.
  * Checks now report service health, response times, and availability in workflow summaries.
  * Added pull-request and manually triggered service checks with restricted permissions.
  * CI reports warnings for optional slowness and fails when critical services are unavailable or fail health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->