### PR TITLE
fix(rspack): honour .meteorignore negations and METEOR_IGNORE in test filters

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'tools/**'
       - 'scripts/**'
+      # testMatch also covers this package, so a PR that only touches it must
+      # still run the suite.
+      - 'npm-packages/meteor-rspack/**'
       - 'package.json'
       - '.github/workflows/unit-tests.yml'
   push:

--- a/dev/modern-tools/rspack/E2E_COVERAGE.md
+++ b/dev/modern-tools/rspack/E2E_COVERAGE.md
@@ -231,6 +231,7 @@ Server-only app (no client entry point).
 | No client tests (test client skipped) | Test |
 | Server entry loads (`server/main.js loaded`) | Run |
 | Server Rspack process exits before first compilation and Meteor fails promptly | Run |
+| `.meteorignore` negation re-includes a test file an earlier pattern ignored (`regressions/meteorignore-negation.test.js`, [#14742](https://github.com/meteor/meteor/issues/14742)) | Test once |
 
 ### Focused server runtime regressions
 

--- a/npm-packages/meteor-rspack/lib/ignore.js
+++ b/npm-packages/meteor-rspack/lib/ignore.js
@@ -2,8 +2,26 @@ var fs = require('fs');
 var path = require('path');
 
 /**
- * Reads the .meteorignore file from the given project directory and returns
- * the parsed entries. Empty lines and comment lines (starting with #) are filtered out.
+ * Splits a whitespace-delimited list of ignore patterns, as accepted by the
+ * METEOR_IGNORE environment variable.
+ *
+ * @param {string} value - Raw environment variable value
+ * @returns {string[]} - Array of ignore patterns
+ */
+function parseIgnoreEnv(value) {
+  return (value || '').trim().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Reads the ignore patterns that apply to the given project directory: the
+ * entries of its .meteorignore file followed by the ones in the METEOR_IGNORE
+ * environment variable. Empty lines and comment lines (starting with #) are
+ * filtered out.
+ *
+ * The two sources are combined the way meteor-tool combines them (see
+ * optimisticReadMeteorIgnore in tools/fs/optimistic.ts), with METEOR_IGNORE
+ * last so that it can override the file under gitignore's last-match-wins
+ * rule.
  *
  * @param {string} projectDir - The project directory path
  * @returns {string[]} - Array of ignore patterns
@@ -11,20 +29,22 @@ var path = require('path');
 const getMeteorIgnoreEntries = function (projectDir) {
   const meteorIgnorePath = path.join(projectDir, '.meteorignore');
 
+  let fileEntries = [];
+
   // Check if .meteorignore file exists
   try {
     const fileContent = fs.readFileSync(meteorIgnorePath, 'utf8');
 
     // Process each line in the file
-    const entries = fileContent.split(/\r?\n/)
+    fileEntries = fileContent.split(/\r?\n/)
       .map(line => line.trim())
       .filter(line => line !== '' && !line.startsWith('#'));
-
-    return entries;
   } catch (e) {
-    // If the file doesn't exist or can't be read, return empty array
-    return [];
+    // If the file doesn't exist or can't be read, fall back to the
+    // environment variable alone.
   }
+
+  return [...fileEntries, ...parseIgnoreEnv(process.env.METEOR_IGNORE)];
 };
 
 /**
@@ -86,6 +106,11 @@ function createIgnoreGlobConfig(entries = []) {
  * Creates a regex pattern to match the specified glob patterns.
  * Converts glob patterns with * and ** into regex equivalents.
  *
+ * Negation patterns cannot be expressed in a single regex and are dropped, so
+ * this only suits pattern lists known to be positive-only — Rspack's `exclude`
+ * option, which accepts nothing but a RegExp. Patterns that come from the app
+ * author go through createIgnoreMatcherSource instead.
+ *
  * @param {string[]} globPatterns - Array of glob patterns from createIgnoreGlobConfig
  * @param {string} [rootPath] - Absolute root that matched paths must belong to
  * @returns {RegExp} - Regex pattern to match the specified patterns
@@ -140,8 +165,51 @@ function createIgnoreRegex(globPatterns, rootPath) {
   return new RegExp(combinedPattern);
 }
 
+/**
+ * Builds the pieces a generated eager-test module needs to decide which test
+ * files .meteorignore keeps.
+ *
+ * .meteorignore uses gitignore syntax, where the last matching pattern wins and
+ * a `!pattern` re-includes a path an earlier pattern excluded. Reimplementing
+ * that on top of a RegExp lost every negation, which silently reduced a sharded
+ * test run to zero test files, so the generated module is handed the same
+ * `ignore` package meteor-tool applies to .meteorignore (see
+ * tools/fs/optimistic.ts). Both bundlers then agree on the semantics.
+ *
+ * Returned as source rather than as a predicate because it runs inside the
+ * bundle, not in this process: the paths it tests come from
+ * import.meta.webpackContext.
+ *
+ * @param {string[]} entries - .meteorignore-style patterns, in order
+ * @returns {{ modulePath: string, source: string }|null} - The `ignore` module
+ *   to import, and a `(createIgnore) => (contextKey) => boolean` factory
+ *   expression. Null when there is nothing to filter.
+ */
+function createIgnoreMatcherSource(entries = []) {
+  if (!Array.isArray(entries)) {
+    throw new Error('Entries must be an array');
+  }
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return {
+    // Resolved here rather than at module load so that requiring this file
+    // stays cheap and does not depend on `ignore` being installed.
+    modulePath: require.resolve('ignore'),
+    source: `(createIgnore => {
+  const ig = createIgnore().add(${JSON.stringify(entries)});
+  // import.meta.webpackContext keys look like './imports/a.tests.ts', but
+  // \`ignore\` wants a path relative to the project root and rejects the './'.
+  return key => ig.ignores(key.replace(/^\\.\\//, ''));
+})`,
+  };
+}
+
 module.exports = {
+  createIgnoreGlobConfig,
+  createIgnoreMatcherSource,
   createIgnoreRegex,
   getMeteorIgnoreEntries,
-  createIgnoreGlobConfig,
 };

--- a/npm-packages/meteor-rspack/lib/ignore.test.js
+++ b/npm-packages/meteor-rspack/lib/ignore.test.js
@@ -1,0 +1,172 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createIgnoreGlobConfig,
+  createIgnoreMatcherSource,
+  createIgnoreRegex,
+  getMeteorIgnoreEntries,
+} = require('./ignore.js');
+
+// Compiles the factory emitted into the generated eager-test module and wires
+// it to the same `ignore` module that module imports, so the assertions below
+// exercise the exact code that runs inside the bundle.
+const compileMatcher = entries => {
+  const { modulePath, source } = createIgnoreMatcherSource(entries);
+
+  // eslint-disable-next-line no-new-func -- the input is this package's own
+  // generated source, not user data.
+  return new Function('createIgnore', `return (${source})(createIgnore);`)(
+    require(modulePath),
+  );
+};
+
+const withMeteorIgnoreEnv = (value, fn) => {
+  const previous = process.env.METEOR_IGNORE;
+  if (value === undefined) {
+    delete process.env.METEOR_IGNORE;
+  } else {
+    process.env.METEOR_IGNORE = value;
+  }
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.METEOR_IGNORE;
+    } else {
+      process.env.METEOR_IGNORE = previous;
+    }
+  }
+};
+
+describe('createIgnoreMatcherSource', () => {
+  test('re-includes a file a later negation pattern rescues', () => {
+    const isIgnored = compileMatcher([
+      '*.tests.ts',
+      '!/imports/localization/LanguageSections.tests.ts',
+    ]);
+
+    expect(isIgnored('./imports/localization/LanguageSections.tests.ts')).toBe(
+      false,
+    );
+  });
+
+  test('still ignores files no negation pattern rescues', () => {
+    const isIgnored = compileMatcher([
+      '*.tests.ts',
+      '!/imports/localization/LanguageSections.tests.ts',
+    ]);
+
+    expect(isIgnored('./imports/localization/Other.tests.ts')).toBe(true);
+  });
+
+  test('lets the last matching pattern win when a positive follows a negation', () => {
+    const isIgnored = compileMatcher([
+      '*.tests.ts',
+      '!/imports/a/B.tests.ts',
+      '/imports/a/',
+    ]);
+
+    expect(isIgnored('./imports/a/B.tests.ts')).toBe(true);
+  });
+
+  test('ignores nothing when every pattern is a negation', () => {
+    const isIgnored = compileMatcher(['!/imports/a/B.tests.ts']);
+
+    expect(isIgnored('./imports/a/B.tests.ts')).toBe(false);
+  });
+
+  test('returns null when there are no patterns', () => {
+    expect(createIgnoreMatcherSource([])).toBeNull();
+  });
+
+  test('anchors a rooted pattern to the project root', () => {
+    const isIgnored = compileMatcher(['/imports/a.tests.ts']);
+
+    expect(isIgnored('./imports/a.tests.ts')).toBe(true);
+    expect(isIgnored('./packages/imports/a.tests.ts')).toBe(false);
+  });
+
+  test('supports character classes', () => {
+    const isIgnored = compileMatcher(['shard-[a-c].tests.ts']);
+
+    expect(isIgnored('./imports/shard-b.tests.ts')).toBe(true);
+    expect(isIgnored('./imports/shard-d.tests.ts')).toBe(false);
+  });
+
+  test('supports the single-character wildcard', () => {
+    const isIgnored = compileMatcher(['shard-?.tests.ts']);
+
+    expect(isIgnored('./imports/shard-1.tests.ts')).toBe(true);
+    expect(isIgnored('./imports/shard-12.tests.ts')).toBe(false);
+  });
+
+  test('matches a **/ pattern at the project root too', () => {
+    const isIgnored = compileMatcher(['**/legacy.tests.ts']);
+
+    expect(isIgnored('./legacy.tests.ts')).toBe(true);
+    expect(isIgnored('./imports/legacy.tests.ts')).toBe(true);
+  });
+
+  test('does not let a negation rescue a file under an excluded directory', () => {
+    const isIgnored = compileMatcher(['/imports/', '!/imports/a.tests.ts']);
+
+    expect(isIgnored('./imports/a.tests.ts')).toBe(true);
+  });
+});
+
+describe('createIgnoreRegex', () => {
+  test('matches paths covered by a positive pattern', () => {
+    const regex = createIgnoreRegex(createIgnoreGlobConfig(['node_modules/']));
+
+    expect(regex.test('./node_modules/foo/index.js')).toBe(true);
+    expect(regex.test('./imports/a.js')).toBe(false);
+  });
+});
+
+describe('getMeteorIgnoreEntries', () => {
+  let projectDir;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'meteor-ignore-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test('appends METEOR_IGNORE patterns after the .meteorignore ones', () => {
+    fs.writeFileSync(
+      path.join(projectDir, '.meteorignore'),
+      '# comment\n*.tests.ts\n\n',
+    );
+
+    const entries = withMeteorIgnoreEnv(
+      '!/imports/a/B.tests.ts  /imports/c',
+      () => getMeteorIgnoreEntries(projectDir),
+    );
+
+    expect(entries).toEqual([
+      '*.tests.ts',
+      '!/imports/a/B.tests.ts',
+      '/imports/c',
+    ]);
+  });
+
+  test('returns METEOR_IGNORE patterns when there is no .meteorignore file', () => {
+    const entries = withMeteorIgnoreEnv('*.tests.ts', () =>
+      getMeteorIgnoreEntries(projectDir),
+    );
+
+    expect(entries).toEqual(['*.tests.ts']);
+  });
+
+  test('returns an empty array when neither source has patterns', () => {
+    const entries = withMeteorIgnoreEnv(undefined, () =>
+      getMeteorIgnoreEntries(projectDir),
+    );
+
+    expect(entries).toEqual([]);
+  });
+});

