### PR TITLE
Use external source maps for JavaScript images

### DIFF
--- a/tools/isobuild/bundler.js
+++ b/tools/isobuild/bundler.js
@@ -169,6 +169,7 @@ var release = require('../packaging/release.js');
 import { loadIsopackage } from '../tool-env/isopackets.js';
 import { CORDOVA_PLATFORM_VERSIONS } from '../cordova';
 import { gzipSync } from "zlib";
+import { pathToFileURL } from "url";
 import { PackageRegistry } from "../../packages/core-runtime/package-registry.js";
 import { optimisticLStatOrNull } from '../fs/optimistic';
 
@@ -2540,15 +2541,13 @@ class JsImage {
         );
 
         const sourceMappingURL =
-            "data:application/json;charset=utf8;base64," +
-            sourceMapBuffer.toString("base64");
+            encodeURIComponent(files.pathBasename(loadItem.sourceMap));
 
         // Remove any existing sourceMappingURL line. (eg, if roundtripping
         // through JsImage.readFromDisk, don't end up with two!)
         sourceBuffer = addSourceMappingURL(
             item.source,
             sourceMappingURL,
-            item.targetPath,
         );
 
         if (item.sourceMapRoot) {
@@ -2736,9 +2735,16 @@ class JsImage {
       if (item.sourceMap) {
         // XXX this is the same code as isopack.initFromPath
         rejectBadPath(item.sourceMap);
+        const sourceMapPath = files.pathResolve(dir, item.sourceMap);
         loadItem.sourceMap = JSON.parse(files.readFile(
-            files.pathJoin(dir, item.sourceMap), 'utf8'));
+            sourceMapPath, 'utf8'));
         loadItem.sourceMapRoot = item.sourceMapRoot;
+
+        loadItem.source = addSourceMappingURL(
+            loadItem.source,
+            pathToFileURL(files.convertToOSPath(sourceMapPath)).href,
+            item.path,
+        ).toString('utf8');
       }
 
       if (!_.isEmpty(item.assets)) {

--- a/tools/isobuild/compiler.js
+++ b/tools/isobuild/compiler.js
@@ -34,7 +34,7 @@ var compiler = exports;
 // dependencies. (At least for now, packages only used in target creation (eg
 // minifiers) don't require you to update BUILT_BY, though you will need to quit
 // and rerun "meteor run".)
-compiler.BUILT_BY = 'meteor/34';
+compiler.BUILT_BY = 'meteor/35';
 
 // This is a list of all possible architectures that a build can target. (Client
 // is expanded into 'web.browser' and 'web.cordova')


### PR DESCRIPTION
Fixes #14748 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved source map references in generated and loaded files, making them easier for debugging tools to locate and use.

- **Chores**
  - Updated the build metadata version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->