### PR TITLE
Deliver the DDP 'failed' frame under the uws transport

### DIFF
--- a/.github/workflows/test-ddp-transport.yml
+++ b/.github/workflows/test-ddp-transport.yml
@@ -57,3 +57,9 @@ jobs:
 
       - name: Run DDP server tests (${{ matrix.transport }})
         run: ./packages/test-in-console/run.sh "ddp-server"
+
+      # ddp-client holds the DDP version negotiation tests, which exercise the
+      # server's send-then-close path. Running them per transport is what keeps
+      # a transport from silently breaking negotiation.
+      - name: Run DDP client tests (${{ matrix.transport }})
+        run: ./packages/test-in-console/run.sh "ddp-client"

--- a/packages/ddp-server/package.js
+++ b/packages/ddp-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data server",
-  version: '3.4.0',
+  version: '3.4.1',
   documentation: null,
 });
 

--- a/packages/ddp-server/transports/index.js
+++ b/packages/ddp-server/transports/index.js
@@ -1,6 +1,27 @@
 import { createSockJSTransport } from './sockjs.js';
 import { createUwsTransport } from './uws.js';
 
+/**
+ * Socket contract
+ *
+ * A transport emits 'connection' with a socket object, and the rest of
+ * ddp-server drives that socket through this interface only:
+ *
+ *   on('data', cb)     receive one decoded text frame per call
+ *   on('close', cb)    called once when the socket is gone
+ *   send(string)       queue one text frame
+ *   close()            close the socket AFTER flushing what send() queued
+ *   isClosed           truthy once closed
+ *   protocol           'websocket' or 'websocket-raw'
+ *   headers            the upgrade request headers
+ *   setWebsocketTimeout(ms)
+ *
+ * The flushing guarantee in close() is load-bearing: livedata_server ends
+ * DDP version negotiation by sending 'failed' and closing in the same tick,
+ * so a close that discards queued frames silently breaks negotiation. A
+ * transport whose native close does not flush must adapt it, as uws.js does.
+ */
+
 const TRANSPORTS = {
   sockjs: createSockJSTransport,
   uws: createUwsTransport,

--- a/packages/ddp-server/transports/uws.js
+++ b/packages/ddp-server/transports/uws.js
@@ -61,6 +61,17 @@ export function createUwsTransport() {
             // uWS manages its own timeouts internally
           };
 
+          // uWS names its two shutdowns the other way round from the socket
+          // contract in ./index.js: close() is documented as "Forcefully
+          // closes this WebSocket [...] No WebSocket close message is sent"
+          // and drops what send() queued, while end() closes gracefully and
+          // delivers it. livedata_server ends DDP version negotiation by
+          // sending 'failed' and closing in the same tick, so close() must
+          // map onto end() or that frame never reaches the client.
+          socket.close = function () {
+            socket.end();
+          };
+
           socket.protocol = 'websocket-raw';
           socket.headers = socket.headers || {};
 

--- a/packages/ddp-server/transports/uws_tests.js
+++ b/packages/ddp-server/transports/uws_tests.js
@@ -145,3 +145,82 @@ Tinytest.add(
     }
   }
 );
+
+// Why uws.js maps socket.close() onto socket.end().
+//
+// The socket contract in ./index.js requires close() to flush what send()
+// queued, because livedata_server ends DDP version negotiation by sending
+// 'failed' and closing in the same tick. uWS names its shutdowns the other
+// way round: close() is the forceful one and drops the queued frame, end()
+// is the graceful one and delivers it. This test pins that asymmetry down,
+// so that a change in uWebSockets.js is caught here rather than through a
+// silent negotiation failure.
+function sendThenShutdown(shutdown, onResult) {
+  const port = pickTestPort();
+  const host = '127.0.0.1';
+  const payload = JSON.stringify({ msg: 'failed', version: '1' });
+  const app = uws.App();
+
+  app.ws('/*', {
+    open(socket) {
+      socket.send(payload);
+      socket[shutdown]();
+    },
+  });
+
+  app.listen(host, port, uws.LIBUS_LISTEN_EXCLUSIVE_PORT, function (token) {
+    if (!token) {
+      onResult(null);
+      return;
+    }
+
+    const received = [];
+    let finished = false;
+    const socket = new WebSocket('ws://' + host + ':' + port);
+
+    function finish() {
+      if (finished) return;
+      finished = true;
+      Meteor.clearTimeout(timer);
+      try { socket.close(); } catch (e) { /* ignore */ }
+      try { uws.us_listen_socket_close(token); } catch (e) { /* ignore */ }
+      onResult(received);
+    }
+
+    const timer = Meteor.setTimeout(finish, 3000);
+    socket.addEventListener('message', function (event) {
+      received.push(String(event.data));
+    });
+    // Assert a tick after the close, so a frame still in flight is counted.
+    socket.addEventListener('close', function () {
+      Meteor.setTimeout(finish, 50);
+    });
+    socket.addEventListener('error', function () { /* asserted through the frames */ });
+  });
+}
+
+Tinytest.addAsync(
+  'ddp-server/uws - end() delivers a frame sent in the same tick, close() drops it',
+  function (test, onComplete) {
+    sendThenShutdown('end', function (afterEnd) {
+      test.isNotNull(afterEnd, 'could not listen for the end() case');
+      test.equal(
+        afterEnd,
+        [JSON.stringify({ msg: 'failed', version: '1' })],
+        'end() must deliver the frame queued just before it'
+      );
+
+      sendThenShutdown('close', function (afterClose) {
+        test.isNotNull(afterClose, 'could not listen for the close() case');
+        test.equal(
+          afterClose.length,
+          0,
+          'close() is expected to drop the queued frame; if this now passes, ' +
+          'uWebSockets.js changed and the close()/end() adapter in uws.js ' +
+          'should be revisited'
+        );
+        onComplete();
+      });
+    });
+  }
+);