--- a/npm-packages/meteor-rspack/lib/test.js
+++ b/npm-packages/meteor-rspack/lib/test.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-const { createIgnoreRegex, createIgnoreGlobConfig } = require("./ignore.js");
+const {
+  createIgnoreGlobConfig,
+  createIgnoreMatcherSource,
+  createIgnoreRegex,
+} = require("./ignore.js");
 
 // Normalize a path to always use forward slashes (POSIX style).
 // Module identifiers in bundled JS must use '/' regardless of OS.
@@ -47,10 +51,11 @@ const generateEagerTestFile = ({
     createIgnoreGlobConfig(ignoreEntries),
     projectDir,
   );
-  // Create regex from meteor ignore entries
-  const excludeMeteorIgnoreRegex = inMeteorIgnoreEntries.length > 0
-    ? createIgnoreRegex(createIgnoreGlobConfig(inMeteorIgnoreEntries))
-    : null;
+  // Build the .meteorignore filter. It is `ignore`-backed rather than a regex
+  // because gitignore's last-match-wins rule cannot be expressed as one, and
+  // collapsing it into one used to drop every `!` pattern — silently loading
+  // zero test files for a sharded run.
+  const meteorIgnoreMatcher = createIgnoreMatcherSource(inMeteorIgnoreEntries);
 
   const prefix = (inPrefix && `${inPrefix}-`) || "";
   const filename = isAppTest
@@ -64,8 +69,9 @@ const generateEagerTestFile = ({
   const content = `${
     globalImportPath ? `import '${toPosix(globalImportPath)}';\n\n` : ""
   }${
-    excludeMeteorIgnoreRegex
-      ? `const MeteorIgnoreRegex = ${excludeMeteorIgnoreRegex.toString()};`
+    meteorIgnoreMatcher
+      ? `import MeteorIgnore from '${toPosix(meteorIgnoreMatcher.modulePath)}';\n\n` +
+        `const MeteorIgnoreMatcher = ${meteorIgnoreMatcher.source}(MeteorIgnore);`
       : ""
   }
 {
@@ -77,9 +83,9 @@ const generateEagerTestFile = ({
   });
   await Promise.all(ctx.keys().filter((k) => {
     ${
-      excludeMeteorIgnoreRegex
+      meteorIgnoreMatcher
         ? `// Only exclude based on *relative* path segments.
-    return !MeteorIgnoreRegex.test(k);`
+    return !MeteorIgnoreMatcher(k);`
         : "return true;"
     }
   }).map(ctx));

