### PR TITLE
fix(test-in-browser): restore jQuery dependency

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,6 +9,7 @@ on:
       - "packages/tools-core/**"
       - "packages/babel-compiler/**"
       - "packages/meteor-tool/**"
+      - "packages/test-in-browser/**"
       - "npm-packages/meteor-rspack/**"
       - "tools/isobuild/**"
       - "scripts/dev-bundle-tool-package.js"

--- a/dev/modern-tools/rspack/E2E_COVERAGE.md
+++ b/dev/modern-tools/rspack/E2E_COVERAGE.md
@@ -27,6 +27,7 @@ Default assertions on every run phase: build artifacts exist, page title matches
 | What is covered | Test |
 |-----------------|------|
 | Packed `@meteorjs/rspack` consumer installs its runtime dependencies, applies `npm audit fix`, and reports zero critical production vulnerabilities | `rspack-audit.test.js` |
+| Fresh `meteor create --package` output completes both client and server Tinytests with the default browser driver and no browser errors, without adding a separate jQuery dependency (#14735) | `regressions/test-in-browser.test.js` |
 
 ---
 

--- a/packages/test-in-browser/package.js
+++ b/packages/test-in-browser/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Run tests interactively in the browser",
-  version: '1.6.0',
+  version: '1.6.1',
   documentation: null
 });
 
@@ -23,6 +23,7 @@ Package.onUse(function (api) {
     'blaze',
     'templating',
     'spacebars',
+    'jquery@3.0.0',
     'ddp',
     'tracker',
   ], 'client');

--- a/tools/e2e-tests/regressions/test-in-browser.test.js
+++ b/tools/e2e-tests/regressions/test-in-browser.test.js
@@ -1,0 +1,80 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import {
+  cleanupTempDir,
+  killMeteorProcess,
+  runMeteorCommand,
+  waitForMeteorOutput,
+} from '../helpers';
+
+describe('Regressions / Test-in-browser /', () => {
+  const port = 3156;
+  let tempDir;
+  let meteorProcess;
+  let testPage;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'meteortest-test-in-browser-'));
+    testPage = await browser.newPage();
+  });
+
+  afterEach(async () => {
+    if (testPage) await testPage.close();
+    await killMeteorProcess(meteorProcess);
+    await cleanupTempDir(tempDir);
+    meteorProcess = null;
+  });
+
+  it('runs a newly created package\'s client and server tests with the default browser driver', async () => {
+    const packageName = 'browser-driver-regression';
+    const browserErrors = [];
+    testPage.on('pageerror', error => browserErrors.push(error.message));
+
+    // Reproduce #14735 with the generated package as-is. Adding jquery here
+    // or using test-in-console would mask a missing dependency in the driver.
+    await runMeteorCommand('create', ['--package', packageName], tempDir, {
+      checkExitCode: true,
+      captureOutput: true,
+    });
+
+    const result = await runMeteorCommand(
+      'test-packages',
+      ['./', '--port', String(port), '--test-app-path', path.join(tempDir, 'test-app')],
+      path.join(tempDir, packageName),
+      { captureOutput: true },
+    );
+    meteorProcess = result.meteorProcess;
+
+    await waitForMeteorOutput(
+      result.outputLines,
+      `=> App running at http://localhost:${port}/`,
+      { meteorProcess },
+    );
+
+    await testPage.goto(`http://localhost:${port}/`);
+    // Report startup errors directly, including "jQuery not found", instead
+    // of waiting for a UI that cannot render when the driver fails to load.
+    expect(browserErrors).toEqual([]);
+
+    await testPage.waitForFunction(() => {
+      const summary = document.querySelector('.navbar-brand')?.textContent.trim();
+      return summary === 'All tests pass!' || summary === 'There are failures.';
+    });
+
+    const results = await testPage.evaluate(() => ({
+      summary: document.querySelector('.navbar-brand').textContent.trim(),
+      progress: document.querySelector('#testProgressBar .in-progress').textContent.trim(),
+      tests: [...document.querySelectorAll('.testname')]
+        .map(node => node.textContent.replace(/\s+/g, ' ').trim())
+        .sort(),
+    }));
+
+    expect(browserErrors).toEqual([]);
+    expect(results).toEqual({
+      summary: 'All tests pass!',
+      progress: 'Passed 2 of 2',
+      tests: ['C: example', 'S: example'],
+    });
+  }, 300000);
+});


### PR DESCRIPTION
Fixes: #14735

Restore the client-side `jquery@3.0.0` dependency removed from `test-in-browser` in #14308. The released Blaze version still requires jQuery, so testing a newly created package fails with `jQuery not found` and an undefined `test-in-browser.runTests`.

Bump `test-in-browser` from `1.6.0` to `1.6.1`. This version has been published as a standalone package patch for Meteor 3.5.2.

Add an E2E regression that uses the checkout's `meteor create --package` and `meteor test-packages ./` with the default browser driver. It requires both client and server Tinytests to pass and checks for browser startup errors. The generated package supplies no separate jQuery dependency, so the test catches the driver dependency regression while allowing a future Blaze version that works without jQuery.

Include `packages/test-in-browser/**` in the E2E workflow's path triggers and document the regression in the coverage report.

Validation:

- `npm run test:e2e -- --runTestsByPath regressions/test-in-browser.test.js` passes.
- Temporarily removing the jQuery dependency makes that same E2E test fail with both `jQuery not found` and `Cannot read properties of undefined (reading 'runTests')`. Restoring the dependency makes it pass again.
- Verified the published `test-in-browser@1.6.1` using the issue's reproduction and a fresh Meteor 3.5.2 project: both client and server tests pass with no browser errors.
- Added automated E2E coverage for creating and running browser-based package tests and ensure issues around this use case won't make a regression anymore in a release.
- `git diff --check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated the `test-in-browser` package to version 1.6.1.
  - Added jQuery 3.0.0 to the package’s client-side dependencies.

- **Testing**
  - Added automated end-to-end coverage for creating and running browser-based package tests.
  - Test verification now confirms successful results and detects browser-page errors.

- **Documentation**
  - Documented coverage for the browser-based package testing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
