### PR TITLE
fix(minimongo): gate the string form of $where on the server behind a setting

### DIFF
--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -3,6 +3,27 @@ import LocalCollection from './local_collection.js';
 export const hasOwn = Object.prototype.hasOwnProperty;
 
 export class MiniMongoQueryError extends Error {}
+
+// Whether the string form of $where is allowed on the server (default: off;
+// see the $where operator). `undefined` defers to the
+// Meteor.settings.packages.minimongo.allowStringWhere setting.
+let _allowStringWhereOverride;
+
+export function _setAllowStringWhere(value) {
+  _allowStringWhereOverride = value === undefined ? undefined : !!value;
+}
+
+export function _getAllowStringWhere() {
+  return _allowStringWhereOverride;
+}
+
+function stringWhereAllowedOnServer() {
+  if (_allowStringWhereOverride !== undefined) {
+    return _allowStringWhereOverride;
+  }
+
+  return !!Meteor.settings?.packages?.minimongo?.allowStringWhere;
+}
 // Each element selector contains:
 //  - compileElementSelector, a function with args:
 //    - operand - the "right hand side" of the operator
@@ -304,6 +325,18 @@ const LOGICAL_OPERATORS = {
     matcher._hasWhere = true;
 
     if (!(selectorValue instanceof Function)) {
+      // The string form compiles to Function() and runs in the server process,
+      // so it only suits trusted selectors. Off by default on the server; opt
+      // in with the setting below.
+      if (Meteor.isServer && !stringWhereAllowedOnServer()) {
+        throw new MiniMongoQueryError(
+          'A string argument to $where is disabled on the server by default. ' +
+          'Use the function form ({ $where() { return ... } }), or set ' +
+          'Meteor.settings.packages.minimongo.allowStringWhere to true to ' +
+          'enable it.'
+        );
+      }
+
       // XXX MongoDB seems to have more complex logic to decide where or or not
       // to add 'return'; not sure exactly what it is.
       selectorValue = Function('obj', `return ${selectorValue}`);

--- a/packages/minimongo/common.js
+++ b/packages/minimongo/common.js
@@ -10,7 +10,7 @@ export class MiniMongoQueryError extends Error {}
 let _allowStringWhereOverride;
 
 export function _setAllowStringWhere(value) {
-  _allowStringWhereOverride = value === undefined ? undefined : !!value;
+  _allowStringWhereOverride = value === undefined ? undefined : value === true;
 }
 
 export function _getAllowStringWhere() {
@@ -22,7 +22,7 @@ function stringWhereAllowedOnServer() {
     return _allowStringWhereOverride;
   }
 
-  return !!Meteor.settings?.packages?.minimongo?.allowStringWhere;
+  return Meteor.settings?.packages?.minimongo?.allowStringWhere === true;
 }
 // Each element selector contains:
 //  - compileElementSelector, a function with args:

--- a/packages/minimongo/minimongo_common.js
+++ b/packages/minimongo/minimongo_common.js
@@ -1,10 +1,13 @@
 import LocalCollection_ from './local_collection.js';
 import Matcher from './matcher.js';
 import Sorter from './sorter.js';
+import { _setAllowStringWhere, _getAllowStringWhere } from './common.js';
 
 LocalCollection = LocalCollection_;
 Minimongo = {
     LocalCollection: LocalCollection_,
     Matcher,
-    Sorter
+    Sorter,
+    _setAllowStringWhere,
+    _getAllowStringWhere,
 };

--- a/packages/minimongo/minimongo_tests_server.js
+++ b/packages/minimongo/minimongo_tests_server.js
@@ -567,3 +567,40 @@ Tinytest.add('minimongo - sorter and projection combination', test => {
     T({ a: { $ne: { a: 2 } } }, { $set: { a: { a: 2 } } }, '$ne object');
   });
 }))();
+
+
+Tinytest.add(
+  'minimongo - $where string is refused on the server by default',
+  test => {
+    // Function form is always allowed (cannot arrive over DDP).
+    const fnMatcher = new Minimongo.Matcher({ $where() { return this.a === 1; } });
+    test.isTrue(fnMatcher.documentMatches({ a: 1 }).result);
+    test.isFalse(fnMatcher.documentMatches({ a: 2 }).result);
+
+    // String form is refused by default on the server.
+    test.throws(
+      () => new Minimongo.Matcher({ $where: 'this.a === 1' }),
+      /string argument to \$where is disabled/
+    );
+
+    const coll = new LocalCollection();
+    test.throws(
+      () => coll.find({ $where: 'true' }),
+      /string argument to \$where is disabled/
+    );
+
+    Minimongo._setAllowStringWhere(true);
+    try {
+      const strMatcher = new Minimongo.Matcher({ $where: 'this.a === 1' });
+      test.isTrue(strMatcher.documentMatches({ a: 1 }).result);
+      test.isFalse(strMatcher.documentMatches({ a: 2 }).result);
+    } finally {
+      Minimongo._setAllowStringWhere(undefined);
+    }
+
+    test.throws(
+      () => new Minimongo.Matcher({ $where: 'this.a === 1' }),
+      /disabled/
+    );
+  }
+);