--- a/npm-packages/meteor-rspack/lib/test.test.js
+++ b/npm-packages/meteor-rspack/lib/test.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createIgnoreMatcherSource } = require('./ignore.js');
+const { generateEagerTestFile } = require('./test.js');
+
+describe('generateEagerTestFile', () => {
+  let projectDir;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'meteor-eager-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  const generate = meteorIgnoreEntries =>
+    fs.readFileSync(
+      generateEagerTestFile({
+        isAppTest: false,
+        projectDir,
+        buildContext: '_build',
+        meteorIgnoreEntries,
+      }),
+      'utf8',
+    );
+
+  test('filters test files through a matcher built from the ignore package', () => {
+    const entries = ['*.tests.ts', '!/imports/a/B.tests.ts'];
+    const { modulePath, source } = createIgnoreMatcherSource(entries);
+
+    const content = generate(entries);
+
+    expect(content).toContain(
+      `import MeteorIgnore from '${modulePath.replace(/\\/g, '/')}';`,
+    );
+    expect(content).toContain(source);
+    expect(content).toContain('!MeteorIgnoreMatcher(k)');
+  });
+
+  test('keeps every test file when there are no meteor ignore entries', () => {
+    const content = generate([]);
+
+    expect(content).not.toContain('MeteorIgnore');
+    expect(content).toContain('return true;');
+  });
+});

