### PR TITLE
Document meteor mongo flags and the mongosh requirement

### DIFF
--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -498,11 +498,12 @@ Instead of opening a shell, specifying --url (-U) will return a URL
 suitable for an external program to connect to the database. For remote
 databases on deployed applications, the URL is valid for one hour.
 
-Note that you must have mongosh installed to use this option.
+Note that you must have mongosh installed to open the shell. The --url
+option does not need it.
 
 Options:
   --url, -U return a Mongo database URL
-  --verbose, -v to show the errors that have occurred while connecting to the
+  --verbose, -V to show the errors that have occurred while connecting to the
                 database
 
 Currently, this feature can only be used when developing locally.

--- a/v3-docs/docs/cli/index.md
+++ b/v3-docs/docs/cli/index.md
@@ -974,11 +974,19 @@ Opens a MongoDB shell on your local development database.
 
 **Usage:**
 ```bash
-meteor mongo
+meteor mongo [--url]
 ```
+
+**Flags:**
+- `--url`, `-U` - Print the database URL instead of opening a shell
+- `--verbose`, `-V` - Print the full error if the shell fails to start
 
 ::: warning
 For now, you must already have your application running locally with `meteor run`. This will be easier in the future.
+:::
+
+::: info
+The shell is [`mongosh`](https://www.mongodb.com/docs/mongodb-shell/), which is not installed with Meteor. [Install it](https://www.mongodb.com/docs/mongodb-shell/install/) and make sure it is on your `PATH`, otherwise the command exits with `The 'mongosh' command line tool was not found in your PATH.` `--url` does not need `mongosh`, so you can use it to connect with any MongoDB client.
 :::
 
 ## meteor reset {#meteor-reset}


### PR DESCRIPTION
## Description

`meteor mongo` opens the shell with `mongosh`, which Meteor does not install, but the v3 CLI docs never say so. Without it the command exits with `The 'mongosh' command line tool was not found in your PATH.` and nothing in the docs explains why (#12941). The docs also don't list the command's flags, and `meteor help mongo` shows `--verbose, -v` while the command declares `short: 'V'`, so `-v` fails with `-v: unknown option.`

## User-Facing Changes

- `v3-docs/docs/cli/index.md`: the `meteor mongo` section lists `--url`/`-U` and `--verbose`/`-V`, plus an info box saying `mongosh` has to be installed separately and `--url` doesn't need it.
- `tools/cli/help.txt`: `-v` becomes `-V`. The mongosh note now says it's needed to open the shell; it sat under the `--url` paragraph, but `--url` works without it.

No code change. The other four commands with `--verbose` use `-v`, so if you'd rather make `-v` work here, I can change `commands.js` instead.

## Tests

Meteor 3.5.2 on Linux, app running, no `mongosh` on PATH: `meteor mongo` exits 2 with the message above, `--url`, `-U`, `--verbose` and `-V` are accepted, and `-v` is rejected. With `mongosh` 2.10.0 on PATH the shell connects. `npm run docs:build` passes.

Refs #12941

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that `mongosh` is required to open the MongoDB shell, but not when using `--url`.
  - Documented the `--url` (`-U`) option for printing the database URL.
  - Documented the `--verbose` (`-V`) option for displaying full shell-startup errors.
  - Noted that `mongosh` must be installed separately and available on `PATH`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->