--- a/packages/minimongo/minimongo_tests_server.js
+++ b/packages/minimongo/minimongo_tests_server.js
@@ -602,5 +602,28 @@ Tinytest.add(
       () => new Minimongo.Matcher({ $where: 'this.a === 1' }),
       /disabled/
     );
+
+    // Enabled through Meteor.settings, with no runtime override.
+    const previousPackages = Meteor.settings.packages;
+    Meteor.settings.packages = {
+      ...previousPackages,
+      minimongo: { ...previousPackages?.minimongo, allowStringWhere: true },
+    };
+    try {
+      const settingsMatcher = new Minimongo.Matcher({ $where: 'this.a === 1' });
+      test.isTrue(settingsMatcher.documentMatches({ a: 1 }).result);
+      test.isFalse(settingsMatcher.documentMatches({ a: 2 }).result);
+    } finally {
+      if (previousPackages === undefined) {
+        delete Meteor.settings.packages;
+      } else {
+        Meteor.settings.packages = previousPackages;
+      }
+    }
+
+    test.throws(
+      () => new Minimongo.Matcher({ $where: 'this.a === 1' }),
+      /disabled/
+    );
   }
 );

--- a/v3-docs/docs/api/collections.md
+++ b/v3-docs/docs/api/collections.md
@@ -1111,6 +1111,41 @@ But they can also contain more complicated tests:
 
 See the [complete documentation](https://www.mongodb.com/docs/manual/reference/operator/).
 
+### The `$where` operator {#where}
+
+`$where` matches documents against a JavaScript predicate. It accepts either a
+function or a string:
+
+```js
+// Function form — written in your app source.
+Posts.find({ $where() { return this.score > this.threshold; } });
+
+// String form — compiled and evaluated as JavaScript.
+Posts.find({ $where: 'this.score > this.threshold' });
+```
+
+On the **server**, the string form is compiled with `Function()` and runs in
+the server process, so it is only appropriate for selectors your own code
+controls. It is therefore **disabled on the server by default** — mirroring
+MongoDB's own `security.javascriptEnabled` — and Minimongo throws if a string
+`$where` reaches the server. The function form is unaffected and always works.
+
+To use the string form for trusted selectors, enable it explicitly:
+
+```json
+// settings.json
+{
+  "packages": {
+    "minimongo": {
+      "allowStringWhere": true
+    }
+  }
+}
+```
+
+Run with `meteor run --settings settings.json`. On the client the string form is
+unaffected. Prefer the function form where you can — it needs no setting.
+
 ## Modifiers {#modifiers}
 
 

--- a/v3-docs/docs/api/collections.md
+++ b/v3-docs/docs/api/collections.md
@@ -1126,14 +1126,14 @@ Posts.find({ $where: 'this.score > this.threshold' });
 
 On the **server**, the string form is compiled with `Function()` and runs in
 the server process, so it is only appropriate for selectors your own code
-controls. It is therefore **disabled on the server by default** — mirroring
-MongoDB's own `security.javascriptEnabled` — and Minimongo throws if a string
-`$where` reaches the server. The function form is unaffected and always works.
+controls. It is therefore **disabled on the server by default**, and Minimongo
+throws if a string `$where` reaches the server. The function form is unaffected
+and always works.
 
-To use the string form for trusted selectors, enable it explicitly:
+To use the string form for trusted selectors, enable it explicitly in
+`settings.json`:
 
 ```json
-// settings.json
 {
   "packages": {
     "minimongo": {


### PR DESCRIPTION
`$where` accepts a function or a string. The string form is compiled with `Function()` and runs in the server process, so it only suits selectors your own code controls. MongoDB gates server-side JavaScript behind `security.javascriptEnabled`; Meteor had no equivalent switch.

This adds one. On the server the string form is now off by default and enabled with `Meteor.settings.packages.minimongo.allowStringWhere: true` (or `Minimongo._setAllowStringWhere(true)` at runtime). The function form is unchanged.

## Breaking change

Server-side code that passes a string `$where` to an in-memory collection or to `Minimongo.Matcher` now throws. Use the function form, or set `packages.minimongo.allowStringWhere: true` in settings.

## Scope

Gated: server-side local collections, and the observe drivers' matcher build (which already falls back to polling when the matcher throws).

Unaffected:
- The function form of `$where`.
- The client.
- Server-side queries on Mongo-backed collections (`find`/`fetch`/`countAsync`): `$where` is sent to MongoDB and never builds a `Minimongo.Matcher`.

Docs: new **The `$where` operator** section under Selectors in the collections API reference.

## Testing

`./packages/test-in-console/run.sh minimongo` — `minimongo - $where string is refused on the server by default` (function form works, string form refused, setting re-enables it).

## Changelog

- `$where`: the string form is disabled on the server by default and can be re-enabled with `Meteor.settings.packages.minimongo.allowStringWhere`. The function form is unchanged.

Related: #14733 aligns the Change Streams cursor-support check with oplog (same `$where`/`$near` handling).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable server-side handling for string-based `$where` selectors.
  - String `$where` selectors are disabled by default and can be enabled through settings or runtime configuration using an exact `true` value.
  - Function-based `$where` selectors remain available.
  - Disabled string selectors now provide a descriptive error.

- **Documentation**
  - Clarified server-side `$where` restrictions, configuration options, and security considerations.
  - Updated the settings example with valid JSON and explicit configuration-file guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->