--- a/npm-packages/meteor-rspack/package-lock.json
+++ b/npm-packages/meteor-rspack/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "ignore": "^7.0.5",
         "ignore-loader": "^0.1.2",
         "isomorphic-timers-promises": "^1.0.1",
         "webpack-merge": "^6.0.1"
@@ -2579,6 +2580,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/ignore-loader": {

--- a/npm-packages/meteor-rspack/package.json
+++ b/npm-packages/meteor-rspack/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
+    "ignore": "^7.0.5",
     "ignore-loader": "^0.1.2",
     "isomorphic-timers-promises": "^1.0.1",
     "webpack-merge": "^6.0.1"

--- a/packages/rspack/lib/processes.js
+++ b/packages/rspack/lib/processes.js
@@ -70,26 +70,36 @@ import {
   shouldLogVerbose,
   stripRspackLabel,
 } from "./logging";
-import { isMeteorAppProfile } from "../../tools-core/lib/meteor";
+import {
+  getUserMeteorIgnore,
+  isMeteorAppProfile,
+} from "../../tools-core/lib/meteor";
 
 // Rspack's native code prints this marker when it aborts, e.g. when its
 // persistent cache was corrupted by a previous hard kill mid-write.
 const RSPACK_PANIC_PATTERN = 'Panic occurred at runtime';
