### PR TITLE
fix(mongo): align Change Streams cursor support with the oplog driver

### DIFF
--- a/packages/mongo/mongo_connection.js
+++ b/packages/mongo/mongo_connection.js
@@ -1158,6 +1158,15 @@ MongoConnection.prototype._observeChanges = async function (
             };
           }
 
+          // $where/$near are re-matched locally on live events and can
+          // diverge from the snapshot; oplog declines them for the same reason.
+          if (localMatcher.hasWhere() || localMatcher.hasGeoQuery()) {
+            return {
+              available: false,
+              reason: 'Selector with $where or $near not supported by Change Streams',
+            };
+          }
+
           return {
             available: true,
             matcher: localMatcher,

--- a/packages/mongo/tests/changestream_observe_driver_tests.js
+++ b/packages/mongo/tests/changestream_observe_driver_tests.js
@@ -90,6 +90,34 @@ if (!IS_CHANGESTREAM) {
 }
 
 // ============================================================================
+// CURSOR SUPPORT TESTS
+// ============================================================================
+
+// $where/$near must fall back, like oplog's cursorSupported already does.
+Tinytest.addAsync(
+  'changestream - cursorSupported rejects $where and $near',
+  async function (test) {
+    // Never written to: the fallback's server-side find only evaluates
+    // $where / $near once the namespace exists.
+    const c = makeCollection();
+
+    const supported = async function (expected, selector) {
+      const handle = await c.find(selector).observeChanges({ added() {} });
+      test.equal(isChangeStreamDriver(handle), expected, EJSON.stringify(selector));
+      handle.stop();
+    };
+
+    await supported(true, { foo: 'asdf' });
+    await supported(true, { $and: [{ foo: 'asdf' }, { bar: 'baz' }] });
+
+    await supported(false, { $where: 'xxx' });
+    await supported(false, { $and: [{ foo: 'adsf' }, { $where: 'xxx' }] });
+    await supported(false, { foo: 'fn', $where() { return true; } });
+    await supported(false, { x: { $near: [1, 1] } });
+  }
+);
+
+// ============================================================================
 // BASIC CRUD OPERATIONS TESTS
 // ============================================================================
 

--- a/v3-docs/docs/performance/change-streams-observer-driver.md
+++ b/v3-docs/docs/performance/change-streams-observer-driver.md
@@ -11,7 +11,7 @@ Before moving production traffic to Change Streams, validate that your MongoDB d
 - MongoDB 6+ on a replica set or sharded cluster (Change Streams are not available on standalone or some shared-tier deployments).
 - Works only for unordered observers. Publications that rely on ordered callbacks (`addedBefore`, `movedBefore`) will keep using another driver.
 - Selectors must compile with `Minimongo.Matcher`. Unsupported selectors fall back to the next configured driver.
-- Cursors using `$where` or `$near` selectors, `skip`/`limit`, or projections Minimongo cannot apply are handed to the next configured driver, following the same rules as oplog tailing: live change events are re-matched locally by Minimongo, which cannot evaluate those the way MongoDB does.
+- Cursors with `skip` or `limit`, projections Minimongo cannot apply, or `$where`/`$near` selectors are handed to the next configured driver. Live change events are re-matched locally by Minimongo, which cannot evaluate `$where`/`$near` the way MongoDB does; oplog tailing declines those selectors for the same reason.
 - If Change Streams are unavailable, Meteor automatically moves to the next driver in your configured order.
 
 ## Choosing the Reactivity Driver Order

--- a/v3-docs/docs/performance/change-streams-observer-driver.md
+++ b/v3-docs/docs/performance/change-streams-observer-driver.md
@@ -11,6 +11,7 @@ Before moving production traffic to Change Streams, validate that your MongoDB d
 - MongoDB 6+ on a replica set or sharded cluster (Change Streams are not available on standalone or some shared-tier deployments).
 - Works only for unordered observers. Publications that rely on ordered callbacks (`addedBefore`, `movedBefore`) will keep using another driver.
 - Selectors must compile with `Minimongo.Matcher`. Unsupported selectors fall back to the next configured driver.
+- Cursors using `$where` or `$near` selectors, `skip`/`limit`, or projections Minimongo cannot apply are handed to the next configured driver, following the same rules as oplog tailing: live change events are re-matched locally by Minimongo, which cannot evaluate those the way MongoDB does.
 - If Change Streams are unavailable, Meteor automatically moves to the next driver in your configured order.
 
 ## Choosing the Reactivity Driver Order


### PR DESCRIPTION
The Change Streams driver re-matches live change events locally with Minimongo, while the initial snapshot comes from MongoDB. For `$where` and `$near` those two evaluations can differ, which is why oplog tailing has always declined such cursors in `cursorSupported`. The Change Streams check mirrored oplog's `skip`/`limit` and projection rules but not this one, so the two drivers accepted different cursors.

This adds the missing rule. Both drivers now apply the same cursor-support checks.

## Changes

- `mongo_connection.js`: the Change Streams check declines a cursor when `matcher.hasWhere() || matcher.hasGeoQuery()`, the predicate oplog already uses. Such cursors fall back to the next configured driver.
- Test: `changestream - cursorSupported rejects $where and $near`, mirroring `mongo-livedata - oplog - cursorSupported`.
- Docs: the Change Streams limitations list now names `$where`/`$near`.

## Testing

`METEOR_REACTIVITY_ORDER=changeStreams,polling TINYTEST_FILTER=changestream ./packages/test-in-console/run.sh mongo`

## Changelog

- Change Streams: fall back to the next driver for `$where`/`$near` cursors, matching the oplog driver.

Related: #14734 gates the string form of `$where` on the server (same `$where` handling).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Queries using `$where` or `$near` selectors now use a compatible fallback driver instead of the change-stream driver, improving result consistency.
  - Unsupported queries are no longer re-matched locally from change-stream events.

- **Documentation**
  - Clarified change-stream observer limitations for `$where`/`$near` selectors, pagination, and projections, including how unsupported queries are handed off to another configured driver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->