### PR TITLE
ci: benchmark Test Tools devel baseline 2026-09-08

### DIFF
--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,4 +1,5 @@
 name: Test Tools
+# Benchmark trigger: 2026-09-08
 
 on:
   pull_request:


### PR DESCRIPTION
Temporary baseline for a CI benchmark. Changes only an inert workflow comment and will be closed after collection.