### PR DESCRIPTION
# Deliver the DDP `failed` frame under the uws transport

Fixes #14746

## Problem

With `DDP_TRANSPORT=uws`, DDP version negotiation never completes. `livedata_server` answers a client that proposes the wrong version by sending `failed` and closing the socket in the same tick, at `livedata_server.js:1486-1488` and `:1500-1501`:

```js
socket.send(DDPCommon.stringifyDDP({msg: 'failed', version: version}));
socket.close();
```

uWebSockets.js names its two shutdowns the other way round from what the rest of `ddp-server` assumes. `index.d.ts:70-78` of `uWebSockets.js@20.66.0` documents `close()` as *"Forcefully closes this WebSocket [...] No WebSocket close message is sent"* and `end()` as *"Gracefully closes this WebSocket [...] A WebSocket close message is sent"*. Measured on a bare uWS server, the forceful variant also drops the frame queued immediately before it:

| server call | frames received by a client | close code |
|---|---:|---:|
| `socket.close()` | 0 | 1006 |
| `socket.end()` | 1 | 1005 |

`transports/uws.js` adapts the native socket for the rest of `ddp-server` (it installs `on` at line 47, `setWebsocketTimeout` at line 60, `protocol` and `headers` at lines 64-65) but leaves `close()` as the native one, so both negotiation failure paths lose their frame. The client receives nothing, `onDDPVersionNegotiationFailure` never fires, and the connection stalls.

## Change

- `transports/uws.js`: map `close()` onto `end()` alongside the other adapters, so the socket honours the contract the callers were written against.
- `transports/index.js`: write down that contract. Nothing stated it, which is how the gap went unnoticed; the flushing guarantee of `close()` is the load-bearing part.
- `transports/uws_tests.js`: pin the `close()` / `end()` asymmetry of the library, with a message telling a future reader what to reconsider if `close()` ever starts flushing.
- `.github/workflows/test-ddp-transport.yml`: run `ddp-client` in the transport matrix. The DDP version negotiation tests live there, so the uws leg never reached them; this is what makes them a regression guard.
- `ddp-server` `3.4.0` → `3.4.1`.

The fix stays in the transport rather than at the call sites: `livedata_server` closes sockets in three places (`:326`, `:1488`, `:1501`) and must remain transport-agnostic, which is the point of the pluggable transport work in #14231.

## Verification

Against a raw WebSocket client, same checkout and same app, only `DDP_TRANSPORT` differing:

| `connect` sent | sockjs | uws before | uws after |
|---|---|---|---|
| `version: '1'`, `support: ['1']` | `connected` | `connected` | `connected` |
| `version: 'garbled'`, `support: ['garbled', '1']` | `failed, version: "1"` | nothing, times out | `failed, version: "1"` |
| `version: 'garbled'`, `support: ['garbled']` | `failed, version: "1"` | nothing, times out | `failed, version: "1"` |

Package suites on Node 24.15:

| Suite | before | after |
|---|---|---|
| `ddp-client` with `DDP_TRANSPORT=uws` | 2 failures, then hangs with no total | 153 passes, 0 failures |
| `ddp-server` | 0 failures | 65 passes, 0 failures, the new test included |

An end-to-end smoke over uws (pub/sub `added` with dates, `changed` with `cleared` from `$unset`, malformed frames, binary result) passes before and after.