-const RSPACK_UNSET_ENV = ['METEOR_IGNORE'];
 
 /**
- * Builds the environment passed to Rspack child processes. METEOR_IGNORE is
- * consumed by meteor-tool, not Rspack, so it is omitted here and explicitly
- * removed again by spawnProcess after the parent environment is merged.
+ * Builds the environment passed to Rspack child processes.
+ *
+ * METEOR_IGNORE is overwritten rather than inherited. @meteorjs/rspack reads it
+ * to build the same ignore filters it builds from .meteorignore, so the app
+ * author's patterns must reach the child — but the patterns meteor-tool
+ * appends to the variable for its own bundler must not:
+ * Rspack never reads them, and on large projects their dir-times-extension
+ * expansion grows to tens of kilobytes, wasting execve arg+env budget (risking
+ * E2BIG on constrained systems).
+ *
+ * Setting it here is enough on its own: spawnProcess merges `options.env` over
+ * `process.env`, so this value wins over the one meteor-tool has been growing.
+ *
  * @param {Object} envs - Rspack-specific environment variables
  * @returns {Object} Environment variables for spawnProcess
  */
 function getRspackSpawnEnv(envs) {
-  const parentEnv = { ...process.env };
-  delete parentEnv.METEOR_IGNORE;
-
   return inheritMeteorToolNodeFlags({
-    ...parentEnv,
+    ...process.env,
+    METEOR_IGNORE: getUserMeteorIgnore(),
     ...getNodeBinEnv(),
     ...envs,
   });
@@ -551,7 +561,6 @@ export function startRspackClientServe(options = {}) {
       // SIGTERM/SIGINT on its own.
       detached: process.platform !== 'win32',
       env: getRspackSpawnEnv(envs),
-      unsetEnv: RSPACK_UNSET_ENV,
       onStdout: (data) => {
         const { cleanedData, config } = parseMeteorRspackOutput(data);
         if (config && !!config?.devServerUrl) {
@@ -670,7 +679,6 @@ export function startRspackServerWatch(options = {}) {
     // Detach for the same reason as the client serve process; see comment there.
     detached: process.platform !== 'win32',
     env: getRspackSpawnEnv(envs),
-    unsetEnv: RSPACK_UNSET_ENV,
     onStdout: (data) => {
       const { cleanedData, config } = parseMeteorRspackOutput(data);
       if (onCompile && config && (config?.compilationCount || 0) > 0) {
@@ -777,7 +785,6 @@ export function runRspackBuild({ isClient, isServer, isTest, isTestModule, isTes
       {
       cwd: appDir,
       env: getRspackSpawnEnv(envs),
-      unsetEnv: RSPACK_UNSET_ENV,
       onStdout: (data) => {
         const { cleanedData, config } = parseMeteorRspackOutput(data);
         if (onCompile && config && (config?.compilationCount || 0) > 0) {

--- a/packages/tools-core/lib/meteor.js
+++ b/packages/tools-core/lib/meteor.js
@@ -194,6 +194,22 @@ export function setMeteorAppEntrypoints({
   global.reinitializeMeteorConfig?.();
 }
 
+// METEOR_IGNORE as the app author set it, captured before the first
+// setMeteorAppIgnore() call starts appending meteor-tool-specific patterns to
+// it. Integrations that hand the variable on to their own tooling need the
+// author's patterns alone: the appended ones mean nothing to them and, on
+// large projects, grow to tens of kilobytes.
+const USER_METEOR_IGNORE = process.env.METEOR_IGNORE || '';
+
+/**
+ * Returns the METEOR_IGNORE patterns the app author set, without the ones
+ * Meteor appends for its own bundler.
+ * @returns {string} Space-delimited ignore patterns, or an empty string.
+ */
+export function getUserMeteorIgnore() {
+  return USER_METEOR_IGNORE;
+}
+
 /**
  * Sets patterns to be ignored by the Meteor application in the environment variable.
  * Appends new patterns while deduplicating by keeping the last occurrence of

--- a/packages/tools-core/lib/meteor.js
+++ b/packages/tools-core/lib/meteor.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { logError } = require("./log");
+const { getGlobalState, setGlobalState } = require("./global-state");
 
 // Normalize a path to always use forward slashes (POSIX style).
 // Module identifiers must use '/' regardless of OS.
@@ -194,20 +195,42 @@ export function setMeteorAppEntrypoints({
   global.reinitializeMeteorConfig?.();
 }
 
-// METEOR_IGNORE as the app author set it, captured before the first
-// setMeteorAppIgnore() call starts appending meteor-tool-specific patterns to
-// it. Integrations that hand the variable on to their own tooling need the
-// author's patterns alone: the appended ones mean nothing to them and, on
-// large projects, grow to tens of kilobytes.
-const USER_METEOR_IGNORE = process.env.METEOR_IGNORE || '';
+const USER_METEOR_IGNORE_KEY = 'userMeteorIgnore';
+
+/**
+ * Records METEOR_IGNORE as the app author set it, before the first
+ * setMeteorAppIgnore() call starts appending meteor-tool-specific patterns to
+ * it. Integrations that hand the variable on to their own tooling need the
+ * author's patterns alone: the appended ones mean nothing to them and, on
+ * large projects, grow to tens of kilobytes.
+ *
+ * Called once as this module is evaluated, and idempotent because that is not
+ * once per process: build-plugin sources are evaluated per Isopack instance,
+ * and by the time a later instance runs, METEOR_IGNORE has already grown. The
+ * value therefore lives in global state, which survives re-instantiation,
+ * rather than in a module-level constant.
+ */
+export function captureUserMeteorIgnore() {
+  if (getGlobalState(USER_METEOR_IGNORE_KEY) === undefined) {
+    setGlobalState(USER_METEOR_IGNORE_KEY, process.env.METEOR_IGNORE || '');
+  }
+}
+
+captureUserMeteorIgnore();
 
 /**
  * Returns the METEOR_IGNORE patterns the app author set, without the ones
  * Meteor appends for its own bundler.
+ *
+ * Only meaningful inside meteor-tool — the CLI and its build plugins, where
+ * setMeteorAppIgnore() does the appending. An app's server process inherits an
+ * already-grown METEOR_IGNORE and never calls setMeteorAppIgnore(), so there is
+ * no author-only value to recover there.
+ *
  * @returns {string} Space-delimited ignore patterns, or an empty string.
  */
 export function getUserMeteorIgnore() {
-  return USER_METEOR_IGNORE;
+  return getGlobalState(USER_METEOR_IGNORE_KEY, '');
 }
 
 /**

--- a/packages/tools-core/lib/meteor.js
+++ b/packages/tools-core/lib/meteor.js
@@ -195,7 +195,8 @@ export function setMeteorAppEntrypoints({
   global.reinitializeMeteorConfig?.();
 }
 
-const USER_METEOR_IGNORE_KEY = 'userMeteorIgnore';
+// Exported so tests can model a fresh build-plugin evaluation.
+export const USER_METEOR_IGNORE_KEY = 'userMeteorIgnore';
 
 /**
  * Records METEOR_IGNORE as the app author set it, before the first

--- a/packages/tools-core/tests/meteor_tests.js
+++ b/packages/tools-core/tests/meteor_tests.js
@@ -1,4 +1,5 @@
 import {
+  captureUserMeteorIgnore,
   getUserMeteorIgnore,
   inheritMeteorToolNodeFlags,
   setMeteorAppIgnore,
@@ -301,6 +302,34 @@ Tinytest.add(
         getUserMeteorIgnore(),
         userIgnore,
         "Should keep reporting the patterns the user set, not the ones meteor-tool appends"
+      );
+    } finally {
+      if (previousIgnore === undefined) {
+        delete process.env.METEOR_IGNORE;
+      } else {
+        process.env.METEOR_IGNORE = previousIgnore;
+      }
+    }
+  }
+);
+
+Tinytest.add(
+  "tools-core - captureUserMeteorIgnore - a later evaluation does not overwrite the first capture",
+  function (test) {
+    const previousIgnore = process.env.METEOR_IGNORE;
+    const userIgnore = getUserMeteorIgnore();
+
+    try {
+      // This file is a build-plugin source, so it is evaluated once per Isopack
+      // instance rather than once per process. By the time a later instance
+      // runs, setMeteorAppIgnore has already grown METEOR_IGNORE.
+      process.env.METEOR_IGNORE = "client/*.css !client/meteor.css /_build-daemon";
+      captureUserMeteorIgnore();
+
+      test.equal(
+        getUserMeteorIgnore(),
+        userIgnore,
+        "Should keep the value captured by the first evaluation in this process"
       );
     } finally {
       if (previousIgnore === undefined) {

--- a/packages/tools-core/tests/meteor_tests.js
+++ b/packages/tools-core/tests/meteor_tests.js
@@ -3,7 +3,13 @@ import {
   getUserMeteorIgnore,
   inheritMeteorToolNodeFlags,
   setMeteorAppIgnore,
+  USER_METEOR_IGNORE_KEY,
 } from "../lib/meteor.js";
+import {
+  getGlobalState,
+  removeGlobalState,
+  setGlobalState,
+} from "../lib/global-state.js";
 
 Tinytest.add(
   "tools-core - inheritMeteorToolNodeFlags - no TOOL_NODE_FLAGS",
@@ -314,24 +320,41 @@ Tinytest.add(
 );
 
 Tinytest.add(
-  "tools-core - captureUserMeteorIgnore - a later evaluation does not overwrite the first capture",
+  "tools-core - captureUserMeteorIgnore - keeps the value from before setMeteorAppIgnore grew it",
   function (test) {
     const previousIgnore = process.env.METEOR_IGNORE;
-    const userIgnore = getUserMeteorIgnore();
+    const previousCapture = getGlobalState(USER_METEOR_IGNORE_KEY);
 
     try {
-      // This file is a build-plugin source, so it is evaluated once per Isopack
-      // instance rather than once per process. By the time a later instance
-      // runs, setMeteorAppIgnore has already grown METEOR_IGNORE.
-      process.env.METEOR_IGNORE = "client/*.css !client/meteor.css /_build-daemon";
+      // Model the build-plugin sequence: the author's value, then meteor-tool
+      // grows it, then a later Isopack instance re-evaluates lib/meteor.js.
+      process.env.METEOR_IGNORE = "author/*.ts";
+      removeGlobalState(USER_METEOR_IGNORE_KEY);
       captureUserMeteorIgnore();
 
+      setMeteorAppIgnore("/_build /_build-*");
+      test.notEqual(
+        process.env.METEOR_IGNORE,
+        "author/*.ts",
+        "Precondition: setMeteorAppIgnore should have grown METEOR_IGNORE"
+      );
+
+      captureUserMeteorIgnore();
+
+      // Asserted against the author's literal value rather than against an
+      // earlier read: comparing two reads passes even when nothing is stored
+      // at all, since both are then the empty default.
       test.equal(
         getUserMeteorIgnore(),
-        userIgnore,
-        "Should keep the value captured by the first evaluation in this process"
+        "author/*.ts",
+        "Should still report the value captured before setMeteorAppIgnore grew it"
       );
     } finally {
+      if (previousCapture === undefined) {
+        removeGlobalState(USER_METEOR_IGNORE_KEY);
+      } else {
+        setGlobalState(USER_METEOR_IGNORE_KEY, previousCapture);
+      }
       if (previousIgnore === undefined) {
         delete process.env.METEOR_IGNORE;
       } else {

--- a/packages/tools-core/tests/meteor_tests.js
+++ b/packages/tools-core/tests/meteor_tests.js
@@ -1,4 +1,5 @@
 import {
+  getUserMeteorIgnore,
   inheritMeteorToolNodeFlags,
   setMeteorAppIgnore,
 } from "../lib/meteor.js";
@@ -275,6 +276,31 @@ Tinytest.add(
         process.env.METEOR_IGNORE,
         "client/*.css",
         "Should avoid growing METEOR_IGNORE when the same pattern is appended repeatedly"
+      );
+    } finally {
+      if (previousIgnore === undefined) {
+        delete process.env.METEOR_IGNORE;
+      } else {
+        process.env.METEOR_IGNORE = previousIgnore;
+      }
+    }
+  }
+);
+
+Tinytest.add(
+  "tools-core - getUserMeteorIgnore - is unaffected by setMeteorAppIgnore",
+  function (test) {
+    const previousIgnore = process.env.METEOR_IGNORE;
+    const userIgnore = getUserMeteorIgnore();
+
+    try {
+      process.env.METEOR_IGNORE = "*.tests.ts";
+      setMeteorAppIgnore("client/*.css");
+
+      test.equal(
+        getUserMeteorIgnore(),
+        userIgnore,
+        "Should keep reporting the patterns the user set, not the ones meteor-tool appends"
       );
     } finally {
       if (previousIgnore === undefined) {

--- a/tools/e2e-tests/regressions/meteorignore-negation.test.js
+++ b/tools/e2e-tests/regressions/meteorignore-negation.test.js
@@ -1,0 +1,68 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import {
+  cleanupTempDir,
+  killProcessByPort,
+  runMeteorTests,
+  setupMeteorApp,
+} from '../helpers';
+
+const { linkLocalRspack } = require('../scripts/link-rspack');
+
+const PORT = 3125;
+
+const testFile = (name, title) => `import assert from 'assert';
+
+describe('${name}', function () {
+  it('${title}', function () {
+    assert.ok(true);
+  });
+});
+`;
+
+describe('Regressions / .meteorignore negation patterns /', () => {
+  let tempDir;
+
+  beforeAll(async () => {
+    tempDir = (await setupMeteorApp('server-only'))?.tempDir;
+
+    await linkLocalRspack(tempDir);
+
+    await fs.outputFile(
+      path.join(tempDir, 'imports', 'included.tests.js'),
+      testFile('included', 'runs the re-included test file'),
+    );
+    await fs.outputFile(
+      path.join(tempDir, 'imports', 'excluded.tests.js'),
+      testFile('excluded', 'runs the ignored test file'),
+    );
+
+    // Ignore every test file, then re-include one — the way a suite is sharded
+    // across CI containers. Rspack used to drop the negation and load nothing,
+    // reporting "0 passing" with exit code 0.
+    await fs.writeFile(
+      path.join(tempDir, '.meteorignore'),
+      '*.tests.js\n!/imports/included.tests.js\n',
+    );
+  });
+
+  afterAll(async () => {
+    await killProcessByPort(PORT);
+    await cleanupTempDir(tempDir);
+  });
+
+  it('runs only the test files a later negation pattern re-includes', async () => {
+    const { outputLines } = await runMeteorTests(tempDir, PORT, {
+      commandOptions: ['--once'],
+      checkTestResults: true,
+      testClient: false,
+    });
+
+    const output = outputLines.join('\n');
+
+    expect(output).toContain('runs the re-included test file');
+    expect(output).not.toContain('runs the ignored test file');
+    expect(output).toMatch(/1 passing/);
+  });
+});

--- a/tools/unit-tests/jest.config.js
+++ b/tools/unit-tests/jest.config.js
@@ -24,8 +24,10 @@ module.exports = {
     "<rootDir>/tools/static-assets/",
     // meteor-rspack ships plain CommonJS helpers that are unit-tested here, so
     // it stays visible to the module loader; the rest of npm-packages/ does not.
-    // (No trailing slash: the crawler also tests the bare directory path.)
-    "<rootDir>/npm-packages/(?!meteor-rspack)",
+    // The `/|$` alternation keeps the boundary at the directory: without the
+    // `$` the crawler prunes the bare directory path and finds no tests, and
+    // without the `/` a sibling like meteor-rspack-tools would escape too.
+    "<rootDir>/npm-packages/(?!meteor-rspack(?:/|$))",
     "<rootDir>/scripts/admin/",
     "<rootDir>/docs/",
     "<rootDir>/packages/non-core/",

--- a/tools/unit-tests/jest.config.js
+++ b/tools/unit-tests/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   testMatch: [
     "<rootDir>/tools/**/*.test.js",
     "<rootDir>/scripts/**/*.test.js",
+    "<rootDir>/npm-packages/meteor-rspack/**/*.test.js",
   ],
   testPathIgnorePatterns: [
     "/node_modules/",
@@ -21,7 +22,10 @@ module.exports = {
     "<rootDir>/tools/native-tests/",
     "<rootDir>/tools/tests/",
     "<rootDir>/tools/static-assets/",
-    "<rootDir>/npm-packages/",
+    // meteor-rspack ships plain CommonJS helpers that are unit-tested here, so
+    // it stays visible to the module loader; the rest of npm-packages/ does not.
+    // (No trailing slash: the crawler also tests the bare directory path.)
+    "<rootDir>/npm-packages/(?!meteor-rspack)",
     "<rootDir>/scripts/admin/",
     "<rootDir>/docs/",
     "<rootDir>/packages/non-core/",

--- a/tools/unit-tests/package-lock.json
+++ b/tools/unit-tests/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@swc/core": "^1.15.18",
         "@swc/jest": "^0.2.39",
+        "ignore": "^7.0.5",
         "jest": "^30.2.0",
         "semver": "^7.7.2",
         "underscore": "^1.13.7"
@@ -2584,6 +2585,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.9.tgz",
+      "integrity": "sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/import-local": {

--- a/tools/unit-tests/package.json
+++ b/tools/unit-tests/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@swc/core": "^1.15.18",
     "@swc/jest": "^0.2.39",
+    "ignore": "^7.0.5",
     "jest": "^30.2.0",
     "semver": "^7.7.2",
     "underscore": "^1.13.7"


### PR DESCRIPTION
Fixes #14742 — both the primary bug and the secondary one.

## Bug 1 — `.meteorignore` negations were dropped, silently

`createIgnoreRegex` collapsed `.meteorignore` into one alternation and returned `null` for every `!` pattern. `.meteorignore` is documented as using gitignore syntax, where the last matching pattern wins, so a file like

```
*.tests.ts
!/imports/localization/LanguageSections.tests.ts
```

— the standard way to shard a suite across CI containers — matched *every* test file and the run loaded none. Mocha printed `0 passing`, the process exited 0, and CI went green while executing zero tests.

### Approach

The issue sketched two fixes; this goes further than either. Rather than reimplement gitignore semantics on top of regexes, the generated eager-test module is handed the **same `ignore` package meteor-tool already applies to `.meteorignore`** (`tools/fs/optimistic.ts`), so the Rspack and classic bundlers agree by construction **for the eager-test filter**. `watchOptions.ignored` still goes through `createIgnoreGlobConfig`, which rewrites a rooted `/dist/` to `**/dist/**` and so unwatches `src/dist/` too — a pre-existing discrepancy left untouched here rather than widening the diff.

Besides negations, that also fixes cases the glob-to-regex converter never translated at all:

| Pattern | Old | New |
|---|---|---|
| `!/imports/a.tests.ts` after `*.tests.ts` | dropped | re-included |
| `shard-[a-c].tests.ts` | `[`/`]` escaped, never matched | character class |
| `shard-?.tests.ts` | `?` escaped, never matched | single-char wildcard |
| `**/legacy.tests.ts` | compiled to `.*/legacy…`, missed the root | matches at root |
| `!/imports/a.tests.ts` under `/imports/` | n/a | correctly *not* rescued (gitignore's excluded-parent rule) |

`createIgnoreRegex` stays for Rspack's `exclude` option, which accepts nothing but a `RegExp`. It is now documented as dropping negations and as being only for the internal, negation-free folder excludes.

`ignore@^7.0.5` is added to `@meteorjs/rspack` dependencies (19 KB, zero deps, browser-safe, same major as meteor-tool's). It is only pulled into test bundles, never production ones.

> **The two halves ship on different schedules.** Bug 1's fix lives entirely in `npm-packages/meteor-rspack`, which apps install from npm rather than receiving with a Meteor release. `package.json` there is deliberately left at `2.2.0` (version bumps are a release-time chore in this repo), so **no app sees this fix until `@meteorjs/rspack` is republished** — until then a sharded run still reports `0 passing`. Bug 2's fix is in `packages/rspack` and `packages/tools-core`, and does ship with the release.

## Bug 2 — `METEOR_IGNORE` never reached the filter

`getMeteorIgnoreEntries` read only the `.meteorignore` *file*, and `packages/rspack` cleared `METEOR_IGNORE` for its child processes, so an app sharding through the environment variable got no filtering at all — every test file loaded in every container.

- `getMeteorIgnoreEntries` now appends `process.env.METEOR_IGNORE`, file-first, matching how `optimisticReadMeteorIgnore` combines them. This is what the docs already promise.
- `getRspackSpawnEnv` now *sets* `METEOR_IGNORE` for Rspack children instead of deleting it. It passes `getUserMeteorIgnore()` — a new snapshot in `tools-core` taken before `setMeteorAppIgnore` starts appending — so the app author's patterns get through while the meteor-tool-injected ones do not. That preserves the reason `RSPACK_UNSET_ENV` existed (cf0e3d95cd): those patterns grow to tens of kilobytes on large projects and risk `E2BIG`, and Rspack never reads them. `RSPACK_UNSET_ENV` is removed, since `spawnProcess` merges `options.env` over `process.env` and the explicit value already wins.

## Tests

Written test-first; each was watched failing before the fix.

- **16 Jest unit tests** (`npm-packages/meteor-rspack/lib/{ignore,test}.test.js`) covering every row of the table above plus the `METEOR_IGNORE` merge. They compile the *emitted* matcher source and wire it to the real `ignore` module, so they exercise the code that actually runs inside the bundle.
- **1 tinytest** for `getUserMeteorIgnore` (`tools-core`) — 37/37 passing.
- **1 E2E regression** (`tools/e2e-tests/regressions/meteorignore-negation.test.js`) that writes the issue's exact `.meteorignore` into the `server-only` fixture and asserts `1 passing`, guarding the silent-zero-tests failure mode end to end.

`tools/unit-tests/jest.config.js` now sees `npm-packages/meteor-rspack` (the negative lookahead deliberately has no trailing slash — with one, the crawler prunes the bare directory path and finds no tests).

The E2E test has since run on CI and passed: `✓ Regressions / .meteorignore negation patterns / runs only the test files a later negation pattern re-includes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `.meteorignore` negation patterns now correctly re-include explicitly restored files.
  * User-defined `METEOR_IGNORE` patterns are preserved and applied during Rspack builds, serving, watching, and testing.
  * Ignore rules now consistently combine entries from `.meteorignore` and environment configuration.

* **Tests**
  * Added unit and end-to-end coverage for ignore-rule merging, negation behavior, and generated test-file filtering.
  * Confirmed that excluded files remain skipped while explicitly re-included files are processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
