### PR TITLE
fix(rspack): gate the config dump on isVerbose rather than isDebug

### DIFF
--- a/npm-packages/meteor-rspack/rspack.config.js
+++ b/npm-packages/meteor-rspack/rspack.config.js
@@ -445,7 +445,7 @@ module.exports = async function (inMeteor = {}, argv = {}) {
     ],
   };
 
-  if (Meteor.isDebug || Meteor.isVerbose) {
+  if (Meteor.isVerbose) {
     console.log("[i] Rspack mode:", mode);
     console.log("[i] Meteor flags:", Meteor);
   }
@@ -909,8 +909,8 @@ module.exports = async function (inMeteor = {}, argv = {}) {
 
   delete config["meteor.enablePortableBuild"];
 
-  if (Meteor.isDebug || Meteor.isVerbose) {
-  console.log("Config:", inspect(config, { depth: null, colors: true }));
+  if (Meteor.isVerbose) {
+    console.log("Config:", inspect(config, { depth: null, colors: true }));
   }
 
   // Check if lazyCompilation is enabled and warn the user


### PR DESCRIPTION
Fixes #14731.

`--inspect` should attach a debugger, not change build logging. Right now it does both.

Two `console.log`s in `npm-packages/meteor-rspack/rspack.config.js` are gated on `Meteor.isDebug || Meteor.isVerbose`, and `isDebug` comes from the command options rather than from config — `tools-core`'s `isMeteorAppDebug()` returns true for `--inspect`, `--debug` and `--inspect-brk`. So running `meteor run --inspect=9239` prints the entire `Meteor` flag object plus the whole rspack config (`inspect(config, { depth: null })`), once per bundle and again on every rebuild, and there is no app-level way to turn it off.

This moves both gates to `isVerbose` alone. That flag is already declared in the same file (`const isVerbose = !!Meteor.isVerbose;`) and already decides how chatty the build is:

```js
const shouldLogVerbose = isProfile || isVerbose;
const loggingConfig = shouldLogVerbose
  ? {}
  : { stats: "errors-warnings", infrastructureLogging: { level: "warn" } };
```

so `meteor.modern.verbose` in `package.json` becomes the single switch for build output, and anyone who wants the dump while debugging the build can still set it.

The second hunk also fixes the indentation of the `console.log` inside that block.

### Verification

Applied to a real app (Meteor 3.5.2, `@meteorjs/rspack` 2.2.0) and run with `meteor run --inspect=9239`:

| | before | after |
|---|---:|---:|
| `Meteor flags:` dump | 1 | **0** |
| `Config:` dump | 1 | **0** |
| `Debugger listening` | 1 | 1 |
| dev-server startup lines | several hundred | **46** |

The app boots normally and the debugger still attaches.

### Note

The same conflation exists in `packages/rspack/rspack_plugin.js`, where about eight `[i]` lines (npx/npm/yarn prefixes, app ignores, entrypoints, config paths, devserver port) are gated on `isMeteorAppDebug() || isMeteorAppConfigModernVerbose()`. Those are single lines rather than full object dumps, so I left them out to keep this reviewable — happy to move them in the same PR if you'd prefer consistency.
